### PR TITLE
Add import for CA before sending request to registry

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -3621,6 +3621,9 @@ spec:
             limits:
               cpu: 100m
               memory: 128Mi
+          volumeMounts:
+            - name: tmp-cert-dir
+              mountPath: /tmp/dynatrace-operator
           readinessProbe:
             httpGet:
               path: /healthz
@@ -3649,6 +3652,9 @@ spec:
                     operator: In
                     values:
                       - linux
+      volumes:
+        - emptyDir: { }
+          name: tmp-cert-dir
       serviceAccountName: dynatrace-operator
 ---
 # Source: dynatrace-operator/templates/Common/webhook/deployment-webhook.yaml

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -3688,6 +3688,9 @@ spec:
             limits:
               cpu: 100m
               memory: 128Mi
+          volumeMounts:
+            - name: tmp-cert-dir
+              mountPath: /tmp/dynatrace-operator
           readinessProbe:
             httpGet:
               path: /healthz
@@ -3716,6 +3719,9 @@ spec:
                     operator: In
                     values:
                       - linux
+      volumes:
+        - emptyDir: { }
+          name: tmp-cert-dir
       serviceAccountName: dynatrace-operator
 ---
 # Source: dynatrace-operator/templates/Common/webhook/deployment-webhook.yaml

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -67,7 +67,7 @@ spec:
               cpu: {{ default "100m" ((.Values.operator).limits).cpu }}
               memory: {{ default "128Mi" ((.Values.operator).limits).memory }}
           volumeMounts:
-            - name: tmp-dir
+            - name: tmp-cert-dir
               mountPath: /tmp/dynatrace-operator
           readinessProbe:
             httpGet:
@@ -99,7 +99,7 @@ spec:
                       - linux
       volumes:
         - emptyDir: { }
-          name: tmp-dir
+          name: tmp-cert-dir
       serviceAccountName: {{ .Release.Name }}
       {{- if .Values.operator.customPullSecret }}
       imagePullSecrets:

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -66,6 +66,9 @@ spec:
             limits:
               cpu: {{ default "100m" ((.Values.operator).limits).cpu }}
               memory: {{ default "128Mi" ((.Values.operator).limits).memory }}
+          volumeMounts:
+            - name: tmp-dir
+              mountPath: /tmp/dynatrace-operator
           readinessProbe:
             httpGet:
               path: /healthz
@@ -94,6 +97,9 @@ spec:
                     operator: In
                     values:
                       - linux
+      volumes:
+        - emptyDir: { }
+          name: tmp-dir
       serviceAccountName: {{ .Release.Name }}
       {{- if .Values.operator.customPullSecret }}
       imagePullSecrets:

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -65,6 +65,9 @@ tests:
                   limits:
                     cpu: 100m
                     memory: 128Mi
+                volumeMounts:
+                  - name: tmp-dir
+                    mountPath: /tmp/dynatrace-operator
                 readinessProbe:
                   httpGet:
                     path: /healthz
@@ -93,6 +96,9 @@ tests:
                           operator: In
                           values:
                             - linux
+            volumes:
+              - emptyDir: { }
+                name: tmp-dir
             serviceAccountName: RELEASE-NAME
       - isNull:
           path: spec.template.spec.tolerations
@@ -199,6 +205,9 @@ tests:
                   limits:
                     cpu: 100m
                     memory: 128Mi
+                volumeMounts:
+                  - name: tmp-dir
+                    mountPath: /tmp/dynatrace-operator
                 readinessProbe:
                   httpGet:
                     path: /healthz
@@ -227,6 +236,9 @@ tests:
                           operator: In
                           values:
                             - linux
+            volumes:
+              - emptyDir: { }
+                name: tmp-dir
             serviceAccountName: RELEASE-NAME
       - isNull:
           path: spec.template.spec.tolerations

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -66,7 +66,7 @@ tests:
                     cpu: 100m
                     memory: 128Mi
                 volumeMounts:
-                  - name: tmp-dir
+                  - name: tmp-cert-dir
                     mountPath: /tmp/dynatrace-operator
                 readinessProbe:
                   httpGet:
@@ -98,7 +98,7 @@ tests:
                             - linux
             volumes:
               - emptyDir: { }
-                name: tmp-dir
+                name: tmp-cert-dir
             serviceAccountName: RELEASE-NAME
       - isNull:
           path: spec.template.spec.tolerations
@@ -206,7 +206,7 @@ tests:
                     cpu: 100m
                     memory: 128Mi
                 volumeMounts:
-                  - name: tmp-dir
+                  - name: tmp-cert-dir
                     mountPath: /tmp/dynatrace-operator
                 readinessProbe:
                   httpGet:
@@ -238,7 +238,7 @@ tests:
                             - linux
             volumes:
               - emptyDir: { }
-                name: tmp-dir
+                name: tmp-cert-dir
             serviceAccountName: RELEASE-NAME
       - isNull:
           path: spec.template.spec.tolerations

--- a/src/controllers/dynakube/dtclient_builder.go
+++ b/src/controllers/dynakube/dtclient_builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/pkg/errors"
@@ -34,8 +35,7 @@ type DynatraceClientProxy struct {
 }
 
 const (
-	proxy        = "proxy"
-	certificates = "certs"
+	proxy = "proxy"
 )
 
 func NewDynatraceClientProperties(ctx context.Context, apiReader client.Reader, dk dynatracev1beta1.DynaKube) (*DynatraceClientProperties, error) {
@@ -140,10 +140,10 @@ func (opts *options) appendTrustedCerts(apiReader client.Reader, trustedCerts st
 		if err := apiReader.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: trustedCerts}, certs); err != nil {
 			return fmt.Errorf("failed to get certificate configmap: %w", err)
 		}
-		if certs.Data[certificates] == "" {
+		if certs.Data[dtversion.CustomCertificatesConfigMapKey] == "" {
 			return fmt.Errorf("failed to extract certificate configmap field: missing field certs")
 		}
-		opts.Opts = append(opts.Opts, dtclient.Certs([]byte(certs.Data[certificates])))
+		opts.Opts = append(opts.Opts, dtclient.Certs([]byte(certs.Data[dtversion.CustomCertificatesConfigMapKey])))
 	}
 	return nil
 }

--- a/src/controllers/dynakube/dtclient_builder.go
+++ b/src/controllers/dynakube/dtclient_builder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/pkg/errors"
@@ -33,10 +32,6 @@ type DynatraceClientProxy struct {
 	Value     string
 	ValueFrom string
 }
-
-const (
-	proxy = "proxy"
-)
 
 func NewDynatraceClientProperties(ctx context.Context, apiReader client.Reader, dk dynatracev1beta1.DynaKube) (*DynatraceClientProperties, error) {
 	var tokens corev1.Secret
@@ -122,7 +117,7 @@ func (opts *options) appendProxySettings(apiReader client.Reader, proxyEntry *Dy
 				return fmt.Errorf("failed to get proxy secret: %w", err)
 			}
 
-			proxyURL, err := kubeobjects.ExtractToken(proxySecret, proxy)
+			proxyURL, err := kubeobjects.ExtractToken(proxySecret, dtclient.CustomProxySecretKey)
 			if err != nil {
 				return fmt.Errorf("failed to extract proxy secret field: %w", err)
 			}
@@ -140,10 +135,10 @@ func (opts *options) appendTrustedCerts(apiReader client.Reader, trustedCerts st
 		if err := apiReader.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: trustedCerts}, certs); err != nil {
 			return fmt.Errorf("failed to get certificate configmap: %w", err)
 		}
-		if certs.Data[dtversion.CustomCertificatesConfigMapKey] == "" {
+		if certs.Data[dtclient.CustomCertificatesConfigMapKey] == "" {
 			return fmt.Errorf("failed to extract certificate configmap field: missing field certs")
 		}
-		opts.Opts = append(opts.Opts, dtclient.Certs([]byte(certs.Data[dtversion.CustomCertificatesConfigMapKey])))
+		opts.Opts = append(opts.Opts, dtclient.Certs([]byte(certs.Data[dtclient.CustomCertificatesConfigMapKey])))
 	}
 	return nil
 }

--- a/src/controllers/dynakube/dtversion/docker.go
+++ b/src/controllers/dynakube/dtversion/docker.go
@@ -14,10 +14,9 @@ import (
 
 // VersionLabel is the name of the label used on ActiveGate-provided images.
 const (
-	VersionLabel                   = "com.dynatrace.build-version"
-	TmpCAPath                      = "/tmp/dynatrace-operator"
-	TmpCAName                      = "dynatraceCustomCA.crt"
-	CustomCertificatesConfigMapKey = "certs"
+	VersionLabel = "com.dynatrace.build-version"
+	TmpCAPath    = "/tmp/dynatrace-operator"
+	TmpCAName    = "dynatraceCustomCA.crt"
 )
 
 // ImageVersion includes information for a given image. Version can be empty if the corresponding label isn't set.

--- a/src/controllers/dynakube/dtversion/docker.go
+++ b/src/controllers/dynakube/dtversion/docker.go
@@ -13,7 +13,12 @@ import (
 )
 
 // VersionLabel is the name of the label used on ActiveGate-provided images.
-const VersionLabel = "com.dynatrace.build-version"
+const (
+	VersionLabel                   = "com.dynatrace.build-version"
+	TmpCAPath                      = "/tmp/dynatrace-operator"
+	TmpCAName                      = "dynatraceCustomCA.crt"
+	CustomCertificatesConfigMapKey = "certs"
+)
 
 // ImageVersion includes information for a given image. Version can be empty if the corresponding label isn't set.
 type ImageVersion struct {
@@ -83,6 +88,9 @@ func MakeSystemContext(dockerReference reference.Named, dockerConfig *DockerConf
 
 	if dockerConfig.SkipCertCheck {
 		ctx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
+	}
+	if dockerConfig.UseTrustedCerts {
+		ctx.DockerCertPath = TmpCAPath
 	}
 
 	registry := strings.Split(dockerReference.Name(), "/")[0]

--- a/src/controllers/dynakube/dtversion/docker_config.go
+++ b/src/controllers/dynakube/dtversion/docker_config.go
@@ -9,8 +9,9 @@ import (
 )
 
 type DockerConfig struct {
-	Auths         map[string]DockerAuth
-	SkipCertCheck bool
+	Auths           map[string]DockerAuth
+	SkipCertCheck   bool
+	UseTrustedCerts bool
 }
 
 type DockerAuth struct {

--- a/src/controllers/dynakube/updates/version.go
+++ b/src/controllers/dynakube/updates/version.go
@@ -9,6 +9,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/status"
+	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -102,12 +103,12 @@ func saveCustomCAs(cl client.Client, dk dynatracev1beta1.DynaKube) bool {
 		log.Error(err, "failed to load trusted CAs")
 		return false
 	}
-	if certs.Data[dtversion.CustomCertificatesConfigMapKey] == "" {
+	if certs.Data[dtclient.CustomCertificatesConfigMapKey] == "" {
 		log.Info("failed to extract certificate configmap field: missing field certs")
 		return false
 	}
 	_ = os.MkdirAll(dtversion.TmpCAPath, 0755)
-	if err := os.WriteFile(path.Join(dtversion.TmpCAPath, dtversion.TmpCAName), []byte(certs.Data[dtversion.CustomCertificatesConfigMapKey]), 0666); err != nil {
+	if err := os.WriteFile(path.Join(dtversion.TmpCAPath, dtversion.TmpCAName), []byte(certs.Data[dtclient.CustomCertificatesConfigMapKey]), 0666); err != nil {
 		log.Error(err, "failed to save custom certificates")
 		return false
 	}

--- a/src/controllers/dynakube/updates/version.go
+++ b/src/controllers/dynakube/updates/version.go
@@ -2,6 +2,8 @@ package updates
 
 import (
 	"context"
+	"os"
+	"path"
 	"time"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
@@ -59,6 +61,12 @@ func ReconcileVersions(
 	}
 
 	dockerCfg := dtversion.DockerConfig{Auths: auths, SkipCertCheck: dk.Spec.SkipCertCheck}
+	if dk.Spec.TrustedCAs != "" {
+		dockerCfg.UseTrustedCerts = saveCustomCAs(cl, *dk)
+		defer func() {
+			_ = os.Remove(path.Join(dtversion.TmpCAPath, dtversion.TmpCAName))
+		}()
+	}
 	upd = true // updateImageVersion() always updates the status
 
 	if needsActiveGateUpdate {
@@ -86,6 +94,24 @@ func ReconcileVersions(
 	}
 
 	return upd, nil
+}
+
+func saveCustomCAs(cl client.Client, dk dynatracev1beta1.DynaKube) bool {
+	certs := &corev1.ConfigMap{}
+	if err := cl.Get(context.TODO(), client.ObjectKey{Namespace: dk.Namespace, Name: dk.Spec.TrustedCAs}, certs); err != nil {
+		log.Error(err, "failed to load trusted CAs")
+		return false
+	}
+	if certs.Data[dtversion.CustomCertificatesConfigMapKey] == "" {
+		log.Info("failed to extract certificate configmap field: missing field certs")
+		return false
+	}
+	_ = os.MkdirAll(dtversion.TmpCAPath, 0755)
+	if err := os.WriteFile(path.Join(dtversion.TmpCAPath, dtversion.TmpCAName), []byte(certs.Data[dtversion.CustomCertificatesConfigMapKey]), 0666); err != nil {
+		log.Error(err, "failed to save custom certificates")
+		return false
+	}
+	return true
 }
 
 func updateImageVersion(

--- a/src/dtclient/client.go
+++ b/src/dtclient/client.go
@@ -12,9 +12,11 @@ import (
 )
 
 const (
-	DynatracePaasToken       = "paasToken"
-	DynatraceApiToken        = "apiToken"
-	DynatraceDataIngestToken = "dataIngestToken"
+	DynatracePaasToken             = "paasToken"
+	DynatraceApiToken              = "apiToken"
+	DynatraceDataIngestToken       = "dataIngestToken"
+	CustomCertificatesConfigMapKey = "certs"
+	CustomProxySecretKey           = "proxy"
 )
 
 // Client is the interface for the Dynatrace REST API client.


### PR DESCRIPTION
Fixes the bug that custom certificates were not taken into account when sending requests to the image registry.

Resolves #583 