### PR TITLE
Don't include custom labels on selectors

### DIFF
--- a/controllers/kubemon/statefulset.go
+++ b/controllers/kubemon/statefulset.go
@@ -52,9 +52,7 @@ func newStatefulSet(instance *dynatracev1alpha1.DynaKube, kubeSystemUID types.UI
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:            instance.Spec.KubernetesMonitoringSpec.Replicas,
 			PodManagementPolicy: appsv1.ParallelPodManagement,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: BuildLabelsFromInstance(instance),
-			},
+			Selector: &metav1.LabelSelector{ MatchLabels: BuildLabelsFromInstance(instance) },
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: buildLabels(instance),

--- a/controllers/kubemon/statefulset.go
+++ b/controllers/kubemon/statefulset.go
@@ -52,7 +52,7 @@ func newStatefulSet(instance *dynatracev1alpha1.DynaKube, kubeSystemUID types.UI
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:            instance.Spec.KubernetesMonitoringSpec.Replicas,
 			PodManagementPolicy: appsv1.ParallelPodManagement,
-			Selector: &metav1.LabelSelector{ MatchLabels: BuildLabelsFromInstance(instance) },
+			Selector:            &metav1.LabelSelector{MatchLabels: BuildLabelsFromInstance(instance)},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: buildLabels(instance),

--- a/controllers/kubemon/statefulset.go
+++ b/controllers/kubemon/statefulset.go
@@ -52,7 +52,9 @@ func newStatefulSet(instance *dynatracev1alpha1.DynaKube, kubeSystemUID types.UI
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:            instance.Spec.KubernetesMonitoringSpec.Replicas,
 			PodManagementPolicy: appsv1.ParallelPodManagement,
-			Selector:            buildLabelSelector(instance),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: BuildLabelsFromInstance(instance),
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: buildLabels(instance),
@@ -154,14 +156,6 @@ func buildLabels(instance *dynatracev1alpha1.DynaKube) map[string]string {
 	return MergeLabels(instance.Labels,
 		BuildLabelsFromInstance(instance),
 		instance.Spec.KubernetesMonitoringSpec.Labels)
-}
-
-func buildLabelSelector(instance *dynatracev1alpha1.DynaKube) *metav1.LabelSelector {
-	return &metav1.LabelSelector{
-		MatchLabels: MergeLabels(
-			BuildLabelsFromInstance(instance),
-			instance.Spec.KubernetesMonitoringSpec.Labels),
-	}
 }
 
 func buildKubernetesExpression(archKey string, osKey string) []corev1.NodeSelectorRequirement {

--- a/controllers/kubemon/statefulset_test.go
+++ b/controllers/kubemon/statefulset_test.go
@@ -52,7 +52,7 @@ func TestNewStatefulSet(t *testing.T) {
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:            instance.Spec.KubernetesMonitoringSpec.Replicas,
 			PodManagementPolicy: appsv1.ParallelPodManagement,
-			Selector:            buildLabelSelector(&instance),
+			Selector:            &metav1.LabelSelector{MatchLabels: BuildLabelsFromInstance(&instance)},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: buildLabels(&instance),
@@ -85,25 +85,6 @@ func TestBuildLabels(t *testing.T) {
 		"activegate": testName,
 		testKey:      testValue,
 	}, labels)
-}
-
-func TestBuildLabelSelector(t *testing.T) {
-	const testName = "test-instance"
-	instance := &dynatracev1alpha1.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: testName,
-			Labels: map[string]string{
-				testKey: testValue,
-			},
-		},
-	}
-	expectedLabelSelector := metav1.LabelSelector{
-		MatchLabels: BuildLabelsFromInstance(instance),
-	}
-	labelSelector := buildLabelSelector(instance)
-
-	assert.NotNil(t, labelSelector)
-	assert.Equal(t, expectedLabelSelector, *labelSelector)
 }
 
 func TestBuildVolumes(t *testing.T) {


### PR DESCRIPTION
Once the StatefulSet has been created, selector labels can't be updated anymore, so let's not include the custom ones there. We don't need them there anyway.