### PR TITLE
Change image tag for K8s and OCP on 0.3.0 branch

### DIFF
--- a/config/kubernetes/kustomization.yaml
+++ b/config/kubernetes/kustomization.yaml
@@ -13,4 +13,3 @@ images:
   - name: quay.io/dynatrace/dynatrace-operator:snapshot
     newName: quay.io/dynatrace/dynatrace-operator
     newTag: snapshot-release-0-3
-    

--- a/config/kubernetes/kustomization.yaml
+++ b/config/kubernetes/kustomization.yaml
@@ -13,3 +13,4 @@ images:
   - name: quay.io/dynatrace/dynatrace-operator:snapshot
     newName: quay.io/dynatrace/dynatrace-operator
     newTag: snapshot-release-0-3
+    

--- a/config/kubernetes/kustomization.yaml
+++ b/config/kubernetes/kustomization.yaml
@@ -9,3 +9,7 @@ bases:
   - ../common/routing
   - ../common/webhook
   - ../crd/default
+images:
+  - name: quay.io/dynatrace/dynatrace-operator:snapshot
+    newName: quay.io/dynatrace/dynatrace-operator
+    newTag: snapshot-release-0-3

--- a/config/openshift/kustomization.yaml
+++ b/config/openshift/kustomization.yaml
@@ -16,6 +16,10 @@ bases:
   - ../common/routing
   - ../common/webhook
   - ../crd/default
+images:
+  - name: quay.io/dynatrace/dynatrace-operator:snapshot
+    newName: quay.io/dynatrace/dynatrace-operator
+    newTag: snapshot-release-0-3
 patchesJson6902:
   - target:
       group: ""


### PR DESCRIPTION
This PR changes the operator image on the release branch, to "snapshot-release-0-3" instead of "snapshot", so kustomize (-k) can be used to apply the operator