### PR TITLE
Extend clusterrole for clusterversions resource

### DIFF
--- a/config/manifests/clusterrole-kubernetes-monitoring.yaml
+++ b/config/manifests/clusterrole-kubernetes-monitoring.yaml
@@ -8,6 +8,7 @@ rules:
       - batch
       - apps
       - apps.openshift.io
+      - config.openshift.io
     resources:
       - nodes
       - pods
@@ -23,6 +24,7 @@ rules:
       - events
       - resourcequotas
       - pods/proxy
+      - clusterversions
     verbs:
       - list
       - watch


### PR DESCRIPTION
Added the API group 'config.openshift.io' with the resource 'clusterversions' to query the openshift cluster version