### PR TITLE
Remove data-ingest from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - data-ingest
 
 ```
 

--- a/config/samples/applicationMonitoring.yml
+++ b/config/samples/applicationMonitoring.yml
@@ -82,7 +82,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - data-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/classicFullStack.yml
+++ b/config/samples/classicFullStack.yml
@@ -116,7 +116,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - data-ingest
     
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/cloudNativeFullstack.yml
+++ b/config/samples/cloudNativeFullstack.yml
@@ -132,7 +132,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - data-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/hostMonitoring.yml
+++ b/config/samples/hostMonitoring.yml
@@ -116,7 +116,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - data-ingest
     
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/multipleDynakubes.yml
+++ b/config/samples/multipleDynakubes.yml
@@ -68,7 +68,6 @@ spec:
     # Enables listed ActiveGate capabilities
     capabilities:
       - routing
-      - data-ingest
 
     # Amount of replicas of activegate pods
     replicas: 2


### PR DESCRIPTION
`data-ingest` is not supported in 0.3.0 release, so example usages are removed from config samples.