### PR TITLE
AG service: port redirection 80->9998 added

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/controllers/activegate/internal/consts/consts.go
+++ b/controllers/activegate/internal/consts/consts.go
@@ -1,6 +1,8 @@
 package consts
 
 const (
-	ServicePort       = 443
-	ServiceTargetPort = "ag-https"
+	HttpsServicePort       = 443
+	HttpsServiceTargetPort = "ag-https"
+	HttpServicePort        = 80
+	HttpServiceTargetPort  = "ag-http"
 )

--- a/controllers/activegate/reconciler/capability/reconciler.go
+++ b/controllers/activegate/reconciler/capability/reconciler.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	containerPort   = 9999
-	dtDNSEntryPoint = "DT_DNS_ENTRY_POINT"
+	httpsContainerPort = 9999
+	httpContainerPort  = 9998
+	dtDNSEntryPoint    = "DT_DNS_ENTRY_POINT"
 )
 
 type Reconciler struct {
@@ -54,7 +55,7 @@ func NewReconciler(capability capability.Capability, clt client.Client, apiReade
 
 func setReadinessProbePort() events.StatefulSetEvent {
 	return func(sts *appsv1.StatefulSet) {
-		sts.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.FromString(consts.ServiceTargetPort)
+		sts.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.FromString(consts.HttpsServiceTargetPort)
 	}
 }
 
@@ -62,8 +63,12 @@ func setCommunicationsPort(_ *dynatracev1beta1.DynaKube) events.StatefulSetEvent
 	return func(sts *appsv1.StatefulSet) {
 		sts.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
 			{
-				Name:          consts.ServiceTargetPort,
-				ContainerPort: containerPort,
+				Name:          consts.HttpsServiceTargetPort,
+				ContainerPort: httpsContainerPort,
+			},
+			{
+				Name:          consts.HttpServiceTargetPort,
+				ContainerPort: httpContainerPort,
 			},
 		}
 	}

--- a/controllers/activegate/reconciler/capability/reconciler_test.go
+++ b/controllers/activegate/reconciler/capability/reconciler_test.go
@@ -182,7 +182,7 @@ func TestSetReadinessProbePort(t *testing.T) {
 	assert.NotNil(t, sts.Spec.Template.Spec.Containers[0].ReadinessProbe)
 	assert.NotNil(t, sts.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet)
 	assert.NotNil(t, sts.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port)
-	assert.Equal(t, consts.ServiceTargetPort, sts.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.String())
+	assert.Equal(t, consts.HttpsServiceTargetPort, sts.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.String())
 }
 
 func TestReconciler_calculateStatefulSetName(t *testing.T) {

--- a/controllers/activegate/reconciler/capability/service.go
+++ b/controllers/activegate/reconciler/capability/service.go
@@ -24,9 +24,16 @@ func createService(instance *dynatracev1beta1.DynaKube, feature string) *corev1.
 			Selector: statefulset.BuildLabelsFromInstance(instance, feature),
 			Ports: []corev1.ServicePort{
 				{
+					Name:       consts.HttpsServiceTargetPort,
 					Protocol:   corev1.ProtocolTCP,
-					Port:       consts.ServicePort,
-					TargetPort: intstr.FromString(consts.ServiceTargetPort),
+					Port:       consts.HttpsServicePort,
+					TargetPort: intstr.FromString(consts.HttpsServiceTargetPort),
+				},
+				{
+					Name:       consts.HttpServiceTargetPort,
+					Protocol:   corev1.ProtocolTCP,
+					Port:       consts.HttpServicePort,
+					TargetPort: intstr.FromString(consts.HttpServiceTargetPort),
 				},
 			},
 		},

--- a/controllers/activegate/reconciler/capability/service_test.go
+++ b/controllers/activegate/reconciler/capability/service_test.go
@@ -36,11 +36,20 @@ func TestCreateService(t *testing.T) {
 	}, serviceSpec.Selector)
 
 	ports := serviceSpec.Ports
-	assert.Contains(t, ports, corev1.ServicePort{
-		Protocol:   corev1.ProtocolTCP,
-		Port:       consts.ServicePort,
-		TargetPort: intstr.FromString(consts.ServiceTargetPort),
-	})
+	assert.Contains(t, ports,
+		corev1.ServicePort{
+			Name:       consts.HttpsServiceTargetPort,
+			Protocol:   corev1.ProtocolTCP,
+			Port:       consts.HttpsServicePort,
+			TargetPort: intstr.FromString(consts.HttpsServiceTargetPort),
+		},
+		corev1.ServicePort{
+			Name:       consts.HttpServiceTargetPort,
+			Protocol:   corev1.ProtocolTCP,
+			Port:       consts.HttpServicePort,
+			TargetPort: intstr.FromString(consts.HttpServiceTargetPort),
+		},
+	)
 }
 
 func TestBuildServiceNameForDNSEntryPoint(t *testing.T) {


### PR DESCRIPTION
If service mesh is used, http rest endpoint is preferred over https.