### PR TITLE
Change update strategy to RollingUpgrade for Operator/Webhook Deployment

### DIFF
--- a/config/common/operator/deployment-operator.yaml
+++ b/config/common/operator/deployment-operator.yaml
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       name: dynatrace-operator
   strategy:
-    type: Recreate
+    type: RollingUpgrade
   template:
     metadata:
       labels:

--- a/config/common/webhook/deployment-webhook.yaml
+++ b/config/common/webhook/deployment-webhook.yaml
@@ -13,7 +13,7 @@ spec:
       internal.dynatrace.com/component: webhook
       internal.dynatrace.com/app: webhook
   strategy:
-    type: Recreate
+    type: RollingUpgrade
   template:
     metadata:
       annotations:


### PR DESCRIPTION
**Recreate** strategy introduces service interruptions (i.e. pod startup fails or injection does not happen) if adjustments are made to the deployment. To avoid that, .spec.strategy should be set to the default **RollingUpgrade**.