### PR TITLE
Reintroduce annotationInject for pods only

### DIFF
--- a/webhook/mutation/pod_mutator.go
+++ b/webhook/mutation/pod_mutator.go
@@ -139,10 +139,16 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		log.Error(err, "Failed to decode the request for pod injection")
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+
 	var ns corev1.Namespace
 	if err := m.client.Get(ctx, client.ObjectKey{Name: req.Namespace}, &ns); err != nil {
 		log.Error(err, "Failed to query the namespace before pod injection")
 		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	inject := kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInject, "true")
+	if inject == "false" {
+		return admission.Patched("")
 	}
 
 	dkName, ok := ns.Labels[mapper.InstanceLabel]

--- a/webhook/mutation/pod_mutator.go
+++ b/webhook/mutation/pod_mutator.go
@@ -140,15 +140,15 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	inject := kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInject, "true")
+	if inject == "false" {
+		return admission.Patched("")
+	}
+
 	var ns corev1.Namespace
 	if err := m.client.Get(ctx, client.ObjectKey{Name: req.Namespace}, &ns); err != nil {
 		log.Error(err, "Failed to query the namespace before pod injection")
 		return admission.Errored(http.StatusInternalServerError, err)
-	}
-
-	inject := kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInject, "true")
-	if inject == "false" {
-		return admission.Patched("")
 	}
 
 	dkName, ok := ns.Labels[mapper.InstanceLabel]


### PR DESCRIPTION
This was removed accidentally during the namespaceSelector rework.
This annotation could be set on both the namespace or the pod, but after the namespaceSelector was introduced, it no longer made sense to look for it on the namespace, but it still make sense to do it for the pod.