### PR TITLE
Moves toleration feature flag to operator deployment

### DIFF
--- a/api/v1beta1/feature_flags.go
+++ b/api/v1beta1/feature_flags.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 
 	"github.com/Dynatrace/dynatrace-operator/logger"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -31,7 +30,6 @@ const (
 	annotationFeatureOneAgentMaxUnavailable          = annotationFeaturePrefix + "oneagent-max-unavailable"
 	annotationFeatureEnableWebhookReinvocationPolicy = annotationFeaturePrefix + "enable-webhook-reinvocation-policy"
 	annotationFeatureIgnoreUnknownState              = annotationFeaturePrefix + "ignore-unknown-state"
-	annotationFeatureCSITolerations                  = annotationFeaturePrefix + "csi-tolerations"
 	annotationFeatureIgnoredNamespaces               = annotationFeaturePrefix + "ignored-namespaces"
 )
 
@@ -85,22 +83,6 @@ func (dk *DynaKube) GetFeatureEnableWebhookReinvocationPolicy() string {
 // this may cause extra host to appear in the tenant for each process.
 func (dk *DynaKube) FeatureIgnoreUnknownState() bool {
 	return dk.Annotations[annotationFeatureIgnoreUnknownState] == "true"
-}
-
-// FeatureCSITolerations is a feature flag to set tolerations for the csi drive daemonset.
-// example: [{\"key\":\"node-role.kubernetes.io/master\",\"operator\":\"Exists\",\"effect\":\"NoSchedule\"}]
-func (dk *DynaKube) FeatureCSITolerations() []corev1.Toleration {
-	raw, ok := dk.Annotations[annotationFeatureCSITolerations]
-	if !ok || raw == "" {
-		return nil
-	}
-	tolerations := &[]corev1.Toleration{}
-	err := json.Unmarshal([]byte(raw), tolerations)
-	if err != nil {
-		log.Error(err, "failed to unmarshal csi tolerations feature-flag")
-		return nil
-	}
-	return *tolerations
 }
 
 // FeatureIgnoredNamespaces is a feature flag for ignoring certain namespaces.

--- a/controllers/csi/config.go
+++ b/controllers/csi/config.go
@@ -31,6 +31,10 @@ const (
 	DaemonSetName                    = "dynatrace-oneagent-csi-driver"
 	DefaultServiceAccountName        = "dynatrace-oneagent-csi-driver"
 	AnnotationCSIResourcesIdentifier = "dynatrace.com/csi-resources"
+
+	// AnnotationCSITolerations is a feature flag to set tolerations for the csi drive daemonset.
+	// example: [{\"key\":\"node-role.kubernetes.io/master\",\"operator\":\"Exists\",\"effect\":\"NoSchedule\"}]
+	AnnotationCSITolerations = "dynatrace.com/csi-tolerations"
 )
 
 var MetadataAccessPath = filepath.Join(DataPath, "csi.db")

--- a/controllers/csi/daemonset_lifecycle_test.go
+++ b/controllers/csi/daemonset_lifecycle_test.go
@@ -23,7 +23,7 @@ const (
 
 func Test_ConfigureCSIDriver_Enable(t *testing.T) {
 	dynakube := prepareDynakube(testDynakube)
-	fakeClient := prepareFakeClient("")
+	fakeClient := prepareFakeClient("", "")
 	dkState := prepareDynakubeState(dynakube, true)
 
 	err := ConfigureCSIDriver(fakeClient, scheme.Scheme, testOperatorPodName, testNamespace, dkState, 10)
@@ -127,7 +127,7 @@ func prepareFakeClientWithEnabledCSI(dynakubes ...*dynatracev1beta1.DynaKube) cl
 		},
 	}
 
-	fakeClient := prepareFakeClient("", csiDaemonSet)
+	fakeClient := prepareFakeClient("", "", csiDaemonSet)
 	return fakeClient
 }
 


### PR DESCRIPTION
The toleration feature flag was moved to the deployment of the operator instead of the dynakube, because this feature flag will affect multiple dynakubes if used, so if left on the dynakubes conflicts could occur. (1 dynakube has it the other doesn't, who wins ?)   