### PR TITLE
Adds security context for EEC and StatsD containers (statsd-ingest)

### DIFF
--- a/src/controllers/activegate/reconciler/statefulset/container_eec.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/internal/consts"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address_of"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -57,6 +58,7 @@ func (eec *ExtensionController) BuildContainer() corev1.Container {
 			SuccessThreshold:    1,
 			TimeoutSeconds:      1,
 		},
+		SecurityContext: eec.buildSecurityContext(),
 	}
 }
 
@@ -131,5 +133,19 @@ func (eec *ExtensionController) buildEnvs() []corev1.EnvVar {
 		{Name: "TenantId", Value: tenantId},
 		{Name: "ServerUrl", Value: fmt.Sprintf("https://localhost:%d/communication", activeGateInternalCommunicationPort)},
 		{Name: "EecIngestPort", Value: fmt.Sprintf("%d", eecIngestPort)},
+	}
+}
+
+func (eec *ExtensionController) buildSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		Privileged:               address_of.Bool(false),
+		AllowPrivilegeEscalation: address_of.Bool(false),
+		ReadOnlyRootFilesystem:   address_of.Bool(false),
+
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"all",
+			},
+		},
 	}
 }

--- a/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 	assertion := assert.New(t)
+	requirement := require.New(t)
 
 	instance := buildTestInstance()
 	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
@@ -46,6 +48,17 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 		} {
 			assertion.Truef(kubeobjects.EnvVarIsIn(container.Env, envVar), "Expected that EEC container defined environment variable %s", envVar)
 		}
+	})
+
+	t.Run("hardened container security context", func(t *testing.T) {
+		container := NewExtensionController(stsProperties).BuildContainer()
+
+		requirement.NotNil(container.SecurityContext)
+		securityContext := container.SecurityContext
+
+		assertion.False(*securityContext.Privileged)
+		assertion.False(*securityContext.AllowPrivilegeEscalation)
+		assertion.False(*securityContext.ReadOnlyRootFilesystem)
 	})
 
 	t.Run("volumes vs volume mounts", func(t *testing.T) {

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/internal/consts"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address_of"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -65,6 +66,7 @@ func (statsd *Statsd) BuildContainer() corev1.Container {
 			SuccessThreshold:    1,
 			TimeoutSeconds:      1,
 		},
+		SecurityContext: statsd.buildSecurityContext(),
 	}
 }
 
@@ -123,5 +125,23 @@ func (statsd *Statsd) buildEnvs() []corev1.EnvVar {
 		{Name: "ProbeServerPort", Value: fmt.Sprintf("%d", statsdProbesPort)},
 		{Name: "StatsdMetadataDir", Value: dataSourceMetadataMountPoint},
 		{Name: "DsLogFile", Value: statsDLogsDir + "/dynatracesourcestatsd.log"},
+	}
+}
+
+func (statsd *Statsd) buildSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		Privileged:               address_of.Bool(false),
+		AllowPrivilegeEscalation: address_of.Bool(false),
+		ReadOnlyRootFilesystem:   address_of.Bool(true),
+
+		RunAsNonRoot: address_of.Bool(true),
+		RunAsUser:    address_of.Int64(kubeobjects.UnprivilegedUser),
+		RunAsGroup:   address_of.Int64(kubeobjects.UnprivilegedGroup),
+
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"all",
+			},
+		},
 	}
 }

--- a/src/kubeobjects/address_of/address_of.go
+++ b/src/kubeobjects/address_of/address_of.go
@@ -1,0 +1,9 @@
+package address_of
+
+func Int64(i int64) *int64 {
+	return &i
+}
+
+func Bool(i bool) *bool {
+	return &i
+}

--- a/src/kubeobjects/address_of/address_of_test.go
+++ b/src/kubeobjects/address_of/address_of_test.go
@@ -1,0 +1,31 @@
+package address_of
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBool(t *testing.T) {
+	assert.True(t, *Bool(true))
+	assert.False(t, *Bool(false))
+
+	const definitelyYes = true
+	assert.True(t, *Bool(definitelyYes))
+
+	probablyYes := true
+	assert.True(t, *Bool(probablyYes))
+
+	probablyYes = false
+	assert.False(t, *Bool(probablyYes))
+}
+
+func TestInt64(t *testing.T) {
+	assert.Equal(t, int64(23), *Int64(23))
+
+	const twentySeven = 27
+	assert.Equal(t, int64(27), *Int64(twentySeven))
+
+	roughlyThree := int64(4)
+	assert.Equal(t, int64(4), *Int64(roughlyThree))
+}

--- a/src/kubeobjects/security_context.go
+++ b/src/kubeobjects/security_context.go
@@ -1,0 +1,4 @@
+package kubeobjects
+
+const UnprivilegedUser = int64(1000)
+const UnprivilegedGroup = int64(1000)


### PR DESCRIPTION
This changeset implements security architecture review remarks regarding the hardening of `statsd-ingest`-related containers in ActiveGate (EEC and StatsD). In particular, `privileged` and `allowPrivilegeEscalation` are disabled for both containers, and all capabilities are dropped by default.