### PR TITLE
Change beta warning condition for applicationMonitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ OneAgent traffic.
 
 With v0.3.0 the CRD structure has been changed to provide an easier and more understandable way to deploy Dynatrace in your environment.
 - **routing** and **kubernetesMonitoring** within the Dynakube spec are deprecated now and moved to the **activeGate** section.
-- added **applicationMonitoring** mode, a webhook based injection mechanism for automatic-app-only injection
+- (BETA, when used with 'useCSIDriver') added **applicationMonitoring** mode, a webhook based injection mechanism for automatic-app-only injection
 - added **hostMonitoring** for only monitoring the host in the cluster without app-only injection
 - (BETA) added **cloudNativeFullStack** mode, which combines **hostMonitoring**, with the webhook based **applicationMonitoring**
 

--- a/config/samples/applicationMonitoring.yml
+++ b/config/samples/applicationMonitoring.yml
@@ -1,4 +1,3 @@
-# THE FEATURE ENABLED IN THIS YAML IS STILL IN BETA AND SHOULD NOT BE USED IN A PRODUCTION ENVIRONMENT
 apiVersion: dynatrace.com/v1beta1
 kind: DynaKube
 metadata:
@@ -63,6 +62,7 @@ spec:
       #
       # version:
 
+      # ENABLING 'useCSIDriver' IS STILL IN BETA AND SHOULD NOT BE USED IN A PRODUCTION ENVIRONMENT
       # Optional: If you want to use CSIDriver; disable if your cluster does not have 'nodes' to fall back to the volume approach.
       # Defaults to false
       #

--- a/webhook/validation/validation.go
+++ b/webhook/validation/validation.go
@@ -131,7 +131,7 @@ func (validator *dynakubeValidator) Handle(_ context.Context, request admission.
 	if dynakube.CloudNativeFullstackMode() {
 		validator.logger.Info("Dynakube with cloudNativeFullStack was applied, warning was provided.")
 		return admission.Allowed("").WithWarnings(warningCloudNativeFullStack)
-	} else if dynakube.ApplicationMonitoringMode() {
+	} else if dynakube.ApplicationMonitoringMode() && dynakube.NeedsCSIDriver() {
 		validator.logger.Info("Dynakube with applicationMonitoring was applied, warning was provided.")
 		return admission.Allowed("").WithWarnings(warningApplicationMonitoring)
 	}


### PR DESCRIPTION
As applicationMonitoring should only be in beta state, if the CSI Driver is used, then the beta warning should also only be shown if the mentioned conditions are met and not for all applicationMonitoring configurations. Additionally this is mentioned in the readme now.