### PR TITLE
Refactors logging in most packages

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/api/v1beta1/feature_flags.go
+++ b/api/v1beta1/feature_flags.go
@@ -34,7 +34,7 @@ const (
 )
 
 var (
-	log = logger.NewDTLogger()
+	log = logger.NewDTLogger().WithName("dynakube-api")
 
 	defaultIgnoredNamespaces = []string{
 		"^dynatrace$",

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/cmd/operator/debug.go
+++ b/cmd/operator/debug.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"k8s.io/client-go/rest"
@@ -53,7 +52,7 @@ func startComponent(name string, startInfo startupInfo) {
 		os.Exit(1)
 	}
 
-	log.Info(fmt.Sprintf("starting manager '%s'", name))
+	log.Info("starting manager", "name", name)
 	if err := mgr.Start(startInfo.signalHandler); err != nil {
 		log.Error(err, "problem running manager")
 		os.Exit(1)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger()
+	log = logger.NewDTLogger().WithName("main")
 )
 
 const (

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -45,7 +45,7 @@ func main() {
 	pflag.CommandLine.AddFlagSet(csiDriverFlags())
 	pflag.Parse()
 
-	ctrl.SetLogger(logger.NewDTLogger())
+	ctrl.SetLogger(log)
 
 	version.LogVersion()
 
@@ -79,7 +79,7 @@ func main() {
 		exitOnError(err, "webhook-server setup failed")
 		defer cleanUp()
 	default:
-		log.Error(errBadSubcmd, "Unknown subcommand", "command", subCmd)
+		log.Error(errBadSubcmd, "unknown subcommand", "command", subCmd)
 		os.Exit(1)
 	}
 

--- a/cmd/operator/manager.go
+++ b/cmd/operator/manager.go
@@ -50,9 +50,9 @@ func waitForCertificates(watcher *certificateWatcher) {
 
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
-				log.Info("Waiting for certificate secret to be available.")
+				log.Info("waiting for certificate secret to be available.")
 			} else {
-				log.Info("Failed to update certificates", "error", err)
+				log.Info("failed to update certificates", "error", err)
 			}
 			time.Sleep(10 * time.Second)
 			continue

--- a/cmd/operator/watcher.go
+++ b/cmd/operator/watcher.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/spf13/afero"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,7 +34,6 @@ type certificateWatcher struct {
 	certificateDirectory  string
 	namespace             string
 	certificateSecretName string
-	logger                logr.Logger
 }
 
 func newCertificateWatcher(mgr manager.Manager, namespace string, secretName string) *certificateWatcher {
@@ -45,18 +43,17 @@ func newCertificateWatcher(mgr manager.Manager, namespace string, secretName str
 		certificateDirectory:  certsDir,
 		namespace:             namespace,
 		certificateSecretName: secretName,
-		logger:                log,
 	}
 }
 
 func (watcher *certificateWatcher) watchForCertificatesSecret() {
 	for {
 		<-time.After(6 * time.Hour)
-		watcher.logger.Info("checking for new certificates")
+		log.Info("checking for new certificates")
 		if updated, err := watcher.updateCertificatesFromSecret(); err != nil {
-			watcher.logger.Info("failed to update certificates", "error", err)
+			log.Info("failed to update certificates", "error", err)
 		} else if updated {
-			watcher.logger.Info("updated certificate successfully")
+			log.Info("updated certificate successfully")
 		}
 	}
 }

--- a/controllers/activegate/reconciler/capability/config.go
+++ b/controllers/activegate/reconciler/capability/config.go
@@ -1,0 +1,9 @@
+package capability
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("activegate-capability")
+)

--- a/controllers/activegate/reconciler/capability/reconciler.go
+++ b/controllers/activegate/reconciler/capability/reconciler.go
@@ -32,7 +32,7 @@ type Reconciler struct {
 func NewReconciler(capability capability.Capability, clt client.Client, apiReader client.Reader, scheme *runtime.Scheme,
 	instance *dynatracev1beta1.DynaKube) *Reconciler {
 	baseReconciler := sts.NewReconciler(
-		clt, apiReader, scheme, log, instance, capability)
+		clt, apiReader, scheme, instance, capability)
 
 	if capability.Config().SetDnsEntryPoint {
 		baseReconciler.AddOnAfterStatefulSetCreateListener(addDNSEntryPoint(instance, capability.ShortName()))

--- a/controllers/activegate/reconciler/capability/reconciler.go
+++ b/controllers/activegate/reconciler/capability/reconciler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/controllers/activegate/internal/consts"
 	"github.com/Dynatrace/dynatrace-operator/controllers/activegate/internal/events"
 	sts "github.com/Dynatrace/dynatrace-operator/controllers/activegate/reconciler/statefulset"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,11 +26,10 @@ const (
 
 type Reconciler struct {
 	*sts.Reconciler
-	log logr.Logger
 	capability.Capability
 }
 
-func NewReconciler(capability capability.Capability, clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, log logr.Logger,
+func NewReconciler(capability capability.Capability, clt client.Client, apiReader client.Reader, scheme *runtime.Scheme,
 	instance *dynatracev1beta1.DynaKube) *Reconciler {
 	baseReconciler := sts.NewReconciler(
 		clt, apiReader, scheme, log, instance, capability)
@@ -50,7 +48,6 @@ func NewReconciler(capability capability.Capability, clt client.Client, apiReade
 
 	return &Reconciler{
 		Reconciler: baseReconciler,
-		log:        log,
 		Capability: capability,
 	}
 }
@@ -107,7 +104,7 @@ func (r *Reconciler) createServiceIfNotExists() (bool, error) {
 
 	err := r.Get(context.TODO(), client.ObjectKey{Name: service.Name, Namespace: service.Namespace}, service)
 	if err != nil && k8serrors.IsNotFound(err) {
-		r.log.Info("creating service", "module", r.ShortName())
+		log.Info("creating service", "module", r.ShortName())
 		if err := controllerutil.SetControllerReference(r.Instance, service, r.Scheme()); err != nil {
 			return false, errors.WithStack(err)
 		}

--- a/controllers/activegate/reconciler/capability/reconciler_test.go
+++ b/controllers/activegate/reconciler/capability/reconciler_test.go
@@ -10,9 +10,7 @@ import (
 	rsfs "github.com/Dynatrace/dynatrace-operator/controllers/activegate/reconciler/statefulset"
 	"github.com/Dynatrace/dynatrace-operator/controllers/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/controllers/kubesystem"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/scheme"
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -43,7 +41,6 @@ func TestNewReconiler(t *testing.T) {
 }
 
 func createDefaultReconciler(t *testing.T) *Reconciler {
-	log := logger.NewDTLogger()
 	clt := fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
 		WithObjects(&corev1.Namespace{
@@ -57,7 +54,7 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 		}}
-	r := NewReconciler(metricsCapability, clt, clt, scheme.Scheme, log, instance)
+	r := NewReconciler(metricsCapability, clt, clt, scheme.Scheme, instance)
 	require.NotNil(t, r)
 	require.NotNil(t, r.Client)
 	require.NotNil(t, r.Instance)
@@ -191,7 +188,6 @@ func TestSetReadinessProbePort(t *testing.T) {
 func TestReconciler_calculateStatefulSetName(t *testing.T) {
 	type fields struct {
 		Reconciler *rsfs.Reconciler
-		log        logr.Logger
 		Capability *capability.RoutingCapability
 	}
 	tests := []struct {
@@ -232,7 +228,6 @@ func TestReconciler_calculateStatefulSetName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
 				Reconciler: tt.fields.Reconciler,
-				log:        tt.fields.log,
 				Capability: tt.fields.Capability,
 			}
 			if got := r.calculateStatefulSetName(); got != tt.want {

--- a/controllers/activegate/reconciler/statefulset/config.go
+++ b/controllers/activegate/reconciler/statefulset/config.go
@@ -1,0 +1,9 @@
+package statefulset
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("activegate-statefulset")
+)

--- a/controllers/activegate/reconciler/statefulset/reconciler.go
+++ b/controllers/activegate/reconciler/statefulset/reconciler.go
@@ -172,7 +172,7 @@ func (r *Reconciler) deleteStatefulSetIfOldLabelsAreUsed(desiredSts *appsv1.Stat
 	}
 
 	if !reflect.DeepEqual(currentSts.Labels, desiredSts.Labels) {
-		log.Info("Deleting existing stateful set")
+		log.Info("deleting existing stateful set")
 		if err = r.Delete(context.TODO(), desiredSts); err != nil {
 			return false, err
 		}

--- a/controllers/activegate/reconciler/statefulset/reconciler.go
+++ b/controllers/activegate/reconciler/statefulset/reconciler.go
@@ -70,7 +70,7 @@ func (r *Reconciler) AddOnAfterStatefulSetCreateListener(event events.StatefulSe
 func (r *Reconciler) Reconcile() (update bool, err error) {
 	if r.capability.CustomProperties != nil {
 		err = customproperties.
-			NewReconciler(r, r.Instance, r.log, r.serviceAccountOwner, *r.capability.CustomProperties, r.scheme).
+			NewReconciler(r, r.Instance, r.serviceAccountOwner, *r.capability.CustomProperties, r.scheme).
 			Reconcile()
 		if err != nil {
 			r.log.Error(err, "could not reconcile custom properties")

--- a/controllers/activegate/reconciler/statefulset/reconciler_test.go
+++ b/controllers/activegate/reconciler/statefulset/reconciler_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/controllers/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/controllers/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/controllers/kubesystem"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/scheme"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +26,6 @@ func TestNewReconiler(t *testing.T) {
 }
 
 func createDefaultReconciler(t *testing.T) *Reconciler {
-	log := logger.NewDTLogger()
 	clt := fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
 		WithObjects(&corev1.Namespace{
@@ -44,11 +42,10 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 
 	capability.NewRoutingCapability(instance)
 
-	r := NewReconciler(clt, clt, scheme.Scheme, log, instance, capability.NewRoutingCapability(instance))
+	r := NewReconciler(clt, clt, scheme.Scheme, instance, capability.NewRoutingCapability(instance))
 	require.NotNil(t, r)
 	require.NotNil(t, r.Client)
 	require.NotNil(t, r.scheme)
-	require.NotNil(t, r.log)
 	require.NotNil(t, r.Instance)
 
 	return r

--- a/controllers/certificates/certs.go
+++ b/controllers/certificates/certs.go
@@ -67,28 +67,28 @@ func (cs *Certs) ValidateCerts() error {
 
 func (cs *Certs) validateRootCerts(now time.Time) bool {
 	if cs.Data[RootKey] == nil || cs.Data[RootCert] == nil {
-		log.Info("No root certificates found, creating")
+		log.Info("no root certificates found, creating")
 		return true
 	}
 
 	var err error
 
 	if block, _ := pem.Decode(cs.Data[RootCert]); block == nil {
-		log.Info("Failed to parse root certificates, renewing", "error", "can't decode PEM file")
+		log.Info("failed to parse root certificates, renewing", "error", "can't decode PEM file")
 		return true
 	} else if cs.rootPublicCert, err = x509.ParseCertificate(block.Bytes); err != nil {
-		log.Info("Failed to parse root certificates, renewing", "error", err)
+		log.Info("failed to parse root certificates, renewing", "error", err)
 		return true
 	} else if now.After(cs.rootPublicCert.NotAfter.Add(-renewalThreshold)) {
-		log.Info("Root certificates are about to expire, renewing", "current", now, "expiration", cs.rootPublicCert.NotAfter)
+		log.Info("root certificates are about to expire, renewing", "current", now, "expiration", cs.rootPublicCert.NotAfter)
 		return true
 	}
 
 	if block, _ := pem.Decode(cs.Data[RootKey]); block == nil {
-		log.Info("Failed to parse root key, renewing", "error", "can't decode PEM file")
+		log.Info("failed to parse root key, renewing", "error", "can't decode PEM file")
 		return true
 	} else if cs.rootPrivateKey, err = x509.ParseECPrivateKey(block.Bytes); err != nil {
-		log.Info("Failed to parse root key, renewing", "error", err)
+		log.Info("failed to parse root key, renewing", "error", err)
 		return true
 	}
 
@@ -97,24 +97,24 @@ func (cs *Certs) validateRootCerts(now time.Time) bool {
 
 func (cs *Certs) validateServerCerts(now time.Time) bool {
 	if cs.Data[ServerKey] == nil || cs.Data[ServerCert] == nil {
-		log.Info("No server certificates found, creating")
+		log.Info("no server certificates found, creating")
 		return true
 	}
 
 	block, _ := pem.Decode(cs.Data[ServerCert])
 	if block == nil {
-		log.Info("Failed to parse server certificates, renewing", "error", "can't decode PEM file")
+		log.Info("failed to parse server certificates, renewing", "error", "can't decode PEM file")
 		return true
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		log.Info("Failed to parse server certificates, renewing", "error", err)
+		log.Info("failed to parse server certificates, renewing", "error", err)
 		return true
 	}
 
 	if now.After(cert.NotAfter.Add(-renewalThreshold)) {
-		log.Info("Server certificates are about to expire, renewing", "current", now, "expiration", cert.NotAfter)
+		log.Info("server certificates are about to expire, renewing", "current", now, "expiration", cert.NotAfter)
 		return true
 	}
 

--- a/controllers/certificates/certs_test.go
+++ b/controllers/certificates/certs_test.go
@@ -6,17 +6,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCertsValidation(t *testing.T) {
-	log := logger.NewDTLogger()
 	now, _ := time.Parse(time.RFC3339, "2018-01-10T00:00:00Z")
 	domain := "dynatrace-oneagent-webhook.webhook.svc"
 	firstCerts := Certs{
-		Log:    log,
 		Domain: domain,
 		Now:    now,
 	}
@@ -28,7 +25,7 @@ func TestCertsValidation(t *testing.T) {
 	t.Run("up-to-date certs", func(t *testing.T) {
 		newTime := now.Add(5 * time.Minute)
 
-		newCerts := Certs{Log: log, Domain: domain, SrcData: firstCerts.Data, Now: newTime}
+		newCerts := Certs{Domain: domain, SrcData: firstCerts.Data, Now: newTime}
 		require.NoError(t, newCerts.ValidateCerts())
 		requireValidCerts(t, domain, newTime, newCerts.Data[RootCert], newCerts.Data[ServerCert])
 
@@ -43,7 +40,7 @@ func TestCertsValidation(t *testing.T) {
 	t.Run("outdated server certs", func(t *testing.T) {
 		newTime := now.Add((6*24 + 22) * time.Hour) // 6d22h
 
-		newCerts := Certs{Log: log, Domain: domain, SrcData: firstCerts.Data, Now: newTime}
+		newCerts := Certs{Domain: domain, SrcData: firstCerts.Data, Now: newTime}
 		require.NoError(t, newCerts.ValidateCerts())
 		requireValidCerts(t, domain, newTime, newCerts.Data[RootCert], newCerts.Data[ServerCert])
 
@@ -58,7 +55,7 @@ func TestCertsValidation(t *testing.T) {
 	t.Run("outdated root certs", func(t *testing.T) {
 		newTime := now.Add((364*24 + 22) * time.Hour) // 364d22h
 
-		newCerts := Certs{Log: log, Domain: domain, SrcData: firstCerts.Data, Now: newTime}
+		newCerts := Certs{Domain: domain, SrcData: firstCerts.Data, Now: newTime}
 		require.NoError(t, newCerts.ValidateCerts())
 		requireValidCerts(t, domain, newTime, newCerts.Data[RootCert], newCerts.Data[ServerCert])
 

--- a/controllers/certificates/config.go
+++ b/controllers/certificates/config.go
@@ -1,0 +1,9 @@
+package certificates
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("webhook-certificates")
+)

--- a/controllers/certificates/webhook_reconciler.go
+++ b/controllers/certificates/webhook_reconciler.go
@@ -282,7 +282,7 @@ func (r *ReconcileWebhookCertificates) updateCRDConfiguration(ctx context.Contex
 	}
 
 	if !hasConversionWebhook(crd) {
-		log.Info("No conversion webhook config, no cert will be provided")
+		log.Info("no conversion webhook config, no cert will be provided")
 		return nil
 	}
 

--- a/controllers/certificates/webhook_reconciler_test.go
+++ b/controllers/certificates/webhook_reconciler_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/webhook"
 	"github.com/stretchr/testify/assert"
@@ -177,7 +176,6 @@ func prepareFakeClient(withSecret bool, generateValidSecret bool) client.Client 
 		}
 		if generateValidSecret {
 			cert := Certs{
-				Log:    logger.NewDTLogger(),
 				Domain: testDomain,
 				Now:    time.Now(),
 			}
@@ -206,7 +204,6 @@ func prepareReconcile(clt client.Client) (*ReconcileWebhookCertificates, reconci
 		client:    clt,
 		apiReader: clt,
 		namespace: testNamespace,
-		logger:    logger.NewDTLogger(),
 	}
 
 	request := reconcile.Request{
@@ -234,7 +231,6 @@ func testWebhookClientConfig(
 
 func verifyCertificates(t *testing.T, rec *ReconcileWebhookCertificates, secret *corev1.Secret, clt client.Client, isUpdate bool) {
 	cert := Certs{
-		Log:     rec.logger,
 		Domain:  rec.getDomain(),
 		Data:    secret.Data,
 		SrcData: secret.Data,

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -1,0 +1,9 @@
+package controllers
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("controllers")
+)

--- a/controllers/csi/driver/server.go
+++ b/controllers/csi/driver/server.go
@@ -81,7 +81,7 @@ func (svr *CSIDriverServer) Start(ctx context.Context) error {
 		}
 	}
 
-	log.Info("Starting listener", "protocol", proto, "address", addr)
+	log.Info("starting listener", "protocol", proto, "address", addr)
 
 	listener, err := net.Listen(proto, addr)
 	if err != nil {
@@ -95,9 +95,9 @@ func (svr *CSIDriverServer) Start(ctx context.Context) error {
 		for !done {
 			select {
 			case <-ctx.Done():
-				log.Info("Stopping server")
+				log.Info("stopping server")
 				server.GracefulStop()
-				log.Info("Stopped server")
+				log.Info("stopped server")
 				done = true
 			case <-ticker.C:
 				var m runtime.MemStats
@@ -110,7 +110,7 @@ func (svr *CSIDriverServer) Start(ctx context.Context) error {
 	csi.RegisterIdentityServer(server, svr)
 	csi.RegisterNodeServer(server, svr)
 
-	log.Info("Listening for connections on address", "address", listener.Addr())
+	log.Info("listening for connections on address", "address", listener.Addr())
 
 	_ = server.Serve(listener)
 
@@ -151,7 +151,7 @@ func (svr *CSIDriverServer) NodePublishVolume(ctx context.Context, req *csi.Node
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
-	log.Info("Publishing volume",
+	log.Info("publishing volume",
 		"target", volumeCfg.targetPath,
 		"fstype", req.GetVolumeCapability().GetMount().GetFsType(),
 		"readonly", req.GetReadonly(),
@@ -327,7 +327,7 @@ func logGRPC() grpc.UnaryServerInterceptor {
 		}
 		resp, err := handler(ctx, req)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("%s GRPC call failed", methodName))
+			log.Error(err, "GRPC call failed", "method", methodName)
 		}
 		return resp, err
 	}

--- a/controllers/csi/provisioner/reconciler.go
+++ b/controllers/csi/provisioner/reconciler.go
@@ -78,7 +78,7 @@ func (r *OneAgentProvisioner) SetupWithManager(mgr ctrl.Manager) error {
 var _ reconcile.Reconciler = &OneAgentProvisioner{}
 
 func (r *OneAgentProvisioner) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log.Info("Reconciling DynaKube", "namespace", request.Namespace, "dynakube", request.Name)
+	log.Info("reconciling DynaKube", "namespace", request.Namespace, "dynakube", request.Name)
 
 	dk, err := r.getDynaKube(ctx, request.NamespacedName)
 	if err != nil {

--- a/controllers/customproperties/config.go
+++ b/controllers/customproperties/config.go
@@ -1,0 +1,9 @@
+package customproperties
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("activegate-customproperties")
+)

--- a/controllers/customproperties/reconciler.go
+++ b/controllers/customproperties/reconciler.go
@@ -44,14 +44,14 @@ func (r *Reconciler) Reconcile() error {
 	if r.hasCustomPropertiesValueOnly() {
 		mustNotUpdate, err := r.createCustomPropertiesIfNotExists()
 		if err != nil {
-			log.Error(err, fmt.Sprintf("could not create custom properties for '%s'", r.customPropertiesOwnerName))
+			log.Error(err, "could not create custom properties", "owner", r.customPropertiesOwnerName)
 			return errors.WithStack(err)
 		}
 
 		if !mustNotUpdate {
 			err = r.updateCustomPropertiesIfOutdated()
 			if err != nil {
-				log.Error(err, fmt.Sprintf("could not update custom properties for '%s'", r.customPropertiesOwnerName))
+				log.Error(err, "could not update custom properties", "owner", r.customPropertiesOwnerName)
 				return errors.WithStack(err)
 			}
 		}

--- a/controllers/customproperties/reconciler.go
+++ b/controllers/customproperties/reconciler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,18 +25,16 @@ const (
 type Reconciler struct {
 	client.Client
 	scheme                    *runtime.Scheme
-	log                       logr.Logger
 	customPropertiesSource    dynatracev1beta1.DynaKubeValueSource
 	customPropertiesOwnerName string
 	instance                  *dynatracev1beta1.DynaKube
 }
 
-func NewReconciler(clt client.Client, instance *dynatracev1beta1.DynaKube, log logr.Logger, customPropertiesOwnerName string, customPropertiesSource dynatracev1beta1.DynaKubeValueSource, scheme *runtime.Scheme) *Reconciler {
+func NewReconciler(clt client.Client, instance *dynatracev1beta1.DynaKube, customPropertiesOwnerName string, customPropertiesSource dynatracev1beta1.DynaKubeValueSource, scheme *runtime.Scheme) *Reconciler {
 	return &Reconciler{
 		Client:                    clt,
 		instance:                  instance,
 		scheme:                    scheme,
-		log:                       log,
 		customPropertiesSource:    customPropertiesSource,
 		customPropertiesOwnerName: customPropertiesOwnerName,
 	}
@@ -47,14 +44,14 @@ func (r *Reconciler) Reconcile() error {
 	if r.hasCustomPropertiesValueOnly() {
 		mustNotUpdate, err := r.createCustomPropertiesIfNotExists()
 		if err != nil {
-			r.log.Error(err, fmt.Sprintf("could not create custom properties for '%s'", r.customPropertiesOwnerName))
+			log.Error(err, fmt.Sprintf("could not create custom properties for '%s'", r.customPropertiesOwnerName))
 			return errors.WithStack(err)
 		}
 
 		if !mustNotUpdate {
 			err = r.updateCustomPropertiesIfOutdated()
 			if err != nil {
-				r.log.Error(err, fmt.Sprintf("could not update custom properties for '%s'", r.customPropertiesOwnerName))
+				log.Error(err, fmt.Sprintf("could not update custom properties for '%s'", r.customPropertiesOwnerName))
 				return errors.WithStack(err)
 			}
 		}

--- a/controllers/customproperties/reconciler_test.go
+++ b/controllers/customproperties/reconciler_test.go
@@ -23,7 +23,7 @@ const (
 
 func TestReconciler_Reconcile(t *testing.T) {
 	t.Run(`Reconile works with minimal setup`, func(t *testing.T) {
-		r := NewReconciler(nil, nil, nil, "", dynatracev1beta1.DynaKubeValueSource{}, nil)
+		r := NewReconciler(nil, nil, "", dynatracev1beta1.DynaKubeValueSource{}, nil)
 		err := r.Reconcile()
 		assert.NoError(t, err)
 	})
@@ -35,7 +35,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				Namespace: testNamespace,
 			}}
 		fakeClient := fake.NewClient(instance)
-		r := NewReconciler(fakeClient, instance, nil, testOwner, valueSource, scheme.Scheme)
+		r := NewReconciler(fakeClient, instance, testOwner, valueSource, scheme.Scheme)
 		err := r.Reconcile()
 
 		assert.NoError(t, err)
@@ -57,7 +57,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				Namespace: testNamespace,
 			}}
 		fakeClient := fake.NewClient(instance)
-		r := NewReconciler(fakeClient, instance, nil, testOwner, valueSource, scheme.Scheme)
+		r := NewReconciler(fakeClient, instance, testOwner, valueSource, scheme.Scheme)
 		err := r.Reconcile()
 
 		assert.NoError(t, err)

--- a/controllers/dtpullsecret/config.go
+++ b/controllers/dtpullsecret/config.go
@@ -1,0 +1,9 @@
+package dtpullsecret
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("dynakube-pullsecret")
+)

--- a/controllers/dtpullsecret/reconciler.go
+++ b/controllers/dtpullsecret/reconciler.go
@@ -67,7 +67,7 @@ func (r *Reconciler) createPullSecretIfNotExists(pullSecretData map[string][]byt
 	var config corev1.Secret
 	err := r.apiReader.Get(context.TODO(), client.ObjectKey{Name: extendWithPullSecretSuffix(r.instance.Name), Namespace: r.instance.Namespace}, &config)
 	if k8serrors.IsNotFound(err) {
-		log.Info("Creating pull secret")
+		log.Info("creating pull secret")
 		return r.createPullSecret(pullSecretData)
 	}
 	return &config, err
@@ -95,7 +95,7 @@ func (r *Reconciler) createPullSecret(pullSecretData map[string][]byte) (*corev1
 }
 
 func (r *Reconciler) updatePullSecret(pullSecret *corev1.Secret, desiredPullSecretData map[string][]byte) error {
-	log.Info(fmt.Sprintf("Updating secret %s", pullSecret.Name))
+	log.Info("updating secret", "name", pullSecret.Name)
 	pullSecret.Data = desiredPullSecretData
 	if err := r.Update(context.TODO(), pullSecret); err != nil {
 		return fmt.Errorf("failed to update secret %s: %w", pullSecret.Name, err)

--- a/controllers/dtpullsecret/reconciler_test.go
+++ b/controllers/dtpullsecret/reconciler_test.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -36,7 +35,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			Data: map[string][]byte{dtclient.DynatracePaasToken: []byte(testPaasToken)},
 		}
 		fakeClient := fake.NewClient()
-		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, logf.Log, secret)
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, secret)
 
 		mockDTC.
 			On("GetConnectionInfo").
@@ -66,7 +65,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				CustomPullSecret: testValue,
 			}}
-		r := NewReconciler(nil, nil, nil, instance, nil, nil)
+		r := NewReconciler(nil, nil, nil, instance, nil)
 		err := r.Reconcile()
 
 		assert.NoError(t, err)
@@ -88,7 +87,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		fakeClient := fake.NewClient()
-		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, logf.Log,
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance,
 			&corev1.Secret{
 				Data: map[string][]byte{
 					dtclient.DynatracePaasToken: []byte(testValue),
@@ -128,7 +127,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		fakeClient := fake.NewClient()
-		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, logf.Log,
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance,
 			&corev1.Secret{
 				Data: map[string][]byte{
 					dtclient.DynatracePaasToken: []byte(testValue),

--- a/controllers/dynakube/config.go
+++ b/controllers/dynakube/config.go
@@ -1,0 +1,9 @@
+package dynakube
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("dynakube-controller")
+)

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -291,7 +291,7 @@ func (r *ReconcileDynaKube) reconcileActiveGateCapabilities(dkState *controllers
 	for _, c := range caps {
 		if c.Enabled() {
 			upd, err := rcap.NewReconciler(
-				c, r.client, r.apiReader, r.scheme, dkState.Log, dkState.Instance).Reconcile()
+				c, r.client, r.apiReader, r.scheme, dkState.Instance).Reconcile()
 			if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, c.ShortName()+" reconciled") {
 				return false
 			}

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -101,7 +101,7 @@ type DynatraceClientFunc func(properties DynatraceClientProperties) (dtclient.Cl
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileDynaKube) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log.Info("Reconciling DynaKube", "namespace", request.Namespace, "name", request.Name)
+	log.Info("reconciling DynaKube", "namespace", request.Namespace, "name", request.Name)
 
 	// Fetch the DynaKube instance
 	instance := &dynatracev1beta1.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: request.NamespacedName.Name}}
@@ -132,7 +132,7 @@ func (r *ReconcileDynaKube) Reconcile(ctx context.Context, request reconcile.Req
 
 		var serr dtclient.ServerError
 		if ok := errors.As(dkState.Err, &serr); ok && serr.Code == http.StatusTooManyRequests {
-			log.Info("Request limit for Dynatrace API reached! Next reconcile in one minute")
+			log.Info("request limit for Dynatrace API reached! Next reconcile in one minute")
 			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
 

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -197,7 +197,7 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *cont
 	}
 
 	err = dtpullsecret.
-		NewReconciler(r.client, r.apiReader, r.scheme, dkState.Instance, dkState.Log, secret).
+		NewReconciler(r.client, r.apiReader, r.scheme, dkState.Instance, secret).
 		Reconcile()
 	if dkState.Error(err) {
 		dkState.Log.Error(err, "could not reconcile Dynatrace pull secret")

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -248,7 +248,7 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *cont
 		if err := dkMapper.MapFromDynakube(); err != nil {
 			log.Error(err, "update of a map of namespaces failed")
 		}
-		upd, err := initgeneration.NewInitGenerator(r.client, r.apiReader, dkState.Instance.Namespace, log).GenerateForDynakube(ctx, dkState.Instance)
+		upd, err := initgeneration.NewInitGenerator(r.client, r.apiReader, dkState.Instance.Namespace).GenerateForDynakube(ctx, dkState.Instance)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "new init script created") {
 			return
 		}

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -253,7 +253,7 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *cont
 			return
 		}
 
-		upd, err = dtingestendpoint.NewEndpointSecretGenerator(r.client, r.apiReader, dkState.Instance.Namespace, log).GenerateForDynakube(ctx, dkState.Instance)
+		upd, err = dtingestendpoint.NewEndpointSecretGenerator(r.client, r.apiReader, dkState.Instance.Namespace).GenerateForDynakube(ctx, dkState.Instance)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "new data-ingest endpoint secret created") {
 			return
 		}

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -120,7 +120,7 @@ func (r *ReconcileDynaKube) Reconcile(ctx context.Context, request reconcile.Req
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	dkState := controllers.NewDynakubeState(log, instance)
+	dkState := controllers.NewDynakubeState(instance)
 	r.reconcileDynaKube(ctx, dkState, &dkMapper)
 
 	if dkState.Err != nil {
@@ -132,7 +132,7 @@ func (r *ReconcileDynaKube) Reconcile(ctx context.Context, request reconcile.Req
 
 		var serr dtclient.ServerError
 		if ok := errors.As(dkState.Err, &serr); ok && serr.Code == http.StatusTooManyRequests {
-			dkState.Log.Info("Request limit for Dynatrace API reached! Next reconcile in one minute")
+			log.Info("Request limit for Dynatrace API reached! Next reconcile in one minute")
 			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
 
@@ -204,7 +204,7 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *cont
 	}
 	if dkState.Instance.HostMonitoringMode() {
 		upd, err = oneagent.NewOneAgentReconciler(
-			r.client, r.apiReader, r.scheme, log, dkState.Instance, daemonset.HostMonitoringFeature,
+			r.client, r.apiReader, r.scheme, dkState.Instance, daemonset.HostMonitoringFeature,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "infra monitoring reconciled") {
 			return
@@ -218,7 +218,7 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *cont
 
 	if dkState.Instance.CloudNativeFullstackMode() {
 		upd, err = oneagent.NewOneAgentReconciler(
-			r.client, r.apiReader, r.scheme, log, dkState.Instance, daemonset.CloudNativeFeature,
+			r.client, r.apiReader, r.scheme, dkState.Instance, daemonset.CloudNativeFeature,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "cloud native infra monitoring reconciled") {
 			return
@@ -232,7 +232,7 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *cont
 
 	if dkState.Instance.ClassicFullStackMode() {
 		upd, err = oneagent.NewOneAgentReconciler(
-			r.client, r.apiReader, r.scheme, log, dkState.Instance, daemonset.ClassicFeature,
+			r.client, r.apiReader, r.scheme, dkState.Instance, daemonset.ClassicFeature,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "classic fullstack reconciled") {
 			return

--- a/controllers/dynakube/dynakube_controller.go
+++ b/controllers/dynakube/dynakube_controller.go
@@ -105,7 +105,7 @@ func (r *ReconcileDynaKube) Reconcile(ctx context.Context, request reconcile.Req
 
 	// Fetch the DynaKube instance
 	instance := &dynatracev1beta1.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: request.NamespacedName.Name}}
-	dkMapper := mapper.NewDynakubeMapper(ctx, r.client, r.apiReader, r.operatorNamespace, instance, log)
+	dkMapper := mapper.NewDynakubeMapper(ctx, r.client, r.apiReader, r.operatorNamespace, instance)
 	err := r.client.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/controllers/dynakube/updates/config.go
+++ b/controllers/dynakube/updates/config.go
@@ -1,0 +1,9 @@
+package updates
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("dynakube-updates")
+)

--- a/controllers/dynakube/updates/version.go
+++ b/controllers/dynakube/updates/version.go
@@ -55,13 +55,13 @@ func ReconcileVersions(
 
 	if needsActiveGateUpdate {
 		if err := updateImageVersion(dkState, dk.ActiveGateImage(), &dk.Status.ActiveGate.VersionStatus, &dockerCfg, verProvider, true); err != nil {
-			log.Error(err, "Failed to update ActiveGate image version")
+			log.Error(err, "failed to update ActiveGate image version")
 		}
 	}
 
 	if needsOneAgentUpdate {
 		if err := updateImageVersion(dkState, dk.ImmutableOneAgentImage(), &dk.Status.OneAgent.VersionStatus, &dockerCfg, verProvider, false); err != nil {
-			log.Error(err, "Failed to update OneAgent image version")
+			log.Error(err, "failed to update OneAgent image version")
 		}
 	}
 
@@ -95,7 +95,7 @@ func updateImageVersion(
 		}
 	}
 
-	log.Info("Update found",
+	log.Info("update found",
 		"image", img,
 		"oldVersion", target.Version, "newVersion", ver.Version,
 		"oldHash", target.ImageHash, "newHash", ver.Hash)

--- a/controllers/dynakube/updates/version.go
+++ b/controllers/dynakube/updates/version.go
@@ -55,13 +55,13 @@ func ReconcileVersions(
 
 	if needsActiveGateUpdate {
 		if err := updateImageVersion(dkState, dk.ActiveGateImage(), &dk.Status.ActiveGate.VersionStatus, &dockerCfg, verProvider, true); err != nil {
-			dkState.Log.Error(err, "Failed to update ActiveGate image version")
+			log.Error(err, "Failed to update ActiveGate image version")
 		}
 	}
 
 	if needsOneAgentUpdate {
 		if err := updateImageVersion(dkState, dk.ImmutableOneAgentImage(), &dk.Status.OneAgent.VersionStatus, &dockerCfg, verProvider, false); err != nil {
-			dkState.Log.Error(err, "Failed to update OneAgent image version")
+			log.Error(err, "Failed to update OneAgent image version")
 		}
 	}
 
@@ -95,7 +95,7 @@ func updateImageVersion(
 		}
 	}
 
-	dkState.Log.Info("Update found",
+	log.Info("Update found",
 		"image", img,
 		"oldVersion", target.Version, "newVersion", ver.Version,
 		"oldHash", target.ImageHash, "newHash", ver.Hash)

--- a/controllers/dynakube/updates/version_test.go
+++ b/controllers/dynakube/updates/version_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/controllers"
 	"github.com/Dynatrace/dynatrace-operator/controllers/dtpullsecret"
 	"github.com/Dynatrace/dynatrace-operator/controllers/dtversion"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/scheme/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,7 +61,7 @@ func TestReconcile_UpdateImageVersion(t *testing.T) {
 	fakeClient := fake.NewClient()
 
 	now := metav1.Now()
-	dkState := &controllers.DynakubeState{Instance: &dk, Log: logger.NewDTLogger(), Now: now}
+	dkState := &controllers.DynakubeState{Instance: &dk, Now: now}
 
 	errVerProvider := func(img string, dockerConfig *dtversion.DockerConfig) (dtversion.ImageVersion, error) {
 		return dtversion.ImageVersion{}, errors.New("Not implemented")

--- a/controllers/dynakube_state.go
+++ b/controllers/dynakube_state.go
@@ -46,7 +46,7 @@ func (dkState *DynakubeState) Update(upd bool, d time.Duration, cause string) bo
 	if !upd {
 		return false
 	}
-	log.Info("Updating DynaKube CR", "cause", cause)
+	log.Info("updating DynaKube CR", "cause", cause)
 	dkState.Updated = true
 	dkState.RequeueAfter = d
 	return true

--- a/controllers/dynakube_state.go
+++ b/controllers/dynakube_state.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -13,7 +12,6 @@ import (
 // so we pass the to-be-reconciled Dynakube all over the place AND in some cases the reconcilers will update said Dynakube
 // therefore we need to keep track of the state for this Dynakube over the whole Reconcile. (was it updated, etc.)
 type DynakubeState struct {
-	Log      logr.Logger
 	Instance *dynatracev1beta1.DynaKube
 	Now      metav1.Time
 
@@ -28,9 +26,8 @@ type DynakubeState struct {
 	RequeueAfter time.Duration
 }
 
-func NewDynakubeState(log logr.Logger, dk *dynatracev1beta1.DynaKube) *DynakubeState {
+func NewDynakubeState(dk *dynatracev1beta1.DynaKube) *DynakubeState {
 	return &DynakubeState{
-		Log:          log,
 		Instance:     dk,
 		RequeueAfter: 30 * time.Minute,
 		Now:          metav1.Now(),
@@ -49,7 +46,7 @@ func (dkState *DynakubeState) Update(upd bool, d time.Duration, cause string) bo
 	if !upd {
 		return false
 	}
-	dkState.Log.Info("Updating DynaKube CR", "cause", cause)
+	log.Info("Updating DynaKube CR", "cause", cause)
 	dkState.Updated = true
 	dkState.RequeueAfter = d
 	return true

--- a/controllers/ingestendpoint/config.go
+++ b/controllers/ingestendpoint/config.go
@@ -1,6 +1,12 @@
 package ingestendpoint
 
+import "github.com/Dynatrace/dynatrace-operator/logger"
+
 const (
 	// SecretEndpointName is the name of the secret where the Operator replicates data-ingest data (data-ingest url, data-ingest token).
 	SecretEndpointName = "dynatrace-data-ingest-endpoint"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("ingestendpoint")
 )

--- a/controllers/ingestendpoint/secret.go
+++ b/controllers/ingestendpoint/secret.go
@@ -42,7 +42,7 @@ func NewEndpointSecretGenerator(client client.Client, apiReader client.Reader, n
 // GenerateForNamespace creates the data-ingest-endpoint secret for namespace while only having the name of the corresponding dynakube
 // Used by the podInjection webhook in case the namespace lacks the secret.
 func (g *EndpointSecretGenerator) GenerateForNamespace(ctx context.Context, dkName, targetNs string) (bool, error) {
-	log.Info("Reconciling data-ingest endpoint secret for", "namespace", targetNs)
+	log.Info("reconciling data-ingest endpoint secret for", "namespace", targetNs)
 	var dk dynatracev1beta1.DynaKube
 	if err := g.client.Get(ctx, client.ObjectKey{Name: dkName, Namespace: g.namespace}, &dk); err != nil {
 		return false, err
@@ -58,7 +58,7 @@ func (g *EndpointSecretGenerator) GenerateForNamespace(ctx context.Context, dkNa
 // GenerateForDynakube creates/updates the data-ingest-endpoint secret for EVERY namespace for the given dynakube.
 // Used by the dynakube controller during reconcile.
 func (g *EndpointSecretGenerator) GenerateForDynakube(ctx context.Context, dk *dynatracev1beta1.DynaKube) (bool, error) {
-	log.Info("Reconciling data-ingest endpoint secret for", "dynakube", dk.Name)
+	log.Info("reconciling data-ingest endpoint secret for", "dynakube", dk.Name)
 
 	data, err := g.prepare(ctx, dk)
 	if err != nil {
@@ -77,7 +77,7 @@ func (g *EndpointSecretGenerator) GenerateForDynakube(ctx context.Context, dk *d
 			anyUpdate = true
 		}
 	}
-	log.Info("Done updating data-ingest endpoint secrets")
+	log.Info("done updating data-ingest endpoint secrets")
 	return anyUpdate, nil
 }
 

--- a/controllers/ingestendpoint/secret.go
+++ b/controllers/ingestendpoint/secret.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/controllers/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/mapper"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,23 +28,21 @@ const (
 type EndpointSecretGenerator struct {
 	client    client.Client
 	apiReader client.Reader
-	logger    logr.Logger
 	namespace string
 }
 
-func NewEndpointSecretGenerator(client client.Client, apiReader client.Reader, ns string, logger logr.Logger) *EndpointSecretGenerator {
+func NewEndpointSecretGenerator(client client.Client, apiReader client.Reader, ns string) *EndpointSecretGenerator {
 	return &EndpointSecretGenerator{
 		client:    client,
 		apiReader: apiReader,
 		namespace: ns,
-		logger:    logger,
 	}
 }
 
 // GenerateForNamespace creates the data-ingest-endpoint secret for namespace while only having the name of the corresponding dynakube
 // Used by the podInjection webhook in case the namespace lacks the secret.
 func (g *EndpointSecretGenerator) GenerateForNamespace(ctx context.Context, dkName, targetNs string) (bool, error) {
-	g.logger.Info("Reconciling data-ingest endpoint secret for", "namespace", targetNs)
+	log.Info("Reconciling data-ingest endpoint secret for", "namespace", targetNs)
 	var dk dynatracev1beta1.DynaKube
 	if err := g.client.Get(ctx, client.ObjectKey{Name: dkName, Namespace: g.namespace}, &dk); err != nil {
 		return false, err
@@ -55,13 +52,13 @@ func (g *EndpointSecretGenerator) GenerateForNamespace(ctx context.Context, dkNa
 	if err != nil {
 		return false, err
 	}
-	return kubeobjects.CreateOrUpdateSecretIfNotExists(g.client, g.apiReader, SecretEndpointName, targetNs, data, corev1.SecretTypeOpaque, g.logger)
+	return kubeobjects.CreateOrUpdateSecretIfNotExists(g.client, g.apiReader, SecretEndpointName, targetNs, data, corev1.SecretTypeOpaque, log)
 }
 
 // GenerateForDynakube creates/updates the data-ingest-endpoint secret for EVERY namespace for the given dynakube.
 // Used by the dynakube controller during reconcile.
 func (g *EndpointSecretGenerator) GenerateForDynakube(ctx context.Context, dk *dynatracev1beta1.DynaKube) (bool, error) {
-	g.logger.Info("Reconciling data-ingest endpoint secret for", "dynakube", dk.Name)
+	log.Info("Reconciling data-ingest endpoint secret for", "dynakube", dk.Name)
 
 	data, err := g.prepare(ctx, dk)
 	if err != nil {
@@ -74,13 +71,13 @@ func (g *EndpointSecretGenerator) GenerateForDynakube(ctx context.Context, dk *d
 		return false, err
 	}
 	for _, targetNs := range nsList {
-		if upd, err := kubeobjects.CreateOrUpdateSecretIfNotExists(g.client, g.apiReader, SecretEndpointName, targetNs.Name, data, corev1.SecretTypeOpaque, g.logger); err != nil {
+		if upd, err := kubeobjects.CreateOrUpdateSecretIfNotExists(g.client, g.apiReader, SecretEndpointName, targetNs.Name, data, corev1.SecretTypeOpaque, log); err != nil {
 			return upd, err
 		} else if upd {
 			anyUpdate = true
 		}
 	}
-	g.logger.Info("Done updating data-ingest endpoint secrets")
+	log.Info("Done updating data-ingest endpoint secrets")
 	return anyUpdate, nil
 }
 

--- a/controllers/ingestendpoint/secret_test.go
+++ b/controllers/ingestendpoint/secret_test.go
@@ -177,7 +177,7 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 		instance := buildTestDynakubeWithDataIngestCapability()
 		fakeClient := buildTestClient(instance)
 
-		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace, log)
+		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		upd, err := endpointSecretGenerator.GenerateForDynakube(context.TODO(), instance)
 		assert.NoError(t, err)

--- a/controllers/ingestendpoint/secret_test.go
+++ b/controllers/ingestendpoint/secret_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/mapper"
 	"github.com/Dynatrace/dynatrace-operator/scheme/fake"
 	"github.com/stretchr/testify/assert"
@@ -47,14 +46,12 @@ DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
 	testDynakubeName       = "dynakube"
 )
 
-var log = logger.NewDTLogger()
-
 func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 	t.Run(`data-ingest endpoint secret created but not updated`, func(t *testing.T) {
 		instance := buildTestDynakube()
 		fakeClient := buildTestClient(instance)
 
-		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace, log)
+		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), testDynakubeName, testNamespace1)
 		assert.NoError(t, err)
@@ -74,7 +71,7 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 		instance := buildTestDynakube()
 		fakeClient := buildTestClient(instance)
 
-		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace, log)
+		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), testDynakubeName, testNamespace1)
 		assert.NoError(t, err)
@@ -96,7 +93,7 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 		instance := buildTestDynakube()
 		fakeClient := buildTestClient(instance)
 
-		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace, log)
+		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), testDynakubeName, testNamespace1)
 		assert.NoError(t, err)
@@ -119,7 +116,7 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 		instance := buildTestDynakube()
 		fakeClient := buildTestClient(instance)
 
-		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace, log)
+		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		upd, err := endpointSecretGenerator.GenerateForDynakube(context.TODO(), instance)
 		assert.NoError(t, err)
@@ -138,7 +135,7 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 		instance := buildTestDynakube()
 		fakeClient := buildTestClient(instance)
 
-		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace, log)
+		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		upd, err := endpointSecretGenerator.GenerateForDynakube(context.TODO(), instance)
 		assert.NoError(t, err)
@@ -159,7 +156,7 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 		instance := buildTestDynakube()
 		fakeClient := buildTestClient(instance)
 
-		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace, log)
+		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		upd, err := endpointSecretGenerator.GenerateForDynakube(context.TODO(), instance)
 		assert.NoError(t, err)

--- a/controllers/istio/config.go
+++ b/controllers/istio/config.go
@@ -1,0 +1,9 @@
+package istio
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("dynakube-istio")
+)

--- a/controllers/istio/controller.go
+++ b/controllers/istio/controller.go
@@ -139,19 +139,19 @@ func (c *Controller) removeIstioConfigurationForServiceEntry(listOps *metav1.Lis
 
 	list, err := c.istioClient.NetworkingV1alpha3().ServiceEntries(namespace).List(context.TODO(), *listOps)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("istio: error listing service entries, %v", err))
+		log.Error(err, "istio: error listing service entries")
 		return false, err
 	}
 
 	del := false
 	for _, se := range list.Items {
 		if _, inUse := seen[se.GetName()]; !inUse {
-			log.Info(fmt.Sprintf("istio: removing %s: %v", se.Kind, se.GetName()))
+			log.Info("istio: removing", "kind", se.Kind, "name", se.GetName())
 			err = c.istioClient.NetworkingV1alpha3().
 				ServiceEntries(namespace).
 				Delete(context.TODO(), se.GetName(), metav1.DeleteOptions{})
 			if err != nil {
-				log.Error(err, fmt.Sprintf("istio: error deleting service entry, %s : %v", se.GetName(), err))
+				log.Error(err, "istio: error deleting service entry", "name", se.GetName())
 				continue
 			}
 			del = true
@@ -166,19 +166,19 @@ func (c *Controller) removeIstioConfigurationForVirtualService(listOps *metav1.L
 
 	list, err := c.istioClient.NetworkingV1alpha3().VirtualServices(namespace).List(context.TODO(), *listOps)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("istio: error listing virtual service, %v", err))
+		log.Error(err, "istio: error listing virtual service")
 		return false, err
 	}
 
 	del := false
 	for _, vs := range list.Items {
 		if _, inUse := seen[vs.GetName()]; !inUse {
-			log.Info(fmt.Sprintf("istio: removing %s: %v", vs.Kind, vs.GetName()))
+			log.Info("istio: removing", "kind", vs.Kind, "name", vs.GetName())
 			err = c.istioClient.NetworkingV1alpha3().
 				VirtualServices(namespace).
 				Delete(context.TODO(), vs.GetName(), metav1.DeleteOptions{})
 			if err != nil {
-				log.Error(err, fmt.Sprintf("istio: error deleting virtual service, %s : %v", vs.GetName(), err))
+				log.Error(err, "istio: error deleting virtual service", "name", vs.GetName())
 				continue
 			}
 			del = true

--- a/controllers/istio/controller_test.go
+++ b/controllers/istio/controller_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/scheme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,7 +84,6 @@ func TestController_ReconcileIstio(t *testing.T) {
 	controller := Controller{
 		istioClient: fakeistio.NewSimpleClientset(virtualService),
 		scheme:      scheme.Scheme,
-		logger:      logger.NewDTLogger(),
 		config: &rest.Config{
 			Host:    server.URL,
 			APIPath: testApiPath,

--- a/controllers/kubeobjects/daemonset_test.go
+++ b/controllers/kubeobjects/daemonset_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/scheme/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,7 +18,6 @@ const (
 )
 
 func Test_CreateOrUpdateDaemonSet_Create(t *testing.T) {
-	log := logger.NewDTLogger()
 	dsBefore := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
@@ -43,7 +41,6 @@ func Test_CreateOrUpdateDaemonSet_Create(t *testing.T) {
 }
 
 func Test_CreateOrUpdateDaemonSet_Update(t *testing.T) {
-	log := logger.NewDTLogger()
 	dsBefore := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
@@ -82,7 +79,7 @@ func Test_CreateOrUpdateDaemonSet_Update(t *testing.T) {
 }
 
 func Test_CreateOrUpdateDaemonSet_NoUpdateRequired(t *testing.T) {
-	log := logger.NewDTLogger()
+
 	dsBefore := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,

--- a/controllers/kubeobjects/secret.go
+++ b/controllers/kubeobjects/secret.go
@@ -20,7 +20,7 @@ func CreateOrUpdateSecretIfNotExists(c client.Client, r client.Reader, secretNam
 	var cfg corev1.Secret
 	err := r.Get(context.TODO(), client.ObjectKey{Name: secretName, Namespace: targetNS}, &cfg)
 	if k8serrors.IsNotFound(err) {
-		log.Info("Creating secret", "namespace", targetNS, "secret", secretName)
+		log.Info("creating secret", "namespace", targetNS, "secret", secretName)
 		if err := c.Create(context.TODO(), &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
@@ -39,7 +39,7 @@ func CreateOrUpdateSecretIfNotExists(c client.Client, r client.Reader, secretNam
 	}
 
 	if !reflect.DeepEqual(data, cfg.Data) {
-		log.Info("Updating secret", "namespace", targetNS, "secret", secretName)
+		log.Info("updating secret", "namespace", targetNS, "secret", secretName)
 		cfg.Data = data
 		if err := c.Update(context.TODO(), &cfg); err != nil {
 			return false, errors.Wrapf(err, "failed to update secret %s", secretName)

--- a/controllers/nodes/config.go
+++ b/controllers/nodes/config.go
@@ -1,0 +1,9 @@
+package nodes
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("nodes-controller")
+)

--- a/controllers/nodes/nodes_controller.go
+++ b/controllers/nodes/nodes_controller.go
@@ -108,9 +108,7 @@ func (r *ReconcileNodes) onUpdate(node string) error {
 }
 
 func (r *ReconcileNodes) onDeletion(node string) error {
-	logger := log.WithValues("node", node)
-
-	logger.Info("node deletion notification received")
+	log.Info("node deletion notification received", "node", node)
 
 	c, err := r.getCache()
 	if err != nil {

--- a/controllers/nodes/nodes_controller.go
+++ b/controllers/nodes/nodes_controller.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/controllers/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/controllers/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/dtclient"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -34,7 +32,6 @@ type ReconcileNodes struct {
 	client       client.Client
 	cache        cache.Cache
 	scheme       *runtime.Scheme
-	logger       logr.Logger
 	dtClientFunc dynakube.DynatraceClientFunc
 	local        bool
 }
@@ -48,7 +45,6 @@ func Add(mgr manager.Manager, ns string) error {
 		client:       mgr.GetClient(),
 		cache:        mgr.GetCache(),
 		scheme:       mgr.GetScheme(),
-		logger:       log.Log.WithName("nodes.controller"),
 		dtClientFunc: dynakube.BuildDynatraceClient,
 		local:        os.Getenv("RUN_LOCAL") == "true",
 	})
@@ -65,12 +61,12 @@ func (r *ReconcileNodes) Start(stop context.Context) error {
 		//
 		// Start() failing would exit the Operator process. Since this is a minor feature, let's disable
 		// for now until further investigation is done.
-		r.logger.Info("failed to initialize watcher for deleted nodes - disabled", "error", err)
+		log.Info("failed to initialize watcher for deleted nodes - disabled", "error", err)
 		chDels = make(chan string)
 	}
 	chUpdates, err := r.watchUpdates()
 	if err != nil {
-		r.logger.Info("failed to initialize watcher for updating nodes - disabled", "error", err)
+		log.Info("failed to initialize watcher for updating nodes - disabled", "error", err)
 		chUpdates = make(chan string)
 	}
 
@@ -79,19 +75,19 @@ func (r *ReconcileNodes) Start(stop context.Context) error {
 	for {
 		select {
 		case <-stop.Done():
-			r.logger.Info("stopping nodes controller")
+			log.Info("stopping nodes controller")
 			return nil
 		case node := <-chDels:
 			if err := r.onDeletion(node); err != nil {
-				r.logger.Error(err, "failed to reconcile deletion", "node", node)
+				log.Error(err, "failed to reconcile deletion", "node", node)
 			}
 		case node := <-chUpdates:
 			if err := r.onUpdate(node); err != nil {
-				r.logger.Error(err, "failed to reconcile updates", "node", node)
+				log.Error(err, "failed to reconcile updates", "node", node)
 			}
 		case <-chAll:
 			if err := r.reconcileAll(); err != nil {
-				r.logger.Error(err, "failed to reconcile nodes")
+				log.Error(err, "failed to reconcile nodes")
 			}
 		}
 	}
@@ -107,12 +103,12 @@ func (r *ReconcileNodes) onUpdate(node string) error {
 		return err
 	}
 
-	r.logger.Info("updating nodes cache", "node", node)
+	log.Info("updating nodes cache", "node", node)
 	return r.updateCache(c)
 }
 
 func (r *ReconcileNodes) onDeletion(node string) error {
-	logger := r.logger.WithValues("node", node)
+	logger := log.WithValues("node", node)
 
 	logger.Info("node deletion notification received")
 
@@ -135,7 +131,7 @@ func (r *ReconcileNodes) onDeletion(node string) error {
 }
 
 func (r *ReconcileNodes) reconcileAll() error {
-	r.logger.Info("reconciling nodes")
+	log.Info("reconciling nodes")
 
 	var dkList dynatracev1beta1.DynaKubeList
 	if err := r.client.List(context.TODO(), &dkList, client.InNamespace(r.namespace)); err != nil {
@@ -212,7 +208,7 @@ func (r *ReconcileNodes) reconcileAll() error {
 				Resource: dkList.GroupVersionKind().Kind,
 			}, name)
 		}); err != nil {
-			r.logger.Error(err, "failed to remove node", "node", node)
+			log.Error(err, "failed to remove node", "node", node)
 		}
 	}
 
@@ -228,7 +224,7 @@ func (r *ReconcileNodes) getCache() (*Cache, error) {
 	}
 
 	if errors.IsNotFound(err) {
-		r.logger.Info("no cache found, creating")
+		log.Info("no cache found, creating")
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -268,7 +264,7 @@ func (r *ReconcileNodes) updateCache(c *Cache) error {
 }
 
 func (r *ReconcileNodes) removeNode(c *Cache, node string, dkFunc func(name string) (*dynatracev1beta1.DynaKube, error)) error {
-	logger := r.logger.WithValues("node", node)
+	logger := log.WithValues("node", node)
 
 	nodeInfo, err := c.Get(node)
 	if err == ErrNotFound {
@@ -320,7 +316,7 @@ func (r *ReconcileNodes) updateNode(c *Cache, nodeName string) error {
 func (r *ReconcileNodes) sendMarkedForTermination(dk *dynatracev1beta1.DynaKube, nodeIP string, lastSeen time.Time) error {
 	dtp, err := dynakube.NewDynatraceClientProperties(context.TODO(), r.client, *dk)
 	if err != nil {
-		r.logger.Error(err, err.Error())
+		log.Error(err, err.Error())
 	}
 
 	dtc, err := r.dtClientFunc(*dtp)
@@ -330,7 +326,7 @@ func (r *ReconcileNodes) sendMarkedForTermination(dk *dynatracev1beta1.DynaKube,
 
 	entityID, err := dtc.GetEntityIDForIP(nodeIP)
 	if err != nil {
-		r.logger.Info("failed to send mark for termination event",
+		log.Info("failed to send mark for termination event",
 			"reason", "failed to determine entity id", "dynakube", dk.Name, "nodeIP", nodeIP, "cause", err)
 
 		return err
@@ -394,7 +390,7 @@ func (r *ReconcileNodes) markForTermination(c *Cache, dk *dynatracev1beta1.DynaK
 		return err
 	}
 
-	r.logger.Info("sending mark for termination event to dynatrace server", "dynakube", dk.Name, "ip", ipAddress,
+	log.Info("sending mark for termination event to dynatrace server", "dynakube", dk.Name, "ip", ipAddress,
 		"node", nodeName)
 
 	return r.sendMarkedForTermination(dk, ipAddress, cachedNode.LastSeen)

--- a/controllers/nodes/nodes_controller_test.go
+++ b/controllers/nodes/nodes_controller_test.go
@@ -2,7 +2,6 @@ package nodes
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -17,7 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 const testNamespace = "dynatrace"
@@ -160,7 +158,6 @@ func createDefaultReconciler(fakeClient client.Client, dtClient *dtclient.MockDy
 		namespace:    testNamespace,
 		client:       fakeClient,
 		scheme:       scheme.Scheme,
-		logger:       zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)),
 		dtClientFunc: dynakube.StaticDynatraceClient(dtClient),
 		local:        true,
 	}

--- a/controllers/nodes/watchers.go
+++ b/controllers/nodes/watchers.go
@@ -26,7 +26,7 @@ func (r *ReconcileNodes) watchDeletions(stop <-chan struct{}) (chan string, erro
 			if o, err := meta.Accessor(obj); err == nil {
 				chDels <- o.GetName()
 			} else {
-				r.logger.Error(err, "missing Meta", "object", obj, "type", fmt.Sprintf("%T", obj))
+				log.Error(err, "missing Meta", "object", obj, "type", fmt.Sprintf("%T", obj))
 			}
 		},
 	})
@@ -53,7 +53,7 @@ func (r *ReconcileNodes) handleUpdate(chUpdates chan string) func(oldObj, newObj
 	return func(oldObj, newObj interface{}) {
 		newMeta, err := meta.Accessor(newObj)
 		if err != nil {
-			r.logger.Error(err, "missing Meta",
+			log.Error(err, "missing Meta",
 				"new object", newObj, "type", fmt.Sprintf("%T", newObj))
 			return
 		}

--- a/controllers/oneagent/config.go
+++ b/controllers/oneagent/config.go
@@ -1,0 +1,9 @@
+package oneagent
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("dynakube-oneagent")
+)

--- a/controllers/oneagent/daemonset/arguments_test.go
+++ b/controllers/oneagent/daemonset/arguments_test.go
@@ -5,7 +5,6 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/deploymentmetadata"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +23,6 @@ const (
 )
 
 func TestArguments(t *testing.T) {
-	log := logger.NewDTLogger()
 	instance := dynatracev1beta1.DynaKube{
 		Spec: dynatracev1beta1.DynaKubeSpec{
 			APIURL: testURL,
@@ -41,7 +39,6 @@ func TestArguments(t *testing.T) {
 		builderInfo{
 			instance:       &instance,
 			hostInjectSpec: &instance.Spec.OneAgent.ClassicFullStack.HostInjectSpec,
-			logger:         log,
 			clusterId:      testClusterID,
 			relatedImage:   testValue,
 		},
@@ -53,7 +50,6 @@ func TestArguments(t *testing.T) {
 }
 
 func TestPodSpec_Arguments(t *testing.T) {
-	log := logger.NewDTLogger()
 	instance := &dynatracev1beta1.DynaKube{
 		Spec: dynatracev1beta1.DynaKubeSpec{
 			OneAgent: dynatracev1beta1.OneAgentSpec{
@@ -78,7 +74,6 @@ func TestPodSpec_Arguments(t *testing.T) {
 		builderInfo{
 			instance:       instance,
 			hostInjectSpec: hostInjectSpecs,
-			logger:         log,
 			clusterId:      testClusterID,
 			relatedImage:   testValue,
 			deploymentType: deploymentmetadata.DeploymentTypeFullStack,
@@ -126,7 +121,6 @@ func TestPodSpec_Arguments(t *testing.T) {
 			builderInfo{
 				instance:       instance,
 				hostInjectSpec: hostInjectSpecs,
-				logger:         log,
 				clusterId:      testClusterID,
 				relatedImage:   testValue,
 			},

--- a/controllers/oneagent/daemonset/daemonset.go
+++ b/controllers/oneagent/daemonset/daemonset.go
@@ -7,7 +7,6 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/controllers/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/deploymentmetadata"
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -54,7 +53,6 @@ type ClassicFullStack struct {
 type builderInfo struct {
 	instance       *dynatracev1beta1.DynaKube
 	hostInjectSpec *dynatracev1beta1.HostInjectSpec
-	logger         logr.Logger
 	clusterId      string
 	relatedImage   string
 	deploymentType string
@@ -64,12 +62,11 @@ type Builder interface {
 	BuildDaemonSet() (*appsv1.DaemonSet, error)
 }
 
-func NewHostMonitoring(instance *dynatracev1beta1.DynaKube, logger logr.Logger, clusterId string) Builder {
+func NewHostMonitoring(instance *dynatracev1beta1.DynaKube, clusterId string) Builder {
 	return &HostMonitoring{
 		builderInfo{
 			instance:       instance,
 			hostInjectSpec: &instance.Spec.OneAgent.HostMonitoring.HostInjectSpec,
-			logger:         logger,
 			clusterId:      clusterId,
 			relatedImage:   os.Getenv(relatedImageEnvVar),
 			deploymentType: deploymentmetadata.DeploymentTypeHostMonitoring,
@@ -78,12 +75,11 @@ func NewHostMonitoring(instance *dynatracev1beta1.DynaKube, logger logr.Logger, 
 	}
 }
 
-func NewCloudNativeFullStack(instance *dynatracev1beta1.DynaKube, logger logr.Logger, clusterId string) Builder {
+func NewCloudNativeFullStack(instance *dynatracev1beta1.DynaKube, clusterId string) Builder {
 	return &HostMonitoring{
 		builderInfo{
 			instance:       instance,
 			hostInjectSpec: &instance.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec,
-			logger:         logger,
 			clusterId:      clusterId,
 			relatedImage:   os.Getenv(relatedImageEnvVar),
 			deploymentType: deploymentmetadata.DeploymentTypeCloudNative,
@@ -92,12 +88,11 @@ func NewCloudNativeFullStack(instance *dynatracev1beta1.DynaKube, logger logr.Lo
 	}
 }
 
-func NewClassicFullStack(instance *dynatracev1beta1.DynaKube, logger logr.Logger, clusterId string) Builder {
+func NewClassicFullStack(instance *dynatracev1beta1.DynaKube, clusterId string) Builder {
 	return &ClassicFullStack{
 		builderInfo{
 			instance:       instance,
 			hostInjectSpec: &instance.Spec.OneAgent.ClassicFullStack.HostInjectSpec,
-			logger:         logger,
 			clusterId:      clusterId,
 			relatedImage:   os.Getenv(relatedImageEnvVar),
 			deploymentType: deploymentmetadata.DeploymentTypeFullStack,

--- a/controllers/oneagent/daemonset/daemonset_test.go
+++ b/controllers/oneagent/daemonset/daemonset_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -16,7 +15,6 @@ const (
 )
 
 func TestUseImmutableImage(t *testing.T) {
-	log := logger.NewDTLogger()
 	t.Run(`if image is unset, image`, func(t *testing.T) {
 		instance := dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
@@ -26,7 +24,7 @@ func TestUseImmutableImage(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, testClusterID)
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -45,7 +43,7 @@ func TestUseImmutableImage(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, testClusterID)
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -56,7 +54,6 @@ func TestUseImmutableImage(t *testing.T) {
 }
 
 func TestCustomPullSecret(t *testing.T) {
-	log := logger.NewDTLogger()
 	instance := dynatracev1beta1.DynaKube{
 		Spec: dynatracev1beta1.DynaKubeSpec{
 			APIURL: testURL,
@@ -66,7 +63,7 @@ func TestCustomPullSecret(t *testing.T) {
 			CustomPullSecret: testName,
 		},
 	}
-	dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+	dsInfo := NewClassicFullStack(&instance, testClusterID)
 	ds, err := dsInfo.BuildDaemonSet()
 	require.NoError(t, err)
 
@@ -77,7 +74,6 @@ func TestCustomPullSecret(t *testing.T) {
 }
 
 func TestResources(t *testing.T) {
-	log := logger.NewDTLogger()
 	t.Run(`minimal cpu request of 100mC is set if no resources specified`, func(t *testing.T) {
 		instance := dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
@@ -87,7 +83,7 @@ func TestResources(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, testClusterID)
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -126,7 +122,7 @@ func TestResources(t *testing.T) {
 			},
 		}
 
-		dsInfo := NewClassicFullStack(&instance, log, testClusterID)
+		dsInfo := NewClassicFullStack(&instance, testClusterID)
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -147,7 +143,6 @@ func TestResources(t *testing.T) {
 }
 
 func TestInfraMon_SecurityContext(t *testing.T) {
-	log := logger.NewDTLogger()
 	t.Run(`User and group id set when read only mode is enabled`, func(t *testing.T) {
 		instance := dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
@@ -157,7 +152,7 @@ func TestInfraMon_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := NewHostMonitoring(&instance, log, testClusterID)
+		dsInfo := NewHostMonitoring(&instance, testClusterID)
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 

--- a/controllers/oneagent/daemonset/volumes_test.go
+++ b/controllers/oneagent/daemonset/volumes_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +40,6 @@ func TestPrepareVolumes(t *testing.T) {
 			builderInfo{
 				instance:       instance,
 				hostInjectSpec: &instance.Spec.OneAgent.HostMonitoring.HostInjectSpec,
-				logger:         logger.NewDTLogger(),
 				clusterId:      "",
 				relatedImage:   "",
 			},

--- a/controllers/oneagent/error_handler.go
+++ b/controllers/oneagent/error_handler.go
@@ -1,10 +1,9 @@
 package oneagent
 
 import (
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func handlePodListError(logger logr.Logger, err error, listOps []client.ListOption) {
-	logger.Error(err, "failed to list pods", "listops", listOps)
+func handlePodListError(err error, listOps []client.ListOption) {
+	log.Error(err, "failed to list pods", "listops", listOps)
 }

--- a/controllers/oneagent/oneagent_controller.go
+++ b/controllers/oneagent/oneagent_controller.go
@@ -60,20 +60,20 @@ type ReconcileOneAgent struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileOneAgent) Reconcile(ctx context.Context, rec *controllers.DynakubeState) (bool, error) {
-	log.Info("Reconciling OneAgent")
+	log.Info("reconciling OneAgent")
 
 	upd, err := r.reconcileRollout(rec)
 	if err != nil {
 		return false, err
 	} else if upd {
-		log.Info("Rollout reconciled")
+		log.Info("rollout reconciled")
 	}
 
 	updInterval := defaultUpdateInterval
 	if val := os.Getenv(updateEnvVar); val != "" {
 		x, err := strconv.Atoi(val)
 		if err != nil {
-			log.Info("Conversion of ONEAGENT_OPERATOR_UPDATE_INTERVAL failed")
+			log.Info("conversion of ONEAGENT_OPERATOR_UPDATE_INTERVAL failed")
 		} else {
 			updInterval = time.Duration(x) * time.Minute
 		}
@@ -103,7 +103,7 @@ func (r *ReconcileOneAgent) reconcileRollout(dkState *controllers.DynakubeState)
 	// Define a new DaemonSet object
 	dsDesired, err := r.getDesiredDaemonSet(dkState)
 	if err != nil {
-		log.Info("Failed to get desired daemonset")
+		log.Info("failed to get desired daemonset")
 		return false, err
 	}
 

--- a/controllers/oneagent/oneagent_controller.go
+++ b/controllers/oneagent/oneagent_controller.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/controllers/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/controllers/kubesystem"
 	"github.com/Dynatrace/dynatrace-operator/controllers/oneagent/daemonset"
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,14 +33,12 @@ func NewOneAgentReconciler(
 	client client.Client,
 	apiReader client.Reader,
 	scheme *runtime.Scheme,
-	logger logr.Logger,
 	instance *dynatracev1beta1.DynaKube,
 	feature string) *ReconcileOneAgent {
 	return &ReconcileOneAgent{
 		client:    client,
 		apiReader: apiReader,
 		scheme:    scheme,
-		logger:    logger,
 		instance:  instance,
 		feature:   feature,
 	}
@@ -53,7 +50,6 @@ type ReconcileOneAgent struct {
 	client    client.Client
 	apiReader client.Reader
 	scheme    *runtime.Scheme
-	logger    logr.Logger
 	instance  *dynatracev1beta1.DynaKube
 	feature   string
 }
@@ -64,20 +60,20 @@ type ReconcileOneAgent struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileOneAgent) Reconcile(ctx context.Context, rec *controllers.DynakubeState) (bool, error) {
-	r.logger.Info("Reconciling OneAgent")
+	log.Info("Reconciling OneAgent")
 
 	upd, err := r.reconcileRollout(rec)
 	if err != nil {
 		return false, err
 	} else if upd {
-		r.logger.Info("Rollout reconciled")
+		log.Info("Rollout reconciled")
 	}
 
 	updInterval := defaultUpdateInterval
 	if val := os.Getenv(updateEnvVar); val != "" {
 		x, err := strconv.Atoi(val)
 		if err != nil {
-			r.logger.Info("Conversion of ONEAGENT_OPERATOR_UPDATE_INTERVAL failed")
+			log.Info("Conversion of ONEAGENT_OPERATOR_UPDATE_INTERVAL failed")
 		} else {
 			updInterval = time.Duration(x) * time.Minute
 		}
@@ -87,7 +83,7 @@ func (r *ReconcileOneAgent) Reconcile(ctx context.Context, rec *controllers.Dyna
 		r.instance.Status.OneAgent.LastHostsRequestTimestamp = rec.Now.DeepCopy()
 		rec.Update(true, 5*time.Minute, "updated last host request time stamp")
 
-		upd, err = r.reconcileInstanceStatuses(ctx, r.logger, r.instance)
+		upd, err = r.reconcileInstanceStatuses(ctx, r.instance)
 		rec.Update(upd, 5*time.Minute, "Instance statuses reconciled")
 		if rec.Error(err) {
 			return false, err
@@ -107,7 +103,7 @@ func (r *ReconcileOneAgent) reconcileRollout(dkState *controllers.DynakubeState)
 	// Define a new DaemonSet object
 	dsDesired, err := r.getDesiredDaemonSet(dkState)
 	if err != nil {
-		dkState.Log.Info("Failed to get desired daemonset")
+		log.Info("Failed to get desired daemonset")
 		return false, err
 	}
 
@@ -116,7 +112,7 @@ func (r *ReconcileOneAgent) reconcileRollout(dkState *controllers.DynakubeState)
 		return false, err
 	}
 
-	updateCR, err = kubeobjects.CreateOrUpdateDaemonSet(r.client, r.logger, dsDesired)
+	updateCR, err = kubeobjects.CreateOrUpdateDaemonSet(r.client, log, dsDesired)
 	if err != nil {
 		return updateCR, err
 	}
@@ -130,7 +126,7 @@ func (r *ReconcileOneAgent) reconcileRollout(dkState *controllers.DynakubeState)
 		}
 		err = r.client.Delete(context.TODO(), oldClassicDaemonset)
 		if err == nil {
-			r.logger.Info("removed oneagent daemonset with feature in name")
+			log.Info("removed oneagent daemonset with feature in name")
 		} else if !k8serrors.IsNotFound(err) {
 			return false, err
 		}
@@ -172,11 +168,11 @@ func (r *ReconcileOneAgent) newDaemonSetForCR(dkState *controllers.DynakubeState
 	var err error
 
 	if r.feature == daemonset.ClassicFeature {
-		ds, err = daemonset.NewClassicFullStack(dkState.Instance, dkState.Log, clusterID).BuildDaemonSet()
+		ds, err = daemonset.NewClassicFullStack(dkState.Instance, clusterID).BuildDaemonSet()
 	} else if r.feature == daemonset.HostMonitoringFeature {
-		ds, err = daemonset.NewHostMonitoring(dkState.Instance, dkState.Log, clusterID).BuildDaemonSet()
+		ds, err = daemonset.NewHostMonitoring(dkState.Instance, clusterID).BuildDaemonSet()
 	} else if r.feature == daemonset.CloudNativeFeature {
-		ds, err = daemonset.NewCloudNativeFullStack(dkState.Instance, dkState.Log, clusterID).BuildDaemonSet()
+		ds, err = daemonset.NewCloudNativeFullStack(dkState.Instance, clusterID).BuildDaemonSet()
 	}
 	if err != nil {
 		return nil, err
@@ -191,10 +187,10 @@ func (r *ReconcileOneAgent) newDaemonSetForCR(dkState *controllers.DynakubeState
 	return ds, nil
 }
 
-func (r *ReconcileOneAgent) reconcileInstanceStatuses(ctx context.Context, logger logr.Logger, instance *dynatracev1beta1.DynaKube) (bool, error) {
+func (r *ReconcileOneAgent) reconcileInstanceStatuses(ctx context.Context, instance *dynatracev1beta1.DynaKube) (bool, error) {
 	pods, listOpts, err := r.getPods(ctx, instance, r.feature)
 	if err != nil {
-		handlePodListError(logger, err, listOpts)
+		handlePodListError(err, listOpts)
 	}
 
 	instanceStatuses, err := getInstanceStatuses(pods)

--- a/dtclient/agent_version.go
+++ b/dtclient/agent_version.go
@@ -79,7 +79,7 @@ func (dtc *dynatraceClient) GetLatestAgent(os, installerType, flavor, arch strin
 		dtc.url, os, installerType, flavor, arch)
 	md5, err := dtc.makeRequestForBinary(url, dynatracePaaSToken, writer)
 	if err == nil {
-		log.Info("Downloaded agent file", "os", os, "type", installerType, "flavor", flavor, "arch", arch, "md5", md5)
+		log.Info("downloaded agent file", "os", os, "type", installerType, "flavor", flavor, "arch", arch, "md5", md5)
 	}
 	return err
 }
@@ -111,7 +111,7 @@ func (dtc *dynatraceClient) GetAgent(os, installerType, flavor, arch, version st
 	url := dtc.getAgentUrl(os, installerType, flavor, arch, version)
 	md5, err := dtc.makeRequestForBinary(url, dynatracePaaSToken, writer)
 	if err == nil {
-		log.Info("Downloaded agent file", "os", os, "type", installerType, "flavor", flavor, "arch", arch, "md5", md5)
+		log.Info("downloaded agent file", "os", os, "type", installerType, "flavor", flavor, "arch", arch, "md5", md5)
 	}
 	return err
 }

--- a/dtclient/agent_version.go
+++ b/dtclient/agent_version.go
@@ -57,7 +57,7 @@ func (dtc *dynatraceClient) readResponseForLatestVersion(response []byte) (strin
 	jr := &jsonResponse{}
 	err := json.Unmarshal(response, jr)
 	if err != nil {
-		dtc.logger.Error(err, "error unmarshalling json response")
+		log.Error(err, "error unmarshalling json response")
 		return "", err
 	}
 
@@ -79,7 +79,7 @@ func (dtc *dynatraceClient) GetLatestAgent(os, installerType, flavor, arch strin
 		dtc.url, os, installerType, flavor, arch)
 	md5, err := dtc.makeRequestForBinary(url, dynatracePaaSToken, writer)
 	if err == nil {
-		dtc.logger.Info("Downloaded agent file", "os", os, "type", installerType, "flavor", flavor, "arch", arch, "md5", md5)
+		log.Info("Downloaded agent file", "os", os, "type", installerType, "flavor", flavor, "arch", arch, "md5", md5)
 	}
 	return err
 }
@@ -111,7 +111,7 @@ func (dtc *dynatraceClient) GetAgent(os, installerType, flavor, arch, version st
 	url := dtc.getAgentUrl(os, installerType, flavor, arch, version)
 	md5, err := dtc.makeRequestForBinary(url, dynatracePaaSToken, writer)
 	if err == nil {
-		dtc.logger.Info("Downloaded agent file", "os", os, "type", installerType, "flavor", flavor, "arch", arch, "md5", md5)
+		log.Info("Downloaded agent file", "os", os, "type", installerType, "flavor", flavor, "arch", arch, "md5", md5)
 	}
 	return err
 }

--- a/dtclient/agent_version_test.go
+++ b/dtclient/agent_version_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -53,9 +52,7 @@ const (
 )
 
 func TestResponseForLatestVersion(t *testing.T) {
-	dc := &dynatraceClient{
-		logger: consoleLogger,
-	}
+	dc := &dynatraceClient{}
 	readFromString := func(json string) (string, error) {
 		r := []byte(json)
 		return dc.readResponseForLatestVersion(r)
@@ -89,7 +86,6 @@ func TestGetEntityIDForIP(t *testing.T) {
 	defer dynatraceServer.Close()
 
 	dtc := dynatraceClient{
-		logger:     log.Log.WithName("dtc"),
 		apiToken:   apiToken,
 		paasToken:  paasToken,
 		httpClient: dynatraceServer.Client(),
@@ -180,7 +176,6 @@ func TestGetLatestAgent(t *testing.T) {
 	defer dynatraceServer.Close()
 
 	dtc := dynatraceClient{
-		logger:     log.Log.WithName("dtc"),
 		apiToken:   apiToken,
 		paasToken:  paasToken,
 		httpClient: dynatraceServer.Client(),
@@ -214,7 +209,6 @@ func TestDynatraceClient_GetAgent(t *testing.T) {
 		defer dynatraceServer.Close()
 
 		dtc := dynatraceClient{
-			logger:     log.Log.WithName("dtc"),
 			httpClient: dynatraceServer.Client(),
 			url:        dynatraceServer.URL,
 			paasToken:  paasToken,
@@ -230,7 +224,6 @@ func TestDynatraceClient_GetAgent(t *testing.T) {
 		defer dynatraceServer.Close()
 
 		dtc := dynatraceClient{
-			logger:     log.Log.WithName("dtc"),
 			httpClient: dynatraceServer.Client(),
 			url:        dynatraceServer.URL,
 			paasToken:  paasToken,
@@ -248,7 +241,6 @@ func TestDynatraceClient_GetAgentVersions(t *testing.T) {
 		defer dynatraceServer.Close()
 
 		dtc := dynatraceClient{
-			logger:     log.Log.WithName("dtc"),
 			httpClient: dynatraceServer.Client(),
 			url:        dynatraceServer.URL,
 			paasToken:  paasToken,
@@ -267,7 +259,6 @@ func TestDynatraceClient_GetAgentVersions(t *testing.T) {
 		defer dynatraceServer.Close()
 
 		dtc := dynatraceClient{
-			logger:     log.Log.WithName("dtc"),
 			httpClient: dynatraceServer.Client(),
 			url:        dynatraceServer.URL,
 			paasToken:  paasToken,

--- a/dtclient/client.go
+++ b/dtclient/client.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -119,7 +118,6 @@ func NewClient(url, apiToken, paasToken string, opts ...Option) (Client, error) 
 		url:       url,
 		apiToken:  apiToken,
 		paasToken: paasToken,
-		logger:    log.Log.WithName("dynatrace.client"),
 
 		hostCache: make(map[string]hostInfo),
 		httpClient: &http.Client{
@@ -154,7 +152,7 @@ func Proxy(proxyURL string) Option {
 	return func(c *dynatraceClient) {
 		p, err := url.Parse(proxyURL)
 		if err != nil {
-			c.logger.Info("Could not parse proxy URL!")
+			log.Info("Could not parse proxy URL!")
 			return
 		}
 		t := c.httpClient.Transport.(*http.Transport)
@@ -166,7 +164,7 @@ func Certs(certs []byte) Option {
 	return func(c *dynatraceClient) {
 		rootCAs := x509.NewCertPool()
 		if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-			c.logger.Info("Failed to append custom certs!")
+			log.Info("Failed to append custom certs!")
 		}
 
 		t := c.httpClient.Transport.(*http.Transport)

--- a/dtclient/client.go
+++ b/dtclient/client.go
@@ -152,7 +152,7 @@ func Proxy(proxyURL string) Option {
 	return func(c *dynatraceClient) {
 		p, err := url.Parse(proxyURL)
 		if err != nil {
-			log.Info("Could not parse proxy URL!")
+			log.Info("could not parse proxy URL!")
 			return
 		}
 		t := c.httpClient.Transport.(*http.Transport)
@@ -164,7 +164,7 @@ func Certs(certs []byte) Option {
 	return func(c *dynatraceClient) {
 		rootCAs := x509.NewCertPool()
 		if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-			log.Info("Failed to append custom certs!")
+			log.Info("failed to append custom certs!")
 		}
 
 		t := c.httpClient.Transport.(*http.Transport)

--- a/dtclient/client_test.go
+++ b/dtclient/client_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestNewClient(t *testing.T) {
@@ -48,7 +47,6 @@ func TestProxy(t *testing.T) {
 		paasToken:  paasToken,
 		httpClient: dynatraceServer.Client(),
 		hostCache:  nil,
-		logger:     log.Log.WithName("dtc"),
 	}
 	transport := dtc.httpClient.Transport.(*http.Transport)
 	rawURL := "working.url"
@@ -77,7 +75,6 @@ func TestCerts(t *testing.T) {
 		paasToken:  paasToken,
 		httpClient: dynatraceServer.Client(),
 		hostCache:  nil,
-		logger:     log.Log.WithName("dtc"),
 	}
 	transport := dtc.httpClient.Transport.(*http.Transport)
 

--- a/dtclient/communication_hosts.go
+++ b/dtclient/communication_hosts.go
@@ -53,7 +53,7 @@ func (dtc *dynatraceClient) readResponseForConnectionInfo(response []byte) (Conn
 	resp := jsonResponse{}
 	err := json.Unmarshal(response, &resp)
 	if err != nil {
-		dtc.logger.Error(err, "error unmarshalling json response")
+		log.Error(err, "error unmarshalling json response")
 		return ConnectionInfo{}, err
 	}
 
@@ -61,11 +61,9 @@ func (dtc *dynatraceClient) readResponseForConnectionInfo(response []byte) (Conn
 	ch := make([]CommunicationHost, 0, len(resp.CommunicationEndpoints))
 
 	for _, s := range resp.CommunicationEndpoints {
-		logger := dtc.logger.WithValues("url", s)
-
 		e, err := dtc.parseEndpoint(s)
 		if err != nil {
-			logger.Info("failed to parse communication endpoint")
+			log.Info("failed to parse communication endpoint", "url", s)
 			continue
 		}
 		ch = append(ch, e)

--- a/dtclient/communication_hosts_test.go
+++ b/dtclient/communication_hosts_test.go
@@ -32,9 +32,7 @@ const mixedCommunicationEndpointsResponse = `{
 }`
 
 func TestReadCommunicationHosts(t *testing.T) {
-	dc := &dynatraceClient{
-		logger: consoleLogger,
-	}
+	dc := &dynatraceClient{}
 
 	readFromString := func(json string) (ConnectionInfo, error) {
 		r := []byte(json)

--- a/dtclient/config.go
+++ b/dtclient/config.go
@@ -1,0 +1,9 @@
+package dtclient
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("dtclient")
+)

--- a/dtclient/dynatrace_client.go
+++ b/dtclient/dynatrace_client.go
@@ -224,7 +224,7 @@ func (dtc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 
 			for _, ip := range info.IPAddresses {
 				if old, ok := dtc.hostCache[ip]; ok {
-					log.Info("Hosts cache: replacing host", "ip", ip, "new", hostInfo.entityID, "old", old.entityID)
+					log.Info("hosts cache: replacing host", "ip", ip, "new", hostInfo.entityID, "old", old.entityID)
 				}
 
 				dtc.hostCache[ip] = hostInfo
@@ -233,7 +233,7 @@ func (dtc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 	}
 
 	if len(inactive) > 0 {
-		log.Info("Hosts cache: ignoring inactive hosts", "ids", inactive)
+		log.Info("hosts cache: ignoring inactive hosts", "ids", inactive)
 	}
 
 	return nil

--- a/dtclient/dynatrace_client.go
+++ b/dtclient/dynatrace_client.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 )
 
@@ -24,7 +23,6 @@ type dynatraceClient struct {
 	url       string
 	apiToken  string
 	paasToken string
-	logger    logr.Logger
 
 	networkZone string
 
@@ -197,7 +195,7 @@ func (dtc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 	var hostInfoResponses []hostInfoResponse
 	err := json.Unmarshal(response, &hostInfoResponses)
 	if err != nil {
-		dtc.logger.Error(err, "error unmarshalling json response")
+		log.Error(err, "error unmarshalling json response")
 		return errors.WithStack(err)
 	}
 
@@ -226,7 +224,7 @@ func (dtc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 
 			for _, ip := range info.IPAddresses {
 				if old, ok := dtc.hostCache[ip]; ok {
-					dtc.logger.Info("Hosts cache: replacing host", "ip", ip, "new", hostInfo.entityID, "old", old.entityID)
+					log.Info("Hosts cache: replacing host", "ip", ip, "new", hostInfo.entityID, "old", old.entityID)
 				}
 
 				dtc.hostCache[ip] = hostInfo
@@ -235,7 +233,7 @@ func (dtc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 	}
 
 	if len(inactive) > 0 {
-		dtc.logger.Info("Hosts cache: ignoring inactive hosts", "ids", inactive)
+		log.Info("Hosts cache: ignoring inactive hosts", "ids", inactive)
 	}
 
 	return nil

--- a/dtclient/dynatrace_client_test.go
+++ b/dtclient/dynatrace_client_test.go
@@ -5,16 +5,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
-
-var consoleLogger = zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout))
 
 func TestMakeRequest(t *testing.T) {
 	dynatraceServer := httptest.NewServer(dynatraceServerHandler())
@@ -24,7 +20,6 @@ func TestMakeRequest(t *testing.T) {
 		url:       dynatraceServer.URL,
 		apiToken:  apiToken,
 		paasToken: paasToken,
-		logger:    consoleLogger,
 
 		hostCache:  make(map[string]hostInfo),
 		httpClient: http.DefaultClient,
@@ -53,7 +48,6 @@ func TestGetResponseOrServerError(t *testing.T) {
 		url:       dynatraceServer.URL,
 		apiToken:  apiToken,
 		paasToken: paasToken,
-		logger:    consoleLogger,
 
 		hostCache:  make(map[string]hostInfo),
 		httpClient: http.DefaultClient,
@@ -81,7 +75,6 @@ func TestBuildHostCache(t *testing.T) {
 		url:       dynatraceServer.URL,
 		paasToken: paasToken,
 		now:       time.Unix(1521540000, 0),
-		logger:    consoleLogger,
 
 		hostCache:  make(map[string]hostInfo),
 		httpClient: http.DefaultClient,
@@ -192,8 +185,7 @@ func TestIgnoreNonCurrentlySeenHosts(t *testing.T) {
 	// HOST-84 - lastSeenTimestamp: 19/05/2020 01:49 AM UTC
 
 	c := dynatraceClient{
-		logger: consoleLogger,
-		now:    time.Unix(1589969400, 0).UTC(),
+		now: time.Unix(1589969400, 0).UTC(),
 	}
 
 	require.NoError(t, c.setHostCacheFromResponse([]byte(`[

--- a/dtclient/processmoduleconfig.go
+++ b/dtclient/processmoduleconfig.go
@@ -83,7 +83,7 @@ func (dtc *dynatraceClient) specialProcessModuleConfigRequestStatus(resp *http.R
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		dtc.logger.Info("endpoint for ruxitagentproc.conf is not available on the cluster.")
+		log.Info("endpoint for ruxitagentproc.conf is not available on the cluster.")
 		return true
 	}
 
@@ -94,7 +94,7 @@ func (dtc *dynatraceClient) readResponseForProcessModuleConfig(response []byte) 
 	resp := ProcessModuleConfig{}
 	err := json.Unmarshal(response, &resp)
 	if err != nil {
-		dtc.logger.Error(err, "error unmarshalling json response")
+		log.Error(err, "error unmarshalling json response")
 		return nil, err
 	}
 

--- a/dtclient/processmoduleconfig_test.go
+++ b/dtclient/processmoduleconfig_test.go
@@ -29,7 +29,6 @@ const goodProcessModuleConfigResponse = `
 func TestCreateProcessModuleConfigRequest(t *testing.T) {
 	dc := &dynatraceClient{
 		paasToken: "token123",
-		logger:    consoleLogger,
 	}
 	require.NotNil(t, dc)
 
@@ -40,9 +39,7 @@ func TestCreateProcessModuleConfigRequest(t *testing.T) {
 }
 
 func TestSpecialProcessModuleConfigRequestStatus(t *testing.T) {
-	dc := &dynatraceClient{
-		logger: consoleLogger,
-	}
+	dc := &dynatraceClient{}
 	require.NotNil(t, dc)
 
 	assert.True(t, dc.specialProcessModuleConfigRequestStatus(&http.Response{StatusCode: http.StatusNotModified}))
@@ -52,9 +49,7 @@ func TestSpecialProcessModuleConfigRequestStatus(t *testing.T) {
 }
 
 func TestReadResponseForProcessModuleConfig(t *testing.T) {
-	dc := &dynatraceClient{
-		logger: consoleLogger,
-	}
+	dc := &dynatraceClient{}
 	require.NotNil(t, dc)
 
 	processConfig, err := dc.readResponseForProcessModuleConfig([]byte(goodProcessModuleConfigResponse))

--- a/dtclient/tenant.go
+++ b/dtclient/tenant.go
@@ -28,7 +28,7 @@ func (dtc *dynatraceClient) GetTenantInfo() (*TenantInfo, error) {
 	defer func() {
 		err := response.Body.Close()
 		if err != nil {
-			dtc.logger.Error(err, err.Error())
+			log.Error(err, err.Error())
 		}
 	}()
 
@@ -36,18 +36,18 @@ func (dtc *dynatraceClient) GetTenantInfo() (*TenantInfo, error) {
 	if err != nil {
 		err = dtc.handleErrorResponseFromAPI(data, response.StatusCode)
 		if err != nil {
-			dtc.logger.Error(err, err.Error())
+			log.Error(err, err.Error())
 		}
 		return nil, errors.WithStack(err)
 	}
 
 	tenantInfo, err := dtc.readResponseForTenantInfo(data)
 	if err != nil {
-		dtc.logger.Error(err, err.Error())
+		log.Error(err, err.Error())
 		return nil, errors.WithStack(err)
 	}
 	if len(tenantInfo.Endpoints) <= 0 {
-		dtc.logger.Info("tenant has no endpoints")
+		log.Info("tenant has no endpoints")
 	}
 
 	tenantInfo.CommunicationEndpoint = tenantInfo.findCommunicationEndpoint()
@@ -64,7 +64,7 @@ func (dtc *dynatraceClient) readResponseForTenantInfo(response []byte) (*TenantI
 	jr := &jsonResponse{}
 	err := json.Unmarshal(response, jr)
 	if err != nil {
-		dtc.logger.Error(err, "error unmarshalling json response")
+		log.Error(err, "error unmarshalling json response")
 		return nil, errors.WithStack(err)
 	}
 

--- a/e2e/prepare_environment.go
+++ b/e2e/prepare_environment.go
@@ -86,7 +86,7 @@ func getPathToKustomize() (string, error) {
 
 	workingDir = workingDir[:(strings.LastIndex(workingDir, "dynatrace-operator") + len("dynatrace-operator"))]
 	pathToKustomize := fmt.Sprintf("%s/config/kubernetes/", workingDir)
-	log.Info(fmt.Sprintf("assuming 'kustomization.yaml' to be in '%s'", pathToKustomize))
+	log.Info("assuming 'kustomization.yaml' to be in", "path", pathToKustomize)
 	if _, err := os.Stat(fmt.Sprintf("%skustomization.yaml", pathToKustomize)); err != nil {
 		log.Error(err, "'kustomization.yaml' not found in path", "path", pathToKustomize)
 		return "", errors.WithStack(err)

--- a/initgeneration/config.go
+++ b/initgeneration/config.go
@@ -1,0 +1,9 @@
+package initgeneration
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("initgeneration")
+)

--- a/initgeneration/initgeneration.go
+++ b/initgeneration/initgeneration.go
@@ -71,7 +71,7 @@ func NewInitGenerator(client client.Client, apiReader client.Reader, ns string) 
 // GenerateForNamespace creates the init secret for namespace while only having the name of the corresponding dynakube
 // Used by the podInjection webhook in case the namespace lacks the init secret.
 func (g *InitGenerator) GenerateForNamespace(ctx context.Context, dk dynatracev1beta1.DynaKube, targetNs string) (bool, error) {
-	log.Info("Reconciling namespace init secret for", "namespace", targetNs)
+	log.Info("reconciling namespace init secret for", "namespace", targetNs)
 	g.canWatchNodes = false
 	data, err := g.generate(ctx, &dk)
 	if err != nil {
@@ -83,7 +83,7 @@ func (g *InitGenerator) GenerateForNamespace(ctx context.Context, dk dynatracev1
 // GenerateForDynakube creates/updates the init secret for EVERY namespace for the given dynakube.
 // Used by the dynakube controller during reconcile.
 func (g *InitGenerator) GenerateForDynakube(ctx context.Context, dk *dynatracev1beta1.DynaKube) (bool, error) {
-	log.Info("Reconciling namespace init secret for", "dynakube", dk.Name)
+	log.Info("reconciling namespace init secret for", "dynakube", dk.Name)
 	g.canWatchNodes = true
 	data, err := g.generate(ctx, dk)
 	if err != nil {
@@ -102,7 +102,7 @@ func (g *InitGenerator) GenerateForDynakube(ctx context.Context, dk *dynatracev1
 			anyUpdate = true
 		}
 	}
-	log.Info("Done updating init secrets")
+	log.Info("done updating init secrets")
 	return anyUpdate, nil
 }
 

--- a/initgeneration/initgeneration.go
+++ b/initgeneration/initgeneration.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/mapper"
 	"github.com/Dynatrace/dynatrace-operator/webhook"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,7 +38,6 @@ var (
 type InitGenerator struct {
 	client        client.Client
 	apiReader     client.Reader
-	logger        logr.Logger
 	namespace     string
 	canWatchNodes bool
 }
@@ -62,31 +60,30 @@ type script struct {
 	HasHost       bool
 }
 
-func NewInitGenerator(client client.Client, apiReader client.Reader, ns string, logger logr.Logger) *InitGenerator {
+func NewInitGenerator(client client.Client, apiReader client.Reader, ns string) *InitGenerator {
 	return &InitGenerator{
 		client:    client,
 		apiReader: apiReader,
 		namespace: ns,
-		logger:    logger,
 	}
 }
 
 // GenerateForNamespace creates the init secret for namespace while only having the name of the corresponding dynakube
 // Used by the podInjection webhook in case the namespace lacks the init secret.
 func (g *InitGenerator) GenerateForNamespace(ctx context.Context, dk dynatracev1beta1.DynaKube, targetNs string) (bool, error) {
-	g.logger.Info("Reconciling namespace init secret for", "namespace", targetNs)
+	log.Info("Reconciling namespace init secret for", "namespace", targetNs)
 	g.canWatchNodes = false
 	data, err := g.generate(ctx, &dk)
 	if err != nil {
 		return false, err
 	}
-	return kubeobjects.CreateOrUpdateSecretIfNotExists(g.client, g.apiReader, webhook.SecretConfigName, targetNs, data, corev1.SecretTypeOpaque, g.logger)
+	return kubeobjects.CreateOrUpdateSecretIfNotExists(g.client, g.apiReader, webhook.SecretConfigName, targetNs, data, corev1.SecretTypeOpaque, log)
 }
 
 // GenerateForDynakube creates/updates the init secret for EVERY namespace for the given dynakube.
 // Used by the dynakube controller during reconcile.
 func (g *InitGenerator) GenerateForDynakube(ctx context.Context, dk *dynatracev1beta1.DynaKube) (bool, error) {
-	g.logger.Info("Reconciling namespace init secret for", "dynakube", dk.Name)
+	log.Info("Reconciling namespace init secret for", "dynakube", dk.Name)
 	g.canWatchNodes = true
 	data, err := g.generate(ctx, dk)
 	if err != nil {
@@ -99,13 +96,13 @@ func (g *InitGenerator) GenerateForDynakube(ctx context.Context, dk *dynatracev1
 		return false, err
 	}
 	for _, targetNs := range nsList {
-		if upd, err := kubeobjects.CreateOrUpdateSecretIfNotExists(g.client, g.apiReader, webhook.SecretConfigName, targetNs.Name, data, corev1.SecretTypeOpaque, g.logger); err != nil {
+		if upd, err := kubeobjects.CreateOrUpdateSecretIfNotExists(g.client, g.apiReader, webhook.SecretConfigName, targetNs.Name, data, corev1.SecretTypeOpaque, log); err != nil {
 			return false, err
 		} else if upd {
 			anyUpdate = true
 		}
 	}
-	g.logger.Info("Done updating init secrets")
+	log.Info("Done updating init secrets")
 	return anyUpdate, nil
 }
 

--- a/initgeneration/initgeneration_test.go
+++ b/initgeneration/initgeneration_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/mapper"
 	"github.com/Dynatrace/dynatrace-operator/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/webhook"
@@ -155,7 +154,7 @@ func TestGenerateForNamespace(t *testing.T) {
 			},
 		}
 		clt := fake.NewClient(testDynakubeComplex, &testNamespace, testSecretDynakubeComplex, kubeNamespace, caConfigMap, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig := NewInitGenerator(clt, clt, operatorNamespace)
 
 		_, err := ig.GenerateForNamespace(context.TODO(), *testDynakubeComplex, testNamespace.Name)
 		assert.NoError(t, err)
@@ -182,7 +181,7 @@ func TestGenerateForNamespace(t *testing.T) {
 			},
 		}
 		clt := fake.NewClient(testDynakubeSimple, &testNamespace, testSecretDynakubeSimple, kubeNamespace, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig := NewInitGenerator(clt, clt, operatorNamespace)
 
 		_, err := ig.GenerateForNamespace(context.TODO(), *testDynakubeSimple, testNamespace.Name)
 		assert.NoError(t, err)
@@ -207,7 +206,7 @@ func TestGenerateForDynakube(t *testing.T) {
 			},
 		}
 		clt := fake.NewClient(&testNamespace, testSecretDynakubeComplex, kubeNamespace, caConfigMap, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig := NewInitGenerator(clt, clt, operatorNamespace)
 
 		updated, err := ig.GenerateForDynakube(context.TODO(), dk)
 		assert.NoError(t, err)
@@ -236,7 +235,7 @@ func TestGenerateForDynakube(t *testing.T) {
 			},
 		}
 		clt := fake.NewClient(&testNamespace, testSecretDynakubeSimple, kubeNamespace, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig := NewInitGenerator(clt, clt, operatorNamespace)
 
 		updated, err := ig.GenerateForDynakube(context.TODO(), dk)
 		assert.NoError(t, err)
@@ -265,7 +264,7 @@ func TestGenerateForDynakube(t *testing.T) {
 			},
 		}
 		clt := fake.NewClient(&testNamespace, &testOtherNamespace, testSecretDynakubeSimple, kubeNamespace, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig := NewInitGenerator(clt, clt, operatorNamespace)
 
 		updated, err := ig.GenerateForDynakube(context.TODO(), dk)
 		assert.NoError(t, err)
@@ -290,7 +289,7 @@ func TestGenerateForDynakube(t *testing.T) {
 func TestGetInfraMonitoringNodes(t *testing.T) {
 	t.Run("Get IMNodes using nodes", func(t *testing.T) {
 		clt := fake.NewClient(testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig := NewInitGenerator(clt, clt, operatorNamespace)
 		ig.canWatchNodes = true
 		imNodes, err := ig.getInfraMonitoringNodes(testDynakubeSimple)
 		assert.NoError(t, err)
@@ -300,7 +299,7 @@ func TestGetInfraMonitoringNodes(t *testing.T) {
 	})
 	t.Run("Get IMNodes from dynakubes (without node access)", func(t *testing.T) {
 		clt := fake.NewClient()
-		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig := NewInitGenerator(clt, clt, operatorNamespace)
 		ig.canWatchNodes = false
 		imNodes, err := ig.getInfraMonitoringNodes(testDynakubeSimple)
 		assert.NoError(t, err)
@@ -309,7 +308,7 @@ func TestGetInfraMonitoringNodes(t *testing.T) {
 	})
 	t.Run("Get IMNodes from dynakubes with nodeSelector", func(t *testing.T) {
 		clt := fake.NewClient(testNodeWithLabels, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig := NewInitGenerator(clt, clt, operatorNamespace)
 		ig.canWatchNodes = true
 		imNodes, err := ig.getInfraMonitoringNodes(testDynakubeWithSelector)
 		assert.NoError(t, err)
@@ -329,7 +328,7 @@ func TestPrepareScriptForDynaKube(t *testing.T) {
 			},
 		}
 		clt := fake.NewClient(&testNamespace, testSecretDynakubeComplex, caConfigMap)
-		ig := NewInitGenerator(clt, clt, operatorNamespace, logger.NewDTLogger())
+		ig := NewInitGenerator(clt, clt, operatorNamespace)
 		imNodes := map[string]string{testNode1Name: testTenantUUID, testNode2Name: testTenantUUID}
 		sc, err := ig.prepareScriptForDynaKube(dk, kubesystemUID, imNodes)
 		assert.NoError(t, err)

--- a/integrationtests/envutils_test.go
+++ b/integrationtests/envutils_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -96,8 +95,7 @@ func newTestEnvironment() (*ControllerTestEnvironment, error) {
 	}
 	testEnvironment.Reconciler = dynakube.NewDynaKubeReconciler(
 		kubernetesClient, kubernetesClient, scheme.Scheme,
-		mockDynatraceClientFunc(&testEnvironment.CommunicationHosts),
-		zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)), cfg)
+		mockDynatraceClientFunc(&testEnvironment.CommunicationHosts), cfg)
 
 	return testEnvironment, nil
 }

--- a/mapper/config.go
+++ b/mapper/config.go
@@ -1,0 +1,9 @@
+package mapper
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("namespace-mapper")
+)

--- a/mapper/dynakube_test.go
+++ b/mapper/dynakube_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/scheme/fake"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -18,7 +17,7 @@ func TestMapFromDynakube(t *testing.T) {
 
 	t.Run("Add to namespace", func(t *testing.T) {
 		clt := fake.NewClient(dk, namespace)
-		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk, logger.NewDTLogger())
+		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk)
 
 		err := dm.MapFromDynakube()
 
@@ -36,7 +35,7 @@ func TestMapFromDynakube(t *testing.T) {
 		}
 		namespace := createNamespace("test-namespace", nsLabels)
 		clt := fake.NewClient(dk, namespace)
-		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk, logger.NewDTLogger())
+		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk)
 
 		err := dm.MapFromDynakube()
 
@@ -54,7 +53,7 @@ func TestMapFromDynakube(t *testing.T) {
 		}
 		namespace := createNamespace("test-namespace", nsLabels)
 		clt := fake.NewClient(movedDk, namespace)
-		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", movedDk, logger.NewDTLogger())
+		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", movedDk)
 
 		err := dm.MapFromDynakube()
 
@@ -73,7 +72,7 @@ func TestMapFromDynakube(t *testing.T) {
 		}
 		namespace := createNamespace("test-namespace", nsLabels)
 		clt := fake.NewClient(dk, conflictingDk, namespace)
-		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", conflictingDk, logger.NewDTLogger())
+		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", conflictingDk)
 
 		err := dm.MapFromDynakube()
 
@@ -83,7 +82,7 @@ func TestMapFromDynakube(t *testing.T) {
 		dk := createTestDynakubeWithMultipleFeatures("appMonitoring", nil, nil)
 		namespace := createNamespace("kube-something", nil)
 		clt := fake.NewClient(dk, namespace)
-		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk, logger.NewDTLogger())
+		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk)
 
 		err := dm.MapFromDynakube()
 
@@ -99,7 +98,7 @@ func TestMapFromDynakube(t *testing.T) {
 		dk := createTestDynakubeWithMultipleFeatures("appMonitoring", nil, nil)
 		namespace := createNamespace("openshift-something", nil)
 		clt := fake.NewClient(dk, namespace)
-		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk, logger.NewDTLogger())
+		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk)
 
 		err := dm.MapFromDynakube()
 
@@ -117,7 +116,7 @@ func TestMapFromDynakube(t *testing.T) {
 		}
 		namespace := createNamespace("openshift-something", nil)
 		clt := fake.NewClient(dk, namespace)
-		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk, logger.NewDTLogger())
+		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk)
 
 		err := dm.MapFromDynakube()
 
@@ -140,13 +139,13 @@ func TestUnmapFromDynaKube(t *testing.T) {
 
 	t.Run("Remove from no ns => no error", func(t *testing.T) {
 		clt := fake.NewClient()
-		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk, logger.NewDTLogger())
+		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk)
 		err := dm.UnmapFromDynaKube()
 		assert.NoError(t, err)
 	})
 	t.Run("Remove from everywhere, multiple entries", func(t *testing.T) {
 		clt := fake.NewClient(namespace, namespace2)
-		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk, logger.NewDTLogger())
+		dm := NewDynakubeMapper(context.TODO(), clt, clt, "dynatrace", dk)
 		err := dm.UnmapFromDynaKube()
 		assert.NoError(t, err)
 		var ns corev1.Namespace

--- a/mapper/dynakubes.go
+++ b/mapper/dynakubes.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,11 +16,10 @@ type DynakubeMapper struct {
 	apiReader  client.Reader
 	operatorNs string
 	dk         *dynatracev1beta1.DynaKube
-	logger     logr.Logger
 }
 
-func NewDynakubeMapper(ctx context.Context, clt client.Client, apiReader client.Reader, operatorNs string, dk *dynatracev1beta1.DynaKube, logger logr.Logger) DynakubeMapper {
-	return DynakubeMapper{ctx, clt, apiReader, operatorNs, dk, logger}
+func NewDynakubeMapper(ctx context.Context, clt client.Client, apiReader client.Reader, operatorNs string, dk *dynatracev1beta1.DynaKube) DynakubeMapper {
+	return DynakubeMapper{ctx, clt, apiReader, operatorNs, dk}
 }
 
 // MapFromDynakube checks all the namespaces to all the dynakubes
@@ -84,7 +82,7 @@ func (dm DynakubeMapper) mapFromDynakube(nsList *corev1.NamespaceList, dkList *d
 
 	for i := range nsList.Items {
 		namespace := &nsList.Items[i]
-		updated, err = updateNamespace(dm.operatorNs, namespace, dkList, dm.logger)
+		updated, err = updateNamespace(dm.operatorNs, namespace, dkList)
 		if err != nil {
 			return nil, err
 		}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -6,7 +6,6 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/webhook"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,7 +80,7 @@ func match(dk *dynatracev1beta1.DynaKube, namespace *corev1.Namespace) (bool, er
 // updateNamespace tries to match the namespace to every dynakube with codeModules
 // finds conflicting dynakubes(2 dynakube with codeModules on the same namespace)
 // adds/updates/removes labels from the namespace.
-func updateNamespace(operatorNs string, namespace *corev1.Namespace, dkList *dynatracev1beta1.DynaKubeList, log logr.Logger) (bool, error) {
+func updateNamespace(operatorNs string, namespace *corev1.Namespace, dkList *dynatracev1beta1.DynaKubeList) (bool, error) {
 	var updated bool
 	conflict := ConflictChecker{}
 	for i := range dkList.Items {
@@ -99,7 +98,7 @@ func updateNamespace(operatorNs string, namespace *corev1.Namespace, dkList *dyn
 			}
 		}
 
-		upd, err := updateLabels(matches, dynakube, namespace, log)
+		upd, err := updateLabels(matches, dynakube, namespace)
 		if err != nil {
 			return updated, err
 		}
@@ -110,7 +109,7 @@ func updateNamespace(operatorNs string, namespace *corev1.Namespace, dkList *dyn
 	return updated, nil
 }
 
-func updateLabels(matches bool, dynakube *dynatracev1beta1.DynaKube, namespace *corev1.Namespace, log logr.Logger) (bool, error) {
+func updateLabels(matches bool, dynakube *dynatracev1beta1.DynaKube, namespace *corev1.Namespace) (bool, error) {
 	updated := false
 	if namespace.Labels == nil {
 		namespace.Labels = make(map[string]string)

--- a/mapper/namespaces.go
+++ b/mapper/namespaces.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,11 +16,10 @@ type NamespaceMapper struct {
 	apiReader  client.Reader
 	operatorNs string
 	targetNs   *corev1.Namespace
-	logger     logr.Logger
 }
 
-func NewNamespaceMapper(ctx context.Context, clt client.Client, apiReader client.Reader, operatorNs string, targetNs *corev1.Namespace, logger logr.Logger) NamespaceMapper {
-	return NamespaceMapper{ctx, clt, apiReader, operatorNs, targetNs, logger}
+func NewNamespaceMapper(ctx context.Context, clt client.Client, apiReader client.Reader, operatorNs string, targetNs *corev1.Namespace) NamespaceMapper {
+	return NamespaceMapper{ctx, clt, apiReader, operatorNs, targetNs}
 }
 
 // MapFromNamespace adds the labels to the targetNs if there is a matching Dynakube
@@ -41,5 +39,5 @@ func (nm NamespaceMapper) updateNamespace() (bool, error) {
 		return false, errors.Cause(err)
 	}
 
-	return updateNamespace(nm.operatorNs, nm.targetNs, dkList, nm.logger)
+	return updateNamespace(nm.operatorNs, nm.targetNs, dkList)
 }

--- a/mapper/namespaces_test.go
+++ b/mapper/namespaces_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/scheme/fake"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,7 +22,7 @@ func TestMatchForNamespaceNothingEverything(t *testing.T) {
 	t.Run(`Match to unlabeled namespace`, func(t *testing.T) {
 		namespace := createNamespace("test-namespace", nil)
 		clt := fake.NewClient(dynakubes[0], dynakubes[1])
-		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace, logger.NewDTLogger())
+		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace)
 
 		updated, err := nm.updateNamespace()
 		assert.NoError(t, err)
@@ -38,7 +37,7 @@ func TestMapFromNamespace(t *testing.T) {
 
 	t.Run("Add to namespace", func(t *testing.T) {
 		clt := fake.NewClient(dk)
-		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace, logger.NewDTLogger())
+		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace)
 
 		updated, err := nm.MapFromNamespace()
 
@@ -50,7 +49,7 @@ func TestMapFromNamespace(t *testing.T) {
 	t.Run("Error, 2 dynakube point to same namespace", func(t *testing.T) {
 		dk2 := createTestDynakubeWithAppInject("appMonitoring-2", labels, nil)
 		clt := fake.NewClient(dk, dk2)
-		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace, logger.NewDTLogger())
+		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace)
 
 		updated, err := nm.MapFromNamespace()
 
@@ -64,7 +63,7 @@ func TestMapFromNamespace(t *testing.T) {
 		}
 		namespace := createNamespace("test-namespace", labels)
 		clt := fake.NewClient(dk)
-		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace, logger.NewDTLogger())
+		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace)
 
 		updated, err := nm.MapFromNamespace()
 
@@ -77,7 +76,7 @@ func TestMapFromNamespace(t *testing.T) {
 		dk := createTestDynakubeWithMultipleFeatures("appMonitoring", nil, nil)
 		namespace := createNamespace("kube-something", nil)
 		clt := fake.NewClient(dk)
-		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace, logger.NewDTLogger())
+		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace)
 
 		updated, err := nm.MapFromNamespace()
 
@@ -90,7 +89,7 @@ func TestMapFromNamespace(t *testing.T) {
 		dk := createTestDynakubeWithMultipleFeatures("appMonitoring", nil, nil)
 		namespace := createNamespace("openshift-something", nil)
 		clt := fake.NewClient(dk)
-		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace, logger.NewDTLogger())
+		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace)
 
 		updated, err := nm.MapFromNamespace()
 
@@ -106,7 +105,7 @@ func TestMapFromNamespace(t *testing.T) {
 		}
 		namespace := createNamespace("openshift-something", nil)
 		clt := fake.NewClient(dk)
-		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace, logger.NewDTLogger())
+		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace)
 
 		updated, err := nm.MapFromNamespace()
 

--- a/version/version.go
+++ b/version/version.go
@@ -17,12 +17,12 @@ var (
 	// BuildDate is the date when the binary was build. Assigned externally.
 	BuildDate = ""
 
-	log = logger.NewDTLogger().WithName("dynatrace-operator.version")
+	log = logger.NewDTLogger().WithName("dynatrace-operator-version")
 )
 
 // LogVersion logs metadata about the Operator.
 func LogVersion() {
-	log.Info("Dynatrace Operator",
+	log.Info("dynatrace-operator",
 		"version", Version,
 		"gitCommit", Commit,
 		"buildDate", BuildDate,

--- a/webhook/mutation/config.go
+++ b/webhook/mutation/config.go
@@ -1,0 +1,38 @@
+package mutation
+
+import (
+	"os"
+
+	"github.com/Dynatrace/dynatrace-operator/logger"
+)
+
+const (
+	injectEvent          = "Inject"
+	updatePodEvent       = "UpdatePod"
+	missingDynakubeEvent = "MissingDynakube"
+
+	dataIngestInjectedEnvVarName = "DATA_INGEST_INJECTED"
+	oneAgentInjectedEnvVarName   = "ONEAGENT_INJECTED"
+	dynatraceMetadataEnvVarName  = "DT_DEPLOYMENT_METADATA"
+
+	workloadKindEnvVarName = "DT_WORKLOAD_KIND"
+	workloadNameEnvVarName = "DT_WORKLOAD_NAME"
+
+	dataIngestVolumeName = "data-ingest-enrichment"
+	dataIngestMountPath  = "/var/lib/dynatrace/enrichment"
+
+	dataIngestEndpointVolumeName = "data-ingest-endpoint"
+
+	oneAgentBinVolumeName   = "oneagent-bin"
+	oneAgentShareVolumeName = "oneagent-share"
+
+	injectionConfigVolumeName = "injection-config"
+
+	provisionedVolumeMode = "provisioned"
+	installerVolumeMode   = "installer"
+)
+
+var (
+	log   = logger.NewDTLogger().WithName("mutation-webhook")
+	debug = os.Getenv("DEBUG_OPERATOR")
+)

--- a/webhook/mutation/namespace_mutator.go
+++ b/webhook/mutation/namespace_mutator.go
@@ -52,7 +52,7 @@ func (nm *namespaceMutator) Handle(ctx context.Context, request admission.Reques
 
 	nm.logger.Info("Namespace request", "namespace", request.Name, "operation", request.Operation)
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: request.Namespace}}
-	nsMapper := mapper.NewNamespaceMapper(ctx, nm.client, nm.apiReader, nm.namespace, &ns, nm.logger)
+	nsMapper := mapper.NewNamespaceMapper(ctx, nm.client, nm.apiReader, nm.namespace, &ns)
 	if err := decodeRequestToNamespace(request, &ns); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}

--- a/webhook/mutation/namespace_mutator.go
+++ b/webhook/mutation/namespace_mutator.go
@@ -5,10 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/mapper"
 	"github.com/Dynatrace/dynatrace-operator/scheme"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +25,6 @@ func AddNamespaceMutationWebhookToManager(manager ctrl.Manager, ns string) error
 
 // namespaceMutator adds the necessary label to namespaces that match a dynakubes namespace selector
 type namespaceMutator struct {
-	logger    logr.Logger
 	client    client.Client
 	apiReader client.Reader
 	namespace string
@@ -50,7 +47,7 @@ func (nm *namespaceMutator) Handle(ctx context.Context, request admission.Reques
 		return admission.Patched("")
 	}
 
-	nm.logger.Info("Namespace request", "namespace", request.Name, "operation", request.Operation)
+	log.Info("namespace request", "namespace", request.Name, "operation", request.Operation)
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: request.Namespace}}
 	nsMapper := mapper.NewNamespaceMapper(ctx, nm.client, nm.apiReader, nm.namespace, &ns)
 	if err := decodeRequestToNamespace(request, &ns); err != nil {
@@ -58,12 +55,12 @@ func (nm *namespaceMutator) Handle(ctx context.Context, request admission.Reques
 	}
 
 	if _, ok := ns.Annotations[mapper.UpdatedViaDynakubeAnnotation]; ok {
-		nm.logger.Info("Checking namespace labels not necessary", "namespace", request.Name)
+		log.Info("checking namespace labels not necessary", "namespace", request.Name)
 		delete(ns.Annotations, mapper.UpdatedViaDynakubeAnnotation)
 		return getResponseForNamespace(&ns, &request)
 	}
 
-	nm.logger.Info("Checking namespace labels", "namespace", request.Name)
+	log.Info("checking namespace labels", "namespace", request.Name)
 	updatedNamespace, err := nsMapper.MapFromNamespace()
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
@@ -71,7 +68,7 @@ func (nm *namespaceMutator) Handle(ctx context.Context, request admission.Reques
 	if !updatedNamespace {
 		return admission.Patched("")
 	}
-	nm.logger.Info("Namespace", "labels", ns.Labels)
+	log.Info("namespace", "labels", ns.Labels)
 	return getResponseForNamespace(&ns, &request)
 }
 
@@ -91,7 +88,6 @@ func decodeRequestToNamespace(request admission.Request, namespace *corev1.Names
 func newNamespaceMutator(ns string, apiReader client.Reader) admission.Handler {
 	return &namespaceMutator{
 		apiReader: apiReader,
-		logger:    logger.NewDTLogger(),
 		namespace: ns,
 	}
 }

--- a/webhook/mutation/namespace_mutator_test.go
+++ b/webhook/mutation/namespace_mutator_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/mapper"
 	"github.com/Dynatrace/dynatrace-operator/scheme/fake"
 	jsonpatch "github.com/evanphx/json-patch"
@@ -48,7 +47,6 @@ func TestInjection(t *testing.T) {
 		client:    clt,
 		apiReader: clt,
 		namespace: "dynatrace",
-		logger:    logger.NewDTLogger(),
 	}
 	t.Run("Don't inject into operator ns", func(t *testing.T) {
 		baseNs := &corev1.Namespace{

--- a/webhook/mutation/pod_mutator.go
+++ b/webhook/mutation/pod_mutator.go
@@ -681,7 +681,7 @@ func (m *podMutator) ensureInitSecret(ctx context.Context, ns corev1.Namespace, 
 	var rsp admission.Response
 
 	if err := m.apiReader.Get(ctx, client.ObjectKey{Name: dtwebhook.SecretConfigName, Namespace: ns.Name}, &initSecret); k8serrors.IsNotFound(err) {
-		if _, err := initgeneration.NewInitGenerator(m.client, m.apiReader, m.namespace, log).GenerateForNamespace(ctx, dk, ns.Name); err != nil {
+		if _, err := initgeneration.NewInitGenerator(m.client, m.apiReader, m.namespace).GenerateForNamespace(ctx, dk, ns.Name); err != nil {
 			log.Error(err, "Failed to create the init secret before pod injection")
 			rsp = admission.Errored(http.StatusBadRequest, err)
 			return &rsp

--- a/webhook/mutation/pod_mutator.go
+++ b/webhook/mutation/pod_mutator.go
@@ -632,7 +632,7 @@ func (m *podMutator) getNsAndDkName(ctx context.Context, req admission.Request) 
 
 func (m *podMutator) ensureDataIngestSecret(ctx context.Context, ns corev1.Namespace, dkName string, dk dynatracev1beta1.DynaKube) (map[string]string, *admission.Response) {
 	var rsp admission.Response
-	endpointGenerator := dtingestendpoint.NewEndpointSecretGenerator(m.client, m.apiReader, m.namespace, log)
+	endpointGenerator := dtingestendpoint.NewEndpointSecretGenerator(m.client, m.apiReader, m.namespace)
 
 	var endpointSecret corev1.Secret
 	if err := m.apiReader.Get(ctx, client.ObjectKey{Name: dtingestendpoint.SecretEndpointName, Namespace: ns.Name}, &endpointSecret); k8serrors.IsNotFound(err) {

--- a/webhook/mutation/pod_mutator.go
+++ b/webhook/mutation/pod_mutator.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/initgeneration"
-	"github.com/Dynatrace/dynatrace-operator/logger"
 	"github.com/Dynatrace/dynatrace-operator/mapper"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/webhook"
 	corev1 "k8s.io/api/core/v1"
@@ -32,40 +31,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-const (
-	injectEvent          = "Inject"
-	updatePodEvent       = "UpdatePod"
-	missingDynakubeEvent = "MissingDynakube"
-
-	dataIngestInjectedEnvVarName = "DATA_INGEST_INJECTED"
-	oneAgentInjectedEnvVarName   = "ONEAGENT_INJECTED"
-	dynatraceMetadataEnvVarName  = "DT_DEPLOYMENT_METADATA"
-
-	workloadKindEnvVarName = "DT_WORKLOAD_KIND"
-	workloadNameEnvVarName = "DT_WORKLOAD_NAME"
-
-	dataIngestVolumeName = "data-ingest-enrichment"
-	dataIngestMountPath  = "/var/lib/dynatrace/enrichment"
-
-	dataIngestEndpointVolumeName = "data-ingest-endpoint"
-
-	oneAgentBinVolumeName   = "oneagent-bin"
-	oneAgentShareVolumeName = "oneagent-share"
-
-	injectionConfigVolumeName = "injection-config"
-
-	provisionedVolumeMode = "provisioned"
-	installerVolumeMode   = "installer"
-)
-
-var log = logger.NewDTLogger()
-var debug = os.Getenv("DEBUG_OPERATOR")
-
 // AddPodMutationWebhookToManager adds the Webhook server to the Manager
 func AddPodMutationWebhookToManager(mgr manager.Manager, ns string) error {
 	podName := os.Getenv("POD_NAME")
 	if podName == "" {
-		log.Info("No Pod name set for webhook container")
+		log.Info("no Pod name set for webhook container")
 	}
 
 	if podName == "" && debug == "true" {

--- a/webhook/validation/namespace_selector.go
+++ b/webhook/validation/namespace_selector.go
@@ -20,7 +20,7 @@ func conflictingNamespaceSelector(dv *dynakubeValidator, dynakube *dynatracev1be
 	if !dynakube.NeedAppInjection() {
 		return ""
 	}
-	dkMapper := mapper.NewDynakubeMapper(context.TODO(), dv.clt, dv.apiReader, dynakube.Namespace, dynakube, log)
+	dkMapper := mapper.NewDynakubeMapper(context.TODO(), dv.clt, dv.apiReader, dynakube.Namespace, dynakube)
 	_, err := dkMapper.MatchingNamespaces()
 	if err != nil && err.Error() == mapper.ErrorConflictingNamespace {
 		if dynakube.NamespaceSelector().MatchExpressions == nil && dynakube.NamespaceSelector().MatchLabels == nil {

--- a/webhook/validation/preview.go
+++ b/webhook/validation/preview.go
@@ -12,10 +12,10 @@ const (
 
 func previewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.CloudNativeFullstackMode() {
-		log.Info("Dynakube with cloudNativeFullStack was applied, warning was provided.")
+		log.Info("DynaKube with cloudNativeFullStack was applied, warning was provided.")
 		return fmt.Sprintf(warningPreview, "cloudNativeFullStack")
 	} else if dynakube.ApplicationMonitoringMode() && dynakube.NeedsCSIDriver() {
-		log.Info("Dynakube with applicationMonitoring was applied, warning was provided.")
+		log.Info("DynaKube with applicationMonitoring was applied, warning was provided.")
 		return fmt.Sprintf(warningPreview, "applicationMonitoring")
 	}
 	return ""


### PR DESCRIPTION
The webhook package was left out because its has been refactored in another PR.
The kubeobjects package is a helper package so passing in loggers there is fine.