### PR TITLE
Adds preview warning for metrics-ingest (+minor fixes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,25 +128,25 @@ manifests: controller-gen kustomize
 	mkdir -p config/deploy/openshift
 
 	# Generate kubernetes.yaml
-	helm template dynatrace-operator config/helm/chart/default --namespace dynatrace --set platform="kubernetes" --set olm="${OLM}" --set autoCreateSecret=false --set operator.image="$(IMG)" > config/deploy/kubernetes/kubernetes.yaml
+	helm template dynatrace-operator config/helm/chart/default --namespace dynatrace --set platform="kubernetes" --set manifests=true --set olm="${OLM}" --set autoCreateSecret=false --set operator.image="$(IMG)" > config/deploy/kubernetes/kubernetes.yaml
 	grep -v 'app.kubernetes.io' config/deploy/kubernetes/kubernetes.yaml > config/deploy/kubernetes/tmp.yaml
 	grep -v 'helm.sh' config/deploy/kubernetes/tmp.yaml > config/deploy/kubernetes/kubernetes.yaml
 	rm config/deploy/kubernetes/tmp.yaml
 
 	# Generate kubernetes-csi.yaml
-	helm template dynatrace-operator config/helm/chart/default --namespace dynatrace --set partial="csi" --set platform="kubernetes" --set olm="${OLM}" --set autoCreateSecret=false --set operator.image="$(IMG)" > config/deploy/kubernetes/kubernetes-csi.yaml
+	helm template dynatrace-operator config/helm/chart/default --namespace dynatrace --set partial="csi" --set manifests=true --set platform="kubernetes" --set olm="${OLM}" --set autoCreateSecret=false --set operator.image="$(IMG)" > config/deploy/kubernetes/kubernetes-csi.yaml
 	grep -v 'app.kubernetes.io' config/deploy/kubernetes/kubernetes-csi.yaml > config/deploy/kubernetes/tmp.yaml
 	grep -v 'helm.sh' config/deploy/kubernetes/tmp.yaml > config/deploy/kubernetes/kubernetes-csi.yaml
 	rm config/deploy/kubernetes/tmp.yaml
 
 	# Generate openshift.yaml
-	helm template dynatrace-operator config/helm/chart/default --namespace dynatrace --set platform="openshift" --set olm="${OLM}" --set autoCreateSecret=false --set createSecurityContextConstraints="true" --set operator.image="$(IMG)" > config/deploy/openshift/openshift.yaml
+	helm template dynatrace-operator config/helm/chart/default --namespace dynatrace --set platform="openshift" --set manifests=true --set olm="${OLM}" --set autoCreateSecret=false --set createSecurityContextConstraints="true" --set operator.image="$(IMG)" > config/deploy/openshift/openshift.yaml
 	grep -v 'app.kubernetes.io' config/deploy/openshift/openshift.yaml > config/deploy/openshift/tmp.yaml
 	grep -v 'helm.sh' config/deploy/openshift/tmp.yaml > config/deploy/openshift/openshift.yaml
 	rm config/deploy/openshift/tmp.yaml
 
 	# Generate openshift-csi.yaml
-	helm template dynatrace-operator config/helm/chart/default --namespace dynatrace --set partial="csi" --set platform="openshift" --set olm="${OLM}" --set autoCreateSecret=false --set createSecurityContextConstraints="true" --set operator.image="$(IMG)" > config/deploy/openshift/openshift-csi.yaml
+	helm template dynatrace-operator config/helm/chart/default --namespace dynatrace --set partial="csi" --set platform="openshift" --set manifests=true --set olm="${OLM}" --set autoCreateSecret=false --set createSecurityContextConstraints="true" --set operator.image="$(IMG)" > config/deploy/openshift/openshift-csi.yaml
 	grep -v 'app.kubernetes.io' config/deploy/openshift/openshift-csi.yaml > config/deploy/openshift/tmp.yaml
 	grep -v 'helm.sh' config/deploy/openshift/tmp.yaml > config/deploy/openshift/openshift-csi.yaml
 	rm config/deploy/openshift/tmp.yaml

--- a/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
@@ -31,6 +31,9 @@ webhooks:
         path: /validate
     rules:
       - operations:
+          {{- if eq (default false .Values.manifests) true }}
+          - CREATE
+          {{- end }}
           - UPDATE
         apiGroups:
           - dynatrace.com

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -68,9 +68,9 @@ func (dk *DynaKube) ActiveGateMode() bool {
 	return len(dk.Spec.ActiveGate.Capabilities) > 0
 }
 
-func (dk *DynaKube) IsActiveGateMode(mode string) bool {
+func (dk *DynaKube) IsActiveGateMode(mode CapabilityDisplayName) bool {
 	for _, capability := range dk.Spec.ActiveGate.Capabilities {
-		if string(capability) == mode {
+		if capability == mode {
 			return true
 		}
 	}
@@ -78,7 +78,7 @@ func (dk *DynaKube) IsActiveGateMode(mode string) bool {
 }
 
 func (dk *DynaKube) KubernetesMonitoringMode() bool {
-	return dk.IsActiveGateMode(string(KubeMonCapability.DisplayName)) || dk.Spec.KubernetesMonitoring.Enabled
+	return dk.IsActiveGateMode(KubeMonCapability.DisplayName) || dk.Spec.KubernetesMonitoring.Enabled
 }
 
 func (dk *DynaKube) HasActiveGateTLS() bool {

--- a/src/ingestendpoint/secret.go
+++ b/src/ingestendpoint/secret.go
@@ -124,7 +124,7 @@ func (g *EndpointSecretGenerator) PrepareFields(ctx context.Context, dk *dynatra
 }
 
 func dataIngestUrl(dk *dynatracev1beta1.DynaKube) (string, error) {
-	if dk.IsActiveGateMode(dynatracev1beta1.MetricsIngestCapability.ShortName) {
+	if dk.IsActiveGateMode(dynatracev1beta1.MetricsIngestCapability.DisplayName) {
 		return metricsIngestUrlForClusterActiveGate(dk)
 	} else if len(dk.Spec.APIURL) > 0 {
 		return metricsIngestUrlForDynatraceActiveGate(dk)

--- a/src/webhook/validation/activegate_test.go
+++ b/src/webhook/validation/activegate_test.go
@@ -31,6 +31,17 @@ func TestConflictingActiveGateConfiguration(t *testing.T) {
 					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 						dynatracev1beta1.RoutingCapability.DisplayName,
 						dynatracev1beta1.KubeMonCapability.DisplayName,
+					},
+				},
+			},
+		})
+
+		assertAllowedResponseWithWarnings(t, &dynatracev1beta1.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testApiUrl,
+				ActiveGate: dynatracev1beta1.ActiveGateSpec{
+					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 						dynatracev1beta1.MetricsIngestCapability.DisplayName,
 					},
 				},

--- a/src/webhook/validation/activegate_test.go
+++ b/src/webhook/validation/activegate_test.go
@@ -36,7 +36,7 @@ func TestConflictingActiveGateConfiguration(t *testing.T) {
 			},
 		})
 
-		assertAllowedResponseWithWarnings(t, &dynatracev1beta1.DynaKube{
+		assertAllowedResponseWithWarnings(t, 2, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,

--- a/src/webhook/validation/config.go
+++ b/src/webhook/validation/config.go
@@ -21,5 +21,6 @@ var validators = []validator{
 }
 
 var warnings = []validator{
-	previewWarning,
+	oneAgentModePreviewWarning,
+	metricIngestPreviewWarning,
 }

--- a/src/webhook/validation/csi_daemonset_test.go
+++ b/src/webhook/validation/csi_daemonset_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMissingCSIDaemonSet(t *testing.T) {
 	t.Run(`valid dynakube specs`, func(t *testing.T) {
-		assertAllowedResponseWithWarnings(t, &dynatracev1beta1.DynaKube{
+		assertAllowedResponseWithWarnings(t, 2, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,

--- a/src/webhook/validation/oneagent_test.go
+++ b/src/webhook/validation/oneagent_test.go
@@ -109,7 +109,7 @@ func TestConflictingNodeSelector(t *testing.T) {
 				},
 			})
 
-		assertAllowedResponseWithWarnings(t,
+		assertAllowedResponseWithWarnings(t, 2,
 			&dynatracev1beta1.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "conflict2",

--- a/src/webhook/validation/preview.go
+++ b/src/webhook/validation/preview.go
@@ -7,16 +7,26 @@ import (
 )
 
 const (
-	warningPreview = `%s mode is in PREVIEW. Please be aware that it is NOT production ready and you may run into bugs.`
+	oneAgentModePreviewWarningMessage  = `%s mode is in PREVIEW.`
+	metricsIngestPreviewWarningMessage = `metrics-ingest is in PREVIEW.`
+	basePreviewWarning                 = "PREVIEW features are NOT production ready and you may run into bugs."
 )
 
-func previewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func oneAgentModePreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.CloudNativeFullstackMode() {
 		log.Info("DynaKube with cloudNativeFullStack was applied, warning was provided.")
-		return fmt.Sprintf(warningPreview, "cloudNativeFullStack")
+		return fmt.Sprintf(oneAgentModePreviewWarningMessage, "cloudNativeFullStack")
 	} else if dynakube.ApplicationMonitoringMode() && dynakube.NeedsCSIDriver() {
 		log.Info("DynaKube with applicationMonitoring was applied, warning was provided.")
-		return fmt.Sprintf(warningPreview, "applicationMonitoring")
+		return fmt.Sprintf(oneAgentModePreviewWarningMessage, "applicationMonitoring")
+	}
+	return ""
+}
+
+func metricIngestPreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+	if dynakube.IsActiveGateMode(dynatracev1beta1.MetricsIngestCapability.DisplayName) {
+		log.Info("DynaKube with metrics-ingest was applied, warning was provided.")
+		return metricsIngestPreviewWarningMessage
 	}
 	return ""
 }

--- a/src/webhook/validation/preview.go
+++ b/src/webhook/validation/preview.go
@@ -7,18 +7,17 @@ import (
 )
 
 const (
-	oneAgentModePreviewWarningMessage  = `%s mode is in PREVIEW.`
-	metricsIngestPreviewWarningMessage = `metrics-ingest is in PREVIEW.`
-	basePreviewWarning                 = "PREVIEW features are NOT production ready and you may run into bugs."
+	featurePreviewWarningMessage = `%s feature is in PREVIEW.`
+	basePreviewWarning           = "PREVIEW features are NOT production ready and you may run into bugs."
 )
 
 func oneAgentModePreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.CloudNativeFullstackMode() {
 		log.Info("DynaKube with cloudNativeFullStack was applied, warning was provided.")
-		return fmt.Sprintf(oneAgentModePreviewWarningMessage, "cloudNativeFullStack")
+		return fmt.Sprintf(featurePreviewWarningMessage, "cloudNativeFullStack")
 	} else if dynakube.ApplicationMonitoringMode() && dynakube.NeedsCSIDriver() {
 		log.Info("DynaKube with applicationMonitoring was applied, warning was provided.")
-		return fmt.Sprintf(oneAgentModePreviewWarningMessage, "applicationMonitoring")
+		return fmt.Sprintf(featurePreviewWarningMessage, "applicationMonitoring")
 	}
 	return ""
 }
@@ -26,7 +25,7 @@ func oneAgentModePreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta
 func metricIngestPreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.IsActiveGateMode(dynatracev1beta1.MetricsIngestCapability.DisplayName) {
 		log.Info("DynaKube with metrics-ingest was applied, warning was provided.")
-		return metricsIngestPreviewWarningMessage
+		return fmt.Sprintf(featurePreviewWarningMessage, "metrics-ingest")
 	}
 	return ""
 }

--- a/src/webhook/validation/preview_test.go
+++ b/src/webhook/validation/preview_test.go
@@ -21,7 +21,7 @@ func TestPreviewWarning(t *testing.T) {
 
 	t.Run(`warning present`, func(t *testing.T) {
 		useCSIDriver := true
-		assertAllowedResponseWithWarnings(t, &dynatracev1beta1.DynaKube{
+		assertAllowedResponseWithWarnings(t, 2, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,

--- a/src/webhook/validation/validation.go
+++ b/src/webhook/validation/validation.go
@@ -53,6 +53,7 @@ func (validator *dynakubeValidator) Handle(_ context.Context, request admission.
 	}
 	warningMessages := validator.runValidators(warnings, dynakube)
 	if len(warningMessages) > 0 {
+		warningMessages = append(warningMessages, basePreviewWarning)
 		response = response.WithWarnings(warningMessages...)
 	}
 	return response

--- a/src/webhook/validation/validation_test.go
+++ b/src/webhook/validation/validation_test.go
@@ -196,7 +196,7 @@ func assertAllowedResponseWithoutWarnings(t *testing.T, dynakube *dynatracev1bet
 
 func assertAllowedResponseWithWarnings(t *testing.T, dynakube *dynatracev1beta1.DynaKube, other ...client.Object) {
 	response := assertAllowedResponse(t, dynakube, other...)
-	assert.Equal(t, len(response.Warnings), 1)
+	assert.Greater(t, len(response.Warnings), 1)
 }
 
 func assertAllowedResponse(t *testing.T, dynakube *dynatracev1beta1.DynaKube, other ...client.Object) admission.Response {

--- a/src/webhook/validation/validation_test.go
+++ b/src/webhook/validation/validation_test.go
@@ -60,7 +60,7 @@ var dummyNamespace2 = corev1.Namespace{
 func TestDynakubeValidator_Handle(t *testing.T) {
 	t.Run(`valid dynakube specs`, func(t *testing.T) {
 
-		assertAllowedResponseWithWarnings(t, &dynatracev1beta1.DynaKube{
+		assertAllowedResponseWithWarnings(t, 3, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,
@@ -194,9 +194,9 @@ func assertAllowedResponseWithoutWarnings(t *testing.T, dynakube *dynatracev1bet
 	assert.Equal(t, len(response.Warnings), 0)
 }
 
-func assertAllowedResponseWithWarnings(t *testing.T, dynakube *dynatracev1beta1.DynaKube, other ...client.Object) {
+func assertAllowedResponseWithWarnings(t *testing.T, warningAmount int, dynakube *dynatracev1beta1.DynaKube, other ...client.Object) {
 	response := assertAllowedResponse(t, dynakube, other...)
-	assert.Greater(t, len(response.Warnings), 1)
+	assert.Equal(t, len(response.Warnings), warningAmount)
 }
 
 func assertAllowedResponse(t *testing.T, dynakube *dynatracev1beta1.DynaKube, other ...client.Object) admission.Response {


### PR DESCRIPTION
When `metrics-ingest` is configured in the activegate section a warning will tell the user that its a preview feature

There were some minor mistakes in the codebase that it also fixes, regarding the validation webhook yaml and `IsActiveGateMode` function