### PR TITLE
Replace os with afero

### DIFF
--- a/cmd/csidriver/main.go
+++ b/cmd/csidriver/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/scheme"
 	"github.com/Dynatrace/dynatrace-operator/version"
+	"github.com/spf13/afero"
 	"golang.org/x/sys/unix"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -77,12 +78,14 @@ func main() {
 		GCInterval: time.Duration(gcInterval) * time.Minute,
 	}
 
-	if err := os.MkdirAll(filepath.Join(csiOpts.RootDir, dtcsi.DataPath), 0770); err != nil {
+	fs := afero.NewOsFs()
+
+	if err := fs.MkdirAll(filepath.Join(csiOpts.RootDir, dtcsi.DataPath), 0770); err != nil {
 		log.Error(err, "unable to create data directory for CSI Driver")
 		os.Exit(1)
 	}
 
-	if err := os.MkdirAll(filepath.Join(csiOpts.RootDir, dtcsi.GarbageCollectionPath), 0770); err != nil {
+	if err := fs.MkdirAll(filepath.Join(csiOpts.RootDir, dtcsi.GarbageCollectionPath), 0770); err != nil {
 		log.Error(err, "unable to create garbage collector directory for CSI Driver")
 		os.Exit(1)
 	}

--- a/controllers/csi/provisioner/reconciler.go
+++ b/controllers/csi/provisioner/reconciler.go
@@ -169,7 +169,7 @@ func (r *OneAgentProvisioner) installAgentVersion(version string, envDir string,
 	}
 
 	gcDir := filepath.Join(envDir, dtcsi.GarbageCollectionPath, version)
-	if err := os.MkdirAll(gcDir, 0755); err != nil {
+	if err := r.fs.MkdirAll(gcDir, 0755); err != nil {
 		logger.Error(err, "failed to create directory %s: %w", gcDir)
 		return err
 	}


### PR DESCRIPTION
We are still using os in /controllers/csi/driver/mount.
This won't change as the Mount struct in "k8s.io/utils/mount" assumes we use a real file system.