### PR TITLE
Separate statsd-ingest capability from metrics-ingest

### DIFF
--- a/src/api/v1beta1/activegate_types.go
+++ b/src/api/v1beta1/activegate_types.go
@@ -22,7 +22,7 @@ var (
 	RoutingCapability = ActiveGateCapability{
 		DisplayName:  "routing",
 		ShortName:    "routing",
-		ArgumentName: "MSGrouter,extension_controller",
+		ArgumentName: "MSGrouter",
 	}
 
 	KubeMonCapability = ActiveGateCapability{
@@ -42,6 +42,12 @@ var (
 		ShortName:    "dynatrace-api",
 		ArgumentName: "restInterface",
 	}
+
+	StatsDIngestCapability = ActiveGateCapability{
+		DisplayName:  "statsd-ingest",
+		ShortName:    "statsd-ingest",
+		ArgumentName: "extension_controller",
+	}
 )
 
 var ActiveGateDisplayNames = map[CapabilityDisplayName]struct{}{
@@ -49,6 +55,7 @@ var ActiveGateDisplayNames = map[CapabilityDisplayName]struct{}{
 	KubeMonCapability.DisplayName:       {},
 	MetricsIngestCapability.DisplayName: {},
 	DynatraceApiCapability.DisplayName:  {},
+	StatsDIngestCapability.DisplayName:  {},
 }
 
 type ActiveGateSpec struct {

--- a/src/api/v1beta1/activegate_types.go
+++ b/src/api/v1beta1/activegate_types.go
@@ -43,7 +43,7 @@ var (
 		ArgumentName: "restInterface",
 	}
 
-	StatsDIngestCapability = ActiveGateCapability{
+	StatsdIngestCapability = ActiveGateCapability{
 		DisplayName:  "statsd-ingest",
 		ShortName:    "statsd-ingest",
 		ArgumentName: "extension_controller",
@@ -55,7 +55,7 @@ var ActiveGateDisplayNames = map[CapabilityDisplayName]struct{}{
 	KubeMonCapability.DisplayName:       {},
 	MetricsIngestCapability.DisplayName: {},
 	DynatraceApiCapability.DisplayName:  {},
-	StatsDIngestCapability.DisplayName:  {},
+	StatsdIngestCapability.DisplayName:  {},
 }
 
 type ActiveGateSpec struct {

--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -34,7 +34,6 @@ const (
 	annotationFeatureIgnoredNamespaces                = annotationFeaturePrefix + "ignored-namespaces"
 	annotationFeatureAutomaticKubernetesApiMonitoring = annotationFeaturePrefix + "automatic-kubernetes-api-monitoring"
 	annotationFeatureDisableMetadataEnrichment        = annotationFeaturePrefix + "disable-metadata-enrichment"
-	annotationFeatureEnableStatsDIngest               = annotationFeaturePrefix + "enable-statsd"
 	annotationFeatureUseActiveGateImageForStatsD      = annotationFeaturePrefix + "use-activegate-image-for-statsd"
 	AnnotationFeatureReadOnlyOneAgent                 = annotationFeaturePrefix + "oneagent-readonly-host-fs"
 )
@@ -119,12 +118,6 @@ func (dk *DynaKube) FeatureAutomaticKubernetesApiMonitoring() bool {
 // FeatureDisableMetadataEnrichment is a feature flag to disable metadata enrichment,
 func (dk *DynaKube) FeatureDisableMetadataEnrichment() bool {
 	return dk.Annotations[annotationFeatureDisableMetadataEnrichment] == "true"
-}
-
-// FeatureEnableStatsDIngest is a feature flag that makes the operator include 2 extra containers (Extension Controller and StatsD data source)
-// in the ActiveGate pod, and defines an extra UDP port in the AG service for StatsD packets.
-func (dk *DynaKube) FeatureEnableStatsDIngest() bool {
-	return dk.Annotations[annotationFeatureEnableStatsDIngest] == "true"
 }
 
 // FeatureUseActiveGateImageForStatsD is a feature flag that makes the operator use ActiveGate image when initializing Extension Controller and StatsD containers

--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -34,7 +34,7 @@ const (
 	annotationFeatureIgnoredNamespaces                = annotationFeaturePrefix + "ignored-namespaces"
 	annotationFeatureAutomaticKubernetesApiMonitoring = annotationFeaturePrefix + "automatic-kubernetes-api-monitoring"
 	annotationFeatureDisableMetadataEnrichment        = annotationFeaturePrefix + "disable-metadata-enrichment"
-	annotationFeatureUseActiveGateImageForStatsD      = annotationFeaturePrefix + "use-activegate-image-for-statsd"
+	annotationFeatureUseActiveGateImageForStatsd      = annotationFeaturePrefix + "use-activegate-image-for-statsd"
 	AnnotationFeatureReadOnlyOneAgent                 = annotationFeaturePrefix + "oneagent-readonly-host-fs"
 )
 
@@ -120,10 +120,10 @@ func (dk *DynaKube) FeatureDisableMetadataEnrichment() bool {
 	return dk.Annotations[annotationFeatureDisableMetadataEnrichment] == "true"
 }
 
-// FeatureUseActiveGateImageForStatsD is a feature flag that makes the operator use ActiveGate image when initializing Extension Controller and StatsD containers
+// FeatureUseActiveGateImageForStatsd is a feature flag that makes the operator use ActiveGate image when initializing Extension Controller and Statsd containers
 // (using special predefined entry points).
-func (dk *DynaKube) FeatureUseActiveGateImageForStatsD() bool {
-	return dk.Annotations[annotationFeatureUseActiveGateImageForStatsD] == "true"
+func (dk *DynaKube) FeatureUseActiveGateImageForStatsd() bool {
+	return dk.Annotations[annotationFeatureUseActiveGateImageForStatsd] == "true"
 }
 
 // FeatureReadOnlyOneAgent is a feature flag that makes the operator deploy the oneagents in a readonly mode, where the csi-driver provides the volume for logs and such,

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -295,3 +295,15 @@ func splitArg(arg string) (key, value string) {
 	value = split[1]
 	return
 }
+
+func (dk *DynaKube) NeedsStatsD() bool {
+	if dk.FeatureEnableStatsDIngest() {
+		return true
+	}
+	for _, capability := range dk.Spec.ActiveGate.Capabilities {
+		if capability == StatsDIngestCapability.DisplayName {
+			return true
+		}
+	}
+	return false
+}

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -83,8 +83,8 @@ func (dk *DynaKube) KubernetesMonitoringMode() bool {
 	return dk.IsActiveGateMode(KubeMonCapability.DisplayName) || dk.Spec.KubernetesMonitoring.Enabled
 }
 
-func (dk *DynaKube) NeedsStatsD() bool {
-	return dk.IsActiveGateMode(StatsDIngestCapability.DisplayName)
+func (dk *DynaKube) NeedsStatsd() bool {
+	return dk.IsActiveGateMode(StatsdIngestCapability.DisplayName)
 }
 
 func (dk *DynaKube) HasActiveGateTLS() bool {

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -83,6 +83,10 @@ func (dk *DynaKube) KubernetesMonitoringMode() bool {
 	return dk.IsActiveGateMode(KubeMonCapability.DisplayName) || dk.Spec.KubernetesMonitoring.Enabled
 }
 
+func (dk *DynaKube) NeedsStatsD() bool {
+	return dk.IsActiveGateMode(StatsDIngestCapability.DisplayName)
+}
+
 func (dk *DynaKube) HasActiveGateTLS() bool {
 	return dk.ActiveGateMode() && dk.Spec.ActiveGate.TlsSecretName != ""
 }
@@ -294,16 +298,4 @@ func splitArg(arg string) (key, value string) {
 	key = split[0]
 	value = split[1]
 	return
-}
-
-func (dk *DynaKube) NeedsStatsD() bool {
-	if dk.FeatureEnableStatsDIngest() {
-		return true
-	}
-	for _, capability := range dk.Spec.ActiveGate.Capabilities {
-		if capability == StatsDIngestCapability.DisplayName {
-			return true
-		}
-	}
-	return false
 }

--- a/src/controllers/activegate/capability/capability.go
+++ b/src/controllers/activegate/capability/capability.go
@@ -30,7 +30,7 @@ var activeGateCapabilities = map[dynatracev1beta1.CapabilityDisplayName]baseFunc
 	dynatracev1beta1.RoutingCapability.DisplayName:       routingBase,
 	dynatracev1beta1.MetricsIngestCapability.DisplayName: metricsIngestBase,
 	dynatracev1beta1.DynatraceApiCapability.DisplayName:  dynatraceApiBase,
-	dynatracev1beta1.StatsDIngestCapability.DisplayName:  statsDIngestBase,
+	dynatracev1beta1.StatsdIngestCapability.DisplayName:  statsdIngestBase,
 }
 
 type Configuration struct {
@@ -295,10 +295,10 @@ func dynatraceApiBase() *capabilityBase {
 	return &c
 }
 
-func statsDIngestBase() *capabilityBase {
+func statsdIngestBase() *capabilityBase {
 	c := capabilityBase{
-		shortName: dynatracev1beta1.StatsDIngestCapability.ShortName,
-		argName:   dynatracev1beta1.StatsDIngestCapability.ArgumentName,
+		shortName: dynatracev1beta1.StatsdIngestCapability.ShortName,
+		argName:   dynatracev1beta1.StatsdIngestCapability.ArgumentName,
 		Configuration: Configuration{
 			SetDnsEntryPoint:     true,
 			SetReadinessPort:     true,

--- a/src/controllers/activegate/capability/capability.go
+++ b/src/controllers/activegate/capability/capability.go
@@ -30,6 +30,7 @@ var activeGateCapabilities = map[dynatracev1beta1.CapabilityDisplayName]baseFunc
 	dynatracev1beta1.RoutingCapability.DisplayName:       routingBase,
 	dynatracev1beta1.MetricsIngestCapability.DisplayName: metricsIngestBase,
 	dynatracev1beta1.DynatraceApiCapability.DisplayName:  dynatraceApiBase,
+	dynatracev1beta1.StatsDIngestCapability.DisplayName:  statsDIngestBase,
 }
 
 type Configuration struct {
@@ -284,6 +285,20 @@ func dynatraceApiBase() *capabilityBase {
 	c := capabilityBase{
 		shortName: dynatracev1beta1.DynatraceApiCapability.ShortName,
 		argName:   dynatracev1beta1.DynatraceApiCapability.ArgumentName,
+		Configuration: Configuration{
+			SetDnsEntryPoint:     true,
+			SetReadinessPort:     true,
+			SetCommunicationPort: true,
+			CreateService:        true,
+		},
+	}
+	return &c
+}
+
+func statsDIngestBase() *capabilityBase {
+	c := capabilityBase{
+		shortName: dynatracev1beta1.StatsDIngestCapability.ShortName,
+		argName:   dynatracev1beta1.StatsDIngestCapability.ArgumentName,
 		Configuration: Configuration{
 			SetDnsEntryPoint:     true,
 			SetReadinessPort:     true,

--- a/src/controllers/activegate/capability/capability_test.go
+++ b/src/controllers/activegate/capability/capability_test.go
@@ -414,7 +414,7 @@ func TestNewMultiCapability(t *testing.T) {
 					Spec: dynatracev1beta1.DynaKubeSpec{
 						ActiveGate: dynatracev1beta1.ActiveGateSpec{
 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-								dynatracev1beta1.StatsDIngestCapability.DisplayName,
+								dynatracev1beta1.StatsdIngestCapability.DisplayName,
 							},
 						},
 					},
@@ -424,7 +424,7 @@ func TestNewMultiCapability(t *testing.T) {
 				capabilityBase: capabilityBase{
 					enabled:    true,
 					shortName:  MultiActiveGateName,
-					argName:    dynatracev1beta1.StatsDIngestCapability.ArgumentName,
+					argName:    dynatracev1beta1.StatsdIngestCapability.ArgumentName,
 					properties: props,
 					Configuration: Configuration{
 						SetDnsEntryPoint:     true,
@@ -498,7 +498,7 @@ func TestNewMultiCapability(t *testing.T) {
 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 								dynatracev1beta1.KubeMonCapability.DisplayName,
 								dynatracev1beta1.MetricsIngestCapability.DisplayName,
-								dynatracev1beta1.StatsDIngestCapability.DisplayName,
+								dynatracev1beta1.StatsdIngestCapability.DisplayName,
 								dynatracev1beta1.RoutingCapability.DisplayName,
 								dynatracev1beta1.DynatraceApiCapability.DisplayName,
 							},
@@ -513,7 +513,7 @@ func TestNewMultiCapability(t *testing.T) {
 					argName: strings.Join([]string{
 						dynatracev1beta1.KubeMonCapability.ArgumentName,
 						dynatracev1beta1.MetricsIngestCapability.ArgumentName,
-						dynatracev1beta1.StatsDIngestCapability.ArgumentName,
+						dynatracev1beta1.StatsdIngestCapability.ArgumentName,
 						dynatracev1beta1.RoutingCapability.ArgumentName,
 						dynatracev1beta1.DynatraceApiCapability.ArgumentName},
 						","),

--- a/src/controllers/activegate/capability/capability_test.go
+++ b/src/controllers/activegate/capability/capability_test.go
@@ -408,6 +408,35 @@ func TestNewMultiCapability(t *testing.T) {
 			},
 		},
 		{
+			name: "just statsd-ingest",
+			args: args{
+				dynakube: &dynatracev1beta1.DynaKube{
+					Spec: dynatracev1beta1.DynaKubeSpec{
+						ActiveGate: dynatracev1beta1.ActiveGateSpec{
+							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+								dynatracev1beta1.StatsDIngestCapability.DisplayName,
+							},
+						},
+					},
+				},
+			},
+			want: &MultiCapability{
+				capabilityBase: capabilityBase{
+					enabled:    true,
+					shortName:  MultiActiveGateName,
+					argName:    dynatracev1beta1.StatsDIngestCapability.ArgumentName,
+					properties: props,
+					Configuration: Configuration{
+						SetDnsEntryPoint:     true,
+						SetReadinessPort:     true,
+						SetCommunicationPort: true,
+						CreateService:        true,
+						ServiceAccountOwner:  "",
+					},
+				},
+			},
+		},
+		{
 			name: "just kubemon",
 			args: args{
 				dynakube: &dynatracev1beta1.DynaKube{
@@ -469,6 +498,7 @@ func TestNewMultiCapability(t *testing.T) {
 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 								dynatracev1beta1.KubeMonCapability.DisplayName,
 								dynatracev1beta1.MetricsIngestCapability.DisplayName,
+								dynatracev1beta1.StatsDIngestCapability.DisplayName,
 								dynatracev1beta1.RoutingCapability.DisplayName,
 								dynatracev1beta1.DynatraceApiCapability.DisplayName,
 							},
@@ -483,6 +513,7 @@ func TestNewMultiCapability(t *testing.T) {
 					argName: strings.Join([]string{
 						dynatracev1beta1.KubeMonCapability.ArgumentName,
 						dynatracev1beta1.MetricsIngestCapability.ArgumentName,
+						dynatracev1beta1.StatsDIngestCapability.ArgumentName,
 						dynatracev1beta1.RoutingCapability.ArgumentName,
 						dynatracev1beta1.DynatraceApiCapability.ArgumentName},
 						","),

--- a/src/controllers/activegate/internal/consts/consts.go
+++ b/src/controllers/activegate/internal/consts/consts.go
@@ -10,8 +10,8 @@ const (
 
 	EecContainerName = ActiveGateContainerName + "-eec"
 
-	StatsDContainerName    = ActiveGateContainerName + "-statsd"
-	StatsDIngestPortName   = "statsd"
-	StatsDIngestPort       = 18125
-	StatsDIngestTargetPort = "statsd-port"
+	StatsdContainerName    = ActiveGateContainerName + "-statsd"
+	StatsdIngestPortName   = "statsd"
+	StatsdIngestPort       = 18125
+	StatsdIngestTargetPort = "statsd-port"
 )

--- a/src/controllers/activegate/reconciler/capability/reconciler.go
+++ b/src/controllers/activegate/reconciler/capability/reconciler.go
@@ -98,18 +98,18 @@ func setCommunicationsPort(dk *dynatracev1beta1.DynaKube) events.StatefulSetEven
 				log.Info("Cannot find container in the StatefulSet", "container name", consts.ActiveGateContainerName)
 			}
 		}
-		if dk.NeedsStatsD() {
-			statsdContainer, err := getContainerByName(sts.Spec.Template.Spec.Containers, consts.StatsDContainerName)
+		if dk.NeedsStatsd() {
+			statsdContainer, err := getContainerByName(sts.Spec.Template.Spec.Containers, consts.StatsdContainerName)
 			if err == nil {
 				statsdContainer.Ports = []corev1.ContainerPort{
 					{
-						Name:          consts.StatsDIngestTargetPort,
-						ContainerPort: consts.StatsDIngestPort,
+						Name:          consts.StatsdIngestTargetPort,
+						ContainerPort: consts.StatsdIngestPort,
 						Protocol:      corev1.ProtocolUDP,
 					},
 				}
 			} else {
-				log.Info("Cannot find container in the StatefulSet", "container name", consts.StatsDContainerName)
+				log.Info("Cannot find container in the StatefulSet", "container name", consts.StatsdContainerName)
 			}
 		}
 	}

--- a/src/controllers/activegate/reconciler/capability/reconciler.go
+++ b/src/controllers/activegate/reconciler/capability/reconciler.go
@@ -98,7 +98,7 @@ func setCommunicationsPort(dk *dynatracev1beta1.DynaKube) events.StatefulSetEven
 				log.Info("Cannot find container in the StatefulSet", "container name", consts.ActiveGateContainerName)
 			}
 		}
-		if dk.FeatureEnableStatsDIngest() {
+		if dk.NeedsStatsD() {
 			statsdContainer, err := getContainerByName(sts.Spec.Template.Spec.Containers, consts.StatsDContainerName)
 			if err == nil {
 				statsdContainer.Ports = []corev1.ContainerPort{

--- a/src/controllers/activegate/reconciler/capability/reconciler_test.go
+++ b/src/controllers/activegate/reconciler/capability/reconciler_test.go
@@ -95,8 +95,8 @@ func TestReconcile(t *testing.T) {
 		}
 		return capabilities
 	}
-	setStatsDCapability := func(r *Reconciler, wantEnabled bool) {
-		statsdIngest := dynatracev1beta1.StatsDIngestCapability.DisplayName
+	setStatsdCapability := func(r *Reconciler, wantEnabled bool) {
+		statsdIngest := dynatracev1beta1.StatsdIngestCapability.DisplayName
 		hasEnabled := r.Instance.IsActiveGateMode(statsdIngest)
 		capabilities := &r.Instance.Spec.ActiveGate.Capabilities
 
@@ -121,11 +121,11 @@ func TestReconcile(t *testing.T) {
 		Port:       consts.HttpServicePort,
 		TargetPort: intstr.FromString(consts.HttpServicePortName),
 	}
-	statsDIngestServicePort := corev1.ServicePort{
-		Name:       consts.StatsDIngestPortName,
+	statsdIngestServicePort := corev1.ServicePort{
+		Name:       consts.StatsdIngestPortName,
 		Protocol:   corev1.ProtocolUDP,
-		Port:       consts.StatsDIngestPort,
-		TargetPort: intstr.FromString(consts.StatsDIngestTargetPort),
+		Port:       consts.StatsdIngestPort,
+		TargetPort: intstr.FromString(consts.StatsdIngestTargetPort),
 	}
 
 	t.Run(`reconcile custom properties`, func(t *testing.T) {
@@ -217,13 +217,13 @@ func TestReconcile(t *testing.T) {
 		}
 		reconcileAndExpectUpdate(r, false)
 
-		setStatsDCapability(r, true)
+		setStatsdCapability(r, true)
 		reconcileAndExpectUpdate(r, true)
 		{
 			service := assertServiceExists(r)
 			assert.Len(t, service.Spec.Ports, 3)
 			assert.ElementsMatch(t, service.Spec.Ports, []corev1.ServicePort{
-				agIngestServicePort, agIngestHttpServicePort, statsDIngestServicePort,
+				agIngestServicePort, agIngestHttpServicePort, statsdIngestServicePort,
 			})
 
 			statefulSet := assertStatefulSetExists(r)
@@ -234,7 +234,7 @@ func TestReconcile(t *testing.T) {
 		{
 			service := assertServiceExists(r)
 			assert.ElementsMatch(t, service.Spec.Ports, []corev1.ServicePort{
-				agIngestServicePort, agIngestHttpServicePort, statsDIngestServicePort,
+				agIngestServicePort, agIngestHttpServicePort, statsdIngestServicePort,
 			})
 
 			statefulSet := assertStatefulSetExists(r)
@@ -243,7 +243,7 @@ func TestReconcile(t *testing.T) {
 		reconcileAndExpectUpdate(r, false)
 		reconcileAndExpectUpdate(r, false)
 
-		setStatsDCapability(r, false)
+		setStatsdCapability(r, false)
 		reconcileAndExpectUpdate(r, true)
 		reconcileAndExpectUpdate(r, true)
 		reconcileAndExpectUpdate(r, false)
@@ -354,7 +354,7 @@ func TestGetContainerByName(t *testing.T) {
 		verify(t,
 			[]corev1.Container{
 				{Name: consts.ActiveGateContainerName},
-				{Name: consts.StatsDContainerName},
+				{Name: consts.StatsdContainerName},
 			},
 			consts.EecContainerName,
 			fmt.Sprintf(`Cannot find container "%s" in the provided slice (len 2)`, consts.EecContainerName),
@@ -364,9 +364,9 @@ func TestGetContainerByName(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		verify(t,
 			[]corev1.Container{
-				{Name: consts.StatsDContainerName},
+				{Name: consts.StatsdContainerName},
 			},
-			consts.StatsDContainerName,
+			consts.StatsdContainerName,
 			"",
 		)
 	})

--- a/src/controllers/activegate/reconciler/capability/service.go
+++ b/src/controllers/activegate/reconciler/capability/service.go
@@ -13,7 +13,7 @@ import (
 )
 
 func createService(instance *dynatracev1beta1.DynaKube, feature string) *corev1.Service {
-	enableStatsD := instance.NeedsStatsD()
+	enableStatsd := instance.NeedsStatsd()
 	ports := []corev1.ServicePort{
 		{
 			Name:       consts.HttpsServicePortName,
@@ -28,12 +28,12 @@ func createService(instance *dynatracev1beta1.DynaKube, feature string) *corev1.
 			TargetPort: intstr.FromString(consts.HttpServicePortName),
 		},
 	}
-	if enableStatsD {
+	if enableStatsd {
 		ports = append(ports, corev1.ServicePort{
-			Name:       consts.StatsDIngestPortName,
+			Name:       consts.StatsdIngestPortName,
 			Protocol:   corev1.ProtocolUDP,
-			Port:       consts.StatsDIngestPort,
-			TargetPort: intstr.FromString(consts.StatsDIngestTargetPort),
+			Port:       consts.StatsdIngestPort,
+			TargetPort: intstr.FromString(consts.StatsdIngestTargetPort),
 		})
 	}
 

--- a/src/controllers/activegate/reconciler/capability/service.go
+++ b/src/controllers/activegate/reconciler/capability/service.go
@@ -13,7 +13,7 @@ import (
 )
 
 func createService(instance *dynatracev1beta1.DynaKube, feature string) *corev1.Service {
-	enableStatsD := instance.FeatureEnableStatsDIngest()
+	enableStatsD := instance.NeedsStatsD()
 	ports := []corev1.ServicePort{
 		{
 			Name:       consts.HttpsServicePortName,

--- a/src/controllers/activegate/reconciler/capability/service_test.go
+++ b/src/controllers/activegate/reconciler/capability/service_test.go
@@ -55,19 +55,19 @@ func TestCreateService(t *testing.T) {
 			TargetPort: intstr.FromString(consts.HttpServicePortName),
 		},
 	)
-	if instance.NeedsStatsD() {
+	if instance.NeedsStatsd() {
 		assert.Contains(t, ports, corev1.ServicePort{
-			Name:       consts.StatsDIngestPortName,
+			Name:       consts.StatsdIngestPortName,
 			Protocol:   corev1.ProtocolUDP,
-			Port:       consts.StatsDIngestPort,
-			TargetPort: intstr.FromString(consts.StatsDIngestTargetPort),
+			Port:       consts.StatsdIngestPort,
+			TargetPort: intstr.FromString(consts.StatsdIngestTargetPort),
 		})
 	} else {
 		assert.NotContains(t, ports, corev1.ServicePort{
-			Name:       consts.StatsDIngestPortName,
+			Name:       consts.StatsdIngestPortName,
 			Protocol:   corev1.ProtocolUDP,
-			Port:       consts.StatsDIngestPort,
-			TargetPort: intstr.FromString(consts.StatsDIngestTargetPort),
+			Port:       consts.StatsdIngestPort,
+			TargetPort: intstr.FromString(consts.StatsdIngestTargetPort),
 		})
 	}
 }

--- a/src/controllers/activegate/reconciler/capability/service_test.go
+++ b/src/controllers/activegate/reconciler/capability/service_test.go
@@ -55,7 +55,7 @@ func TestCreateService(t *testing.T) {
 			TargetPort: intstr.FromString(consts.HttpServicePortName),
 		},
 	)
-	if instance.FeatureEnableStatsDIngest() {
+	if instance.NeedsStatsD() {
 		assert.Contains(t, ports, corev1.ServicePort{
 			Name:       consts.StatsDIngestPortName,
 			Protocol:   corev1.ProtocolUDP,

--- a/src/controllers/activegate/reconciler/statefulset/container_eec.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec.go
@@ -88,7 +88,7 @@ func (eec *ExtensionController) buildPorts() []corev1.ContainerPort {
 }
 
 func (eec *ExtensionController) buildCommand() []string {
-	if eec.stsProperties.DynaKube.FeatureUseActiveGateImageForStatsD() {
+	if eec.stsProperties.DynaKube.FeatureUseActiveGateImageForStatsd() {
 		return []string{
 			"/bin/bash", "/dt/eec/entrypoint.sh",
 		}

--- a/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
@@ -48,7 +48,7 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 
 	t.Run("volumes vs volume mounts", func(t *testing.T) {
 		eec := NewExtensionController(stsProperties)
-		statsd := NewStatsD(stsProperties)
+		statsd := NewStatsd(stsProperties)
 		volumes := buildVolumes(stsProperties, []kubeobjects.ContainerBuilder{eec, statsd})
 
 		container := eec.BuildContainer()

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd.go
@@ -9,28 +9,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const statsDProbesPortName = "statsd-probes"
-const statsDProbesPort = 14999
+const statsdProbesPortName = "statsd-probes"
+const statsdProbesPort = 14999
 
 const (
 	dataSourceMetadata = "ds-metadata"
 )
 
-var _ kubeobjects.ContainerBuilder = (*StatsD)(nil)
+var _ kubeobjects.ContainerBuilder = (*Statsd)(nil)
 
-type StatsD struct {
+type Statsd struct {
 	stsProperties *statefulSetProperties
 }
 
-func NewStatsD(stsProperties *statefulSetProperties) *StatsD {
-	return &StatsD{
+func NewStatsd(stsProperties *statefulSetProperties) *Statsd {
+	return &Statsd{
 		stsProperties: stsProperties,
 	}
 }
 
-func (statsd *StatsD) BuildContainer() corev1.Container {
+func (statsd *Statsd) BuildContainer() corev1.Container {
 	return corev1.Container{
-		Name:            consts.StatsDContainerName,
+		Name:            consts.StatsdContainerName,
 		Image:           statsd.stsProperties.DynaKube.ActiveGateImage(),
 		ImagePullPolicy: corev1.PullAlways,
 		Env:             statsd.buildEnvs(),
@@ -41,7 +41,7 @@ func (statsd *StatsD) BuildContainer() corev1.Container {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: "/readyz",
-					Port: intstr.IntOrString{IntVal: statsDProbesPort},
+					Port: intstr.IntOrString{IntVal: statsdProbesPort},
 				},
 			},
 			InitialDelaySeconds: 10,
@@ -54,7 +54,7 @@ func (statsd *StatsD) BuildContainer() corev1.Container {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: "/livez",
-					Port: intstr.IntOrString{IntVal: statsDProbesPort},
+					Port: intstr.IntOrString{IntVal: statsdProbesPort},
 				},
 			},
 			InitialDelaySeconds: 10,
@@ -66,7 +66,7 @@ func (statsd *StatsD) BuildContainer() corev1.Container {
 	}
 }
 
-func (statsd *StatsD) BuildVolumes() []corev1.Volume {
+func (statsd *Statsd) BuildVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{
 			Name: dataSourceMetadata,
@@ -77,8 +77,8 @@ func (statsd *StatsD) BuildVolumes() []corev1.Volume {
 	}
 }
 
-func (statsd *StatsD) buildCommand() []string {
-	if statsd.stsProperties.DynaKube.FeatureUseActiveGateImageForStatsD() {
+func (statsd *Statsd) buildCommand() []string {
+	if statsd.stsProperties.DynaKube.FeatureUseActiveGateImageForStatsd() {
 		return []string{
 			"/bin/bash", "/dt/statsd/entrypoint.sh",
 		}
@@ -86,14 +86,14 @@ func (statsd *StatsD) buildCommand() []string {
 	return nil
 }
 
-func (statsd *StatsD) buildPorts() []corev1.ContainerPort {
+func (statsd *Statsd) buildPorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
-		{Name: consts.StatsDIngestTargetPort, ContainerPort: consts.StatsDIngestPort},
-		{Name: statsDProbesPortName, ContainerPort: statsDProbesPort},
+		{Name: consts.StatsdIngestTargetPort, ContainerPort: consts.StatsdIngestPort},
+		{Name: statsdProbesPortName, ContainerPort: statsdProbesPort},
 	}
 }
 
-func (statsd *StatsD) buildVolumeMounts() []corev1.VolumeMount {
+func (statsd *Statsd) buildVolumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{Name: dataSourceStartupArguments, MountPath: "/mnt/dsexecargs"},
 		{Name: dataSourceAuthToken, MountPath: "/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources"},
@@ -101,10 +101,10 @@ func (statsd *StatsD) buildVolumeMounts() []corev1.VolumeMount {
 	}
 }
 
-func (statsd *StatsD) buildEnvs() []corev1.EnvVar {
+func (statsd *Statsd) buildEnvs() []corev1.EnvVar {
 	return []corev1.EnvVar{
-		{Name: "StatsDExecArgsPath", Value: "/mnt/dsexecargs/statsd.process.json"},
-		{Name: "ProbeServerPort", Value: fmt.Sprintf("%d", statsDProbesPort)},
-		{Name: "StatsDMetadataDir", Value: "/mnt/dsmetadata"},
+		{Name: "StatsdExecArgsPath", Value: "/mnt/dsexecargs/statsd.process.json"},
+		{Name: "ProbeServerPort", Value: fmt.Sprintf("%d", statsdProbesPort)},
+		{Name: "StatsdMetadataDir", Value: "/mnt/dsmetadata"},
 	}
 }

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStatsD_BuildContainerAndVolumes(t *testing.T) {
+func TestStatsd_BuildContainerAndVolumes(t *testing.T) {
 	assertion := assert.New(t)
 
 	instance := buildTestInstance()
@@ -19,7 +19,7 @@ func TestStatsD_BuildContainerAndVolumes(t *testing.T) {
 	)
 
 	t.Run("happy path", func(t *testing.T) {
-		statsd := NewStatsD(stsProperties)
+		statsd := NewStatsd(stsProperties)
 		container := statsd.BuildContainer()
 
 		assertion.NotEmpty(container.ReadinessProbe, "Expected readiness probe is defined")
@@ -29,9 +29,9 @@ func TestStatsD_BuildContainerAndVolumes(t *testing.T) {
 		assertion.Empty(container.StartupProbe, "Expected there is no startup probe")
 
 		for _, port := range []int32{
-			consts.StatsDIngestPort, statsDProbesPort,
+			consts.StatsdIngestPort, statsdProbesPort,
 		} {
-			assertion.Truef(kubeobjects.PortIsIn(container.Ports, port), "Expected that StatsD container defines port %d", port)
+			assertion.Truef(kubeobjects.PortIsIn(container.Ports, port), "Expected that Statsd container defines port %d", port)
 		}
 
 		for _, mountPath := range []string{
@@ -39,19 +39,19 @@ func TestStatsD_BuildContainerAndVolumes(t *testing.T) {
 			"/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources",
 			"/mnt/dsmetadata",
 		} {
-			assertion.Truef(kubeobjects.MountPathIsIn(container.VolumeMounts, mountPath), "Expected that StatsD container defines mount point %s", mountPath)
+			assertion.Truef(kubeobjects.MountPathIsIn(container.VolumeMounts, mountPath), "Expected that Statsd container defines mount point %s", mountPath)
 		}
 
 		for _, envVar := range []string{
-			"StatsDExecArgsPath", "ProbeServerPort", "StatsDMetadataDir",
+			"StatsdExecArgsPath", "ProbeServerPort", "StatsdMetadataDir",
 		} {
-			assertion.Truef(kubeobjects.EnvVarIsIn(container.Env, envVar), "Expected that StatsD container defined environment variable %s", envVar)
+			assertion.Truef(kubeobjects.EnvVarIsIn(container.Env, envVar), "Expected that Statsd container defined environment variable %s", envVar)
 		}
 	})
 
 	t.Run("volumes vs volume mounts", func(t *testing.T) {
 		eec := NewExtensionController(stsProperties)
-		statsd := NewStatsD(stsProperties)
+		statsd := NewStatsd(stsProperties)
 		volumes := buildVolumes(stsProperties, []kubeobjects.ContainerBuilder{eec, statsd})
 
 		container := statsd.BuildContainer()

--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -106,7 +106,7 @@ func CreateStatefulSet(stsProperties *statefulSetProperties) (*appsv1.StatefulSe
 }
 
 func getContainerBuilders(stsProperties *statefulSetProperties) []kubeobjects.ContainerBuilder {
-	if stsProperties.DynaKube.FeatureEnableStatsDIngest() {
+	if stsProperties.NeedsStatsD() {
 		return []kubeobjects.ContainerBuilder{
 			NewExtensionController(stsProperties),
 			NewStatsD(stsProperties),
@@ -252,7 +252,7 @@ func buildVolumeMounts(stsProperties *statefulSetProperties) []corev1.VolumeMoun
 		})
 	}
 
-	if stsProperties.DynaKube.FeatureEnableStatsDIngest() {
+	if stsProperties.NeedsStatsD() {
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{Name: eecAuthToken, MountPath: "/var/lib/dynatrace/gateway/config"},
 		)

--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -106,10 +106,10 @@ func CreateStatefulSet(stsProperties *statefulSetProperties) (*appsv1.StatefulSe
 }
 
 func getContainerBuilders(stsProperties *statefulSetProperties) []kubeobjects.ContainerBuilder {
-	if stsProperties.NeedsStatsD() {
+	if stsProperties.NeedsStatsd() {
 		return []kubeobjects.ContainerBuilder{
 			NewExtensionController(stsProperties),
-			NewStatsD(stsProperties),
+			NewStatsd(stsProperties),
 		}
 	}
 	return nil
@@ -252,7 +252,7 @@ func buildVolumeMounts(stsProperties *statefulSetProperties) []corev1.VolumeMoun
 		})
 	}
 
-	if stsProperties.NeedsStatsD() {
+	if stsProperties.NeedsStatsd() {
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{Name: eecAuthToken, MountPath: "/var/lib/dynatrace/gateway/config"},
 		)

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -99,10 +99,10 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 		corev1.NodeSelectorTerm{MatchExpressions: kubeobjects.AffinityNodeRequirement()})
 
 	assert.Equal(t, capabilityProperties.Tolerations, templateSpec.Tolerations)
-	assert.Equalf(t, instance.FeatureEnableStatsDIngest(), len(templateSpec.Volumes) > 0,
+	assert.Equalf(t, instance.NeedsStatsD(), len(templateSpec.Volumes) > 0,
 		"Expected that there are no volumes iff StatsD is disabled",
 	)
-	assert.Equalf(t, instance.FeatureEnableStatsDIngest(), kubeobjects.VolumeIsDefined(templateSpec.Volumes, eecAuthToken),
+	assert.Equalf(t, instance.NeedsStatsD(), kubeobjects.VolumeIsDefined(templateSpec.Volumes, eecAuthToken),
 		"Expected that volume mount %s has a predefined pod volume", eecAuthToken,
 	)
 	assert.NotEmpty(t, templateSpec.ImagePullSecrets)
@@ -124,10 +124,10 @@ func TestStatefulSet_Container(t *testing.T) {
 	assert.Equal(t, corev1.PullAlways, activeGateContainer.ImagePullPolicy)
 	assert.NotEmpty(t, activeGateContainer.Env)
 	assert.Empty(t, activeGateContainer.Args)
-	assert.Equalf(t, instance.FeatureEnableStatsDIngest(), len(activeGateContainer.VolumeMounts) > 0,
+	assert.Equalf(t, instance.NeedsStatsD(), len(activeGateContainer.VolumeMounts) > 0,
 		"Expected that there are no volume mounts iff StatsD is disabled",
 	)
-	assert.Equalf(t, instance.FeatureEnableStatsDIngest(), kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, "/var/lib/dynatrace/gateway/config"),
+	assert.Equalf(t, instance.NeedsStatsD(), kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, "/var/lib/dynatrace/gateway/config"),
 		"Expected that ActiveGate container defines mount point %s if and only if StatsD ingest is enabled", "/var/lib/dynatrace/gateway/config",
 	)
 	assert.NotNil(t, activeGateContainer.ReadinessProbe)

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -99,10 +99,10 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 		corev1.NodeSelectorTerm{MatchExpressions: kubeobjects.AffinityNodeRequirement()})
 
 	assert.Equal(t, capabilityProperties.Tolerations, templateSpec.Tolerations)
-	assert.Equalf(t, instance.NeedsStatsD(), len(templateSpec.Volumes) > 0,
-		"Expected that there are no volumes iff StatsD is disabled",
+	assert.Equalf(t, instance.NeedsStatsd(), len(templateSpec.Volumes) > 0,
+		"Expected that there are no volumes iff Statsd is disabled",
 	)
-	assert.Equalf(t, instance.NeedsStatsD(), kubeobjects.VolumeIsDefined(templateSpec.Volumes, eecAuthToken),
+	assert.Equalf(t, instance.NeedsStatsd(), kubeobjects.VolumeIsDefined(templateSpec.Volumes, eecAuthToken),
 		"Expected that volume mount %s has a predefined pod volume", eecAuthToken,
 	)
 	assert.NotEmpty(t, templateSpec.ImagePullSecrets)
@@ -124,11 +124,11 @@ func TestStatefulSet_Container(t *testing.T) {
 	assert.Equal(t, corev1.PullAlways, activeGateContainer.ImagePullPolicy)
 	assert.NotEmpty(t, activeGateContainer.Env)
 	assert.Empty(t, activeGateContainer.Args)
-	assert.Equalf(t, instance.NeedsStatsD(), len(activeGateContainer.VolumeMounts) > 0,
-		"Expected that there are no volume mounts iff StatsD is disabled",
+	assert.Equalf(t, instance.NeedsStatsd(), len(activeGateContainer.VolumeMounts) > 0,
+		"Expected that there are no volume mounts iff Statsd is disabled",
 	)
-	assert.Equalf(t, instance.NeedsStatsD(), kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, "/var/lib/dynatrace/gateway/config"),
-		"Expected that ActiveGate container defines mount point %s if and only if StatsD ingest is enabled", "/var/lib/dynatrace/gateway/config",
+	assert.Equalf(t, instance.NeedsStatsd(), kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, "/var/lib/dynatrace/gateway/config"),
+		"Expected that ActiveGate container defines mount point %s if and only if Statsd ingest is enabled", "/var/lib/dynatrace/gateway/config",
 	)
 	assert.NotNil(t, activeGateContainer.ReadinessProbe)
 }

--- a/src/webhook/validation/config.go
+++ b/src/webhook/validation/config.go
@@ -24,5 +24,6 @@ var validators = []validator{
 var warnings = []validator{
 	oneAgentModePreviewWarning,
 	metricIngestPreviewWarning,
+	statsdIngestPreviewWarning,
 	missingActiveGateMemoryLimit,
 }

--- a/src/webhook/validation/preview.go
+++ b/src/webhook/validation/preview.go
@@ -29,3 +29,11 @@ func metricIngestPreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta
 	}
 	return ""
 }
+
+func statsdIngestPreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+	if dynakube.IsActiveGateMode(dynatracev1beta1.StatsDIngestCapability.DisplayName) {
+		log.Info("DynaKube with statsd-ingest was applied, warning was provided.")
+		return fmt.Sprintf(featurePreviewWarningMessage, "statsd-ingest")
+	}
+	return ""
+}

--- a/src/webhook/validation/preview.go
+++ b/src/webhook/validation/preview.go
@@ -31,7 +31,7 @@ func metricIngestPreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta
 }
 
 func statsdIngestPreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
-	if dynakube.IsActiveGateMode(dynatracev1beta1.StatsDIngestCapability.DisplayName) {
+	if dynakube.IsActiveGateMode(dynatracev1beta1.StatsdIngestCapability.DisplayName) {
 		log.Info("DynaKube with statsd-ingest was applied, warning was provided.")
 		return fmt.Sprintf(featurePreviewWarningMessage, "statsd-ingest")
 	}


### PR DESCRIPTION
Extracted `statsd-ingest` capability from `metrics-ingest` and removed feature flag to control `statsd-ingest`.