### PR TITLE
Change logging condition when ensuring agProxySecret is deleted

### DIFF
--- a/src/agproxysecret/secret.go
+++ b/src/agproxysecret/secret.go
@@ -56,7 +56,8 @@ func (agProxySecretGenerator *ActiveGateProxySecretGenerator) EnsureDeleted(ctx 
 	secret := corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: dynakube.Namespace}}
 	if err := agProxySecretGenerator.client.Delete(ctx, &secret); err != nil && !k8serrors.IsNotFound(err) {
 		return err
-	} else if err != nil {
+	} else if err == nil {
+		// If the secret is deleted the error is nil, otherwise err is notFound, then we should log nothing
 		agProxySecretGenerator.logger.Info("removed secret", "namespace", dynakube.Namespace, "secret", secretName)
 	}
 	return nil


### PR DESCRIPTION
We currently log everytime reconciliation is called, that we deleted the agProxySecret, when its not in use. This is blowing up our logs. Therefore I changed the logging condition, that the log is only written, when the Secret is really removed