### PR TITLE
Adds preserveUnknownFields to webhook patch

### DIFF
--- a/config/crd/patches/webhook_in_dynakubes.yaml
+++ b/config/crd/patches/webhook_in_dynakubes.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: dynakubes.dynatrace.com
 spec:
+  preserveUnknownFields: false # needed when upgrading CRD from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1
   conversion:
     strategy: Webhook
     webhook:


### PR DESCRIPTION
During an upgrade from a crd version `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1` there is some kind of kubernetes conversion voodoo magic that sets `preserveUnknownFields` to true which is not compatible with the conversion webhook. So we have to set it to false, after which the field is magically removed by kubernetes :shrug: 