### PR TITLE
Adapt readme for v0.4.0 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Depending on the version of the Dynatrace Operator, it supports the following pl
 The Dynatrace Operator acts on its separate namespace `dynatrace`. It holds the operator deployment and all dependent
 objects like permissions, custom resources and corresponding StatefulSets.
 
-#### Kubernetes
+### Installation
 
-<details><summary>Installation</summary>
+> For install instructions on Openshift, head to the [official help page](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/openshift/set-up-ocp-monitoring#set-up-openshift-monitoring)!
 
 To create the namespace and apply the operator run the following commands
 
@@ -80,134 +80,35 @@ $ kubectl -n dynatrace create secret generic dynakube --from-literal="apiToken=D
 The rollout of the Dynatrace components is governed by a custom resource of type `DynaKube`. This custom resource will
 contain parameters for various Dynatrace capabilities (OneAgent deployment mode, ActiveGate capabilities, etc.)
 
-Note: `.spec.tokens` denotes the name of the secret holding access tokens. If not specified Dynatrace Operator searches
-for a secret called like the DynaKube custom resource `.metadata.name`.
+> Note: `.spec.tokens` denotes the name of the secret holding access tokens.
+>
+> If not specified Dynatrace Operator searches for a secret called like the DynaKube custom resource `.metadata.name`.
 
 The recommended approach is using classic Fullstack injection to roll out Dynatrace to your cluster, available as [classicFullStack sample](config/samples/classicFullStack.yaml).
-
 In case you want to have adjustments please have a look at [our DynaKube Custom Resource examples](config/samples).
-Save one of the sample configurations, change the API url to your environment and apply it to your cluster.
 
+Save one of the sample configurations, change the API url to your environment and apply it to your cluster.
 ```sh
 $ kubectl apply -f cr.yaml
 ```
 
 For detailed instructions see
-our [official help page.](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/)
+our [official help page](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/).
 
-</details>
-<details><summary>Uninstall</summary>
 
 ## Uninstall dynatrace-operator
 
-Remove DynaKube custom resources and clean-up all remaining Dynatrace Operator specific objects:
+> For instructions on how to uninstall the dynatrace-operator on Openshift, head to the [official help page](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/openshift/set-up-ocp-monitoring#uninstall-dynatrace-operator)!
 
+Clean-up all Dynatrace Operator specific objects:
 ```sh
 $ kubectl delete -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes.yaml
 ```
 
-</details>
-
-#### OpenShift
-
-<details><summary>Installation</summary>
-
-To create the namespace and apply the operator run the following commands (for OpenShift 4.x)
-
+If the CSI driver was installed, the following command is required as well:
 ```sh
-$ oc adm new-project --node-selector="" dynatrace
-$ oc apply -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/openshift.yaml
+$ kubectl delete -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes-csi.yaml
 ```
-
-A secret holding tokens for authenticating to the Dynatrace cluster needs to be created upfront. Create access tokens of
-type *Dynatrace API* and *Platform as a Service* and use its values in the following commands respectively. For
-assistance please refere
-to [Create user-generated access tokens.](https://www.dynatrace.com/support/help/get-started/introduction/why-do-i-need-an-access-token-and-an-environment-id/#create-user-generated-access-tokens)
-
-Make sure the *Dynatrace API* token has the following permission:
-
-* Access problem and event feed, metrics and topology
-
-```sh
-$ oc -n dynatrace create secret generic dynakube --from-literal="apiToken=DYNATRACE_API_TOKEN" --from-literal="paasToken=PLATFORM_AS_A_SERVICE_TOKEN"
-```
-
-#### Create `DynaKube` custom resource for ActiveGate and OneAgent rollout
-
-The rollout of the Dynatrace components is governed by a custom resource of type `DynaKube`. This custom resource will
-contain parameters for various Dynatrace capabilities (API monitoring, routing, etc.)
-
-Note: `.spec.tokens` denotes the name of the secret holding access tokens. If not specified Dynatrace Operator searches
-for a secret called like the DynaKube custom resource `.metadata.name`.
-
-```yaml
-apiVersion: dynatrace.com/v1beta1
-kind: DynaKube
-metadata:
-  name: dynakube
-  namespace: dynatrace
-spec:
-  # Dynatrace apiUrl including the `/api` path at the end.
-  # For SaaS, set `YOUR_ENVIRONMENT_ID` to your environment ID.
-  # For Managed, change the apiUrl address.
-  # For instructions on how to determine the environment ID and how to configure the apiUrl address, see https://www.dynatrace.com/support/help/reference/dynatrace-concepts/environment-id/.
-  apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
-
-  # name of secret holding `apiToken` and `paasToken`
-  # if unset, name of custom resource is used
-  #
-  # tokens: ""
-
-  # Optional: Sets Network Zone for OneAgent and ActiveGate pods
-  # Make sure networkZones are enabled on your cluster before (see https://www.dynatrace.com/support/help/setup-and-configuration/network-zones/network-zones-basic-info/)
-  #
-  # networkZone: name-of-my-network-zone
-
-  oneAgent:
-    # enable classic fullstack monitoring and change its settings
-    # Cannot be used in conjunction with cloud-native fullstack monitoring, application-only monitoring or host monitoring
-    classicFullStack:
-
-      # Optional: tolerations to include with the OneAgent DaemonSet.
-      # See more here: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-      tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: Exists
-
-  # Configuration for ActiveGate instances.
-  activeGate:
-    # Enables listed ActiveGate capabilities
-    capabilities:
-      - routing
-      - kubernetes-monitoring
-
-```
-
-This is the most basic configuration for the DynaKube object. We recommend you to use classic Fullstack injection to roll out Dynatrace to your cluster, as shown in the example above.
-In case you want to have adjustments please have a look at [our DynaKube Custom Resource examples](config/samples).
-Save one of the sample configurations, change the API url to your environment and apply it to your cluster.
-
-```sh
-$ oc apply -f cr.yaml
-```
-
-For detailed instructions see
-our [official help page.](https://www.dynatrace.com/support/help/technology-support/cloud-platforms/openshift/monitor-openshift-environments/)
-
-</details>
-<details><summary>Uninstall</summary>
-
-## Uninstall dynatrace-operator
-
-Remove DynaKube custom resources and clean-up all remaining Dynatrace Operator specific objects:
-
-```sh
-$ oc delete -n dynatrace dynakube --all
-$ oc delete -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/openshift.yaml
-```
-
-</details>
 
 ## Hacking
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ or our [official help page.](https://www.dynatrace.com/support/help/setup-and-co
 
 Depending on the version of the Dynatrace Operator, it supports the following platforms:
 
-| Dynatrace Operator version | Kubernetes | OpenShift Container Platform               |
-| -------------------------- | ---------- | ------------------------------------------ |
-| master                     | 1.20+      | 4.7+                                       |
-| v0.3.0                     | 1.20+      | 4.7+                                       |
-| v0.2.2                     | 1.18+      | 3.11.188+, 4.5+                            |
-| v0.1.0                     | 1.18+      | 3.11.188+, 4.4+                            |
+| Dynatrace Operator version | Kubernetes | OpenShift Container Platform |
+|----------------------------|------------|------------------------------|
+| master                     | 1.21+      | 4.7+                         |
+| v0.4.0                     | 1.20+      | 4.7+                         |
+| v0.3.0                     | 1.20+      | 4.7+                         |
+| v0.2.2                     | 1.18+      | 3.11.188+, 4.5+              |
+| v0.1.0                     | 1.18+      | 3.11.188+, 4.4+              |
 
 ## Quick Start
 
@@ -49,72 +50,41 @@ $ kubectl create namespace dynatrace
 $ kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes.yaml
 ```
 
+If using `cloudNativeFullStack` or `applicationMonitoring` with CSI driver, the following command is required as well:
+```sh
+$ kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes-csi.yaml
+```
+
 A secret holding tokens for authenticating to the Dynatrace cluster needs to be created upfront. Create access tokens of
-type *Dynatrace API* and *Platform as a Service* and use its values in the following commands respectively. For
+type *Dynatrace API* and use its values in the following commands respectively. For
 assistance please refer
-to [Create user-generated access tokens.](https://www.dynatrace.com/support/help/get-started/introduction/why-do-i-need-an-access-token-and-an-environment-id/#create-user-generated-access-tokens)
+to [Create user-generated access tokens](https://www.dynatrace.com/support/help/get-started/access-tokens#create-api-token).
 
-Make sure the *Dynatrace API* token has the following permission:
+Make sure the tokens have the following permissions:
 
-* Access problem and event feed, metrics and topology
+* API Token
+  * Read Configuration
+  * Write Configuration
+  * Read Entities (if using automatic kubernetes api monitoring)
+  * Installer Download
+  * Access problem and event feed, metrics and topology
+* Data Ingest Token
+  * Ingest Metrics
 
 ```sh
-$ kubectl -n dynatrace create secret generic dynakube --from-literal="apiToken=DYNATRACE_API_TOKEN" --from-literal="paasToken=PLATFORM_AS_A_SERVICE_TOKEN"
+$ kubectl -n dynatrace create secret generic dynakube --from-literal="apiToken=DYNATRACE_API_TOKEN" --from-literal="dataIngestToken=DATA_INGEST_TOKEN"
 ```
 
 #### Create `DynaKube` custom resource for ActiveGate and OneAgent rollout
 
 The rollout of the Dynatrace components is governed by a custom resource of type `DynaKube`. This custom resource will
-contain parameters for various Dynatrace capabilities (API monitoring, routing, etc.)
+contain parameters for various Dynatrace capabilities (OneAgent deployment mode, ActiveGate capabilities, etc.)
 
 Note: `.spec.tokens` denotes the name of the secret holding access tokens. If not specified Dynatrace Operator searches
 for a secret called like the DynaKube custom resource `.metadata.name`.
 
-```yaml
-apiVersion: dynatrace.com/v1beta1
-kind: DynaKube
-metadata:
-  name: dynakube
-  namespace: dynatrace
-spec:
-  # Dynatrace apiUrl including the `/api` path at the end.
-  # For SaaS, set `YOUR_ENVIRONMENT_ID` to your environment ID.
-  # For Managed, change the apiUrl address.
-  # For instructions on how to determine the environment ID and how to configure the apiUrl address, see https://www.dynatrace.com/support/help/reference/dynatrace-concepts/environment-id/.
-  apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
+The recommended approach is using classic Fullstack injection to roll out Dynatrace to your cluster, available as [classicFullStack sample](config/samples/classicFullStack.yaml).
 
-  # name of secret holding `apiToken` and `paasToken`
-  # if unset, name of custom resource is used
-  #
-  # tokens: ""
-
-  # Optional: Sets Network Zone for OneAgent and ActiveGate pods
-  # Make sure networkZones are enabled on your cluster before (see https://www.dynatrace.com/support/help/setup-and-configuration/network-zones/network-zones-basic-info/)
-  #
-  # networkZone: name-of-my-network-zone
-
-  oneAgent:
-    # enable classic fullstack monitoring and change its settings
-    # Cannot be used in conjunction with cloud-native fullstack monitoring, application-only monitoring or host monitoring
-    classicFullStack:
-
-      # Optional: tolerations to include with the OneAgent DaemonSet.
-      # See more here: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-
-  # Configuration for ActiveGate instances.
-  activeGate:
-    # Enables listed ActiveGate capabilities
-    capabilities:
-      - routing
-      - kubernetes-monitoring
-
-```
-
-This is the most basic configuration for the DynaKube object. We recommend you to use classic Fullstack injection to roll out Dynatrace to your cluster, as shown in the example above.
 In case you want to have adjustments please have a look at [our DynaKube Custom Resource examples](config/samples).
 Save one of the sample configurations, change the API url to your environment and apply it to your cluster.
 
@@ -133,7 +103,6 @@ our [official help page.](https://www.dynatrace.com/support/help/setup-and-confi
 Remove DynaKube custom resources and clean-up all remaining Dynatrace Operator specific objects:
 
 ```sh
-$ kubectl delete -n dynatrace dynakube --all
 $ kubectl delete -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes.yaml
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ objects like permissions, custom resources and corresponding StatefulSets.
 ### Installation
 
 > For install instructions on Openshift, head to the
-> [official help page](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/openshift/set-up-ocp-monitoring#set-up-openshift-monitoring)!
+> [official help page](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/openshift/set-up-ocp-monitoring#set-up-openshift-monitoring)
 
 To create the namespace and apply the operator run the following commands
 
@@ -94,7 +94,7 @@ our [official help page](https://www.dynatrace.com/support/help/setup-and-config
 
 ## Uninstall dynatrace-operator
 
-> For instructions on how to uninstall the dynatrace-operator on Openshift, head to the [official help page](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/openshift/set-up-ocp-monitoring#uninstall-dynatrace-operator)!
+> For instructions on how to uninstall the dynatrace-operator on Openshift, head to the [official help page](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/openshift/set-up-ocp-monitoring#uninstall-dynatrace-operator)
 
 Clean-up all Dynatrace Operator specific objects:
 ```sh

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ The Dynatrace Operator supports rollout and lifecycle management of various Dyna
 
 * OneAgent
   * `classicFullStack` rolls out a OneAgent pod per node to monitor pods on it and the node itself
-  * `applicationMonitoring` is webhook based injection mechanism for automatic-app-only injection
-  * `hostMonitoring` is only monitoring the host in the cluster without app-only injection
+  * `applicationMonitoring` is a webhook based injection mechanism for automatic app-only injection
+    * (PREVIEW) CSI Driver can be enabled to cache OneAgent downloads per node
+  * `hostMonitoring` is only monitoring the hosts (i.e. nodes) in the cluster without app-only injection
   * (PREVIEW) `cloudNativeFullStack` is a combination of `applicationMonitoring` with CSI driver and `hostMonitoring`
 * ActiveGate
   * `routing` routes OneAgent traffic through the ActiveGate

--- a/README.md
+++ b/README.md
@@ -2,25 +2,20 @@
 
 # Dynatrace Operator
 
-The Dynatrace Operator supports rollout and lifecycle of various Dynatrace components in Kubernetes and OpenShift.
+The Dynatrace Operator supports rollout and lifecycle management of various Dynatrace components in Kubernetes and OpenShift.
 
-As of launch, the Dynatrace Operator can be used to deploy a containerized ActiveGate for Kubernetes API monitoring. New
-capabilities will be added to the Dynatrace Operator over time including metric routing, and API monitoring for AWS,
-Azure, GCP, and vSphere.
+* OneAgent
+  * `classicFullStack` rolls out a OneAgent pod per node to monitor pods on it and the node itself
+  * `applicationMonitoring` is webhook based injection mechanism for automatic-app-only injection
+  * `hostMonitoring` is only monitoring the host in the cluster without app-only injection
+  * (PREVIEW) `cloudNativeFullStack` is a combination of `applicationMonitoring` with CSI driver and `hostMonitoring`
+* ActiveGate
+  * `routing` routes OneAgent traffic through the ActiveGate
+  * `kubernetes-monitoring` allows monitoring of the Kubernetes API
+  * (PREVIEW) `metrics-ingest` routes enriched metrics through ActiveGate
 
-With v0.2.0 we added the classicFullStack functionality which allows rolling out the OneAgent to your Kubernetes
-cluster. Furthermore, the Dynatrace Operator is now capable of rolling out a containerized ActiveGate for routing the
-OneAgent traffic.
-
-With v0.3.0 the CRD structure has been changed to provide an easier and more understandable way to deploy Dynatrace in your environment.
-- **routing** and **kubernetesMonitoring** within the Dynakube spec are deprecated now and moved to the **activeGate** section.
-- (combination with 'useCSIDriver' is still in PREVIEW) added **applicationMonitoring** mode, a webhook based injection mechanism for automatic-app-only injection
-- added **hostMonitoring** for only monitoring the host in the cluster without app-only injection
-- (PREVIEW) added **cloudNativeFullStack** mode, which combines **hostMonitoring**, with the webhook based **applicationMonitoring**
-
-For more information please have a look at [our DynaKube Custom Resource examples](config/samples),
-or our [official help page.](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/)
-
+For more information please have a look at [our DynaKube Custom Resource examples](config/samples) and
+our [official help page](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/).
 
 ## Supported platforms
 
@@ -29,7 +24,7 @@ Depending on the version of the Dynatrace Operator, it supports the following pl
 | Dynatrace Operator version | Kubernetes | OpenShift Container Platform |
 |----------------------------|------------|------------------------------|
 | master                     | 1.21+      | 4.7+                         |
-| v0.4.0                     | 1.20+      | 4.7+                         |
+| v0.4.0                     | 1.21+      | 4.7+                         |
 | v0.3.0                     | 1.20+      | 4.7+                         |
 | v0.2.2                     | 1.18+      | 3.11.188+, 4.5+              |
 | v0.1.0                     | 1.18+      | 3.11.188+, 4.4+              |
@@ -41,7 +36,8 @@ objects like permissions, custom resources and corresponding StatefulSets.
 
 ### Installation
 
-> For install instructions on Openshift, head to the [official help page](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/openshift/set-up-ocp-monitoring#set-up-openshift-monitoring)!
+> For install instructions on Openshift, head to the
+> [official help page](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/openshift/set-up-ocp-monitoring#set-up-openshift-monitoring)!
 
 To create the namespace and apply the operator run the following commands
 
@@ -61,7 +57,6 @@ assistance please refer
 to [Create user-generated access tokens](https://www.dynatrace.com/support/help/get-started/access-tokens#create-api-token).
 
 Make sure the tokens have the following permissions:
-
 * API Token
   * Read Configuration
   * Write Configuration


### PR DESCRIPTION
* Combine duplicate install/uninstall instruction
  * default is now Kubernetes, with link to official docs for Openshift instructions
* Fixed outdated links
* Add `v0.4.0` to version table
* Update instructions for required scopes and add `dataIngestToken`