### PR TITLE
Propagates tls cert to oneagents

### DIFF
--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -81,6 +81,10 @@ func (dk *DynaKube) KubernetesMonitoringMode() bool {
 	return dk.IsActiveGateMode(string(KubeMonCapability.DisplayName)) || dk.Spec.KubernetesMonitoring.Enabled
 }
 
+func (dk *DynaKube) HasActiveGateTLS() bool {
+	return dk.ActiveGateMode() && dk.Spec.ActiveGate.TlsSecretName != ""
+}
+
 // ShouldAutoUpdateOneAgent returns true if the Operator should update OneAgent instances automatically.
 func (dk *DynaKube) ShouldAutoUpdateOneAgent() bool {
 	if dk.CloudNativeFullstackMode() {

--- a/src/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -13,6 +13,10 @@ func prepareVolumeMounts(instance *dynatracev1beta1.DynaKube) []corev1.VolumeMou
 		volumeMounts = append(volumeMounts, getCertificateMount())
 	}
 
+	if instance.HasActiveGateTLS() {
+		volumeMounts = append(volumeMounts, getTLSMount())
+	}
+
 	volumeMounts = append(volumeMounts, rootMount)
 	return volumeMounts
 }
@@ -21,6 +25,13 @@ func getCertificateMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      "certs",
 		MountPath: "/mnt/dynatrace/certs",
+	}
+}
+
+func getTLSMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      "tls",
+		MountPath: "/var/lib/dynatrace/oneagent/agent/customkeys",
 	}
 }
 
@@ -38,6 +49,10 @@ func prepareVolumes(instance *dynatracev1beta1.DynaKube) []corev1.Volume {
 		volumes = append(volumes, getCertificateVolume(instance))
 	}
 
+	if instance.HasActiveGateTLS() {
+		volumes = append(volumes, getTLSVolume(instance))
+	}
+
 	return volumes
 }
 
@@ -53,6 +68,23 @@ func getCertificateVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 					{
 						Key:  "certs",
 						Path: "certs.pem",
+					},
+				},
+			},
+		},
+	}
+}
+
+func getTLSVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
+	return corev1.Volume{
+		Name: "tls",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: instance.Spec.ActiveGate.TlsSecretName,
+				Items: []corev1.KeyToPath{
+					{
+						Key:  "server.crt",
+						Path: "custom.pem",
 					},
 				},
 			},

--- a/src/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -5,6 +5,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const OneAgentCustomKeysPath = "/var/lib/dynatrace/oneagent/agent/customkeys"
+
 func prepareVolumeMounts(instance *dynatracev1beta1.DynaKube) []corev1.VolumeMount {
 	rootMount := getRootMount()
 	var volumeMounts []corev1.VolumeMount
@@ -31,7 +33,7 @@ func getCertificateMount() corev1.VolumeMount {
 func getTLSMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      "tls",
-		MountPath: "/var/lib/dynatrace/oneagent/agent/customkeys",
+		MountPath: OneAgentCustomKeysPath,
 	}
 }
 

--- a/src/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -27,12 +27,33 @@ func TestPrepareVolumes(t *testing.T) {
 		assert.Contains(t, volumes, getRootVolume())
 		assert.Contains(t, volumes, getCertificateVolume(instance))
 	})
+	t.Run(`has tls volume`, func(t *testing.T) {
+		instance := &dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				TrustedCAs: testName,
+				ActiveGate: dynatracev1beta1.ActiveGateSpec{
+					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+						dynatracev1beta1.KubeMonCapability.DisplayName,
+					},
+					TlsSecretName: "testing",
+				},
+			},
+		}
+		volumes := prepareVolumes(instance)
+		assert.Contains(t, volumes, getTLSVolume(instance))
+	})
 	t.Run(`has all volumes`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				TrustedCAs: testName,
 				OneAgent: dynatracev1beta1.OneAgentSpec{
 					HostMonitoring: &dynatracev1beta1.HostMonitoringSpec{},
+				},
+				ActiveGate: dynatracev1beta1.ActiveGateSpec{
+					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+						dynatracev1beta1.KubeMonCapability.DisplayName,
+					},
+					TlsSecretName: "testing",
 				},
 			},
 		}
@@ -52,5 +73,6 @@ func TestPrepareVolumes(t *testing.T) {
 
 		assert.Contains(t, volumes, getRootVolume())
 		assert.Contains(t, volumes, getCertificateVolume(instance))
+		assert.Contains(t, volumes, getTLSVolume(instance))
 	})
 }

--- a/src/initgeneration/config.go
+++ b/src/initgeneration/config.go
@@ -1,9 +1,25 @@
 package initgeneration
 
 import (
+	_ "embed"
+	"text/template"
+
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
 )
 
 var (
 	log = logger.NewDTLogger().WithName("initgeneration")
+
+	//go:embed init.sh.tmpl
+	scriptContent string
+	scriptTmpl    = template.Must(template.New("initScript").Parse(scriptContent))
+)
+
+const (
+	notMappedIM              = "-"
+	trustedCASecretField     = "certs"
+	proxyInitSecretField     = "proxy"
+	trustedCAInitSecretField = "ca.pem"
+	initScriptSecretField    = "init.sh"
+	tlsCertKey               = "server.crt"
 )

--- a/src/initgeneration/init.sh.test-sample
+++ b/src/initgeneration/init.sh.test-sample
@@ -18,6 +18,7 @@ custom_ca="true"
 fail_code=0
 cluster_id="42"
 has_host="true"
+tls_cert="testing"
 
 declare -A im_nodes
 im_nodes=(
@@ -155,6 +156,12 @@ createConfigurationFilesDataIngest() {
 	writeConfEnrichmentTo "/var/lib/dynatrace/enrichment" "dt_metadata"
 }
 
+propagateTLSCert() {
+	if [[ "${tls_cert}" != "" ]]; then
+		echo "${tls_cert}" > "${share_dir}/custom.pem"
+	fi
+}
+
 ####### MAIN #######
 printf "\nSetting fail code\n"
 setFailCode
@@ -164,6 +171,7 @@ if [[ "${ONEAGENT_INJECTED}" == "true" ]]; then
   downloadOneAgentIfNecessary
   printf "\nCreating configuration files for containers\n"
   createConfigurationFilesOneAgent
+  propagateTLSCert
 fi
 
 if [[ "${DATA_INGEST_INJECTED}" == "true" ]]; then

--- a/src/initgeneration/init.sh.tmpl
+++ b/src/initgeneration/init.sh.tmpl
@@ -18,6 +18,7 @@ custom_ca="{{if .TrustedCAs}}true{{else}}false{{end}}"
 fail_code=0
 cluster_id="{{.ClusterID}}"
 has_host="{{.HasHost}}"
+tls_cert="{{.TlsCert}}"
 
 declare -A im_nodes
 im_nodes=(
@@ -156,6 +157,12 @@ createConfigurationFilesDataIngest() {
 	writeConfEnrichmentTo "/var/lib/dynatrace/enrichment" "dt_metadata"
 }
 
+propagateTLSCert() {
+	if [[ "${tls_cert}" != "" ]]; then
+		echo "${tls_cert}" > "${share_dir}/custom.pem"
+	fi
+}
+
 ####### MAIN #######
 printf "\nSetting fail code\n"
 setFailCode
@@ -165,6 +172,7 @@ if [[ "${ONEAGENT_INJECTED}" == "true" ]]; then
   downloadOneAgentIfNecessary
   printf "\nCreating configuration files for containers\n"
   createConfigurationFilesOneAgent
+  propagateTLSCert
 fi
 
 if [[ "${DATA_INGEST_INJECTED}" == "true" ]]; then

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -687,7 +687,7 @@ func updateInstallContainerOneAgent(ic *corev1.Container, number int, name strin
 }
 
 // updateContainerOA sets missing preload Variables
-func updateContainerOneAgent(c *corev1.Container, oa *dynatracev1beta1.DynaKube, pod *corev1.Pod, deploymentMetadata *deploymentmetadata.DeploymentMetadata) {
+func updateContainerOneAgent(c *corev1.Container, dk *dynatracev1beta1.DynaKube, pod *corev1.Pod, deploymentMetadata *deploymentmetadata.DeploymentMetadata) {
 
 	podLog.Info("updating container with missing preload variables", "containerName", c.Name)
 	installPath := kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInstallPath, dtwebhook.DefaultInstallPath)
@@ -716,7 +716,7 @@ func updateContainerOneAgent(c *corev1.Container, oa *dynatracev1beta1.DynaKube,
 			Value: installPath + "/agent/lib64/liboneagentproc.so",
 		})
 
-	if oa.Spec.Proxy != nil && (oa.Spec.Proxy.Value != "" || oa.Spec.Proxy.ValueFrom != "") {
+	if dk.Spec.Proxy != nil && (dk.Spec.Proxy.Value != "" || dk.Spec.Proxy.ValueFrom != "") {
 		c.Env = append(c.Env,
 			corev1.EnvVar{
 				Name: "DT_PROXY",
@@ -731,8 +731,8 @@ func updateContainerOneAgent(c *corev1.Container, oa *dynatracev1beta1.DynaKube,
 			})
 	}
 
-	if oa.Spec.NetworkZone != "" {
-		c.Env = append(c.Env, corev1.EnvVar{Name: "DT_NETWORK_ZONE", Value: oa.Spec.NetworkZone})
+	if dk.Spec.NetworkZone != "" {
+		c.Env = append(c.Env, corev1.EnvVar{Name: "DT_NETWORK_ZONE", Value: dk.Spec.NetworkZone})
 	}
 
 }

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
+	oneagent "github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/src/ingestendpoint"
@@ -709,12 +711,11 @@ func updateContainerOneAgent(c *corev1.Container, dk *dynatracev1beta1.DynaKube,
 			MountPath: "/var/lib/dynatrace/oneagent/agent/config/container.conf",
 			SubPath:   fmt.Sprintf("container_%s.conf", c.Name),
 		})
-
 	if dk.HasActiveGateTLS() {
 		c.VolumeMounts = append(c.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      oneAgentShareVolumeName,
-				MountPath: "/var/lib/dynatrace/oneagent/agent/customkeys/custom.pem",
+				MountPath: filepath.Join(oneagent.OneAgentCustomKeysPath, "custom.pem"),
 				SubPath:   "custom.pem",
 			})
 	}

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -710,6 +710,15 @@ func updateContainerOneAgent(c *corev1.Container, dk *dynatracev1beta1.DynaKube,
 			SubPath:   fmt.Sprintf("container_%s.conf", c.Name),
 		})
 
+	if dk.HasActiveGateTLS() {
+		c.VolumeMounts = append(c.VolumeMounts,
+			corev1.VolumeMount{
+				Name:      oneAgentShareVolumeName,
+				MountPath: "/var/lib/dynatrace/oneagent/agent/customkeys/custom.pem",
+				SubPath:   "custom.pem",
+			})
+	}
+
 	c.Env = append(c.Env,
 		corev1.EnvVar{
 			Name:  "LD_PRELOAD",


### PR DESCRIPTION
If `tlsSecretName` is set in the activeGate section then the value of the `server.crt` key in the provided secret will be propagated into
the oneagent Daemonset, and to the standalone agents. 

The value is put into `/var/lib/dynatrace/oneagent/agent/customkeys/custom.pem`.