### PR TITLE
Remove unused KeyValue pair to fix wrong logging

### DIFF
--- a/src/cmd/operator/main.go
+++ b/src/cmd/operator/main.go
@@ -94,9 +94,9 @@ func main() {
 	exitOnError(mgr.Start(signalHandler), "problem running manager")
 }
 
-func exitOnError(err error, msg string, keysAndValues ...interface{}) {
+func exitOnError(err error, msg string) {
 	if err != nil {
-		log.Error(err, msg, keysAndValues)
+		log.Error(err, msg)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
If the operator had problems and crashed, the exitOnError() method is called. The method had a KeyValue pair as an parameter, but what happend was, that if nothing was passed for that parameter, log.Error() was called with nil value, which caused the Logger to panic, because it only had a single item (nil) as KeyValuePair. Parameter was unused so I just removed it.