### PR TITLE
Update comments for OneAgent and ActiveGate image location

### DIFF
--- a/api/v1beta1/activegate_types.go
+++ b/api/v1beta1/activegate_types.go
@@ -67,7 +67,6 @@ type CapabilityProperties struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Optional: the ActiveGate container image. Defaults to the latest ActiveGate image provided by the registry on the tenant
-	// implementation from the Dynatrace environment set as API URL.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=10,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Image string `json:"image,omitempty"`
 

--- a/api/v1beta1/activegate_types.go
+++ b/api/v1beta1/activegate_types.go
@@ -66,7 +66,7 @@ type CapabilityProperties struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Replicas",order=30,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount"
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Optional: the ActiveGate container image. Defaults to the latest ActiveGate image provided by the Docker Registry
+	// Optional: the ActiveGate container image. Defaults to the latest ActiveGate image provided by the registry on the tenant
 	// implementation from the Dynatrace environment set as API URL.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=10,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Image string `json:"image,omitempty"`

--- a/api/v1beta1/oneagent_types.go
+++ b/api/v1beta1/oneagent_types.go
@@ -57,7 +57,7 @@ type ClassicFullStackSpec struct {
 
 type HostMonitoringSpec struct {
 	// Optional: the Dynatrace installer container image
-	// Defaults to docker.io/dynatrace/oneagent:latest for Kubernetes and to registry.connect.redhat.com/dynatrace/oneagent for OpenShift
+	// Defaults to the registry on the tenant for both Kubernetes and for OpenShift
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=12,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Image string `json:"image,omitempty"`
 

--- a/api/v1beta1/oneagent_types.go
+++ b/api/v1beta1/oneagent_types.go
@@ -42,7 +42,7 @@ type CloudNativeFullStackSpec struct {
 
 type ClassicFullStackSpec struct {
 	// Optional: the Dynatrace installer container image
-	// Defaults to docker.io/dynatrace/oneagent:latest for Kubernetes and to registry.connect.redhat.com/dynatrace/oneagent for OpenShift
+	// Defaults to the registry in the tenant for both Kubernetes and for OpenShift
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=12,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Image string `json:"image,omitempty"`
 

--- a/api/v1beta1/oneagent_types.go
+++ b/api/v1beta1/oneagent_types.go
@@ -42,7 +42,7 @@ type CloudNativeFullStackSpec struct {
 
 type ClassicFullStackSpec struct {
 	// Optional: the Dynatrace installer container image
-	// Defaults to the registry in the tenant for both Kubernetes and for OpenShift
+	// Defaults to the registry on the tenant for both Kubernetes and for OpenShift
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=12,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Image string `json:"image,omitempty"`
 

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1128,8 +1128,7 @@ spec:
                   image:
                     description: 'Optional: the ActiveGate container image. Defaults
                       to the latest ActiveGate image provided by the registry on the
-                      tenant implementation from the Dynatrace environment set as
-                      API URL.'
+                      tenant'
                     type: string
                   labels:
                     additionalProperties:
@@ -1367,8 +1366,7 @@ spec:
                   image:
                     description: 'Optional: the ActiveGate container image. Defaults
                       to the latest ActiveGate image provided by the registry on the
-                      tenant implementation from the Dynatrace environment set as
-                      API URL.'
+                      tenant'
                     type: string
                   labels:
                     additionalProperties:
@@ -1691,7 +1689,7 @@ spec:
                         type: array
                       image:
                         description: 'Optional: the Dynatrace installer container
-                          image Defaults to the registry in the tenant for both Kubernetes
+                          image Defaults to the registry on the tenant for both Kubernetes
                           and for OpenShift'
                         type: string
                       labels:
@@ -2422,8 +2420,7 @@ spec:
                   image:
                     description: 'Optional: the ActiveGate container image. Defaults
                       to the latest ActiveGate image provided by the registry on the
-                      tenant implementation from the Dynatrace environment set as
-                      API URL.'
+                      tenant'
                     type: string
                   labels:
                     additionalProperties:

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1127,8 +1127,9 @@ spec:
                     type: string
                   image:
                     description: 'Optional: the ActiveGate container image. Defaults
-                      to the latest ActiveGate image provided by the Docker Registry
-                      implementation from the Dynatrace environment set as API URL.'
+                      to the latest ActiveGate image provided by the registry on the
+                      tenant implementation from the Dynatrace environment set as
+                      API URL.'
                     type: string
                   labels:
                     additionalProperties:
@@ -1365,8 +1366,9 @@ spec:
                     type: string
                   image:
                     description: 'Optional: the ActiveGate container image. Defaults
-                      to the latest ActiveGate image provided by the Docker Registry
-                      implementation from the Dynatrace environment set as API URL.'
+                      to the latest ActiveGate image provided by the registry on the
+                      tenant implementation from the Dynatrace environment set as
+                      API URL.'
                     type: string
                   labels:
                     additionalProperties:
@@ -1689,9 +1691,8 @@ spec:
                         type: array
                       image:
                         description: 'Optional: the Dynatrace installer container
-                          image Defaults to docker.io/dynatrace/oneagent:latest for
-                          Kubernetes and to registry.connect.redhat.com/dynatrace/oneagent
-                          for OpenShift'
+                          image Defaults to the registry in the tenant for both Kubernetes
+                          and for OpenShift'
                         type: string
                       labels:
                         additionalProperties:
@@ -2420,8 +2421,9 @@ spec:
                     type: string
                   image:
                     description: 'Optional: the ActiveGate container image. Defaults
-                      to the latest ActiveGate image provided by the Docker Registry
-                      implementation from the Dynatrace environment set as API URL.'
+                      to the latest ActiveGate image provided by the registry on the
+                      tenant implementation from the Dynatrace environment set as
+                      API URL.'
                     type: string
                   labels:
                     additionalProperties:

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -2179,9 +2179,8 @@ spec:
                         type: array
                       image:
                         description: 'Optional: the Dynatrace installer container
-                          image Defaults to docker.io/dynatrace/oneagent:latest for
-                          Kubernetes and to registry.connect.redhat.com/dynatrace/oneagent
-                          for OpenShift'
+                          image Defaults to the registry on the tenant for both Kubernetes
+                          and for OpenShift'
                         type: string
                       labels:
                         additionalProperties:


### PR DESCRIPTION
Updating the comments which describe, where the ActiveGate and the OneAgent are per default (Registry on the tenant