### PR TITLE
Brings helm up-to-speed

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -71,11 +71,11 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: {{ default "300m" .Values.csi.limits.cpu }}
-            memory: {{ default "100Mi" .Values.csi.limits.memory }}
+            cpu: {{ default "300m" ((.Values.csi).limits).cpu }}
+            memory: {{ default "100Mi" ((.Values.csi).limits).memory }}
           requests:
-            cpu: {{ default "300m" .Values.csi.requests.cpu }}
-            memory: {{ default "100Mi" .Values.csi.requests.memory }}
+            cpu: {{ default "300m" ((.Values.csi).requests).cpu }}
+            memory: {{ default "100Mi" ((.Values.csi).requests).memory }}
         securityContext:
           privileged: true
           runAsUser: 0

--- a/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
@@ -60,8 +60,7 @@ spec:
   namespaceSelector: {{ .Values.namespaceSelector | toYaml | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.activeGate }}
-  {{- if .Values.activeGate.capabilities }} {{/* For compatibility between 0.2.3 and 0.3.0 */}}
+  {{- if (.Values.activeGate).capabilities }}
   {{- if ge (len .Values.activeGate.capabilities) 1 }}
   activeGate:
 
@@ -114,11 +113,9 @@ spec:
     {{- end }}
   {{- end }}
   {{- end }}
-  {{- end }}
 
   oneAgent:
-    {{- if .Values.cloudNativeFullStack }} {{/* For compatibility between 0.2.3 and 0.3.0 */}}
-    {{- if.Values.cloudNativeFullStack.enabled }}
+    {{- if (.Values.cloudNativeFullStack).enabled }}
     cloudNativeFullStack:
       {{- if .Values.cloudNativeFullStack.version }}
       version: {{.Values.cloudNativeFullStack.version}}
@@ -162,10 +159,8 @@ spec:
       initResources: {{ .Values.cloudNativeFullStack.initResources | toYaml | nindent 10 }}
       {{- end }}
     {{- end }}
-    {{- end }}
 
-    {{- if .Values.applicationMonitoring }} {{/* For compatibility between 0.2.3 and 0.3.0 */}}
-    {{- if .Values.applicationMonitoring.enabled }}
+    {{- if (.Values.applicationMonitoring).enabled }}
     applicationMonitoring:
       {{- if .Values.applicationMonitoring.image }}
       image: {{.Values.applicationMonitoring.image}}
@@ -181,10 +176,8 @@ spec:
       initResources: {{ .Values.applicationMonitoring.initResources | toYaml | nindent 10 }}
       {{- end }}
     {{- end }}
-    {{- end }}
 
-    {{- if .Values.hostMonitoring }} {{/* For compatibility between 0.2.3 and 0.3.0 */}}
-    {{- if .Values.hostMonitoring.enabled }}
+    {{- if (.Values.hostMonitoring).enabled }}
     hostMonitoring:
       {{- if .Values.hostMonitoring.image }}
       image: {{.Values.hostMonitoring.image}}
@@ -227,7 +220,6 @@ spec:
       {{- if .Values.hostMonitoring.labels }}
       labels: {{ .Values.hostMonitoring.labels | toYaml | nindent 8 }}
       {{- end }}
-    {{- end }}
     {{- end }}
 
   {{- if .Values.classicFullStack.enabled }}

--- a/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     {{- if ne .Values.platform "google"}}
     "helm.sh/hook": post-install,post-upgrade
-    {{ end }}
+    {{- end }}
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -61,11 +61,11 @@ spec:
               name: server-port
           resources:
             requests:
-              cpu: {{ default "50m" .Values.operator.requests.cpu }}
-              memory: {{ default "64Mi" .Values.operator.requests.memory }}
+              cpu: {{ default "50m" ((.Values.operator).requests).cpu }}
+              memory: {{ default "64Mi" ((.Values.operator).requests).memory }}
             limits:
-              cpu: {{ default "100m" .Values.operator.limits.cpu }}
-              memory: {{ default "128Mi" .Values.operator.limits.memory }}
+              cpu: {{ default "100m" ((.Values.operator).limits).cpu }}
+              memory: {{ default "128Mi" ((.Values.operator).limits).memory }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/config/helm/chart/default/templates/Common/secret.yaml
+++ b/config/helm/chart/default/templates/Common/secret.yaml
@@ -22,7 +22,12 @@ metadata:
   {{- include "dynatrace-operator.labels" . | nindent 4 }}
 data:
   apiToken: {{ required "apiToken is required for generating secret" (.Values.apiToken | b64enc) }}
-  paasToken: {{ required "paasToken is required for generating secret" (.Values.paasToken | b64enc) }}
+  {{- if .Values.paasToken }}
+  paasToken: {{ .Values.paasToken | b64enc }}
+  {{- end }}
+  {{- if .Values.dataIngestToken }}
+  dataIngestToken: {{ .Values.dataIngestToken | b64enc }}
+  {{- end }}
   {{- if .Values.proxy }}
   proxy: {{ .Values.proxy | b64enc }}
   {{- end }}

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -89,11 +89,11 @@ spec:
               containerPort: 8443
           resources:
             requests:
-              cpu: {{ default "300m" .Values.webhook.requests.cpu }}
-              memory: {{ default "128Mi" .Values.webhook.requests.memory }}
+              cpu: {{ default "300m" ((.Values.webhook).requests).cpu }}
+              memory: {{ default "128Mi" ((.Values.webhook).requests).memory }}
             limits:
-              cpu: {{ default "300m" .Values.webhook.limits.cpu }}
-              memory: {{ default "128Mi" .Values.webhook.limits.memory }}
+              cpu: {{ default "300m" ((.Values.webhook).limits).cpu }}
+              memory: {{ default "128Mi" ((.Values.webhook).limits).memory }}
       serviceAccountName: dynatrace-webhook
       {{- if .Values.operator.customPullSecret }}
       imagePullSecrets:

--- a/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_applicationmonitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_applicationmonitoring_test.yaml
@@ -10,7 +10,7 @@ tests:
       applicationMonitoring.enabled: false
     asserts:
       - isNull:
-          path: spec.oneAgent.applicationMonitoring
+          path: spec.oneAgent
 
   - it: should exist if enabled
     set:

--- a/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_cloudnativefullstack.yaml
+++ b/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_cloudnativefullstack.yaml
@@ -10,7 +10,7 @@ tests:
       cloudNativeFullStack.enabled: false
     asserts:
       - isNull:
-          path: spec.oneAgent.cloudNativeFullStack
+          path: spec.oneAgent
 
   - it: should exist if enabled
     set:

--- a/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_hostmonitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_hostmonitoring_test.yaml
@@ -10,7 +10,7 @@ tests:
       hostMonitoring.enabled: false
     asserts:
       - isNull:
-          path: spec.oneAgent.hostMonitoring
+          path: spec.oneAgent
 
   - it: should exist if enabled
     set:

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -32,6 +32,7 @@ namespaceSelector: {}
 autoCreateSecret: true
 apiToken: ""
 paasToken: ""
+dataIngestToken: ""
 
 operator:
   image: ""
@@ -66,7 +67,7 @@ createSecurityContextConstraints: true # Only applicable for Openshift
 ### module properties
 
 classicFullStack:
-  enabled: true
+  enabled: false
   image: ""
   version: ""
   nodeSelector: {}


### PR DESCRIPTION
- Adds the `dataIngestToken` in the `values.yaml`
- Makes resource limit/requests setting logic nil safe
- classicFullStack in no longer on by default (causes too much confusion)
- Updates tests accordingly