### PR TITLE
Migrate to Go 1.16, and use embedded files for init.sh script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
-go:
-  1.15.x
+go: 1.16.x
 os: linux
 dist: xenial
 
@@ -48,7 +47,6 @@ jobs:
     - stage: preparation
       name: Linting
       language: go
-      go: "1.15.x"
       script:
         - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
         - golangci-lint run --build-tags integration,containers_image_storage_stub --timeout 300s

--- a/controllers/namespace/init.sh.test-sample
+++ b/controllers/namespace/init.sh.test-sample
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [[ -f "/var/lib/dynatrace/oneagent/agent/config/ruxithost.id" ]]; then
+	echo "WARNING: full-stack OneAgent has been injected to this container. App-only and full-stack injection can conflict with each other."
+fi
+
+api_url="https://test-url/api"
+config_dir="/mnt/config"
+target_dir="/mnt/oneagent"
+paas_token="42"
+proxy=""
+skip_cert_checks="false"
+custom_ca="false"
+fail_code=0
+cluster_id="42"
+
+declare -A im_nodes
+im_nodes=(
+	["node1"]="abc12345"
+)
+
+set +u
+host_tenant="${im_nodes[${K8S_NODE_NAME}]}"
+set -u
+
+archive="/mnt/init/tmp.$RANDOM"
+
+if [[ "${FAILURE_POLICY}" == "fail" ]]; then
+	fail_code=1
+fi
+
+if [[ "${MODE}" == "installer" ]]; then
+	curl_params=(
+		"--silent"
+		"--output" "${archive}"
+	)
+
+	if [[ "${INSTALLER_URL}" != "" ]]; then
+		curl_params+=("${INSTALLER_URL}")
+	else
+		curl_params+=(
+			"${api_url}/v1/deployment/installer/agent/unix/paas/latest?flavor=${FLAVOR}&include=${TECHNOLOGIES}&bitness=64"
+			"--header" "Authorization: Api-Token ${paas_token}"
+		)
+	fi
+
+	if [[ "${skip_cert_checks}" == "true" ]]; then
+		curl_params+=("--insecure")
+	fi
+
+	if [[ "${custom_ca}" == "true" ]]; then
+		curl_params+=("--cacert" "${config_dir}/ca.pem")
+	fi
+
+	if [[ "${proxy}" != "" ]]; then
+		curl_params+=("--proxy" "${proxy}")
+	fi
+
+	echo "Downloading OneAgent package..."
+	if ! curl "${curl_params[@]}"; then
+		echo "Failed to download the OneAgent package."
+		exit "${fail_code}"
+	fi
+
+	echo "Unpacking OneAgent package..."
+	if ! unzip -o -d "${target_dir}" "${archive}"; then
+		echo "Failed to unpack the OneAgent package."
+		mv "${archive}" "${target_dir}/package.zip"
+		exit "${fail_code}"
+	fi
+fi
+
+echo "Configuring OneAgent..."
+echo -n "${INSTALLPATH}/agent/lib64/liboneagentproc.so" >> "${target_dir}/ld.so.preload"
+
+for i in $(seq 1 $CONTAINERS_COUNT)
+do
+	container_name_var="CONTAINER_${i}_NAME"
+	container_image_var="CONTAINER_${i}_IMAGE"
+
+	container_name="${!container_name_var}"
+	container_image="${!container_image_var}"
+
+	container_conf_file="${target_dir}/container_${container_name}.conf"
+
+	echo "Writing ${container_conf_file} file..."
+	echo "[container]
+containerName ${container_name}
+imageName ${container_image}
+k8s_fullpodname ${K8S_PODNAME}
+k8s_poduid ${K8S_PODUID}
+k8s_containername ${container_name}
+k8s_basepodname ${K8S_BASEPODNAME}
+k8s_namespace ${K8S_NAMESPACE}">>${container_conf_file}
+
+	if [[ ! -z "${host_tenant}" ]]; then
+		if [[ "abc12345" == "${host_tenant}" ]]; then
+			echo "k8s_node_name ${K8S_NODE_NAME}
+k8s_cluster_id ${cluster_id}">>${container_conf_file}
+		fi
+
+	echo "
+[host]
+tenant ${host_tenant}">>${container_conf_file}
+	fi
+done

--- a/controllers/namespace/init.sh.tmpl
+++ b/controllers/namespace/init.sh.tmpl
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [[ -f "/var/lib/dynatrace/oneagent/agent/config/ruxithost.id" ]]; then
+	echo "WARNING: full-stack OneAgent has been injected to this container. App-only and full-stack injection can conflict with each other."
+fi
+
+api_url="{{.DynaKube.Spec.APIURL}}"
+config_dir="/mnt/config"
+target_dir="/mnt/oneagent"
+paas_token="{{.PaaSToken}}"
+proxy="{{.Proxy}}"
+skip_cert_checks="{{if .DynaKube.Spec.SkipCertCheck}}true{{else}}false{{end}}"
+custom_ca="{{if .TrustedCAs}}true{{else}}false{{end}}"
+fail_code=0
+cluster_id="{{.ClusterID}}"
+
+declare -A im_nodes
+im_nodes=(
+	{{- range $node, $tenant := .IMNodes}}
+	["{{$node}}"]="{{$tenant}}"
+	{{- end}}
+)
+
+set +u
+host_tenant="${im_nodes[${K8S_NODE_NAME}]}"
+set -u
+
+archive="/mnt/init/tmp.$RANDOM"
+
+if [[ "${FAILURE_POLICY}" == "fail" ]]; then
+	fail_code=1
+fi
+
+if [[ "${MODE}" == "installer" ]]; then
+	curl_params=(
+		"--silent"
+		"--output" "${archive}"
+	)
+
+	if [[ "${INSTALLER_URL}" != "" ]]; then
+		curl_params+=("${INSTALLER_URL}")
+	else
+		curl_params+=(
+			"${api_url}/v1/deployment/installer/agent/unix/paas/latest?flavor=${FLAVOR}&include=${TECHNOLOGIES}&bitness=64"
+			"--header" "Authorization: Api-Token ${paas_token}"
+		)
+	fi
+
+	if [[ "${skip_cert_checks}" == "true" ]]; then
+		curl_params+=("--insecure")
+	fi
+
+	if [[ "${custom_ca}" == "true" ]]; then
+		curl_params+=("--cacert" "${config_dir}/ca.pem")
+	fi
+
+	if [[ "${proxy}" != "" ]]; then
+		curl_params+=("--proxy" "${proxy}")
+	fi
+
+	echo "Downloading OneAgent package..."
+	if ! curl "${curl_params[@]}"; then
+		echo "Failed to download the OneAgent package."
+		exit "${fail_code}"
+	fi
+
+	echo "Unpacking OneAgent package..."
+	if ! unzip -o -d "${target_dir}" "${archive}"; then
+		echo "Failed to unpack the OneAgent package."
+		mv "${archive}" "${target_dir}/package.zip"
+		exit "${fail_code}"
+	fi
+fi
+
+echo "Configuring OneAgent..."
+echo -n "${INSTALLPATH}/agent/lib64/liboneagentproc.so" >> "${target_dir}/ld.so.preload"
+
+for i in $(seq 1 $CONTAINERS_COUNT)
+do
+	container_name_var="CONTAINER_${i}_NAME"
+	container_image_var="CONTAINER_${i}_IMAGE"
+
+	container_name="${!container_name_var}"
+	container_image="${!container_image_var}"
+
+	container_conf_file="${target_dir}/container_${container_name}.conf"
+
+	echo "Writing ${container_conf_file} file..."
+	echo "[container]
+containerName ${container_name}
+imageName ${container_image}
+k8s_fullpodname ${K8S_PODNAME}
+k8s_poduid ${K8S_PODUID}
+k8s_containername ${container_name}
+k8s_basepodname ${K8S_BASEPODNAME}
+k8s_namespace ${K8S_NAMESPACE}">>${container_conf_file}
+
+	if [[ ! -z "${host_tenant}" ]]; then
+		if [[ "{{.DynaKube.Status.EnvironmentID}}" == "${host_tenant}" ]]; then
+			echo "k8s_node_name ${K8S_NODE_NAME}
+k8s_cluster_id ${cluster_id}">>${container_conf_file}
+		fi
+
+	echo "
+[host]
+tenant ${host_tenant}">>${container_conf_file}
+	fi
+done

--- a/controllers/namespace/namespace_controller.go
+++ b/controllers/namespace/namespace_controller.go
@@ -3,6 +3,7 @@ package namespace
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"fmt"
 	"text/template"
 	"time"
@@ -22,6 +23,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
+
+//go:embed init.sh.tmpl
+var scriptContent string
+
+var scriptTmpl = template.Must(template.New("initScript").Parse(scriptContent))
 
 func Add(mgr manager.Manager, ns string) error {
 	logger := log.Log.WithName("namespaces.controller")
@@ -192,118 +198,6 @@ func newScript(ctx context.Context, c client.Client, dynaKube dynatracev1alpha1.
 		IMNodes:    imNodes,
 	}, nil
 }
-
-var scriptTmpl = template.Must(template.New("initScript").Parse(`#!/usr/bin/env bash
-
-set -eu
-
-if [[ -f "/var/lib/dynatrace/oneagent/agent/config/ruxithost.id" ]]; then
-	echo "WARNING: full-stack OneAgent has been injected to this container. App-only and full-stack injection can conflict with each other."
-fi
-
-api_url="{{.DynaKube.Spec.APIURL}}"
-config_dir="/mnt/config"
-target_dir="/mnt/oneagent"
-paas_token="{{.PaaSToken}}"
-proxy="{{.Proxy}}"
-skip_cert_checks="{{if .DynaKube.Spec.SkipCertCheck}}true{{else}}false{{end}}"
-custom_ca="{{if .TrustedCAs}}true{{else}}false{{end}}"
-fail_code=0
-cluster_id="{{.ClusterID}}"
-
-declare -A im_nodes
-im_nodes=(
-	{{- range $node, $tenant := .IMNodes}}
-	["{{$node}}"]="{{$tenant}}"
-	{{- end}}
-)
-
-set +u
-host_tenant="${im_nodes[${K8S_NODE_NAME}]}"
-set -u
-
-archive="/mnt/init/tmp.$RANDOM"
-
-if [[ "${FAILURE_POLICY}" == "fail" ]]; then
-	fail_code=1
-fi
-
-if [[ "${MODE}" == "installer" ]]; then
-	curl_params=(
-		"--silent"
-		"--output" "${archive}"
-	)
-
-	if [[ "${INSTALLER_URL}" != "" ]]; then
-		curl_params+=("${INSTALLER_URL}")
-	else
-		curl_params+=(
-			"${api_url}/v1/deployment/installer/agent/unix/paas/latest?flavor=${FLAVOR}&include=${TECHNOLOGIES}&bitness=64"
-			"--header" "Authorization: Api-Token ${paas_token}"
-		)
-	fi
-
-	if [[ "${skip_cert_checks}" == "true" ]]; then
-		curl_params+=("--insecure")
-	fi
-
-	if [[ "${custom_ca}" == "true" ]]; then
-		curl_params+=("--cacert" "${config_dir}/ca.pem")
-	fi
-
-	if [[ "${proxy}" != "" ]]; then
-		curl_params+=("--proxy" "${proxy}")
-	fi
-
-	echo "Downloading OneAgent package..."
-	if ! curl "${curl_params[@]}"; then
-		echo "Failed to download the OneAgent package."
-		exit "${fail_code}"
-	fi
-
-	echo "Unpacking OneAgent package..."
-	if ! unzip -o -d "${target_dir}" "${archive}"; then
-		echo "Failed to unpack the OneAgent package."
-		mv "${archive}" "${target_dir}/package.zip"
-		exit "${fail_code}"
-	fi
-fi
-
-echo "Configuring OneAgent..."
-echo -n "${INSTALLPATH}/agent/lib64/liboneagentproc.so" >> "${target_dir}/ld.so.preload"
-
-for i in $(seq 1 $CONTAINERS_COUNT)
-do
-	container_name_var="CONTAINER_${i}_NAME"
-	container_image_var="CONTAINER_${i}_IMAGE"
-
-	container_name="${!container_name_var}"
-	container_image="${!container_image_var}"
-
-	container_conf_file="${target_dir}/container_${container_name}.conf"
-
-	echo "Writing ${container_conf_file} file..."
-	echo "[container]
-containerName ${container_name}
-imageName ${container_image}
-k8s_fullpodname ${K8S_PODNAME}
-k8s_poduid ${K8S_PODUID}
-k8s_containername ${container_name}
-k8s_basepodname ${K8S_BASEPODNAME}
-k8s_namespace ${K8S_NAMESPACE}">>${container_conf_file}
-
-	if [[ ! -z "${host_tenant}" ]]; then
-		if [[ "{{.DynaKube.Status.EnvironmentID}}" == "${host_tenant}" ]]; then
-			echo "k8s_node_name ${K8S_NODE_NAME}
-k8s_cluster_id ${cluster_id}">>${container_conf_file}
-		fi
-
-	echo "
-[host]
-tenant ${host_tenant}">>${container_conf_file}
-	fi
-done
-`))
 
 func (s *script) generate() (map[string][]byte, error) {
 	var buf bytes.Buffer

--- a/controllers/namespace/namespace_controller_test.go
+++ b/controllers/namespace/namespace_controller_test.go
@@ -2,6 +2,7 @@ package namespace
 
 import (
 	"context"
+	_ "embed"
 	"os"
 	"testing"
 
@@ -18,6 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+//go:embed init.sh.test-sample
+var scriptSample string
 
 func init() {
 	utilruntime.Must(scheme.AddToScheme(scheme.Scheme))
@@ -82,113 +86,6 @@ func TestReconcileNamespace(t *testing.T) {
 
 	require.Len(t, nsSecret.Data, 1)
 	require.Contains(t, nsSecret.Data, "init.sh")
-	require.Equal(t, `#!/usr/bin/env bash
-
-set -eu
-
-if [[ -f "/var/lib/dynatrace/oneagent/agent/config/ruxithost.id" ]]; then
-	echo "WARNING: full-stack OneAgent has been injected to this container. App-only and full-stack injection can conflict with each other."
-fi
-
-api_url="https://test-url/api"
-config_dir="/mnt/config"
-target_dir="/mnt/oneagent"
-paas_token="42"
-proxy=""
-skip_cert_checks="false"
-custom_ca="false"
-fail_code=0
-cluster_id="42"
-
-declare -A im_nodes
-im_nodes=(
-	["node1"]="abc12345"
-)
-
-set +u
-host_tenant="${im_nodes[${K8S_NODE_NAME}]}"
-set -u
-
-archive="/mnt/init/tmp.$RANDOM"
-
-if [[ "${FAILURE_POLICY}" == "fail" ]]; then
-	fail_code=1
-fi
-
-if [[ "${MODE}" == "installer" ]]; then
-	curl_params=(
-		"--silent"
-		"--output" "${archive}"
-	)
-
-	if [[ "${INSTALLER_URL}" != "" ]]; then
-		curl_params+=("${INSTALLER_URL}")
-	else
-		curl_params+=(
-			"${api_url}/v1/deployment/installer/agent/unix/paas/latest?flavor=${FLAVOR}&include=${TECHNOLOGIES}&bitness=64"
-			"--header" "Authorization: Api-Token ${paas_token}"
-		)
-	fi
-
-	if [[ "${skip_cert_checks}" == "true" ]]; then
-		curl_params+=("--insecure")
-	fi
-
-	if [[ "${custom_ca}" == "true" ]]; then
-		curl_params+=("--cacert" "${config_dir}/ca.pem")
-	fi
-
-	if [[ "${proxy}" != "" ]]; then
-		curl_params+=("--proxy" "${proxy}")
-	fi
-
-	echo "Downloading OneAgent package..."
-	if ! curl "${curl_params[@]}"; then
-		echo "Failed to download the OneAgent package."
-		exit "${fail_code}"
-	fi
-
-	echo "Unpacking OneAgent package..."
-	if ! unzip -o -d "${target_dir}" "${archive}"; then
-		echo "Failed to unpack the OneAgent package."
-		mv "${archive}" "${target_dir}/package.zip"
-		exit "${fail_code}"
-	fi
-fi
-
-echo "Configuring OneAgent..."
-echo -n "${INSTALLPATH}/agent/lib64/liboneagentproc.so" >> "${target_dir}/ld.so.preload"
-
-for i in $(seq 1 $CONTAINERS_COUNT)
-do
-	container_name_var="CONTAINER_${i}_NAME"
-	container_image_var="CONTAINER_${i}_IMAGE"
-
-	container_name="${!container_name_var}"
-	container_image="${!container_image_var}"
-
-	container_conf_file="${target_dir}/container_${container_name}.conf"
-
-	echo "Writing ${container_conf_file} file..."
-	echo "[container]
-containerName ${container_name}
-imageName ${container_image}
-k8s_fullpodname ${K8S_PODNAME}
-k8s_poduid ${K8S_PODUID}
-k8s_containername ${container_name}
-k8s_basepodname ${K8S_BASEPODNAME}
-k8s_namespace ${K8S_NAMESPACE}">>${container_conf_file}
-
-	if [[ ! -z "${host_tenant}" ]]; then
-		if [[ "abc12345" == "${host_tenant}" ]]; then
-			echo "k8s_node_name ${K8S_NODE_NAME}
-k8s_cluster_id ${cluster_id}">>${container_conf_file}
-		fi
-
-	echo "
-[host]
-tenant ${host_tenant}">>${container_conf_file}
-	fi
-done
-`, string(nsSecret.Data["init.sh"]))
+	require.NotEmpty(t, scriptSample) // sanity check to confirm that the sample script has been embedded
+	require.Equal(t, scriptSample, string(nsSecret.Data["init.sh"]))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Dynatrace/dynatrace-operator
 
-go 1.15
+go 1.16
 
 require (
 	github.com/containers/image/v5 v5.9.0


### PR DESCRIPTION
With Go 1.16, we can finally move the scripts to their own files. Remember to upgrade your Go installation if needed.