### PR TITLE
Fixes deploy_local.sh to work with 'new' Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |
-            GO_BUILD_ARGS='${{ steps.prep.outputs.goargs }}'
+            GO_BUILD_ARGS=${{ steps.prep.outputs.goargs }}
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
@@ -124,7 +124,7 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |
-            GO_BUILD_ARGS='${{ steps.prep.outputs.goargs }}'
+            GO_BUILD_ARGS=${{ steps.prep.outputs.goargs }}
           context: .
           file: ./Dockerfile
           platforms: linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 # move previously cached go modules to gopath
 RUN if [ -d ./mod ]; then mkdir -p ${GOPATH}/pkg && [ -d mod ] && mv ./mod ${GOPATH}/pkg; fi;
 
-RUN CGO_ENABLED=1 go build -ldflags "${GO_BUILD_ARGS:1:-1}" -o ./build/_output/bin/dynatrace-operator ./src/cmd/operator/
+RUN CGO_ENABLED=1 go build -ldflags "${GO_BUILD_ARGS}" -o ./build/_output/bin/dynatrace-operator ./src/cmd/operator/
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/build/deploy_local.sh
+++ b/build/deploy_local.sh
@@ -9,12 +9,10 @@ fi
 commit=$(git rev-parse HEAD)
 build_date="$(date -u +"%Y-%m-%d %H:%M:%S+00:00")"
 go_build_args=(
-  ""
   "-linkmode external -extldflags '-static' -s -w"
   "-X 'github.com/Dynatrace/dynatrace-operator/version.Version=${TAG}'"
   "-X 'github.com/Dynatrace/dynatrace-operator/version.Commit=${commit}'"
   "-X 'github.com/Dynatrace/dynatrace-operator/version.BuildDate=${build_date}'"
-  ""
 )
 base_image="dynatrace-operator"
 out_image="quay.io/dynatrace/dynatrace-operator:${TAG}"

--- a/build/deploy_local.sh
+++ b/build/deploy_local.sh
@@ -9,10 +9,12 @@ fi
 commit=$(git rev-parse HEAD)
 build_date="$(date -u +"%Y-%m-%d %H:%M:%S+00:00")"
 go_build_args=(
-  "-X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${TAG}'"
-  "-X 'github.com/Dynatrace/dynatrace-operator/src/version.Commit=${commit}'"
-  "-X 'github.com/Dynatrace/dynatrace-operator/src/version.BuildDate=${build_date}'"
+  ""
   "-linkmode external -extldflags '-static' -s -w"
+  "-X 'github.com/Dynatrace/dynatrace-operator/version.Version=${TAG}'"
+  "-X 'github.com/Dynatrace/dynatrace-operator/version.Commit=${commit}'"
+  "-X 'github.com/Dynatrace/dynatrace-operator/version.BuildDate=${build_date}'"
+  ""
 )
 base_image="dynatrace-operator"
 out_image="quay.io/dynatrace/dynatrace-operator:${TAG}"


### PR DESCRIPTION
When using the `deploy_local.sh` the images that is builds are broken. The following error can be seen in the cluster:
```
> k logs -n dynatrace dynatrace-operator-5d4db8759d-cm47c 
/usr/local/bin/entrypoint: line 3: /usr/local/bin/dynatrace-operator: No such file or directory
```

# Source of the issue:

Since the change https://github.com/Dynatrace/dynatrace-operator/pull/412 the `Dockerfile` changed a bit.

The important part:
```
RUN CGO_ENABLED=1 go build -ldflags "${GO_BUILD_ARGS:1:-1}" -o ./build/_output/bin/dynatrace-operator ./src/cmd/operator/
```

🔍  ENHANCE!!: (the problematic part)
```
${GO_BUILD_ARGS:1:-1}
```

🔍  ENHANCE!! : (the weird part)
```
:1:-1
```

This is somehow necessary for the github actions to work. (removing the first and last character from the build args)
Why? No idea. (github actions ci yaml voodoo magic moon logic)

In the case of the `deploy_local.sh` it turned
this:
```
"-X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${TAG}'
  -X 'github.com/Dynatrace/dynatrace-operator/src/version.Commit=${commit}'
  -X 'github.com/Dynatrace/dynatrace-operator/src/version.BuildDate=${build_date}'
  -linkmode external -extldflags '-static' -s -w"
```
into this: (which is broken, and for some reason doesn't throw an error at build time 🤷‍♂️ )
```
"X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${TAG}'
  -X 'github.com/Dynatrace/dynatrace-operator/src/version.Commit=${commit}'
  -X 'github.com/Dynatrace/dynatrace-operator/src/version.BuildDate=${build_date}'
  -linkmode external -extldflags '-static' -s -"
```
 

### UPDATE
There were sneaky `'` in the `ci.yaml` that made the `${GO_BUILD_ARGS:1:-1}` necessary, but if the `'` and `1:-1` are removed then everything works as it should