### PR TITLE
Value of DT_METRICS_INGEST_API_TOKEN environment variable defined by a secret reference instead of plain text

### DIFF
--- a/src/ingestendpoint/secret.go
+++ b/src/ingestendpoint/secret.go
@@ -118,7 +118,8 @@ func (g *EndpointSecretGenerator) prepare(ctx context.Context, dk *dynatracev1be
 	}
 
 	data := map[string][]byte{
-		configFile: endpointBuf.Bytes(),
+		configFile:       endpointBuf.Bytes(),
+		TokenSecretField: []byte(fields[TokenSecretField]),
 	}
 	return data, nil
 }

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -774,8 +774,15 @@ func updateContainerDataIngest(c *corev1.Container, pod *corev1.Pod, deploymentM
 			Value: dataIngestFields[dtingestendpoint.UrlSecretField],
 		},
 		corev1.EnvVar{
-			Name:  dtingestendpoint.TokenSecretField,
-			Value: dataIngestFields[dtingestendpoint.TokenSecretField],
+			Name: dtingestendpoint.TokenSecretField,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: dtingestendpoint.SecretEndpointName,
+					},
+					Key: dtingestendpoint.TokenSecretField,
+				},
+			},
 		},
 	)
 }

--- a/src/webhook/mutation/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator_test.go
@@ -1347,7 +1347,17 @@ func buildResultPod(_ *testing.T, oneAgentFf FeatureFlag, dataIngestFf FeatureFl
 
 		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env,
 			corev1.EnvVar{Name: dtingestendpoint.UrlSecretField, Value: "https://tenant.test-api-url.com/api/v2/metrics/ingest"},
-			corev1.EnvVar{Name: dtingestendpoint.TokenSecretField, Value: dataIngestToken},
+			corev1.EnvVar{
+				Name: dtingestendpoint.TokenSecretField,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: dtingestendpoint.SecretEndpointName,
+						},
+						Key: dtingestendpoint.TokenSecretField,
+					},
+				},
+			},
 		)
 
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts,


### PR DESCRIPTION
New field DT_METRICS_INGEST_API_TOKEN added to "secret/dynatrace-data-ingest-endpoint"
>    "data": {
>       "DT_METRICS_INGEST_API_TOKEN": "ZHQwYzA...",
>        "endpoint.properties": "RFRfT..."
>    },

where
- endpoint.properties field contains two properties
> DT_METRICS_INGEST_URL=https://dk...
> DT_METRICS_INGEST_API_TOKEN=dt...

  and is mounted to "/var/lib/dynatrace/enrichment/endpoint" path

- "DT_METRICS_INGEST_API_TOKEN" field is referenced by a secret reference.