### PR TITLE
Remove unsupported architecture ARM64 from ActiveGate node affinity selector

### DIFF
--- a/controllers/activegate/statefulset.go
+++ b/controllers/activegate/statefulset.go
@@ -26,7 +26,6 @@ const (
 	kubernetesBetaOS   = "beta.kubernetes.io/os"
 
 	amd64 = "amd64"
-	arm64 = "arm64"
 	linux = "linux"
 
 	AnnotationTemplateHash    = "internal.operator.dynatrace.com/template-hash"
@@ -247,7 +246,7 @@ func buildKubernetesExpression(archKey string, osKey string) []corev1.NodeSelect
 		{
 			Key:      archKey,
 			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{amd64, arm64},
+			Values:   []string{amd64},
 		},
 		{
 			Key:      osKey,

--- a/controllers/activegate/statefulset_test.go
+++ b/controllers/activegate/statefulset_test.go
@@ -98,7 +98,7 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 			{
 				Key:      kubernetesBetaArch,
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{amd64, arm64},
+				Values:   []string{amd64},
 			},
 			{
 				Key:      kubernetesBetaOS,
@@ -111,7 +111,7 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 			{
 				Key:      kubernetesArch,
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{amd64, arm64},
+				Values:   []string{amd64},
 			},
 			{
 				Key:      kubernetesOS,


### PR DESCRIPTION
ARM64 node affinity selector for ActiveGate based capabilities like KubeMon causes pods to fail on this architecture. Therefore removed the unsupported architecture from the node affinity selector.

Fixes #139 