### PR TITLE
Fix CSI volume permissions

### DIFF
--- a/cmd/csidriver/main.go
+++ b/cmd/csidriver/main.go
@@ -57,7 +57,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	defaultUmask := unix.Umask(0002)
+	defaultUmask := unix.Umask(0000)
 	defer unix.Umask(defaultUmask)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/controllers/csi/driver/bind_config.go
+++ b/controllers/csi/driver/bind_config.go
@@ -43,7 +43,7 @@ func newBindConfig(ctx context.Context, svr *CSIDriverServer, volumeCfg *volumeC
 		filepath.Join(envDir, "log", volumeCfg.podUID),
 		filepath.Join(envDir, "datastorage", volumeCfg.podUID),
 	} {
-		if err = mkDirFunc(dir, 0770); err != nil {
+		if err = mkDirFunc(dir, 0777); err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}

--- a/controllers/csi/driver/bind_config_test.go
+++ b/controllers/csi/driver/bind_config_test.go
@@ -2,24 +2,24 @@ package csidriver
 
 import (
 	"context"
-	"fmt"
-	"io/fs"
-	"path"
-	"strings"
+	"os"
+	"path/filepath"
 	"testing"
 
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/webhook"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	dkName     = "a-dynakube"
-	tenantUuid = "a-tenant-uuid"
+	dkName       = "a-dynakube"
+	tenantUuid   = "a-tenant-uuid"
+	agentVersion = "1.2-3"
 )
 
 func TestCSIDriverServer_NewBindConfig(t *testing.T) {
@@ -33,13 +33,7 @@ func TestCSIDriverServer_NewBindConfig(t *testing.T) {
 			podUID:    podUid,
 		}
 
-		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg,
-			func(filename string) ([]byte, error) {
-				return []byte(""), nil
-			},
-			func(path string, perm fs.FileMode) error {
-				return nil
-			})
+		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg, afero.Afero{})
 
 		assert.Error(t, err)
 		assert.Nil(t, bindCfg)
@@ -55,13 +49,7 @@ func TestCSIDriverServer_NewBindConfig(t *testing.T) {
 			podUID:    podUid,
 		}
 
-		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg,
-			func(filename string) ([]byte, error) {
-				return []byte(""), nil
-			},
-			func(path string, perm fs.FileMode) error {
-				return nil
-			})
+		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg, afero.Afero{})
 
 		assert.Error(t, err)
 		assert.Nil(t, bindCfg)
@@ -71,19 +59,14 @@ func TestCSIDriverServer_NewBindConfig(t *testing.T) {
 			&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: map[string]string{webhook.LabelInstance: dkName}}})
 		srv := &CSIDriverServer{
 			client: clt,
+			fs:     afero.Afero{Fs: afero.NewMemMapFs()},
 		}
 		volumeCfg := &volumeConfig{
 			namespace: namespace,
 			podUID:    podUid,
 		}
 
-		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg,
-			func(filename string) ([]byte, error) {
-				return []byte(""), fmt.Errorf(testError)
-			},
-			func(path string, perm fs.FileMode) error {
-				return nil
-			})
+		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg, srv.fs)
 
 		assert.Error(t, err)
 		assert.Nil(t, bindCfg)
@@ -93,21 +76,19 @@ func TestCSIDriverServer_NewBindConfig(t *testing.T) {
 			&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: map[string]string{webhook.LabelInstance: dkName}}})
 		srv := &CSIDriverServer{
 			client: clt,
+			opts:   dtcsi.CSIOptions{RootDir: "/"},
+			fs:     afero.Afero{Fs: afero.NewMemMapFs()},
 		}
 		volumeCfg := &volumeConfig{
 			namespace: namespace,
 			podUID:    podUid,
 		}
 
-		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg,
-			func(filename string) ([]byte, error) {
-				return []byte(tenantUuid), nil
-			},
-			func(path string, perm fs.FileMode) error {
-				return fmt.Errorf(testError)
-			})
+		_ = srv.fs.WriteFile(filepath.Join(srv.opts.RootDir, dtcsi.DataPath, "tenant-"+dkName), []byte(tenantUuid), os.ModePerm)
 
-		assert.EqualError(t, err, "rpc error: code = Internal desc = test error message")
+		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg, srv.fs)
+
+		assert.Error(t, err)
 		assert.Nil(t, bindCfg)
 	})
 	t.Run(`failed to read version file`, func(t *testing.T) {
@@ -115,22 +96,14 @@ func TestCSIDriverServer_NewBindConfig(t *testing.T) {
 			&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: map[string]string{webhook.LabelInstance: dkName}}})
 		srv := &CSIDriverServer{
 			client: clt,
+			fs:     afero.Afero{Fs: afero.NewMemMapFs()},
 		}
 		volumeCfg := &volumeConfig{
 			namespace: namespace,
 			podUID:    podUid,
 		}
 
-		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg,
-			func(filename string) ([]byte, error) {
-				if strings.HasSuffix(filename, "version") {
-					return []byte(""), fmt.Errorf(testError)
-				}
-				return []byte(tenantUuid), nil
-			},
-			func(path string, perm fs.FileMode) error {
-				return nil
-			})
+		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg, srv.fs)
 
 		assert.Error(t, err)
 		assert.Nil(t, bindCfg)
@@ -144,23 +117,22 @@ func TestCSIDriverServer_NewBindConfig(t *testing.T) {
 		)
 		srv := &CSIDriverServer{
 			client: clt,
+			opts:   dtcsi.CSIOptions{RootDir: "/"},
+			fs:     afero.Afero{Fs: afero.NewMemMapFs()},
 		}
 		volumeCfg := &volumeConfig{
 			namespace: namespace,
 			podUID:    podUid,
 		}
 
-		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg,
-			func(filename string) ([]byte, error) {
-				return []byte(tenantUuid), nil
-			},
-			func(path string, perm fs.FileMode) error {
-				return nil
-			})
+		_ = srv.fs.WriteFile(filepath.Join(srv.opts.RootDir, dtcsi.DataPath, "tenant-"+dkName), []byte(tenantUuid), os.ModePerm)
+		_ = srv.fs.WriteFile(filepath.Join(srv.opts.RootDir, dtcsi.DataPath, tenantUuid, "version"), []byte(agentVersion), os.ModePerm)
+
+		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg, srv.fs)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, bindCfg)
-		assert.Equal(t, path.Join(dtcsi.DataPath, tenantUuid, "bin", tenantUuid), bindCfg.agentDir)
-		assert.Equal(t, path.Join(dtcsi.DataPath, tenantUuid), bindCfg.envDir)
+		assert.Equal(t, filepath.Join(srv.opts.RootDir, dtcsi.DataPath, tenantUuid, "bin", agentVersion), bindCfg.agentDir)
+		assert.Equal(t, filepath.Join(srv.opts.RootDir, dtcsi.DataPath, tenantUuid), bindCfg.envDir)
 	})
 }

--- a/controllers/csi/driver/server.go
+++ b/controllers/csi/driver/server.go
@@ -19,7 +19,6 @@ package csidriver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -30,6 +29,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/version"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/go-logr/logr"
+	"github.com/spf13/afero"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -50,6 +50,7 @@ type CSIDriverServer struct {
 	client client.Client
 	log    logr.Logger
 	opts   dtcsi.CSIOptions
+	fs     afero.Afero
 }
 
 var _ manager.Runnable = &CSIDriverServer{}
@@ -61,6 +62,7 @@ func NewServer(mgr ctrl.Manager, opts dtcsi.CSIOptions) *CSIDriverServer {
 		client: mgr.GetClient(),
 		log:    log,
 		opts:   opts,
+		fs:     afero.Afero{Fs: afero.NewOsFs()},
 	}
 }
 
@@ -75,7 +77,7 @@ func (svr *CSIDriverServer) Start(ctx context.Context) error {
 	}
 
 	if proto == "unix" {
-		if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {
+		if err := svr.fs.Remove(addr); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("failed to remove old endpoint on '%s': %w", addr, err)
 		}
 	}
@@ -153,7 +155,7 @@ func (svr *CSIDriverServer) NodePublishVolume(ctx context.Context, req *csi.Node
 		"mountflags", req.GetVolumeCapability().GetMount().GetMountFlags(),
 	)
 
-	bindCfg, err := newBindConfig(ctx, svr, volumeCfg, ioutil.ReadFile, os.MkdirAll)
+	bindCfg, err := newBindConfig(ctx, svr, volumeCfg, svr.fs)
 	if err != nil {
 		return nil, err
 	}
@@ -178,10 +180,11 @@ func (svr *CSIDriverServer) NodePublishVolume(ctx context.Context, req *csi.Node
 	}
 
 	podToVersionReference := filepath.Join(bindCfg.envDir, dtcsi.GarbageCollectionPath, bindCfg.version, volumeCfg.podUID)
-	if err = ioutil.WriteFile(podToVersionReference, nil, 0770); err != nil {
+	if err = svr.fs.WriteFile(podToVersionReference, nil, 0770); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to create pod to version reference file - error: %s", err))
 	}
-	if err = os.Symlink(podToVersionReference, filepath.Join(svr.opts.RootDir, dtcsi.GarbageCollectionPath, volumeCfg.volumeId)); err != nil {
+
+	if err = svr.fs.Fs.(afero.Linker).SymlinkIfPossible(podToVersionReference, filepath.Join(svr.opts.RootDir, dtcsi.GarbageCollectionPath, volumeCfg.volumeId)); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to create volume to pod reference SymLink for garbage collector - error: %s", err))
 	}
 
@@ -211,21 +214,21 @@ func (svr *CSIDriverServer) NodeUnpublishVolume(_ context.Context, req *csi.Node
 
 	volumeToPodReference := filepath.Join(svr.opts.RootDir, dtcsi.GarbageCollectionPath, volumeID)
 
-	podToVersionReference, err := os.Readlink(volumeToPodReference)
+	podToVersionReference, err := svr.fs.Fs.(afero.LinkReader).ReadlinkIfPossible(volumeToPodReference)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to read volume to pod SymLink for garbage collector - error: %s", err))
 	} else if !os.IsNotExist(err) {
-		if err = os.Remove(podToVersionReference); err != nil && !os.IsNotExist(err) {
+		if err = svr.fs.Remove(podToVersionReference); err != nil && !os.IsNotExist(err) {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to remove pod to version reference file for garbage collector - error: %s", err))
 		}
-		if err = os.Remove(volumeToPodReference); err != nil && !os.IsNotExist(err) {
+		if err = svr.fs.Remove(volumeToPodReference); err != nil && !os.IsNotExist(err) {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to remove volume to pod SymLink for garbage collector - error: %s", err))
 		}
 	}
 
 	// Delete the mount point.
 	// Does not return error for non-existent path, repeated calls OK for idempotency.
-	if err := os.RemoveAll(targetPath); err != nil {
+	if err := svr.fs.RemoveAll(targetPath); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 


### PR DESCRIPTION
Per Pod log and datastorage directories were not accessible to applications due to missing permissions. This PR changes permissions to be accessible to any user.

Additionally, filesystem operations in `controllers/csi/driver` got replaced be Afero.