### PR TITLE
Creates symlink for current version in CSI driver in the agent bin

### DIFF
--- a/src/controllers/csi/metadata/path_resolver.go
+++ b/src/controllers/csi/metadata/path_resolver.go
@@ -34,6 +34,14 @@ func (pr PathResolver) AgentBinaryDirForVersion(tenantUUID string, version strin
 	return filepath.Join(pr.AgentBinaryDir(tenantUUID), version)
 }
 
+func (pr PathResolver) RelativeSymlinkForVersion(version string) string {
+	return filepath.Join(".", version)
+}
+
+func (pr PathResolver) InnerAgentBinaryDirForSymlinkForVersion(tenantUUID string, version string) string {
+	return filepath.Join(pr.AgentBinaryDirForVersion(tenantUUID, version), "agent", "bin", "current")
+}
+
 func (pr PathResolver) AgentRunDir(tenantUUID string) string {
 	return filepath.Join(pr.EnvDir(tenantUUID), dtcsi.AgentRunDir)
 }

--- a/src/controllers/csi/metadata/path_resolver.go
+++ b/src/controllers/csi/metadata/path_resolver.go
@@ -34,10 +34,6 @@ func (pr PathResolver) AgentBinaryDirForVersion(tenantUUID string, version strin
 	return filepath.Join(pr.AgentBinaryDir(tenantUUID), version)
 }
 
-func (pr PathResolver) RelativeSymlinkForVersion(version string) string {
-	return filepath.Join(".", version)
-}
-
 func (pr PathResolver) InnerAgentBinaryDirForSymlinkForVersion(tenantUUID string, version string) string {
 	return filepath.Join(pr.AgentBinaryDirForVersion(tenantUUID, version), "agent", "bin", "current")
 }

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -216,10 +216,10 @@ func (installAgentCfg *installAgentConfig) unzip(file afero.File, version, tenan
 		return nil
 	}
 
-	sourceSymlink := installAgentCfg.path.RelativeSymlinkForVersion(version)
-	targetSymlink := installAgentCfg.path.InnerAgentBinaryDirForSymlinkForVersion(tenantUUID, version)
-	log.Info("creating symlink", "source", sourceSymlink, "target", targetSymlink)
-	if err := linker.SymlinkIfPossible(sourceSymlink, targetSymlink); err != nil {
+	relativeSymlinkPath := version
+	symlinkTargetPath := installAgentCfg.path.InnerAgentBinaryDirForSymlinkForVersion(tenantUUID, version)
+	log.Info("creating symlink", "points-to(relative)", relativeSymlinkPath, "location", symlinkTargetPath)
+	if err := linker.SymlinkIfPossible(relativeSymlinkPath, symlinkTargetPath); err != nil {
 		log.Error(err, "symlinking failed", "version", version)
 		return err
 	}


### PR DESCRIPTION
```
I have no name!@java-glibc-56978775fb-rbpfs:/$ ls -l opt/dynatrace/oneagent-paas/agent/bin/
total 16
drwxr-xr-x 6 root root 4096 Jan  3 15:14 1.233.1.20211231-040645
drwxr-xr-x 2 root root 4096 Jan  3 15:14 any
lrwxrwxrwx 1 root root   23 Jan  3 15:24 current -> 1.233.1.20211231-040645     <== ADDS THIS SYMLINK 
drwxr-xr-x 2 root root 4096 Jan  3 15:14 linux-musl-x86-64
drwxr-xr-x 2 root root 4096 Jan  3 15:14 linux-x86-64
```