### PR TITLE
Add oneagent installer environment variables when needed

### DIFF
--- a/config/openshift/kustomization.yaml
+++ b/config/openshift/kustomization.yaml
@@ -20,13 +20,6 @@ bases:
   - ../crd/default
 patchesJson6902:
   - target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: dynatrace-operator
-      namespace: dynatrace
-    path: operator/deployment-operator-patch.yaml
-  - target:
       group: ""
       version: v1
       kind: ServiceAccount

--- a/config/openshift/operator/deployment-operator-patch.yaml
+++ b/config/openshift/operator/deployment-operator-patch.yaml
@@ -1,5 +1,0 @@
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
-    name: RELATED_IMAGE_DYNATRACE_ONEAGENT
-    value: registry.connect.redhat.com/dynatrace/oneagent

--- a/controllers/oneagent/daemonset/env_vars.go
+++ b/controllers/oneagent/daemonset/env_vars.go
@@ -1,8 +1,11 @@
 package daemonset
 
 import (
+	"fmt"
 	"sort"
+	"strconv"
 
+	"github.com/Dynatrace/dynatrace-operator/dtclient"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -11,6 +14,9 @@ const (
 	dtNodeName  = "DT_K8S_NODE_NAME"
 	dtClusterId = "DT_K8S_CLUSTER_ID"
 
+	oneagentDownloadToken             = "ONEAGENT_INSTALLER_DOWNLOAD_TOKEN"
+	oneagentInstallScript             = "ONEAGENT_INSTALLER_SCRIPT_URL"
+	oneagentSkipCertCheck             = "ONEAGENT_INSTALLER_SKIP_CERT_CHECK"
 	oneagentDisableContainerInjection = "ONEAGENT_DISABLE_CONTAINER_INJECTION"
 
 	proxy = "https_proxy"
@@ -22,11 +28,32 @@ func (dsInfo *builderInfo) environmentVariables() []corev1.EnvVar {
 	envVarMap = setDefaultValueSource(envVarMap, dtNodeName, &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}})
 	envVarMap = setDefaultValue(envVarMap, dtClusterId, dsInfo.clusterId)
 
+	if dsInfo.relatedImage != "" {
+		envVarMap = dsInfo.setInstallerEnvs(envVarMap)
+	}
+
 	if dsInfo.hasProxy() {
 		envVarMap = dsInfo.setDefaultProxy(envVarMap)
 	}
 
 	return mapToArray(envVarMap)
+}
+
+func (dsInfo *builderInfo) setInstallerEnvs(envVarMap map[string]corev1.EnvVar) map[string]corev1.EnvVar {
+	envVarMap = setDefaultValueSource(envVarMap, oneagentDownloadToken, &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: dsInfo.instance.Tokens()},
+			Key:                  dtclient.DynatracePaasToken,
+		},
+	})
+	envVarMap = setDefaultValue(envVarMap, oneagentInstallScript, dsInfo.installerUrl())
+	envVarMap = setDefaultValue(envVarMap, oneagentSkipCertCheck, strconv.FormatBool(dsInfo.instance.Spec.SkipCertCheck))
+
+	return envVarMap
+}
+
+func (dsInfo *builderInfo) installerUrl() string {
+	return fmt.Sprintf("%s/v1/deployment/installer/agent/unix/default/latest?arch=x86&flavor=default", dsInfo.instance.Spec.APIURL)
 }
 
 func (dsInfo *HostMonitoring) appendInfraMonEnvVars(daemonset *appsv1.DaemonSet) {


### PR DESCRIPTION
* OneAgent installer environment variables were missing in case of non-immutable image
* Remove `RELATED_IMAGE` environment variable being set per default on Openshift (set in CSV anyway)