### PR TITLE
Adds is isCloudNativeFullStack into the conf file when cloud native full stack mode is on

### DIFF
--- a/controllers/namespace/init.sh.test-sample
+++ b/controllers/namespace/init.sh.test-sample
@@ -95,7 +95,8 @@ k8s_cluster_id ${cluster_id}" >> ${1}
 
 writeConfHostTo() {
 	echo "[host]
-tenant ${host_tenant}" >> ${1}
+tenant ${host_tenant}
+isCloudNativeFullStack true" >> ${1}
 }
 
 createConfigurationFiles() {

--- a/controllers/namespace/init.sh.tmpl
+++ b/controllers/namespace/init.sh.tmpl
@@ -97,7 +97,8 @@ k8s_cluster_id ${cluster_id}" >> ${1}
 
 writeConfHostTo() {
 	echo "[host]
-tenant ${host_tenant}" >> ${1}
+tenant ${host_tenant}
+isCloudNativeFullStack true" >> ${1}
 }
 
 createConfigurationFiles() {


### PR DESCRIPTION
Cloud Native FullStack == codeModules + infraMonitoring enabled

init.sh gets created if codeModules enabled
`${host_tenant}" != ""` is true when infraMonitoring is enabled
==> This change is simple