### PR TITLE
Renames tenants table to dynakubes

### DIFF
--- a/controllers/csi/driver/bind_config.go
+++ b/controllers/csi/driver/bind_config.go
@@ -27,7 +27,7 @@ func newBindConfig(ctx context.Context, svr *CSIDriverServer, volumeCfg *volumeC
 		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("namespace '%s' doesn't have DynaKube assigned", volumeCfg.namespace))
 	}
 
-	tenant, err := svr.db.GetTenant(dkName)
+	tenant, err := svr.db.GetDynakube(dkName)
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmt.Sprintf("failed to extract tenant for DynaKube %s: %s", dkName, err.Error()))
 	}

--- a/controllers/csi/driver/bind_config.go
+++ b/controllers/csi/driver/bind_config.go
@@ -27,15 +27,15 @@ func newBindConfig(ctx context.Context, svr *CSIDriverServer, volumeCfg *volumeC
 		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("namespace '%s' doesn't have DynaKube assigned", volumeCfg.namespace))
 	}
 
-	tenant, err := svr.db.GetDynakube(dkName)
+	dynakube, err := svr.db.GetDynakube(dkName)
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmt.Sprintf("failed to extract tenant for DynaKube %s: %s", dkName, err.Error()))
 	}
-	if tenant == nil {
-		return nil, status.Error(codes.Unavailable, fmt.Sprintf("tenant is missing from metadata for DynaKube %s", dkName))
+	if dynakube == nil {
+		return nil, status.Error(codes.Unavailable, fmt.Sprintf("dynakube (%s) is missing from metadata database", dkName))
 	}
 	return &bindConfig{
-		tenantUUID: tenant.TenantUUID,
-		version:    tenant.LatestVersion,
+		tenantUUID: dynakube.TenantUUID,
+		version:    dynakube.LatestVersion,
 	}, nil
 }

--- a/controllers/csi/driver/bind_config_test.go
+++ b/controllers/csi/driver/bind_config_test.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	dkName       = "a-dynakube"
-	tenantUuid   = "a-tenant-uuid"
+	tenantUUID   = "a-tenant-uuid"
 	agentVersion = "1.2-3"
 )
 
@@ -128,13 +128,13 @@ func TestCSIDriverServer_NewBindConfig(t *testing.T) {
 			namespace: namespace,
 		}
 
-		srv.db.InsertTenant(metadata.NewTenant(tenantUuid, agentVersion, dkName))
+		srv.db.InsertDynakube(metadata.NewDynakube(dkName, tenantUUID, agentVersion))
 
 		bindCfg, err := newBindConfig(context.TODO(), srv, volumeCfg)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, bindCfg)
-		assert.Equal(t, filepath.Join(srv.opts.RootDir, tenantUuid, "bin", agentVersion), srv.path.AgentBinaryDirForVersion(tenantUuid, agentVersion))
-		assert.Equal(t, filepath.Join(srv.opts.RootDir, tenantUuid), srv.path.EnvDir(tenantUuid))
+		assert.Equal(t, filepath.Join(srv.opts.RootDir, tenantUUID, "bin", agentVersion), srv.path.AgentBinaryDirForVersion(tenantUUID, agentVersion))
+		assert.Equal(t, filepath.Join(srv.opts.RootDir, tenantUUID), srv.path.EnvDir(tenantUUID))
 	})
 }

--- a/controllers/csi/driver/bind_config_test.go
+++ b/controllers/csi/driver/bind_config_test.go
@@ -54,7 +54,7 @@ func TestCSIDriverServer_NewBindConfig(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, bindCfg)
 	})
-	t.Run(`no tenant in storage`, func(t *testing.T) {
+	t.Run(`no dynakube in storage`, func(t *testing.T) {
 		clt := fake.NewClient(
 			&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
 			&dynatracev1beta1.DynaKube{

--- a/controllers/csi/driver/server_test.go
+++ b/controllers/csi/driver/server_test.go
@@ -163,7 +163,7 @@ func TestServer_NodeUnpublishVolume(t *testing.T) {
 		resetMetrics()
 		mounter := mount.NewFakeMounter([]mount.MountPoint{
 			{Path: testTargetPath},
-			{Path: fmt.Sprintf("/%s/run/%s/mapped", tenantUuid, volumeId)},
+			{Path: fmt.Sprintf("/%s/run/%s/mapped", tenantUUID, volumeId)},
 		})
 		server := newServerForTesting(t, mounter)
 		mockPublishedVolume(t, &server)
@@ -186,7 +186,7 @@ func TestServer_NodeUnpublishVolume(t *testing.T) {
 		resetMetrics()
 		mounter := mount.NewFakeMounter([]mount.MountPoint{
 			{Path: testTargetPath},
-			{Path: fmt.Sprintf("/%s/run/%s/mapped", tenantUuid, volumeId)},
+			{Path: fmt.Sprintf("/%s/run/%s/mapped", tenantUUID, volumeId)},
 		})
 		server := newServerForTesting(t, mounter)
 
@@ -250,7 +250,7 @@ func TestStoreAndLoadPodInfo(t *testing.T) {
 
 	bindCfg := &bindConfig{
 		version:    agentVersion,
-		tenantUUID: tenantUuid,
+		tenantUUID: tenantUUID,
 	}
 
 	volumeCfg := volumeConfig{
@@ -268,7 +268,7 @@ func TestStoreAndLoadPodInfo(t *testing.T) {
 	assert.Equal(t, volumeId, volume.VolumeID)
 	assert.Equal(t, podUID, volume.PodName)
 	assert.Equal(t, agentVersion, volume.Version)
-	assert.Equal(t, tenantUuid, volume.TenantUUID)
+	assert.Equal(t, tenantUUID, volume.TenantUUID)
 }
 
 func TestLoadPodInfo_Empty(t *testing.T) {
@@ -323,13 +323,13 @@ func newServerForTesting(t *testing.T, mounter *mount.FakeMounter) CSIDriverServ
 
 func mockPublishedVolume(t *testing.T, server *CSIDriverServer) {
 	mockOneAgent(t, server)
-	err := server.db.InsertVolume(metadata.NewVolume(volumeId, podUID, agentVersion, tenantUuid))
+	err := server.db.InsertVolume(metadata.NewVolume(volumeId, podUID, agentVersion, tenantUUID))
 	require.NoError(t, err)
 	agentsVersionsMetric.WithLabelValues(agentVersion).Inc()
 }
 
 func mockOneAgent(t *testing.T, server *CSIDriverServer) {
-	err := server.db.InsertTenant(metadata.NewTenant(tenantUuid, agentVersion, dkName))
+	err := server.db.InsertDynakube(metadata.NewDynakube(dkName, tenantUUID, agentVersion))
 	require.NoError(t, err)
 }
 
@@ -340,7 +340,7 @@ func assertReferencesForPublishedVolume(t *testing.T, server *CSIDriverServer, m
 	assert.Equal(t, volume.VolumeID, volumeId)
 	assert.Equal(t, volume.PodName, podUID)
 	assert.Equal(t, volume.Version, agentVersion)
-	assert.Equal(t, volume.TenantUUID, tenantUuid)
+	assert.Equal(t, volume.TenantUUID, tenantUUID)
 }
 
 func assertNoReferencesForUnpublishedVolume(t *testing.T, server *CSIDriverServer) {

--- a/controllers/csi/metadata/correctness.go
+++ b/controllers/csi/metadata/correctness.go
@@ -46,7 +46,7 @@ func correctVolumes(cl client.Client, access Access, log logr.Logger) error {
 
 // Removes tenant entries if their dynakube no longer exists
 func correctTenants(cl client.Client, access Access, log logr.Logger) error {
-	tenants, err := access.GetTenants()
+	tenants, err := access.GetDynakubes()
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func correctTenants(cl client.Client, access Access, log logr.Logger) error {
 		if err := cl.Get(context.TODO(), client.ObjectKey{Name: dynakubeName}, &dynakube); !k8serrors.IsNotFound(err) {
 			continue
 		}
-		if err := access.DeleteTenant(dynakubeName); err != nil {
+		if err := access.DeleteDynakube(dynakubeName); err != nil {
 			return err
 		}
 		tenantUUID := tenants[dynakubeName]

--- a/controllers/csi/metadata/correctness_test.go
+++ b/controllers/csi/metadata/correctness_test.go
@@ -37,7 +37,7 @@ func TestCheckStorageCorrectness_DoNothing(t *testing.T) {
 	log := logger.NewDTLogger()
 	client := fake.NewClient(
 		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: testVolume1.PodName}},
-		&dynatracev1beta1.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testTenant1.Dynakube}},
+		&dynatracev1beta1.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testDynakube1.Name}},
 	)
 
 	err := CorrectMetadata(client, db, log)
@@ -53,13 +53,13 @@ func TestCheckStorageCorrectness_PURGE(t *testing.T) {
 	db.InsertVolume(&testVolume1)
 	db.InsertVolume(&testVolume2)
 	db.InsertVolume(&testVolume3)
-	db.InsertTenant(&testTenant1)
-	db.InsertTenant(&testTenant2)
-	db.InsertTenant(&testTenant3)
+	db.InsertDynakube(&testDynakube1)
+	db.InsertDynakube(&testDynakube2)
+	db.InsertDynakube(&testDynakube3)
 	log := logger.NewDTLogger()
 	client := fake.NewClient(
 		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: testVolume1.PodName}},
-		&dynatracev1beta1.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testTenant1.Dynakube}},
+		&dynatracev1beta1.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testDynakube1.Name}},
 	)
 
 	err := CorrectMetadata(client, db, log)
@@ -69,9 +69,9 @@ func TestCheckStorageCorrectness_PURGE(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, &testVolume1, vol)
 
-	ten, err := db.GetTenant(testTenant1.Dynakube)
+	ten, err := db.GetDynakube(testDynakube1.Name)
 	assert.NoError(t, err)
-	assert.Equal(t, &testTenant1, ten)
+	assert.Equal(t, &testDynakube1, ten)
 
 	// PURGED
 	vol, err = db.GetVolume(testVolume2.VolumeID)
@@ -84,12 +84,12 @@ func TestCheckStorageCorrectness_PURGE(t *testing.T) {
 	assert.Nil(t, vol)
 
 	// PURGED
-	ten, err = db.GetTenant(testTenant2.TenantUUID)
+	ten, err = db.GetDynakube(testDynakube2.TenantUUID)
 	assert.NoError(t, err)
 	assert.Nil(t, ten)
 
 	// PURGED
-	ten, err = db.GetTenant(testTenant3.TenantUUID)
+	ten, err = db.GetDynakube(testDynakube3.TenantUUID)
 	assert.NoError(t, err)
 	assert.Nil(t, ten)
 }

--- a/controllers/csi/metadata/fakes.go
+++ b/controllers/csi/metadata/fakes.go
@@ -5,39 +5,39 @@ import (
 )
 
 var (
-	testTenant1 = Tenant{
+	testDynakube1 = Dynakube{
 		TenantUUID:    "asc1",
 		LatestVersion: "123",
-		Dynakube:      "dk1",
+		Name:          "dk1",
 	}
-	testTenant2 = Tenant{
+	testDynakube2 = Dynakube{
 		TenantUUID:    "asc2",
 		LatestVersion: "223",
-		Dynakube:      "dk2",
+		Name:          "dk2",
 	}
-	testTenant3 = Tenant{
+	testDynakube3 = Dynakube{
 		TenantUUID:    "asc3",
 		LatestVersion: "323",
-		Dynakube:      "dk3",
+		Name:          "dk3",
 	}
 
 	testVolume1 = Volume{
 		VolumeID:   "vol-1",
 		PodName:    "pod1",
-		Version:    testTenant1.LatestVersion,
-		TenantUUID: testTenant1.TenantUUID,
+		Version:    testDynakube1.LatestVersion,
+		TenantUUID: testDynakube1.TenantUUID,
 	}
 	testVolume2 = Volume{
 		VolumeID:   "vol-2",
 		PodName:    "pod2",
-		Version:    testTenant2.LatestVersion,
-		TenantUUID: testTenant2.TenantUUID,
+		Version:    testDynakube2.LatestVersion,
+		TenantUUID: testDynakube2.TenantUUID,
 	}
 	testVolume3 = Volume{
 		VolumeID:   "vol-3",
 		PodName:    "pod3",
-		Version:    testTenant3.LatestVersion,
-		TenantUUID: testTenant3.TenantUUID,
+		Version:    testDynakube3.LatestVersion,
+		TenantUUID: testDynakube3.TenantUUID,
 	}
 )
 
@@ -62,12 +62,12 @@ func checkIfTablesExist(db *SqliteAccess) bool {
 		return false
 	}
 	var tentatsTable string
-	row = db.conn.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?;", tenantsTableName)
+	row = db.conn.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?;", dynakubesTableName)
 	err = row.Scan(&tentatsTable)
 	if err != nil {
 		return false
 	}
-	if tentatsTable != tenantsTableName || volumesTable != volumesTableName {
+	if tentatsTable != dynakubesTableName || volumesTable != volumesTableName {
 		return false
 	}
 	return true
@@ -75,13 +75,13 @@ func checkIfTablesExist(db *SqliteAccess) bool {
 
 type FakeFailDB struct{}
 
-func (f *FakeFailDB) Setup(dbPath string) error                      { return sql.ErrTxDone }
-func (f *FakeFailDB) InsertTenant(tenant *Tenant) error              { return sql.ErrTxDone }
-func (f *FakeFailDB) UpdateTenant(tenant *Tenant) error              { return sql.ErrTxDone }
-func (f *FakeFailDB) DeleteTenant(dynakubeName string) error         { return sql.ErrTxDone }
-func (f *FakeFailDB) GetTenant(dynakubeName string) (*Tenant, error) { return nil, sql.ErrTxDone }
+func (f *FakeFailDB) Setup(dbPath string) error                          { return sql.ErrTxDone }
+func (f *FakeFailDB) InsertDynakube(tenant *Dynakube) error              { return sql.ErrTxDone }
+func (f *FakeFailDB) UpdateDynakube(tenant *Dynakube) error              { return sql.ErrTxDone }
+func (f *FakeFailDB) DeleteDynakube(dynakubeName string) error           { return sql.ErrTxDone }
+func (f *FakeFailDB) GetDynakube(dynakubeName string) (*Dynakube, error) { return nil, sql.ErrTxDone }
 
-func (f *FakeFailDB) GetTenants() (map[string]string, error)     { return nil, sql.ErrTxDone }
+func (f *FakeFailDB) GetDynakubes() (map[string]string, error)   { return nil, sql.ErrTxDone }
 func (f *FakeFailDB) InsertVolume(volume *Volume) error          { return sql.ErrTxDone }
 func (f *FakeFailDB) DeleteVolume(volumeID string) error         { return sql.ErrTxDone }
 func (f *FakeFailDB) GetVolume(volumeID string) (*Volume, error) { return nil, sql.ErrTxDone }

--- a/controllers/csi/metadata/metadata.go
+++ b/controllers/csi/metadata/metadata.go
@@ -1,17 +1,17 @@
 package metadata
 
-type Tenant struct {
+type Dynakube struct {
+	Name          string
 	TenantUUID    string
 	LatestVersion string
-	Dynakube      string
 }
 
-// NewTenant returns a new Tenant if all fields are set.
-func NewTenant(uuid, latestVersion, dynakube string) *Tenant {
-	if uuid == "" || latestVersion == "" || dynakube == "" {
+// NewDynakube returns a new Tenant if all fields are set.
+func NewDynakube(dynakubeName, tenantUUID, latestVersion string) *Dynakube {
+	if tenantUUID == "" || latestVersion == "" || dynakubeName == "" {
 		return nil
 	}
-	return &Tenant{uuid, latestVersion, dynakube}
+	return &Dynakube{dynakubeName, tenantUUID, latestVersion}
 }
 
 type Volume struct {
@@ -32,11 +32,11 @@ func NewVolume(id, podUID, version, tenantUUID string) *Volume {
 type Access interface {
 	Setup(path string) error
 
-	InsertTenant(tenant *Tenant) error
-	UpdateTenant(tenant *Tenant) error
-	DeleteTenant(dynakubeName string) error
-	GetTenant(dynakubeName string) (*Tenant, error)
-	GetTenants() (map[string]string, error)
+	InsertDynakube(dynakube *Dynakube) error
+	UpdateDynakube(dynakube *Dynakube) error
+	DeleteDynakube(dynakubeName string) error
+	GetDynakube(dynakubeName string) (*Dynakube, error)
+	GetDynakubes() (map[string]string, error)
 
 	InsertVolume(volume *Volume) error
 	DeleteVolume(volumeID string) error

--- a/controllers/csi/metadata/metadata.go
+++ b/controllers/csi/metadata/metadata.go
@@ -1,12 +1,13 @@
 package metadata
 
+// Stores the necessary info from the Dynakube that is needed to be used during volume mount/unmount.
 type Dynakube struct {
 	Name          string
 	TenantUUID    string
 	LatestVersion string
 }
 
-// NewDynakube returns a new Tenant if all fields are set.
+// NewDynakube returns a new metadata.Dynakube if all fields are set.
 func NewDynakube(dynakubeName, tenantUUID, latestVersion string) *Dynakube {
 	if tenantUUID == "" || latestVersion == "" || dynakubeName == "" {
 		return nil

--- a/controllers/csi/metadata/sqlite.go
+++ b/controllers/csi/metadata/sqlite.go
@@ -11,13 +11,13 @@ import (
 const (
 	sqliteDriverName = "sqlite3"
 
-	tenantsTableName       = "tenants"
-	tenantsCreateStatement = `
-	CREATE TABLE IF NOT EXISTS tenants (
-		UUID VARCHAR NOT NULL,
+	dynakubesTableName       = "dynakubes"
+	dynakubesCreateStatement = `
+	CREATE TABLE IF NOT EXISTS dynakubes (
+		Name VARCHAR NOT NULL,
+		TenantUUID VARCHAR NOT NULL,
 		LatestVersion VARCHAR NOT NULL,
-		Dynakube VARCHAR NOT NULL,
-		PRIMARY KEY (Dynakube)
+		PRIMARY KEY (Name)
 	); `
 
 	volumesTableName       = "volumes"
@@ -30,20 +30,20 @@ const (
 		PRIMARY KEY (ID)
 	);`
 
-	insertTenantStatement = `
-	INSERT INTO tenants (UUID, LatestVersion, Dynakube)
+	insertDynakubeStatement = `
+	INSERT INTO dynakubes (Name, TenantUUID, LatestVersion)
 	VALUES (?,?,?);
 	`
-	updateTenantStatement = `
-	UPDATE tenants
-	SET LatestVersion = ?, UUID = ?
-	WHERE Dynakube = ?;
+	updateDynakubeStatement = `
+	UPDATE dynakubes
+	SET LatestVersion = ?, TenantUUID = ?
+	WHERE Name = ?;
 	`
 
-	getTenantStatement = `
-	SELECT UUID, LatestVersion
-	FROM tenants
-	WHERE Dynakube = ?;
+	getDynakubeStatement = `
+	SELECT TenantUUID, LatestVersion
+	FROM dynakubes
+	WHERE Name = ?;
 	`
 
 	insertVolumeStatement = `
@@ -59,7 +59,7 @@ const (
 
 	deleteVolumeStatement = "DELETE FROM volumes WHERE ID = ?;"
 
-	deleteTenantStatement = "DELETE FROM tenants WHERE Dynakube = ?;"
+	deleteDynakubeStatement = "DELETE FROM dynakubes WHERE Name = ?;"
 
 	getUsedVersionsStatement = `
 	SELECT Version
@@ -72,9 +72,9 @@ const (
 	FROM volumes;
 	`
 
-	getTenantsStatement = `
-	SELECT UUID, Dynakube
-	FROM tenants;
+	getDynakubesStatement = `
+	SELECT tenantUUID, Name
+	FROM dynakubes;
 	`
 )
 
@@ -109,8 +109,8 @@ func (a *SqliteAccess) connect(driver, path string) error {
 }
 
 func (a *SqliteAccess) createTables() error {
-	if _, err := a.conn.Exec(tenantsCreateStatement); err != nil {
-		return fmt.Errorf("couldn't create the table %s, err: %s", tenantsTableName, err)
+	if _, err := a.conn.Exec(dynakubesCreateStatement); err != nil {
+		return fmt.Errorf("couldn't create the table %s, err: %s", dynakubesTableName, err)
 	}
 	if _, err := a.conn.Exec(volumesCreateStatement); err != nil {
 		return fmt.Errorf("couldn't create the table %s, err: %s", volumesTableName, err)
@@ -129,50 +129,50 @@ func (a *SqliteAccess) Setup(path string) error {
 	return nil
 }
 
-// InsertTenant inserts a new Tenant
-func (a *SqliteAccess) InsertTenant(tenant *Tenant) error {
-	err := a.executeStatement(insertTenantStatement, tenant.TenantUUID, tenant.LatestVersion, tenant.Dynakube)
+// InsertDynakube inserts a new Tenant
+func (a *SqliteAccess) InsertDynakube(dynakube *Dynakube) error {
+	err := a.executeStatement(insertDynakubeStatement, dynakube.Name, dynakube.TenantUUID, dynakube.LatestVersion)
 	if err != nil {
-		err = fmt.Errorf("couldn't insert tenant, uuid '%s', latest version '%s', dynakube '%s', err: %s",
-			tenant.TenantUUID,
-			tenant.LatestVersion,
-			tenant.Dynakube,
+		err = fmt.Errorf("couldn't insert dynakube entry, tenantUUID '%s', latest version '%s', dynakube '%s', err: %s",
+			dynakube.TenantUUID,
+			dynakube.LatestVersion,
+			dynakube.Name,
 			err)
 	}
 	return err
 }
 
-// UpdateTenant updates an existing Tenant by matching the Dynakube name
-func (a *SqliteAccess) UpdateTenant(tenant *Tenant) error {
-	err := a.executeStatement(updateTenantStatement, tenant.LatestVersion, tenant.TenantUUID, tenant.Dynakube)
+// UpdateDynakube updates an existing Tenant by matching the Dynakube name
+func (a *SqliteAccess) UpdateDynakube(tenant *Dynakube) error {
+	err := a.executeStatement(updateDynakubeStatement, tenant.LatestVersion, tenant.TenantUUID, tenant.Name)
 	if err != nil {
-		err = fmt.Errorf("couldn't update tenant, uuid '%s', latest version '%s', dynakube '%s', err: %s",
+		err = fmt.Errorf("couldn't update dynakube, tenantUUID '%s', latest version '%s', name '%s', err: %s",
 			tenant.TenantUUID,
 			tenant.LatestVersion,
-			tenant.Dynakube,
+			tenant.Name,
 			err)
 	}
 	return err
 }
 
-// DeleteTenant deletes an existing Tenant by Dynakube name
-func (a *SqliteAccess) DeleteTenant(dynakubeName string) error {
-	err := a.executeStatement(deleteTenantStatement, dynakubeName)
+// DeleteDynakube deletes an existing Tenant by Dynakube name
+func (a *SqliteAccess) DeleteDynakube(dynakubeName string) error {
+	err := a.executeStatement(deleteDynakubeStatement, dynakubeName)
 	if err != nil {
 		err = fmt.Errorf("couldn't delete tenant, dynakube '%s', err: %s", dynakubeName, err)
 	}
 	return err
 }
 
-// GetTenant gets Tenant by Dynakube name
-func (a *SqliteAccess) GetTenant(dynakubeName string) (*Tenant, error) {
+// GetDynakube gets Tenant by Dynakube name
+func (a *SqliteAccess) GetDynakube(dynakubeName string) (*Dynakube, error) {
 	var tenantUUID string
 	var latestVersion string
-	err := a.querySimpleStatement(getTenantStatement, dynakubeName, &tenantUUID, &latestVersion)
+	err := a.querySimpleStatement(getDynakubeStatement, dynakubeName, &tenantUUID, &latestVersion)
 	if err != nil {
-		err = fmt.Errorf("couldn't get tenant, dynakube '%s', err: %s", dynakubeName, err)
+		err = fmt.Errorf("couldn't get dynakube, name '%s', err: %s", dynakubeName, err)
 	}
-	return NewTenant(tenantUUID, latestVersion, dynakubeName), err
+	return NewDynakube(dynakubeName, tenantUUID, latestVersion), err
 }
 
 // InsertVolume inserts a new Volume
@@ -253,9 +253,9 @@ func (a *SqliteAccess) GetPodNames() (map[string]string, error) {
 	return podNames, nil
 }
 
-// GetTenants gets all Tenants and maps their tenantUUID to the corresponding Dynakubes.
-func (a *SqliteAccess) GetTenants() (map[string]string, error) {
-	rows, err := a.conn.Query(getTenantsStatement)
+// GetDynakubes gets all Tenants and maps their tenantUUID to the corresponding Dynakubes.
+func (a *SqliteAccess) GetDynakubes() (map[string]string, error) {
+	rows, err := a.conn.Query(getDynakubesStatement)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get tenants, err: %s", err)
 	}

--- a/controllers/csi/metadata/sqlite.go
+++ b/controllers/csi/metadata/sqlite.go
@@ -129,7 +129,7 @@ func (a *SqliteAccess) Setup(path string) error {
 	return nil
 }
 
-// InsertDynakube inserts a new Tenant
+// InsertDynakube inserts a new Dynakube
 func (a *SqliteAccess) InsertDynakube(dynakube *Dynakube) error {
 	err := a.executeStatement(insertDynakubeStatement, dynakube.Name, dynakube.TenantUUID, dynakube.LatestVersion)
 	if err != nil {
@@ -142,29 +142,29 @@ func (a *SqliteAccess) InsertDynakube(dynakube *Dynakube) error {
 	return err
 }
 
-// UpdateDynakube updates an existing Tenant by matching the Dynakube name
-func (a *SqliteAccess) UpdateDynakube(tenant *Dynakube) error {
-	err := a.executeStatement(updateDynakubeStatement, tenant.LatestVersion, tenant.TenantUUID, tenant.Name)
+// UpdateDynakube updates an existing Dynakube by matching the name
+func (a *SqliteAccess) UpdateDynakube(dynakube *Dynakube) error {
+	err := a.executeStatement(updateDynakubeStatement, dynakube.LatestVersion, dynakube.TenantUUID, dynakube.Name)
 	if err != nil {
 		err = fmt.Errorf("couldn't update dynakube, tenantUUID '%s', latest version '%s', name '%s', err: %s",
-			tenant.TenantUUID,
-			tenant.LatestVersion,
-			tenant.Name,
+			dynakube.TenantUUID,
+			dynakube.LatestVersion,
+			dynakube.Name,
 			err)
 	}
 	return err
 }
 
-// DeleteDynakube deletes an existing Tenant by Dynakube name
+// DeleteDynakube deletes an existing Dynakube using its name
 func (a *SqliteAccess) DeleteDynakube(dynakubeName string) error {
 	err := a.executeStatement(deleteDynakubeStatement, dynakubeName)
 	if err != nil {
-		err = fmt.Errorf("couldn't delete tenant, dynakube '%s', err: %s", dynakubeName, err)
+		err = fmt.Errorf("couldn't delete dynakube, name '%s', err: %s", dynakubeName, err)
 	}
 	return err
 }
 
-// GetDynakube gets Tenant by Dynakube name
+// GetDynakube gets Dynakube using its name
 func (a *SqliteAccess) GetDynakube(dynakubeName string) (*Dynakube, error) {
 	var tenantUUID string
 	var latestVersion string
@@ -253,24 +253,24 @@ func (a *SqliteAccess) GetPodNames() (map[string]string, error) {
 	return podNames, nil
 }
 
-// GetDynakubes gets all Tenants and maps their tenantUUID to the corresponding Dynakubes.
+// GetDynakubes gets all Dynakubes and maps their name to the corresponding TenantUUID.
 func (a *SqliteAccess) GetDynakubes() (map[string]string, error) {
 	rows, err := a.conn.Query(getDynakubesStatement)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't get tenants, err: %s", err)
+		return nil, fmt.Errorf("couldn't get dynakubes, err: %s", err)
 	}
-	tenants := map[string]string{}
+	dynakubes := map[string]string{}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var uuid string
 		var dynakube string
 		err := rows.Scan(&uuid, &dynakube)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan from database for tenant, err: %s", err)
+			return nil, fmt.Errorf("failed to scan from database for dynakube, err: %s", err)
 		}
-		tenants[dynakube] = uuid
+		dynakubes[dynakube] = uuid
 	}
-	return tenants, nil
+	return dynakubes, nil
 }
 
 // Executes the provided SQL statement on the database.

--- a/controllers/csi/metadata/sqlite_test.go
+++ b/controllers/csi/metadata/sqlite_test.go
@@ -58,93 +58,93 @@ func TestCreateTables(t *testing.T) {
 	assert.Equal(t, podsTable, volumesTableName)
 
 	var tenantsTable string
-	row = db.conn.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?;", tenantsTableName)
+	row = db.conn.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?;", dynakubesTableName)
 	row.Scan(&tenantsTable)
-	assert.Equal(t, tenantsTable, tenantsTableName)
+	assert.Equal(t, tenantsTable, dynakubesTableName)
 
 }
 
-func TestInsertTenant(t *testing.T) {
+func TestInsertDynakube(t *testing.T) {
 	db := FakeMemoryDB()
 
 	// Insert
-	err := db.InsertTenant(&testTenant1)
+	err := db.InsertDynakube(&testDynakube1)
 	assert.Nil(t, err)
-	row := db.conn.QueryRow(fmt.Sprintf("SELECT * FROM %s WHERE UUID = ?;", tenantsTableName), testTenant1.TenantUUID)
+	row := db.conn.QueryRow(fmt.Sprintf("SELECT * FROM %s WHERE TenantUUID = ?;", dynakubesTableName), testDynakube1.TenantUUID)
 	var uuid string
 	var lv string
 	var dk string
-	err = row.Scan(&uuid, &lv, &dk)
+	err = row.Scan(&dk, &uuid, &lv)
 	assert.NoError(t, err)
-	assert.Equal(t, uuid, testTenant1.TenantUUID)
-	assert.Equal(t, lv, testTenant1.LatestVersion)
-	assert.Equal(t, dk, testTenant1.Dynakube)
+	assert.Equal(t, uuid, testDynakube1.TenantUUID)
+	assert.Equal(t, lv, testDynakube1.LatestVersion)
+	assert.Equal(t, dk, testDynakube1.Name)
 }
 
-func TestGetTenant_Empty(t *testing.T) {
+func TestGetDynakube_Empty(t *testing.T) {
 	db := FakeMemoryDB()
 
-	gt, err := db.GetTenant(testTenant1.TenantUUID)
+	gt, err := db.GetDynakube(testDynakube1.TenantUUID)
 	assert.NoError(t, err)
 	assert.Nil(t, gt)
 }
 
-func TestGetTenant(t *testing.T) {
+func TestGetDynakube(t *testing.T) {
 	db := FakeMemoryDB()
-	err := db.InsertTenant(&testTenant1)
+	err := db.InsertDynakube(&testDynakube1)
 	assert.Nil(t, err)
 
-	tenant, err := db.GetTenant(testTenant1.Dynakube)
+	tenant, err := db.GetDynakube(testDynakube1.Name)
 	assert.NoError(t, err)
-	assert.Equal(t, testTenant1, *tenant)
+	assert.Equal(t, testDynakube1, *tenant)
 }
 
-func TestUpdateTenant(t *testing.T) {
+func TestUpdateDynakube(t *testing.T) {
 	db := FakeMemoryDB()
-	err := db.InsertTenant(&testTenant1)
+	err := db.InsertDynakube(&testDynakube1)
 	assert.Nil(t, err)
 
-	testTenant1.LatestVersion = "132.546"
-	err = db.UpdateTenant(&testTenant1)
+	testDynakube1.LatestVersion = "132.546"
+	err = db.UpdateDynakube(&testDynakube1)
 	var uuid string
 	var lv string
 	var dk string
 	assert.NoError(t, err)
-	row := db.conn.QueryRow(fmt.Sprintf("SELECT * FROM %s WHERE Dynakube = ?;", tenantsTableName), testTenant1.Dynakube)
-	err = row.Scan(&uuid, &lv, &dk)
+	row := db.conn.QueryRow(fmt.Sprintf("SELECT * FROM %s WHERE Name = ?;", dynakubesTableName), testDynakube1.Name)
+	err = row.Scan(&dk, &uuid, &lv)
 	assert.NoError(t, err)
-	assert.Equal(t, uuid, testTenant1.TenantUUID)
+	assert.Equal(t, uuid, testDynakube1.TenantUUID)
 	assert.Equal(t, lv, "132.546")
-	assert.Equal(t, dk, testTenant1.Dynakube)
+	assert.Equal(t, dk, testDynakube1.Name)
 }
 
 func TestGetDynakubes(t *testing.T) {
 	db := FakeMemoryDB()
-	err := db.InsertTenant(&testTenant1)
+	err := db.InsertDynakube(&testDynakube1)
 	assert.Nil(t, err)
-	err = db.InsertTenant(&testTenant2)
+	err = db.InsertDynakube(&testDynakube2)
 	assert.Nil(t, err)
 
-	tenants, err := db.GetTenants()
+	tenants, err := db.GetDynakubes()
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(tenants))
-	assert.Equal(t, testTenant1.TenantUUID, tenants[testTenant1.Dynakube])
-	assert.Equal(t, testTenant2.TenantUUID, tenants[testTenant2.Dynakube])
+	assert.Equal(t, testDynakube1.TenantUUID, tenants[testDynakube1.Name])
+	assert.Equal(t, testDynakube2.TenantUUID, tenants[testDynakube2.Name])
 }
 
-func TestDeleteTenant(t *testing.T) {
+func TestDeleteDynakube(t *testing.T) {
 	db := FakeMemoryDB()
-	err := db.InsertTenant(&testTenant1)
+	err := db.InsertDynakube(&testDynakube1)
 	assert.Nil(t, err)
-	err = db.InsertTenant(&testTenant2)
+	err = db.InsertDynakube(&testDynakube2)
 	assert.Nil(t, err)
 
-	err = db.DeleteTenant(testTenant1.Dynakube)
+	err = db.DeleteDynakube(testDynakube1.Name)
 	assert.NoError(t, err)
-	tenants, err := db.GetTenants()
+	tenants, err := db.GetDynakubes()
 	assert.NoError(t, err)
 	assert.Equal(t, len(tenants), 1)
-	assert.Equal(t, testTenant2.TenantUUID, tenants[testTenant2.Dynakube])
+	assert.Equal(t, testDynakube2.TenantUUID, tenants[testDynakube2.Name])
 }
 
 func TestGetVolume_Empty(t *testing.T) {

--- a/controllers/csi/metadata/sqlite_test.go
+++ b/controllers/csi/metadata/sqlite_test.go
@@ -57,10 +57,10 @@ func TestCreateTables(t *testing.T) {
 	row.Scan(&podsTable)
 	assert.Equal(t, podsTable, volumesTableName)
 
-	var tenantsTable string
+	var dkTable string
 	row = db.conn.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?;", dynakubesTableName)
-	row.Scan(&tenantsTable)
-	assert.Equal(t, tenantsTable, dynakubesTableName)
+	row.Scan(&dkTable)
+	assert.Equal(t, dkTable, dynakubesTableName)
 
 }
 
@@ -73,12 +73,12 @@ func TestInsertDynakube(t *testing.T) {
 	row := db.conn.QueryRow(fmt.Sprintf("SELECT * FROM %s WHERE TenantUUID = ?;", dynakubesTableName), testDynakube1.TenantUUID)
 	var uuid string
 	var lv string
-	var dk string
-	err = row.Scan(&dk, &uuid, &lv)
+	var name string
+	err = row.Scan(&name, &uuid, &lv)
 	assert.NoError(t, err)
 	assert.Equal(t, uuid, testDynakube1.TenantUUID)
 	assert.Equal(t, lv, testDynakube1.LatestVersion)
-	assert.Equal(t, dk, testDynakube1.Name)
+	assert.Equal(t, name, testDynakube1.Name)
 }
 
 func TestGetDynakube_Empty(t *testing.T) {
@@ -94,9 +94,9 @@ func TestGetDynakube(t *testing.T) {
 	err := db.InsertDynakube(&testDynakube1)
 	assert.Nil(t, err)
 
-	tenant, err := db.GetDynakube(testDynakube1.Name)
+	dynakube, err := db.GetDynakube(testDynakube1.Name)
 	assert.NoError(t, err)
-	assert.Equal(t, testDynakube1, *tenant)
+	assert.Equal(t, testDynakube1, *dynakube)
 }
 
 func TestUpdateDynakube(t *testing.T) {
@@ -108,14 +108,14 @@ func TestUpdateDynakube(t *testing.T) {
 	err = db.UpdateDynakube(&testDynakube1)
 	var uuid string
 	var lv string
-	var dk string
+	var name string
 	assert.NoError(t, err)
 	row := db.conn.QueryRow(fmt.Sprintf("SELECT * FROM %s WHERE Name = ?;", dynakubesTableName), testDynakube1.Name)
-	err = row.Scan(&dk, &uuid, &lv)
+	err = row.Scan(&name, &uuid, &lv)
 	assert.NoError(t, err)
 	assert.Equal(t, uuid, testDynakube1.TenantUUID)
 	assert.Equal(t, lv, "132.546")
-	assert.Equal(t, dk, testDynakube1.Name)
+	assert.Equal(t, name, testDynakube1.Name)
 }
 
 func TestGetDynakubes(t *testing.T) {
@@ -125,11 +125,11 @@ func TestGetDynakubes(t *testing.T) {
 	err = db.InsertDynakube(&testDynakube2)
 	assert.Nil(t, err)
 
-	tenants, err := db.GetDynakubes()
+	dynakubes, err := db.GetDynakubes()
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(tenants))
-	assert.Equal(t, testDynakube1.TenantUUID, tenants[testDynakube1.Name])
-	assert.Equal(t, testDynakube2.TenantUUID, tenants[testDynakube2.Name])
+	assert.Equal(t, 2, len(dynakubes))
+	assert.Equal(t, testDynakube1.TenantUUID, dynakubes[testDynakube1.Name])
+	assert.Equal(t, testDynakube2.TenantUUID, dynakubes[testDynakube2.Name])
 }
 
 func TestDeleteDynakube(t *testing.T) {
@@ -141,10 +141,10 @@ func TestDeleteDynakube(t *testing.T) {
 
 	err = db.DeleteDynakube(testDynakube1.Name)
 	assert.NoError(t, err)
-	tenants, err := db.GetDynakubes()
+	dynakubes, err := db.GetDynakubes()
 	assert.NoError(t, err)
-	assert.Equal(t, len(tenants), 1)
-	assert.Equal(t, testDynakube2.TenantUUID, tenants[testDynakube2.Name])
+	assert.Equal(t, len(dynakubes), 1)
+	assert.Equal(t, testDynakube2.TenantUUID, dynakubes[testDynakube2.Name])
 }
 
 func TestGetVolume_Empty(t *testing.T) {
@@ -155,7 +155,7 @@ func TestGetVolume_Empty(t *testing.T) {
 	assert.Nil(t, vo)
 }
 
-func TestGetInsert(t *testing.T) {
+func TestInsertVolume(t *testing.T) {
 	db := FakeMemoryDB()
 
 	err := db.InsertVolume(&testVolume1)

--- a/controllers/csi/provisioner/reconciler.go
+++ b/controllers/csi/provisioner/reconciler.go
@@ -112,40 +112,40 @@ func (r *OneAgentProvisioner) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	tenant, err := r.db.GetDynakube(dk.Name)
+	dynakube, err := r.db.GetDynakube(dk.Name)
 	if err != nil {
 		return reconcile.Result{}, errors.WithStack(err)
 	}
 
-	// In case of a new tenant
-	var oldTenant metadata.Dynakube
-	if tenant == nil {
-		tenant = &metadata.Dynakube{}
+	// In case of a new dynakube
+	var oldDynakube metadata.Dynakube
+	if dynakube == nil {
+		dynakube = &metadata.Dynakube{}
 	} else {
-		oldTenant = *tenant
+		oldDynakube = *dynakube
 	}
-	rlog.Info("checking tenant", "dynakube", tenant.Name,
-		"uuid", tenant.TenantUUID, "version", tenant.LatestVersion)
+	rlog.Info("checking dynakube", "name", dynakube.Name,
+		"tenantUUID", dynakube.TenantUUID, "version", dynakube.LatestVersion)
 
-	tenant.Name = dk.Name
-	tenant.TenantUUID = dk.ConnectionInfo().TenantUUID
+	dynakube.Name = dk.Name
+	dynakube.TenantUUID = dk.ConnectionInfo().TenantUUID
 
-	if err = r.createCSIDirectories(r.path.EnvDir(tenant.TenantUUID)); err != nil {
-		rlog.Error(err, "error when creating csi directories", "path", r.path.EnvDir(tenant.TenantUUID))
+	if err = r.createCSIDirectories(r.path.EnvDir(dynakube.TenantUUID)); err != nil {
+		rlog.Error(err, "error when creating csi directories", "path", r.path.EnvDir(dynakube.TenantUUID))
 		return reconcile.Result{}, errors.WithStack(err)
 	}
-	rlog.Info("csi directories exist", "path", r.path.EnvDir(tenant.TenantUUID)) /*  */
+	rlog.Info("csi directories exist", "path", r.path.EnvDir(dynakube.TenantUUID))
 
 	installAgentCfg := newInstallAgentConfig(rlog, dtc, r.path, r.fs, r.recorder, dk)
-	if updatedVersion, err := installAgentCfg.updateAgent(tenant.LatestVersion, tenant.TenantUUID); err != nil {
+	if updatedVersion, err := installAgentCfg.updateAgent(dynakube.LatestVersion, dynakube.TenantUUID); err != nil {
 		rlog.Info("error when updating agent", "error", err.Error())
 		// reporting error but not returning it to avoid immediate requeue and subsequently calling the API every few seconds
 		return reconcile.Result{RequeueAfter: defaultRequeueDuration}, nil
 	} else if updatedVersion != "" {
-		tenant.LatestVersion = updatedVersion
+		dynakube.LatestVersion = updatedVersion
 	}
 
-	err = r.createOrUpdateDynakube(oldTenant, tenant)
+	err = r.createOrUpdateDynakube(oldDynakube, dynakube)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -153,27 +153,23 @@ func (r *OneAgentProvisioner) Reconcile(ctx context.Context, request reconcile.R
 	return reconcile.Result{RequeueAfter: defaultRequeueDuration}, nil
 }
 
-func (r *OneAgentProvisioner) createOrUpdateDynakube(oldTenant metadata.Dynakube, tenant *metadata.Dynakube) error {
-	if hasTenantChanged(oldTenant, *tenant) {
-		log.Info("tenant has changed",
-			"dynakube", tenant.Name, "uuid", tenant.TenantUUID, "version", tenant.LatestVersion)
-		if oldTenant == (metadata.Dynakube{}) {
-			log.Info("Adding tenant",
-				"dynakube", tenant.Name, "uuid", tenant.TenantUUID, "version", tenant.LatestVersion)
-			return r.db.InsertDynakube(tenant)
+func (r *OneAgentProvisioner) createOrUpdateDynakube(oldDynakube metadata.Dynakube, dynakube *metadata.Dynakube) error {
+	if oldDynakube != *dynakube {
+		log.Info("dynakube has changed",
+			"name", dynakube.Name, "tenantUUID", dynakube.TenantUUID, "version", dynakube.LatestVersion)
+		if oldDynakube == (metadata.Dynakube{}) {
+			log.Info("adding dynakube to db",
+				"name", dynakube.Name, "tenantUUID", dynakube.TenantUUID, "version", dynakube.LatestVersion)
+			return r.db.InsertDynakube(dynakube)
 		} else {
-			log.Info("Updating tenant",
-				"dynakube", tenant.Name,
-				"old version", oldTenant.LatestVersion, "new version", tenant.LatestVersion,
-				"old tenant UUID", oldTenant.TenantUUID, "new tenant UUID", tenant.TenantUUID)
-			return r.db.UpdateDynakube(tenant)
+			log.Info("updating dynakube in db",
+				"name", dynakube.Name,
+				"old version", oldDynakube.LatestVersion, "new version", dynakube.LatestVersion,
+				"old tenantUUID", oldDynakube.TenantUUID, "new tenantUUID", dynakube.TenantUUID)
+			return r.db.UpdateDynakube(dynakube)
 		}
 	}
 	return nil
-}
-
-func hasTenantChanged(old, new metadata.Dynakube) bool {
-	return old != new
 }
 
 func buildDtc(r *OneAgentProvisioner, ctx context.Context, dk *dynatracev1beta1.DynaKube) (dtclient.Client, error) {

--- a/controllers/csi/provisioner/reconciler_test.go
+++ b/controllers/csi/provisioner/reconciler_test.go
@@ -55,19 +55,19 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 	})
 	t.Run(`dynakube deleted`, func(t *testing.T) {
 		db := metadata.FakeMemoryDB()
-		tenant := metadata.Dynakube{TenantUUID: tenantUUID, LatestVersion: agentVersion, Name: dkName}
-		_ = db.InsertDynakube(&tenant)
+		dynakube := metadata.Dynakube{TenantUUID: tenantUUID, LatestVersion: agentVersion, Name: dkName}
+		_ = db.InsertDynakube(&dynakube)
 		r := &OneAgentProvisioner{
 			apiReader: fake.NewClient(),
 			db:        db,
 		}
-		result, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tenant.Name}})
+		result, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: dynakube.Name}})
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 		assert.Equal(t, reconcile.Result{}, result)
 
-		ten, err := db.GetDynakube(tenant.TenantUUID)
+		ten, err := db.GetDynakube(dynakube.TenantUUID)
 		assert.NoError(t, err)
 		assert.Nil(t, ten)
 	})
@@ -303,7 +303,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, exists)
 	})
-	t.Run(`error getting tenant`, func(t *testing.T) {
+	t.Run(`error getting dynakube from db`, func(t *testing.T) {
 		memFs := afero.NewMemMapFs()
 		mockClient := &dtclient.MockDynatraceClient{}
 		mockClient.On("GetConnectionInfo").Return(dtclient.ConnectionInfo{
@@ -479,45 +479,45 @@ func TestProvisioner_CreateTenant(t *testing.T) {
 		db: db,
 	}
 
-	oldTenant := metadata.Dynakube{}
-	newTenant := metadata.NewDynakube(dkName, tenantUUID, "v1")
+	oldDynakube := metadata.Dynakube{}
+	newDynakube := metadata.NewDynakube(dkName, tenantUUID, "v1")
 
-	err := r.createOrUpdateDynakube(oldTenant, newTenant)
+	err := r.createOrUpdateDynakube(oldDynakube, newDynakube)
 	require.NoError(t, err)
 
-	tenant, err := db.GetDynakube(dkName)
+	dynakube, err := db.GetDynakube(dkName)
 	assert.NoError(t, err)
-	assert.NotNil(t, tenant)
-	assert.Equal(t, *newTenant, *tenant)
+	assert.NotNil(t, dynakube)
+	assert.Equal(t, *newDynakube, *dynakube)
 
-	otherTenant, err := db.GetDynakube(otherDkName)
+	otherDynakube, err := db.GetDynakube(otherDkName)
 	assert.NoError(t, err)
-	assert.NotNil(t, tenant)
-	assert.Equal(t, *expectedOtherDynakube, *otherTenant)
+	assert.NotNil(t, dynakube)
+	assert.Equal(t, *expectedOtherDynakube, *otherDynakube)
 }
 
 func TestProvisioner_UpdateDynakube(t *testing.T) {
 	db := metadata.FakeMemoryDB()
-	oldTenant := metadata.NewDynakube(dkName, tenantUUID, "v1")
-	db.InsertDynakube(oldTenant)
+	oldDynakube := metadata.NewDynakube(dkName, tenantUUID, "v1")
+	db.InsertDynakube(oldDynakube)
 	expectedOtherDynakube := metadata.NewDynakube(otherDkName, tenantUUID, "v1")
 	db.InsertDynakube(expectedOtherDynakube)
 
 	r := &OneAgentProvisioner{
 		db: db,
 	}
-	newTenant := metadata.NewDynakube(dkName, "new-uuid", "v2")
+	newDynakube := metadata.NewDynakube(dkName, "new-uuid", "v2")
 
-	err := r.createOrUpdateDynakube(*oldTenant, newTenant)
+	err := r.createOrUpdateDynakube(*oldDynakube, newDynakube)
 	require.NoError(t, err)
 
-	tenant, err := db.GetDynakube(dkName)
+	dynakube, err := db.GetDynakube(dkName)
 	assert.NoError(t, err)
-	assert.NotNil(t, tenant)
-	assert.Equal(t, *newTenant, *tenant)
+	assert.NotNil(t, dynakube)
+	assert.Equal(t, *newDynakube, *dynakube)
 
 	otherDynakube, err := db.GetDynakube(otherDkName)
 	assert.NoError(t, err)
-	assert.NotNil(t, tenant)
+	assert.NotNil(t, dynakube)
 	assert.Equal(t, *expectedOtherDynakube, *otherDynakube)
 }


### PR DESCRIPTION
The name `tenants` for the CSI driver database is no longer correct.
Since the `namespaceSeletor` change,  the key for the `tenants` table needed to be changed to the dynakube name from the tenantUUID. 

The current name is confusing and we should change it as soon as possible to avoid db migrations. 