### PR TITLE
Fixes nil pointer issue during processmoduleconfig update

### DIFF
--- a/controllers/csi/provisioner/processmoduleconfig.go
+++ b/controllers/csi/provisioner/processmoduleconfig.go
@@ -137,6 +137,9 @@ func (installAgentCfg *installAgentConfig) checkProcessModuleConfigCopy(sourcePa
 }
 
 func addHostGroup(dk *dynatracev1beta1.DynaKube, pmc *dtclient.ProcessModuleConfig) *dtclient.ProcessModuleConfig {
+	if pmc == nil {
+		pmc = &dtclient.ProcessModuleConfig{}
+	}
 	hostGroup := dk.HostGroup()
 	if hostGroup == "" {
 		newProps := []dtclient.ProcessModuleProperty{}


### PR DESCRIPTION
When there is no api we need (clusters with older versions) we receive nil from the `dtclient`,  `addHostGroup` doesn't check for this