### PR TITLE
Use webhook lock names different than OneAgent Operator's

### DIFF
--- a/webhook_bootstrapper.go
+++ b/webhook_bootstrapper.go
@@ -31,7 +31,7 @@ func startWebhookBoostrapper(ns string, cfg *rest.Config) (manager.Manager, erro
 		Scheme:                     scheme,
 		MetricsBindAddress:         ":8484",
 		LeaderElection:             true,
-		LeaderElectionID:           "dynatrace-oneagent-webhook-bootstrapper-lock",
+		LeaderElectionID:           "dynatrace-webhook-bootstrapper-lock",
 		LeaderElectionResourceLock: "configmaps",
 		LeaderElectionNamespace:    ns,
 		HealthProbeBindAddress:     "0.0.0.0:9080",

--- a/webhook_server.go
+++ b/webhook_server.go
@@ -34,7 +34,7 @@ func startWebhookServer(ns string, cfg *rest.Config) (manager.Manager, error) {
 		MetricsBindAddress:         ":8383",
 		Port:                       8443,
 		LeaderElection:             true,
-		LeaderElectionID:           "dynatrace-oneagent-webhook-server-lock",
+		LeaderElectionID:           "dynatrace-webhook-server-lock",
 		LeaderElectionResourceLock: "configmaps",
 		LeaderElectionNamespace:    ns,
 	})


### PR DESCRIPTION
We're currently using the same as the OneAgent Operator's and there are conflicts.