### PR TITLE
Adds token scope check for activeGate features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.43.0
-          args: --build-tags integration,containers_image_storage_stub --timeout 300s --out-format json
+          args: --build-tags integration,containers_image_storage_stub --timeout 300s
 
   builddockerimage:
     name: Build docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.43.0
-          args: --build-tags integration,containers_image_storage_stub --timeout 300s
+          args: --build-tags integration,containers_image_storage_stub --timeout 300s --out-format json
 
   builddockerimage:
     name: Build docker image

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,4 +19,4 @@ linters:
   - misspell
 
 service:
-  golangci-lint-version: 1.31.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.43.x # use the fixed version to not introduce new linters unexpectedly

--- a/src/controllers/dynakube/dtclient_reconciler.go
+++ b/src/controllers/dynakube/dtclient_reconciler.go
@@ -144,6 +144,14 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance *dyn
 			}}
 	}
 
+	if instance.FeatureAutomaticKubernetesApiMonitoring() {
+		tokens[0].Scopes = append(tokens[0].Scopes, dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeEntitiesWrite)
+	}
+
+	if instance.IsActiveGateMode(dynatracev1beta1.MetricsIngestCapability.DisplayName) {
+		tokens[0].Scopes = append(tokens[0].Scopes, dtclient.TokenScopeMetricsIngest)
+	}
+
 	for _, token := range tokens {
 		updateCR = r.CheckToken(dtc, token) || updateCR
 	}

--- a/src/controllers/dynakube/dtclient_reconciler.go
+++ b/src/controllers/dynakube/dtclient_reconciler.go
@@ -144,7 +144,8 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance *dyn
 			}}
 	}
 
-	if instance.FeatureAutomaticKubernetesApiMonitoring() {
+	if instance.IsActiveGateMode(dynatracev1beta1.KubeMonCapability.DisplayName) &&
+		instance.FeatureAutomaticKubernetesApiMonitoring() {
 		tokens[0].Scopes = append(tokens[0].Scopes, dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeEntitiesWrite)
 	}
 

--- a/src/controllers/dynakube/dtclient_reconciler.go
+++ b/src/controllers/dynakube/dtclient_reconciler.go
@@ -144,7 +144,7 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance *dyn
 			}}
 	}
 
-	if instance.IsActiveGateMode(dynatracev1beta1.KubeMonCapability.DisplayName) &&
+	if instance.KubernetesMonitoringMode() &&
 		instance.FeatureAutomaticKubernetesApiMonitoring() {
 		tokens[0].Scopes = append(tokens[0].Scopes, dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeEntitiesWrite)
 	}

--- a/src/controllers/dynakube/dtclient_reconciler_test.go
+++ b/src/controllers/dynakube/dtclient_reconciler_test.go
@@ -216,6 +216,71 @@ func TestReconcileDynatraceClient_TokenValidation(t *testing.T) {
 			"Token on secret dynatrace:dynakube missing scopes [WriteConfig]")
 		mock.AssertExpectationsForObjects(t, dtcMock)
 	})
+	t.Run("API token has missing scope for automatic kubernetes api monitoring", func(t *testing.T) {
+		dk := base.DeepCopy()
+		dk.Annotations = map[string]string{
+			"alpha.operator.dynatrace.com/feature-automatic-kubernetes-api-monitoring": "true",
+		}
+		c := fake.NewClient(NewSecret(dynaKube, namespace, map[string]string{dtclient.DynatracePaasToken: "42", dtclient.DynatraceApiToken: "84"}))
+
+		dtcMock := &dtclient.MockDynatraceClient{}
+		dtcMock.On("GetTokenScopes", "42").Return(dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, nil)
+		dtcMock.On("GetTokenScopes", "84").Return(dtclient.TokenScopes{dtclient.TokenScopeDataExport,
+			dtclient.TokenScopeReadConfig,
+			dtclient.TokenScopeWriteConfig,
+			dtclient.TokenScopeEntitiesWrite,
+		}, nil)
+
+		rec := &DynatraceClientReconciler{
+			Client:              c,
+			DynatraceClientFunc: StaticDynatraceClient(dtcMock),
+			Now:                 metav1.Now(),
+		}
+
+		dtc, ucr, err := rec.Reconcile(context.TODO(), dk)
+		assert.Equal(t, dtcMock, dtc)
+		assert.True(t, ucr)
+		assert.NoError(t, err)
+		assert.False(t, rec.ValidTokens)
+
+		AssertCondition(t, dk, dynatracev1beta1.PaaSTokenConditionType, true, dynatracev1beta1.ReasonTokenReady, "Ready")
+		AssertCondition(t, dk, dynatracev1beta1.APITokenConditionType, false, dynatracev1beta1.ReasonTokenScopeMissing,
+			"Token on secret dynatrace:dynakube missing scopes [entities.read]")
+		mock.AssertExpectationsForObjects(t, dtcMock)
+	})
+	t.Run("API token has missing scope for metrics ingest", func(t *testing.T) {
+		dk := base.DeepCopy()
+		dk.Spec.ActiveGate = dynatracev1beta1.ActiveGateSpec{
+			Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+				dynatracev1beta1.MetricsIngestCapability.DisplayName,
+			},
+		}
+		c := fake.NewClient(NewSecret(dynaKube, namespace, map[string]string{dtclient.DynatracePaasToken: "42", dtclient.DynatraceApiToken: "84"}))
+
+		dtcMock := &dtclient.MockDynatraceClient{}
+		dtcMock.On("GetTokenScopes", "42").Return(dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, nil)
+		dtcMock.On("GetTokenScopes", "84").Return(dtclient.TokenScopes{dtclient.TokenScopeDataExport,
+			dtclient.TokenScopeReadConfig,
+			dtclient.TokenScopeWriteConfig,
+		}, nil)
+
+		rec := &DynatraceClientReconciler{
+			Client:              c,
+			DynatraceClientFunc: StaticDynatraceClient(dtcMock),
+			Now:                 metav1.Now(),
+		}
+
+		dtc, ucr, err := rec.Reconcile(context.TODO(), dk)
+		assert.Equal(t, dtcMock, dtc)
+		assert.True(t, ucr)
+		assert.NoError(t, err)
+		assert.False(t, rec.ValidTokens)
+
+		AssertCondition(t, dk, dynatracev1beta1.PaaSTokenConditionType, true, dynatracev1beta1.ReasonTokenReady, "Ready")
+		AssertCondition(t, dk, dynatracev1beta1.APITokenConditionType, false, dynatracev1beta1.ReasonTokenScopeMissing,
+			"Token on secret dynatrace:dynakube missing scopes [metrics.ingest]")
+		mock.AssertExpectationsForObjects(t, dtcMock)
+	})
 }
 
 func TestReconcileDynatraceClient_ProbeRequests(t *testing.T) {

--- a/src/controllers/dynakube/dtclient_reconciler_test.go
+++ b/src/controllers/dynakube/dtclient_reconciler_test.go
@@ -221,6 +221,9 @@ func TestReconcileDynatraceClient_TokenValidation(t *testing.T) {
 		dk.Annotations = map[string]string{
 			"alpha.operator.dynatrace.com/feature-automatic-kubernetes-api-monitoring": "true",
 		}
+		dk.Spec.ActiveGate = dynatracev1beta1.ActiveGateSpec{
+			Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.KubeMonCapability.DisplayName},
+		}
 		c := fake.NewClient(NewSecret(dynaKube, namespace, map[string]string{dtclient.DynatracePaasToken: "42", dtclient.DynatraceApiToken: "84"}))
 
 		dtcMock := &dtclient.MockDynatraceClient{}

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -275,6 +275,7 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 		dtclient.TokenScopes{dtclient.TokenScopeDataExport,
 			dtclient.TokenScopeReadConfig,
 			dtclient.TokenScopeWriteConfig,
+			dtclient.TokenScopeMetricsIngest,
 		})
 	instance := &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{

--- a/src/dtclient/client.go
+++ b/src/dtclient/client.go
@@ -107,6 +107,9 @@ const (
 	TokenScopeDataExport        = "DataExport"
 	TokenScopeReadConfig        = "ReadConfig"
 	TokenScopeWriteConfig       = "WriteConfig"
+	TokenScopeMetricsIngest     = "metrics.ingest"
+	TokenScopeEntitiesRead      = "entities.read"
+	TokenScopeEntitiesWrite     = "entities.write"
 )
 
 // NewClient creates a REST client for the given API base URL and authentication tokens.

--- a/src/dtclient/tenant.go
+++ b/src/dtclient/tenant.go
@@ -34,11 +34,7 @@ func (dtc *dynatraceClient) GetTenantInfo() (*TenantInfo, error) {
 
 	data, err := dtc.getServerResponseData(response)
 	if err != nil {
-		err = dtc.handleErrorResponseFromAPI(data, response.StatusCode)
-		if err != nil {
-			log.Error(err, err.Error())
-		}
-		return nil, errors.WithStack(err)
+		return nil, errors.WithStack(dtc.handleErrorResponseFromAPI(data, response.StatusCode))
 	}
 
 	tenantInfo, err := dtc.readResponseForTenantInfo(data)


### PR DESCRIPTION
In case of select activeGate features the apiToken needs special scopes, if these are not present we notify the user

Automatic kubernetes api monitoring need:
`entities.read`
`entities.write`

Metrics ingest need:
`metrics.ingest`
