### PR TITLE
Update support-matrix to remove OCP 3.11 from v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Depending on the version of the Dynatrace Operator, it supports the following pl
 
 | Dynatrace Operator version | Kubernetes | OpenShift Container Platform               |
 | -------------------------- | ---------- | ------------------------------------------ |
-| master                     | 1.20+      | 4.7+                            |
-| v0.3.0                     | 1.20+      | 3.11.188+, 4.7+                            |
+| master                     | 1.20+      | 4.7+                                       |
+| v0.3.0                     | 1.20+      | 4.7+                                       |
 | v0.2.2                     | 1.18+      | 3.11.188+, 4.5+                            |
 | v0.1.0                     | 1.18+      | 3.11.188+, 4.4+                            |
 


### PR DESCRIPTION
The readme should indicate, that OCP 3.11 is not support by the next release v0.3.0 anymore