### PR TITLE
Removes unused image field for applicationMonitoring

### DIFF
--- a/api/v1beta1/oneagent_types.go
+++ b/api/v1beta1/oneagent_types.go
@@ -115,11 +115,6 @@ type HostInjectSpec struct {
 type ApplicationMonitoringSpec struct {
 	AppInjectionSpec `json:",inline"`
 
-	// Optional: the Dynatrace installer container image
-	// Defaults to docker.io/dynatrace/oneagent:latest for Kubernetes and to registry.connect.redhat.com/dynatrace/oneagent for OpenShift
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=12,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
-	Image string `json:"image,omitempty"`
-
 	// Optional: If specified, indicates the OneAgent version to use
 	// Defaults to latest
 	// Example: {major.minor.release} - 1.200.0

--- a/api/v1beta1/properties.go
+++ b/api/v1beta1/properties.go
@@ -109,9 +109,6 @@ func (dk *DynaKube) ActiveGateImage() string {
 }
 
 func (dk *DynaKube) NeedsCSIDriver() bool {
-	if dk.ApplicationMonitoringMode() && dk.Spec.OneAgent.ApplicationMonitoring.Image != "" {
-		return false
-	}
 	return dk.CloudNativeFullstackMode() || (dk.ApplicationMonitoringMode() && dk.Spec.OneAgent.ApplicationMonitoring.UseCSIDriver != nil && *dk.Spec.OneAgent.ApplicationMonitoring.UseCSIDriver)
 }
 
@@ -123,10 +120,7 @@ func (dk *DynaKube) Image() string {
 		return dk.Spec.OneAgent.ClassicFullStack.Image
 	} else if dk.HostMonitoringMode() {
 		return dk.Spec.OneAgent.HostMonitoring.Image
-	} else if dk.ApplicationMonitoringMode() {
-		return dk.Spec.OneAgent.ApplicationMonitoring.Image
 	}
-
 	return ""
 }
 

--- a/api/v1beta1/properties_test.go
+++ b/api/v1beta1/properties_test.go
@@ -69,50 +69,34 @@ func TestDynaKube_UseCSIDriver(t *testing.T) {
 		assert.Equal(t, true, dk.NeedsCSIDriver())
 	})
 
-	t.Run(`DynaKube with application monitoring with csi driver enabled and with an image set`, func(t *testing.T) {
-		useCSIDriver := true
-		dk := DynaKube{
-			Spec: DynaKubeSpec{
-				OneAgent: OneAgentSpec{
-					ApplicationMonitoring: &ApplicationMonitoringSpec{
-						UseCSIDriver: &useCSIDriver,
-						Image:        `test-endpoint/linux/image:latest`,
-					},
-				},
-			},
-		}
-		assert.Equal(t, false, dk.NeedsCSIDriver())
-	})
-
 	t.Run(`DynaKube with cloud native`, func(t *testing.T) {
 		dk := DynaKube{Spec: DynaKubeSpec{OneAgent: OneAgentSpec{CloudNativeFullStack: &CloudNativeFullStackSpec{}}}}
 		assert.Equal(t, true, dk.NeedsCSIDriver())
 	})
 }
 
-//
-//func TestOneAgentImage(t *testing.T) {
-//	t.Run(`OneAgentImage with no API URL`, func(t *testing.T) {
-//		dk := DynaKube{}
-//		assert.Equal(t, "", dk.ImmutableOneAgentImage())
-//	})
-//
-//	t.Run(`OneAgentImage with API URL`, func(t *testing.T) {
-//		dk := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
-//		assert.Equal(t, "test-endpoint/linux/oneagent:latest", dk.ImmutableOneAgentImage())
-//	})
-//
-//	t.Run(`OneAgentImage with API URL and custom version`, func(t *testing.T) {
-//		dk := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL, OneAgent: OneAgentSpec{Version: "1.234.5"}}}
-//		assert.Equal(t, "test-endpoint/linux/oneagent:1.234.5", dk.ImmutableOneAgentImage())
-//	})
-//
-//	t.Run(`OneAgentImage with custom image`, func(t *testing.T) {
-//		customImg := "registry/my/oneagent:latest"
-//		dk := DynaKube{Spec: DynaKubeSpec{OneAgent: OneAgentSpec{Image: customImg}}}
-//		assert.Equal(t, customImg, dk.ImmutableOneAgentImage())
-//	})
-//}
+func TestOneAgentImage(t *testing.T) {
+	t.Run(`OneAgentImage with no API URL`, func(t *testing.T) {
+		dk := DynaKube{}
+		assert.Equal(t, "", dk.ImmutableOneAgentImage())
+	})
+
+	t.Run(`OneAgentImage with API URL`, func(t *testing.T) {
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
+		assert.Equal(t, "test-endpoint/linux/oneagent:latest", dk.ImmutableOneAgentImage())
+	})
+
+	t.Run(`OneAgentImage with API URL and custom version`, func(t *testing.T) {
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL, OneAgent: OneAgentSpec{ClassicFullStack: &ClassicFullStackSpec{Version: "1.234.5"}}}}
+		assert.Equal(t, "test-endpoint/linux/oneagent:1.234.5", dk.ImmutableOneAgentImage())
+	})
+
+	t.Run(`OneAgentImage with custom image`, func(t *testing.T) {
+		customImg := "registry/my/oneagent:latest"
+		dk := DynaKube{Spec: DynaKubeSpec{OneAgent: OneAgentSpec{ClassicFullStack: &ClassicFullStackSpec{Image: customImg}}}}
+		assert.Equal(t, customImg, dk.ImmutableOneAgentImage())
+	})
+}
 
 func TestTokens(t *testing.T) {
 	testName := "test-name"

--- a/config/crd/default/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/default/bases/dynatrace.com_dynakubes.yaml
@@ -1462,12 +1462,6 @@ spec:
                       monitoring'
                     nullable: true
                     properties:
-                      image:
-                        description: 'Optional: the Dynatrace installer container
-                          image Defaults to docker.io/dynatrace/oneagent:latest for
-                          Kubernetes and to registry.connect.redhat.com/dynatrace/oneagent
-                          for OpenShift'
-                        type: string
                       initResources:
                         description: 'Optional: define resources requests and limits
                           for the initContainer'

--- a/config/crd/ocp311/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/ocp311/bases/dynatrace.com_dynakubes.yaml
@@ -1454,12 +1454,6 @@ spec:
                       monitoring'
                     nullable: true
                     properties:
-                      image:
-                        description: 'Optional: the Dynatrace installer container
-                          image Defaults to docker.io/dynatrace/oneagent:latest for
-                          Kubernetes and to registry.connect.redhat.com/dynatrace/oneagent
-                          for OpenShift'
-                        type: string
                       initResources:
                         description: 'Optional: define resources requests and limits
                           for the initContainer'

--- a/config/samples/applicationMonitoring.yml
+++ b/config/samples/applicationMonitoring.yml
@@ -54,10 +54,6 @@ spec:
       #
       # version:
 
-      # Optional: to use a custom OneAgent Docker image. Defaults to docker.io/dynatrace/oneagent in
-      # Kubernetes and registry.connect.redhat.com/dynatrace/oneagent in OpenShift, if deployed via CSV
-      image: ""
-
       # Optional: If you want to use CSIDriver; disable if your cluster does not have 'nodes' to fall back to the volume approach.
       # Defaults to false
       #
@@ -77,7 +73,7 @@ spec:
       #   limits:
       #     cpu: 300m
       #     memory: 1.5Gi
-  
+
   # Configuration for ActiveGate instances.
   activeGate:
     # Enables listed ActiveGate capabilities
@@ -85,7 +81,7 @@ spec:
       - routing
       - kubernetes-monitoring
       - data-ingest
-    
+
     # Optional: to use a custom ActiveGate Docker image.
     image: ""
 

--- a/config/samples/multipleDynakubes.yml
+++ b/config/samples/multipleDynakubes.yml
@@ -18,7 +18,7 @@ spec:
 
   oneAgent:
     # Enable application monitoring
-    applicationMonitoring: 
+    applicationMonitoring:
       namespaceSelector:
         matchLabels:
           monitor: applicationMonitoring
@@ -51,7 +51,7 @@ spec:
 
   oneAgent:
     # Enable cloud-native fullstack monitoring
-    cloudNativeFullStack: 
+    cloudNativeFullStack:
       # Optional: tolerations to include with the OneAgent DaemonSet.
       # See more here: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
       tolerations:


### PR DESCRIPTION
The image field in the applicationMonitoring sections is never used in any meaningful way.
The CSI driver can't use it because it downloads a zip not an image.

In case of installer mode we do the same, we download a zip by default.
However there is an annotation that the user can set on the pod `oneagent.dynatrace.com/installer-url`, which if set will be used to during the download, so I'm guessing this was confused with the ability set an image.
