### PR TITLE
Makes checking the statusCode safer for ProcessModuleConfig enpoint

### DIFF
--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -103,6 +103,10 @@ func (dtc *dynatraceClient) createProcessModuleConfigRequest(prevRevision uint) 
 }
 
 func (dtc *dynatraceClient) specialProcessModuleConfigRequestStatus(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
+
 	if resp.StatusCode == http.StatusNotModified {
 		return true
 	}


### PR DESCRIPTION
In case the `resp` was nil we got a nil pointer panic, which furthermore hides the error causing the nil response