### PR TITLE
Include Git commit hash and build date in Operator version log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ stages:
 
 env:
   global:
+    - COMMIT=$TRAVIS_COMMIT
     - TAG=$TRAVIS_TAG
     - VERSION_TAG=/^v.*/
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -2,14 +2,14 @@
 
 set -eu
 
-if [[ -z "$TRAVIS_TAG" ]]; then
-  version="snapshot-$(echo "$TRAVIS_BRANCH" | sed 's#[^a-zA-Z0-9_-]#-#g')"
-else
-  version="${TRAVIS_TAG}"
-fi
+build_date="$(date -u --rfc-3339=seconds)"
+go_build_args=(
+  "-ldflags=-X 'github.com/Dynatrace/dynatrace-operator/version.Version=${TAG}' -X 'github.com/Dynatrace/dynatrace-operator/version.Commit=${COMMIT}' -X 'github.com/Dynatrace/dynatrace-operator/version.BuildDate=${build_date}'"
+  "-tags" "containers_image_storage_stub"
+)
 
-go build -ldflags="-X 'github.com/Dynatrace/dynatrace-operator/version.Version=${version}'" -tags containers_image_storage_stub -o ./build/_output/bin/dynatrace-operator ./cmd/operator/
-go build -ldflags="-X 'github.com/Dynatrace/dynatrace-operator/version.Version=${version}'" -tags containers_image_storage_stub -o ./build/_output/bin/csi-driver ./cmd/csidriver
+go build "${go_build_args[@]}" -o ./build/_output/bin/dynatrace-operator ./cmd/operator/
+go build "${go_build_args[@]}" -o ./build/_output/bin/csi-driver ./cmd/csidriver
 
 if [[ "${GCR:-}" == "true" ]]; then
   echo "$GCLOUD_SERVICE_KEY" | base64 -d | docker login -u _json_key --password-stdin https://gcr.io

--- a/cmd/csidriver/main.go
+++ b/cmd/csidriver/main.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
-	"runtime"
 
 	dtcsi "github.com/Dynatrace/dynatrace-operator/controllers/csi"
 	csidriver "github.com/Dynatrace/dynatrace-operator/controllers/csi/driver"
@@ -44,7 +42,7 @@ func main() {
 	flag.Parse()
 	ctrl.SetLogger(log)
 
-	printVersion()
+	version.LogVersion()
 
 	defaultUmask := unix.Umask(0002)
 	defer unix.Umask(defaultUmask)
@@ -79,10 +77,4 @@ func main() {
 		log.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-}
-
-func printVersion() {
-	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 }

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -16,9 +16,7 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"runtime"
 
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
 	"github.com/Dynatrace/dynatrace-operator/logger"
@@ -73,7 +71,7 @@ func main() {
 
 	ctrl.SetLogger(logger.NewDTLogger())
 
-	printVersion()
+	version.LogVersion()
 
 	subcmd := "operator"
 	if args := pflag.Args(); len(args) > 0 {
@@ -113,10 +111,4 @@ func main() {
 		log.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-}
-
-func printVersion() {
-	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,32 @@
 package version
 
-var (
-	Version = "snapshot"
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/Dynatrace/dynatrace-operator/logger"
 )
+
+var (
+	// Version contains the version of the Operator. Assigned externally.
+	Version = "snapshot"
+
+	// Commit indicates the Git commit hash the binary was build from. Assigned externally.
+	Commit = ""
+
+	// BuildDate is the date when the binary was build. Assigned externally.
+	BuildDate = ""
+
+	log = logger.NewDTLogger().WithName("dynatrace-operator.version")
+)
+
+// LogVersion logs metadata about the Operator.
+func LogVersion() {
+	log.Info("Dynatrace Operator",
+		"version", Version,
+		"gitCommit", Commit,
+		"buildDate", BuildDate,
+		"goVersion", runtime.Version(),
+		"platform", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	)
+}


### PR DESCRIPTION
We just logged the version. This PR logs a few things,

```json
{"level":"info","ts":"2021-03-11T09:28:01.276Z","logger":"dynatrace-operator.version","msg":"Dynatrace Operator","version":"snapshot-feature-commit-version","gitCommit":"b86e8496baeb550ff715e4df65f49668f6713e5e","buildDate":"2021-03-11 09:22:10+00:00","goVersion":"go1.16.1","platform":"linux/amd64"}
```