### PR TITLE
Remove node watch access from the webhook

### DIFF
--- a/config/common/webhook/clusterrole-webhook.yaml
+++ b/config/common/webhook/clusterrole-webhook.yaml
@@ -7,14 +7,6 @@ metadata:
     internal.dynatrace.com/component: webhook
 rules:
   - apiGroups:
-      - "" # "" indicates the core API group
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - ""
     resources:
       - namespaces

--- a/initgeneration/init.sh.test-sample
+++ b/initgeneration/init.sh.test-sample
@@ -25,6 +25,8 @@ im_nodes=(
   ["node2"]="abc12345"
 )
 ###############################################
+# Script fails if empty
+host_tenant="${im_nodes[${K8S_NODE_NAME}]}"
 
 setFailCode(){
 	if [[ "${FAILURE_POLICY}" == "fail" ]]; then

--- a/initgeneration/init.sh.tmpl
+++ b/initgeneration/init.sh.tmpl
@@ -26,6 +26,8 @@ im_nodes=(
   {{- end}}
 )
 ###############################################
+# Script fails if empty
+host_tenant="${im_nodes[${K8S_NODE_NAME}]}"
 
 setFailCode(){
 	if [[ "${FAILURE_POLICY}" == "fail" ]]; then

--- a/initgeneration/initgeneration.go
+++ b/initgeneration/initgeneration.go
@@ -38,10 +38,11 @@ var (
 
 // InitGenerator manages the init secret generation for the user namespaces.
 type InitGenerator struct {
-	client    client.Client
-	apiReader client.Reader
-	logger    logr.Logger
-	namespace string
+	client        client.Client
+	apiReader     client.Reader
+	logger        logr.Logger
+	namespace     string
+	canWatchNodes bool
 }
 
 type nodeInfo struct {
@@ -73,12 +74,9 @@ func NewInitGenerator(client client.Client, apiReader client.Reader, ns string, 
 
 // GenerateForNamespace creates the init secret for namespace while only having the name of the corresponding dynakube
 // Used by the podInjection webhook in case the namespace lacks the init secret.
-func (g *InitGenerator) GenerateForNamespace(ctx context.Context, dkName, targetNs string) error {
+func (g *InitGenerator) GenerateForNamespace(ctx context.Context, dk dynatracev1beta1.DynaKube, targetNs string) error {
 	g.logger.Info("Reconciling namespace init secret for", "namespace", targetNs)
-	var dk dynatracev1beta1.DynaKube
-	if err := g.client.Get(context.TODO(), client.ObjectKey{Name: dkName, Namespace: g.namespace}, &dk); err != nil {
-		return err
-	}
+	g.canWatchNodes = false
 	data, err := g.generate(ctx, &dk)
 	if err != nil {
 		return err
@@ -90,6 +88,7 @@ func (g *InitGenerator) GenerateForNamespace(ctx context.Context, dkName, target
 // Used by the dynakube controller during reconcile.
 func (g *InitGenerator) GenerateForDynakube(ctx context.Context, dk *dynatracev1beta1.DynaKube) (bool, error) {
 	g.logger.Info("Reconciling namespace init secret for", "dynakube", dk.Name)
+	g.canWatchNodes = true
 	data, err := g.generate(ctx, dk)
 	if err != nil {
 		return false, err
@@ -211,36 +210,62 @@ func (g *InitGenerator) getInfraMonitoringNodes(dk *dynatracev1beta1.DynaKube) (
 		return nil, errors.WithMessage(err, "failed to query DynaKubeList")
 	}
 
-	nodeInf, err := g.initIMNodes()
-	if err != nil {
-		return nil, err
-	}
+	imNodes := map[string]string{}
 
-	for i := range dks.Items {
-		status := &dks.Items[i].Status
-		if dk != nil && dk.Name == dks.Items[i].Name {
-			status = &dk.Status
+	if g.canWatchNodes {
+		nodeInf, err := g.initIMNodes()
+		if err != nil {
+			return nil, err
 		}
-		if dks.Items[i].NeedsOneAgent() {
-			tenantUUID := ""
-			if status.ConnectionInfo.TenantUUID != "" {
-				tenantUUID = status.ConnectionInfo.TenantUUID
+
+		for i := range dks.Items {
+			status := &dks.Items[i].Status
+			if dk != nil && dk.Name == dks.Items[i].Name {
+				status = &dk.Status
 			}
-			nodeSelector := labels.SelectorFromSet(dks.Items[i].NodeSelector())
-			for _, node := range nodeInf.nodes {
-				nodeLabels := labels.Set(node.Labels)
-				if nodeSelector.Matches(nodeLabels) {
+			if dks.Items[i].NeedsOneAgent() {
+				tenantUUID := ""
+				if status.ConnectionInfo.TenantUUID != "" {
+					tenantUUID = status.ConnectionInfo.TenantUUID
+				}
+				nodeSelector := labels.SelectorFromSet(dks.Items[i].NodeSelector())
+				for _, node := range nodeInf.nodes {
+					nodeLabels := labels.Set(node.Labels)
+					if nodeSelector.Matches(nodeLabels) {
+						if tenantUUID != "" {
+							nodeInf.imNodes[node.Name] = tenantUUID
+						} else if !dk.FeatureIgnoreUnknownState() {
+							delete(nodeInf.imNodes, node.Name)
+						}
+					}
+				}
+			}
+		}
+		imNodes = nodeInf.imNodes
+
+	} else {
+		for i := range dks.Items {
+			status := &dks.Items[i].Status
+			if dk != nil && dk.Name == dks.Items[i].Name {
+				status = &dk.Status
+			}
+			if dks.Items[i].NeedsOneAgent() {
+				tenantUUID := ""
+				if status.ConnectionInfo.TenantUUID != "" {
+					tenantUUID = status.ConnectionInfo.TenantUUID
+				}
+				for nodeName := range dks.Items[i].Status.OneAgent.Instances {
 					if tenantUUID != "" {
-						nodeInf.imNodes[node.Name] = tenantUUID
+						imNodes[nodeName] = tenantUUID
 					} else if !dk.FeatureIgnoreUnknownState() {
-						delete(nodeInf.imNodes, node.Name)
+						delete(imNodes, nodeName)
 					}
 				}
 			}
 		}
 	}
 
-	return nodeInf.imNodes, nil
+	return imNodes, nil
 }
 
 func (g *InitGenerator) initIMNodes() (nodeInfo, error) {

--- a/initgeneration/initgeneration_test.go
+++ b/initgeneration/initgeneration_test.go
@@ -103,6 +103,11 @@ var (
 			ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
 				TenantUUID: testTenantUUID,
 			},
+			OneAgent: dynatracev1beta1.OneAgentStatus{
+				Instances: map[string]dynatracev1beta1.OneAgentInstance{
+					testNodeWithSelectorName: {},
+				},
+			},
 		},
 	}
 
@@ -154,7 +159,7 @@ func TestGenerateForNamespace(t *testing.T) {
 		clt := fake.NewClient(testDynakubeComplex, &testNamespace, testSecretDynakubeComplex, kubeNamespace, caConfigMap, testNode1, testNode2)
 		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
 
-		err := ig.GenerateForNamespace(context.TODO(), testDynakubeComplex.Name, testNamespace.Name)
+		err := ig.GenerateForNamespace(context.TODO(), *testDynakubeComplex, testNamespace.Name)
 		assert.NoError(t, err)
 
 		var initSecret corev1.Secret
@@ -181,7 +186,7 @@ func TestGenerateForNamespace(t *testing.T) {
 		clt := fake.NewClient(testDynakubeSimple, &testNamespace, testSecretDynakubeSimple, kubeNamespace, testNode1, testNode2)
 		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
 
-		err := ig.GenerateForNamespace(context.TODO(), testDynakubeSimple.Name, testNamespace.Name)
+		err := ig.GenerateForNamespace(context.TODO(), *testDynakubeSimple, testNamespace.Name)
 		assert.NoError(t, err)
 
 		var initSecret corev1.Secret
@@ -288,6 +293,17 @@ func TestGetInfraMonitoringNodes(t *testing.T) {
 	t.Run("Get IMNodes from multiple dynakubes", func(t *testing.T) {
 		clt := fake.NewClient(testDynakubeComplex, testDynakubeSimple, testNode1, testNode2)
 		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig.canWatchNodes = true
+		imNodes, err := ig.getInfraMonitoringNodes(testDynakubeSimple)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(imNodes))
+		assert.Equal(t, testTenantUUID, imNodes[testNode1Name])
+		assert.Equal(t, testTenantUUID, imNodes[testNode2Name])
+	})
+	t.Run("Get IMNodes from multiple dynakubes without node access", func(t *testing.T) {
+		clt := fake.NewClient(testDynakubeComplex, testDynakubeSimple, testNode1, testNode2)
+		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig.canWatchNodes = false
 		imNodes, err := ig.getInfraMonitoringNodes(testDynakubeSimple)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(imNodes))
@@ -297,6 +313,7 @@ func TestGetInfraMonitoringNodes(t *testing.T) {
 	t.Run("Get IMNodes from dynakubes with nodeSelector", func(t *testing.T) {
 		clt := fake.NewClient(testNodeWithLabels, testDynakubeWithSelector, testNode1, testNode2)
 		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig.canWatchNodes = true
 		imNodes, err := ig.getInfraMonitoringNodes(testDynakubeWithSelector)
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(imNodes))

--- a/webhook/mutation/pod_mutator.go
+++ b/webhook/mutation/pod_mutator.go
@@ -174,7 +174,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 
 	var initSecret corev1.Secret
 	if err := m.apiReader.Get(ctx, client.ObjectKey{Name: dtwebhook.SecretConfigName, Namespace: ns.Name}, &initSecret); k8serrors.IsNotFound(err) {
-		if err := initgeneration.NewInitGenerator(m.client, m.apiReader, m.namespace, log).GenerateForNamespace(ctx, dkName, ns.Name); err != nil {
+		if err := initgeneration.NewInitGenerator(m.client, m.apiReader, m.namespace, log).GenerateForNamespace(ctx, dk, ns.Name); err != nil {
 			log.Error(err, "Failed to create the init secret before pod injection")
 			return admission.Errored(http.StatusBadRequest, err)
 		}


### PR DESCRIPTION
GKE Autopilot decided (see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#webhooks_limitations) that they don't support webhooks with any kind of permissions for `nodes`. 

So the `podInjection` webhook can no longer use the nodes to create the init secret in the case the operator was to slow to do so for a given namespace. 
So now it again uses the `dynakube.Status.OneAgent.Instances` for doing it, which is not perfect.
The problem is that if we don't have hostMonitoring on a node (or at all), then ONLY the operator can generate a correct init secret for init containers, and it can cause a slowdown in newly created namespaces.

The "slowdown" is that the init containers will be in a `crashloopbackoff` state until the dynakube gets reconciled and a correct init-secret gets created for the namespace. The default reconcile interval is 5 minutes, so worse case is the pods will be stuck in init for ~5 min. 