### PR TITLE
Remove dataingest environment variable from pod injection

### DIFF
--- a/src/ingestendpoint/secret.go
+++ b/src/ingestendpoint/secret.go
@@ -118,8 +118,7 @@ func (g *EndpointSecretGenerator) prepare(ctx context.Context, dk *dynatracev1be
 	}
 
 	data := map[string][]byte{
-		configFile:       endpointBuf.Bytes(),
-		TokenSecretField: []byte(fields[TokenSecretField]),
+		configFile: endpointBuf.Bytes(),
 	}
 	return data, nil
 }


### PR DESCRIPTION
Removes following environment variables from injected pods:
* `DT_METRICS_INGEST_URL`
* `DT_METRICS_INGEST_API_TOKEN`

These values will only exist on the pod in the `endpoint.properties` file going forward.