### PR TITLE
Makefile explicitly uses bash instead of sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = bash
+
 # Current Operator version
 VERSION ?= 0.0.1
 # Default bundle image tag


### PR DESCRIPTION
```
$ make test
...
source /home/michal/workspace/dynatrace-operator/testbin/setup-envtest.sh; fetch_envtest_tools /home/michal/workspace/dynatrace-operator/testbin; setup_envtest_env /home/michal/workspace/dynatrace-operator/testbin; go test ./... -coverprofile cover.out
/bin/sh: 1: source: not found
/bin/sh: 1: fetch_envtest_tools: not found
/bin/sh: 1: setup_envtest_env: not found
ok      github.com/Dynatrace/dynatrace-operator/api/v1alpha1    0.007s  coverage: 8.0% of statements
?       github.com/Dynatrace/dynatrace-operator/cmd/csidriver   [no test files]
?       github.com/Dynatrace/dynatrace-operator/cmd/operator    [no test files]
...
```

Makefile uses `sh` as the default shell, on ubuntu:
```
$ ls -l `which sh`
lrwxrwxrwx 1 root root 4 lut  6 12:03 /usr/bin/sh -> dash
```
`dash` supports only using POSIX features. 

`source` is not POSIX compliant, `.` should be used instead.
Problem is that loaded scripts shebang is `bash`, so it doesn't work:
```
...
. /home/michal/workspace/dynatrace-operator/testbin/setup-envtest.sh; fetch_envtest_tools /home/michal/workspace/dynatrace-operator/testbin; setup_envtest_env /home/michal/workspace/dynatrace-operator/testbin; go test ./... -coverprofile cover.out
/bin/sh: 18: set: Illegal option -o pipefail
make: *** [Makefile:42: test] Error 2
```

Therefore the solution is simply to use `SHELL = bash` in `Makefile`:
```
source /home/michal/workspace/dynatrace-operator/testbin/setup-envtest.sh; fetch_envtest_tools /home/michal/workspace/dynatrace-operator/testbin; setup_envtest_env /home/michal/workspace/dynatrace-operator/testbin; go test ./... -coverprofile cover.out
Using cached envtest tools from /home/michal/workspace/dynatrace-operator/testbin
setting up env vars
```