### PR TITLE
Miscellaneous fixes

### DIFF
--- a/config/manifests/deployment-operator.yaml
+++ b/config/manifests/deployment-operator.yaml
@@ -21,10 +21,7 @@ spec:
       serviceAccountName: dynatrace-operator
       containers:
         - name: dynatrace-operator
-          # Replace this with the built image name
-          image: docker.io/dynatrace/dynatrace-operator:snapshot
-          command:
-            - dynatrace-operator
+          image: quay.io/dynatrace/dynatrace-operator:snapshot
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -35,5 +32,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "dynatrace-operator"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi

--- a/controllers/kubemon/statefulset.go
+++ b/controllers/kubemon/statefulset.go
@@ -50,8 +50,9 @@ func newStatefulSet(instance *dynatracev1alpha1.DynaKube, kubeSystemUID types.UI
 			Annotations: map[string]string{},
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: instance.Spec.KubernetesMonitoringSpec.Replicas,
-			Selector: buildLabelSelector(instance),
+			Replicas:            instance.Spec.KubernetesMonitoringSpec.Replicas,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
+			Selector:            buildLabelSelector(instance),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: buildLabels(instance),

--- a/controllers/kubemon/statefulset_test.go
+++ b/controllers/kubemon/statefulset_test.go
@@ -50,8 +50,9 @@ func TestNewStatefulSet(t *testing.T) {
 			Annotations: map[string]string{},
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: instance.Spec.KubernetesMonitoringSpec.Replicas,
-			Selector: buildLabelSelector(&instance),
+			Replicas:            instance.Spec.KubernetesMonitoringSpec.Replicas,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
+			Selector:            buildLabelSelector(&instance),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: buildLabels(&instance),


### PR DESCRIPTION
* Use Quay image for dev deployments.
* Add resources limits to deployments.
* Remove command line argument from deployment and environment variable with the name, since they are unused.
* Use ParallelPodManagement for the StatefulSet deployment, allowing the StatefulSet to redeploy Pods even if they aren't ready.