### PR TITLE
Updated link to Operator SDK user guide

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -3,7 +3,7 @@
 ## Hack on Dynatrace Operator
 
 [Operator SDK](https://github.com/operator-framework/operator-sdk) is the underlying framework for Dynatrace Operator. The `operator-sdk` tool needs to be installed upfront as outlined in the
-[Operator SDK User Guide](https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md#install-the-operator-sdk-cli).
+[Operator SDK User Guide](https://sdk.operatorframework.io/docs/installation/).
 
 ### Installation
 


### PR DESCRIPTION
Current docs is at https://sdk.operatorframework.io/docs/installation.

(The last known version was at: https://github.com/operator-framework/operator-sdk/blob/b448429687fd7cb2343d022814ed70c9d264612b/doc/user/install-operator-sdk.md)