### PR TITLE
Skip symlink creation if folder exists already

### DIFF
--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -143,6 +143,10 @@ func (installAgentCfg *installAgentConfig) installAgent(version, tenantUUID stri
 	}
 	log.Info("unzipped OneAgent package")
 
+	if err = installAgentCfg.createSymlinkIfNotExists(version, tenantUUID); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -210,8 +214,14 @@ func (installAgentCfg *installAgentConfig) unzip(file afero.File, version, tenan
 		}
 	}
 
+	return nil
+}
+
+func (installAgentCfg *installAgentConfig) createSymlinkIfNotExists(version, tenantUUID string) error {
+	fs := installAgentCfg.fs
+
 	// MemMapFs (used for testing) doesn't comply with the Linker interface
-	linker, ok := installAgentCfg.fs.(afero.Linker)
+	linker, ok := fs.(afero.Linker)
 	if !ok {
 		log.Info("symlinking not possible", "version", version, "fs", installAgentCfg.fs)
 		return nil
@@ -229,6 +239,5 @@ func (installAgentCfg *installAgentConfig) unzip(file afero.File, version, tenan
 		log.Error(err, "symlinking failed", "version", version)
 		return err
 	}
-
 	return nil
 }

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -209,6 +209,7 @@ func (installAgentCfg *installAgentConfig) unzip(file afero.File, version, tenan
 			return err
 		}
 	}
+
 	// MemMapFs (used for testing) doesn't comply with the Linker interface
 	linker, ok := installAgentCfg.fs.(afero.Linker)
 	if !ok {
@@ -218,6 +219,11 @@ func (installAgentCfg *installAgentConfig) unzip(file afero.File, version, tenan
 
 	relativeSymlinkPath := version
 	symlinkTargetPath := installAgentCfg.path.InnerAgentBinaryDirForSymlinkForVersion(tenantUUID, version)
+	if fi, _ := fs.Stat(symlinkTargetPath); fi != nil {
+		log.Info("symlink already exists", "location", symlinkTargetPath)
+		return nil
+	}
+
 	log.Info("creating symlink", "points-to(relative)", relativeSymlinkPath, "location", symlinkTargetPath)
 	if err := linker.SymlinkIfPossible(relativeSymlinkPath, symlinkTargetPath); err != nil {
 		log.Error(err, "symlinking failed", "version", version)

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -229,7 +229,7 @@ func (installAgentCfg *installAgentConfig) createSymlinkIfNotExists(version, ten
 
 	relativeSymlinkPath := version
 	symlinkTargetPath := installAgentCfg.path.InnerAgentBinaryDirForSymlinkForVersion(tenantUUID, version)
-	if fi, _ := fs.Stat(symlinkTargetPath); fi != nil {
+	if fileInfo, _ := fs.Stat(symlinkTargetPath); fileInfo != nil {
 		log.Info("symlink already exists", "location", symlinkTargetPath)
 		return nil
 	}

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -236,7 +236,7 @@ func (installAgentCfg *installAgentConfig) createSymlinkIfNotExists(version, ten
 
 	log.Info("creating symlink", "points-to(relative)", relativeSymlinkPath, "location", symlinkTargetPath)
 	if err := linker.SymlinkIfPossible(relativeSymlinkPath, symlinkTargetPath); err != nil {
-		log.Error(err, "symlinking failed", "version", version)
+		log.Info("symlinking failed", "version", version)
 		return err
 	}
 	return nil


### PR DESCRIPTION
If multiple Dynakubes are used, symlink creation can fail because the target already exists.