### PR TITLE
Adds Extension Controller/StatsD logs to the ActiveGate support archive

### DIFF
--- a/src/controllers/activegate/reconciler/statefulset/container_eec.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec.go
@@ -11,6 +11,7 @@ import (
 
 const eecIngestPortName = "eec-http"
 const eecIngestPort = 14599
+const extensionsLogsDir = "/var/lib/dynatrace/remotepluginmodule/log/extensions"
 
 const activeGateInternalCommunicationPort = 9999
 
@@ -78,6 +79,12 @@ func (eec *ExtensionController) BuildVolumes() []corev1.Volume {
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
+		{
+			Name: "extensions-logs",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 	}
 }
 
@@ -105,10 +112,12 @@ func (eec *ExtensionController) buildCommand() []string {
 
 func (eec *ExtensionController) buildVolumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
-		{Name: eecAuthToken, MountPath: "/var/lib/dynatrace/gateway/config"},
+		{Name: eecAuthToken, MountPath: activeGateConfigDir},
 		{Name: dataSourceStartupArguments, MountPath: "/mnt/dsexecargs"},
 		{Name: dataSourceAuthToken, MountPath: "/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources"},
 		{Name: dataSourceMetadata, MountPath: "/opt/dynatrace/remotepluginmodule/agent/datasources/statsd", ReadOnly: true},
+		{Name: "extensions-logs", MountPath: extensionsLogsDir},
+		{Name: "statsd-logs", MountPath: statsDLogsDir, ReadOnly: true},
 	}
 }
 

--- a/src/controllers/activegate/reconciler/statefulset/container_eec.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec.go
@@ -20,6 +20,7 @@ const (
 
 	dataSourceStartupArguments = "eec-ds-shared"
 	dataSourceAuthToken        = "dsauthtokendir"
+	eecLogs                    = "extensions-logs"
 )
 
 var _ kubeobjects.ContainerBuilder = (*ExtensionController)(nil)
@@ -80,7 +81,7 @@ func (eec *ExtensionController) BuildVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: "extensions-logs",
+			Name: eecLogs,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -113,11 +114,11 @@ func (eec *ExtensionController) buildCommand() []string {
 func (eec *ExtensionController) buildVolumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{Name: eecAuthToken, MountPath: activeGateConfigDir},
-		{Name: dataSourceStartupArguments, MountPath: "/mnt/dsexecargs"},
-		{Name: dataSourceAuthToken, MountPath: "/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources"},
-		{Name: dataSourceMetadata, MountPath: "/opt/dynatrace/remotepluginmodule/agent/datasources/statsd", ReadOnly: true},
-		{Name: "extensions-logs", MountPath: extensionsLogsDir},
-		{Name: "statsd-logs", MountPath: statsDLogsDir, ReadOnly: true},
+		{Name: dataSourceStartupArguments, MountPath: dataSourceStartupArgsMountPoint},
+		{Name: dataSourceAuthToken, MountPath: dataSourceAuthTokenMountPoint},
+		{Name: dataSourceMetadata, MountPath: statsdMetadataMountPoint, ReadOnly: true},
+		{Name: eecLogs, MountPath: extensionsLogsDir},
+		{Name: dataSourceStatsdLogs, MountPath: statsDLogsDir, ReadOnly: true},
 	}
 }
 

--- a/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
@@ -31,10 +31,12 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 		}
 
 		for _, mountPath := range []string{
-			"/var/lib/dynatrace/gateway/config",
+			activeGateConfigDir,
 			"/mnt/dsexecargs",
 			"/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources",
 			"/opt/dynatrace/remotepluginmodule/agent/datasources/statsd",
+			extensionsLogsDir,
+			statsDLogsDir,
 		} {
 			assertion.Truef(kubeobjects.MountPathIsIn(container.VolumeMounts, mountPath), "Expected that EEC container defines mount point %s", mountPath)
 		}

--- a/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
@@ -32,9 +32,9 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 
 		for _, mountPath := range []string{
 			activeGateConfigDir,
-			"/mnt/dsexecargs",
-			"/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources",
-			"/opt/dynatrace/remotepluginmodule/agent/datasources/statsd",
+			dataSourceStartupArgsMountPoint,
+			dataSourceAuthTokenMountPoint,
+			statsdMetadataMountPoint,
 			extensionsLogsDir,
 			statsDLogsDir,
 		} {

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd.go
@@ -11,6 +11,7 @@ import (
 
 const statsdProbesPortName = "statsd-probes"
 const statsdProbesPort = 14999
+const statsDLogsDir = extensionsLogsDir + "/datasources-statsd"
 
 const (
 	dataSourceMetadata = "ds-metadata"
@@ -74,6 +75,12 @@ func (statsd *Statsd) BuildVolumes() []corev1.Volume {
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
+		{
+			Name: "statsd-logs",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 	}
 }
 
@@ -105,6 +112,7 @@ func (statsd *Statsd) buildVolumeMounts() []corev1.VolumeMount {
 		{Name: dataSourceStartupArguments, MountPath: "/mnt/dsexecargs"},
 		{Name: dataSourceAuthToken, MountPath: "/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources"},
 		{Name: dataSourceMetadata, MountPath: "/mnt/dsmetadata"},
+		{Name: "statsd-logs", MountPath: statsDLogsDir},
 	}
 }
 
@@ -113,5 +121,6 @@ func (statsd *Statsd) buildEnvs() []corev1.EnvVar {
 		{Name: "StatsdExecArgsPath", Value: "/mnt/dsexecargs/statsd.process.json"},
 		{Name: "ProbeServerPort", Value: fmt.Sprintf("%d", statsdProbesPort)},
 		{Name: "StatsdMetadataDir", Value: "/mnt/dsmetadata"},
+		{Name: "DsLogFile", Value: statsDLogsDir + "/dynatracesourcestatsd.log"},
 	}
 }

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd.go
@@ -14,7 +14,8 @@ const statsdProbesPort = 14999
 const statsDLogsDir = extensionsLogsDir + "/datasources-statsd"
 
 const (
-	dataSourceMetadata = "ds-metadata"
+	dataSourceMetadata   = "ds-metadata"
+	dataSourceStatsdLogs = "statsd-logs"
 )
 
 var _ kubeobjects.ContainerBuilder = (*Statsd)(nil)
@@ -76,7 +77,7 @@ func (statsd *Statsd) BuildVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: "statsd-logs",
+			Name: dataSourceStatsdLogs,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -109,18 +110,18 @@ func (statsd *Statsd) buildPorts() []corev1.ContainerPort {
 
 func (statsd *Statsd) buildVolumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
-		{Name: dataSourceStartupArguments, MountPath: "/mnt/dsexecargs"},
-		{Name: dataSourceAuthToken, MountPath: "/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources"},
-		{Name: dataSourceMetadata, MountPath: "/mnt/dsmetadata"},
-		{Name: "statsd-logs", MountPath: statsDLogsDir},
+		{Name: dataSourceStartupArguments, MountPath: dataSourceStartupArgsMountPoint},
+		{Name: dataSourceAuthToken, MountPath: dataSourceAuthTokenMountPoint},
+		{Name: dataSourceMetadata, MountPath: dataSourceMetadataMountPoint},
+		{Name: dataSourceStatsdLogs, MountPath: statsDLogsDir},
 	}
 }
 
 func (statsd *Statsd) buildEnvs() []corev1.EnvVar {
 	return []corev1.EnvVar{
-		{Name: "StatsdExecArgsPath", Value: "/mnt/dsexecargs/statsd.process.json"},
+		{Name: "StatsdExecArgsPath", Value: dataSourceStartupArgsMountPoint + "/statsd.process.json"},
 		{Name: "ProbeServerPort", Value: fmt.Sprintf("%d", statsdProbesPort)},
-		{Name: "StatsdMetadataDir", Value: "/mnt/dsmetadata"},
+		{Name: "StatsdMetadataDir", Value: dataSourceMetadataMountPoint},
 		{Name: "DsLogFile", Value: statsDLogsDir + "/dynatracesourcestatsd.log"},
 	}
 }

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd_test.go
@@ -38,12 +38,13 @@ func TestStatsd_BuildContainerAndVolumes(t *testing.T) {
 			"/mnt/dsexecargs",
 			"/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources",
 			"/mnt/dsmetadata",
+			statsDLogsDir,
 		} {
 			assertion.Truef(kubeobjects.MountPathIsIn(container.VolumeMounts, mountPath), "Expected that StatsD container defines mount point %s", mountPath)
 		}
 
 		for _, envVar := range []string{
-			"StatsdExecArgsPath", "ProbeServerPort", "StatsdMetadataDir",
+			"StatsdExecArgsPath", "ProbeServerPort", "StatsdMetadataDir", "DsLogFile",
 		} {
 			assertion.Truef(kubeobjects.EnvVarIsIn(container.Env, envVar), "Expected that StatsD container defined environment variable %s", envVar)
 		}

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd_test.go
@@ -35,9 +35,9 @@ func TestStatsd_BuildContainerAndVolumes(t *testing.T) {
 		}
 
 		for _, mountPath := range []string{
-			"/mnt/dsexecargs",
-			"/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources",
-			"/mnt/dsmetadata",
+			dataSourceStartupArgsMountPoint,
+			dataSourceAuthTokenMountPoint,
+			dataSourceMetadataMountPoint,
 			statsDLogsDir,
 		} {
 			assertion.Truef(kubeobjects.MountPathIsIn(container.VolumeMounts, mountPath), "Expected that StatsD container defines mount point %s", mountPath)

--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -30,6 +30,8 @@ const (
 	DTNetworkZone        = "DT_NETWORK_ZONE"
 	DTGroup              = "DT_GROUP"
 	DTDeploymentMetadata = "DT_DEPLOYMENT_METADATA"
+
+	activeGateConfigDir = "/var/lib/dynatrace/gateway/config"
 )
 
 type statefulSetProperties struct {
@@ -254,7 +256,9 @@ func buildVolumeMounts(stsProperties *statefulSetProperties) []corev1.VolumeMoun
 
 	if stsProperties.NeedsStatsd() {
 		volumeMounts = append(volumeMounts,
-			corev1.VolumeMount{Name: eecAuthToken, MountPath: "/var/lib/dynatrace/gateway/config"},
+			corev1.VolumeMount{Name: eecAuthToken, MountPath: activeGateConfigDir},
+			corev1.VolumeMount{Name: "extensions-logs", MountPath: extensionsLogsDir + "/eec", ReadOnly: true},
+			corev1.VolumeMount{Name: "statsd-logs", MountPath: extensionsLogsDir + "/statsd", ReadOnly: true},
 		)
 	}
 

--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -31,7 +31,11 @@ const (
 	DTGroup              = "DT_GROUP"
 	DTDeploymentMetadata = "DT_DEPLOYMENT_METADATA"
 
-	activeGateConfigDir = "/var/lib/dynatrace/gateway/config"
+	activeGateConfigDir             = "/var/lib/dynatrace/gateway/config"
+	dataSourceStartupArgsMountPoint = "/mnt/dsexecargs"
+	dataSourceAuthTokenMountPoint   = "/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources"
+	dataSourceMetadataMountPoint    = "/mnt/dsmetadata"
+	statsdMetadataMountPoint        = "/opt/dynatrace/remotepluginmodule/agent/datasources/statsd"
 )
 
 type statefulSetProperties struct {
@@ -257,8 +261,8 @@ func buildVolumeMounts(stsProperties *statefulSetProperties) []corev1.VolumeMoun
 	if stsProperties.NeedsStatsd() {
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{Name: eecAuthToken, MountPath: activeGateConfigDir},
-			corev1.VolumeMount{Name: "extensions-logs", MountPath: extensionsLogsDir + "/eec", ReadOnly: true},
-			corev1.VolumeMount{Name: "statsd-logs", MountPath: extensionsLogsDir + "/statsd", ReadOnly: true},
+			corev1.VolumeMount{Name: eecLogs, MountPath: extensionsLogsDir + "/eec", ReadOnly: true},
+			corev1.VolumeMount{Name: dataSourceStatsdLogs, MountPath: extensionsLogsDir + "/statsd", ReadOnly: true},
 		)
 	}
 

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -109,14 +109,14 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 		assert.Equalf(t, expected, kubeobjects.VolumeIsDefined(templateSpec.Volumes, "auth-tokens"),
 			"Expected that volume mount %s has a predefined pod volume", "auth-tokens",
 		)
-		assert.Equalf(t, expected, kubeobjects.VolumeIsDefined(templateSpec.Volumes, "ds-metadata"),
-			"Expected that volume mount %s has a predefined pod volume", "ds-metadata",
+		assert.Equalf(t, expected, kubeobjects.VolumeIsDefined(templateSpec.Volumes, dataSourceMetadata),
+			"Expected that volume mount %s has a predefined pod volume", dataSourceMetadata,
 		)
-		assert.Equalf(t, expected, kubeobjects.VolumeIsDefined(templateSpec.Volumes, "extensions-logs"),
-			"Expected that volume mount %s has a predefined pod volume", "extensions-logs",
+		assert.Equalf(t, expected, kubeobjects.VolumeIsDefined(templateSpec.Volumes, eecLogs),
+			"Expected that volume mount %s has a predefined pod volume", eecLogs,
 		)
-		assert.Equalf(t, expected, kubeobjects.VolumeIsDefined(templateSpec.Volumes, "statsd-logs"),
-			"Expected that volume mount %s has a predefined pod volume", "statsd-logs",
+		assert.Equalf(t, expected, kubeobjects.VolumeIsDefined(templateSpec.Volumes, dataSourceStatsdLogs),
+			"Expected that volume mount %s has a predefined pod volume", dataSourceStatsdLogs,
 		)
 	}
 


### PR DESCRIPTION
ActiveGate offers the option to collect a support archive remotely from Debug UI (or the user-facing UI). It is useful when there is no log monitoring enabled in the cluster.

This PR links relevant directories between ActiveGate, Extension Controller and StatsD data source containers using volume mounts so that ActiveGate automatically picks up EEC/StatsD logs when a support archive is generated.