### PR TITLE
Add missing conversion of env section

### DIFF
--- a/src/api/v1beta1/dynakube_conversion.go
+++ b/src/api/v1beta1/dynakube_conversion.go
@@ -33,6 +33,7 @@ func (src *DynaKube) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.ClassicFullStack.Tolerations = src.Spec.OneAgent.ClassicFullStack.Tolerations
 		dst.Spec.ClassicFullStack.Resources = src.Spec.OneAgent.ClassicFullStack.OneAgentResources
 		dst.Spec.ClassicFullStack.Args = src.Spec.OneAgent.ClassicFullStack.Args
+		dst.Spec.ClassicFullStack.Env = src.Spec.OneAgent.ClassicFullStack.Env
 		dst.Spec.ClassicFullStack.DNSPolicy = src.Spec.OneAgent.ClassicFullStack.DNSPolicy
 		dst.Spec.ClassicFullStack.Labels = src.Spec.OneAgent.ClassicFullStack.Labels
 	}
@@ -135,6 +136,7 @@ func (dst *DynaKube) ConvertFrom(srcRaw conversion.Hub) error {
 		dst.Spec.OneAgent.ClassicFullStack.Tolerations = src.Spec.ClassicFullStack.Tolerations
 		dst.Spec.OneAgent.ClassicFullStack.OneAgentResources = src.Spec.ClassicFullStack.Resources
 		dst.Spec.OneAgent.ClassicFullStack.Args = src.Spec.ClassicFullStack.Args
+		dst.Spec.OneAgent.ClassicFullStack.Env = src.Spec.ClassicFullStack.Env
 		dst.Spec.OneAgent.ClassicFullStack.DNSPolicy = src.Spec.ClassicFullStack.DNSPolicy
 		dst.Spec.OneAgent.ClassicFullStack.Labels = src.Spec.ClassicFullStack.Labels
 	}

--- a/src/api/v1beta1/dynakube_conversion_test.go
+++ b/src/api/v1beta1/dynakube_conversion_test.go
@@ -209,6 +209,7 @@ func TestConversion_ConvertFrom(t *testing.T) {
 	assert.Equal(t, oldDynakube.Spec.ClassicFullStack.Tolerations, convertedDynakube.Spec.OneAgent.ClassicFullStack.Tolerations)
 	assert.Equal(t, oldDynakube.Spec.ClassicFullStack.Resources, convertedDynakube.Spec.OneAgent.ClassicFullStack.OneAgentResources)
 	assert.Equal(t, oldDynakube.Spec.ClassicFullStack.Args, convertedDynakube.Spec.OneAgent.ClassicFullStack.Args)
+	assert.Equal(t, oldDynakube.Spec.ClassicFullStack.Env, convertedDynakube.Spec.OneAgent.ClassicFullStack.Env)
 	assert.Equal(t, oldDynakube.Spec.ClassicFullStack.DNSPolicy, convertedDynakube.Spec.OneAgent.ClassicFullStack.DNSPolicy)
 	assert.Equal(t, oldDynakube.Spec.ClassicFullStack.Labels, convertedDynakube.Spec.OneAgent.ClassicFullStack.Labels)
 
@@ -432,6 +433,7 @@ func TestConversion_ConvertTo(t *testing.T) {
 	assert.Equal(t, oldDynakube.Spec.OneAgent.ClassicFullStack.Tolerations, convertedDynakube.Spec.ClassicFullStack.Tolerations)
 	assert.Equal(t, oldDynakube.Spec.OneAgent.ClassicFullStack.OneAgentResources, convertedDynakube.Spec.ClassicFullStack.Resources)
 	assert.Equal(t, oldDynakube.Spec.OneAgent.ClassicFullStack.Args, convertedDynakube.Spec.ClassicFullStack.Args)
+	assert.Equal(t, oldDynakube.Spec.OneAgent.ClassicFullStack.Env, convertedDynakube.Spec.ClassicFullStack.Env)
 	assert.Equal(t, oldDynakube.Spec.OneAgent.ClassicFullStack.DNSPolicy, convertedDynakube.Spec.ClassicFullStack.DNSPolicy)
 	assert.Equal(t, oldDynakube.Spec.OneAgent.ClassicFullStack.Labels, convertedDynakube.Spec.ClassicFullStack.Labels)
 


### PR DESCRIPTION
`env` section was ignored during conversion