### PR TITLE
Feature/increase webhook resources

### DIFF
--- a/config/common/webhook/deployment-webhook.yaml
+++ b/config/common/webhook/deployment-webhook.yaml
@@ -76,10 +76,10 @@ spec:
               containerPort: 8443
           resources:
             requests:
-              cpu: 10m
-              memory: 64Mi
+              cpu: 300m
+              memory: 128Mi
             limits:
-              cpu: 100m
+              cpu: 600m
               memory: 256Mi
           volumeMounts:
             - name: certs-volume

--- a/config/common/webhook/deployment-webhook.yaml
+++ b/config/common/webhook/deployment-webhook.yaml
@@ -69,13 +69,6 @@ spec:
               scheme: HTTPS
             initialDelaySeconds: 60
             periodSeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: server-port
-              scheme: HTTPS
-            initialDelaySeconds: 60
-            periodSeconds: 10
           ports:
             - name: metrics
               containerPort: 8383


### PR DESCRIPTION
The webhook pod always crashed during creation of > 300 pods

Increasing the resources should fix this issue.

Note that the Kubernetes API Server will eventually reach a ceiling on processing new Pods, which means also more stable requests to the webhook as well.