### PR TITLE
Use branch image in make deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,4 +80,4 @@ tags
 /debug.sh
 /tmp/
 /reapply-all.sh
-
+config/deploy/kustomization.yaml

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,14 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
-IMG ?= dynatrace-operator:latest
+ifeq ($(origin IMG),undefined)
+ifeq ($(shell git branch --show-current),master)
+IMG=quay.io/dynatrace/dynatrace-operator:snapshot
+else
+IMG=quay.io/dynatrace/dynatrace-operator:snapshot-$(shell git branch --show-current | sed "s\#[^a-zA-Z0-9_-]\#-\#g")
+endif
+endif
+
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
@@ -52,8 +59,23 @@ uninstall: manifests kustomize
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests kustomize
-	cd config/manifests && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	kubectl get namespace dynatrace || kubectl create namespace dynatrace
+	rm -f config/deploy/kustomization.yaml
+	mkdir -p config/deploy
+	cd config/deploy && $(KUSTOMIZE) create
+	cd config/deploy && $(KUSTOMIZE) edit add base ../manifests
+	cd config/deploy && $(KUSTOMIZE) edit set image "quay.io/dynatrace/dynatrace-operator:snapshot"=${IMG}
+	$(KUSTOMIZE) build config/deploy | kubectl apply -f -
+
+# Deploy controller in the configured OpenShift cluster in ~/.kube/config
+deploy-ocp: manifests kustomize
+	oc get project dynatrace || oc adm new-project --node-selector="" dynatrace
+	rm -f config/deploy/kustomization.yaml
+	mkdir -p config/deploy
+	cd config/deploy && $(KUSTOMIZE) create
+	cd config/deploy && $(KUSTOMIZE) edit add base ../manifests
+	cd config/deploy && $(KUSTOMIZE) edit set image "quay.io/dynatrace/dynatrace-operator:snapshot"=${IMG}
+	$(KUSTOMIZE) build config/deploy | oc apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen


### PR DESCRIPTION
There are few steps needed when deploying the Operator in dev clusters.

In particular, if using the dev images built from branches, it needs to be updated on the Deployment, and soon other places. I've updated the Makefile to,

* Create namespace/project if it doesn't exist.
* Create a temporary kustomization.yaml in "config/deploy" to make changes on.
* Set the image to the one that gets published for the branch on the CI pipeline to Quay.

The temporary kustomization.yaml file is inside .gitignore as well to avoid dirtying the directory.

The idea is that you can run `make deploy` and things will be deployed as they should, assuming that the image has been built already by the CI pipeline.

I also added `make deploy-ocp` for when using OpenShift.