### PR TITLE
Enables the monitoring of the operator's namespace via feature-flag

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
@@ -37,12 +38,6 @@ const (
 
 var (
 	log = logger.NewDTLogger().WithName("dynakube-api")
-
-	defaultIgnoredNamespaces = []string{
-		"^dynatrace$",
-		"^kube-.*",
-		"^openshift(-.*)?",
-	}
 )
 
 // FeatureDisableActiveGateUpdates is a feature flag to disable ActiveGate updates.
@@ -92,15 +87,24 @@ func (dk *DynaKube) FeatureIgnoreUnknownState() bool {
 func (dk *DynaKube) FeatureIgnoredNamespaces() []string {
 	raw, ok := dk.Annotations[annotationFeatureIgnoredNamespaces]
 	if !ok || raw == "" {
-		return defaultIgnoredNamespaces
+		return dk.getDefaultIgnoredNamespaces()
 	}
 	ignoredNamespaces := &[]string{}
 	err := json.Unmarshal([]byte(raw), ignoredNamespaces)
 	if err != nil {
 		log.Error(err, "failed to unmarshal ignoredNamespaces feature-flag")
-		return defaultIgnoredNamespaces
+		return dk.getDefaultIgnoredNamespaces()
 	}
 	return *ignoredNamespaces
+}
+
+func (dk *DynaKube) getDefaultIgnoredNamespaces() []string {
+	defaultIgnoredNamespaces := []string{
+		fmt.Sprintf("^%s$", dk.Namespace),
+		"^kube-.*",
+		"^openshift(-.*)?",
+	}
+	return defaultIgnoredNamespaces
 }
 
 // FeatureAutomaticKubernetesApiMonitoring is a feature flag to enable automatic kubernetes api monitoring,

--- a/src/mapper/mapper.go
+++ b/src/mapper/mapper.go
@@ -85,7 +85,7 @@ func updateNamespace(operatorNs string, namespace *corev1.Namespace, dkList *dyn
 	conflict := ConflictChecker{}
 	for i := range dkList.Items {
 		dynakube := &dkList.Items[i]
-		if operatorNs == namespace.Name || isIgnoredNamespace(dynakube, namespace.Name) {
+		if isIgnoredNamespace(dynakube, namespace.Name) {
 			return false, nil
 		}
 		matches, err := match(dynakube, namespace)


### PR DESCRIPTION
The ignored namespace feature-flag now gets its default value based on the dynakube so the extra check in the mapper can be safely removed.