### PR TITLE
Update image default registry in sample comments

### DIFF
--- a/config/samples/classicFullStack.yaml
+++ b/config/samples/classicFullStack.yaml
@@ -54,8 +54,8 @@ spec:
       #
       # version:
 
-      # Optional: to use a custom OneAgent Docker image. Defaults to docker.io/dynatrace/oneagent in
-      # Kubernetes and registry.connect.redhat.com/dynatrace/oneagent in OpenShift, if deployed via CSV
+      # Optional: to use a custom OneAgent Docker image. Defaults to the image from
+      # the Dynatrace cluster
       image: ""
 
       # Optional: node selector to control on which nodes the OneAgent will be deployed.

--- a/config/samples/hostMonitoring.yaml
+++ b/config/samples/hostMonitoring.yaml
@@ -54,8 +54,8 @@ spec:
       #
       # version:
 
-      # Optional: to use a custom OneAgent Docker image. Defaults to docker.io/dynatrace/oneagent in
-      # Kubernetes and registry.connect.redhat.com/dynatrace/oneagent in OpenShift, if deployed via CSV
+      # Optional: to use a custom OneAgent Docker image. Defaults to the image from
+      # the Dynatrace cluster
       image: ""
 
       # Optional: node selector to control on which nodes the OneAgent will be deployed.


### PR DESCRIPTION
The comment, that the default image registry is docker or redhat.connect in the samples is wrong, as the default location from which oneAgent images are pulled is the DT cluster.