### PR TITLE
Bugfix/message routing

### DIFF
--- a/controllers/capability/routing/service.go
+++ b/controllers/capability/routing/service.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
+	"github.com/Dynatrace/dynatrace-operator/controllers/capability"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -24,8 +25,10 @@ func createService(instance *v1alpha1.DynaKube, feature string) corev1.Service {
 			Namespace: instance.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
-			Type:     corev1.ServiceTypeClusterIP,
-			Selector: map[string]string{keyFeature: feature},
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: capability.MergeLabels(
+				capability.BuildLabelsFromInstance(instance),
+				map[string]string{keyFeature: feature}),
 			Ports: []corev1.ServicePort{
 				{
 					Protocol:   corev1.ProtocolTCP,

--- a/controllers/capability/routing/service_test.go
+++ b/controllers/capability/routing/service_test.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"github.com/Dynatrace/dynatrace-operator/controllers/capability"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
@@ -28,7 +29,9 @@ func TestCreateService(t *testing.T) {
 	serviceSpec := service.Spec
 	assert.Equal(t, corev1.ServiceTypeClusterIP, serviceSpec.Type)
 	assert.Equal(t, map[string]string{
-		keyFeature: testFeature,
+		capability.KeyActiveGate: testName,
+		capability.KeyDynatrace:  capability.ValueActiveGate,
+		keyFeature:               testFeature,
 	}, serviceSpec.Selector)
 
 	ports := serviceSpec.Ports

--- a/controllers/capability/routing/service_test.go
+++ b/controllers/capability/routing/service_test.go
@@ -1,10 +1,10 @@
 package routing
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/controllers/capability"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
+	"github.com/Dynatrace/dynatrace-operator/controllers/capability"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Because our selector for the dynatrace service was to general, traffic was probably routed to the wrong endpoint/msg-routing-pod if more than one dynakube object existed in the cluster