### PR TITLE
APM-308295 Add explicit nonResourceURLs endpoints for kubernetes-monitoring

### DIFF
--- a/config/common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
+++ b/config/common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
@@ -33,5 +33,8 @@ rules:
       - get
   - nonResourceURLs:
       - /metrics
+      - /version
+      - /readyz
+      - /healthz
     verbs:
       - get


### PR DESCRIPTION
Add explicit nonResourceURLs endpoints in kubernetes-monitoring cluster role:

- readyz
- healthz
- version