### PR TITLE
Include build information in image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,13 +125,15 @@ jobs:
 
           build_date="$(date -u +"%Y-%m-%d %H:%M:%S+00:00")"
 
-          go_build_args="-ldflags=-X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${VERSION}' \
-          -X 'github.com/Dynatrace/dynatrace-operator/src/version.Commit=${GITHUB_SHA}' \
-          -X 'github.com/Dynatrace/dynatrace-operator/src/version.BuildDate=${build_date}' \
-          -linkmode external -extldflags '-static' -s -w"
+          go_build_args=(
+            "-ldflags=-X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${VERSION}'"
+            "-X 'github.com/Dynatrace/dynatrace-operator/src/version.Commit=${GITHUB_SHA}'"
+            "-X 'github.com/Dynatrace/dynatrace-operator/src/version.BuildDate=${build_date}'"
+            "-linkmode external -extldflags '-static' -s -w"
+          )
 
           # Set output parameters.
-          echo ::set-output name=goargs::${go_build_args}
+          echo ::set-output name=goargs::"${go_build_args[@]}"
           echo ::set-output name=labels::${LABELS}
 
           # Get licenses if no cache exists

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
             LABELS="quay.expires-after=10d"
           fi
 
-          build_date="$(date -u +"%Y-%m-%d %H:%M:%S+00:00")"
+          build_date="$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
 
           go_build_args=(
             "-ldflags=-X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${VERSION}'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,10 @@ jobs:
 
           build_date="$(date -u +"%Y-%m-%d %H:%M:%S+00:00")"
 
-          go_build_args="-linkmode external -extldflags '-static' -s -w \
-          -X 'github.com/Dynatrace/dynatrace-operator/version.Version=${VERSION}' \
-          -X 'github.com/Dynatrace/dynatrace-operator/version.Commit=${GITHUB_SHA}' \
-          -X 'github.com/Dynatrace/dynatrace-operator/version.BuildDate=${build_date}'"
+          go_build_args="-ldflags=-X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${VERSION}' \
+          -X 'github.com/Dynatrace/dynatrace-operator/src/version.Commit=${GITHUB_SHA}' \
+          -X 'github.com/Dynatrace/dynatrace-operator/src/version.BuildDate=${build_date}' \
+          -linkmode external -extldflags '-static' -s -w"
 
           # Set output parameters.
           echo ::set-output name=goargs::${go_build_args}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 # move previously cached go modules to gopath
 RUN if [ -d ./mod ]; then mkdir -p ${GOPATH}/pkg && [ -d mod ] && mv ./mod ${GOPATH}/pkg; fi;
 
-RUN CGO_ENABLED=1 go build -ldflags "${GO_BUILD_ARGS}" -o ./build/_output/bin/dynatrace-operator ./src/cmd/operator/
+RUN CGO_ENABLED=1 go build ${GO_BUILD_ARGS} -o ./build/_output/bin/dynatrace-operator ./src/cmd/operator/
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 # move previously cached go modules to gopath
 RUN if [ -d ./mod ]; then mkdir -p ${GOPATH}/pkg && [ -d mod ] && mv ./mod ${GOPATH}/pkg; fi;
 
-RUN CGO_ENABLED=1 go build ${GO_BUILD_ARGS} -o ./build/_output/bin/dynatrace-operator ./src/cmd/operator/
+RUN CGO_ENABLED=1 go build "${GO_BUILD_ARGS}" -o ./build/_output/bin/dynatrace-operator ./src/cmd/operator/
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/build/deploy_local.sh
+++ b/build/deploy_local.sh
@@ -7,7 +7,7 @@ if [[ ! "${TAG}" ]]; then
 fi
 
 commit=$(git rev-parse HEAD)
-build_date="$(date -u +"%Y-%m-%d %H:%M:%S+00:00")"
+build_date="$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
 go_build_args=(
   "-ldflags=-X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${TAG}'"
   "-X 'github.com/Dynatrace/dynatrace-operator/src/version.Commit=${commit}'"

--- a/build/deploy_local.sh
+++ b/build/deploy_local.sh
@@ -9,13 +9,14 @@ fi
 commit=$(git rev-parse HEAD)
 build_date="$(date -u +"%Y-%m-%d %H:%M:%S+00:00")"
 go_build_args=(
+  "-ldflags=-X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${TAG}'"
+  "-X 'github.com/Dynatrace/dynatrace-operator/src/version.Commit=${commit}'"
+  "-X 'github.com/Dynatrace/dynatrace-operator/src/version.BuildDate=${build_date}'"
   "-linkmode external -extldflags '-static' -s -w"
-  "-X 'github.com/Dynatrace/dynatrace-operator/version.Version=${TAG}'"
-  "-X 'github.com/Dynatrace/dynatrace-operator/version.Commit=${commit}'"
-  "-X 'github.com/Dynatrace/dynatrace-operator/version.BuildDate=${build_date}'"
 )
 base_image="dynatrace-operator"
 out_image="quay.io/dynatrace/dynatrace-operator:${TAG}"
+
 
 args="${go_build_args[@]}"
 if [[ "${LOCALBUILD}" ]]; then


### PR DESCRIPTION
* Update package path from `github.com/Dynatrace/dynatrace-operator/version` to `github.com/Dynatrace/dynatrace-operator/src/version`
* Move `-ldflags` to build args

Verify by checking for build information in the logs:
```
❯ kubectl logs deployment/dynatrace-operator
{"level":"info","ts":"2022-01-31T17:46:21.231Z","logger":"dynatrace-operator-version","msg":"dynatrace-operator","version":"latest","gitCommit":"4301342975c97392ca2bc878bd0653e1451c67a7","buildDate":"2022-01-31T17:39:11+00:00","goVersion":"go1.17.6","platform":"linux/amd64"}
```