### PR TITLE
Send Mark for termination event also, when node is not found in the cluster anymore

### DIFF
--- a/src/controllers/nodes/nodes_controller.go
+++ b/src/controllers/nodes/nodes_controller.go
@@ -245,7 +245,7 @@ func (controller *NodesController) handleOutdatedCache(nodeCache *Cache) error {
 		// if node is not in cluster -> probably deleted
 		if !cachedNodeInCluster {
 			log.Info("Removing unfound cached node from cluster", "node", cachedNodeName)
-			controller.reconcileNodeDeletion(cachedNodeName)
+			return controller.reconcileNodeDeletion(cachedNodeName)
 		}
 	}
 	return nil

--- a/src/controllers/nodes/nodes_controller.go
+++ b/src/controllers/nodes/nodes_controller.go
@@ -227,7 +227,7 @@ func (controller *NodesController) handleOutdatedCache(nodeCache *Cache) error {
 	}
 
 	for _, cachedNodeName := range nodeCache.Keys() {
-		var cachedNodeInCluster = false
+		cachedNodeInCluster := false
 		for _, clusterNode := range nodeLst.Items {
 			if clusterNode.Name == cachedNodeName {
 				cachedNodeInfo, err := nodeCache.Get(cachedNodeName)

--- a/src/controllers/nodes/nodes_controller.go
+++ b/src/controllers/nodes/nodes_controller.go
@@ -245,7 +245,10 @@ func (controller *NodesController) handleOutdatedCache(nodeCache *Cache) error {
 		// if node is not in cluster -> probably deleted
 		if !cachedNodeInCluster {
 			log.Info("Removing unfound cached node from cluster", "node", cachedNodeName)
-			return controller.reconcileNodeDeletion(cachedNodeName)
+			err := controller.reconcileNodeDeletion(cachedNodeName)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Apparently we send the mark for termination event, also for nodes which we cached, but then could not be found in the cluster after sometime, therefor, we need to check and send the event, when the cache is periodically checked for outdated nodes aswell. 