### PR TITLE
Add resources to all csi driver containers

### DIFF
--- a/controllers/csi/daemonset.go
+++ b/controllers/csi/daemonset.go
@@ -231,16 +231,7 @@ func prepareDriverResources(client client.Client, operatorNS string, logger logr
 		}
 	}
 
-	return corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    getQuantity(DriverDefaultCPU, resource.Milli),
-			corev1.ResourceMemory: getQuantity(DriverDefaultMemory, resource.Mega),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    getQuantity(DriverDefaultCPU, resource.Milli),
-			corev1.ResourceMemory: getQuantity(DriverDefaultMemory, resource.Mega),
-		},
-	}
+	return prepareResources(DriverDefaultCPU, DriverDefaultMemory)
 }
 
 func getQuantity(value int64, scale resource.Scale) resource.Quantity {
@@ -319,25 +310,12 @@ func prepareRegistrarContainer(operatorImage string) corev1.Container {
 				ContainerPort: 9809,
 			},
 		},
-		Resources:     prepareRegistrarResources(),
+		Resources:     prepareResources(RegistrarDefaultCPU, RegistrarDefaultMemory),
 		LivenessProbe: &livenessProbe,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser: &userID,
 		},
 		VolumeMounts: volumeMounts,
-	}
-}
-
-func prepareRegistrarResources() corev1.ResourceRequirements {
-	return corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    getQuantity(RegistrarDefaultCPU, resource.Milli),
-			corev1.ResourceMemory: getQuantity(RegistrarDefaultMemory, resource.Mega),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    getQuantity(RegistrarDefaultCPU, resource.Milli),
-			corev1.ResourceMemory: getQuantity(RegistrarDefaultMemory, resource.Mega),
-		},
 	}
 }
 
@@ -389,20 +367,7 @@ func prepareLivenessProbeContainer(operatorImage string) corev1.Container {
 				MountPath: "/csi",
 			},
 		},
-		Resources: prepareLivenessProbeResources(),
-	}
-}
-
-func prepareLivenessProbeResources() corev1.ResourceRequirements {
-	return corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    getQuantity(LivenessProbeDefaultCPU, resource.Milli),
-			corev1.ResourceMemory: getQuantity(LivenessProbeDefaultMemory, resource.Mega),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    getQuantity(LivenessProbeDefaultCPU, resource.Milli),
-			corev1.ResourceMemory: getQuantity(LivenessProbeDefaultMemory, resource.Mega),
-		},
+		Resources: prepareResources(LivenessProbeDefaultCPU, LivenessProbeDefaultMemory),
 	}
 }
 
@@ -463,6 +428,19 @@ func prepareVolumes() []corev1.Volume {
 					Type: &hostPathDirOrCreate,
 				},
 			},
+		},
+	}
+}
+
+func prepareResources(cpu int64, memory int64) corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    getQuantity(cpu, resource.Milli),
+			corev1.ResourceMemory: getQuantity(memory, resource.Mega),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    getQuantity(cpu, resource.Milli),
+			corev1.ResourceMemory: getQuantity(memory, resource.Mega),
 		},
 	}
 }

--- a/controllers/csi/daemonset.go
+++ b/controllers/csi/daemonset.go
@@ -29,11 +29,11 @@ const (
 	DriverDefaultCPU    = 200
 	DriverDefaultMemory = 100
 
-	RegistrarDefaultCPU    = 50
-	RegistrarDefaultMemory = 50
+	RegistrarDefaultCPU    = 5
+	RegistrarDefaultMemory = 10
 
-	LivenessProbeDefaultCPU    = 50
-	LivenessProbeDefaultMemory = 50
+	LivenessProbeDefaultCPU    = 5
+	LivenessProbeDefaultMemory = 10
 )
 
 type Reconciler struct {

--- a/controllers/csi/daemonset.go
+++ b/controllers/csi/daemonset.go
@@ -26,14 +26,14 @@ const (
 	MountpointDirPath   = "/var/lib/kubelet/pods"
 	OneAgentDataDirPath = "/var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/data"
 
-	DriverDefaultCPU    = 200
-	DriverDefaultMemory = 100
+	driverDefaultCPU    = 200
+	driverDefaultMemory = 100
 
-	RegistrarDefaultCPU    = 5
-	RegistrarDefaultMemory = 10
+	registrarDefaultCPU    = 5
+	registrarDefaultMemory = 10
 
-	LivenessProbeDefaultCPU    = 5
-	LivenessProbeDefaultMemory = 10
+	livenessProbeDefaultCPU    = 5
+	livenessProbeDefaultMemory = 10
 )
 
 type Reconciler struct {
@@ -231,7 +231,7 @@ func prepareDriverResources(client client.Client, operatorNS string, logger logr
 		}
 	}
 
-	return prepareResources(DriverDefaultCPU, DriverDefaultMemory)
+	return prepareResources(driverDefaultCPU, driverDefaultMemory)
 }
 
 func getQuantity(value int64, scale resource.Scale) resource.Quantity {
@@ -310,7 +310,7 @@ func prepareRegistrarContainer(operatorImage string) corev1.Container {
 				ContainerPort: 9809,
 			},
 		},
-		Resources:     prepareResources(RegistrarDefaultCPU, RegistrarDefaultMemory),
+		Resources:     prepareResources(registrarDefaultCPU, registrarDefaultMemory),
 		LivenessProbe: &livenessProbe,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser: &userID,
@@ -367,7 +367,7 @@ func prepareLivenessProbeContainer(operatorImage string) corev1.Container {
 				MountPath: "/csi",
 			},
 		},
-		Resources: prepareResources(LivenessProbeDefaultCPU, LivenessProbeDefaultMemory),
+		Resources: prepareResources(livenessProbeDefaultCPU, livenessProbeDefaultMemory),
 	}
 }
 

--- a/controllers/csi/daemonset_test.go
+++ b/controllers/csi/daemonset_test.go
@@ -116,6 +116,17 @@ func TestReconcile_CreateDaemonSet(t *testing.T) {
 
 		assert.Len(t, registrar.Ports, 1)
 
+		assert.NotNil(t, registrar.Resources)
+		assert.NotNil(t, registrar.Resources.Requests)
+		assert.Len(t, registrar.Resources.Requests, 2)
+		testQuantity(t, registrar.Resources.Requests, corev1.ResourceCPU, "50m")
+		testQuantity(t, registrar.Resources.Requests, corev1.ResourceMemory, "50M")
+
+		assert.NotNil(t, registrar.Resources.Limits)
+		assert.Len(t, registrar.Resources.Limits, 2)
+		testQuantity(t, registrar.Resources.Limits, corev1.ResourceCPU, "50m")
+		testQuantity(t, registrar.Resources.Limits, corev1.ResourceMemory, "50M")
+
 		assert.NotNil(t, registrar.LivenessProbe)
 
 		assert.Len(t, registrar.VolumeMounts, 2)
@@ -125,6 +136,17 @@ func TestReconcile_CreateDaemonSet(t *testing.T) {
 		assert.Equal(t, livenessProbe.Name, "liveness-probe")
 
 		assert.Len(t, livenessProbe.Args, 2)
+
+		assert.NotNil(t, livenessProbe.Resources)
+		assert.NotNil(t, livenessProbe.Resources.Requests)
+		assert.Len(t, livenessProbe.Resources.Requests, 2)
+		testQuantity(t, livenessProbe.Resources.Requests, corev1.ResourceCPU, "50m")
+		testQuantity(t, livenessProbe.Resources.Requests, corev1.ResourceMemory, "50M")
+
+		assert.NotNil(t, livenessProbe.Resources.Limits)
+		assert.Len(t, livenessProbe.Resources.Limits, 2)
+		testQuantity(t, livenessProbe.Resources.Limits, corev1.ResourceCPU, "50m")
+		testQuantity(t, livenessProbe.Resources.Limits, corev1.ResourceMemory, "50M")
 
 		assert.Len(t, livenessProbe.VolumeMounts, 1)
 	})

--- a/controllers/csi/daemonset_test.go
+++ b/controllers/csi/daemonset_test.go
@@ -119,13 +119,13 @@ func TestReconcile_CreateDaemonSet(t *testing.T) {
 		assert.NotNil(t, registrar.Resources)
 		assert.NotNil(t, registrar.Resources.Requests)
 		assert.Len(t, registrar.Resources.Requests, 2)
-		testQuantity(t, registrar.Resources.Requests, corev1.ResourceCPU, "50m")
-		testQuantity(t, registrar.Resources.Requests, corev1.ResourceMemory, "50M")
+		testQuantity(t, registrar.Resources.Requests, corev1.ResourceCPU, "5m")
+		testQuantity(t, registrar.Resources.Requests, corev1.ResourceMemory, "10M")
 
 		assert.NotNil(t, registrar.Resources.Limits)
 		assert.Len(t, registrar.Resources.Limits, 2)
-		testQuantity(t, registrar.Resources.Limits, corev1.ResourceCPU, "50m")
-		testQuantity(t, registrar.Resources.Limits, corev1.ResourceMemory, "50M")
+		testQuantity(t, registrar.Resources.Limits, corev1.ResourceCPU, "5m")
+		testQuantity(t, registrar.Resources.Limits, corev1.ResourceMemory, "10M")
 
 		assert.NotNil(t, registrar.LivenessProbe)
 
@@ -140,13 +140,13 @@ func TestReconcile_CreateDaemonSet(t *testing.T) {
 		assert.NotNil(t, livenessProbe.Resources)
 		assert.NotNil(t, livenessProbe.Resources.Requests)
 		assert.Len(t, livenessProbe.Resources.Requests, 2)
-		testQuantity(t, livenessProbe.Resources.Requests, corev1.ResourceCPU, "50m")
-		testQuantity(t, livenessProbe.Resources.Requests, corev1.ResourceMemory, "50M")
+		testQuantity(t, livenessProbe.Resources.Requests, corev1.ResourceCPU, "5m")
+		testQuantity(t, livenessProbe.Resources.Requests, corev1.ResourceMemory, "10M")
 
 		assert.NotNil(t, livenessProbe.Resources.Limits)
 		assert.Len(t, livenessProbe.Resources.Limits, 2)
-		testQuantity(t, livenessProbe.Resources.Limits, corev1.ResourceCPU, "50m")
-		testQuantity(t, livenessProbe.Resources.Limits, corev1.ResourceMemory, "50M")
+		testQuantity(t, livenessProbe.Resources.Limits, corev1.ResourceCPU, "5m")
+		testQuantity(t, livenessProbe.Resources.Limits, corev1.ResourceMemory, "10M")
 
 		assert.Len(t, livenessProbe.VolumeMounts, 1)
 	})


### PR DESCRIPTION
* Move `driver` limits/requests to same constant
* Add default resource requests/limits to `registrar` and `liveness-probe` container

If no mismatched values are configured via the `csi-resources` annotation, the csi driver pod now gets the `qosClass` of `Guaranteed`