### PR TITLE
Add CSI driver health probe

### DIFF
--- a/cmd/csidriver/main.go
+++ b/cmd/csidriver/main.go
@@ -80,11 +80,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		log.Error(err, "unable to set up ready check")
-		os.Exit(1)
-	}
-
 	log.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		log.Error(err, "problem running manager")

--- a/cmd/csidriver/main.go
+++ b/cmd/csidriver/main.go
@@ -29,11 +29,13 @@ import (
 	"golang.org/x/sys/unix"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 var (
-	nodeID   = flag.String("node-id", "", "node id")
-	endpoint = flag.String("endpoint", "unix:///tmp/csi.sock", "CSI endpoint")
+	nodeID    = flag.String("node-id", "", "node id")
+	endpoint  = flag.String("endpoint", "unix:///tmp/csi.sock", "CSI endpoint")
+	probeAddr = flag.String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 
 	log = logger.NewDTLogger().WithName("server")
 )
@@ -48,8 +50,9 @@ func main() {
 	defer unix.Umask(defaultUmask)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Namespace: os.Getenv("POD_NAMESPACE"),
-		Scheme:    scheme.Scheme,
+		Namespace:              os.Getenv("POD_NAMESPACE"),
+		Scheme:                 scheme.Scheme,
+		HealthProbeBindAddress: *probeAddr,
 	})
 	if err != nil {
 		log.Error(err, "unable to start manager")
@@ -69,6 +72,16 @@ func main() {
 
 	if err := csiprovisioner.NewReconciler(mgr, csiOpts).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create CSI Provisioner")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		log.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		log.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
 

--- a/config/kubernetes/csi/daemonset-csi.yaml
+++ b/config/kubernetes/csi/daemonset-csi.yaml
@@ -26,6 +26,7 @@ spec:
           args:
             - --endpoint=unix://csi/csi.sock
             - --node-id=$(KUBE_NODE_NAME)
+            - --health-probe-bind-address=:10080
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -37,6 +38,24 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
           imagePullPolicy: Always
+          ports:
+            - containerPort: 10080
+              name: healthPort
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthPort
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthPort
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
           securityContext:
             privileged: true
             runAsUser: 0

--- a/config/kubernetes/csi/daemonset-csi.yaml
+++ b/config/kubernetes/csi/daemonset-csi.yaml
@@ -40,21 +40,17 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 10080
-              name: health-port
+              name: healthz
               protocol: TCP
           livenessProbe:
+            failureThreshold: 3
             httpGet:
               path: /healthz
-              port: health-port
+              port: healthz
               scheme: HTTP
             initialDelaySeconds: 5
-            timeoutSeconds: 1
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: health-port
-              scheme: HTTP
-            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
             timeoutSeconds: 1
           securityContext:
             privileged: true

--- a/config/kubernetes/csi/daemonset-csi.yaml
+++ b/config/kubernetes/csi/daemonset-csi.yaml
@@ -40,19 +40,19 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 10080
-              name: healthPort
+              name: health-port
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: healthPort
+              port: health-port
               scheme: HTTP
             initialDelaySeconds: 5
             timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /readyz
-              port: healthPort
+              port: health-port
               scheme: HTTP
             initialDelaySeconds: 5
             timeoutSeconds: 1


### PR DESCRIPTION
The CSI driver process/container lacks a health check. This PR adds a liveness probe to the driver container in addition to the liveness-probe sidecar container.