### PR TITLE
Add bootstrap manager for certificates

### DIFF
--- a/cmd/operator/csi_driver.go
+++ b/cmd/operator/csi_driver.go
@@ -50,7 +50,7 @@ func csiDriverFlags() *pflag.FlagSet {
 	return csiDriverFlags
 }
 
-func startCSIDriver(ns string, cfg *rest.Config) (manager.Manager, func(), error) {
+func setupCSIDriver(ns string, cfg *rest.Config) (manager.Manager, func(), error) {
 	defaultUmask := unix.Umask(0000)
 	cleanUp := func() {
 		unix.Umask(defaultUmask)

--- a/cmd/operator/debug.go
+++ b/cmd/operator/debug.go
@@ -45,25 +45,8 @@ func startWebhookManager(info startupInfo) {
 	startComponent("webhook-server", info)
 }
 
-func startComponent(name string, info startupInfo) {
-	subCmd, err := getSubcommand(name)
-	if err != nil {
-		return
-	}
-	startSubCommand(name, subCmd, &info)
-}
-
-func getSubcommand(name string) (subCommand, error) {
-	subcmdFn, hasSubCommand := subcmdCallbacks[name]
-	if !hasSubCommand {
-		log.Error(errBadSubcmd, "unknown command", "command", "webhook-server")
-		return subcmdFn, errBadSubcmd
-	}
-	return subcmdFn, nil
-}
-
-func startSubCommand(name string, cmd subCommand, startInfo *startupInfo) {
-	mgr, cleanUp, err := cmd(startInfo.namespace, startInfo.cfg)
+func startComponent(name string, startInfo startupInfo) {
+	mgr, cleanUp, err := startWebhookServer(startInfo.namespace, startInfo.cfg)
 	defer cleanUp()
 	if err != nil {
 		log.Error(err, "")

--- a/cmd/operator/debug.go
+++ b/cmd/operator/debug.go
@@ -46,7 +46,7 @@ func startWebhookManager(info startupInfo) {
 }
 
 func startComponent(name string, startInfo startupInfo) {
-	mgr, cleanUp, err := startWebhookServer(startInfo.namespace, startInfo.cfg)
+	mgr, cleanUp, err := setupWebhookServer(startInfo.namespace, startInfo.cfg)
 	defer cleanUp()
 	if err != nil {
 		log.Error(err, "")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -65,7 +65,7 @@ func main() {
 	case operatorCmd:
 		// start manager only for certificates
 		bootstrapperCtx, done := context.WithCancel(context.TODO())
-		mgr, err := startBootstrapper(namespace, cfg, done)
+		mgr, err = startBootstrapper(namespace, cfg, done)
 		exitOnError(err, "bootstrapper could not be configured")
 		exitOnError(mgr.Start(bootstrapperCtx), "problem running bootstrap manager")
 		// bootstrap manager stopped, starting full manager

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+
 	"github.com/Dynatrace/dynatrace-operator/controllers/certificates"
 	"github.com/Dynatrace/dynatrace-operator/controllers/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/controllers/nodes"
@@ -30,7 +31,7 @@ import (
 )
 
 func startBootstrapper(ns string, cfg *rest.Config, cancelMgr context.CancelFunc) (manager.Manager, error) {
-	log.Info(ns)
+	log.Info("starting certificate bootstrapper", "namespace", ns)
 	mgr, err := setupMgr(ns, cfg)
 	if err != nil {
 		return mgr, err
@@ -40,7 +41,7 @@ func startBootstrapper(ns string, cfg *rest.Config, cancelMgr context.CancelFunc
 }
 
 func startOperator(ns string, cfg *rest.Config) (manager.Manager, func(), error) {
-	log.Info(ns)
+	log.Info("starting operator", "namespace", ns)
 	cleanUp := func() {}
 	mgr, err := setupMgr(ns, cfg)
 	if err != nil {
@@ -78,8 +79,7 @@ func setupMgr(ns string, cfg *rest.Config) (manager.Manager, error) {
 		return nil, err
 	}
 
-	log.Info("Registering Components.")
-
+	log.Info("registering manager components")
 	if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		log.Error(err, "could not start health endpoint for operator")
 	}

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -32,7 +32,7 @@ import (
 
 func startBootstrapper(ns string, cfg *rest.Config, cancelMgr context.CancelFunc) (manager.Manager, error) {
 	log.Info("starting certificate bootstrapper", "namespace", ns)
-	mgr, err := setupMgr(ns, cfg)
+	mgr, err := setupBootstrapMgr(ns, cfg)
 	if err != nil {
 		return mgr, err
 	}
@@ -60,6 +60,18 @@ func startOperator(ns string, cfg *rest.Config) (manager.Manager, error) {
 	}
 
 	return mgr, nil
+}
+
+func setupBootstrapMgr(ns string, cfg *rest.Config) (manager.Manager, error) {
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Namespace: ns,
+		Scheme:    scheme.Scheme,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return mgr, err
 }
 
 func setupMgr(ns string, cfg *rest.Config) (manager.Manager, error) {

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-func startBootstrapper(ns string, cfg *rest.Config, cancelMgr context.CancelFunc) (manager.Manager, error) {
+func setupBootstrapper(ns string, cfg *rest.Config, cancelMgr context.CancelFunc) (manager.Manager, error) {
 	log.Info("starting certificate bootstrapper", "namespace", ns)
 	mgr, err := setupBootstrapMgr(ns, cfg)
 	if err != nil {
@@ -40,7 +40,7 @@ func startBootstrapper(ns string, cfg *rest.Config, cancelMgr context.CancelFunc
 	return mgr, certificates.AddBootstrap(mgr, ns, cancelMgr)
 }
 
-func startOperator(ns string, cfg *rest.Config) (manager.Manager, error) {
+func setupOperator(ns string, cfg *rest.Config) (manager.Manager, error) {
 	log.Info("starting operator", "namespace", ns)
 	mgr, err := setupMgr(ns, cfg)
 	if err != nil {

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -40,12 +40,11 @@ func startBootstrapper(ns string, cfg *rest.Config, cancelMgr context.CancelFunc
 	return mgr, certificates.AddBootstrap(mgr, ns, cancelMgr)
 }
 
-func startOperator(ns string, cfg *rest.Config) (manager.Manager, func(), error) {
+func startOperator(ns string, cfg *rest.Config) (manager.Manager, error) {
 	log.Info("starting operator", "namespace", ns)
-	cleanUp := func() {}
 	mgr, err := setupMgr(ns, cfg)
 	if err != nil {
-		return mgr, cleanUp, err
+		return mgr, err
 	}
 
 	funcs := []func(manager.Manager, string) error{
@@ -56,11 +55,11 @@ func startOperator(ns string, cfg *rest.Config) (manager.Manager, func(), error)
 
 	for _, f := range funcs {
 		if err := f(mgr, ns); err != nil {
-			return nil, cleanUp, err
+			return nil, err
 		}
 	}
 
-	return mgr, cleanUp, nil
+	return mgr, nil
 }
 
 func setupMgr(ns string, cfg *rest.Config) (manager.Manager, error) {

--- a/cmd/operator/webhook.go
+++ b/cmd/operator/webhook.go
@@ -40,7 +40,7 @@ func webhookServerFlags() *pflag.FlagSet {
 	return webhookServerFlagSet
 }
 
-func startWebhookServer(ns string, cfg *rest.Config) (manager.Manager, func(), error) {
+func setupWebhookServer(ns string, cfg *rest.Config) (manager.Manager, func(), error) {
 	mgr, cleanUp, err := newManagerWithCertificates(ns, cfg)
 	if err != nil {
 		return nil, cleanUp, err

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -98,6 +98,7 @@ type ReconcileDynaKube struct {
 	config            *rest.Config
 	operatorPodName   string
 	operatorNamespace string
+	mgr               manager.Manager
 }
 
 type DynatraceClientFunc func(properties DynatraceClientProperties) (dtclient.Client, error)

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -98,7 +98,6 @@ type ReconcileDynaKube struct {
 	config            *rest.Config
 	operatorPodName   string
 	operatorNamespace string
-	mgr               manager.Manager
 }
 
 type DynatraceClientFunc func(properties DynatraceClientProperties) (dtclient.Client, error)


### PR DESCRIPTION
* Add 2nd manager to create and add certificates to CRD/webhook configurations on initial run
* Start remaining controllers after successful bootstrapper run
* Refactor subcommands in `main.go` to use switch