### PR TITLE
Adds DNSPolicy to the ActiveGate section

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1011,6 +1011,9 @@ spec:
                       valueFrom:
                         type: string
                     type: object
+                  dnsPolicy:
+                    description: 'Optional: Sets DNS Policy for the ActiveGate pods'
+                    type: string
                   env:
                     description: 'Optional: List of environment variables to set for
                       the ActiveGate'

--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -1020,6 +1020,9 @@ spec:
                       valueFrom:
                         type: string
                     type: object
+                  dnsPolicy:
+                    description: 'Optional: Sets DNS Policy for the ActiveGate pods'
+                    type: string
                   env:
                     description: 'Optional: List of environment variables to set for
                       the ActiveGate'

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -1020,6 +1020,9 @@ spec:
                       valueFrom:
                         type: string
                     type: object
+                  dnsPolicy:
+                    description: 'Optional: Sets DNS Policy for the ActiveGate pods'
+                    type: string
                   env:
                     description: 'Optional: List of environment variables to set for
                       the ActiveGate'

--- a/config/samples/applicationMonitoring.yaml
+++ b/config/samples/applicationMonitoring.yaml
@@ -144,4 +144,5 @@ spec:
     # tlsSecretName: "my-tls-secret"
 
     # Optional: Sets DNS Policy for the ActiveGate pods
+    #
     # dnsPolicy: "Default"

--- a/config/samples/applicationMonitoring.yaml
+++ b/config/samples/applicationMonitoring.yaml
@@ -142,3 +142,6 @@ spec:
     # server.p12: certificate+key pair in pkcs12 format
     #
     # tlsSecretName: "my-tls-secret"
+
+    # Optional: Sets DNS Policy for the ActiveGate pods
+    # dnsPolicy: "Default"

--- a/config/samples/classicFullStack.yaml
+++ b/config/samples/classicFullStack.yaml
@@ -176,5 +176,6 @@ spec:
     # server.p12: certificate+key pair in pkcs12 format
     #
     # tlsSecretName: "my-tls-secret"
+
     # Optional: Sets DNS Policy for the ActiveGate pods
     # dnsPolicy: "Default"

--- a/config/samples/classicFullStack.yaml
+++ b/config/samples/classicFullStack.yaml
@@ -178,4 +178,5 @@ spec:
     # tlsSecretName: "my-tls-secret"
 
     # Optional: Sets DNS Policy for the ActiveGate pods
+    #
     # dnsPolicy: "Default"

--- a/config/samples/classicFullStack.yaml
+++ b/config/samples/classicFullStack.yaml
@@ -176,3 +176,5 @@ spec:
     # server.p12: certificate+key pair in pkcs12 format
     #
     # tlsSecretName: "my-tls-secret"
+    # Optional: Sets DNS Policy for the ActiveGate pods
+    # dnsPolicy: "Default"

--- a/config/samples/cloudNativeFullStack.yaml
+++ b/config/samples/cloudNativeFullStack.yaml
@@ -193,6 +193,6 @@ spec:
     #
     # tlsSecretName: "my-tls-secret"
 
-
     # Optional: Sets DNS Policy for the ActiveGate pods
+    #
     # dnsPolicy: "Default"

--- a/config/samples/cloudNativeFullStack.yaml
+++ b/config/samples/cloudNativeFullStack.yaml
@@ -192,3 +192,7 @@ spec:
     # server.p12: certificate+key pair in pkcs12 format
     #
     # tlsSecretName: "my-tls-secret"
+
+
+    # Optional: Sets DNS Policy for the ActiveGate pods
+    # dnsPolicy: "Default"

--- a/config/samples/hostMonitoring.yaml
+++ b/config/samples/hostMonitoring.yaml
@@ -178,4 +178,5 @@ spec:
     # tlsSecretName: "my-tls-secret"
 
     # Optional: Sets DNS Policy for the ActiveGate pods
+    #
     # dnsPolicy: "Default"

--- a/config/samples/hostMonitoring.yaml
+++ b/config/samples/hostMonitoring.yaml
@@ -176,3 +176,6 @@ spec:
     # server.p12: certificate+key pair in pkcs12 format
     #
     # tlsSecretName: "my-tls-secret"
+
+    # Optional: Sets DNS Policy for the ActiveGate pods
+    # dnsPolicy: "Default"

--- a/src/api/v1beta1/activegate_types.go
+++ b/src/api/v1beta1/activegate_types.go
@@ -56,6 +56,10 @@ type ActiveGateSpec struct {
 	// password: passphrase to read server.p12
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TlsSecretName",order=10,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	TlsSecretName string `json:"tlsSecretName,omitempty"`
+
+	// Optional: Sets DNS Policy for the ActiveGate pods
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="DNS Policy",order=24,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
 }
 
 // CapabilityProperties is a struct which can be embedded by ActiveGate capabilities

--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -107,7 +107,7 @@ func CreateStatefulSet(stsProperties *statefulSetProperties) (*appsv1.StatefulSe
 }
 
 func buildTemplateSpec(stsProperties *statefulSetProperties) corev1.PodSpec {
-	return corev1.PodSpec{
+	podSpec := corev1.PodSpec{
 		Containers:         []corev1.Container{buildContainer(stsProperties)},
 		InitContainers:     buildInitContainers(stsProperties),
 		NodeSelector:       stsProperties.CapabilityProperties.NodeSelector,
@@ -119,6 +119,17 @@ func buildTemplateSpec(stsProperties *statefulSetProperties) corev1.PodSpec {
 			{Name: stsProperties.PullSecret()},
 		},
 	}
+	if dnsPolicy := buildDNSPolicy(stsProperties); dnsPolicy != "" {
+		podSpec.DNSPolicy = dnsPolicy
+	}
+	return podSpec
+}
+
+func buildDNSPolicy(stsProperties *statefulSetProperties) corev1.DNSPolicy {
+	if stsProperties.ActiveGateMode() {
+		return stsProperties.Spec.ActiveGate.DNSPolicy
+	}
+	return ""
 }
 
 func buildInitContainers(stsProperties *statefulSetProperties) []corev1.Container {

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -24,6 +24,7 @@ const (
 	testUID                  = "test-uid"
 	routingStatefulSetSuffix = "-router"
 	testFeature              = "router"
+	testDNSPolicy            = corev1.DNSPolicy("dns")
 )
 
 func TestNewStatefulSetBuilder(t *testing.T) {
@@ -39,7 +40,7 @@ func TestNewStatefulSetBuilder(t *testing.T) {
 
 func TestStatefulSetBuilder_Build(t *testing.T) {
 	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.Routing.CapabilityProperties
+	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 	sts, err := CreateStatefulSet(NewStatefulSetProperties(instance, capabilityProperties,
 		"", "", testFeature, "", "", nil, nil, nil))
 
@@ -52,7 +53,7 @@ func TestStatefulSetBuilder_Build(t *testing.T) {
 		KeyActiveGate: instance.Name,
 		KeyFeature:    testFeature,
 	}, sts.Labels)
-	assert.Equal(t, instance.Spec.Routing.Replicas, sts.Spec.Replicas)
+	assert.Equal(t, instance.Spec.ActiveGate.Replicas, sts.Spec.Replicas)
 	assert.Equal(t, appsv1.ParallelPodManagement, sts.Spec.PodManagementPolicy)
 	assert.Equal(t, metav1.LabelSelector{
 		MatchLabels: BuildLabelsFromInstance(instance, testFeature),
@@ -81,7 +82,7 @@ func TestStatefulSetBuilder_Build(t *testing.T) {
 
 func TestStatefulSet_TemplateSpec(t *testing.T) {
 	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.Routing.CapabilityProperties
+	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 	templateSpec := buildTemplateSpec(NewStatefulSetProperties(instance, capabilityProperties,
 		"", "", "", "", "", nil, nil, nil))
 
@@ -104,7 +105,7 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 
 func TestStatefulSet_Container(t *testing.T) {
 	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.Routing.CapabilityProperties
+	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 	container := buildContainer(NewStatefulSetProperties(instance, capabilityProperties,
 		"", "", "", "", "", nil, nil, nil))
 
@@ -120,7 +121,7 @@ func TestStatefulSet_Container(t *testing.T) {
 
 func TestStatefulSet_Volumes(t *testing.T) {
 	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.Routing.CapabilityProperties
+	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 
 	t.Run(`without custom properties`, func(t *testing.T) {
 		volumes := buildVolumes(NewStatefulSetProperties(instance, capabilityProperties,
@@ -170,7 +171,7 @@ func TestStatefulSet_Volumes(t *testing.T) {
 
 func TestStatefulSet_Env(t *testing.T) {
 	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.Routing.CapabilityProperties
+	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 	deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(string(testUID), deploymentmetadata.DeploymentTypeActiveGate)
 
 	t.Run(`without proxy`, func(t *testing.T) {
@@ -187,7 +188,7 @@ func TestStatefulSet_Env(t *testing.T) {
 	t.Run(`with networkzone`, func(t *testing.T) {
 		instance := buildTestInstance()
 		instance.Spec.NetworkZone = testName
-		capabilityProperties := &instance.Spec.Routing.CapabilityProperties
+		capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 		envVars := buildEnvs(NewStatefulSetProperties(instance, capabilityProperties,
 			"", "", "", "", "", nil, nil, nil))
 
@@ -200,8 +201,8 @@ func TestStatefulSet_Env(t *testing.T) {
 	})
 	t.Run(`with group`, func(t *testing.T) {
 		instance := buildTestInstance()
-		instance.Spec.Routing.Group = testValue
-		capabilityProperties := &instance.Spec.Routing.CapabilityProperties
+		instance.Spec.ActiveGate.Group = testValue
+		capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 		envVars := buildEnvs(NewStatefulSetProperties(instance, capabilityProperties,
 			"", "", "", "", "", nil, nil, nil))
 
@@ -216,7 +217,7 @@ func TestStatefulSet_Env(t *testing.T) {
 
 func TestStatefulSet_VolumeMounts(t *testing.T) {
 	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.Routing.CapabilityProperties
+	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 
 	t.Run(`without custom properties`, func(t *testing.T) {
 		volumeMounts := buildVolumeMounts(NewStatefulSetProperties(instance, capabilityProperties,
@@ -306,14 +307,14 @@ func TestStatefulSet_VolumeMounts(t *testing.T) {
 
 func TestStatefulSet_Resources(t *testing.T) {
 	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.Routing.CapabilityProperties
+	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 
 	quantityCpuLimit := resource.NewScaledQuantity(700, resource.Milli)
 	quantityMemoryLimit := resource.NewScaledQuantity(7, resource.Giga)
 	quantityCpuRequest := resource.NewScaledQuantity(500, resource.Milli)
 	quantityMemoryRequest := resource.NewScaledQuantity(5, resource.Giga)
 
-	instance.Spec.Routing.Resources = corev1.ResourceRequirements{
+	instance.Spec.ActiveGate.Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    *quantityCpuLimit,
 			corev1.ResourceMemory: *quantityMemoryLimit,
@@ -332,16 +333,28 @@ func TestStatefulSet_Resources(t *testing.T) {
 	assert.True(t, quantityMemoryRequest.Equal(container.Resources.Requests[corev1.ResourceMemory]))
 }
 
+func TestStatefulSet_DNSPolicy(t *testing.T) {
+	instance := buildTestInstance()
+	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
+
+	podSpec := buildTemplateSpec(NewStatefulSetProperties(instance, capabilityProperties, "", "", "", "", "", nil, nil, nil))
+
+	assert.Equal(t, testDNSPolicy, podSpec.DNSPolicy)
+}
+
 func buildTestInstance() *dynatracev1beta1.DynaKube {
 	replicas := int32(3)
-
 	return &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
 		},
 		Spec: dynatracev1beta1.DynaKubeSpec{
-			Routing: dynatracev1beta1.RoutingSpec{
+			ActiveGate: dynatracev1beta1.ActiveGateSpec{
+				Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+					dynatracev1beta1.RoutingCapability.DisplayName,
+				},
+				DNSPolicy: testDNSPolicy,
 				CapabilityProperties: dynatracev1beta1.CapabilityProperties{
 					Replicas:    &replicas,
 					Tolerations: []corev1.Toleration{{Value: testValue}},
@@ -351,7 +364,8 @@ func buildTestInstance() *dynatracev1beta1.DynaKube {
 					Env: []corev1.EnvVar{
 						{Name: testKey, Value: testValue},
 					},
-				}},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Adds the DNSPolicy option the the `Dynakube.Spec.ActivGate` section.
Updates the yamls accordingly.
Updates the `statefulset_test.go` to use not use the now deprecated `Dynakube.Spec.Routing` section.