### PR TITLE
fix: re-added affinity support for openshift 3.11

### DIFF
--- a/config/openshift3.11/operator/deployment-operator-patch.yaml
+++ b/config/openshift3.11/operator/deployment-operator-patch.yaml
@@ -8,3 +8,16 @@
   value:
     name: DISABLE_WEBHOOK
     value: "true"
+- op: add
+  path: /spec/template/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/-
+  value:
+    matchExpressions:
+      - key: beta.kubernetes.io/arch
+        operator: In
+        values:
+          - amd64
+          - arm64
+      - key: beta.kubernetes.io/os
+        operator: In
+        values:
+          - linux

--- a/controllers/activegate/reconciler/capability/reconciler.go
+++ b/controllers/activegate/reconciler/capability/reconciler.go
@@ -17,6 +17,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -32,10 +33,10 @@ type Reconciler struct {
 	capability.Capability
 }
 
-func NewReconciler(capability capability.Capability, clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, log logr.Logger,
+func NewReconciler(capability capability.Capability, clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, config *rest.Config, log logr.Logger,
 	instance *dynatracev1alpha1.DynaKube, imageVersionProvider dtversion.ImageVersionProvider) *Reconciler {
 	baseReconciler := sts.NewReconciler(
-		clt, apiReader, scheme, log, instance, imageVersionProvider, capability)
+		clt, apiReader, scheme, config, log, instance, imageVersionProvider, capability)
 
 	if capability.GetConfiguration().SetDnsEntryPoint {
 		baseReconciler.AddOnAfterStatefulSetCreateListener(addDNSEntryPoint(instance, capability.GetModuleName()))

--- a/controllers/activegate/reconciler/capability/reconciler_test.go
+++ b/controllers/activegate/reconciler/capability/reconciler_test.go
@@ -59,7 +59,7 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 		return dtversion.ImageVersion{}, nil
 	}
 
-	r := NewReconciler(metricsCapability, clt, clt, scheme.Scheme, log, instance, imgVerProvider)
+	r := NewReconciler(metricsCapability, clt, clt, scheme.Scheme, nil, log, instance, imgVerProvider)
 	require.NotNil(t, r)
 	require.NotNil(t, r.Client)
 	require.NotNil(t, r.Instance)
@@ -175,7 +175,7 @@ func TestReconcile(t *testing.T) {
 
 func TestSetReadinessProbePort(t *testing.T) {
 	r := createDefaultReconciler(t)
-	stsProps := rsfs.NewStatefulSetProperties(r.Instance, metricsCapability.GetProperties(), "", "", "", "", "", nil, nil, nil)
+	stsProps := rsfs.NewStatefulSetProperties(r.Instance, metricsCapability.GetProperties(), "", "", "", "", "", "", "", nil, nil, nil)
 	sts, err := rsfs.CreateStatefulSet(stsProps)
 
 	assert.NoError(t, err)

--- a/controllers/activegate/reconciler/statefulset/affinity.go
+++ b/controllers/activegate/reconciler/statefulset/affinity.go
@@ -1,4 +1,4 @@
-package daemonset
+package statefulset
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/controllers/kubeobjects"
@@ -10,22 +10,22 @@ const (
 	kubernetesWithBetaVersion = 1.14
 )
 
-func (dsInfo *builderInfo) affinity() *corev1.Affinity {
+func affinity(stsProperties *statefulSetProperties) *corev1.Affinity {
 	return &corev1.Affinity{
 		NodeAffinity: &corev1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: dsInfo.affinityNodeSelectorTerms(),
+				NodeSelectorTerms: affinityNodeSelectorTerms(stsProperties),
 			},
 		},
 	}
 }
 
-func (dsInfo *builderInfo) affinityNodeSelectorTerms() []corev1.NodeSelectorTerm {
+func affinityNodeSelectorTerms(stsProperties *statefulSetProperties) []corev1.NodeSelectorTerm {
 	nodeSelectorTerms := []corev1.NodeSelectorTerm{
 		kubernetesArchOsSelectorTerm(),
 	}
 
-	if kubesystem.KubernetesVersionAsFloat(dsInfo.majorKubernetesVersion, dsInfo.minorKubernetesVersion) < kubernetesWithBetaVersion {
+	if kubesystem.KubernetesVersionAsFloat(stsProperties.majorKubernetesVersion, stsProperties.minorKubernetesVersion) < kubernetesWithBetaVersion {
 		nodeSelectorTerms = append(nodeSelectorTerms, kubernetesBetaArchOsSelectorTerm())
 	}
 
@@ -34,12 +34,12 @@ func (dsInfo *builderInfo) affinityNodeSelectorTerms() []corev1.NodeSelectorTerm
 
 func kubernetesArchOsSelectorTerm() corev1.NodeSelectorTerm {
 	return corev1.NodeSelectorTerm{
-		MatchExpressions: kubeobjects.AffinityNodeRequirementWithARM64(),
+		MatchExpressions: kubeobjects.AffinityNodeRequirement(),
 	}
 }
 
 func kubernetesBetaArchOsSelectorTerm() corev1.NodeSelectorTerm {
 	return corev1.NodeSelectorTerm{
-		MatchExpressions: kubeobjects.AffinityBetaNodeRequirementWithARM64(),
+		MatchExpressions: kubeobjects.AffinityBetaNodeRequirement(),
 	}
 }

--- a/controllers/activegate/reconciler/statefulset/affinity_test.go
+++ b/controllers/activegate/reconciler/statefulset/affinity_test.go
@@ -1,0 +1,29 @@
+package statefulset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAffinity(t *testing.T) {
+	affinitySpec := affinity(&statefulSetProperties{
+		majorKubernetesVersion: "1",
+		minorKubernetesVersion: "20",
+	})
+	affinitySpecWithBeta := affinity(&statefulSetProperties{
+		majorKubernetesVersion: "1",
+		minorKubernetesVersion: "13",
+	})
+	nodeSelectorTerms := affinitySpec.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	betaNodeSelectorTerms := affinitySpecWithBeta.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+
+	assert.Equal(t, 1, len(nodeSelectorTerms))
+	assert.Equal(t, 2, len(betaNodeSelectorTerms))
+
+	assert.Contains(t, nodeSelectorTerms, kubernetesArchOsSelectorTerm())
+	assert.NotContains(t, nodeSelectorTerms, kubernetesBetaArchOsSelectorTerm())
+
+	assert.Contains(t, betaNodeSelectorTerms, kubernetesArchOsSelectorTerm())
+	assert.Contains(t, betaNodeSelectorTerms, kubernetesBetaArchOsSelectorTerm())
+}

--- a/controllers/activegate/reconciler/statefulset/reconciler.go
+++ b/controllers/activegate/reconciler/statefulset/reconciler.go
@@ -29,7 +29,6 @@ type Reconciler struct {
 	Instance                         *v1alpha1.DynaKube
 	apiReader                        client.Reader
 	scheme                           *runtime.Scheme
-	config                           *rest.Config
 	log                              logr.Logger
 	imageVersionProvider             dtversion.ImageVersionProvider
 	feature                          string
@@ -134,12 +133,12 @@ func (r *Reconciler) buildDesiredStatefulSet() (*appsv1.StatefulSet, error) {
 
 	major, err := r.versionProvider.Major()
 	if err != nil {
-		r.log.Error(err, "could not get major kubernetes version")
+		r.log.Info("could not get major kubernetes version", "error", err)
 	}
 
 	minor, err := r.versionProvider.Minor()
 	if err != nil {
-		r.log.Error(err, "could not get minor kubernetes version")
+		r.log.Info("could not get minor kubernetes version", "error", err)
 	}
 
 	stsProperties := NewStatefulSetProperties(

--- a/controllers/activegate/reconciler/statefulset/reconciler.go
+++ b/controllers/activegate/reconciler/statefulset/reconciler.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -28,6 +29,7 @@ type Reconciler struct {
 	Instance                         *v1alpha1.DynaKube
 	apiReader                        client.Reader
 	scheme                           *runtime.Scheme
+	config                           *rest.Config
 	log                              logr.Logger
 	imageVersionProvider             dtversion.ImageVersionProvider
 	feature                          string
@@ -38,9 +40,10 @@ type Reconciler struct {
 	initContainersTemplates          []corev1.Container
 	containerVolumeMounts            []corev1.VolumeMount
 	volumes                          []corev1.Volume
+	versionProvider                  kubesystem.VersionProvider
 }
 
-func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, log logr.Logger,
+func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, config *rest.Config, log logr.Logger,
 	instance *v1alpha1.DynaKube, imageVersionProvider dtversion.ImageVersionProvider, capability capability.Capability) *Reconciler {
 
 	serviceAccountOwner := capability.GetConfiguration().ServiceAccountOwner
@@ -63,6 +66,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.S
 		initContainersTemplates:          capability.GetInitContainersTemplates(),
 		containerVolumeMounts:            capability.GetContainerVolumeMounts(),
 		volumes:                          capability.GetVolumes(),
+		versionProvider:                  kubesystem.NewVersionProvider(config),
 	}
 }
 
@@ -128,8 +132,19 @@ func (r *Reconciler) buildDesiredStatefulSet() (*appsv1.StatefulSet, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	major, err := r.versionProvider.Major()
+	if err != nil {
+		r.log.Error(err, "could not get major kubernetes version")
+	}
+
+	minor, err := r.versionProvider.Minor()
+	if err != nil {
+		r.log.Error(err, "could not get minor kubernetes version")
+	}
+
 	stsProperties := NewStatefulSetProperties(
-		r.Instance, r.capability, kubeUID, cpHash, r.feature, r.capabilityName, r.serviceAccountOwner, r.initContainersTemplates, r.containerVolumeMounts, r.volumes)
+		r.Instance, r.capability, kubeUID, cpHash, r.feature, r.capabilityName, r.serviceAccountOwner,
+		major, minor, r.initContainersTemplates, r.containerVolumeMounts, r.volumes)
 	stsProperties.OnAfterCreateListener = r.onAfterStatefulSetCreateListener
 
 	desiredSts, err := CreateStatefulSet(stsProperties)

--- a/controllers/activegate/reconciler/statefulset/reconciler_test.go
+++ b/controllers/activegate/reconciler/statefulset/reconciler_test.go
@@ -48,7 +48,7 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 
 	capability.NewRoutingCapability(&instance.Spec.RoutingSpec.CapabilityProperties, nil)
 
-	r := NewReconciler(clt, clt, scheme.Scheme, log, instance, imgVerProvider,
+	r := NewReconciler(clt, clt, scheme.Scheme, nil, log, instance, imgVerProvider,
 		capability.NewRoutingCapability(&instance.Spec.RoutingSpec.CapabilityProperties, nil))
 	require.NotNil(t, r)
 	require.NotNil(t, r.Client)

--- a/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -28,7 +28,7 @@ const (
 
 func TestNewStatefulSetBuilder(t *testing.T) {
 	stsBuilder := NewStatefulSetProperties(&dynatracev1alpha1.DynaKube{}, &dynatracev1alpha1.CapabilityProperties{},
-		testUID, testValue, "", "", "", nil, nil, nil)
+		testUID, testValue, "", "", "", "", "", nil, nil, nil)
 	assert.NotNil(t, stsBuilder)
 	assert.NotNil(t, stsBuilder.DynaKube)
 	assert.NotNil(t, stsBuilder.CapabilityProperties)
@@ -41,7 +41,7 @@ func TestStatefulSetBuilder_Build(t *testing.T) {
 	instance := buildTestInstance()
 	capabilityProperties := &instance.Spec.RoutingSpec.CapabilityProperties
 	sts, err := CreateStatefulSet(NewStatefulSetProperties(instance, capabilityProperties,
-		"", "", testFeature, "", "", nil, nil, nil))
+		"", "", testFeature, "", "", "", "", nil, nil, nil))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, sts)
@@ -71,7 +71,7 @@ func TestStatefulSetBuilder_Build(t *testing.T) {
 
 	t.Run(`template has annotations`, func(t *testing.T) {
 		sts, _ := CreateStatefulSet(NewStatefulSetProperties(instance, capabilityProperties,
-			"", testValue, "", "", "", nil, nil, nil))
+			"", testValue, "", "", "", "", "", nil, nil, nil))
 		assert.Equal(t, map[string]string{
 			AnnotationVersion:         instance.Status.ActiveGate.Version,
 			AnnotationCustomPropsHash: testValue,
@@ -83,7 +83,7 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 	instance := buildTestInstance()
 	capabilityProperties := &instance.Spec.RoutingSpec.CapabilityProperties
 	templateSpec := buildTemplateSpec(NewStatefulSetProperties(instance, capabilityProperties,
-		"", "", "", "", "", nil, nil, nil))
+		"", "", "", "", "", "", "", nil, nil, nil))
 
 	assert.NotEqual(t, corev1.PodSpec{}, templateSpec)
 	assert.NotEmpty(t, templateSpec.Containers)
@@ -107,7 +107,7 @@ func TestStatefulSet_Container(t *testing.T) {
 	instance := buildTestInstance()
 	capabilityProperties := &instance.Spec.RoutingSpec.CapabilityProperties
 	container := buildContainer(NewStatefulSetProperties(instance, capabilityProperties,
-		"", "", "", "", "", nil, nil, nil))
+		"", "", "", "", "", "", "", nil, nil, nil))
 
 	assert.Equal(t, dynatracev1alpha1.OperatorName, container.Name)
 	assert.Equal(t, instance.ActiveGateImage(), container.Image)
@@ -125,7 +125,7 @@ func TestStatefulSet_Volumes(t *testing.T) {
 
 	t.Run(`without custom properties`, func(t *testing.T) {
 		volumes := buildVolumes(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", "", "", "", nil, nil, nil))
+			"", "", "", "", "", "", "", nil, nil, nil))
 
 		assert.Empty(t, volumes)
 	})
@@ -134,7 +134,7 @@ func TestStatefulSet_Volumes(t *testing.T) {
 			Value: testValue,
 		}
 		volumes := buildVolumes(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", testFeature, "", "", nil, nil, nil))
+			"", "", testFeature, "", "", "", "", nil, nil, nil))
 		expectedSecretName := instance.Name + "-router-" + customproperties.Suffix
 
 		require.NotEmpty(t, volumes)
@@ -153,7 +153,7 @@ func TestStatefulSet_Volumes(t *testing.T) {
 			ValueFrom: testKey,
 		}
 		volumes := buildVolumes(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", "", "", "", nil, nil, nil))
+			"", "", "", "", "", "", "", nil, nil, nil))
 		expectedSecretName := testKey
 
 		require.NotEmpty(t, volumes)
@@ -176,7 +176,7 @@ func TestStatefulSet_Env(t *testing.T) {
 
 	t.Run(`without proxy`, func(t *testing.T) {
 		envVars := buildEnvs(NewStatefulSetProperties(instance, capabilityProperties,
-			testUID, "", testFeature, "MSGrouter", "", nil, nil, nil))
+			testUID, "", testFeature, "MSGrouter", "", "", "", nil, nil, nil))
 		assert.Equal(t, []corev1.EnvVar{
 			{Name: DTCapabilities, Value: "MSGrouter"},
 			{Name: DTIdSeedNamespace, Value: instance.Namespace},
@@ -188,7 +188,7 @@ func TestStatefulSet_Env(t *testing.T) {
 	t.Run(`with proxy from value`, func(t *testing.T) {
 		instance.Spec.Proxy = &dynatracev1alpha1.DynaKubeProxy{Value: testValue}
 		envVars := buildEnvs(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", "", "", "", nil, nil, nil))
+			"", "", "", "", "", "", "", nil, nil, nil))
 
 		assert.Contains(t, envVars, corev1.EnvVar{
 			Name:  DTInternalProxy,
@@ -198,7 +198,7 @@ func TestStatefulSet_Env(t *testing.T) {
 	t.Run(`with proxy from value source`, func(t *testing.T) {
 		instance.Spec.Proxy = &dynatracev1alpha1.DynaKubeProxy{ValueFrom: testName}
 		envVars := buildEnvs(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", "", "", "", nil, nil, nil))
+			"", "", "", "", "", "", "", nil, nil, nil))
 
 		assert.NotEmpty(t, envVars)
 
@@ -214,7 +214,7 @@ func TestStatefulSet_Env(t *testing.T) {
 		instance.Spec.NetworkZone = testName
 		capabilityProperties := &instance.Spec.RoutingSpec.CapabilityProperties
 		envVars := buildEnvs(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", "", "", "", nil, nil, nil))
+			"", "", "", "", "", "", "", nil, nil, nil))
 
 		assert.NotEmpty(t, envVars)
 
@@ -228,7 +228,7 @@ func TestStatefulSet_Env(t *testing.T) {
 		instance.Spec.RoutingSpec.Group = testValue
 		capabilityProperties := &instance.Spec.RoutingSpec.CapabilityProperties
 		envVars := buildEnvs(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", "", "", "", nil, nil, nil))
+			"", "", "", "", "", "", "", nil, nil, nil))
 
 		assert.NotEmpty(t, envVars)
 
@@ -245,13 +245,13 @@ func TestStatefulSet_VolumeMounts(t *testing.T) {
 
 	t.Run(`without custom properties`, func(t *testing.T) {
 		volumeMounts := buildVolumeMounts(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", "", "", "", nil, nil, nil))
+			"", "", "", "", "", "", "", nil, nil, nil))
 		assert.Empty(t, volumeMounts)
 	})
 	t.Run(`with custom properties`, func(t *testing.T) {
 		capabilityProperties.CustomProperties = &dynatracev1alpha1.DynaKubeValueSource{Value: testValue}
 		volumeMounts := buildVolumeMounts(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", "", "", "", nil, nil, nil))
+			"", "", "", "", "", "", "", nil, nil, nil))
 
 		assert.NotEmpty(t, volumeMounts)
 		assert.Contains(t, volumeMounts, corev1.VolumeMount{
@@ -283,7 +283,7 @@ func TestStatefulSet_Resources(t *testing.T) {
 		},
 	}
 
-	container := buildContainer(NewStatefulSetProperties(instance, capabilityProperties, "", "", "", "", "", nil, nil, nil))
+	container := buildContainer(NewStatefulSetProperties(instance, capabilityProperties, "", "", "", "", "", "", "", nil, nil, nil))
 
 	assert.True(t, quantityCpuLimit.Equal(container.Resources.Limits[corev1.ResourceCPU]))
 	assert.True(t, quantityMemoryLimit.Equal(container.Resources.Limits[corev1.ResourceMemory]))

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -215,7 +215,7 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *cont
 
 	if dkState.Instance.Spec.InfraMonitoring.Enabled {
 		upd, err = oneagent.NewOneAgentReconciler(
-			r.client, r.apiReader, r.scheme, dkState.Log, dkState.Instance, &dkState.Instance.Spec.InfraMonitoring.FullStackSpec, daemonset.InframonFeature,
+			r.client, r.apiReader, r.scheme, r.config, dkState.Log, dkState.Instance, &dkState.Instance.Spec.InfraMonitoring.FullStackSpec, daemonset.InframonFeature,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "infra monitoring reconciled") {
 			return
@@ -229,7 +229,7 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *cont
 
 	if dkState.Instance.Spec.ClassicFullStack.Enabled {
 		upd, err = oneagent.NewOneAgentReconciler(
-			r.client, r.apiReader, r.scheme, dkState.Log, dkState.Instance, &dkState.Instance.Spec.ClassicFullStack, daemonset.ClassicFeature,
+			r.client, r.apiReader, r.scheme, r.config, dkState.Log, dkState.Instance, &dkState.Instance.Spec.ClassicFullStack, daemonset.ClassicFeature,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "classic fullstack reconciled") {
 			return
@@ -259,7 +259,7 @@ func (r *ReconcileDynaKube) reconcileActiveGateCapabilities(dkState *controllers
 	for _, c := range caps {
 		if c.GetProperties().Enabled {
 			upd, err := rcap.NewReconciler(
-				c, r.client, r.apiReader, r.scheme, dkState.Log, dkState.Instance, dtversion.GetImageVersion,
+				c, r.client, r.apiReader, r.scheme, r.config, dkState.Log, dkState.Instance, dtversion.GetImageVersion,
 			).Reconcile()
 			if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, c.GetModuleName()+" reconciled") {
 				return false

--- a/controllers/kubeobjects/affinity.go
+++ b/controllers/kubeobjects/affinity.go
@@ -6,6 +6,9 @@ const (
 	kubernetesArch = "kubernetes.io/arch"
 	kubernetesOS   = "kubernetes.io/os"
 
+	kubernetesBetaArch = "beta.kubernetes.io/arch"
+	kubernetesBetaOS   = "beta.kubernetes.io/os"
+
 	amd64 = "amd64"
 	arm64 = "arm64"
 	linux = "linux"
@@ -19,6 +22,14 @@ func AffinityNodeRequirementWithARM64() []corev1.NodeSelectorRequirement {
 	return affinityNodeRequirementsForArches(amd64, arm64)
 }
 
+func AffinityBetaNodeRequirement() []corev1.NodeSelectorRequirement {
+	return affinityBetaNodeRequirementsForArches(amd64)
+}
+
+func AffinityBetaNodeRequirementWithARM64() []corev1.NodeSelectorRequirement {
+	return affinityBetaNodeRequirementsForArches(amd64, arm64)
+}
+
 func affinityNodeRequirementsForArches(arches ...string) []corev1.NodeSelectorRequirement {
 	return []corev1.NodeSelectorRequirement{
 		{
@@ -28,6 +39,21 @@ func affinityNodeRequirementsForArches(arches ...string) []corev1.NodeSelectorRe
 		},
 		{
 			Key:      kubernetesOS,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{linux},
+		},
+	}
+}
+
+func affinityBetaNodeRequirementsForArches(arches ...string) []corev1.NodeSelectorRequirement {
+	return []corev1.NodeSelectorRequirement{
+		{
+			Key:      kubernetesBetaArch,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   arches,
+		},
+		{
+			Key:      kubernetesBetaOS,
 			Operator: corev1.NodeSelectorOpIn,
 			Values:   []string{linux},
 		},

--- a/controllers/kubeobjects/affinity_test.go
+++ b/controllers/kubeobjects/affinity_test.go
@@ -25,3 +25,20 @@ func linuxRequirement() corev1.NodeSelectorRequirement {
 		Values:   []string{linux},
 	}
 }
+
+func TestAffinityBetaNodeRequirement(t *testing.T) {
+	assert.Equal(t, AffinityBetaNodeRequirement(), affinityBetaNodeRequirementsForArches(amd64))
+	assert.Equal(t, AffinityBetaNodeRequirementWithARM64(), affinityBetaNodeRequirementsForArches(amd64, arm64))
+	assert.Equal(t, len(AffinityBetaNodeRequirement()), nodeSelectorRequirements)
+
+	assert.Contains(t, AffinityBetaNodeRequirement(), linuxBetaRequirement())
+	assert.Contains(t, AffinityBetaNodeRequirementWithARM64(), linuxBetaRequirement())
+}
+
+func linuxBetaRequirement() corev1.NodeSelectorRequirement {
+	return corev1.NodeSelectorRequirement{
+		Key:      kubernetesBetaOS,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{linux},
+	}
+}

--- a/controllers/kubesystem/version_provider.go
+++ b/controllers/kubesystem/version_provider.go
@@ -1,0 +1,95 @@
+package kubesystem
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	float64BitSize = 64
+)
+
+const errorConfigIsNil = "rest config for Kubernetes version provider is nil"
+
+type VersionProvider interface {
+	Major() (string, error)
+	Minor() (string, error)
+}
+
+type discoveryVersionProvider struct {
+	config      *rest.Config
+	versionInfo *version.Info
+}
+
+func NewVersionProvider(config *rest.Config) VersionProvider {
+	return &discoveryVersionProvider{
+		config: config,
+	}
+}
+
+func (versionProvider *discoveryVersionProvider) Major() (string, error) {
+	versionInfo, err := versionProvider.getVersionInfo()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return versionInfo.Major, nil
+}
+
+func (versionProvider *discoveryVersionProvider) Minor() (string, error) {
+	versionInfo, err := versionProvider.getVersionInfo()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return versionInfo.Minor, nil
+}
+
+func (versionProvider *discoveryVersionProvider) getVersionInfo() (*version.Info, error) {
+	if versionProvider.versionInfo != nil {
+		return versionProvider.versionInfo, nil
+	}
+
+	if versionProvider.config == nil {
+		return nil, errors.New(errorConfigIsNil)
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(versionProvider.config)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	versionInfo, err := discoveryClient.ServerVersion()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	versionProvider.versionInfo = versionInfo
+	return versionInfo, nil
+}
+
+func KubernetesVersionAsFloat(major, minor string) float64 {
+	versionString := combinedKubernetesVersion(major, minor)
+	return parseVersionString(versionString)
+}
+
+func parseVersionString(versionString string) float64 {
+	parsedVersion, err := strconv.ParseFloat(versionString, float64BitSize)
+	if err != nil {
+		return 0
+	}
+	if parsedVersion < 0 {
+		return 0
+	}
+	return parsedVersion
+}
+
+func combinedKubernetesVersion(major, minor string) string {
+	combinedVersion := fmt.Sprintf("%s.%s", major, minor)
+	neitherNumberNorDot := regexp.MustCompile("[^0-9.]")
+	return neitherNumberNorDot.ReplaceAllString(combinedVersion, "")
+}

--- a/controllers/kubesystem/version_provider_test.go
+++ b/controllers/kubesystem/version_provider_test.go
@@ -1,0 +1,110 @@
+package kubesystem
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/version"
+	restclient "k8s.io/client-go/rest"
+)
+
+func TestDiscoveryVersionProvider(t *testing.T) {
+	t.Run(`retrieves version info`, func(t *testing.T) {
+		expect := version.Info{
+			Major: "1",
+			Minor: "20",
+		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			output, err := json.Marshal(expect)
+			if err != nil {
+				t.Errorf("unexpected encoding error: %v", err)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(output)
+		}))
+		defer server.Close()
+
+		versionProvider := NewVersionProvider(&restclient.Config{Host: server.URL})
+		major, err := versionProvider.Major()
+
+		assert.NoError(t, err)
+		assert.Equal(t, major, "1")
+
+		minor, err := versionProvider.Minor()
+
+		assert.NoError(t, err)
+		assert.Equal(t, minor, "20")
+	})
+
+	t.Run(`handles server errors`, func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(""))
+		}))
+		defer server.Close()
+
+		versionProvider := NewVersionProvider(&restclient.Config{Host: server.URL})
+		major, err := versionProvider.Major()
+
+		assert.Error(t, err)
+		assert.Equal(t, major, "")
+
+		minor, err := versionProvider.Minor()
+
+		assert.Error(t, err)
+		assert.Equal(t, minor, "")
+	})
+
+	t.Run(`handles nil config`, func(t *testing.T) {
+		versionProvider := NewVersionProvider(nil)
+		major, err := versionProvider.Major()
+
+		assert.EqualError(t, err, errorConfigIsNil)
+		assert.Equal(t, major, "")
+
+		minor, err := versionProvider.Minor()
+
+		assert.EqualError(t, err, errorConfigIsNil)
+		assert.Equal(t, minor, "")
+	})
+
+	t.Run(`handles invalid config`, func(t *testing.T) {
+		versionProvider := NewVersionProvider(&restclient.Config{})
+		major, err := versionProvider.Major()
+
+		assert.Error(t, err)
+		assert.Equal(t, major, "")
+
+		minor, err := versionProvider.Minor()
+
+		assert.Error(t, err)
+		assert.Equal(t, minor, "")
+	})
+}
+
+func TestKubernetesVersion(t *testing.T) {
+	const zeroFloat = float64(0)
+
+	assert.Equal(t, 1.14, KubernetesVersionAsFloat("1", "14"))
+	assert.Equal(t, 1.14, KubernetesVersionAsFloat("-1", "-14"))
+	assert.Equal(t, 1.14, KubernetesVersionAsFloat("-1", "14"))
+	assert.Equal(t, 1.14, KubernetesVersionAsFloat("1", "-14"))
+
+	assert.Equal(t, 1.20, KubernetesVersionAsFloat("1", "20+"))
+	assert.Equal(t, 1.20, KubernetesVersionAsFloat("1+", "20+"))
+	assert.Equal(t, 1.20, KubernetesVersionAsFloat("1+", "20"))
+
+	assert.Equal(t, 0.14, KubernetesVersionAsFloat("", "-14"))
+	assert.Equal(t, 0.14, KubernetesVersionAsFloat("0", "14"))
+
+	assert.Equal(t, 123.2345, KubernetesVersionAsFloat("123", "2345"))
+	assert.Equal(t, float64(1), KubernetesVersionAsFloat("1", ""))
+	assert.Equal(t, 0.1, KubernetesVersionAsFloat("", "1"))
+	assert.Equal(t, zeroFloat, KubernetesVersionAsFloat("", ""))
+}

--- a/controllers/oneagent/daemonset/affinity_test.go
+++ b/controllers/oneagent/daemonset/affinity_test.go
@@ -8,10 +8,101 @@ import (
 )
 
 func TestAffinity(t *testing.T) {
-
-	dsInfo := builderInfo{}
+	dsInfo := builderInfo{
+		majorKubernetesVersion: "1",
+		minorKubernetesVersion: "14",
+	}
 	affinity := dsInfo.affinity()
 	assert.NotContains(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, corev1.NodeSelectorTerm{
+		MatchExpressions: []corev1.NodeSelectorRequirement{
+			{
+				Key:      "beta.kubernetes.io/arch",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"amd64", "arm64"},
+			},
+			{
+				Key:      "beta.kubernetes.io/os",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"linux"},
+			},
+		},
+	})
+
+	dsInfo = builderInfo{
+		majorKubernetesVersion: "1",
+		minorKubernetesVersion: "20+",
+	}
+	affinity = dsInfo.affinity()
+	assert.NotContains(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, corev1.NodeSelectorTerm{
+		MatchExpressions: []corev1.NodeSelectorRequirement{
+			{
+				Key:      "beta.kubernetes.io/arch",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"amd64", "arm64"},
+			},
+			{
+				Key:      "beta.kubernetes.io/os",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"linux"},
+			},
+		},
+	})
+	assert.Contains(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, corev1.NodeSelectorTerm{
+		MatchExpressions: []corev1.NodeSelectorRequirement{
+			{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"amd64", "arm64"},
+			},
+			{
+				Key:      "kubernetes.io/os",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"linux"},
+			},
+		},
+	})
+
+	dsInfo = builderInfo{
+		majorKubernetesVersion: "1",
+		minorKubernetesVersion: "15",
+	}
+	affinity = dsInfo.affinity()
+
+	assert.NotContains(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, corev1.NodeSelectorTerm{
+		MatchExpressions: []corev1.NodeSelectorRequirement{
+			{
+				Key:      "beta.kubernetes.io/arch",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"amd64", "arm64"},
+			},
+			{
+				Key:      "beta.kubernetes.io/os",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"linux"},
+			},
+		},
+	})
+	assert.Contains(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, corev1.NodeSelectorTerm{
+		MatchExpressions: []corev1.NodeSelectorRequirement{
+			{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"amd64", "arm64"},
+			},
+			{
+				Key:      "kubernetes.io/os",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"linux"},
+			},
+		},
+	})
+
+	dsInfo = builderInfo{
+		majorKubernetesVersion: "1",
+		minorKubernetesVersion: "13",
+	}
+	affinity = dsInfo.affinity()
+	assert.Contains(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, corev1.NodeSelectorTerm{
 		MatchExpressions: []corev1.NodeSelectorRequirement{
 			{
 				Key:      "beta.kubernetes.io/arch",

--- a/controllers/oneagent/daemonset/daemonset.go
+++ b/controllers/oneagent/daemonset/daemonset.go
@@ -55,40 +55,46 @@ type ClassicFullStack struct {
 }
 
 type builderInfo struct {
-	instance       *v1alpha1.DynaKube
-	fullstackSpec  *v1alpha1.FullStackSpec
-	logger         logr.Logger
-	clusterId      string
-	relatedImage   string
-	deploymentType string
+	instance               *v1alpha1.DynaKube
+	fullstackSpec          *v1alpha1.FullStackSpec
+	logger                 logr.Logger
+	clusterId              string
+	relatedImage           string
+	deploymentType         string
+	minorKubernetesVersion string
+	majorKubernetesVersion string
 }
 
 type Builder interface {
 	BuildDaemonSet() (*appsv1.DaemonSet, error)
 }
 
-func NewInfraMonitoring(instance *v1alpha1.DynaKube, logger logr.Logger, clusterId string) Builder {
+func NewInfraMonitoring(instance *v1alpha1.DynaKube, logger logr.Logger, clusterId string, majorKubernetesVersion string, minorKubernetesVersion string) Builder {
 	return &InfraMonitoring{
 		builderInfo{
-			instance:       instance,
-			fullstackSpec:  &instance.Spec.InfraMonitoring.FullStackSpec,
-			logger:         logger,
-			clusterId:      clusterId,
-			relatedImage:   os.Getenv(relatedImageEnvVar),
-			deploymentType: deploymentmetadata.DeploymentTypeHM,
+			instance:               instance,
+			fullstackSpec:          &instance.Spec.InfraMonitoring.FullStackSpec,
+			logger:                 logger,
+			clusterId:              clusterId,
+			relatedImage:           os.Getenv(relatedImageEnvVar),
+			deploymentType:         deploymentmetadata.DeploymentTypeHM,
+			majorKubernetesVersion: majorKubernetesVersion,
+			minorKubernetesVersion: minorKubernetesVersion,
 		},
 	}
 }
 
-func NewClassicFullStack(instance *v1alpha1.DynaKube, logger logr.Logger, clusterId string) Builder {
+func NewClassicFullStack(instance *v1alpha1.DynaKube, logger logr.Logger, clusterId string, majorKubernetesVersion string, minorKubernetesVersion string) Builder {
 	return &ClassicFullStack{
 		builderInfo{
-			instance:       instance,
-			fullstackSpec:  &instance.Spec.ClassicFullStack,
-			logger:         logger,
-			clusterId:      clusterId,
-			relatedImage:   os.Getenv(relatedImageEnvVar),
-			deploymentType: deploymentmetadata.DeploymentTypeFS,
+			instance:               instance,
+			fullstackSpec:          &instance.Spec.ClassicFullStack,
+			logger:                 logger,
+			clusterId:              clusterId,
+			relatedImage:           os.Getenv(relatedImageEnvVar),
+			deploymentType:         deploymentmetadata.DeploymentTypeFS,
+			majorKubernetesVersion: majorKubernetesVersion,
+			minorKubernetesVersion: minorKubernetesVersion,
 		},
 	}
 }

--- a/controllers/oneagent/daemonset/daemonset_test.go
+++ b/controllers/oneagent/daemonset/daemonset_test.go
@@ -27,7 +27,7 @@ func TestUseImmutableImage(t *testing.T) {
 				ClassicFullStack: dynatracev1alpha1.FullStackSpec{},
 			},
 		}
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -44,7 +44,7 @@ func TestUseImmutableImage(t *testing.T) {
 				ClassicFullStack: dynatracev1alpha1.FullStackSpec{},
 			},
 		}
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -63,7 +63,7 @@ func TestUseImmutableImage(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -86,7 +86,7 @@ func TestUseImmutableImage(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -95,7 +95,7 @@ func TestUseImmutableImage(t *testing.T) {
 		assert.Equal(t, podSpecs.Containers[0].Image, fmt.Sprintf("%s/linux/oneagent:latest", strings.TrimPrefix(testURL, "https://")))
 
 		instance.Spec.OneAgent.Version = testValue
-		dsInfo = NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo = NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err = dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -122,7 +122,7 @@ func TestCustomPullSecret(t *testing.T) {
 			},
 		},
 	}
-	dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+	dsInfo := NewClassicFullStack(&instance, log, testClusterID, "", "")
 	ds, err := dsInfo.BuildDaemonSet()
 	require.NoError(t, err)
 
@@ -149,7 +149,7 @@ func TestResources(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -191,7 +191,7 @@ func TestResources(t *testing.T) {
 			},
 		}
 
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -229,7 +229,7 @@ func TestServiceAccountName(t *testing.T) {
 			},
 		}
 
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -251,7 +251,7 @@ func TestServiceAccountName(t *testing.T) {
 				},
 			},
 		}
-		dsInfo = NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo = NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err = dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -273,7 +273,7 @@ func TestServiceAccountName(t *testing.T) {
 				},
 			},
 		}
-		dsInfo = NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo = NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err = dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -296,7 +296,7 @@ func TestServiceAccountName(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -319,7 +319,7 @@ func TestServiceAccountName(t *testing.T) {
 			},
 		}
 
-		dsInfo = NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo = NewClassicFullStack(&instance, log, testClusterID, "", "")
 		ds, err = dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -342,7 +342,7 @@ func TestInfraMon_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := NewInfraMonitoring(&instance, log, testClusterID)
+		dsInfo := NewInfraMonitoring(&instance, log, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -369,7 +369,7 @@ func TestInfraMon_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := NewInfraMonitoring(&instance, log, testClusterID)
+		dsInfo := NewInfraMonitoring(&instance, log, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 

--- a/controllers/oneagent/oneagent_controller_test.go
+++ b/controllers/oneagent/oneagent_controller_test.go
@@ -30,6 +30,20 @@ const (
 	testClusterID = "test-cluster-id"
 )
 
+type fakeVersionProvider struct {
+	mock.Mock
+}
+
+func (f *fakeVersionProvider) Major() (string, error) {
+	args := f.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (f *fakeVersionProvider) Minor() (string, error) {
+	args := f.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
 var consoleLogger = zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout))
 
 var sampleKubeSystemNS = &corev1.Namespace{
@@ -265,7 +279,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 	t.Run(`reconileImp Instances set, if autoUpdate is true`, func(t *testing.T) {
 		dk := base.DeepCopy()
 		dk.Status.OneAgent.Version = oldVersion
-		dsInfo := daemonset.NewClassicFullStack(dk, consoleLogger, testClusterID)
+		dsInfo := daemonset.NewClassicFullStack(dk, consoleLogger, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -299,7 +313,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 		autoUpdate := false
 		dk.Spec.OneAgent.AutoUpdate = &autoUpdate
 		dk.Status.OneAgent.Version = oldVersion
-		dsInfo := daemonset.NewClassicFullStack(dk, consoleLogger, testClusterID)
+		dsInfo := daemonset.NewClassicFullStack(dk, consoleLogger, testClusterID, "", "")
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -464,13 +478,17 @@ func TestHasSpecChanged(t *testing.T) {
 
 func TestNewDaemonset_Affinity(t *testing.T) {
 	t.Run(`adds correct affinities`, func(t *testing.T) {
+		versionProvider := &fakeVersionProvider{}
 		r := ReconcileOneAgent{
-			feature: daemonset.InframonFeature,
+			versionProvider: versionProvider,
+			feature:         daemonset.InframonFeature,
 		}
 		dkState := &controllers.DynakubeState{
 			Instance: newDynaKube(),
 			Log:      consoleLogger,
 		}
+		versionProvider.On("Major").Return("1", nil)
+		versionProvider.On("Minor").Return("20+", nil)
 		ds, err := r.newDaemonSetForCR(dkState, "cluster1")
 
 		assert.NoError(t, err)
@@ -506,6 +524,72 @@ func TestNewDaemonset_Affinity(t *testing.T) {
 				},
 			},
 		})
+
+		versionProvider = &fakeVersionProvider{}
+		versionProvider.On("Major").Return("1", nil)
+		versionProvider.On("Minor").Return("13", nil)
+		r.versionProvider = versionProvider
+		ds, err = r.newDaemonSetForCR(dkState, "cluster1")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, ds)
+
+		affinity = ds.Spec.Template.Spec.Affinity
+
+		assert.Contains(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, corev1.NodeSelectorTerm{
+			MatchExpressions: []corev1.NodeSelectorRequirement{
+				{
+					Key:      "beta.kubernetes.io/arch",
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"amd64", "arm64"},
+				},
+				{
+					Key:      "beta.kubernetes.io/os",
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"linux"},
+				},
+			},
+		})
+		assert.Contains(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, corev1.NodeSelectorTerm{
+			MatchExpressions: []corev1.NodeSelectorRequirement{
+				{
+					Key:      "kubernetes.io/arch",
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"amd64", "arm64"},
+				},
+				{
+					Key:      "kubernetes.io/os",
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"linux"},
+				},
+			},
+		})
+	})
+	t.Run(`handle errors`, func(t *testing.T) {
+		versionProvider := &fakeVersionProvider{}
+		r := ReconcileOneAgent{
+			versionProvider: versionProvider,
+			feature:         daemonset.InframonFeature,
+		}
+		dkState := &controllers.DynakubeState{
+			Instance: newDynaKube(),
+			Log:      consoleLogger,
+		}
+		versionProvider.On("Major").Return("", errors.New("test-error"))
+		versionProvider.On("Minor").Return("20+", nil)
+		ds, err := r.newDaemonSetForCR(dkState, "cluster1")
+
+		assert.EqualError(t, err, "test-error")
+		assert.Nil(t, ds)
+
+		versionProvider = &fakeVersionProvider{}
+		versionProvider.On("Major").Return("1", nil)
+		versionProvider.On("Minor").Return("", errors.New("test-error"))
+		r.versionProvider = versionProvider
+		ds, err = r.newDaemonSetForCR(dkState, "cluster1")
+
+		assert.EqualError(t, err, "test-error")
+		assert.Nil(t, ds)
 	})
 }
 


### PR DESCRIPTION
implemented adding beta-os and beta-arch node affinities if deployed on openshift 3.11