### PR TITLE
Feature/ag connection info

### DIFF
--- a/api/v1alpha1/dynakube_types.go
+++ b/api/v1alpha1/dynakube_types.go
@@ -27,6 +27,10 @@ type DynaKubeSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Custom PullSecret",order=8,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:Secret"}
 	CustomPullSecret string `json:"customPullSecret,omitempty"`
 
+	// Tokens for ActiveGates
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="AG Tokens",order=2,xDescriptors="urn:alm:descriptor:io.kubernetes:Secret"
+	AGTokensSecret string `json:"agTokensSecret,omitempty"`
+
 	// Disable certificate validation checks for installer download and API communication
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Skip Certificate Check",order=3,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	SkipCertCheck bool `json:"skipCertCheck,omitempty"`

--- a/api/v1alpha1/helpers.go
+++ b/api/v1alpha1/helpers.go
@@ -96,7 +96,7 @@ func buildImageRegistry(apiURL string) string {
 	return registry
 }
 
-// Tokens returns the name of the Secret to be used for tokens.
+// Tokens returns the name of the Secret to be used for Api- and Paas- tokens.
 func (dk *DynaKube) Tokens() string {
 	if tkns := dk.Spec.Tokens; tkns != "" {
 		return tkns

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -59,6 +59,9 @@ spec:
                     implementation from the Dynatrace environment set as API URL.'
                   type: string
               type: object
+            agTokensSecret:
+              description: Tokens for ActiveGates
+              type: string
             apiUrl:
               description: Location of the Dynatrace API to connect to, including
                 your specific environment ID

--- a/controllers/activegate/capability/reconciler.go
+++ b/controllers/activegate/capability/reconciler.go
@@ -24,7 +24,6 @@ const (
 	containerPort   = 9999
 	dtDNSEntryPoint = "DT_DNS_ENTRY_POINT"
 	dtTenantUUID    = "DT_TENANT"
-	dtTenantToken   = "DT_TOKEN"
 	dtServer        = "DT_SERVER"
 )
 
@@ -97,10 +96,6 @@ func addTenantInfo(dtc dtclient.Client) activegate.StatefulSetEvent {
 			corev1.EnvVar{
 				Name:  dtTenantUUID,
 				Value: info.ID,
-			},
-			corev1.EnvVar{
-				Name:  dtTenantToken,
-				Value: info.Token,
 			})
 	}
 }

--- a/controllers/activegate/capability/reconciler.go
+++ b/controllers/activegate/capability/reconciler.go
@@ -3,6 +3,7 @@ package capability
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
 	"github.com/Dynatrace/dynatrace-operator/controllers/activegate"
@@ -22,6 +23,9 @@ import (
 const (
 	containerPort   = 9999
 	dtDNSEntryPoint = "DT_DNS_ENTRY_POINT"
+	dtTenantUUID    = "DT_TENANT"
+	dtTenantToken   = "DT_TOKEN"
+	dtServer        = "DT_SERVER"
 )
 
 type Reconciler struct {
@@ -35,6 +39,8 @@ func NewReconciler(capability Capability, clt client.Client, apiReader client.Re
 	baseReconciler := activegate.NewReconciler(
 		clt, apiReader, scheme, dtc, log, instance, imageVersionProvider,
 		capability.GetProperties(), capability.GetModuleName(), capability.GetCapabilityName(), capability.GetConfiguration().ServiceAccountOwner)
+
+	baseReconciler.AddOnAfterStatefulSetCreateListener(addTenantInfo(dtc))
 
 	if capability.GetConfiguration().SetDnsEntryPoint {
 		baseReconciler.AddOnAfterStatefulSetCreateListener(addDNSEntryPoint(instance, capability.GetModuleName()))
@@ -74,6 +80,29 @@ func setCommunicationsPort(_ *dynatracev1alpha1.DynaKube) activegate.StatefulSet
 
 func (r *Reconciler) calculateStatefulSetName() string {
 	return CalculateStatefulSetName(r.Capability, r.Instance.Name)
+}
+
+func addTenantInfo(dtc dtclient.Client) activegate.StatefulSetEvent {
+	info, err := dtc.GetAGTenantInfo()
+	if err != nil {
+		return nil
+	}
+
+	return func(sts *appsv1.StatefulSet) {
+		sts.Spec.Template.Spec.Containers[0].Env = append(sts.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name:  dtServer,
+				Value: strings.Join(info.Endpoints, ","),
+			},
+			corev1.EnvVar{
+				Name:  dtTenantUUID,
+				Value: info.ID,
+			},
+			corev1.EnvVar{
+				Name:  dtTenantToken,
+				Value: info.Token,
+			})
+	}
 }
 
 func addDNSEntryPoint(instance *dynatracev1alpha1.DynaKube, moduleName string) activegate.StatefulSetEvent {

--- a/controllers/activegate/capability/reconciler_test.go
+++ b/controllers/activegate/capability/reconciler_test.go
@@ -50,6 +50,14 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 		}).
 		Build()
 	dtc := &dtclient.MockDynatraceClient{}
+
+	dtc.On("GetAGTenantInfo").
+		Return(&dtclient.TenantInfo{
+			ID:                    "123",
+			Token:                 "asdf",
+			Endpoints:             []string{"aaa", "bbb", "ccc"},
+			CommunicationEndpoint: "comm",
+		}, nil)
 	instance := &v1alpha1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,

--- a/controllers/activegate/reconciler.go
+++ b/controllers/activegate/reconciler.go
@@ -172,7 +172,6 @@ func (r *Reconciler) deleteStatefulSetIfOldLabelsAreUsed(desiredSts *appsv1.Stat
 	if !reflect.DeepEqual(currentSts.Labels, desiredSts.Labels) {
 		r.log.Info("Deleting existing stateful set")
 
-		// why do we delete desiredSts instead of currentSts???
 		if err = r.Delete(context.TODO(), desiredSts); err != nil {
 			return false, err
 		}

--- a/controllers/activegate/reconciler.go
+++ b/controllers/activegate/reconciler.go
@@ -171,6 +171,8 @@ func (r *Reconciler) deleteStatefulSetIfOldLabelsAreUsed(desiredSts *appsv1.Stat
 
 	if !reflect.DeepEqual(currentSts.Labels, desiredSts.Labels) {
 		r.log.Info("Deleting existing stateful set")
+
+		// why do we delete desiredSts instead of currentSts???
 		if err = r.Delete(context.TODO(), desiredSts); err != nil {
 			return false, err
 		}

--- a/controllers/activegate/statefulset.go
+++ b/controllers/activegate/statefulset.go
@@ -3,13 +3,13 @@ package activegate
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/controllers/tokens"
 	"hash/fnv"
 	"strconv"
 
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
 	"github.com/Dynatrace/dynatrace-operator/controllers/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/controllers/dtpullsecret"
+	"github.com/Dynatrace/dynatrace-operator/controllers/tokens"
 	"github.com/Dynatrace/dynatrace-operator/deploymentmetadata"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -178,7 +178,7 @@ func buildVolumes(stsProperties *statefulSetProperties) []corev1.Volume {
 		Name: TokensSecretVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: tokens.TokensSecretsName,
+				SecretName: tokens.SecretsName,
 			},
 		},
 	})

--- a/controllers/activegate/statefulset.go
+++ b/controllers/activegate/statefulset.go
@@ -3,6 +3,7 @@ package activegate
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/Dynatrace/dynatrace-operator/controllers/tokens"
 	"hash/fnv"
 	"strconv"
 
@@ -42,6 +43,8 @@ const (
 	DTDeploymentMetadata = "DT_DEPLOYMENT_METADATA"
 
 	ProxyKey = "ProxyKey"
+
+	TokensSecretVolumeName = "dynatrace-tokens-volume"
 )
 
 type StatefulSetEvent func(sts *appsv1.StatefulSet)
@@ -172,10 +175,10 @@ func buildVolumes(stsProperties *statefulSetProperties) []corev1.Volume {
 	}
 
 	volumes = append(volumes, corev1.Volume{
-		Name: "ag-secrets",
+		Name: TokensSecretVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: "ag-secrets",
+				SecretName: tokens.TokensSecretsName,
 			},
 		},
 	})
@@ -194,8 +197,8 @@ func buildVolumeMounts(stsProperties *statefulSetProperties) []corev1.VolumeMoun
 	var volumeMounts []corev1.VolumeMount
 
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      TokensSecretVolumeName,
 		ReadOnly:  true,
-		Name:      "ag-secrets",
 		MountPath: "/var/lib/dynatrace/secrets",
 	})
 

--- a/controllers/activegate/statefulset.go
+++ b/controllers/activegate/statefulset.go
@@ -171,6 +171,15 @@ func buildVolumes(stsProperties *statefulSetProperties) []corev1.Volume {
 		)
 	}
 
+	volumes = append(volumes, corev1.Volume{
+		Name: "ag-secrets",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "ag-secrets",
+			},
+		},
+	})
+
 	return volumes
 }
 
@@ -183,6 +192,12 @@ func determineCustomPropertiesSource(stsProperties *statefulSetProperties) strin
 
 func buildVolumeMounts(stsProperties *statefulSetProperties) []corev1.VolumeMount {
 	var volumeMounts []corev1.VolumeMount
+
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		ReadOnly:  true,
+		Name:      "ag-secrets",
+		MountPath: "/var/lib/dynatrace/secrets",
+	})
 
 	if !isCustomPropertiesNilOrEmpty(stsProperties.CustomProperties) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{

--- a/controllers/activegate/statefulset_test.go
+++ b/controllers/activegate/statefulset_test.go
@@ -1,12 +1,12 @@
 package activegate
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/controllers/tokens"
 	"testing"
 
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
 	"github.com/Dynatrace/dynatrace-operator/controllers/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/controllers/dtpullsecret"
+	"github.com/Dynatrace/dynatrace-operator/controllers/tokens"
 	"github.com/Dynatrace/dynatrace-operator/deploymentmetadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -127,7 +127,7 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 		Name: TokensSecretVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: tokens.TokensSecretsName,
+				SecretName: tokens.SecretsName,
 			},
 		},
 	})
@@ -169,7 +169,7 @@ func TestStatefulSet_Volumes(t *testing.T) {
 			Name: TokensSecretVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: tokens.TokensSecretsName,
+					SecretName: tokens.SecretsName,
 				},
 			},
 		})

--- a/controllers/activegate/statefulset_test.go
+++ b/controllers/activegate/statefulset_test.go
@@ -1,6 +1,7 @@
 package activegate
 
 import (
+	"github.com/Dynatrace/dynatrace-operator/controllers/tokens"
 	"testing"
 
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
@@ -121,7 +122,15 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 			},
 		}})
 	assert.Equal(t, capabilityProperties.Tolerations, templateSpec.Tolerations)
-	assert.Empty(t, templateSpec.Volumes)
+	assert.Len(t, templateSpec.Volumes, 1)
+	assert.Contains(t, templateSpec.Volumes, corev1.Volume{
+		Name: TokensSecretVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: tokens.TokensSecretsName,
+			},
+		},
+	})
 	assert.NotEmpty(t, templateSpec.ImagePullSecrets)
 	assert.Contains(t, templateSpec.ImagePullSecrets, corev1.LocalObjectReference{Name: instance.Name + dtpullsecret.PullSecretSuffix})
 }
@@ -138,7 +147,12 @@ func TestStatefulSet_Container(t *testing.T) {
 	assert.Equal(t, corev1.PullAlways, container.ImagePullPolicy)
 	assert.NotEmpty(t, container.Env)
 	assert.Empty(t, container.Args)
-	assert.Empty(t, container.VolumeMounts)
+	assert.Len(t, container.VolumeMounts, 1)
+	assert.Contains(t, container.VolumeMounts, corev1.VolumeMount{
+		ReadOnly:  true,
+		Name:      TokensSecretVolumeName,
+		MountPath: "/var/lib/dynatrace/secrets",
+	})
 	assert.NotNil(t, container.ReadinessProbe)
 }
 
@@ -150,7 +164,15 @@ func TestStatefulSet_Volumes(t *testing.T) {
 		volumes := buildVolumes(NewStatefulSetProperties(instance, capabilityProperties,
 			"", "", "", "", ""))
 
-		assert.Empty(t, volumes)
+		assert.Len(t, volumes, 1)
+		assert.Contains(t, volumes, corev1.Volume{
+			Name: TokensSecretVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: tokens.TokensSecretsName,
+				},
+			},
+		})
 	})
 	t.Run(`custom properties from value string`, func(t *testing.T) {
 		capabilityProperties.CustomProperties = &dynatracev1alpha1.DynaKubeValueSource{
@@ -269,19 +291,29 @@ func TestStatefulSet_VolumeMounts(t *testing.T) {
 	t.Run(`without custom properties`, func(t *testing.T) {
 		volumeMounts := buildVolumeMounts(NewStatefulSetProperties(instance, capabilityProperties,
 			"", "", "", "", ""))
-		assert.Empty(t, volumeMounts)
+		assert.Len(t, volumeMounts, 1)
+		assert.Contains(t, volumeMounts, corev1.VolumeMount{
+			ReadOnly:  true,
+			Name:      TokensSecretVolumeName,
+			MountPath: "/var/lib/dynatrace/secrets",
+		})
 	})
 	t.Run(`with custom properties`, func(t *testing.T) {
 		capabilityProperties.CustomProperties = &dynatracev1alpha1.DynaKubeValueSource{Value: testValue}
 		volumeMounts := buildVolumeMounts(NewStatefulSetProperties(instance, capabilityProperties,
 			"", "", "", "", ""))
 
-		assert.NotEmpty(t, volumeMounts)
+		assert.Len(t, volumeMounts, 2)
 		assert.Contains(t, volumeMounts, corev1.VolumeMount{
 			ReadOnly:  true,
 			Name:      customproperties.VolumeName,
 			MountPath: customproperties.MountPath,
 			SubPath:   customproperties.DataPath,
+		})
+		assert.Contains(t, volumeMounts, corev1.VolumeMount{
+			ReadOnly:  true,
+			Name:      TokensSecretVolumeName,
+			MountPath: "/var/lib/dynatrace/secrets",
 		})
 	})
 }

--- a/controllers/dynakube/dtclient_reconciler.go
+++ b/controllers/dynakube/dtclient_reconciler.go
@@ -46,25 +46,7 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance *dyn
 	ns := instance.GetNamespace()
 	secretName := instance.Tokens()
 
-	var tokens []*tokenConfig
-
-	if r.UpdatePaaSToken {
-		tokens = append(tokens, &tokenConfig{
-			Type:      dynatracev1alpha1.PaaSTokenConditionType,
-			Key:       dtclient.DynatracePaasToken,
-			Scope:     dtclient.TokenScopeInstallerDownload,
-			Timestamp: &sts.LastPaaSTokenProbeTimestamp,
-		})
-	}
-
-	if r.UpdateAPIToken {
-		tokens = append(tokens, &tokenConfig{
-			Type:      dynatracev1alpha1.APITokenConditionType,
-			Key:       dtclient.DynatraceApiToken,
-			Scope:     dtclient.TokenScopeDataExport,
-			Timestamp: &sts.LastAPITokenProbeTimestamp,
-		})
-	}
+	tokens := r.collectTokens(sts)
 
 	updateCR := false
 
@@ -208,6 +190,29 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance *dyn
 	}
 
 	return dtc, updateCR, nil
+}
+
+func (r *DynatraceClientReconciler) collectTokens(sts *dynatracev1alpha1.DynaKubeStatus) []*tokenConfig {
+	var tokens []*tokenConfig
+
+	if r.UpdatePaaSToken {
+		tokens = append(tokens, &tokenConfig{
+			Type:      dynatracev1alpha1.PaaSTokenConditionType,
+			Key:       dtclient.DynatracePaasToken,
+			Scope:     dtclient.TokenScopeInstallerDownload,
+			Timestamp: &sts.LastPaaSTokenProbeTimestamp,
+		})
+	}
+
+	if r.UpdateAPIToken {
+		tokens = append(tokens, &tokenConfig{
+			Type:      dynatracev1alpha1.APITokenConditionType,
+			Key:       dtclient.DynatraceApiToken,
+			Scope:     dtclient.TokenScopeDataExport,
+			Timestamp: &sts.LastAPITokenProbeTimestamp,
+		})
+	}
+	return tokens
 }
 
 func setCondition(conditions *[]metav1.Condition, condition metav1.Condition) bool {

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -3,7 +3,6 @@ package dynakube
 import (
 	"context"
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/controllers/tokens"
 	"net/http"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/controllers/dynakube/updates"
 	"github.com/Dynatrace/dynatrace-operator/controllers/istio"
 	"github.com/Dynatrace/dynatrace-operator/controllers/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/controllers/tokens"
 	"github.com/Dynatrace/dynatrace-operator/controllers/utils"
 	"github.com/Dynatrace/dynatrace-operator/dtclient"
 	"github.com/go-logr/logr"

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -3,6 +3,7 @@ package dynakube
 import (
 	"context"
 	"fmt"
+	"github.com/Dynatrace/dynatrace-operator/controllers/tokens"
 	"net/http"
 	"time"
 
@@ -156,6 +157,15 @@ func (r *ReconcileDynaKube) reconcileImpl(ctx context.Context, rec *utils.Reconc
 	secret, err := r.getTokenSecret(ctx, rec.Instance)
 	if err != nil {
 		rec.Log.Error(err, "could not find token secret")
+		return
+	}
+
+	upd, err = tokens.
+		NewReconciler(r.client, r.apiReader, r.scheme, rec.Instance, dtc, rec.Log).
+		Reconcile()
+	rec.Update(upd, defaultUpdateInterval, "AG tokens conditions updated")
+	if rec.Error(err) {
+		rec.Log.Error(err, "could not reconcile AG tokens")
 		return
 	}
 

--- a/controllers/dynakube/dynakube_controller_test.go
+++ b/controllers/dynakube/dynakube_controller_test.go
@@ -117,6 +117,13 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 			}, nil)
 		mockClient.On("GetTokenScopes", testPaasToken).Return(dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, nil)
 		mockClient.On("GetTokenScopes", testAPIToken).Return(dtclient.TokenScopes{dtclient.TokenScopeDataExport}, nil)
+		mockClient.On("GetAGTenantInfo").
+			Return(&dtclient.TenantInfo{
+				ID:                    "123",
+				Token:                 "asdf",
+				Endpoints:             []string{"aaa", "bbb", "ccc"},
+				CommunicationEndpoint: "comm",
+			}, nil)
 
 		result, err := r.Reconcile(context.TODO(), reconcile.Request{
 			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
@@ -182,6 +189,13 @@ func TestReconcile_RemoveRoutingIfDisabled(t *testing.T) {
 		}, nil)
 	mockClient.On("GetTokenScopes", testPaasToken).Return(dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, nil)
 	mockClient.On("GetTokenScopes", testAPIToken).Return(dtclient.TokenScopes{dtclient.TokenScopeDataExport}, nil)
+	mockClient.On("GetAGTenantInfo").
+		Return(&dtclient.TenantInfo{
+			ID:                    "123",
+			Token:                 "asdf",
+			Endpoints:             []string{"aaa", "bbb", "ccc"},
+			CommunicationEndpoint: "comm",
+		}, nil)
 
 	_, err := r.Reconcile(context.TODO(), request)
 	assert.NoError(t, err)

--- a/controllers/dynakube/dynakube_controller_test.go
+++ b/controllers/dynakube/dynakube_controller_test.go
@@ -42,6 +42,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		mockClient.On("GetTokenScopes", testPaasToken).Return(dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, nil)
 		mockClient.On("GetTokenScopes", testAPIToken).Return(dtclient.TokenScopes{dtclient.TokenScopeDataExport}, nil)
 		mockClient.On("GetConnectionInfo").Return(dtclient.ConnectionInfo{TenantUUID: "abc123456"}, nil)
+		mockClient.On("GetAGTenantInfo").Return(&dtclient.TenantInfo{}, nil)
 		instance := &v1alpha1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,

--- a/controllers/tokens/agtokens_reconciler.go
+++ b/controllers/tokens/agtokens_reconciler.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	TokensSecretsName = "dynatrace-tokens"
+	SecretsName = "dynatrace-tokens"
 )
 
 type Reconciler struct {
@@ -69,7 +69,7 @@ func (r *Reconciler) reconcileAGTokens() error {
 
 func (r *Reconciler) createAGTokensSecretIfNotExists(secretData map[string][]byte) (*corev1.Secret, error) {
 	var config corev1.Secret
-	err := r.apiReader.Get(context.TODO(), client.ObjectKey{Name: TokensSecretsName, Namespace: r.instance.Namespace}, &config)
+	err := r.apiReader.Get(context.TODO(), client.ObjectKey{Name: SecretsName, Namespace: r.instance.Namespace}, &config)
 	if k8serrors.IsNotFound(err) {
 		r.log.Info("Creating AG Tokens secret")
 		return r.createAGTokensSecret(secretData)
@@ -93,7 +93,7 @@ func (r *Reconciler) createAGTokensSecret(agTokensSecretData map[string][]byte) 
 
 	err := r.Create(context.TODO(), agTokens)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create secret '%s': %w", TokensSecretsName, err)
+		return nil, fmt.Errorf("failed to create secret '%s': %w", SecretsName, err)
 	}
 	return agTokens, nil
 }
@@ -123,7 +123,7 @@ func isAGTokensSecretEqual(currentSecret *corev1.Secret, desired map[string][]by
 func BuildAGTokensSecret(instance *dynatracev1alpha1.DynaKube, agTokensSecretData map[string][]byte) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      TokensSecretsName,
+			Name:      SecretsName,
 			Namespace: instance.Namespace,
 		},
 		Type: corev1.SecretTypeOpaque,

--- a/controllers/tokens/agtokens_reconciler.go
+++ b/controllers/tokens/agtokens_reconciler.go
@@ -1,0 +1,132 @@
+package tokens
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
+	"github.com/Dynatrace/dynatrace-operator/dtclient"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	TokensSecretsName = "dynatrace-tokens"
+)
+
+type Reconciler struct {
+	client.Client
+	apiReader client.Reader
+	instance  *dynatracev1alpha1.DynaKube
+	dtc       dtclient.Client
+	log       logr.Logger
+	scheme    *runtime.Scheme
+}
+
+func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, instance *dynatracev1alpha1.DynaKube, dtc dtclient.Client, log logr.Logger) *Reconciler {
+	return &Reconciler{
+		Client:    clt,
+		apiReader: apiReader,
+		scheme:    scheme,
+		instance:  instance,
+		dtc:       dtc,
+		log:       log,
+	}
+}
+
+func (r *Reconciler) Reconcile() (bool, error) {
+	if r.instance.Spec.AGTokensSecret == "" {
+		err := r.reconcileAGTokens()
+		if err != nil {
+			r.log.Error(err, "could not reconcile ag tokens")
+			return false, errors.WithStack(err)
+		}
+	}
+
+	return false, nil
+}
+
+func (r *Reconciler) reconcileAGTokens() error {
+	agTokens, err := r.getAGTokens()
+	if err != nil {
+		return fmt.Errorf("could not fetch AG tokens: %w", err)
+	}
+
+	agTokensSecret, err := r.createAGTokensSecretIfNotExists(agTokens)
+	if err != nil {
+		return fmt.Errorf("failed to create or update secret: %w", err)
+	}
+
+	return r.updateAGTokensIfOutdated(agTokensSecret, agTokens)
+}
+
+func (r *Reconciler) createAGTokensSecretIfNotExists(secretData map[string][]byte) (*corev1.Secret, error) {
+	var config corev1.Secret
+	err := r.apiReader.Get(context.TODO(), client.ObjectKey{Name: TokensSecretsName, Namespace: r.instance.Namespace}, &config)
+	if k8serrors.IsNotFound(err) {
+		r.log.Info("Creating AG Tokens secret")
+		return r.createAGTokensSecret(secretData)
+	}
+	return &config, err
+}
+
+func (r *Reconciler) updateAGTokensIfOutdated(agTokens *corev1.Secret, agTokensSecretData map[string][]byte) error {
+	if !isAGTokensSecretEqual(agTokens, agTokensSecretData) {
+		return r.updateAGTokensSecret(agTokens, agTokensSecretData)
+	}
+	return nil
+}
+
+func (r *Reconciler) createAGTokensSecret(agTokensSecretData map[string][]byte) (*corev1.Secret, error) {
+	agTokens := BuildAGTokensSecret(r.instance, agTokensSecretData)
+
+	if err := controllerutil.SetControllerReference(r.instance, agTokens, r.scheme); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	err := r.Create(context.TODO(), agTokens)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create secret '%s': %w", TokensSecretsName, err)
+	}
+	return agTokens, nil
+}
+
+func (r *Reconciler) updateAGTokensSecret(agTokensSecret *corev1.Secret, desiredAGTokensSecretData map[string][]byte) error {
+	r.log.Info(fmt.Sprintf("Updating secret %s", agTokensSecret.Name))
+	agTokensSecret.Data = desiredAGTokensSecretData
+	if err := r.Update(context.TODO(), agTokensSecret); err != nil {
+		return fmt.Errorf("failed to update secret %s: %w", agTokensSecret.Name, err)
+	}
+	return nil
+}
+
+func (r *Reconciler) getAGTokens() (map[string][]byte, error) {
+	info, err := r.dtc.GetAGTenantInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string][]byte{"tenant-token": []byte(info.Token)}, nil
+}
+
+func isAGTokensSecretEqual(currentSecret *corev1.Secret, desired map[string][]byte) bool {
+	return reflect.DeepEqual(desired, currentSecret.Data)
+}
+
+func BuildAGTokensSecret(instance *dynatracev1alpha1.DynaKube, agTokensSecretData map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TokensSecretsName,
+			Namespace: instance.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: agTokensSecretData,
+	}
+}

--- a/controllers/tokens/agtokens_reconciler_test.go
+++ b/controllers/tokens/agtokens_reconciler_test.go
@@ -1,0 +1,183 @@
+package tokens
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/api/v1alpha1"
+	"github.com/Dynatrace/dynatrace-operator/dtclient"
+	"github.com/Dynatrace/dynatrace-operator/scheme"
+	"github.com/Dynatrace/dynatrace-operator/scheme/fake"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	testName      = "test-name"
+	testNamespace = "test-namespace"
+)
+
+var instance *v1alpha1.DynaKube
+var secretsData map[string][]byte
+var moreSecretsData map[string][]byte
+var lessSecretsData map[string][]byte
+
+func init() {
+	instance = &v1alpha1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
+	}
+
+	secretsData = map[string][]byte{
+		"tokenname":    []byte("secretdata"),
+		"anothertoken": []byte("topsecret"),
+	}
+
+	moreSecretsData = map[string][]byte{
+		"tokenname":    []byte("secretdata"),
+		"anothertoken": []byte("topsecret"),
+		"extra":        []byte("aaa"),
+	}
+
+	lessSecretsData = map[string][]byte{
+		"tokenname": []byte("secretdata"),
+	}
+}
+
+func TestBuildAGTokensSecret(t *testing.T) {
+	type args struct {
+		instance           *v1alpha1.DynaKube
+		agTokensSecretData map[string][]byte
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Secret
+	}{
+		{
+			name: "",
+			args: args{
+				instance:           instance,
+				agTokensSecretData: secretsData,
+			},
+			want: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      SecretsName,
+					Namespace: instance.Namespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: secretsData,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BuildAGTokensSecret(tt.args.instance, tt.args.agTokensSecretData); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BuildAGTokensSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func createDefaultReconciler(fakeClient client.Client, dtc *dtclient.MockDynatraceClient) *Reconciler {
+	return &Reconciler{
+		Client:    fakeClient,
+		apiReader: fakeClient,
+		instance:  instance,
+		dtc:       dtc,
+		log:       zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)),
+		scheme:    scheme.Scheme,
+	}
+}
+
+func TestReconciler_getAGTokens(t *testing.T) {
+	tenantToken := "blablabla"
+
+	mockDtcClient := &dtclient.MockDynatraceClient{}
+	fakeClient := fake.NewClient()
+
+	mockDtcClient.On("GetAGTenantInfo").
+		Return(&dtclient.TenantInfo{
+			Token: tenantToken,
+		}, nil)
+
+	tests := []struct {
+		name    string
+		want    map[string][]byte
+		wantErr bool
+	}{
+		{
+			name:    "",
+			want:    map[string][]byte{"tenant-token": []byte(tenantToken)},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := createDefaultReconciler(fakeClient, mockDtcClient)
+			got, err := r.getAGTokens()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getAGTokens() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAGTokens() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isAGTokensSecretEqual(t *testing.T) {
+	type args struct {
+		currentSecret *corev1.Secret
+		desired       map[string][]byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "equal",
+			args: args{
+				currentSecret: BuildAGTokensSecret(&v1alpha1.DynaKube{}, secretsData),
+				desired:       secretsData,
+			},
+			want: true,
+		},
+		{
+			name: "inequal - subset of data",
+			args: args{
+				currentSecret: BuildAGTokensSecret(&v1alpha1.DynaKube{}, lessSecretsData),
+				desired:       secretsData,
+			},
+			want: false,
+		},
+		{
+			name: "inequal - superset of data",
+			args: args{
+				currentSecret: BuildAGTokensSecret(&v1alpha1.DynaKube{}, moreSecretsData),
+				desired:       secretsData,
+			},
+			want: false,
+		},
+		{
+			name: "inequal - completly different data",
+			args: args{
+				currentSecret: BuildAGTokensSecret(&v1alpha1.DynaKube{}, map[string][]byte{"other": []byte("data")}),
+				desired:       secretsData,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAGTokensSecretEqual(tt.args.currentSecret, tt.args.desired); got != tt.want {
+				t.Errorf("isAGTokensSecretEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/dtclient/client.go
+++ b/dtclient/client.go
@@ -52,8 +52,11 @@ type Client interface {
 	// GetTokenScopes returns the list of scopes assigned to a token if successful.
 	GetTokenScopes(token string) (TokenScopes, error)
 
-	// GetTenantInfo returns TenantInfo that holds UUID, Tenant Token and Endpoints
-	GetTenantInfo() (*TenantInfo, error)
+	// GetAgentTenantInfo returns TenantInfo that holds UUID, Tenant Token and Endpoints
+	GetAgentTenantInfo() (*TenantInfo, error)
+
+	// GetAGTenantInfo returns TenantInfo that holds UUID, Tenant Token and Endpoints
+	GetAGTenantInfo() (*TenantInfo, error)
 }
 
 // Known OS values.

--- a/dtclient/mock_client.go
+++ b/dtclient/mock_client.go
@@ -11,7 +11,12 @@ type MockDynatraceClient struct {
 	mock.Mock
 }
 
-func (o *MockDynatraceClient) GetTenantInfo() (*TenantInfo, error) {
+func (o *MockDynatraceClient) GetAGTenantInfo() (*TenantInfo, error) {
+	args := o.Called()
+	return args.Get(0).(*TenantInfo), args.Error(1)
+}
+
+func (o *MockDynatraceClient) GetAgentTenantInfo() (*TenantInfo, error) {
 	args := o.Called()
 	return args.Get(0).(*TenantInfo), args.Error(1)
 }

--- a/dtclient/tenant_test.go
+++ b/dtclient/tenant_test.go
@@ -22,11 +22,11 @@ var tenantResponse = struct {
 }
 
 func TestTenant(t *testing.T) {
-	t.Run("GetTenantInfo", func(t *testing.T) {
+	t.Run("GetAgentTenantInfo", func(t *testing.T) {
 		dynatraceServer, dynatraceClient := createTestDynatraceClient(t, tenantServerHandler())
 		defer dynatraceServer.Close()
 
-		tenantInfo, err := dynatraceClient.GetTenantInfo()
+		tenantInfo, err := dynatraceClient.GetAgentTenantInfo()
 		assert.NoError(t, err)
 		assert.NotNil(t, tenantInfo)
 
@@ -37,21 +37,21 @@ func TestTenant(t *testing.T) {
 			strings.Join([]string{tenantResponse.CommunicationEndpoints[0], DtCommunicationSuffix}, Slash),
 			tenantInfo.CommunicationEndpoint)
 	})
-	t.Run("GetTenantInfo handle internal server error", func(t *testing.T) {
+	t.Run("GetAgentTenantInfo handle internal server error", func(t *testing.T) {
 		faultyDynatraceServer, faultyDynatraceClient := createTestDynatraceClient(t, tenantInternalServerError())
 		defer faultyDynatraceServer.Close()
 
-		tenantInfo, err := faultyDynatraceClient.GetTenantInfo()
+		tenantInfo, err := faultyDynatraceClient.GetAgentTenantInfo()
 		assert.Error(t, err)
 		assert.Nil(t, tenantInfo)
 
 		assert.Equal(t, "dynatrace server error 500: error retrieving tenant info", err.Error())
 	})
-	t.Run("GetTenantInfo handle malformed json", func(t *testing.T) {
+	t.Run("GetAgentTenantInfo handle malformed json", func(t *testing.T) {
 		faultyDynatraceServer, faultyDynatraceClient := createTestDynatraceClient(t, tenantMalformedJson())
 		defer faultyDynatraceServer.Close()
 
-		tenantInfo, err := faultyDynatraceClient.GetTenantInfo()
+		tenantInfo, err := faultyDynatraceClient.GetAgentTenantInfo()
 		assert.Error(t, err)
 		assert.Nil(t, tenantInfo)
 


### PR DESCRIPTION
_Connection info_ is:
* tenantUUID
* tenantToken
* communicationEndpoint

Operator retrieves connection info from DT cluster using REST API.
Non-secrets are set as environment variables in AG pod.
Secrets are mounted as volumes.

The complementary change was made in AG Dockerfile to make use of these data - if Operator sets them, they override data set by cluster in `entrypoint.properties`.