### PR TITLE
Update applicationMonitoring sample to create yaml object explicitly

### DIFF
--- a/config/samples/applicationMonitoring.yml
+++ b/config/samples/applicationMonitoring.yml
@@ -66,7 +66,7 @@ spec:
       # Optional: If you want to use CSIDriver; disable if your cluster does not have 'nodes' to fall back to the volume approach.
       # Defaults to false
       #
-      # useCSIDriver: true
+      useCSIDriver: false
 
       # initResources:
       #   requests:


### PR DESCRIPTION
In order for the applicationMonitoring sample to work, we have to create a yaml object explicitly