### PR TITLE
Implement log garbage collector for CSI driver

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/controllers/csi/gc/binaries.go
+++ b/controllers/csi/gc/binaries.go
@@ -1,12 +1,12 @@
 package csigc
 
 import (
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 
 	dtcsi "github.com/Dynatrace/dynatrace-operator/controllers/csi"
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/afero"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"

--- a/controllers/csi/gc/binaries_test.go
+++ b/controllers/csi/gc/binaries_test.go
@@ -28,7 +28,10 @@ func TestBinaryGarbageCollector_succeedsWhenVersionReferenceBaseDirectoryNotExis
 	resetMetrics()
 	gc := newMockGarbageCollector()
 
-	err := gc.runBinaryGarbageCollection(tenantUUID, version_1)
+	versionReferences, err := gc.getVersionReferences(tenantUUID)
+	assert.NoError(t, err)
+
+	err = gc.runBinaryGarbageCollection(versionReferences, tenantUUID, version_1)
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
 	assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
@@ -42,7 +45,10 @@ func TestBinaryGarbageCollector_succeedsWhenNoVersionsAvailable(t *testing.T) {
 	gc := newMockGarbageCollector()
 	_ = gc.fs.MkdirAll(versionReferenceBasePath, 0770)
 
-	err := gc.runBinaryGarbageCollection(tenantUUID, version_1)
+	versionReferences, err := gc.getVersionReferences(tenantUUID)
+	assert.NoError(t, err)
+
+	err = gc.runBinaryGarbageCollection(versionReferences, tenantUUID, version_1)
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
 	assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
@@ -56,7 +62,10 @@ func TestBinaryGarbageCollector_ignoresLatest(t *testing.T) {
 	gc := newMockGarbageCollector()
 	gc.mockUnusedVersions(version_1)
 
-	err := gc.runBinaryGarbageCollection(tenantUUID, version_1)
+	versionReferences, err := gc.getVersionReferences(tenantUUID)
+	assert.NoError(t, err)
+
+	err = gc.runBinaryGarbageCollection(versionReferences, tenantUUID, version_1)
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
 	assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
@@ -71,7 +80,10 @@ func TestBinaryGarbageCollector_removesUnused(t *testing.T) {
 	gc := newMockGarbageCollector()
 	gc.mockUnusedVersions(version_1, version_2, version_3)
 
-	err := gc.runBinaryGarbageCollection(tenantUUID, version_2)
+	versionReferences, err := gc.getVersionReferences(tenantUUID)
+	assert.NoError(t, err)
+
+	err = gc.runBinaryGarbageCollection(versionReferences, tenantUUID, version_2)
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
 	assert.Equal(t, float64(2), testutil.ToFloat64(foldersRemovedMetric))
@@ -85,7 +97,10 @@ func TestBinaryGarbageCollector_ignoresUsed(t *testing.T) {
 	gc := newMockGarbageCollector()
 	gc.mockUsedVersions(version_1, version_2, version_3)
 
-	err := gc.runBinaryGarbageCollection(tenantUUID, version_3)
+	versionReferences, err := gc.getVersionReferences(tenantUUID)
+	assert.NoError(t, err)
+
+	err = gc.runBinaryGarbageCollection(versionReferences, tenantUUID, version_3)
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
 	assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))

--- a/controllers/csi/gc/binaries_test.go
+++ b/controllers/csi/gc/binaries_test.go
@@ -26,7 +26,7 @@ var (
 
 func TestBinaryGarbageCollector_succeedsWhenVersionReferenceBaseDirectoryNotExists(t *testing.T) {
 	resetMetrics()
-	gc := newMockGarbageCollector()
+	gc := NewMockGarbageCollector()
 
 	versionReferences, err := gc.getVersionReferences(tenantUUID)
 	assert.NoError(t, err)
@@ -42,7 +42,7 @@ func TestBinaryGarbageCollector_succeedsWhenVersionReferenceBaseDirectoryNotExis
 
 func TestBinaryGarbageCollector_succeedsWhenNoVersionsAvailable(t *testing.T) {
 	resetMetrics()
-	gc := newMockGarbageCollector()
+	gc := NewMockGarbageCollector()
 	_ = gc.fs.MkdirAll(versionReferenceBasePath, 0770)
 
 	versionReferences, err := gc.getVersionReferences(tenantUUID)
@@ -59,7 +59,7 @@ func TestBinaryGarbageCollector_succeedsWhenNoVersionsAvailable(t *testing.T) {
 
 func TestBinaryGarbageCollector_ignoresLatest(t *testing.T) {
 	resetMetrics()
-	gc := newMockGarbageCollector()
+	gc := NewMockGarbageCollector()
 	gc.mockUnusedVersions(version_1)
 
 	versionReferences, err := gc.getVersionReferences(tenantUUID)
@@ -77,7 +77,7 @@ func TestBinaryGarbageCollector_ignoresLatest(t *testing.T) {
 
 func TestBinaryGarbageCollector_removesUnused(t *testing.T) {
 	resetMetrics()
-	gc := newMockGarbageCollector()
+	gc := NewMockGarbageCollector()
 	gc.mockUnusedVersions(version_1, version_2, version_3)
 
 	versionReferences, err := gc.getVersionReferences(tenantUUID)
@@ -94,8 +94,8 @@ func TestBinaryGarbageCollector_removesUnused(t *testing.T) {
 
 func TestBinaryGarbageCollector_ignoresUsed(t *testing.T) {
 	resetMetrics()
-	gc := newMockGarbageCollector()
-	gc.mockUsedVersions(version_1, version_2, version_3)
+	gc := NewMockGarbageCollector()
+	gc.MockUsedVersions(version_1, version_2, version_3)
 
 	versionReferences, err := gc.getVersionReferences(tenantUUID)
 	assert.NoError(t, err)
@@ -110,7 +110,7 @@ func TestBinaryGarbageCollector_ignoresUsed(t *testing.T) {
 	gc.assertVersionExists(t, version_1, version_2, version_3)
 }
 
-func newMockGarbageCollector() *CSIGarbageCollector {
+func NewMockGarbageCollector() *CSIGarbageCollector {
 	return &CSIGarbageCollector{
 		logger: logger.NewDTLogger(),
 		opts:   dtcsi.CSIOptions{RootDir: rootDir},
@@ -123,7 +123,7 @@ func (gc *CSIGarbageCollector) mockUnusedVersions(versions ...string) {
 		_ = gc.fs.MkdirAll(filepath.Join(versionReferenceBasePath, version), 0770)
 	}
 }
-func (gc *CSIGarbageCollector) mockUsedVersions(versions ...string) {
+func (gc *CSIGarbageCollector) MockUsedVersions(versions ...string) {
 	for _, version := range versions {
 		_ = gc.fs.MkdirAll(filepath.Join(versionReferenceBasePath, version), 0770)
 		_, _ = gc.fs.Create(filepath.Join(versionReferenceBasePath, version, "somePodID"))

--- a/controllers/csi/gc/binaries_test.go
+++ b/controllers/csi/gc/binaries_test.go
@@ -38,19 +38,12 @@ func TestBinaryGarbageCollector_versionReferenceGenerationSuccess(t *testing.T) 
 func TestBinaryGarbageCollector_succeedsWhenVersionReferenceBaseDirectoryNotExists(t *testing.T) {
 	resetMetrics()
 	gc := NewMockGarbageCollector()
-	gc.mockUnusedVersions(version_1, version_2, version_3)
-
-	versionReferences, err := gc.getVersionReferences(tenantUUID)
-	assert.NoError(t, err)
 
 	gc.runBinaryGarbageCollection(tenantUUID, version_1)
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
 	assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
 	assert.Equal(t, float64(0), testutil.ToFloat64(reclaimedMemoryMetric))
-
-	assert.NotNil(t, versionReferences)
-	assert.NoError(t, err)
 }
 
 func TestBinaryGarbageCollector_succeedsWhenNoVersionsAvailable(t *testing.T) {

--- a/controllers/csi/gc/logs.go
+++ b/controllers/csi/gc/logs.go
@@ -1,0 +1,124 @@
+package csigc
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	dtcsi "github.com/Dynatrace/dynatrace-operator/controllers/csi"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+)
+
+const (
+	maxLogFolderSize    = 300000
+	maxAmountOfLogFiles = 1000
+	maxLogAge           = 14 * 24 * time.Hour
+)
+
+func (gc *CSIGarbageCollector) runLogGarbageCollection(versionReferences []os.FileInfo, tenantUUID string) error {
+	fs := &afero.Afero{Fs: gc.fs}
+	gcPodUIDs, err := gc.getPodUIDs(fs, versionReferences, tenantUUID)
+	if err != nil {
+		gc.logger.Error(err, "failed to get podUIDs")
+		return errors.WithStack(err)
+	}
+
+	logPath := filepath.Join(gc.opts.RootDir, dtcsi.DataPath, tenantUUID, dtcsi.LogDir)
+	logPodUIDs, err := fs.ReadDir(logPath)
+	if err != nil {
+		gc.logger.Error(err, "skipped, failed to get references")
+		return errors.WithStack(err)
+	}
+
+	deadPods := difference(gcPodUIDs, logPodUIDs)
+
+	shouldDelete := len(deadPods) > 0 && (sizeTooBig(fs, logPath) || len(deadPods) > maxAmountOfLogFiles)
+	if shouldDelete {
+		err = gc.removeDeadLogFolders(deadPods, fs, logPath)
+		if err != nil {
+			gc.logger.Error(err, "failed to remove dead log directories")
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
+func (gc *CSIGarbageCollector) removeDeadLogFolders(deadPods []os.FileInfo, fs *afero.Afero, logPath string) error {
+	for _, deadPod := range deadPods {
+		if isOlderThanTwoWeeks(deadPod.ModTime()) {
+			if err := fs.RemoveAll(filepath.Join(logPath, deadPod.Name())); err != nil {
+				gc.logger.Error(err, "failed to remove logs for pod", "podUID", deadPod.Name())
+				return errors.WithStack(err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func isOlderThanTwoWeeks(t time.Time) bool {
+	return time.Since(t) > maxLogAge
+}
+
+func sizeTooBig(fs *afero.Afero, logPath string) bool {
+	var size int64
+	_ = fs.Walk(logPath, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+
+	return size > maxLogFolderSize
+}
+
+func (gc *CSIGarbageCollector) getPodUIDs(fs *afero.Afero, versionReferences []os.FileInfo, tenantUUID string) ([]os.FileInfo, error) {
+	var podUIDs []os.FileInfo
+	versionReferencesBase := filepath.Join(gc.opts.RootDir, dtcsi.DataPath, tenantUUID, dtcsi.GarbageCollectionPath)
+	gc.logger.Info("run garbage collection for binaries", "versionReferencesBase", versionReferencesBase)
+
+	for _, fileInfo := range versionReferences {
+		references := filepath.Join(versionReferencesBase, fileInfo.Name())
+
+		podReferences, err := fs.ReadDir(references)
+		if err != nil {
+			gc.logger.Error(err, "skipped, failed to get references")
+			return nil, errors.WithStack(err)
+		}
+
+		podUIDs = append(podUIDs, podReferences...)
+	}
+
+	return podUIDs, nil
+}
+
+func difference(slice1 []os.FileInfo, slice2 []os.FileInfo) []os.FileInfo {
+	var diff []os.FileInfo
+
+	for i := 0; i < 2; i++ {
+		for _, s1 := range slice1 {
+			found := false
+			for _, s2 := range slice2 {
+				if s1 == s2 {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				diff = append(diff, s1)
+			}
+		}
+
+		if i == 0 {
+			slice1, slice2 = slice2, slice1
+		}
+	}
+
+	return diff
+}

--- a/controllers/csi/gc/logs.go
+++ b/controllers/csi/gc/logs.go
@@ -11,14 +11,14 @@ import (
 )
 
 const (
-	maxLogFolderSize    = 300000
-	maxAmountOfLogFiles = 1000
-	maxLogAge           = 14 * 24 * time.Hour
+	maxLogFolderSizeBytes = 300000
+	maxNumberOfLogFiles   = 1000
+	maxLogAge             = 14 * 24 * time.Hour
 )
 
 func (gc *CSIGarbageCollector) runLogGarbageCollection(versionReferences []os.FileInfo, tenantUUID string) error {
 	fs := &afero.Afero{Fs: gc.fs}
-	gcPodUIDs, err := gc.getPodUIDs(fs, versionReferences, tenantUUID)
+	gcPodUIDs, err := gc.getCurrentlyUsedPodReferencePodUIDs(fs, versionReferences, tenantUUID)
 	if err != nil {
 		gc.logger.Info("skipped, failed to get podUIDs")
 		return errors.WithStack(err)
@@ -31,11 +31,13 @@ func (gc *CSIGarbageCollector) runLogGarbageCollection(versionReferences []os.Fi
 		return errors.WithStack(err)
 	}
 
-	deadPods := difference(gcPodUIDs, logPodUIDs)
+	deadPods := getDeadPodUIDsDelta(gcPodUIDs, logPodUIDs)
 
-	shouldDelete := len(deadPods) > 0 && (sizeTooBig(fs, logPath) || len(deadPods) > maxAmountOfLogFiles)
+	nrOfLogFiles := gc.getNumberOfLogFiles(deadPods, fs, logPath)
+
+	shouldDelete := len(deadPods) > 0 && (sizeTooBig(fs, logPath) || nrOfLogFiles > maxNumberOfLogFiles)
 	if shouldDelete {
-		err = gc.removeDeadLogFolders(deadPods, fs, logPath)
+		err = gc.tryRemoveLogFolders(deadPods, fs, logPath)
 		if err != nil {
 			gc.logger.Error(err, "failed to remove dead log directories")
 			return errors.WithStack(err)
@@ -45,7 +47,24 @@ func (gc *CSIGarbageCollector) runLogGarbageCollection(versionReferences []os.Fi
 	return nil
 }
 
-func (gc *CSIGarbageCollector) removeDeadLogFolders(deadPods []os.FileInfo, fs *afero.Afero, logPath string) error {
+func (gc *CSIGarbageCollector) getNumberOfLogFiles(deadPods []os.FileInfo, fs *afero.Afero, logPath string) int64 {
+	var nrOfFiles int64
+	for _, podUID := range deadPods {
+		_ = fs.Walk(filepath.Join(logPath, podUID.Name()), func(_ string, file os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !file.IsDir() {
+				nrOfFiles++
+			}
+			return err
+		})
+	}
+
+	return nrOfFiles
+}
+
+func (gc *CSIGarbageCollector) tryRemoveLogFolders(deadPods []os.FileInfo, fs *afero.Afero, logPath string) error {
 	for _, deadPod := range deadPods {
 		if isOlderThanTwoWeeks(deadPod.ModTime()) {
 			if err := fs.RemoveAll(filepath.Join(logPath, deadPod.Name())); err != nil {
@@ -56,6 +75,25 @@ func (gc *CSIGarbageCollector) removeDeadLogFolders(deadPods []os.FileInfo, fs *
 	}
 
 	return nil
+}
+
+func (gc *CSIGarbageCollector) getCurrentlyUsedPodReferencePodUIDs(fs *afero.Afero, versionReferences []os.FileInfo, tenantUUID string) ([]os.FileInfo, error) {
+	var podUIDs []os.FileInfo
+	versionReferencesBase := filepath.Join(gc.opts.RootDir, dtcsi.DataPath, tenantUUID, dtcsi.GarbageCollectionPath)
+
+	for _, fileInfo := range versionReferences {
+		references := filepath.Join(versionReferencesBase, fileInfo.Name())
+
+		podReferences, err := fs.ReadDir(references)
+		if err != nil {
+			gc.logger.Info("skipped, failed to get references")
+			return nil, errors.WithStack(err)
+		}
+
+		podUIDs = append(podUIDs, podReferences...)
+	}
+
+	return podUIDs, nil
 }
 
 func isOlderThanTwoWeeks(t time.Time) bool {
@@ -74,36 +112,16 @@ func sizeTooBig(fs *afero.Afero, logPath string) bool {
 		return err
 	})
 
-	return size > maxLogFolderSize
+	return size > maxLogFolderSizeBytes
 }
 
-func (gc *CSIGarbageCollector) getPodUIDs(fs *afero.Afero, versionReferences []os.FileInfo, tenantUUID string) ([]os.FileInfo, error) {
-	var podUIDs []os.FileInfo
-	versionReferencesBase := filepath.Join(gc.opts.RootDir, dtcsi.DataPath, tenantUUID, dtcsi.GarbageCollectionPath)
-	gc.logger.Info("run garbage collection for binaries", "versionReferencesBase", versionReferencesBase)
-
-	for _, fileInfo := range versionReferences {
-		references := filepath.Join(versionReferencesBase, fileInfo.Name())
-
-		podReferences, err := fs.ReadDir(references)
-		if err != nil {
-			gc.logger.Info("skipped, failed to get references")
-			return nil, errors.WithStack(err)
-		}
-
-		podUIDs = append(podUIDs, podReferences...)
-	}
-
-	return podUIDs, nil
-}
-
-func difference(slice1 []os.FileInfo, slice2 []os.FileInfo) []os.FileInfo {
+func getDeadPodUIDsDelta(currentlyUsedPodReferencePodUIDs []os.FileInfo, logPodUIDs []os.FileInfo) []os.FileInfo {
 	var diff []os.FileInfo
 
 	for i := 0; i < 2; i++ {
-		for _, s1 := range slice1 {
+		for _, s1 := range currentlyUsedPodReferencePodUIDs {
 			found := false
-			for _, s2 := range slice2 {
+			for _, s2 := range logPodUIDs {
 				if s1 == s2 {
 					found = true
 					break
@@ -116,7 +134,7 @@ func difference(slice1 []os.FileInfo, slice2 []os.FileInfo) []os.FileInfo {
 		}
 
 		if i == 0 {
-			slice1, slice2 = slice2, slice1
+			currentlyUsedPodReferencePodUIDs, logPodUIDs = logPodUIDs, currentlyUsedPodReferencePodUIDs
 		}
 	}
 

--- a/controllers/csi/gc/logs.go
+++ b/controllers/csi/gc/logs.go
@@ -28,7 +28,11 @@ func (gc *CSIGarbageCollector) runLogGarbageCollection(tenantUUID string) {
 		return
 	}
 
-	shouldDelete := logs.NumberOfFiles > 0 && (logs.OverallSize > maxLogFolderSizeBytes || logs.NumberOfFiles > maxNumberOfLogFiles)
+	gc.removeLogsIfNecessary(logs, maxLogFolderSizeBytes, maxNumberOfLogFiles, tenantUUID, fs)
+}
+
+func (gc *CSIGarbageCollector) removeLogsIfNecessary(logs *logFileInfo, maxSize int64, maxFile int64, tenantUUID string, fs *afero.Afero) {
+	shouldDelete := logs.NumberOfFiles > 0 && (logs.OverallSize > maxSize || logs.NumberOfFiles > maxFile)
 	if shouldDelete {
 		gc.tryRemoveLogFolders(logs.UnusedVolumeIDs, tenantUUID, fs)
 	}

--- a/controllers/csi/gc/logs.go
+++ b/controllers/csi/gc/logs.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"time"
 
-	dtcsi "github.com/Dynatrace/dynatrace-operator/controllers/csi"
-	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )
 
@@ -16,127 +14,87 @@ const (
 	maxLogAge             = 14 * 24 * time.Hour
 )
 
-func (gc *CSIGarbageCollector) runLogGarbageCollection(versionReferences []os.FileInfo, tenantUUID string) error {
-	fs := &afero.Afero{Fs: gc.fs}
-	gcPodUIDs, err := gc.getCurrentlyUsedPodReferencePodUIDs(fs, versionReferences, tenantUUID)
-	if err != nil {
-		gc.logger.Info("skipped, failed to get podUIDs")
-		return errors.WithStack(err)
-	}
-
-	logPath := filepath.Join(gc.opts.RootDir, dtcsi.DataPath, tenantUUID, dtcsi.LogDir)
-	logPodUIDs, err := fs.ReadDir(logPath)
-	if err != nil {
-		gc.logger.Info("skipped, failed to get references")
-		return errors.WithStack(err)
-	}
-
-	deadPods := getDeadPodUIDsDelta(gcPodUIDs, logPodUIDs)
-
-	nrOfLogFiles := gc.getNumberOfLogFiles(deadPods, fs, logPath)
-
-	shouldDelete := len(deadPods) > 0 && (sizeTooBig(fs, logPath) || nrOfLogFiles > maxNumberOfLogFiles)
-	if shouldDelete {
-		err = gc.tryRemoveLogFolders(deadPods, fs, logPath)
-		if err != nil {
-			gc.logger.Error(err, "failed to remove dead log directories")
-			return errors.WithStack(err)
-		}
-	}
-
-	return nil
+type logFileInfo struct {
+	UnusedVolumeIDs []os.FileInfo
+	NumberOfFiles   int64
+	OverallSize     int64
 }
 
-func (gc *CSIGarbageCollector) getNumberOfLogFiles(deadPods []os.FileInfo, fs *afero.Afero, logPath string) int64 {
+func (gc *CSIGarbageCollector) runLogGarbageCollection(tenantUUID string) {
+	fs := &afero.Afero{Fs: gc.fs}
+	logs, err := gc.getLogFileInfo(tenantUUID, fs)
+	if err != nil {
+		gc.logger.Info("failed to get log file information")
+		return
+	}
+
+	shouldDelete := logs.NumberOfFiles > 0 && (logs.OverallSize > maxLogFolderSizeBytes || logs.NumberOfFiles > maxNumberOfLogFiles)
+	if shouldDelete {
+		gc.tryRemoveLogFolders(logs.UnusedVolumeIDs, tenantUUID, fs)
+	}
+}
+
+func (gc *CSIGarbageCollector) getLogFileInfo(tenantUUID string, fs *afero.Afero) (*logFileInfo, error) {
+	unusedVolumeIDs, err := gc.getUnusedVolumeIDs(tenantUUID, fs)
+	if err != nil {
+		return nil, err
+	}
+
 	var nrOfFiles int64
-	for _, podUID := range deadPods {
-		_ = fs.Walk(filepath.Join(logPath, podUID.Name()), func(_ string, file os.FileInfo, err error) error {
+	var size int64
+	for _, volumeID := range unusedVolumeIDs {
+		_ = fs.Walk(filepath.Join(gc.opts.RootDir, tenantUUID, "run", volumeID.Name(), "var"), func(_ string, file os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
 			if !file.IsDir() {
 				nrOfFiles++
+				size += file.Size()
 			}
-			return err
+			return nil
 		})
 	}
 
-	return nrOfFiles
+	return &logFileInfo{
+		UnusedVolumeIDs: unusedVolumeIDs,
+		NumberOfFiles:   nrOfFiles,
+		OverallSize:     size,
+	}, nil
 }
 
-func (gc *CSIGarbageCollector) tryRemoveLogFolders(deadPods []os.FileInfo, fs *afero.Afero, logPath string) error {
-	for _, deadPod := range deadPods {
-		if isOlderThanTwoWeeks(deadPod.ModTime()) {
-			if err := fs.RemoveAll(filepath.Join(logPath, deadPod.Name())); err != nil {
-				gc.logger.Error(err, "failed to remove logs for pod", "podUID", deadPod.Name())
-				return errors.WithStack(err)
+func (gc *CSIGarbageCollector) getUnusedVolumeIDs(tenantUUID string, fs *afero.Afero) ([]os.FileInfo, error) {
+	var unusedVolumeIDs []os.FileInfo
+
+	agentDirectoryForPod := filepath.Join(gc.opts.RootDir, tenantUUID, "run")
+	volumeIDs, err := fs.ReadDir(agentDirectoryForPod)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, volumeID := range volumeIDs {
+		unused, err := fs.IsEmpty(filepath.Join(agentDirectoryForPod, volumeID.Name(), "mapped"))
+		if err != nil {
+			return nil, err
+		}
+
+		if unused {
+			unusedVolumeIDs = append(unusedVolumeIDs, volumeID)
+		}
+	}
+
+	return unusedVolumeIDs, nil
+}
+
+func (gc *CSIGarbageCollector) tryRemoveLogFolders(unusedVolumeIDs []os.FileInfo, tenantUUID string, fs *afero.Afero) {
+	for _, unusedVolumeID := range unusedVolumeIDs {
+		if isOlderThanTwoWeeks(unusedVolumeID.ModTime()) {
+			if err := fs.RemoveAll(filepath.Join(gc.opts.RootDir, tenantUUID, "run", unusedVolumeID.Name())); err != nil {
+				gc.logger.Info("failed to remove logs for pod", "podUID", unusedVolumeID.Name(), "error", err)
 			}
 		}
 	}
-
-	return nil
-}
-
-func (gc *CSIGarbageCollector) getCurrentlyUsedPodReferencePodUIDs(fs *afero.Afero, versionReferences []os.FileInfo, tenantUUID string) ([]os.FileInfo, error) {
-	var podUIDs []os.FileInfo
-	versionReferencesBase := filepath.Join(gc.opts.RootDir, dtcsi.DataPath, tenantUUID, dtcsi.GarbageCollectionPath)
-
-	for _, fileInfo := range versionReferences {
-		references := filepath.Join(versionReferencesBase, fileInfo.Name())
-
-		podReferences, err := fs.ReadDir(references)
-		if err != nil {
-			gc.logger.Info("skipped, failed to get references")
-			return nil, errors.WithStack(err)
-		}
-
-		podUIDs = append(podUIDs, podReferences...)
-	}
-
-	return podUIDs, nil
 }
 
 func isOlderThanTwoWeeks(t time.Time) bool {
 	return time.Since(t) > maxLogAge
-}
-
-func sizeTooBig(fs *afero.Afero, logPath string) bool {
-	var size int64
-	_ = fs.Walk(logPath, func(_ string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			size += info.Size()
-		}
-		return err
-	})
-
-	return size > maxLogFolderSizeBytes
-}
-
-func getDeadPodUIDsDelta(currentlyUsedPodReferencePodUIDs []os.FileInfo, logPodUIDs []os.FileInfo) []os.FileInfo {
-	var diff []os.FileInfo
-
-	for i := 0; i < 2; i++ {
-		for _, s1 := range currentlyUsedPodReferencePodUIDs {
-			found := false
-			for _, s2 := range logPodUIDs {
-				if s1 == s2 {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				diff = append(diff, s1)
-			}
-		}
-
-		if i == 0 {
-			currentlyUsedPodReferencePodUIDs, logPodUIDs = logPodUIDs, currentlyUsedPodReferencePodUIDs
-		}
-	}
-
-	return diff
 }

--- a/controllers/csi/gc/logs_test.go
+++ b/controllers/csi/gc/logs_test.go
@@ -1,0 +1,73 @@
+package csigc
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	dtcsi "github.com/Dynatrace/dynatrace-operator/controllers/csi"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	logPath    = filepath.Join(rootDir, dtcsi.DataPath, tenantUUID, dtcsi.LogDir)
+	technology = "go"
+)
+
+func TestLogGarbageCollector_succeedsWhenNoFilesAreGiven(t *testing.T) {
+	gc := NewMockGarbageCollector()
+
+	_ = gc.fs.MkdirAll(versionReferenceBasePath, 0770)
+	_ = gc.fs.MkdirAll(logPath, 0770)
+
+	versionReferences, err := gc.getVersionReferences(tenantUUID)
+	assert.NoError(t, err)
+
+	err = gc.runLogGarbageCollection(versionReferences, tenantUUID)
+	assert.NoError(t, err)
+}
+
+func TestLogGarbageCollector_succeedsUsedFilesFound(t *testing.T) {
+	gc := NewMockGarbageCollector()
+
+	_ = gc.fs.MkdirAll(versionReferenceBasePath, 0770)
+	_ = gc.fs.MkdirAll(logPath, 0770)
+	gc.MockUsedVersions(version_1, version_2, version_3)
+
+	versionReferences, err := gc.getVersionReferences(tenantUUID)
+	assert.NoError(t, err)
+
+	err = gc.runLogGarbageCollection(versionReferences, tenantUUID)
+	assert.NoError(t, err)
+}
+
+func TestLogGarbageCollector_assertNumberOfLogsFilesAreEqual(t *testing.T) {
+	gc := NewMockGarbageCollector()
+
+	_ = gc.fs.MkdirAll(versionReferenceBasePath, 0770)
+	_ = gc.fs.MkdirAll(logPath, 0770)
+
+	versionReferences, err := gc.getVersionReferences(tenantUUID)
+	assert.NoError(t, err)
+
+	gc.mockLogPodFolders(version_1, version_2)
+	gc.mockLogsInPodFolders(5, version_1, version_2)
+
+	err = gc.runLogGarbageCollection(versionReferences, tenantUUID)
+	assert.NoError(t, err)
+}
+
+func (gc *CSIGarbageCollector) mockLogPodFolders(podIDs ...string) {
+	for _, podID := range podIDs {
+		_, _ = gc.fs.Create(filepath.Join(logPath, podID))
+	}
+}
+
+func (gc *CSIGarbageCollector) mockLogsInPodFolders(nrOfLogFiles int, podIDs ...string) {
+	for _, podID := range podIDs {
+		_ = gc.fs.Mkdir(filepath.Join(logPath, podID, technology), 0770)
+		for i := 0; i < nrOfLogFiles; i++ {
+			_, _ = gc.fs.Create(filepath.Join(logPath, podID, technology, "logfile"+strconv.Itoa(i)))
+		}
+	}
+}

--- a/controllers/csi/gc/logs_test.go
+++ b/controllers/csi/gc/logs_test.go
@@ -110,18 +110,17 @@ func TestLogGarbageCollector_logFileInfo_MultipleVolumeIDs_WithUnmountedAndMount
 }
 
 func TestLogGarbageCollector_modificationDateOlderThanTwoWeeks(t *testing.T) {
-	gc := NewMockGarbageCollector()
+	t.Run("is false for current timestamp", func(t *testing.T) {
+		isOlder := isOlderThanTwoWeeks(time.Now())
 
-	_ = gc.fs.MkdirAll(logPath, 0770)
-	gc.mockUnmountedVolumeIDPath(version_1, version_2)
-	gc.mockLogsInPodFolders(5, version_1, version_2)
+		assert.False(t, isOlder)
+	})
+	
+	t.Run("is true for timestamp 14 days in past", func(t *testing.T) {
+		isOlder := isOlderThanTwoWeeks(time.Now().AddDate(0, 0, -14))
 
-	logs, err := gc.getLogFileInfo(tenantUUID, &afero.Afero{Fs: gc.fs})
-	assert.NoError(t, err)
-	assert.NotNil(t, logs)
-
-	older := isOlderThanTwoWeeks(logs.UnusedVolumeIDs[0].ModTime())
-	assert.True(t, older)
+		assert.True(t, isOlder)
+	})
 }
 
 func TestLogGarbageCollector_cleanUpSuccessful(t *testing.T) {

--- a/controllers/csi/gc/logs_test.go
+++ b/controllers/csi/gc/logs_test.go
@@ -46,7 +46,6 @@ func TestLogGarbageCollector_emptyLogFileInfoWithNoUnmountedLogs(t *testing.T) {
 func TestLogGarbageCollector_logFileInfo_JustVolumeID_WithUnmountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(logPath, 0770)
 	gc.mockUnmountedVolumeIDPath(version_1)
 
 	logs, err := gc.getLogFileInfo(tenantUUID)
@@ -60,7 +59,6 @@ func TestLogGarbageCollector_logFileInfo_JustVolumeID_WithUnmountedLogs(t *testi
 func TestLogGarbageCollector_logFileInfo_SingleVolumeID_WithUnmountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(logPath, 0770)
 	gc.mockUnmountedVolumeIDPath(version_1)
 	gc.mockLogsInPodFolders(5, version_1)
 
@@ -75,7 +73,6 @@ func TestLogGarbageCollector_logFileInfo_SingleVolumeID_WithUnmountedLogs(t *tes
 func TestLogGarbageCollector_logFileInfo_MultipleVolumeIDs_WithUnmountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(logPath, 0770)
 	gc.mockUnmountedVolumeIDPath(version_1, version_2, version_3)
 	gc.mockLogsInPodFolders(5, version_1, version_2)
 
@@ -92,7 +89,6 @@ func TestLogGarbageCollector_logFileInfo_MultipleVolumeIDs_WithUnmountedLogs(t *
 func TestLogGarbageCollector_logFileInfo_MultipleVolumeIDs_WithUnmountedAndMountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(logPath, 0770)
 	gc.mockMountedVolumeIDPath(version_3)
 	gc.mockUnmountedVolumeIDPath(version_1, version_2)
 	gc.mockLogsInPodFolders(5, version_1, version_2)
@@ -124,7 +120,6 @@ func TestLogGarbageCollector_modificationDateOlderThanTwoWeeks(t *testing.T) {
 func TestLogGarbageCollector_cleanUpSuccessful(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(logPath, 0770)
 	gc.mockUnmountedVolumeIDPath(version_1, version_2)
 	gc.mockLogsInPodFolders(5, version_1, version_2)
 
@@ -142,7 +137,6 @@ func TestLogGarbageCollector_cleanUpSuccessful(t *testing.T) {
 func TestLogGarbageCollector_removeLogsNecessary_filesGetDeleted(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(logPath, 0770)
 	gc.mockUnmountedVolumeIDPath(version_1, version_2)
 	gc.mockLogsInPodFolders(5, version_1, version_2)
 
@@ -160,7 +154,6 @@ func TestLogGarbageCollector_removeLogsNecessary_filesGetDeleted(t *testing.T) {
 func TestLogGarbageCollector_removeLogsNecessary_tooLessFiles(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(logPath, 0770)
 	gc.mockUnmountedVolumeIDPath(version_1, version_2)
 	gc.mockLogsInPodFolders(5, version_1, version_2)
 
@@ -178,7 +171,6 @@ func TestLogGarbageCollector_removeLogsNecessary_tooLessFiles(t *testing.T) {
 func TestLogGarbageCollector_removeLogsNecessary_FileSizeTooSmall(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(logPath, 0770)
 	gc.mockUnmountedVolumeIDPath(version_1, version_2)
 	gc.mockLogsInPodFolders(5, version_1, version_2)
 

--- a/controllers/csi/gc/logs_test.go
+++ b/controllers/csi/gc/logs_test.go
@@ -1,73 +1,165 @@
 package csigc
 
 import (
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 
-	dtcsi "github.com/Dynatrace/dynatrace-operator/controllers/csi"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	logPath    = filepath.Join(rootDir, dtcsi.DataPath, tenantUUID, dtcsi.LogDir)
+	logPath    = filepath.Join(rootDir, tenantUUID, "run")
 	technology = "go"
 )
 
-func TestLogGarbageCollector_succeedsWhenNoFilesAreGiven(t *testing.T) {
+func TestLogGarbageCollector_noErrorWithoutLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(versionReferenceBasePath, 0770)
 	_ = gc.fs.MkdirAll(logPath, 0770)
+	logs, err := gc.getLogFileInfo(tenantUUID, &afero.Afero{Fs: gc.fs})
 
-	versionReferences, err := gc.getVersionReferences(tenantUUID)
 	assert.NoError(t, err)
-
-	err = gc.runLogGarbageCollection(versionReferences, tenantUUID)
-	assert.NoError(t, err)
+	assert.Equal(t, &logFileInfo{
+		UnusedVolumeIDs: []os.FileInfo(nil),
+		NumberOfFiles:   0,
+		OverallSize:     0,
+	}, logs)
 }
 
-func TestLogGarbageCollector_succeedsUsedFilesFound(t *testing.T) {
+func TestLogGarbageCollector_emptyLogFileInfoWithNoUnmountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(versionReferenceBasePath, 0770)
 	_ = gc.fs.MkdirAll(logPath, 0770)
-	gc.MockUsedVersions(version_1, version_2, version_3)
+	gc.mockMountedVolumeIDPath(version_1)
 
-	versionReferences, err := gc.getVersionReferences(tenantUUID)
-	assert.NoError(t, err)
+	logs, err := gc.getLogFileInfo(tenantUUID, &afero.Afero{Fs: gc.fs})
 
-	err = gc.runLogGarbageCollection(versionReferences, tenantUUID)
 	assert.NoError(t, err)
+	assert.Equal(t, &logFileInfo{
+		UnusedVolumeIDs: []os.FileInfo(nil),
+		NumberOfFiles:   0,
+		OverallSize:     0,
+	}, logs)
 }
 
-func TestLogGarbageCollector_assertNumberOfLogsFilesAreEqual(t *testing.T) {
+func TestLogGarbageCollector_logFileInfo_JustVolumeID_WithUnmountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(versionReferenceBasePath, 0770)
 	_ = gc.fs.MkdirAll(logPath, 0770)
+	gc.mockUnmountedVolumeIDPath(version_1)
 
-	versionReferences, err := gc.getVersionReferences(tenantUUID)
+	logs, err := gc.getLogFileInfo(tenantUUID, &afero.Afero{Fs: gc.fs})
+
 	assert.NoError(t, err)
+	assert.Equal(t, int64(0), logs.NumberOfFiles)
+	assert.Equal(t, int64(0), logs.OverallSize)
+	assert.Equal(t, version_1, logs.UnusedVolumeIDs[0].Name())
+}
 
-	gc.mockLogPodFolders(version_1, version_2)
+func TestLogGarbageCollector_logFileInfo_SingleVolumeID_WithUnmountedLogs(t *testing.T) {
+	gc := NewMockGarbageCollector()
+
+	_ = gc.fs.MkdirAll(logPath, 0770)
+	gc.mockUnmountedVolumeIDPath(version_1)
+	gc.mockLogsInPodFolders(5, version_1)
+
+	logs, err := gc.getLogFileInfo(tenantUUID, &afero.Afero{Fs: gc.fs})
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), logs.NumberOfFiles)
+	assert.Equal(t, int64(0), logs.OverallSize)
+	assert.Equal(t, version_1, logs.UnusedVolumeIDs[0].Name())
+}
+
+func TestLogGarbageCollector_logFileInfo_MultipleVolumeIDs_WithUnmountedLogs(t *testing.T) {
+	gc := NewMockGarbageCollector()
+
+	_ = gc.fs.MkdirAll(logPath, 0770)
+	gc.mockUnmountedVolumeIDPath(version_1, version_2, version_3)
 	gc.mockLogsInPodFolders(5, version_1, version_2)
 
-	err = gc.runLogGarbageCollection(versionReferences, tenantUUID)
+	logs, err := gc.getLogFileInfo(tenantUUID, &afero.Afero{Fs: gc.fs})
+
 	assert.NoError(t, err)
+	assert.Equal(t, int64(10), logs.NumberOfFiles)
+	assert.Equal(t, int64(0), logs.OverallSize)
+	assert.Equal(t, version_1, logs.UnusedVolumeIDs[0].Name())
+	assert.Equal(t, version_2, logs.UnusedVolumeIDs[1].Name())
+	assert.Equal(t, version_3, logs.UnusedVolumeIDs[2].Name())
 }
 
-func (gc *CSIGarbageCollector) mockLogPodFolders(podIDs ...string) {
-	for _, podID := range podIDs {
-		_, _ = gc.fs.Create(filepath.Join(logPath, podID))
+func TestLogGarbageCollector_logFileInfo_MultipleVolumeIDs_WithUnmountedAndMountedLogs(t *testing.T) {
+	gc := NewMockGarbageCollector()
+
+	_ = gc.fs.MkdirAll(logPath, 0770)
+	gc.mockMountedVolumeIDPath(version_3)
+	gc.mockUnmountedVolumeIDPath(version_1, version_2)
+	gc.mockLogsInPodFolders(5, version_1, version_2)
+
+	logs, err := gc.getLogFileInfo(tenantUUID, &afero.Afero{Fs: gc.fs})
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(10), logs.NumberOfFiles)
+	assert.Equal(t, int64(0), logs.OverallSize)
+	assert.Equal(t, version_1, logs.UnusedVolumeIDs[0].Name())
+	assert.Equal(t, version_2, logs.UnusedVolumeIDs[1].Name())
+	assert.Equal(t, 2, len(logs.UnusedVolumeIDs))
+}
+
+func TestLogGarbageCollector_modificationDateOlderThanTwoWeeks(t *testing.T) {
+	gc := NewMockGarbageCollector()
+
+	_ = gc.fs.MkdirAll(logPath, 0770)
+	gc.mockUnmountedVolumeIDPath(version_1, version_2)
+	gc.mockLogsInPodFolders(5, version_1, version_2)
+
+	logs, err := gc.getLogFileInfo(tenantUUID, &afero.Afero{Fs: gc.fs})
+	assert.NoError(t, err)
+	assert.NotNil(t, logs)
+
+	older := isOlderThanTwoWeeks(logs.UnusedVolumeIDs[0].ModTime())
+	assert.True(t, older)
+}
+
+func TestLogGarbageCollector_cleanUpSuccessful(t *testing.T) {
+	gc := NewMockGarbageCollector()
+
+	_ = gc.fs.MkdirAll(logPath, 0770)
+	gc.mockUnmountedVolumeIDPath(version_1, version_2)
+	gc.mockLogsInPodFolders(5, version_1, version_2)
+
+	logs, err := gc.getLogFileInfo(tenantUUID, &afero.Afero{Fs: gc.fs})
+	assert.NoError(t, err)
+	assert.NotNil(t, logs)
+
+	older := isOlderThanTwoWeeks(logs.UnusedVolumeIDs[0].ModTime())
+	assert.True(t, older)
+
+	gc.tryRemoveLogFolders(logs.UnusedVolumeIDs, tenantUUID, &afero.Afero{Fs: gc.fs})
+	assert.NoDirExists(t, filepath.Join(logPath, logs.UnusedVolumeIDs[0].Name()))
+}
+
+func (gc *CSIGarbageCollector) mockMountedVolumeIDPath(volumeIDs ...string) {
+	for _, volumeID := range volumeIDs {
+		_ = gc.fs.MkdirAll(filepath.Join(logPath, volumeID, "mapped", "something"), os.ModePerm)
 	}
 }
 
-func (gc *CSIGarbageCollector) mockLogsInPodFolders(nrOfLogFiles int, podIDs ...string) {
-	for _, podID := range podIDs {
-		_ = gc.fs.Mkdir(filepath.Join(logPath, podID, technology), 0770)
+func (gc *CSIGarbageCollector) mockUnmountedVolumeIDPath(volumeIDs ...string) {
+	for _, volumeID := range volumeIDs {
+		_ = gc.fs.MkdirAll(filepath.Join(logPath, volumeID, "mapped"), os.ModePerm)
+	}
+}
+
+func (gc *CSIGarbageCollector) mockLogsInPodFolders(nrOfLogFiles int, volumeIDs ...string) {
+	for _, volumeID := range volumeIDs {
+		technologyLogPath := filepath.Join(logPath, volumeID, "var", "log", technology)
+		_ = gc.fs.Mkdir(filepath.Join(technologyLogPath), 0770)
 		for i := 0; i < nrOfLogFiles; i++ {
-			_, _ = gc.fs.Create(filepath.Join(logPath, podID, technology, "logfile"+strconv.Itoa(i)))
+			_, _ = gc.fs.Create(filepath.Join(technologyLogPath, "logfile"+strconv.Itoa(i)))
 		}
 	}
 }

--- a/controllers/csi/gc/logs_test.go
+++ b/controllers/csi/gc/logs_test.go
@@ -152,6 +152,7 @@ func TestLogGarbageCollector_removeLogsNecessary_filesGetDeleted(t *testing.T) {
 
 	gc.removeLogsIfNecessary(logs, int64(0), int64(1), tenantUUID)
 	newLogs, err := gc.getLogFileInfo(tenantUUID)
+	assert.NoError(t, err)
 	assert.NotEqual(t, newLogs, logs)
 	assert.Equal(t, newLogs.NumberOfFiles, int64(0))
 }
@@ -169,6 +170,7 @@ func TestLogGarbageCollector_removeLogsNecessary_tooLessFiles(t *testing.T) {
 
 	gc.removeLogsIfNecessary(logs, int64(0), int64(11), tenantUUID)
 	newLogs, err := gc.getLogFileInfo(tenantUUID)
+	assert.NoError(t, err)
 	assert.Equal(t, newLogs, logs)
 	assert.Equal(t, newLogs.NumberOfFiles, int64(10))
 }
@@ -186,6 +188,7 @@ func TestLogGarbageCollector_removeLogsNecessary_FileSizeTooSmall(t *testing.T) 
 
 	gc.removeLogsIfNecessary(logs, int64(10), int64(11), tenantUUID)
 	newLogs, err := gc.getLogFileInfo(tenantUUID)
+	assert.NoError(t, err)
 	assert.Equal(t, newLogs, logs)
 	assert.Equal(t, newLogs.NumberOfFiles, int64(10))
 }


### PR DESCRIPTION
To prevent filling up the storage on the CSI driver with logs we implemented a garbage collector.

The logs are stored in `/tmp/data/<tenant>/log/<podUID>`
If a pod gets deleted (or dies) the folder gets persisted on the CSI driver.

To identify the folders created by non-existing pods we get the pod references files (which are stored under `/tmp/data/<tenant>/gc/<agentVersion>/<podUID>`) used for the binary garbage collector, diff them against all the existing folders within the log folder and create the delta, which are considered as dead folders.

Those will eventually get deleted when the following conditions are met:
1. the folder is older than 14 days **and**
2. the size of the overall log folder is bigger than 300MB **or**
3. the amount of log folders of dead pods is bigger than 1000