### PR TITLE
Clarify autoUpdate comment

### DIFF
--- a/api/v1beta1/oneagent_types.go
+++ b/api/v1beta1/oneagent_types.go
@@ -98,7 +98,8 @@ type HostInjectSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OneAgent environment variable installer arguments",order=22,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
-	// Disable automatic restarts of OneAgent pods in case a new version is available
+	// Optional: Enables automatic restarts of OneAgent pods in case a new version is available
+	// Defaults to true
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Automatically update Agent",order=13,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	AutoUpdate *bool `json:"autoUpdate,omitempty"`
 

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1566,8 +1566,8 @@ spec:
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: Disable automatic restarts of OneAgent pods in
-                          case a new version is available
+                        description: 'Optional: Enables automatic restarts of OneAgent
+                          pods in case a new version is available Defaults to true'
                         type: boolean
                       dnsPolicy:
                         description: 'Optional: Sets DNS Policy for the OneAgent pods'
@@ -1801,8 +1801,8 @@ spec:
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: Disable automatic restarts of OneAgent pods in
-                          case a new version is available
+                        description: 'Optional: Enables automatic restarts of OneAgent
+                          pods in case a new version is available Defaults to true'
                         type: boolean
                       dnsPolicy:
                         description: 'Optional: Sets DNS Policy for the OneAgent pods'
@@ -2057,8 +2057,8 @@ spec:
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: Disable automatic restarts of OneAgent pods in
-                          case a new version is available
+                        description: 'Optional: Enables automatic restarts of OneAgent
+                          pods in case a new version is available Defaults to true'
                         type: boolean
                       dnsPolicy:
                         description: 'Optional: Sets DNS Policy for the OneAgent pods'


### PR DESCRIPTION
Previous wording was confusing, so this PR clarifies that the field is used to enable autoUpdate (which is enabled by default)