### PR TITLE
Restart Pods when custom.properties change

### DIFF
--- a/controllers/customproperties/reconciler.go
+++ b/controllers/customproperties/reconciler.go
@@ -19,7 +19,7 @@ const (
 	DataKey    = "customProperties"
 	DataPath   = "custom.properties"
 	VolumeName = "custom-properties"
-	MountPath  = "/mnt/dynatrace/gateway/config_template"
+	MountPath  = "/mnt/dynatrace/gateway/config_template/custom.properties"
 )
 
 type Reconciler struct {

--- a/controllers/customproperties/reconciler.go
+++ b/controllers/customproperties/reconciler.go
@@ -19,7 +19,7 @@ const (
 	DataKey    = "customProperties"
 	DataPath   = "custom.properties"
 	VolumeName = "custom-properties"
-	MountPath  = "/mnt/dynatrace/gateway/config"
+	MountPath  = "/mnt/dynatrace/gateway/config_template"
 )
 
 type Reconciler struct {

--- a/controllers/customproperties/reconciler.go
+++ b/controllers/customproperties/reconciler.go
@@ -19,7 +19,7 @@ const (
 	DataKey    = "customProperties"
 	DataPath   = "custom.properties"
 	VolumeName = "custom-properties"
-	MountPath  = "/mnt/dynatrace/gateway/config_template/custom.properties"
+	MountPath  = "/var/lib/dynatrace/gateway/config_template/custom.properties"
 )
 
 type Reconciler struct {

--- a/controllers/kubemon/reconciler_test.go
+++ b/controllers/kubemon/reconciler_test.go
@@ -82,7 +82,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: instance.Name + StatefulSetSuffix, Namespace: instance.Namespace}, &statefulSet)
 		assert.NoError(t, err)
 
-		expected, err := newStatefulSet(instance, testUID)
+		expected, err := newStatefulSet(instance, testUID, "")
 		assert.NoError(t, err)
 
 		expected.Spec.Template.Spec.Volumes = nil

--- a/controllers/kubemon/statefulset.go
+++ b/controllers/kubemon/statefulset.go
@@ -112,7 +112,7 @@ func buildContainer(instance *dynatracev1alpha1.DynaKube, kubeSystemUID types.UI
 			ReadOnly:  true,
 			Name:      customproperties.VolumeName,
 			MountPath: customproperties.MountPath,
-			SubPath:   customproperties.DataKey,
+			SubPath:   customproperties.DataPath,
 		})
 	}
 

--- a/controllers/kubemon/statefulset.go
+++ b/controllers/kubemon/statefulset.go
@@ -111,6 +111,7 @@ func buildContainer(instance *dynatracev1alpha1.DynaKube, kubeSystemUID types.UI
 			ReadOnly:  true,
 			Name:      customproperties.VolumeName,
 			MountPath: customproperties.MountPath,
+			SubPath:   customproperties.DataKey,
 		})
 	}
 

--- a/controllers/kubemon/statefulset.go
+++ b/controllers/kubemon/statefulset.go
@@ -41,7 +41,7 @@ const (
 	StatefulSetSuffix = "-kubemon"
 )
 
-func newStatefulSet(instance *dynatracev1alpha1.DynaKube, kubeSystemUID types.UID) (*appsv1.StatefulSet, error) {
+func newStatefulSet(instance *dynatracev1alpha1.DynaKube, kubeSystemUID types.UID, customPropsHash string) (*appsv1.StatefulSet, error) {
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        instance.Name + StatefulSetSuffix,
@@ -57,8 +57,9 @@ func newStatefulSet(instance *dynatracev1alpha1.DynaKube, kubeSystemUID types.UI
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: buildLabels(instance),
 					Annotations: map[string]string{
-						annotationImageHash:    instance.Status.ActiveGateImageHash,
-						annotationImageVersion: instance.Status.ActiveGateImageVersion,
+						annotationImageHash:       instance.Status.ActiveGateImageHash,
+						annotationImageVersion:    instance.Status.ActiveGateImageVersion,
+						annotationCustomPropsHash: customPropsHash,
 					},
 				},
 				Spec: buildTemplateSpec(instance, kubeSystemUID),

--- a/controllers/kubemon/statefulset_test.go
+++ b/controllers/kubemon/statefulset_test.go
@@ -33,7 +33,7 @@ func TestNewStatefulSet(t *testing.T) {
 		},
 	}
 
-	sts, err := newStatefulSet(&instance, testUID)
+	sts, err := newStatefulSet(&instance, testUID, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, sts)
 
@@ -57,8 +57,9 @@ func TestNewStatefulSet(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: buildLabels(&instance),
 					Annotations: map[string]string{
-						annotationImageHash:    testImageHash,
-						annotationImageVersion: testImageVersion,
+						annotationImageHash:       testImageHash,
+						annotationImageVersion:    testImageVersion,
+						annotationCustomPropsHash: "",
 					},
 				},
 				Spec: buildTemplateSpec(&instance, testUID),


### PR DESCRIPTION
On this PR,
* The custom.properties file is mounted into the correct location.
* If there are changes, Pods get restarted, including,
  * Changes on `.value`
  * Changes on the secret being pointed by `.valueFrom` (checked each reconciliation, so there may be a delay.)