### PR TITLE
Fix message routing service not delete

### DIFF
--- a/controllers/capability/routing/reconciler.go
+++ b/controllers/capability/routing/reconciler.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	module            = "msgrouting"
-	StatefulSetSuffix = "-" + module
+	Module            = "msgrouting"
+	StatefulSetSuffix = "-" + Module
 	capabilityName    = "MSGrouter"
 	containerPort     = 9999
 	DTDNSEntryPoint   = "DT_DNS_ENTRY_POINT"
@@ -36,7 +36,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.S
 	instance *dynatracev1alpha1.DynaKube, imageVersionProvider dtversion.ImageVersionProvider, enableUpdates bool) *Reconciler {
 	baseReconciler := capability.NewReconciler(
 		clt, apiReader, scheme, dtc, log, instance, imageVersionProvider, enableUpdates,
-		&instance.Spec.RoutingSpec.CapabilityProperties, module, capabilityName, "")
+		&instance.Spec.RoutingSpec.CapabilityProperties, Module, capabilityName, "")
 	baseReconciler.AddOnAfterStatefulSetCreateListener(addDNSEntryPoint(instance))
 	baseReconciler.AddOnAfterStatefulSetCreateListener(setCommunicationsPort(instance))
 	baseReconciler.AddOnAfterStatefulSetCreateListener(setLivenessProbePort(instance))
@@ -81,7 +81,7 @@ func addDNSEntryPoint(instance *dynatracev1alpha1.DynaKube) capability.StatefulS
 }
 
 func buildDNSEntryPoint(instance *dynatracev1alpha1.DynaKube) string {
-	return fmt.Sprintf("https://%s/communication", buildServiceHostName(instance.Name, module))
+	return fmt.Sprintf("https://%s/communication", buildServiceHostName(instance.Name, Module))
 }
 
 func (r *Reconciler) Reconcile() (update bool, err error) {
@@ -95,7 +95,7 @@ func (r *Reconciler) Reconcile() (update bool, err error) {
 }
 
 func (r *Reconciler) createServiceIfNotExists() (bool, error) {
-	service := createService(r.Instance, module)
+	service := createService(r.Instance, Module)
 
 	if err := controllerutil.SetControllerReference(r.Instance, service, r.Scheme()); err != nil {
 		return false, errors.WithStack(err)

--- a/controllers/capability/routing/reconciler.go
+++ b/controllers/capability/routing/reconciler.go
@@ -97,13 +97,14 @@ func (r *Reconciler) Reconcile() (update bool, err error) {
 func (r *Reconciler) createServiceIfNotExists() (bool, error) {
 	service := createService(r.Instance, Module)
 
-	if err := controllerutil.SetControllerReference(r.Instance, service, r.Scheme()); err != nil {
-		return false, errors.WithStack(err)
-	}
-
 	err := r.Get(context.TODO(), client.ObjectKey{Name: service.Name, Namespace: service.Namespace}, service)
 	if err != nil && k8serrors.IsNotFound(err) {
 		r.log.Info("creating service for msgrouter")
+
+		if err := controllerutil.SetControllerReference(r.Instance, service, r.Scheme()); err != nil {
+			return false, errors.WithStack(err)
+		}
+
 		err = r.Create(context.TODO(), service)
 		return true, errors.WithStack(err)
 	}

--- a/controllers/capability/routing/reconiler_test.go
+++ b/controllers/capability/routing/reconiler_test.go
@@ -79,7 +79,7 @@ func TestReconcile(t *testing.T) {
 		assert.NoError(t, err)
 
 		var customProperties corev1.Secret
-		err = r.Get(context.TODO(), client.ObjectKey{Name: r.Instance.Name + "-" + module + "-" + customproperties.Suffix, Namespace: r.Instance.Namespace}, &customProperties)
+		err = r.Get(context.TODO(), client.ObjectKey{Name: r.Instance.Name + "-" + Module + "-" + customproperties.Suffix, Namespace: r.Instance.Namespace}, &customProperties)
 		assert.NoError(t, err)
 		assert.NotNil(t, customProperties)
 		assert.Contains(t, customProperties.Data, customproperties.DataKey)
@@ -155,7 +155,7 @@ func TestReconcile(t *testing.T) {
 		assert.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = r.Get(context.TODO(), client.ObjectKey{Name: buildServiceName(r.Instance.Name, module), Namespace: r.Instance.Namespace}, service)
+		err = r.Get(context.TODO(), client.ObjectKey{Name: BuildServiceName(r.Instance.Name, Module), Namespace: r.Instance.Namespace}, service)
 		assert.NoError(t, err)
 		assert.NotNil(t, service)
 

--- a/controllers/capability/routing/service.go
+++ b/controllers/capability/routing/service.go
@@ -19,7 +19,7 @@ const (
 func createService(instance *v1alpha1.DynaKube, feature string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      buildServiceName(instance.Name, feature),
+			Name:      BuildServiceName(instance.Name, feature),
 			Namespace: instance.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
@@ -36,18 +36,18 @@ func createService(instance *v1alpha1.DynaKube, feature string) *corev1.Service 
 	}
 }
 
-func buildServiceName(instanceName string, module string) string {
+func BuildServiceName(instanceName string, module string) string {
 	return instanceName + "-" + module
 }
 
-// buildServiceHostName converts the name returned by buildServiceName
+// buildServiceHostName converts the name returned by BuildServiceName
 // into the variable name which Kubernetes uses to reference the associated service.
 // For more information see: https://kubernetes.io/docs/concepts/services-networking/service/
 func buildServiceHostName(instanceName string, module string) string {
 	serviceName :=
 		strings.ReplaceAll(
 			strings.ToUpper(
-				buildServiceName(instanceName, module)),
+				BuildServiceName(instanceName, module)),
 			"-", "_")
 
 	return fmt.Sprintf("$(%s_SERVICE_HOST):$(%s_SERVICE_PORT)", serviceName, serviceName)

--- a/controllers/capability/routing/service.go
+++ b/controllers/capability/routing/service.go
@@ -16,8 +16,8 @@ const (
 	serviceTargetPort = "ag-https"
 )
 
-func createService(instance *v1alpha1.DynaKube, feature string) corev1.Service {
-	return corev1.Service{
+func createService(instance *v1alpha1.DynaKube, feature string) *corev1.Service {
+	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildServiceName(instance.Name, feature),
 			Namespace: instance.Namespace,

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -261,13 +261,13 @@ func (r *ReconcileDynaKube) reconcileRouting(rec *utils.Reconciliation, dtc dtcl
 			return false
 		}
 
-		ser := corev1.Service{
+		svc := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      routing.BuildServiceName(rec.Instance.Name, routing.Module),
 				Namespace: rec.Instance.Namespace,
 			},
 		}
-		if err := r.ensureDeleted(&ser); rec.Error(err) {
+		if err := r.ensureDeleted(&svc); rec.Error(err) {
 			return false
 		}
 	}

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -260,6 +260,16 @@ func (r *ReconcileDynaKube) reconcileRouting(rec *utils.Reconciliation, dtc dtcl
 		if err := r.ensureDeleted(&sts); rec.Error(err) {
 			return false
 		}
+
+		ser := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      routing.BuildServiceName(rec.Instance.Name, routing.Module),
+				Namespace: rec.Instance.Namespace,
+			},
+		}
+		if err := r.ensureDeleted(&ser); rec.Error(err) {
+			return false
+		}
 	}
 	return true
 }

--- a/controllers/dynakube/dynakube_controller_test.go
+++ b/controllers/dynakube/dynakube_controller_test.go
@@ -203,6 +203,14 @@ func TestReconcile_RemoveRoutingIfDisabled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, routingSts)
 
+	routingSer := &corev1.Service{}
+	err = r.client.Get(context.TODO(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      routing.BuildServiceName(testName, routing.Module),
+	}, routingSer)
+	assert.NoError(t, err)
+	assert.NotNil(t, routingSer)
+
 	err = r.client.Get(context.TODO(), client.ObjectKey{Name: instance.Name, Namespace: instance.Namespace}, instance)
 	require.NoError(t, err)
 
@@ -217,6 +225,13 @@ func TestReconcile_RemoveRoutingIfDisabled(t *testing.T) {
 		Namespace: testNamespace,
 		Name:      testName + routing.StatefulSetSuffix,
 	}, routingSts)
+	assert.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
+
+	err = r.client.Get(context.TODO(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      routing.BuildServiceName(testName, routing.Module),
+	}, routingSer)
 	assert.Error(t, err)
 	assert.True(t, k8serrors.IsNotFound(err))
 }

--- a/controllers/dynakube/dynakube_controller_test.go
+++ b/controllers/dynakube/dynakube_controller_test.go
@@ -203,13 +203,13 @@ func TestReconcile_RemoveRoutingIfDisabled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, routingSts)
 
-	routingSer := &corev1.Service{}
+	routingSvc := &corev1.Service{}
 	err = r.client.Get(context.TODO(), client.ObjectKey{
 		Namespace: testNamespace,
 		Name:      routing.BuildServiceName(testName, routing.Module),
-	}, routingSer)
+	}, routingSvc)
 	assert.NoError(t, err)
-	assert.NotNil(t, routingSer)
+	assert.NotNil(t, routingSvc)
 
 	err = r.client.Get(context.TODO(), client.ObjectKey{Name: instance.Name, Namespace: instance.Namespace}, instance)
 	require.NoError(t, err)
@@ -231,7 +231,7 @@ func TestReconcile_RemoveRoutingIfDisabled(t *testing.T) {
 	err = r.client.Get(context.TODO(), client.ObjectKey{
 		Namespace: testNamespace,
 		Name:      routing.BuildServiceName(testName, routing.Module),
-	}, routingSer)
+	}, routingSvc)
 	assert.Error(t, err)
 	assert.True(t, k8serrors.IsNotFound(err))
 }


### PR DESCRIPTION
Fix 2 bugs where msg routing service not deleted: 
- After deletion of dynakube object, msgrouting not destroyed
- After disabling of routing in CR-file, msgrouting not destroyed