### PR TITLE
Service selector for routing matches all instances - new keys

### DIFF
--- a/controllers/capability/labels.go
+++ b/controllers/capability/labels.go
@@ -3,21 +3,23 @@ package capability
 import "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
 
 const (
-	KeyDynatrace    = "dynatrace"
+	KeyDynatrace    = "dynatrace.com/component"
+	KeyActiveGate   = "operator.dynatrace.com/instance"
+	KeyFeature      = "operator.dynatrace.com/feature"
 	ValueActiveGate = "activegate"
-	KeyActiveGate   = "activegate"
 )
 
-func BuildLabels(instance *v1alpha1.DynaKube, capabilityProperties *v1alpha1.CapabilityProperties) map[string]string {
+func BuildLabels(instance *v1alpha1.DynaKube, feature string, capabilityProperties *v1alpha1.CapabilityProperties) map[string]string {
 	return MergeLabels(instance.Labels,
-		BuildLabelsFromInstance(instance),
+		BuildLabelsFromInstance(instance, feature),
 		capabilityProperties.Labels)
 }
 
-func BuildLabelsFromInstance(instance *v1alpha1.DynaKube) map[string]string {
+func BuildLabelsFromInstance(instance *v1alpha1.DynaKube, feature string) map[string]string {
 	return map[string]string{
 		KeyDynatrace:  ValueActiveGate,
 		KeyActiveGate: instance.Name,
+		KeyFeature:    feature,
 	}
 }
 

--- a/controllers/capability/routing/service.go
+++ b/controllers/capability/routing/service.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	keyFeature = "feature"
-
 	servicePort       = 443
 	serviceTargetPort = "ag-https"
 )
@@ -25,10 +23,8 @@ func createService(instance *v1alpha1.DynaKube, feature string) corev1.Service {
 			Namespace: instance.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Selector: capability.MergeLabels(
-				capability.BuildLabelsFromInstance(instance),
-				map[string]string{keyFeature: feature}),
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: capability.BuildLabelsFromInstance(instance, feature),
 			Ports: []corev1.ServicePort{
 				{
 					Protocol:   corev1.ProtocolTCP,

--- a/controllers/capability/routing/service_test.go
+++ b/controllers/capability/routing/service_test.go
@@ -31,7 +31,7 @@ func TestCreateService(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		capability.KeyActiveGate: testName,
 		capability.KeyDynatrace:  capability.ValueActiveGate,
-		keyFeature:               testFeature,
+		capability.KeyFeature:    testFeature,
 	}, serviceSpec.Selector)
 
 	ports := serviceSpec.Ports

--- a/controllers/capability/statefulset.go
+++ b/controllers/capability/statefulset.go
@@ -41,8 +41,6 @@ const (
 	DTInternalProxy   = "DT_INTERNAL_PROXY"
 
 	ProxyKey = "ProxyKey"
-
-	keyFeature = "feature"
 )
 
 type StatefulSetEvent func(sts *appsv1.StatefulSet)
@@ -79,22 +77,18 @@ func NewStatefulSetProperties(instance *dynatracev1alpha1.DynaKube, capabilityPr
 func CreateStatefulSet(stsProperties *statefulSetProperties) (*appsv1.StatefulSet, error) {
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      stsProperties.Name + "-" + stsProperties.feature,
-			Namespace: stsProperties.Namespace,
-			Labels: MergeLabels(
-				BuildLabels(stsProperties.DynaKube, stsProperties.CapabilityProperties),
-				map[string]string{keyFeature: stsProperties.feature}),
+			Name:        stsProperties.Name + "-" + stsProperties.feature,
+			Namespace:   stsProperties.Namespace,
+			Labels:      BuildLabels(stsProperties.DynaKube, stsProperties.feature, stsProperties.CapabilityProperties),
 			Annotations: map[string]string{},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:            stsProperties.Replicas,
 			PodManagementPolicy: appsv1.ParallelPodManagement,
-			Selector:            &metav1.LabelSelector{MatchLabels: BuildLabelsFromInstance(stsProperties.DynaKube)},
+			Selector:            &metav1.LabelSelector{MatchLabels: BuildLabelsFromInstance(stsProperties.DynaKube, stsProperties.feature)},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: MergeLabels(
-						BuildLabels(stsProperties.DynaKube, stsProperties.CapabilityProperties),
-						map[string]string{keyFeature: stsProperties.feature}),
+					Labels: BuildLabels(stsProperties.DynaKube, stsProperties.feature, stsProperties.CapabilityProperties),
 					Annotations: map[string]string{
 						AnnotationImageVersion:    stsProperties.Status.ActiveGate.ImageVersion,
 						AnnotationCustomPropsHash: stsProperties.customPropertiesHash,

--- a/controllers/capability/statefulset_test.go
+++ b/controllers/capability/statefulset_test.go
@@ -47,17 +47,15 @@ func TestStatefulSetBuilder_Build(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		KeyDynatrace:  ValueActiveGate,
 		KeyActiveGate: instance.Name,
-		keyFeature:    testFeature,
+		KeyFeature:    testFeature,
 	}, sts.Labels)
 	assert.Equal(t, instance.Spec.RoutingSpec.Replicas, sts.Spec.Replicas)
 	assert.Equal(t, appsv1.ParallelPodManagement, sts.Spec.PodManagementPolicy)
 	assert.Equal(t, metav1.LabelSelector{
-		MatchLabels: BuildLabelsFromInstance(instance),
+		MatchLabels: BuildLabelsFromInstance(instance, testFeature),
 	}, *sts.Spec.Selector)
 	assert.NotEqual(t, corev1.PodTemplateSpec{}, sts.Spec.Template)
-	assert.Equal(t, MergeLabels(
-		BuildLabels(instance, capabilityProperties),
-		map[string]string{keyFeature: testFeature}), sts.Spec.Template.Labels)
+	assert.Equal(t, BuildLabels(instance, testFeature, capabilityProperties), sts.Spec.Template.Labels)
 	assert.Equal(t, sts.Labels, sts.Spec.Template.Labels)
 	assert.NotEqual(t, corev1.PodSpec{}, sts.Spec.Template.Spec)
 	assert.Contains(t, sts.Annotations, AnnotationTemplateHash)


### PR DESCRIPTION
changed labels on the four locations again
- Label of sts
- match label of sts
- label of pod template
- selector of service

Example of labels: 
```
    dynatrace.com/component: activegate
    operator.dynatrace.com/feature: msgrouting
    operator.dynatrace.com/instance: dynakube
```

only for the stateful set as it is immutable, we need to destroy it by hand, if the labels are not correct
