### PR TITLE
Removes the label in case the appInjection is just disabled

### DIFF
--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -270,6 +270,11 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *cont
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "new init script created") {
 			return
 		}
+	} else {
+		if err := dkMapper.UnmapFromDynaKube(); err != nil {
+			dkState.Log.Error(err, "could not unmap dynakube from namespace")
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Before this the inject label ("dynakube.internal.dynatrace.com/instance") only got removed in the case when:
- dynakube was removed
- multiple dynakubes with application inject but different namespaceSelector cleaned up after each other (so if one got removed then the other "cleaned" up)
- namespaceSelector changed on the dynakube

But the 1 case that wasn't covered is: 1 dynakube, disables app injection. (this pr is fixes this)