### PR TITLE
Simplify the permissions for the certificate generation

### DIFF
--- a/config/common/operator/clusterrole-operator.yaml
+++ b/config/common/operator/clusterrole-operator.yaml
@@ -7,7 +7,7 @@ metadata:
     operator: dynakube
 rules:
   - apiGroups:
-      - "" # "" indicates the core API group
+      - ""
     resources:
       - nodes
     verbs:
@@ -15,7 +15,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "" # "" indicates the core API group
+      - ""
     resources:
       - namespaces
     verbs:
@@ -41,40 +41,6 @@ rules:
       - update
       - delete
   - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-    verbs:
-      - list
-      - create
-      - watch
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingwebhookconfigurations
-    verbs:
-      - list
-      - create
-      - watch
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-    resourceNames:
-      - dynatrace-webhook
-    verbs:
-      - get
-      - update
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingwebhookconfigurations
-    resourceNames:
-      - dynatrace-webhook
-    verbs:
-      - get
-      - update
-  - apiGroups:
       - ""
     resources:
       - events
@@ -82,18 +48,30 @@ rules:
       - create
       - patch
   - apiGroups:
-      - apiextensions.k8s.io
+      - admissionregistration.k8s.io
     resources:
-      - customresourcedefinitions
+      - mutatingwebhookconfigurations
     resourceNames:
-      - "dynakubes.dynatrace.com"
+      - dynatrace-webhook
     verbs:
       - get
       - update
   - apiGroups:
-    - apiextensions.k8s.io
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    resourceNames:
+      - dynatrace-webhook
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
+    resourceNames:
+      - dynakubes.dynatrace.com
     verbs:
-      - list
-      - watch
+      - get
+      - update
+

--- a/controllers/certificates/webhook_reconciler_test.go
+++ b/controllers/certificates/webhook_reconciler_test.go
@@ -32,8 +32,9 @@ func TestGetSecret(t *testing.T) {
 	t.Run(`get nil if secret does not exists`, func(t *testing.T) {
 		clt := fake.NewClient()
 		r := &ReconcileWebhookCertificates{
-			client: clt,
-			ctx:    context.TODO(),
+			client:    clt,
+			apiReader: clt,
+			ctx:       context.TODO(),
 		}
 		secret, err := r.getSecret()
 		require.NoError(t, err)
@@ -48,6 +49,7 @@ func TestGetSecret(t *testing.T) {
 		})
 		r := &ReconcileWebhookCertificates{
 			client:    clt,
+			apiReader: clt,
 			ctx:       context.TODO(),
 			namespace: testNamespace,
 		}
@@ -202,6 +204,7 @@ func prepareReconcile(clt client.Client) (*ReconcileWebhookCertificates, reconci
 	rec := &ReconcileWebhookCertificates{
 		ctx:       context.TODO(),
 		client:    clt,
+		apiReader: clt,
 		namespace: testNamespace,
 		logger:    logger.NewDTLogger(),
 	}


### PR DESCRIPTION
the `client.Client` uses a cache in the background that needs clusterwide list/watch permissions for resources that we get via `client.Get`. (why? I don't know, its an issue in the controller-runtime)
Cache is not needed for the certificate controller because it only runs every 3 hours (on success).
So this introduces an `apiReader` to be used for getting the resources. (the `client.Client` is still needed for updating resources)