### PR TITLE
Prevent update bug where old dynakube version conflicts with newer one

### DIFF
--- a/webhook/validation/validation.go
+++ b/webhook/validation/validation.go
@@ -158,7 +158,7 @@ func hasConflictingNodeSelector(client client.Client, dynakube *dynatracev1beta1
 	for _, item := range validDynakubes.Items {
 		nodeSelectorMap := dynakube.NodeSelector()
 		validNodeSelectorMap := item.NodeSelector()
-		if hasConflictingMatchLabels(nodeSelectorMap, validNodeSelectorMap) && item.Name != dynakube.Name {
+		if item.Name != dynakube.Name && hasConflictingMatchLabels(nodeSelectorMap, validNodeSelectorMap) {
 			return fmt.Sprintf(errorNodeSelectorConflict, item.Name)
 		}
 	}


### PR DESCRIPTION
In our webhook on updates we did not check if the dynakube already exists in the cluster. If so the new version conflicted with the old one.