### PR TITLE
Fix install.sh for kubectl 1.23 or later

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -111,7 +111,7 @@ applyDynatraceOperator() {
     fi
   fi
 
-  "${CLI}" -n dynatrace create secret generic dynakube --from-literal="apiToken=${API_TOKEN}" --from-literal="paasToken=${PAAS_TOKEN}" --dry-run -o yaml | "${CLI}" apply -f -
+  "${CLI}" -n dynatrace create secret generic dynakube --from-literal="apiToken=${API_TOKEN}" --from-literal="paasToken=${PAAS_TOKEN}" --dry-run=client -o yaml | "${CLI}" apply -f -
 }
 
 buildGlobalSection() {


### PR DESCRIPTION
The install.sh script uses the `--dry-run` mode of kubectl. This flag
without further value has been deprecated with version 1.18 and entirely
removed with 1.23. This change makes the dry-run to run on client side.