### PR TITLE
Update dependencies before install of packages in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Download dependencies
         id: depdownload
         run: |
+          sudo apt-get update
           sudo apt-get install -y libdevmapper-dev libbtrfs-dev
       - name: Run Unit tests
         id: unittest
@@ -41,6 +42,7 @@ jobs:
       - name: Download dependencies
         id: depdownload
         run: |
+          sudo apt-get update
           sudo apt-get install -y libdevmapper-dev libbtrfs-dev
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2


### PR DESCRIPTION
- We need to update the package cache on the github action runner before installing the packages, otherwise the index could reference to no longer existing package locations.