### PR TITLE
Store activegate proxy in secret instead of environment variable

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -3025,6 +3025,7 @@ rules:
     resourceNames:
       - dynatrace-dynakube-config
       - dynatrace-data-ingest-endpoint
+      - dynatrace-activegate-internal-proxy
     verbs:
       - get
       - update
@@ -3844,6 +3845,7 @@ webhooks:
         path: /validate
     rules:
       - operations:
+          - CREATE
           - UPDATE
         apiGroups:
           - dynatrace.com

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -3039,6 +3039,7 @@ rules:
     resourceNames:
       - dynatrace-dynakube-config
       - dynatrace-data-ingest-endpoint
+      - dynatrace-activegate-internal-proxy
     verbs:
       - get
       - update
@@ -4083,6 +4084,7 @@ webhooks:
         path: /validate
     rules:
       - operations:
+          - CREATE
           - UPDATE
         apiGroups:
           - dynatrace.com

--- a/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
@@ -50,6 +50,7 @@ rules:
     resourceNames:
       - dynatrace-dynakube-config
       - dynatrace-data-ingest-endpoint
+      - dynatrace-activegate-internal-proxy
     verbs:
       - get
       - update

--- a/src/agproxysecret/secret.go
+++ b/src/agproxysecret/secret.go
@@ -1,0 +1,126 @@
+package agproxysecret
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	agcapability "github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/capability"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	proxyHostField     = "host"
+	proxyPortField     = "port"
+	proxyUsernameField = "username"
+	proxyPasswordField = "password"
+
+	proxySecretKey              = "proxy"
+	activeGateProxySecretSuffix = "internal-proxy"
+)
+
+// ActiveGateProxySecretGenerator manages the ActiveGate proxy secret generation for the dynatrace namespace.
+type ActiveGateProxySecretGenerator struct {
+	client    client.Client
+	apiReader client.Reader
+	logger    logr.Logger
+	namespace string
+}
+
+func NewActiveGateProxySecretGenerator(client client.Client, apiReader client.Reader, ns string, logger logr.Logger) *ActiveGateProxySecretGenerator {
+	return &ActiveGateProxySecretGenerator{
+		client:    client,
+		apiReader: apiReader,
+		namespace: ns,
+		logger:    logger,
+	}
+}
+
+func (agProxySecretGenerator *ActiveGateProxySecretGenerator) GenerateForDynakube(ctx context.Context, dynakube *dynatracev1beta1.DynaKube) (bool, error) {
+	data, err := agProxySecretGenerator.createProxyMap(ctx, dynakube)
+	if err != nil {
+		return false, err
+	}
+	return kubeobjects.CreateOrUpdateSecretIfNotExists(agProxySecretGenerator.client, agProxySecretGenerator.apiReader, BuildProxySecretName(), agProxySecretGenerator.namespace, data, corev1.SecretTypeOpaque, agProxySecretGenerator.logger)
+}
+
+func (agProxySecretGenerator *ActiveGateProxySecretGenerator) EnsureDeleted(ctx context.Context, dynakube *dynatracev1beta1.DynaKube) error {
+	secretName := BuildProxySecretName()
+	secret := corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: dynakube.Namespace}}
+	if err := agProxySecretGenerator.client.Delete(ctx, &secret); err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	} else if err != nil {
+		agProxySecretGenerator.logger.Info("removed secret", "namespace", dynakube.Namespace, "secret", secretName)
+	}
+	return nil
+}
+
+func BuildProxySecretName() string {
+	return "dynatrace" + "-" + agcapability.MultiActiveGateName + "-" + activeGateProxySecretSuffix
+}
+
+func (agProxySecretGenerator *ActiveGateProxySecretGenerator) createProxyMap(ctx context.Context, dynakube *dynatracev1beta1.DynaKube) (map[string][]byte, error) {
+	var err error
+	proxyUrl := ""
+	if dynakube.Spec.Proxy != nil && dynakube.Spec.Proxy.ValueFrom != "" {
+		if proxyUrl, err = agProxySecretGenerator.proxyUrlFromUserSecret(ctx, dynakube); err != nil {
+			return nil, err
+		}
+	} else if dynakube.Spec.Proxy != nil && len(dynakube.Spec.Proxy.Value) > 0 {
+		proxyUrl = proxyUrlFromSpec(dynakube)
+	} else {
+		// the parsed-proxy secret is expected to exist and the entrypoint.sh script handles empty values properly
+		return map[string][]byte{
+			proxyHostField:     []byte(""),
+			proxyPortField:     []byte(""),
+			proxyUsernameField: []byte(""),
+			proxyPasswordField: []byte(""),
+		}, nil
+	}
+
+	host, port, username, password, err := parseProxyUrl(proxyUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string][]byte{
+		proxyHostField:     []byte(host),
+		proxyPortField:     []byte(port),
+		proxyUsernameField: []byte(username),
+		proxyPasswordField: []byte(password),
+	}, nil
+}
+
+func proxyUrlFromSpec(dynakube *dynatracev1beta1.DynaKube) string {
+	return dynakube.Spec.Proxy.Value
+}
+
+func (agProxySecretGenerator *ActiveGateProxySecretGenerator) proxyUrlFromUserSecret(ctx context.Context, dynakube *dynatracev1beta1.DynaKube) (string, error) {
+	var proxySecret corev1.Secret
+	if err := agProxySecretGenerator.client.Get(ctx, client.ObjectKey{Name: dynakube.Spec.Proxy.ValueFrom, Namespace: agProxySecretGenerator.namespace}, &proxySecret); err != nil {
+		return "", errors.WithMessage(err, fmt.Sprintf("failed to query %s secret", dynakube.Spec.Proxy.ValueFrom))
+	}
+
+	proxy, ok := proxySecret.Data[proxySecretKey]
+	if !ok {
+		return "", fmt.Errorf("invalid secret %s", dynakube.Spec.Proxy.ValueFrom)
+	}
+	return string(proxy), nil
+}
+
+func parseProxyUrl(proxy string) (host string, port string, username string, password string, err error) {
+	proxyUrl, err := url.Parse(proxy)
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	passwd, _ := proxyUrl.User.Password()
+	return proxyUrl.Hostname(), proxyUrl.Port(), proxyUrl.User.Username(), passwd, nil
+}

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -85,6 +85,10 @@ func (dk *DynaKube) HasActiveGateTLS() bool {
 	return dk.ActiveGateMode() && dk.Spec.ActiveGate.TlsSecretName != ""
 }
 
+func (dk *DynaKube) HasProxy() bool {
+	return dk.Spec.Proxy != nil && (dk.Spec.Proxy.Value != "" || dk.Spec.Proxy.ValueFrom != "")
+}
+
 // ShouldAutoUpdateOneAgent returns true if the Operator should update OneAgent instances automatically.
 func (dk *DynaKube) ShouldAutoUpdateOneAgent() bool {
 	if dk.CloudNativeFullstackMode() {

--- a/src/controllers/activegate/reconciler/capability/reconciler_test.go
+++ b/src/controllers/activegate/reconciler/capability/reconciler_test.go
@@ -137,14 +137,13 @@ func TestReconcile(t *testing.T) {
 		assert.NotNil(t, statefulSet)
 		assert.NoError(t, err)
 
-		found := false
-		for _, env := range newStatefulSet.Spec.Template.Spec.Containers[0].Env {
-			if env.Name == rsfs.DTInternalProxy {
-				found = true
-				assert.Equal(t, testValue, env.Value)
+		found := 0
+		for _, vm := range newStatefulSet.Spec.Template.Spec.Containers[0].VolumeMounts {
+			if vm.Name == rsfs.InternalProxySecretVolumeName {
+				found = found + 1
 			}
 		}
-		assert.True(t, found)
+		assert.Equal(t, 4, found)
 	})
 	t.Run(`create service`, func(t *testing.T) {
 		r := createDefaultReconciler(t)

--- a/src/controllers/activegate/reconciler/statefulset/config.go
+++ b/src/controllers/activegate/reconciler/statefulset/config.go
@@ -4,6 +4,24 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
 )
 
+const (
+	InternalProxySecretMountPath = "/var/lib/dynatrace/secrets/internal-proxy"
+
+	InternalProxySecretVolumeName = "internal-proxy-secret-volume"
+
+	InternalProxySecretHost          = "host"
+	InternalProxySecretHostMountPath = InternalProxySecretMountPath + "/" + InternalProxySecretHost
+
+	InternalProxySecretPort          = "port"
+	InternalProxySecretPortMountPath = InternalProxySecretMountPath + "/" + InternalProxySecretPort
+
+	InternalProxySecretUsername          = "username"
+	InternalProxySecretUsernameMountPath = InternalProxySecretMountPath + "/" + InternalProxySecretUsername
+
+	InternalProxySecretPassword          = "password"
+	InternalProxySecretPasswordMountPath = InternalProxySecretMountPath + "/" + InternalProxySecretPassword
+)
+
 var (
 	log = logger.NewDTLogger().WithName("activegate-statefulset")
 )

--- a/src/controllers/activegate/reconciler/statefulset/reconciler_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/reconciler_test.go
@@ -106,14 +106,13 @@ func TestReconcile(t *testing.T) {
 		assert.NotNil(t, statefulSet)
 		assert.NoError(t, err)
 
-		found := false
-		for _, env := range newStatefulSet.Spec.Template.Spec.Containers[0].Env {
-			if env.Name == DTInternalProxy {
-				found = true
-				assert.Equal(t, testValue, env.Value)
+		found := 0
+		for _, vm := range newStatefulSet.Spec.Template.Spec.Containers[0].VolumeMounts {
+			if vm.Name == InternalProxySecretVolumeName {
+				found = found + 1
 			}
 		}
-		assert.True(t, found)
+		assert.Equal(t, 4, found)
 	})
 }
 

--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -3,6 +3,7 @@ package statefulset
 import (
 	"fmt"
 
+	"github.com/Dynatrace/dynatrace-operator/src/agproxysecret"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/internal/events"
@@ -27,10 +28,7 @@ const (
 	DTIdSeedClusterId    = "DT_ID_SEED_K8S_CLUSTER_ID"
 	DTNetworkZone        = "DT_NETWORK_ZONE"
 	DTGroup              = "DT_GROUP"
-	DTInternalProxy      = "DT_INTERNAL_PROXY"
 	DTDeploymentMetadata = "DT_DEPLOYMENT_METADATA"
-
-	ProxySecretKey = "proxy"
 
 	ActivegateContainerName = "activegate"
 )
@@ -175,7 +173,24 @@ func buildVolumes(stsProperties *statefulSetProperties) []corev1.Volume {
 
 	volumes = append(volumes, stsProperties.volumes...)
 
+	if stsProperties.HasProxy() {
+		volumes = append(volumes, buildProxyVolumes(stsProperties)...)
+	}
+
 	return volumes
+}
+
+func buildProxyVolumes(stsProperties *statefulSetProperties) []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: InternalProxySecretVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: agproxysecret.BuildProxySecretName(),
+				},
+			},
+		},
+	}
 }
 
 func determineCustomPropertiesSource(stsProperties *statefulSetProperties) string {
@@ -199,7 +214,40 @@ func buildVolumeMounts(stsProperties *statefulSetProperties) []corev1.VolumeMoun
 
 	volumeMounts = append(volumeMounts, stsProperties.containerVolumeMounts...)
 
+	if stsProperties.HasProxy() {
+		volumeMounts = append(volumeMounts, buildProxyMounts()...)
+	}
+
 	return volumeMounts
+}
+
+func buildProxyMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretHostMountPath,
+			SubPath:   InternalProxySecretHost,
+		},
+		{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretPortMountPath,
+			SubPath:   InternalProxySecretPort,
+		},
+		{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretUsernameMountPath,
+			SubPath:   InternalProxySecretUsername,
+		},
+		{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretPasswordMountPath,
+			SubPath:   InternalProxySecretPassword,
+		},
+	}
 }
 
 func buildEnvs(stsProperties *statefulSetProperties) []corev1.EnvVar {
@@ -213,9 +261,6 @@ func buildEnvs(stsProperties *statefulSetProperties) []corev1.EnvVar {
 	}
 	envs = append(envs, stsProperties.Env...)
 
-	if !isProxyNilOrEmpty(stsProperties.Spec.Proxy) {
-		envs = append(envs, buildProxyEnv(stsProperties.Spec.Proxy))
-	}
 	if stsProperties.Group != "" {
 		envs = append(envs, corev1.EnvVar{Name: DTGroup, Value: stsProperties.Group})
 	}
@@ -226,25 +271,6 @@ func buildEnvs(stsProperties *statefulSetProperties) []corev1.EnvVar {
 	return envs
 }
 
-func buildProxyEnv(proxy *dynatracev1beta1.DynaKubeProxy) corev1.EnvVar {
-	if proxy.ValueFrom != "" {
-		return corev1.EnvVar{
-			Name: DTInternalProxy,
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: proxy.ValueFrom},
-					Key:                  ProxySecretKey,
-				},
-			},
-		}
-	} else {
-		return corev1.EnvVar{
-			Name:  DTInternalProxy,
-			Value: proxy.Value,
-		}
-	}
-}
-
 func determineServiceAccountName(stsProperties *statefulSetProperties) string {
 	return serviceAccountPrefix + stsProperties.serviceAccountOwner
 }
@@ -253,8 +279,4 @@ func isCustomPropertiesNilOrEmpty(customProperties *dynatracev1beta1.DynaKubeVal
 	return customProperties == nil ||
 		(customProperties.Value == "" &&
 			customProperties.ValueFrom == "")
-}
-
-func isProxyNilOrEmpty(proxy *dynatracev1beta1.DynaKubeProxy) bool {
-	return proxy == nil || (proxy.Value == "" && proxy.ValueFrom == "")
 }

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -184,30 +184,6 @@ func TestStatefulSet_Env(t *testing.T) {
 			{Name: testKey, Value: testValue},
 		}, envVars)
 	})
-	t.Run(`with proxy from value`, func(t *testing.T) {
-		instance.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: testValue}
-		envVars := buildEnvs(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", "", "", "", nil, nil, nil))
-
-		assert.Contains(t, envVars, corev1.EnvVar{
-			Name:  DTInternalProxy,
-			Value: testValue,
-		})
-	})
-	t.Run(`with proxy from value source`, func(t *testing.T) {
-		instance.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{ValueFrom: testName}
-		envVars := buildEnvs(NewStatefulSetProperties(instance, capabilityProperties,
-			"", "", "", "", "", nil, nil, nil))
-
-		assert.NotEmpty(t, envVars)
-
-		for _, envVar := range envVars {
-			if envVar.Name == DTInternalProxy {
-				assert.Equal(t, ProxySecretKey, envVar.ValueFrom.SecretKeyRef.Key)
-				assert.Equal(t, corev1.LocalObjectReference{Name: testName}, envVar.ValueFrom.SecretKeyRef.LocalObjectReference)
-			}
-		}
-	})
 	t.Run(`with networkzone`, func(t *testing.T) {
 		instance := buildTestInstance()
 		instance.Spec.NetworkZone = testName
@@ -258,6 +234,72 @@ func TestStatefulSet_VolumeMounts(t *testing.T) {
 			Name:      customproperties.VolumeName,
 			MountPath: customproperties.MountPath,
 			SubPath:   customproperties.DataPath,
+		})
+	})
+	t.Run(`with proxy from value`, func(t *testing.T) {
+		instance.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: testValue}
+		volumeMounts := buildVolumeMounts(NewStatefulSetProperties(instance, capabilityProperties,
+			"", "", "", "", "", nil, nil, nil))
+
+		assert.Contains(t, volumeMounts, corev1.VolumeMount{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretHostMountPath,
+			SubPath:   InternalProxySecretHost,
+		})
+
+		assert.Contains(t, volumeMounts, corev1.VolumeMount{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretPortMountPath,
+			SubPath:   InternalProxySecretPort,
+		})
+
+		assert.Contains(t, volumeMounts, corev1.VolumeMount{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretUsernameMountPath,
+			SubPath:   InternalProxySecretUsername,
+		})
+
+		assert.Contains(t, volumeMounts, corev1.VolumeMount{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretPasswordMountPath,
+			SubPath:   InternalProxySecretPassword,
+		})
+	})
+	t.Run(`with proxy from value source`, func(t *testing.T) {
+		instance.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{ValueFrom: testName}
+		volumeMounts := buildVolumeMounts(NewStatefulSetProperties(instance, capabilityProperties,
+			"", "", "", "", "", nil, nil, nil))
+
+		assert.Contains(t, volumeMounts, corev1.VolumeMount{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretHostMountPath,
+			SubPath:   InternalProxySecretHost,
+		})
+
+		assert.Contains(t, volumeMounts, corev1.VolumeMount{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretPortMountPath,
+			SubPath:   InternalProxySecretPort,
+		})
+
+		assert.Contains(t, volumeMounts, corev1.VolumeMount{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretUsernameMountPath,
+			SubPath:   InternalProxySecretUsername,
+		})
+
+		assert.Contains(t, volumeMounts, corev1.VolumeMount{
+			ReadOnly:  true,
+			Name:      InternalProxySecretVolumeName,
+			MountPath: InternalProxySecretPasswordMountPath,
+			SubPath:   InternalProxySecretPassword,
 		})
 	})
 }

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Dynatrace/dynatrace-operator/src/agproxysecret"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/reconciler/automaticapimonitoring"
@@ -200,7 +201,7 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *stat
 	dkState.Update(upd, defaultUpdateInterval, "Found updates")
 	dkState.Error(err)
 
-	if !r.reconcileActiveGateCapabilities(dkState, dtc) {
+	if !r.reconcileActiveGate(ctx, dkState, dtc) {
 		return
 	}
 	if dkState.Instance.HostMonitoringMode() {
@@ -276,7 +277,6 @@ func (r *ReconcileDynaKube) reconcileDynaKube(ctx context.Context, dkState *stat
 			return
 		}
 	}
-
 }
 
 func (r *ReconcileDynaKube) ensureDeleted(obj client.Object) error {
@@ -286,39 +286,61 @@ func (r *ReconcileDynaKube) ensureDeleted(obj client.Object) error {
 	return nil
 }
 
-func (r *ReconcileDynaKube) reconcileActiveGateCapabilities(dkState *status.DynakubeState, dtc dtclient.Client) bool {
+func (r *ReconcileDynaKube) reconcileActiveGate(ctx context.Context, dynakubeState *status.DynakubeState, dtc dtclient.Client) bool {
+	if !r.reconcileActiveGateProxySecret(ctx, dynakubeState) {
+		return false
+	}
+	return r.reconcileActiveGateCapabilities(dynakubeState, dtc)
+}
+
+func (r *ReconcileDynaKube) reconcileActiveGateProxySecret(ctx context.Context, dynakubeState *status.DynakubeState) bool {
+	gen := agproxysecret.NewActiveGateProxySecretGenerator(r.client, r.apiReader, dynakubeState.Instance.Namespace, log)
+	if dynakubeState.Instance.HasProxy() {
+		upd, err := gen.GenerateForDynakube(ctx, dynakubeState.Instance)
+		if dynakubeState.Error(err) || dynakubeState.Update(upd, defaultUpdateInterval, "new ActiveGate proxy secret created") {
+			return false
+		}
+	} else {
+		if err := gen.EnsureDeleted(ctx, dynakubeState.Instance); dynakubeState.Error(err) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *ReconcileDynaKube) reconcileActiveGateCapabilities(dynakubeState *status.DynakubeState, dtc dtclient.Client) bool {
 	var caps = []capability.Capability{
-		capability.NewKubeMonCapability(dkState.Instance),
-		capability.NewRoutingCapability(dkState.Instance),
-		capability.NewMultiCapability(dkState.Instance),
+		capability.NewKubeMonCapability(dynakubeState.Instance),
+		capability.NewRoutingCapability(dynakubeState.Instance),
+		capability.NewMultiCapability(dynakubeState.Instance),
 	}
 
 	for _, c := range caps {
 		if c.Enabled() {
 			upd, err := rcap.NewReconciler(
-				c, r.client, r.apiReader, r.scheme, dkState.Instance).Reconcile()
-			if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, c.ShortName()+" reconciled") {
+				c, r.client, r.apiReader, r.scheme, dynakubeState.Instance).Reconcile()
+			if dynakubeState.Error(err) || dynakubeState.Update(upd, defaultUpdateInterval, c.ShortName()+" reconciled") {
 				return false
 			}
 		} else {
 			sts := appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      capability.CalculateStatefulSetName(c, dkState.Instance.Name),
-					Namespace: dkState.Instance.Namespace,
+					Name:      capability.CalculateStatefulSetName(c, dynakubeState.Instance.Name),
+					Namespace: dynakubeState.Instance.Namespace,
 				},
 			}
-			if err := r.ensureDeleted(&sts); dkState.Error(err) {
+			if err := r.ensureDeleted(&sts); dynakubeState.Error(err) {
 				return false
 			}
 
 			if c.Config().CreateService {
 				svc := corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      rcap.BuildServiceName(dkState.Instance.Name, c.ShortName()),
-						Namespace: dkState.Instance.Namespace,
+						Name:      rcap.BuildServiceName(dynakubeState.Instance.Name, c.ShortName()),
+						Namespace: dynakubeState.Instance.Namespace,
 					},
 				}
-				if err := r.ensureDeleted(&svc); dkState.Error(err) {
+				if err := r.ensureDeleted(&svc); dynakubeState.Error(err) {
 					return false
 				}
 			}
@@ -326,10 +348,10 @@ func (r *ReconcileDynaKube) reconcileActiveGateCapabilities(dkState *status.Dyna
 	}
 
 	//start automatic config creation
-	if dkState.Instance.Status.KubeSystemUUID != "" &&
-		dkState.Instance.FeatureAutomaticKubernetesApiMonitoring() &&
-		dkState.Instance.KubernetesMonitoringMode() {
-		err := automaticapimonitoring.NewReconciler(dtc, dkState.Instance.Name, dkState.Instance.Status.KubeSystemUUID).
+	if dynakubeState.Instance.Status.KubeSystemUUID != "" &&
+		dynakubeState.Instance.FeatureAutomaticKubernetesApiMonitoring() &&
+		dynakubeState.Instance.KubernetesMonitoringMode() {
+		err := automaticapimonitoring.NewReconciler(dtc, dynakubeState.Instance.Name, dynakubeState.Instance.Status.KubeSystemUUID).
 			Reconcile()
 		if err != nil {
 			log.Error(err, "could not create setting")


### PR DESCRIPTION
DT_INTERNAL_PROXY variable may contain plain text username and password and is displayed for instance by kubectl describe command. To avoid that operator creates intermediate secret 'dynatrace-activegate-internal-proxy' mounted as a volume on activegate container.