### PR TITLE
Replaces deprecated logs annotation from webhook deployment

### DIFF
--- a/config/common/webhook/deployment-webhook.yaml
+++ b/config/common/webhook/deployment-webhook.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-logs-container: webhook
+        kubectl.kubernetes.io/default-container: webhook
       labels:
         dynatrace.com/operator: oneagent
         internal.dynatrace.com/component: webhook


### PR DESCRIPTION
`kubectl.kubernetes.io/default-logs-container` is deprecated and was replaced by `kubectl.kubernetes.io/default-container`
(we already use it here https://github.com/Dynatrace/dynatrace-operator/blob/master/config/common/csi/daemonset.yaml#L17)