### PR TITLE
Add VolumeAttribute to csi volume

### DIFF
--- a/src/controllers/csi/driver/config.go
+++ b/src/controllers/csi/driver/config.go
@@ -19,6 +19,9 @@ var (
 	memoryMetricTick = 5000 * time.Millisecond
 )
 
+// CSIVolumeAttributeName used for identifying the origin of the NodePublishVolume request
+const CSIVolumeAttributeName = "mode"
+
 func init() {
 	metrics.Registry.MustRegister(memoryUsageMetric)
 }

--- a/src/controllers/csi/driver/server.go
+++ b/src/controllers/csi/driver/server.go
@@ -145,21 +145,19 @@ func (svr *CSIDriverServer) NodePublishVolume(ctx context.Context, req *csi.Node
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
-	log.Info("publishing app volume",
-		"target", volumeCfg.TargetPath,
-		"fstype", req.GetVolumeCapability().GetMount().GetFsType(),
-		"readonly", req.GetReadonly(),
-		"volumeID", volumeCfg.VolumeId,
-		"attributes", req.GetVolumeContext(),
-		"mountflags", req.GetVolumeCapability().GetMount().GetMountFlags(),
-	)
-
-	response, err := svr.publishers[appvolumes.Mode].PublishVolume(ctx, volumeCfg)
-	if err != nil {
-		return nil, err
+	volumeAttributes := req.GetVolumeContext()
+	if volumeAttributes[CSIVolumeAttributeName] == appvolumes.Mode {
+		log.Info("publishing app volume",
+			"target", volumeCfg.TargetPath,
+			"fstype", req.GetVolumeCapability().GetMount().GetFsType(),
+			"readonly", req.GetReadonly(),
+			"volumeID", volumeCfg.VolumeId,
+			"attributes", req.GetVolumeContext(),
+			"mountflags", req.GetVolumeCapability().GetMount().GetMountFlags(),
+		)
+		return svr.publishers[appvolumes.Mode].PublishVolume(ctx, volumeCfg)
 	}
-
-	return response, nil
+	return &csi.NodePublishVolumeResponse{}, nil
 }
 
 func (svr *CSIDriverServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -13,6 +13,8 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
+	csidriver "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver"
+	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"
 	oneagent "github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
@@ -472,7 +474,8 @@ func ensureDynakubeVolume(dk dynatracev1beta1.DynaKube) (corev1.VolumeSource, st
 	mode := ""
 	if dk.NeedsCSIDriver() {
 		dkVol.CSI = &corev1.CSIVolumeSource{
-			Driver: dtcsi.DriverName,
+			Driver:           dtcsi.DriverName,
+			VolumeAttributes: map[string]string{csidriver.CSIVolumeAttributeName: appvolumes.Mode},
 		}
 		mode = provisionedVolumeMode
 	} else {

--- a/src/webhook/mutation/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator_test.go
@@ -9,6 +9,8 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
+	csidriver "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver"
+	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/src/ingestendpoint"
 	"github.com/Dynatrace/dynatrace-operator/src/mapper"
@@ -705,7 +707,8 @@ func addCSIVolumeSource(expected *corev1.Pod) {
 	if idx < len(expected.Spec.Volumes) {
 		expected.Spec.Volumes[idx].VolumeSource = corev1.VolumeSource{
 			CSI: &corev1.CSIVolumeSource{
-				Driver: dtcsi.DriverName,
+				Driver:           dtcsi.DriverName,
+				VolumeAttributes: map[string]string{csidriver.CSIVolumeAttributeName: appvolumes.Mode},
 			},
 		}
 	}
@@ -1307,7 +1310,8 @@ func buildResultPod(_ *testing.T, oneAgentFf FeatureFlag, dataIngestFf FeatureFl
 				Name: oneAgentBinVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					CSI: &corev1.CSIVolumeSource{
-						Driver: dtcsi.DriverName,
+						Driver:           dtcsi.DriverName,
+						VolumeAttributes: map[string]string{csidriver.CSIVolumeAttributeName: appvolumes.Mode},
 					},
 				},
 			},


### PR DESCRIPTION
There was no way to to differentiate what kind of volume (app or host) is mounted in the NodePublishVolume request of the CSI driver. This is now handled by adding VolumeAttributes within the webhook to the csi volume. These attribute is now checked in the PublishVolume request.