### PR TITLE
Fix missing proxy when using value field

### DIFF
--- a/controllers/oneagent/daemonset.go
+++ b/controllers/oneagent/daemonset.go
@@ -11,7 +11,11 @@ import (
 func prepareArgs(instance *dynatracev1alpha1.DynaKube, fs *dynatracev1alpha1.FullStackSpec, feature string, clusterID string) []string {
 	args := fs.Args
 	if p := instance.Spec.Proxy; p != nil && (p.ValueFrom != "" || p.Value != "") {
-		args = append(args, fmt.Sprintf("--set-proxy=${%s}", DTProxy))
+		if p.Value != "" {
+			args = append(args, fmt.Sprintf("--set-proxy=%s", p.Value))
+		} else {
+			args = append(args, fmt.Sprintf("--set-proxy=${%s}", DTProxy))
+		}
 	}
 
 	if instance.Spec.NetworkZone != "" {

--- a/controllers/oneagent/daemonset.go
+++ b/controllers/oneagent/daemonset.go
@@ -11,7 +11,7 @@ import (
 func prepareArgs(instance *dynatracev1alpha1.DynaKube, fs *dynatracev1alpha1.FullStackSpec, feature string, clusterID string) []string {
 	args := fs.Args
 	if p := instance.Spec.Proxy; p != nil && (p.ValueFrom != "" || p.Value != "") {
-		args = append(args, fmt.Sprintf("--set-proxy=$(%s)", DTProxy))
+		args = append(args, fmt.Sprintf("--set-proxy=${%s}", DTProxy))
 	}
 
 	if instance.Spec.NetworkZone != "" {

--- a/controllers/oneagent/daemonset.go
+++ b/controllers/oneagent/daemonset.go
@@ -10,8 +10,8 @@ import (
 
 func prepareArgs(instance *dynatracev1alpha1.DynaKube, fs *dynatracev1alpha1.FullStackSpec, feature string, clusterID string) []string {
 	args := fs.Args
-	if instance.Spec.Proxy != nil && (instance.Spec.Proxy.ValueFrom != "" || instance.Spec.Proxy.Value != "") {
-		args = append(args, "--set-proxy=$(https_proxy)")
+	if p := instance.Spec.Proxy; p != nil && (p.ValueFrom != "" || p.Value != "") {
+		args = append(args, fmt.Sprintf("--set-proxy=$(%s)", DTProxy))
 	}
 
 	if instance.Spec.NetworkZone != "" {

--- a/controllers/oneagent/daemonset.go
+++ b/controllers/oneagent/daemonset.go
@@ -11,11 +11,7 @@ import (
 func prepareArgs(instance *dynatracev1alpha1.DynaKube, fs *dynatracev1alpha1.FullStackSpec, feature string, clusterID string) []string {
 	args := fs.Args
 	if p := instance.Spec.Proxy; p != nil && (p.ValueFrom != "" || p.Value != "") {
-		if p.Value != "" {
-			args = append(args, fmt.Sprintf("--set-proxy=%s", p.Value))
-		} else {
-			args = append(args, fmt.Sprintf("--set-proxy=${%s}", DTProxy))
-		}
+		args = append(args, fmt.Sprintf("--set-proxy=$(%s)", EnvProxy))
 	}
 
 	if instance.Spec.NetworkZone != "" {

--- a/controllers/oneagent/daemonset_test.go
+++ b/controllers/oneagent/daemonset_test.go
@@ -48,15 +48,15 @@ func TestNewPodSpecForCR_Arguments(t *testing.T) {
 		assert.Contains(t, podSpecs.Containers[0].Args, metadataArg)
 	}
 
-	t.Run(`has proxy arg`, func(t *testing.T) {
-		instance.Spec.Proxy = &dynatracev1alpha1.DynaKubeProxy{Value: testValue}
-		podSpecs := newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)
-		assert.Contains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
-
-		instance.Spec.Proxy = nil
-		podSpecs = newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)
-		assert.NotContains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
-	})
+	//t.Run(`has proxy arg`, func(t *testing.T) {
+	//	instance.Spec.Proxy = &dynatracev1alpha1.DynaKubeProxy{Value: testValue}
+	//	podSpecs := newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)
+	//	assert.Contains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
+	//
+	//	instance.Spec.Proxy = nil
+	//	podSpecs = newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)
+	//	assert.NotContains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
+	//})
 	t.Run(`has network zone arg`, func(t *testing.T) {
 		instance.Spec.NetworkZone = testValue
 		podSpecs := newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)

--- a/controllers/oneagent/daemonset_test.go
+++ b/controllers/oneagent/daemonset_test.go
@@ -52,7 +52,7 @@ func TestNewPodSpecForCR_Arguments(t *testing.T) {
 	t.Run(`has proxy arg`, func(t *testing.T) {
 		instance.Spec.Proxy = &dynatracev1alpha1.DynaKubeProxy{Value: testValue}
 		podSpecs := newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)
-		assert.Contains(t, podSpecs.Containers[0].Args, "--set-proxy=$(ONEAGENT_PROXY)")
+		assert.Contains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
 		assert.Contains(t, podSpecs.Containers[0].Env, corev1.EnvVar{Name: EnvProxy, Value: testValue})
 
 		instance.Spec.Proxy = nil

--- a/controllers/oneagent/daemonset_test.go
+++ b/controllers/oneagent/daemonset_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -48,15 +49,16 @@ func TestNewPodSpecForCR_Arguments(t *testing.T) {
 		assert.Contains(t, podSpecs.Containers[0].Args, metadataArg)
 	}
 
-	//t.Run(`has proxy arg`, func(t *testing.T) {
-	//	instance.Spec.Proxy = &dynatracev1alpha1.DynaKubeProxy{Value: testValue}
-	//	podSpecs := newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)
-	//	assert.Contains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
-	//
-	//	instance.Spec.Proxy = nil
-	//	podSpecs = newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)
-	//	assert.NotContains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
-	//})
+	t.Run(`has proxy arg`, func(t *testing.T) {
+		instance.Spec.Proxy = &dynatracev1alpha1.DynaKubeProxy{Value: testValue}
+		podSpecs := newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)
+		assert.Contains(t, podSpecs.Containers[0].Args, "--set-proxy=$(ONEAGENT_PROXY)")
+		assert.Contains(t, podSpecs.Containers[0].Env, corev1.EnvVar{Name: EnvProxy, Value: testValue})
+
+		instance.Spec.Proxy = nil
+		podSpecs = newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)
+		assert.NotContains(t, podSpecs.Containers[0].Args, "--set-proxy=$(ONEAGENT_PROXY)")
+	})
 	t.Run(`has network zone arg`, func(t *testing.T) {
 		instance.Spec.NetworkZone = testValue
 		podSpecs := newPodSpecForCR(instance, fullStackSpecs, ClassicFeature, true, log, testUID)

--- a/controllers/oneagent/oneagent_controller.go
+++ b/controllers/oneagent/oneagent_controller.go
@@ -39,7 +39,7 @@ const (
 	defaultServiceAccountName             = "dynatrace-dynakube-oneagent"
 	defaultUnprivilegedServiceAccountName = "dynatrace-dynakube-oneagent-unprivileged"
 
-	EnvProxy       = "ONEAGENT_PROXY"
+	EnvProxy       = "https_proxy"
 	ProxySecretKey = "proxy"
 )
 

--- a/controllers/oneagent/oneagent_controller.go
+++ b/controllers/oneagent/oneagent_controller.go
@@ -39,7 +39,8 @@ const (
 	defaultServiceAccountName             = "dynatrace-dynakube-oneagent"
 	defaultUnprivilegedServiceAccountName = "dynatrace-dynakube-oneagent-unprivileged"
 
-	EnvProxy = "ONEAGENT_PROXY"
+	EnvProxy       = "ONEAGENT_PROXY"
+	ProxySecretKey = "proxy"
 )
 
 // NewOneAgentReconciler initializes a new ReconcileOneAgent instance
@@ -560,12 +561,12 @@ func prepareEnvVars(instance *dynatracev1alpha1.DynaKube, fs *dynatracev1alpha1.
 				if p.ValueFrom != "" {
 					ev.ValueFrom = &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: instance.Spec.Proxy.ValueFrom},
-							Key:                  "proxy",
+							LocalObjectReference: corev1.LocalObjectReference{Name: p.ValueFrom},
+							Key:                  ProxySecretKey,
 						},
 					}
 				} else {
-					ev.Value = instance.Spec.Proxy.Value
+					ev.Value = p.Value
 				}
 			},
 		})

--- a/controllers/oneagent/oneagent_controller.go
+++ b/controllers/oneagent/oneagent_controller.go
@@ -554,7 +554,9 @@ func prepareEnvVars(instance *dynatracev1alpha1.DynaKube, fs *dynatracev1alpha1.
 	}
 
 	if p := instance.Spec.Proxy; p != nil && (p.Value != "" || p.ValueFrom != "") {
-		proxyEnvVar := &corev1.EnvVar{}
+		proxyEnvVar := &corev1.EnvVar{
+			Name: DTProxy,
+		}
 		if p.ValueFrom != "" {
 			proxyEnvVar.ValueFrom = &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{

--- a/controllers/oneagent/oneagent_controller.go
+++ b/controllers/oneagent/oneagent_controller.go
@@ -39,7 +39,7 @@ const (
 	defaultServiceAccountName             = "dynatrace-dynakube-oneagent"
 	defaultUnprivilegedServiceAccountName = "dynatrace-dynakube-oneagent-unprivileged"
 
-	DTProxy = "DT_PROXY"
+	EnvProxy = "ONEAGENT_PROXY"
 )
 
 // NewOneAgentReconciler initializes a new ReconcileOneAgent instance
@@ -554,22 +554,20 @@ func prepareEnvVars(instance *dynatracev1alpha1.DynaKube, fs *dynatracev1alpha1.
 	}
 
 	if p := instance.Spec.Proxy; p != nil && (p.Value != "" || p.ValueFrom != "") {
-		proxyEnvVar := &corev1.EnvVar{
-			Name: DTProxy,
-		}
-		if p.ValueFrom != "" {
-			proxyEnvVar.ValueFrom = &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: p.ValueFrom},
-					Key:                  "proxy",
-				},
-			}
-		} else {
-			proxyEnvVar.Value = p.Value
-		}
 		reserved = append(reserved, reservedEnvVar{
-			Name:  DTProxy,
-			Value: proxyEnvVar,
+			Name: EnvProxy,
+			Default: func(ev *corev1.EnvVar) {
+				if p.ValueFrom != "" {
+					ev.ValueFrom = &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: instance.Spec.Proxy.ValueFrom},
+							Key:                  "proxy",
+						},
+					}
+				} else {
+					ev.Value = instance.Spec.Proxy.Value
+				}
+			},
 		})
 	}
 


### PR DESCRIPTION
`.proxy.value` is currently not passed correctly on release v0.2