### PR TITLE
Remove metric-ingest capability from non-preview samples for 0.4

### DIFF
--- a/config/samples/applicationMonitoring.yaml
+++ b/config/samples/applicationMonitoring.yaml
@@ -82,7 +82,7 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - metrics-ingest
+#      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/classicFullStack.yaml
+++ b/config/samples/classicFullStack.yaml
@@ -116,7 +116,7 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - metrics-ingest
+#      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/hostMonitoring.yaml
+++ b/config/samples/hostMonitoring.yaml
@@ -116,7 +116,7 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - metrics-ingest
+#      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""


### PR DESCRIPTION
For samples that are using a non-preview mode, the `metrics-ingest` capability should be disabled by default as it's in preview.
It's now only enabled for samples with `cloudNativeFullStack`.