### PR TITLE
Cleaner metrics

### DIFF
--- a/controllers/csi/driver/server.go
+++ b/controllers/csi/driver/server.go
@@ -256,7 +256,7 @@ func (svr *CSIDriverServer) fireVolumeUnpublishedMetric(usageFilePath string) {
 		agentsVersionsMetric.WithLabelValues(version).Dec()
 		var m = &dto.Metric{}
 		if err := agentsVersionsMetric.WithLabelValues(version).Write(m); err != nil {
-			svr.log.Error(err, "Failed to get the value of agent version metric")
+			svr.log.Error(err, "failed to get the value of agent version metric")
 		}
 		if m.Gauge.GetValue() <= float64(0) {
 			agentsVersionsMetric.DeleteLabelValues(version)

--- a/controllers/csi/driver/server.go
+++ b/controllers/csi/driver/server.go
@@ -61,7 +61,7 @@ var (
 		Namespace: "dynatrace",
 		Subsystem: "csi_driver",
 		Name:      "agent_versions",
-		Help:      "Number of an agent version currently mounted by the CI driver",
+		Help:      "Number of an agent version currently mounted by the CSI driver",
 	}, []string{"version"})
 	memoryMetricTick = 5000 * time.Millisecond
 )

--- a/controllers/csi/driver/server_test.go
+++ b/controllers/csi/driver/server_test.go
@@ -173,7 +173,7 @@ func TestServer_NodeUnpublishVolume(t *testing.T) {
 
 		response, err := server.NodeUnpublishVolume(context.TODO(), nodeUnpublishVolumeRequest)
 
-		assert.Equal(t, 1, testutil.CollectAndCount(agentsVersionsMetric))
+		assert.Equal(t, 0, testutil.CollectAndCount(agentsVersionsMetric))
 		assert.Equal(t, float64(0), testutil.ToFloat64(agentsVersionsMetric.WithLabelValues(agentVersion)))
 
 		assert.NoError(t, err)
@@ -192,7 +192,7 @@ func TestServer_NodeUnpublishVolume(t *testing.T) {
 
 		response, err := server.NodeUnpublishVolume(context.TODO(), nodeUnpublishVolumeRequest)
 
-		assert.Equal(t, 1, testutil.CollectAndCount(agentsVersionsMetric))
+		assert.Equal(t, 0, testutil.CollectAndCount(agentsVersionsMetric))
 		assert.Equal(t, float64(0), testutil.ToFloat64(agentsVersionsMetric.WithLabelValues(agentVersion)))
 
 		assert.NoError(t, err)
@@ -234,7 +234,7 @@ func TestCSIDriverServer_NodePublishAndUnpublishVolume(t *testing.T) {
 
 	unpublishResponse, err := server.NodeUnpublishVolume(context.TODO(), nodeUnpublishVolumeRequest)
 
-	assert.Equal(t, 1, testutil.CollectAndCount(agentsVersionsMetric))
+	assert.Equal(t, 0, testutil.CollectAndCount(agentsVersionsMetric))
 	assert.Equal(t, float64(0), testutil.ToFloat64(agentsVersionsMetric.WithLabelValues(agentVersion)))
 
 	assert.NoError(t, err)
@@ -351,5 +351,5 @@ func assertNoReferencesForUnpublishedVolume(t *testing.T, fs afero.Afero) {
 }
 
 func resetMetrics() {
-	agentsVersionsMetric.WithLabelValues(agentVersion).Set(0)
+	agentsVersionsMetric.DeleteLabelValues(agentVersion)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/go-logr/logr v0.3.0
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.7.1 // indirect
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.15.0 // indirect
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/pflag v1.0.5
@@ -19,7 +20,7 @@ require (
 	istio.io/api v0.0.0-20201217173512-1f62aaeb5ee3
 	istio.io/client-go v1.8.1
 	k8s.io/api v0.19.4
-	k8s.io/apiextensions-apiserver v0.19.4
+	k8s.io/apiextensions-apiserver v0.19.4 // indirect
 	k8s.io/apimachinery v0.19.4
 	k8s.io/client-go v0.19.4
 	k8s.io/utils v0.0.0-20200912215256-4140de9c8800


### PR DESCRIPTION
To not have a bunch of 0 values for no longer used version labels in `agentsVersionsMetric`, now it deletes these labels