### PR TITLE
Recognize skipCertCheck when looking for the image hash/version

### DIFF
--- a/controllers/dtpullsecret/generate.go
+++ b/controllers/dtpullsecret/generate.go
@@ -4,19 +4,19 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
+	"net/url"
 
 	"github.com/Dynatrace/dynatrace-operator/dtclient"
 )
 
 type dockerAuthentication struct {
-	Username string
-	Password string
-	Auth     string
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Auth     string `json:"auth"`
 }
 
 type dockerConfig struct {
-	Auths map[string]dockerAuthentication
+	Auths map[string]dockerAuthentication `json:"auths"`
 }
 
 func newDockerConfigWithAuth(username string, password string, registry string, auth string) *dockerConfig {
@@ -70,10 +70,11 @@ func (r *Reconciler) buildAuthString(connectionInfo dtclient.ConnectionInfo) str
 }
 
 func getImageRegistryFromAPIURL(apiURL string) (string, error) {
-	r := strings.TrimPrefix(apiURL, "https://")
-	r = strings.TrimPrefix(r, "http://")
-	r = strings.TrimSuffix(r, "/api")
-	return r, nil
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		return "", err
+	}
+	return u.Host, nil
 }
 
 func pullSecretDataFromDockerConfig(dockerConf *dockerConfig) (map[string][]byte, error) {

--- a/controllers/dtpullsecret/generate_test.go
+++ b/controllers/dtpullsecret/generate_test.go
@@ -1,0 +1,21 @@
+package dtpullsecret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetImageRegistryFromAPIURL(t *testing.T) {
+	for _, url := range []string{
+		"https://host.com/api",
+		"https://host.com/e/abc1234/api",
+		"http://host.com/api",
+		"http://host.com/e/abc1234/api",
+	} {
+		host, err := getImageRegistryFromAPIURL(url)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "host.com", host)
+		}
+	}
+}

--- a/controllers/dtpullsecret/reconciler_test.go
+++ b/controllers/dtpullsecret/reconciler_test.go
@@ -90,7 +90,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run(`Reconcile creates correct docker config`, func(t *testing.T) {
-		expectedJson := []byte(`{"Auths":{"test-endpoint.com":{"Username":"test-name","Password":"test-value","Auth":"dGVzdC1uYW1lOnRlc3QtdmFsdWU="}}}`)
+		expectedJSON := `{"auths":{"test-endpoint.com":{"username":"test-name","password":"test-value","auth":"dGVzdC1uYW1lOnRlc3QtdmFsdWU="}}}`
 		mockDTC := &dtclient.MockDynatraceClient{}
 		instance := &dynatracev1alpha1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -128,10 +128,10 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.NotEmpty(t, pullSecret.Data)
 		assert.Contains(t, pullSecret.Data, ".dockerconfigjson")
 		assert.NotEmpty(t, pullSecret.Data[".dockerconfigjson"])
-		assert.Equal(t, expectedJson, pullSecret.Data[".dockerconfigjson"])
+		assert.Equal(t, expectedJSON, string(pullSecret.Data[".dockerconfigjson"]))
 	})
 	t.Run(`Reconcile update secret if data changed`, func(t *testing.T) {
-		expectedJson := []byte(`{"Auths":{"test-endpoint.com":{"Username":"test-name","Password":"test-value","Auth":"dGVzdC1uYW1lOnRlc3QtdmFsdWU="}}}`)
+		expectedJSON := `{"auths":{"test-endpoint.com":{"username":"test-name","password":"test-value","auth":"dGVzdC1uYW1lOnRlc3QtdmFsdWU="}}}`
 		mockDTC := &dtclient.MockDynatraceClient{}
 		instance := &dynatracev1alpha1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -184,6 +184,6 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.NotEmpty(t, pullSecret.Data)
 		assert.Contains(t, pullSecret.Data, ".dockerconfigjson")
 		assert.NotEmpty(t, pullSecret.Data[".dockerconfigjson"])
-		assert.Equal(t, expectedJson, pullSecret.Data[".dockerconfigjson"])
+		assert.Equal(t, expectedJSON, string(pullSecret.Data[".dockerconfigjson"]))
 	})
 }

--- a/controllers/dtversion/docker.go
+++ b/controllers/dtversion/docker.go
@@ -90,7 +90,6 @@ func MakeSystemContext(dockerReference reference.Named, dockerConfig *DockerConf
 	for _, r := range []string{registry, "https://" + registry} {
 		if creds, ok := dockerConfig.Auths[r]; ok {
 			ctx.DockerAuthConfig = &types.DockerAuthConfig{Username: creds.Username, Password: creds.Password}
-			break
 		}
 	}
 

--- a/controllers/dtversion/docker_config.go
+++ b/controllers/dtversion/docker_config.go
@@ -7,16 +7,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type DockerConfigAuth struct {
-	Username string
-	Password string
-}
-
 type DockerConfig struct {
-	Auths map[string]DockerConfigAuth
+	Auths         map[string]DockerAuth
+	SkipCertCheck bool
 }
 
-func NewDockerConfig(secret *corev1.Secret) (*DockerConfig, error) {
+type DockerAuth struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func ParseDockerConfigJSON(secret *corev1.Secret) (map[string]DockerAuth, error) {
 	if secret == nil {
 		return nil, fmt.Errorf("given secret is nil")
 	}
@@ -26,11 +27,13 @@ func NewDockerConfig(secret *corev1.Secret) (*DockerConfig, error) {
 		return nil, fmt.Errorf("could not find any docker config in image pull secret")
 	}
 
-	var dockerConf DockerConfig
-	err := json.Unmarshal(config, &dockerConf)
-	if err != nil {
+	var dockerConf struct {
+		Auths map[string]DockerAuth `json:"auths"`
+	}
+
+	if err := json.Unmarshal(config, &dockerConf); err != nil {
 		return nil, err
 	}
 
-	return &dockerConf, nil
+	return dockerConf.Auths, nil
 }

--- a/controllers/dtversion/docker_config.go
+++ b/controllers/dtversion/docker_config.go
@@ -28,7 +28,7 @@ func ParseDockerAuthsFromSecret(secret *corev1.Secret) (map[string]DockerAuth, e
 		return nil, fmt.Errorf("could not find any docker config in image pull secret")
 	}
 
-  var dockerConf struct {
+	var dockerConf struct {
 		Auths map[string]DockerAuth `json:"auths"`
 	}
 	err := json.Unmarshal(config, &dockerConf)

--- a/controllers/dtversion/docker_config.go
+++ b/controllers/dtversion/docker_config.go
@@ -17,7 +17,7 @@ type DockerAuth struct {
 	Password string `json:"password"`
 }
 
-func ParseDockerConfigJSON(secret *corev1.Secret) (map[string]DockerAuth, error) {
+func ParseDockerAuthsFromSecret(secret *corev1.Secret) (map[string]DockerAuth, error) {
 	if secret == nil {
 		return nil, fmt.Errorf("given secret is nil")
 	}

--- a/controllers/dtversion/docker_config_test.go
+++ b/controllers/dtversion/docker_config_test.go
@@ -16,27 +16,27 @@ const (
 
 func TestNewDockerConfig(t *testing.T) {
 	t.Run(`NewDockerConfig handles nil secret`, func(t *testing.T) {
-		config, err := NewDockerConfig(nil)
-		assert.Nil(t, config)
+		auths, err := ParseDockerConfigJSON(nil)
+		assert.Nil(t, auths)
 		assert.Error(t, err)
 	})
 	t.Run(`NewDockerConfig handles missing secret data`, func(t *testing.T) {
-		config, err := NewDockerConfig(&corev1.Secret{})
-		assert.Nil(t, config)
+		auths, err := ParseDockerConfigJSON(&corev1.Secret{})
+		assert.Nil(t, auths)
 		assert.Error(t, err)
 	})
 	t.Run(`NewDockerConfig handles invalid json`, func(t *testing.T) {
-		config, err := NewDockerConfig(&corev1.Secret{
+		auths, err := ParseDockerConfigJSON(&corev1.Secret{
 			Data: map[string][]byte{
 				".dockerconfigjson": []byte(`invalid json`),
 			},
 		})
 
-		assert.Nil(t, config)
+		assert.Nil(t, auths)
 		assert.Error(t, err)
 	})
 	t.Run(`NewDockerConfig returns docker config from valid secret`, func(t *testing.T) {
-		config, err := NewDockerConfig(&corev1.Secret{
+		auths, err := ParseDockerConfigJSON(&corev1.Secret{
 			Data: map[string][]byte{
 				".dockerconfigjson": []byte(
 					fmt.Sprintf(`{ "auths": { "%s": { "username": "%s", "password": "%s" } } }`, testKey, testName, testValue)),
@@ -44,10 +44,9 @@ func TestNewDockerConfig(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.NotNil(t, config)
-		assert.NotEmpty(t, config.Auths)
-		assert.Contains(t, config.Auths, testKey)
-		assert.Equal(t, testName, config.Auths[testKey].Username)
-		assert.Equal(t, testValue, config.Auths[testKey].Password)
+		assert.NotEmpty(t, auths)
+		assert.Contains(t, auths, testKey)
+		assert.Equal(t, testName, auths[testKey].Username)
+		assert.Equal(t, testValue, auths[testKey].Password)
 	})
 }

--- a/controllers/dtversion/docker_config_test.go
+++ b/controllers/dtversion/docker_config_test.go
@@ -16,17 +16,17 @@ const (
 
 func TestNewDockerConfig(t *testing.T) {
 	t.Run(`NewDockerConfig handles nil secret`, func(t *testing.T) {
-		auths, err := ParseDockerConfigJSON(nil)
+		auths, err := ParseDockerAuthsFromSecret(nil)
 		assert.Nil(t, auths)
 		assert.Error(t, err)
 	})
 	t.Run(`NewDockerConfig handles missing secret data`, func(t *testing.T) {
-		auths, err := ParseDockerConfigJSON(&corev1.Secret{})
+		auths, err := ParseDockerAuthsFromSecret(&corev1.Secret{})
 		assert.Nil(t, auths)
 		assert.Error(t, err)
 	})
 	t.Run(`NewDockerConfig handles invalid json`, func(t *testing.T) {
-		auths, err := ParseDockerConfigJSON(&corev1.Secret{
+		auths, err := ParseDockerAuthsFromSecret(&corev1.Secret{
 			Data: map[string][]byte{
 				".dockerconfigjson": []byte(`invalid json`),
 			},
@@ -36,7 +36,7 @@ func TestNewDockerConfig(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run(`NewDockerConfig returns docker config from valid secret`, func(t *testing.T) {
-		auths, err := ParseDockerConfigJSON(&corev1.Secret{
+		auths, err := ParseDockerAuthsFromSecret(&corev1.Secret{
 			Data: map[string][]byte{
 				".dockerconfigjson": []byte(
 					fmt.Sprintf(`{ "auths": { "%s": { "username": "%s", "password": "%s" } } }`, testKey, testName, testValue)),

--- a/controllers/dtversion/docker_test.go
+++ b/controllers/dtversion/docker_test.go
@@ -21,7 +21,7 @@ func TestMakeSystemContext(t *testing.T) {
 	})
 	t.Run(`MakeSystemContext sets credentials from docker config`, func(t *testing.T) {
 		systemContext := MakeSystemContext(&mockDockerReference{}, &DockerConfig{
-			Auths: map[string]DockerConfigAuth{
+			Auths: map[string]DockerAuth{
 				testName: {
 					Username: testName,
 					Password: testString,

--- a/controllers/kubemon/reconciler.go
+++ b/controllers/kubemon/reconciler.go
@@ -132,7 +132,7 @@ func (r *Reconciler) updateImageVersion(instance *dynatracev1alpha1.DynaKube, im
 		return false, fmt.Errorf("failed to get image pull secret: %w", err)
 	}
 
-	dockerCfg, err := dtversion.NewDockerConfig(pullSecret)
+	auths, err := dtversion.ParseDockerConfigJSON(pullSecret)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Dockerconfig for pull secret: %w", err)
 	}
@@ -142,7 +142,10 @@ func (r *Reconciler) updateImageVersion(instance *dynatracev1alpha1.DynaKube, im
 		verProvider = r.imageVersionProvider
 	}
 
-	ver, err := verProvider(img, dockerCfg)
+	ver, err := verProvider(img, &dtversion.DockerConfig{
+		Auths:         auths,
+		SkipCertCheck: instance.Spec.SkipCertCheck,
+	})
 	if err != nil {
 		return false, fmt.Errorf("failed to get image version: %w", err)
 	}

--- a/controllers/kubemon/reconciler.go
+++ b/controllers/kubemon/reconciler.go
@@ -132,7 +132,7 @@ func (r *Reconciler) updateImageVersion(instance *dynatracev1alpha1.DynaKube, im
 		return false, fmt.Errorf("failed to get image pull secret: %w", err)
 	}
 
-	auths, err := dtversion.ParseDockerConfigJSON(pullSecret)
+	auths, err := dtversion.ParseDockerAuthsFromSecret(pullSecret)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Dockerconfig for pull secret: %w", err)
 	}


### PR DESCRIPTION
* Recognize skipCertCheck when looking for the image hash/version. The container runtimes still need to be updated for them to be able to pull images.
* Fix the generation of the Dynatrace's Pull Secret for ActiveGate/Managed API URLs (i.e., only put the domain as the registry.)