### PR TITLE
Removed quotes around ${CLUSTER_NAME} in host group parameter.

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -134,7 +134,7 @@ buildClassicFullStackArgsField() {
   if [ -n "$CLUSTER_NAME" ]; then
     cat <<EOF
     args:
-    - --set-host-group="${CLUSTER_NAME}"
+    - --set-host-group=${CLUSTER_NAME}
 EOF
   fi
 }


### PR DESCRIPTION
Issue #160
Host Group parameter not applied

Modify the host group in install.sh file, remove the double quotes.
OLD:
- --set-host-group="${CLUSTER_NAME}"
NEW:
- --set-host-group=${CLUSTER_NAME}