### PR TITLE
Fixed error when deploying via GKE deployer image

### DIFF
--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -54,7 +54,7 @@ spec:
             - name: RELATED_IMAGE_DYNATRACE_ONEAGENT
               value: registry.connect.redhat.com/dynatrace/oneagent
             {{ end }}
-            {{ if eq .Values.olm true}}
+            {{ if eq (default false .Values.olm) true}}
             - name: DEPLOYED_VIA_OLM
               value: "true"
             {{ end }}

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -66,7 +66,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            {{ if eq .Values.olm true}}
+            {{ if eq (default false .Values.olm) true}}
             - name: DEPLOYED_VIA_OLM
               value: "true"
             {{ end }}


### PR DESCRIPTION
When testing the deployment via GKE deployer image, the deployer job ran into an error when no value for .Values.olm was given.
Adding a default value fixes this error.