### PR TITLE
Add feature flags to DynaKube objects through annotations

### DIFF
--- a/api/v1alpha1/dynakube_types.go
+++ b/api/v1alpha1/dynakube_types.go
@@ -318,7 +318,6 @@ type OneAgentStatus struct {
 
 type OneAgentInstance struct {
 	PodName   string `json:"podName,omitempty"`
-	Version   string `json:"version,omitempty"`
 	IPAddress string `json:"ipAddress,omitempty"`
 }
 

--- a/api/v1alpha1/feature_flags.go
+++ b/api/v1alpha1/feature_flags.go
@@ -39,7 +39,7 @@ func (dk *DynaKube) FeatureDisableHostsRequests() bool {
 
 // FeatureOneAgentMaxUnavailable is a feature flag to configure maxUnavailable on the OneAgent DaemonSets rolling upgrades.
 func (dk *DynaKube) FeatureOneAgentMaxUnavailable() int {
-	raw := dk.Annotations[AnnotationFeatureDisableHostsRequests]
+	raw := dk.Annotations[AnnotationFeatureOneAgentMaxUnavailable]
 	if raw == "" {
 		return 1
 	}

--- a/api/v1alpha1/feature_flags.go
+++ b/api/v1alpha1/feature_flags.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 Dynatrace LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"strconv"
+)
+
+const (
+	AnnotationFeaturePrefix                   = "alpha.operator.dynatrace.com/feature-"
+	AnnotationFeatureDisableActiveGateUpdates = AnnotationFeaturePrefix + "disable-activegate-updates"
+	AnnotationFeatureDisableHostsRequests     = AnnotationFeaturePrefix + "disable-hosts-requests"
+	AnnotationFeatureOneAgentMaxUnavailable   = AnnotationFeaturePrefix + "oneagent-max-unavailable"
+)
+
+// FeatureDisableActiveGateUpdates is a feature flag to disable ActiveGate updates.
+func (dk *DynaKube) FeatureDisableActiveGateUpdates() bool {
+	return dk.Annotations[AnnotationFeatureDisableActiveGateUpdates] == "true"
+}
+
+// FeatureDisableHostsRequests is a feature flag to disable queries to the Hosts API.
+func (dk *DynaKube) FeatureDisableHostsRequests() bool {
+	return dk.Annotations[AnnotationFeatureDisableHostsRequests] == "true"
+}
+
+// FeatureOneAgentMaxUnavailable is a feature flag to configure maxUnavailable on the OneAgent DaemonSets rolling upgrades.
+func (dk *DynaKube) FeatureOneAgentMaxUnavailable() int {
+	raw := dk.Annotations[AnnotationFeatureDisableHostsRequests]
+	if raw == "" {
+		return 1
+	}
+
+	val, err := strconv.Atoi(raw)
+	if err != nil {
+		return 1
+	}
+
+	return val
+}

--- a/api/v1alpha1/feature_flags.go
+++ b/api/v1alpha1/feature_flags.go
@@ -21,25 +21,25 @@ import (
 )
 
 const (
-	AnnotationFeaturePrefix                   = "alpha.operator.dynatrace.com/feature-"
-	AnnotationFeatureDisableActiveGateUpdates = AnnotationFeaturePrefix + "disable-activegate-updates"
-	AnnotationFeatureDisableHostsRequests     = AnnotationFeaturePrefix + "disable-hosts-requests"
-	AnnotationFeatureOneAgentMaxUnavailable   = AnnotationFeaturePrefix + "oneagent-max-unavailable"
+	annotationFeaturePrefix                   = "alpha.operator.dynatrace.com/feature-"
+	annotationFeatureDisableActiveGateUpdates = annotationFeaturePrefix + "disable-activegate-updates"
+	annotationFeatureDisableHostsRequests     = annotationFeaturePrefix + "disable-hosts-requests"
+	annotationFeatureOneAgentMaxUnavailable   = annotationFeaturePrefix + "oneagent-max-unavailable"
 )
 
 // FeatureDisableActiveGateUpdates is a feature flag to disable ActiveGate updates.
 func (dk *DynaKube) FeatureDisableActiveGateUpdates() bool {
-	return dk.Annotations[AnnotationFeatureDisableActiveGateUpdates] == "true"
+	return dk.Annotations[annotationFeatureDisableActiveGateUpdates] == "true"
 }
 
 // FeatureDisableHostsRequests is a feature flag to disable queries to the Hosts API.
 func (dk *DynaKube) FeatureDisableHostsRequests() bool {
-	return dk.Annotations[AnnotationFeatureDisableHostsRequests] == "true"
+	return dk.Annotations[annotationFeatureDisableHostsRequests] == "true"
 }
 
 // FeatureOneAgentMaxUnavailable is a feature flag to configure maxUnavailable on the OneAgent DaemonSets rolling upgrades.
 func (dk *DynaKube) FeatureOneAgentMaxUnavailable() int {
-	raw := dk.Annotations[AnnotationFeatureOneAgentMaxUnavailable]
+	raw := dk.Annotations[annotationFeatureOneAgentMaxUnavailable]
 	if raw == "" {
 		return 1
 	}

--- a/api/v1alpha1/helpers.go
+++ b/api/v1alpha1/helpers.go
@@ -95,3 +95,11 @@ func buildImageRegistry(apiURL string) string {
 	registry = strings.TrimSuffix(registry, "/api")
 	return registry
 }
+
+// Tokens returns the name of the Secret to be used for tokens.
+func (dk *DynaKube) Tokens() string {
+	if tkns := dk.Spec.Tokens; tkns != "" {
+		return tkns
+	}
+	return dk.Name
+}

--- a/api/v1alpha1/helpers_test.go
+++ b/api/v1alpha1/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const testAPIURL = "http://test-endpoint/api"
@@ -62,5 +63,22 @@ func TestOneAgentImage(t *testing.T) {
 		customImg := "registry/my/oneagent:latest"
 		dk := DynaKube{Spec: DynaKubeSpec{OneAgent: OneAgentSpec{Image: customImg}}}
 		assert.Equal(t, customImg, dk.ImmutableOneAgentImage())
+	})
+}
+
+func TestTokens(t *testing.T) {
+	testName := "test-name"
+	testValue := "test-value"
+
+	t.Run(`GetTokensName returns custom token name`, func(t *testing.T) {
+		dk := DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName},
+			Spec:       DynaKubeSpec{Tokens: testValue},
+		}
+		assert.Equal(t, dk.Tokens(), testValue)
+	})
+	t.Run(`GetTokensName uses instance name as default value`, func(t *testing.T) {
+		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testName}}
+		assert.Equal(t, dk.Tokens(), testName)
 	})
 }

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -2484,8 +2484,6 @@ spec:
                         type: string
                       podName:
                         type: string
-                      version:
-                        type: string
                     type: object
                   type: object
                 lastHostsRequestTimestamp:

--- a/controllers/capability/kubemon/reconciler.go
+++ b/controllers/capability/kubemon/reconciler.go
@@ -24,10 +24,10 @@ type Reconciler struct {
 }
 
 func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dtc dtclient.Client, log logr.Logger,
-	instance *v1alpha1.DynaKube, imageVersionProvider dtversion.ImageVersionProvider, enableUpdates bool) *Reconciler {
+	instance *v1alpha1.DynaKube, imageVersionProvider dtversion.ImageVersionProvider) *Reconciler {
 	return &Reconciler{
 		capability.NewReconciler(
-			clt, apiReader, scheme, dtc, log, instance, imageVersionProvider, enableUpdates,
+			clt, apiReader, scheme, dtc, log, instance, imageVersionProvider,
 			&instance.Spec.KubernetesMonitoringSpec.CapabilityProperties, module, capabilityName, serviceAccountOwner),
 	}
 }

--- a/controllers/capability/kubemon/reconciler_test.go
+++ b/controllers/capability/kubemon/reconciler_test.go
@@ -60,7 +60,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			}},
 			instance, secret)
 		reconciler := NewReconciler(
-			fakeClient, fakeClient, scheme.Scheme, dtcMock, log, instance, mockImageVersionProvider, false,
+			fakeClient, fakeClient, scheme.Scheme, dtcMock, log, instance, mockImageVersionProvider,
 		)
 		connectionInfo := dtclient.ConnectionInfo{TenantUUID: testUID}
 		tenantInfo := &dtclient.TenantInfo{ID: testUID}
@@ -123,7 +123,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			}},
 			instance, secret)
 		reconciler := NewReconciler(
-			fakeClient, fakeClient, scheme.Scheme, dtcMock, log, instance, mockImageVersionProvider, false,
+			fakeClient, fakeClient, scheme.Scheme, dtcMock, log, instance, mockImageVersionProvider,
 		)
 		connectionInfo := dtclient.ConnectionInfo{TenantUUID: testUID}
 		tenantInfo := &dtclient.TenantInfo{ID: testUID}

--- a/controllers/capability/reconciler.go
+++ b/controllers/capability/reconciler.go
@@ -29,7 +29,6 @@ type Reconciler struct {
 	dtc                              dtclient.Client
 	log                              logr.Logger
 	imageVersionProvider             dtversion.ImageVersionProvider
-	enableUpdates                    bool
 	feature                          string
 	capabilityName                   string
 	serviceAccountOwner              string
@@ -38,7 +37,7 @@ type Reconciler struct {
 }
 
 func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dtc dtclient.Client, log logr.Logger,
-	instance *v1alpha1.DynaKube, imageVersionProvider dtversion.ImageVersionProvider, enableUpdates bool,
+	instance *v1alpha1.DynaKube, imageVersionProvider dtversion.ImageVersionProvider,
 	capability *v1alpha1.CapabilityProperties, feature string, capabilityName string, serviceAccountOwner string) *Reconciler {
 	if serviceAccountOwner == "" {
 		serviceAccountOwner = feature
@@ -52,7 +51,6 @@ func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.S
 		log:                              log,
 		Instance:                         instance,
 		imageVersionProvider:             imageVersionProvider,
-		enableUpdates:                    enableUpdates,
 		feature:                          feature,
 		capabilityName:                   capabilityName,
 		serviceAccountOwner:              serviceAccountOwner,

--- a/controllers/capability/reconciler_test.go
+++ b/controllers/capability/reconciler_test.go
@@ -47,7 +47,7 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 		return dtversion.ImageVersion{}, nil
 	}
 
-	r := NewReconciler(clt, clt, scheme.Scheme, dtc, log, instance, imgVerProvider, false,
+	r := NewReconciler(clt, clt, scheme.Scheme, dtc, log, instance, imgVerProvider,
 		&instance.Spec.RoutingSpec.CapabilityProperties, "router", "MSGrouter", "")
 	require.NotNil(t, r)
 	require.NotNil(t, r.Client)

--- a/controllers/capability/routing/reconciler.go
+++ b/controllers/capability/routing/reconciler.go
@@ -33,9 +33,9 @@ type Reconciler struct {
 }
 
 func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dtc dtclient.Client, log logr.Logger,
-	instance *dynatracev1alpha1.DynaKube, imageVersionProvider dtversion.ImageVersionProvider, enableUpdates bool) *Reconciler {
+	instance *dynatracev1alpha1.DynaKube, imageVersionProvider dtversion.ImageVersionProvider) *Reconciler {
 	baseReconciler := capability.NewReconciler(
-		clt, apiReader, scheme, dtc, log, instance, imageVersionProvider, enableUpdates,
+		clt, apiReader, scheme, dtc, log, instance, imageVersionProvider,
 		&instance.Spec.RoutingSpec.CapabilityProperties, Module, capabilityName, "")
 	baseReconciler.AddOnAfterStatefulSetCreateListener(addDNSEntryPoint(instance))
 	baseReconciler.AddOnAfterStatefulSetCreateListener(setCommunicationsPort(instance))

--- a/controllers/capability/routing/reconciler_test.go
+++ b/controllers/capability/routing/reconciler_test.go
@@ -51,7 +51,7 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 		return dtversion.ImageVersion{}, nil
 	}
 
-	r := NewReconciler(clt, clt, scheme.Scheme, dtc, log, instance, imgVerProvider, false)
+	r := NewReconciler(clt, clt, scheme.Scheme, dtc, log, instance, imgVerProvider)
 	require.NotNil(t, r)
 	require.NotNil(t, r.Client)
 	require.NotNil(t, r.Instance)

--- a/controllers/csi/provisioner/reconciler.go
+++ b/controllers/csi/provisioner/reconciler.go
@@ -31,7 +31,6 @@ import (
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/controllers/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/controllers/utils"
 	"github.com/Dynatrace/dynatrace-operator/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/go-logr/logr"
@@ -87,7 +86,7 @@ func (r *OneAgentProvisioner) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	var tkns corev1.Secret
-	if err := r.client.Get(ctx, client.ObjectKey{Name: utils.GetTokensName(&dk), Namespace: dk.Namespace}, &tkns); err != nil {
+	if err := r.client.Get(ctx, client.ObjectKey{Name: dk.Tokens(), Namespace: dk.Namespace}, &tkns); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to query tokens: %w", err)
 	}
 

--- a/controllers/dynakube/dtclient_builder.go
+++ b/controllers/dynakube/dtclient_builder.go
@@ -41,6 +41,7 @@ func BuildDynatraceClient(rtc client.Client, instance *dynatracev1alpha1.DynaKub
 	opts := newOptions()
 	opts.appendCertCheck(&spec)
 	opts.appendNetworkZone(&spec)
+	opts.appendDisableHostsRequests(instance.FeatureDisableHostsRequests())
 
 	err = opts.appendProxySettings(rtc, &spec, namespace)
 	if err != nil {
@@ -76,6 +77,10 @@ func (opts *options) appendNetworkZone(spec *dynatracev1alpha1.DynaKubeSpec) {
 
 func (opts *options) appendCertCheck(spec *dynatracev1alpha1.DynaKubeSpec) {
 	opts.Opts = append(opts.Opts, dtclient.SkipCertificateValidation(spec.SkipCertCheck))
+}
+
+func (opts *options) appendDisableHostsRequests(disableHostsRequests bool) {
+	opts.Opts = append(opts.Opts, dtclient.DisableHostsRequests(disableHostsRequests))
 }
 
 func (opts *options) appendProxySettings(rtc client.Client, spec *dynatracev1alpha1.DynaKubeSpec, namespace string) error {

--- a/controllers/dynakube/dtclient_reconciler.go
+++ b/controllers/dynakube/dtclient_reconciler.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
-	"github.com/Dynatrace/dynatrace-operator/controllers/utils"
 	"github.com/Dynatrace/dynatrace-operator/dtclient"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,7 +44,7 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance *dyn
 
 	sts := &instance.Status
 	ns := instance.GetNamespace()
-	secretName := utils.GetTokensName(instance)
+	secretName := instance.Tokens()
 
 	var tokens []*tokenConfig
 

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -33,10 +33,6 @@ import (
 
 const (
 	defaultUpdateInterval = 5 * time.Minute
-
-	// EnvVarDisableActiveGateUpdates is an internal environment variable to disable ActiveGate updates, since there is
-	// no documented way to do so otherwise.
-	EnvVarDisableActiveGateUpdates = "OPERATOR_ACTIVEGATE_DISABLE_UPDATES"
 )
 
 var log = logf.Log.WithName("controller_dynakube")

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -273,7 +273,7 @@ func (r *ReconcileDynaKube) reconcileRouting(rec *utils.Reconciliation, dtc dtcl
 
 func (r *ReconcileDynaKube) getTokenSecret(ctx context.Context, instance *dynatracev1alpha1.DynaKube) (*corev1.Secret, error) {
 	var secret corev1.Secret
-	err := r.client.Get(ctx, client.ObjectKey{Name: utils.GetTokensName(instance), Namespace: instance.Namespace}, &secret)
+	err := r.client.Get(ctx, client.ObjectKey{Name: instance.Tokens(), Namespace: instance.Namespace}, &secret)
 	return &secret, errors.WithStack(err)
 }
 

--- a/controllers/dynakube/dynakube_controller_test.go
+++ b/controllers/dynakube/dynakube_controller_test.go
@@ -109,7 +109,6 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 			dtcBuildFunc: func(_ client.Client, _ *v1alpha1.DynaKube, _ *corev1.Secret) (dtclient.Client, error) {
 				return mockClient, nil
 			},
-			enableUpdates: false,
 		}
 
 		mockClient.
@@ -170,7 +169,6 @@ func TestReconcile_RemoveRoutingIfDisabled(t *testing.T) {
 		dtcBuildFunc: func(_ client.Client, _ *v1alpha1.DynaKube, _ *corev1.Secret) (dtclient.Client, error) {
 			return mockClient, nil
 		},
-		enableUpdates: false,
 	}
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},

--- a/controllers/dynakube/updates/version.go
+++ b/controllers/dynakube/updates/version.go
@@ -25,7 +25,6 @@ func ReconcileVersions(
 	rec *utils.Reconciliation,
 	cl client.Client,
 	dtc dtclient.Client,
-	updateActiveGate bool,
 	verProvider VersionProviderCallback,
 ) (bool, error) {
 	upd := false
@@ -42,8 +41,8 @@ func ReconcileVersions(
 		}
 	}
 
-	needsActiveGateUpdate := updateActiveGate &&
-		dk.NeedsActiveGate() &&
+	needsActiveGateUpdate := dk.NeedsActiveGate() &&
+		!dk.FeatureDisableActiveGateUpdates() &&
 		rec.IsOutdated(dk.Status.ActiveGate.LastUpdateProbeTimestamp, ProbeThreshold)
 
 	needsImmutableOneAgentUpdate := dk.NeedsImmutableOneAgent() && needsOneAgentUpdate

--- a/controllers/dynakube/updates/version_test.go
+++ b/controllers/dynakube/updates/version_test.go
@@ -66,7 +66,7 @@ func TestReconcile_UpdateImageVersion(t *testing.T) {
 		return dtversion.ImageVersion{}, errors.New("Not implemented")
 	}
 
-	upd, err := ReconcileVersions(ctx, rec, fakeClient, nil, true, errVerProvider)
+	upd, err := ReconcileVersions(ctx, rec, fakeClient, nil, errVerProvider)
 	assert.Error(t, err)
 	assert.False(t, upd)
 
@@ -80,7 +80,7 @@ func TestReconcile_UpdateImageVersion(t *testing.T) {
 		return dtversion.ImageVersion{Version: testVersion, Hash: testHash}, nil
 	}
 
-	upd, err = ReconcileVersions(ctx, rec, fakeClient, nil, true, sampleVerProvider)
+	upd, err = ReconcileVersions(ctx, rec, fakeClient, nil, sampleVerProvider)
 	assert.NoError(t, err)
 	assert.True(t, upd)
 
@@ -96,7 +96,7 @@ func TestReconcile_UpdateImageVersion(t *testing.T) {
 		assert.Equal(t, now, *ts)
 	}
 
-	upd, err = ReconcileVersions(ctx, rec, fakeClient, nil, true, sampleVerProvider)
+	upd, err = ReconcileVersions(ctx, rec, fakeClient, nil, sampleVerProvider)
 	assert.NoError(t, err)
 	assert.False(t, upd)
 }

--- a/controllers/namespace/namespace_controller.go
+++ b/controllers/namespace/namespace_controller.go
@@ -92,13 +92,13 @@ func (r *ReconcileNamespaces) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, nil
 	}
 
-	var apm dynatracev1alpha1.DynaKube
-	if err := r.client.Get(ctx, client.ObjectKey{Name: oaName, Namespace: r.namespace}, &apm); err != nil {
+	var dk dynatracev1alpha1.DynaKube
+	if err := r.client.Get(ctx, client.ObjectKey{Name: oaName, Namespace: r.namespace}, &dk); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to query DynaKubes: %w", err)
 	}
 
-	tokenName := utils.GetTokensName(&apm)
-	if !apm.Spec.CodeModules.Enabled {
+	tokenName := dk.Tokens()
+	if !dk.Spec.CodeModules.Enabled {
 		r.ensureSecretDeleted(tokenName, targetNS)
 		return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
@@ -124,7 +124,7 @@ func (r *ReconcileNamespaces) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, fmt.Errorf("failed to query tokens: %w", err)
 	}
 
-	script, err := newScript(ctx, r.client, apm, tkns, imNodes, r.namespace)
+	script, err := newScript(ctx, r.client, dk, tkns, imNodes, r.namespace)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to generate init script: %w", err)
 	}

--- a/controllers/nodes/nodes_controller.go
+++ b/controllers/nodes/nodes_controller.go
@@ -389,12 +389,6 @@ func (r *ReconcileNodes) markForTermination(c *Cache, dk *dynatracev1alpha1.Dyna
 		return err
 	}
 
-	if dk.FeatureDisableHostsRequests() {
-		r.logger.Info("not sending mark for termination event, requests to the hosts API are disabled", "dynakube", dk.Name,
-			"ip", ipAddress, "node", nodeName)
-		return nil
-	}
-
 	r.logger.Info("sending mark for termination event to dynatrace server", "dynakube", dk.Name, "ip", ipAddress,
 		"node", nodeName)
 

--- a/controllers/nodes/nodes_controller.go
+++ b/controllers/nodes/nodes_controller.go
@@ -327,7 +327,10 @@ func (r *ReconcileNodes) sendMarkedForTermination(dk *dynatracev1alpha1.DynaKube
 
 	entityID, err := dtc.GetEntityIDForIP(nodeIP)
 	if err != nil {
-		return err
+		r.logger.Info("failed to send mark for termination event",
+			"reason", "failed to determine entity id", "dynakube", dk.Name, "nodeIP", nodeIP, "cause", err)
+
+		return nil
 	}
 
 	ts := uint64(lastSeen.Add(-10*time.Minute).UnixNano()) / uint64(time.Millisecond)

--- a/controllers/oneagent/error_handler.go
+++ b/controllers/oneagent/error_handler.go
@@ -1,30 +1,10 @@
 package oneagent
 
 import (
-	"errors"
-	"net/http"
-
-	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
-	"github.com/Dynatrace/dynatrace-operator/dtclient"
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func handlePodListError(logger logr.Logger, err error, listOps []client.ListOption) {
 	logger.Error(err, "failed to list pods", "listops", listOps)
-}
-
-func handleAgentVersionForIPError(err error, instance *dynatracev1alpha1.DynaKube, pod corev1.Pod, instanceStatus *dynatracev1alpha1.OneAgentInstance) error {
-	if err != nil {
-		var serr dtclient.ServerError
-		if ok := errors.As(err, &serr); ok && serr.Code == http.StatusTooManyRequests {
-			return err
-		}
-		// use last know version if available
-		if i, ok := instance.Status.OneAgent.Instances[pod.Spec.NodeName]; ok && instanceStatus != nil {
-			instanceStatus.Version = i.Version
-		}
-	}
-	return nil
 }

--- a/controllers/oneagent/oneagent_controller.go
+++ b/controllers/oneagent/oneagent_controller.go
@@ -149,8 +149,8 @@ func (r *ReconcileOneAgent) reconcileRollout(ctx context.Context, rec *utils.Rec
 		}
 	}
 
-	if rec.Instance.Status.Tokens != utils.GetTokensName(rec.Instance) {
-		rec.Instance.Status.Tokens = utils.GetTokensName(rec.Instance)
+	if rec.Instance.Status.Tokens != rec.Instance.Tokens() {
+		rec.Instance.Status.Tokens = rec.Instance.Tokens()
 		updateCR = true
 	}
 
@@ -501,7 +501,7 @@ func prepareEnvVars(instance *dynatracev1alpha1.DynaKube, fs *dynatracev1alpha1.
 				Default: func(ev *corev1.EnvVar) {
 					ev.ValueFrom = &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: utils.GetTokensName(instance)},
+							LocalObjectReference: corev1.LocalObjectReference{Name: instance.Tokens()},
 							Key:                  utils.DynatracePaasToken,
 						},
 					}

--- a/controllers/oneagent/oneagent_controller.go
+++ b/controllers/oneagent/oneagent_controller.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -190,6 +191,8 @@ func newDaemonSetForCR(logger logr.Logger, instance *dynatracev1alpha1.DynaKube,
 	selectorLabels := buildLabels(instance.GetName(), feature)
 	mergedLabels := mergeLabels(fs.Labels, selectorLabels)
 
+	maxUnavailable := intstr.FromInt(instance.FeatureOneAgentMaxUnavailable())
+
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -207,6 +210,11 @@ func newDaemonSetForCR(logger logr.Logger, instance *dynatracev1alpha1.DynaKube,
 					},
 				},
 				Spec: podSpec,
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: &maxUnavailable,
+				},
 			},
 		},
 	}

--- a/controllers/oneagent/oneagent_controller.go
+++ b/controllers/oneagent/oneagent_controller.go
@@ -99,7 +99,7 @@ func (r *ReconcileOneAgent) Reconcile(ctx context.Context, rec *utils.Reconcilia
 		}
 	}
 
-	if rec.IsOutdated(r.instance.Status.OneAgent.LastHostsRequestTimestamp, updInterval) {
+	if !r.instance.FeatureDisableHostsRequests() && rec.IsOutdated(r.instance.Status.OneAgent.LastHostsRequestTimestamp, updInterval) {
 		r.instance.Status.OneAgent.LastHostsRequestTimestamp = rec.Now.DeepCopy()
 		rec.Update(true, 5*time.Minute, "updated last host request time stamp")
 

--- a/controllers/oneagent/oneagent_controller_test.go
+++ b/controllers/oneagent/oneagent_controller_test.go
@@ -255,7 +255,6 @@ func TestReconcile_InstancesSet(t *testing.T) {
 	oldVersion := "1.186"
 	hostIP := "1.2.3.4"
 	dtcMock.On("GetLatestAgentVersion", dtclient.OsUnix, dtclient.InstallerTypeDefault).Return(version, nil)
-	dtcMock.On("GetAgentVersionForIP", hostIP).Return(version, nil)
 	dtcMock.On("GetTokenScopes", "42").Return(dtclient.TokenScopes{utils.DynatracePaasToken}, nil)
 	dtcMock.On("GetTokenScopes", "84").Return(dtclient.TokenScopes{utils.DynatraceApiToken}, nil)
 

--- a/controllers/oneagent/oneagent_controller_test.go
+++ b/controllers/oneagent/oneagent_controller_test.go
@@ -179,7 +179,7 @@ func TestReconcile_TokensSetCorrectly(t *testing.T) {
 
 		// assert
 		assert.True(t, updateCR)
-		assert.Equal(t, utils.GetTokensName(dk), dk.Status.Tokens)
+		assert.Equal(t, dk.Tokens(), dk.Status.Tokens)
 		assert.Equal(t, nil, err)
 	})
 	t.Run("reconcileRollout Tokens status set, if status has wrong name", func(t *testing.T) {
@@ -194,7 +194,7 @@ func TestReconcile_TokensSetCorrectly(t *testing.T) {
 
 		// assert
 		assert.True(t, updateCR)
-		assert.Equal(t, utils.GetTokensName(dk), dk.Status.Tokens)
+		assert.Equal(t, dk.Tokens(), dk.Status.Tokens)
 		assert.Equal(t, nil, err)
 	})
 
@@ -217,7 +217,7 @@ func TestReconcile_TokensSetCorrectly(t *testing.T) {
 		// arrange
 		customTokenName := "custom-token-name"
 		dk := base.DeepCopy()
-		dk.Status.Tokens = utils.GetTokensName(dk)
+		dk.Status.Tokens = dk.Tokens()
 		dk.Spec.Tokens = customTokenName
 		rec := utils.Reconciliation{Log: consoleLogger, Instance: dk}
 
@@ -226,7 +226,7 @@ func TestReconcile_TokensSetCorrectly(t *testing.T) {
 
 		// assert
 		assert.True(t, updateCR)
-		assert.Equal(t, utils.GetTokensName(dk), dk.Status.Tokens)
+		assert.Equal(t, dk.Tokens(), dk.Status.Tokens)
 		assert.Equal(t, customTokenName, dk.Status.Tokens)
 		assert.Equal(t, nil, err)
 	})
@@ -283,7 +283,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 		pod.Labels = buildLabels(dkName, reconciler.feature)
 		pod.Spec = newPodSpecForCR(dk, &dynatracev1alpha1.FullStackSpec{}, reconciler.feature, false, consoleLogger, "cluster1")
 		pod.Status.HostIP = hostIP
-		dk.Status.Tokens = utils.GetTokensName(dk)
+		dk.Status.Tokens = dk.Tokens()
 
 		rec := utils.Reconciliation{Log: consoleLogger, Instance: dk, RequeueAfter: 30 * time.Minute}
 		err := reconciler.client.Create(context.TODO(), pod)
@@ -312,7 +312,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 		pod.Labels = buildLabels(dkName, reconciler.feature)
 		pod.Spec = newPodSpecForCR(dk, &dynatracev1alpha1.FullStackSpec{}, reconciler.feature, false, consoleLogger, "cluster1")
 		pod.Status.HostIP = hostIP
-		dk.Status.Tokens = utils.GetTokensName(dk)
+		dk.Status.Tokens = dk.Tokens()
 
 		rec := utils.Reconciliation{Log: consoleLogger, Instance: dk, RequeueAfter: 30 * time.Minute}
 		err := reconciler.client.Create(context.TODO(), pod)

--- a/controllers/utils/token_parser.go
+++ b/controllers/utils/token_parser.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
 	"github.com/Dynatrace/dynatrace-operator/dtclient"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -59,11 +58,4 @@ func ExtractToken(secret *corev1.Secret, key string) (string, error) {
 	}
 
 	return strings.TrimSpace(string(value)), nil
-}
-
-func GetTokensName(obj *dynatracev1alpha1.DynaKube) string {
-	if tkns := obj.Spec.Tokens; tkns != "" {
-		return tkns
-	}
-	return obj.Name
 }

--- a/controllers/utils/token_parser_test.go
+++ b/controllers/utils/token_parser_test.go
@@ -3,11 +3,9 @@ package utils
 import (
 	"testing"
 
-	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
 	"github.com/Dynatrace/dynatrace-operator/dtclient"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -93,25 +91,5 @@ func TestExtractToken(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Empty(t, value)
-	})
-}
-
-func TestGetTokensName(t *testing.T) {
-	t.Run(`GetTokensName returns custom token name`, func(t *testing.T) {
-		tokens := GetTokensName(&dynatracev1alpha1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: testName,
-			},
-			Spec: dynatracev1alpha1.DynaKubeSpec{
-				Tokens: testValue,
-			}})
-		assert.Equal(t, tokens, testValue)
-	})
-	t.Run(`GetTokensName uses instance name as default value`, func(t *testing.T) {
-		tokens := GetTokensName(&dynatracev1alpha1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: testName,
-			}})
-		assert.Equal(t, tokens, testName)
 	})
 }

--- a/dtclient/agent_version.go
+++ b/dtclient/agent_version.go
@@ -7,22 +7,6 @@ import (
 	"io"
 )
 
-func (dtc *dynatraceClient) GetAgentVersionForIP(ip string) (string, error) {
-	if len(ip) == 0 {
-		return "", errors.New("ip is invalid")
-	}
-
-	hostInfo, err := dtc.getHostInfoForIP(ip)
-	if err != nil {
-		return "", err
-	}
-	if hostInfo.version == "" {
-		return "", errors.New("agent version not set for host")
-	}
-
-	return hostInfo.version, nil
-}
-
 // GetVersionForLatest gets the latest agent version for the given OS and installer type.
 func (dtc *dynatraceClient) GetLatestAgentVersion(os, installerType string) (string, error) {
 	if len(os) == 0 || len(installerType) == 0 {

--- a/dtclient/agent_version_test.go
+++ b/dtclient/agent_version_test.go
@@ -167,30 +167,6 @@ func testAgentVersionGetLatestAgentVersion(t *testing.T, dynatraceClient Client)
 	}
 }
 
-func testAgentVersionGetAgentVersionForIP(t *testing.T, dynatraceClient Client) {
-	{
-		_, err := dynatraceClient.GetAgentVersionForIP("")
-
-		assert.Error(t, err, "lookup empty ip")
-	}
-	{
-		_, err := dynatraceClient.GetAgentVersionForIP(unknownIP)
-
-		assert.Error(t, err, "lookup unknown ip")
-	}
-	{
-		_, err := dynatraceClient.GetAgentVersionForIP(unsetIP)
-
-		assert.Error(t, err, "lookup unset ip")
-	}
-	{
-		version, err := dynatraceClient.GetAgentVersionForIP(goodIP)
-
-		assert.NoError(t, err, "lookup good ip")
-		assert.Equal(t, "1.142.0.20180313-173634", version, "version matches for lookup good ip")
-	}
-}
-
 type ipHandler struct{}
 
 func (ipHandler *ipHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {

--- a/dtclient/agent_version_test.go
+++ b/dtclient/agent_version_test.go
@@ -15,10 +15,6 @@ import (
 const (
 	apiToken  = "some-API-token"
 	paasToken = "some-PaaS-token"
-
-	goodIP    = "192.168.0.1"
-	unsetIP   = "192.168.100.1"
-	unknownIP = "127.0.0.1"
 )
 
 const hostsResponse = `[

--- a/dtclient/client.go
+++ b/dtclient/client.go
@@ -179,3 +179,9 @@ func NetworkZone(networkZone string) Option {
 		c.networkZone = networkZone
 	}
 }
+
+func DisableHostsRequests(disabledHostsRequests bool) Option {
+	return func(c *dynatraceClient) {
+		c.disableHostsRequests = disabledHostsRequests
+	}
+}

--- a/dtclient/client.go
+++ b/dtclient/client.go
@@ -32,20 +32,6 @@ type Client interface {
 	// GetLatestAgent returns a reader with the contents of the download. Must be closed by caller.
 	GetLatestAgent(os, installerType, flavor, arch string) (io.ReadCloser, error)
 
-	// GetAgentVersionForIP returns the agent version running on the host with the given IP address.
-	// Returns the version string formatted as "Major.Minor.Revision.Timestamp" on success.
-	//
-	// Returns an error for the following conditions:
-	//  - the IP is empty
-	//  - IO error or unexpected response
-	//  - error response from the server (e.g. authentication failure)
-	//  - a host with the given IP cannot be found
-	//  - the agent version for the host is not set
-	//
-	// The list of all hosts with their IP addresses is cached the first time this method is called. Use a new
-	// client instance to fetch a new list from the server.
-	GetAgentVersionForIP(ip string) (string, error)
-
 	// GetCommunicationHosts returns, on success, the list of communication hosts used for available
 	// communication endpoints that the Dynatrace OneAgent can use to connect to.
 	//

--- a/dtclient/dynatrace_client.go
+++ b/dtclient/dynatrace_client.go
@@ -25,6 +25,8 @@ type dynatraceClient struct {
 
 	networkZone string
 
+	disableHostsRequests bool
+
 	httpClient *http.Client
 
 	hostCache map[string]hostInfo
@@ -110,6 +112,10 @@ func (dtc *dynatraceClient) getHostInfoForIP(ip string) (*hostInfo, error) {
 }
 
 func (dtc *dynatraceClient) buildHostCache() error {
+	if dtc.disableHostsRequests {
+		return nil
+	}
+
 	url := fmt.Sprintf("%s/v1/entity/infrastructure/hosts?includeDetails=false", dtc.url)
 	resp, err := dtc.makeRequest(url, dynatraceApiToken)
 	if err != nil {

--- a/dtclient/dynatrace_client_test.go
+++ b/dtclient/dynatrace_client_test.go
@@ -137,7 +137,6 @@ func TestDynatraceClientWithServer(t *testing.T) {
 	require.NotNil(t, dtc)
 
 	testAgentVersionGetLatestAgentVersion(t, dtc)
-	testAgentVersionGetAgentVersionForIP(t, dtc)
 	testCommunicationHostsGetCommunicationHosts(t, dtc)
 	testSendEvent(t, dtc)
 	testGetTokenScopes(t, dtc)

--- a/dtclient/mock_client.go
+++ b/dtclient/mock_client.go
@@ -16,11 +16,6 @@ func (o *MockDynatraceClient) GetTenantInfo() (*TenantInfo, error) {
 	return args.Get(0).(*TenantInfo), args.Error(1)
 }
 
-func (o *MockDynatraceClient) GetAgentVersionForIP(ip string) (string, error) {
-	args := o.Called(ip)
-	return args.String(0), args.Error(1)
-}
-
 func (o *MockDynatraceClient) GetLatestAgentVersion(os, installerType string) (string, error) {
 	args := o.Called(os, installerType)
 	return args.String(0), args.Error(1)


### PR DESCRIPTION
On this PR I'm adding a few feature flags, that can be set as annotations on DynaKube objects for features we don't want to add as actual fields on the CR. Currently we have,
* `alpha.operator.dynatrace.com/feature-disable-activegate-updates` - previously set as an environment variable, I've updated it to be a feature flag. It can be "true" to disable ActiveGate updates.
* `alpha.operator.dynatrace.com/feature-disable-hosts-requests` - to disable all queries to the Hosts API, which happens when looking for the status on hosts.
* `alpha.operator.dynatrace.com/feature-oneagent-max-unavailable` - to increase max unavailable on the OneAgent DaemonSets.
