### PR TITLE
AG capability renamed from 'data-ingest' to 'metrics-ingest'

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - data-ingest
 
 ```
 

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -997,7 +997,7 @@ spec:
                 properties:
                   capabilities:
                     description: Activegate capabilities enabled (routing, kubernetes-monitoring,
-                      data-ingest)
+                      metrics-ingest)
                     items:
                       type: string
                     type: array

--- a/config/helm/chart/default/questions.yml
+++ b/config/helm/chart/default/questions.yml
@@ -421,7 +421,7 @@ questions:
       - Please edit as Yaml for the best experience
     default: |
       - routing
-      - data-ingest
+      - metrics-ingest
       - kubernetes-monitoring
     type: multiline
     group: "ActiveGate"

--- a/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_activegate_test.yaml
+++ b/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_activegate_test.yaml
@@ -11,7 +11,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
     asserts:
       - isNotNull:
           path: spec.activeGate
@@ -20,7 +20,7 @@ tests:
           value:
             - kubernetes-monitoring
             - routing
-            - data-ingest
+            - metrics-ingest
 
   - it: should set image if set
     set:
@@ -31,7 +31,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         image: test-image
     asserts:
       - isNotNull:
@@ -49,7 +49,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         replicas: 3
     asserts:
       - isNotNull:
@@ -67,7 +67,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         group: test-group
     asserts:
       - isNotNull:
@@ -85,7 +85,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         customProperties:
           value: test-value
     asserts:
@@ -106,7 +106,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         customProperties:
           valueFrom: test-value
     asserts:
@@ -127,7 +127,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         customProperties:
           value: test-value
           valueFrom: test-value-from
@@ -149,7 +149,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         resources:
           requests:
             cpu: 100m
@@ -186,7 +186,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         nodeSelector:
           disktype: ssd
     asserts:
@@ -205,7 +205,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         tolerations:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
@@ -230,7 +230,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         labels:
           test-label: test-value
     asserts:
@@ -249,7 +249,7 @@ tests:
         capabilities:
           - kubernetes-monitoring
           - routing
-          - data-ingest
+          - metrics-ingest
         env:
           test-env: test-value
     asserts:

--- a/config/samples/applicationMonitoring.yaml
+++ b/config/samples/applicationMonitoring.yaml
@@ -82,7 +82,7 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - data-ingest
+      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/classicFullStack.yaml
+++ b/config/samples/classicFullStack.yaml
@@ -116,7 +116,7 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - data-ingest
+      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/cloudNativeFullStack.yaml
+++ b/config/samples/cloudNativeFullStack.yaml
@@ -132,7 +132,7 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - data-ingest
+      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/hostMonitoring.yaml
+++ b/config/samples/hostMonitoring.yaml
@@ -116,7 +116,7 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - data-ingest
+      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/multipleDynakubes.yaml
+++ b/config/samples/multipleDynakubes.yaml
@@ -69,7 +69,7 @@ spec:
     # Enables listed ActiveGate capabilities
     capabilities:
       - routing
-      - data-ingest
+      - metrics-ingest
 
     # Amount of replicas of activegate pods
     replicas: 2

--- a/src/api/v1alpha1/zz_generated.deepcopy.go
+++ b/src/api/v1alpha1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/src/api/v1beta1/activegate_types.go
+++ b/src/api/v1beta1/activegate_types.go
@@ -31,22 +31,22 @@ var (
 		ArgumentName: "kubernetes_monitoring",
 	}
 
-	DataIngestCapability = ActiveGateCapability{
-		DisplayName:  "data-ingest",
-		ShortName:    "data-ingest",
+	MetricsIngestCapability = ActiveGateCapability{
+		DisplayName:  "metrics-ingest",
+		ShortName:    "metrics-ingest",
 		ArgumentName: "metrics_ingest",
 	}
 )
 
 var ActiveGateDisplayNames = map[CapabilityDisplayName]bool{
-	RoutingCapability.DisplayName:    true,
-	KubeMonCapability.DisplayName:    true,
-	DataIngestCapability.DisplayName: true,
+	RoutingCapability.DisplayName:       true,
+	KubeMonCapability.DisplayName:       true,
+	MetricsIngestCapability.DisplayName: true,
 }
 
 type ActiveGateSpec struct {
 
-	// Activegate capabilities enabled (routing, kubernetes-monitoring, data-ingest)
+	// Activegate capabilities enabled (routing, kubernetes-monitoring, metrics-ingest)
 	Capabilities []CapabilityDisplayName `json:"capabilities,omitempty"`
 
 	CapabilityProperties `json:",inline"`

--- a/src/api/v1beta1/zz_generated.deepcopy.go
+++ b/src/api/v1beta1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/src/controllers/activegate/capability/capability.go
+++ b/src/controllers/activegate/capability/capability.go
@@ -26,9 +26,9 @@ const (
 type baseFunc func() *capabilityBase
 
 var activeGateCapabilities = map[dynatracev1beta1.CapabilityDisplayName]baseFunc{
-	dynatracev1beta1.KubeMonCapability.DisplayName:    kubeMonBase,
-	dynatracev1beta1.RoutingCapability.DisplayName:    routingBase,
-	dynatracev1beta1.DataIngestCapability.DisplayName: dataIngestBase,
+	dynatracev1beta1.KubeMonCapability.DisplayName:       kubeMonBase,
+	dynatracev1beta1.RoutingCapability.DisplayName:       routingBase,
+	dynatracev1beta1.MetricsIngestCapability.DisplayName: metricsIngestBase,
 }
 
 type Configuration struct {
@@ -265,10 +265,10 @@ func routingBase() *capabilityBase {
 	return &c
 }
 
-func dataIngestBase() *capabilityBase {
+func metricsIngestBase() *capabilityBase {
 	c := capabilityBase{
-		shortName: dynatracev1beta1.DataIngestCapability.ShortName,
-		argName:   dynatracev1beta1.DataIngestCapability.ArgumentName,
+		shortName: dynatracev1beta1.MetricsIngestCapability.ShortName,
+		argName:   dynatracev1beta1.MetricsIngestCapability.ArgumentName,
 		Configuration: Configuration{
 			SetDnsEntryPoint:     true,
 			SetReadinessPort:     true,

--- a/src/controllers/activegate/capability/capability_test.go
+++ b/src/controllers/activegate/capability/capability_test.go
@@ -350,13 +350,13 @@ func TestNewMultiCapability(t *testing.T) {
 			},
 		},
 		{
-			name: "just data-ingest",
+			name: "just metrics-ingest",
 			args: args{
 				dynakube: &dynatracev1beta1.DynaKube{
 					Spec: dynatracev1beta1.DynaKubeSpec{
 						ActiveGate: dynatracev1beta1.ActiveGateSpec{
 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-								dynatracev1beta1.DataIngestCapability.DisplayName,
+								dynatracev1beta1.MetricsIngestCapability.DisplayName,
 							},
 						},
 					},
@@ -366,7 +366,7 @@ func TestNewMultiCapability(t *testing.T) {
 				capabilityBase: capabilityBase{
 					enabled:    true,
 					shortName:  MultiActiveGateName,
-					argName:    dynatracev1beta1.DataIngestCapability.ArgumentName,
+					argName:    dynatracev1beta1.MetricsIngestCapability.ArgumentName,
 					properties: props,
 					Configuration: Configuration{
 						SetDnsEntryPoint:     true,
@@ -439,7 +439,7 @@ func TestNewMultiCapability(t *testing.T) {
 						ActiveGate: dynatracev1beta1.ActiveGateSpec{
 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 								dynatracev1beta1.KubeMonCapability.DisplayName,
-								dynatracev1beta1.DataIngestCapability.DisplayName,
+								dynatracev1beta1.MetricsIngestCapability.DisplayName,
 								dynatracev1beta1.RoutingCapability.DisplayName,
 							},
 						},
@@ -450,7 +450,7 @@ func TestNewMultiCapability(t *testing.T) {
 				capabilityBase: capabilityBase{
 					enabled:    true,
 					shortName:  MultiActiveGateName,
-					argName:    strings.Join([]string{dynatracev1beta1.KubeMonCapability.ArgumentName, dynatracev1beta1.DataIngestCapability.ArgumentName, dynatracev1beta1.RoutingCapability.ArgumentName}, ","),
+					argName:    strings.Join([]string{dynatracev1beta1.KubeMonCapability.ArgumentName, dynatracev1beta1.MetricsIngestCapability.ArgumentName, dynatracev1beta1.RoutingCapability.ArgumentName}, ","),
 					properties: props,
 					Configuration: Configuration{
 						SetDnsEntryPoint:     true,

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -251,7 +251,7 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 		Spec: dynatracev1beta1.DynaKubeSpec{
 			ActiveGate: dynatracev1beta1.ActiveGateSpec{
 				Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-					dynatracev1beta1.DataIngestCapability.DisplayName,
+					dynatracev1beta1.MetricsIngestCapability.DisplayName,
 					dynatracev1beta1.KubeMonCapability.DisplayName,
 					dynatracev1beta1.RoutingCapability.DisplayName,
 				},

--- a/src/ingestendpoint/secret.go
+++ b/src/ingestendpoint/secret.go
@@ -124,20 +124,20 @@ func (g *EndpointSecretGenerator) PrepareFields(ctx context.Context, dk *dynatra
 }
 
 func dataIngestUrl(dk *dynatracev1beta1.DynaKube) (string, error) {
-	if dk.IsActiveGateMode(dynatracev1beta1.DataIngestCapability.ShortName) {
-		return dataIngestUrlForClusterActiveGate(dk)
+	if dk.IsActiveGateMode(dynatracev1beta1.MetricsIngestCapability.ShortName) {
+		return metricsIngestUrlForClusterActiveGate(dk)
 	} else if len(dk.Spec.APIURL) > 0 {
-		return dataIngestUrlForDynatraceActiveGate(dk)
+		return metricsIngestUrlForDynatraceActiveGate(dk)
 	} else {
 		return "", fmt.Errorf("failed to create data-ingest endpoint, DynaKube.spec.apiUrl is empty")
 	}
 }
 
-func dataIngestUrlForDynatraceActiveGate(dk *dynatracev1beta1.DynaKube) (string, error) {
+func metricsIngestUrlForDynatraceActiveGate(dk *dynatracev1beta1.DynaKube) (string, error) {
 	return fmt.Sprintf("%s/v2/metrics/ingest", dk.Spec.APIURL), nil
 }
 
-func dataIngestUrlForClusterActiveGate(dk *dynatracev1beta1.DynaKube) (string, error) {
+func metricsIngestUrlForClusterActiveGate(dk *dynatracev1beta1.DynaKube) (string, error) {
 	apiUrl, err := url.Parse(dk.Spec.APIURL)
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to parse DynaKube.spec.apiUrl")

--- a/src/ingestendpoint/secret_test.go
+++ b/src/ingestendpoint/secret_test.go
@@ -255,7 +255,7 @@ func updatedTestDynakubeWithDataIngestCapability() *dynatracev1beta1.DynaKube {
 			ActiveGate: dynatracev1beta1.ActiveGateSpec{
 				Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 					dynatracev1beta1.CapabilityDisplayName(dynatracev1beta1.KubeMonCapability.ShortName),
-					dynatracev1beta1.CapabilityDisplayName(dynatracev1beta1.DataIngestCapability.ShortName),
+					dynatracev1beta1.CapabilityDisplayName(dynatracev1beta1.MetricsIngestCapability.ShortName),
 				},
 			},
 			APIURL: testUpdatedApiUrl,
@@ -296,7 +296,7 @@ func buildTestDynakubeWithDataIngestCapability() *dynatracev1beta1.DynaKube {
 			ActiveGate: dynatracev1beta1.ActiveGateSpec{
 				Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 					dynatracev1beta1.CapabilityDisplayName(dynatracev1beta1.KubeMonCapability.ShortName),
-					dynatracev1beta1.CapabilityDisplayName(dynatracev1beta1.DataIngestCapability.ShortName),
+					dynatracev1beta1.CapabilityDisplayName(dynatracev1beta1.MetricsIngestCapability.ShortName),
 				},
 			},
 			APIURL: testApiUrl,

--- a/src/webhook/validation/activegate_test.go
+++ b/src/webhook/validation/activegate_test.go
@@ -31,7 +31,7 @@ func TestConflictingActiveGateConfiguration(t *testing.T) {
 					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 						dynatracev1beta1.RoutingCapability.DisplayName,
 						dynatracev1beta1.KubeMonCapability.DisplayName,
-						dynatracev1beta1.DataIngestCapability.DisplayName,
+						dynatracev1beta1.MetricsIngestCapability.DisplayName,
 					},
 				},
 			},

--- a/src/webhook/validation/validation_test.go
+++ b/src/webhook/validation/validation_test.go
@@ -80,7 +80,7 @@ func TestDynakubeValidator_Handle(t *testing.T) {
 					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 						dynatracev1beta1.RoutingCapability.DisplayName,
 						dynatracev1beta1.KubeMonCapability.DisplayName,
-						dynatracev1beta1.DataIngestCapability.DisplayName,
+						dynatracev1beta1.MetricsIngestCapability.DisplayName,
 					},
 				},
 				KubernetesMonitoring: dynatracev1beta1.KubernetesMonitoringSpec{


### PR DESCRIPTION
AG's capability renamed from `data-ingest` to `metrics-ingest`
`data-ingest` remains valid in terms of injection type