### PR TITLE
Raise memory limits for CSI driver containers

### DIFF
--- a/controllers/csi/daemonset.go
+++ b/controllers/csi/daemonset.go
@@ -30,10 +30,10 @@ const (
 	driverDefaultMemory = 100
 
 	registrarDefaultCPU    = 5
-	registrarDefaultMemory = 10
+	registrarDefaultMemory = 15
 
 	livenessProbeDefaultCPU    = 5
-	livenessProbeDefaultMemory = 10
+	livenessProbeDefaultMemory = 15
 )
 
 type Reconciler struct {

--- a/controllers/csi/daemonset_test.go
+++ b/controllers/csi/daemonset_test.go
@@ -120,12 +120,12 @@ func TestReconcile_CreateDaemonSet(t *testing.T) {
 		assert.NotNil(t, registrar.Resources.Requests)
 		assert.Len(t, registrar.Resources.Requests, 2)
 		testQuantity(t, registrar.Resources.Requests, corev1.ResourceCPU, "5m")
-		testQuantity(t, registrar.Resources.Requests, corev1.ResourceMemory, "10M")
+		testQuantity(t, registrar.Resources.Requests, corev1.ResourceMemory, "15M")
 
 		assert.NotNil(t, registrar.Resources.Limits)
 		assert.Len(t, registrar.Resources.Limits, 2)
 		testQuantity(t, registrar.Resources.Limits, corev1.ResourceCPU, "5m")
-		testQuantity(t, registrar.Resources.Limits, corev1.ResourceMemory, "10M")
+		testQuantity(t, registrar.Resources.Limits, corev1.ResourceMemory, "15M")
 
 		assert.NotNil(t, registrar.LivenessProbe)
 
@@ -141,12 +141,12 @@ func TestReconcile_CreateDaemonSet(t *testing.T) {
 		assert.NotNil(t, livenessProbe.Resources.Requests)
 		assert.Len(t, livenessProbe.Resources.Requests, 2)
 		testQuantity(t, livenessProbe.Resources.Requests, corev1.ResourceCPU, "5m")
-		testQuantity(t, livenessProbe.Resources.Requests, corev1.ResourceMemory, "10M")
+		testQuantity(t, livenessProbe.Resources.Requests, corev1.ResourceMemory, "15M")
 
 		assert.NotNil(t, livenessProbe.Resources.Limits)
 		assert.Len(t, livenessProbe.Resources.Limits, 2)
 		testQuantity(t, livenessProbe.Resources.Limits, corev1.ResourceCPU, "5m")
-		testQuantity(t, livenessProbe.Resources.Limits, corev1.ResourceMemory, "10M")
+		testQuantity(t, livenessProbe.Resources.Limits, corev1.ResourceMemory, "15M")
 
 		assert.Len(t, livenessProbe.VolumeMounts, 1)
 	})


### PR DESCRIPTION
* Raise registrar and liveness-probe container memory requests/limits to 15M