### PR TITLE
Removed deploymentType name from DaemonSet and pod name

### DIFF
--- a/controllers/oneagent/daemonset/daemonset.go
+++ b/controllers/oneagent/daemonset/daemonset.go
@@ -16,7 +16,11 @@ import (
 )
 
 const (
-	labelFeature = "operator.dynatrace.com/feature"
+	labelFeature        = "operator.dynatrace.com/feature"
+	labelAgentType      = "operator.dynatrace.com/agenttype"
+	labelAgentTypeValue = "os"
+
+	podNameOSAgent = "oneagent"
 
 	annotationUnprivileged      = "container.apparmor.security.beta.kubernetes.io/dynatrace-oneagent"
 	annotationUnprivilegedValue = "unconfined"
@@ -115,10 +119,11 @@ func (dsInfo *HostMonitoring) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 		return nil, err
 	}
 
-	result.Name = dsInfo.instance.Name + fmt.Sprintf("-%s", dsInfo.feature)
+	result.Name = fmt.Sprintf("%s-%s", dsInfo.instance.Name, podNameOSAgent)
 	result.Labels[labelFeature] = dsInfo.feature
-	result.Spec.Selector.MatchLabels[labelFeature] = dsInfo.feature
+	result.Spec.Selector.MatchLabels[labelAgentType] = labelAgentTypeValue
 	result.Spec.Template.Labels[labelFeature] = dsInfo.feature
+	result.Spec.Template.Labels[labelAgentType] = labelAgentTypeValue
 
 	if len(result.Spec.Template.Spec.Containers) > 0 {
 		appendHostIdArgument(result, inframonHostIdSource)
@@ -134,10 +139,11 @@ func (dsInfo *ClassicFullStack) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 		return nil, err
 	}
 
-	result.Name = dsInfo.instance.Name + fmt.Sprintf("-%s", ClassicFeature)
+	result.Name = fmt.Sprintf("%s-%s", dsInfo.instance.Name, podNameOSAgent)
 	result.Labels[labelFeature] = ClassicFeature
-	result.Spec.Selector.MatchLabels[labelFeature] = ClassicFeature
+	result.Spec.Selector.MatchLabels[labelAgentType] = labelAgentTypeValue
 	result.Spec.Template.Labels[labelFeature] = ClassicFeature
+	result.Spec.Template.Labels[labelAgentType] = labelAgentTypeValue
 
 	if len(result.Spec.Template.Spec.Containers) > 0 {
 		appendHostIdArgument(result, classicHostIdSource)

--- a/controllers/oneagent/daemonset/daemonset.go
+++ b/controllers/oneagent/daemonset/daemonset.go
@@ -20,8 +20,6 @@ const (
 	labelAgentType      = "operator.dynatrace.com/agenttype"
 	labelAgentTypeValue = "os"
 
-	podNameOSAgent = "oneagent"
-
 	annotationUnprivileged      = "container.apparmor.security.beta.kubernetes.io/dynatrace-oneagent"
 	annotationUnprivilegedValue = "unconfined"
 	annotationVersion           = "internal.operator.dynatrace.com/version"
@@ -36,6 +34,8 @@ const (
 
 	inframonHostIdSource = "--set-host-id-source=k8s-node-name"
 	classicHostIdSource  = "--set-host-id-source=auto"
+
+	PodNameOSAgent = "oneagent"
 
 	ClassicFeature        = "classic"
 	HostMonitoringFeature = "inframon"
@@ -119,7 +119,7 @@ func (dsInfo *HostMonitoring) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 		return nil, err
 	}
 
-	result.Name = fmt.Sprintf("%s-%s", dsInfo.instance.Name, podNameOSAgent)
+	result.Name = fmt.Sprintf("%s-%s", dsInfo.instance.Name, PodNameOSAgent)
 	result.Labels[labelFeature] = dsInfo.feature
 	result.Spec.Selector.MatchLabels[labelAgentType] = labelAgentTypeValue
 	result.Spec.Template.Labels[labelFeature] = dsInfo.feature
@@ -139,7 +139,7 @@ func (dsInfo *ClassicFullStack) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 		return nil, err
 	}
 
-	result.Name = fmt.Sprintf("%s-%s", dsInfo.instance.Name, podNameOSAgent)
+	result.Name = fmt.Sprintf("%s-%s", dsInfo.instance.Name, PodNameOSAgent)
 	result.Labels[labelFeature] = ClassicFeature
 	result.Spec.Selector.MatchLabels[labelAgentType] = labelAgentTypeValue
 	result.Spec.Template.Labels[labelFeature] = ClassicFeature

--- a/controllers/oneagent/oneagent_controller_test.go
+++ b/controllers/oneagent/oneagent_controller_test.go
@@ -97,10 +97,10 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironmentAndDNSPolicy(t *testing.T)
 	assert.NoError(t, err)
 
 	dsActual := &appsv1.DaemonSet{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: dkName + "-" + reconciler.feature, Namespace: namespace}, dsActual)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: dkName + "-" + daemonset.PodNameOSAgent, Namespace: namespace}, dsActual)
 	assert.NoError(t, err, "failed to get DaemonSet")
 	assert.Equal(t, namespace, dsActual.Namespace, "wrong namespace")
-	assert.Equal(t, dkName+"-"+reconciler.feature, dsActual.GetObjectMeta().GetName(), "wrong name")
+	assert.Equal(t, dkName+"-"+daemonset.PodNameOSAgent, dsActual.GetObjectMeta().GetName(), "wrong name")
 	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, dsActual.Spec.Template.Spec.DNSPolicy, "wrong policy")
 	mock.AssertExpectationsForObjects(t, dtClient)
 }

--- a/integrationtests/oneagent_controller_integration_test.go
+++ b/integrationtests/oneagent_controller_integration_test.go
@@ -37,10 +37,10 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironment(t *testing.T) {
 	// Check if deamonset has been created and has correct namespace and name.
 	dsActual := &appsv1.DaemonSet{}
 
-	err = e.Client.Get(context.TODO(), types.NamespacedName{Name: oaName + "-" + daemonset.ClassicFeature, Namespace: DefaultTestNamespace}, dsActual)
+	err = e.Client.Get(context.TODO(), types.NamespacedName{Name: oaName + "-" + daemonset.PodNameOSAgent, Namespace: DefaultTestNamespace}, dsActual)
 	assert.NoError(t, err, "failed to get daemonset")
 
 	assert.Equal(t, DefaultTestNamespace, dsActual.Namespace, "wrong namespace")
-	assert.Equal(t, oaName+"-"+daemonset.ClassicFeature, dsActual.GetObjectMeta().GetName(), "wrong name")
+	assert.Equal(t, oaName+"-"+daemonset.PodNameOSAgent, dsActual.GetObjectMeta().GetName(), "wrong name")
 	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, dsActual.Spec.Template.Spec.DNSPolicy, "DNS policy should ClusterFirst by default")
 }


### PR DESCRIPTION
- Remove deploymenttype name from ds and pod name
- Add new static label `operator.dynatrace.com/agenttype=os` for ds and pod template matching