### PR TITLE
Maps certain StatsD-related annotations to EEC/StatsD container resource requests or limits

### DIFF
--- a/src/api/v1beta1/feature_flags_resources.go
+++ b/src/api/v1beta1/feature_flags_resources.go
@@ -1,0 +1,133 @@
+package v1beta1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	annotationFeatureActiveGate = annotationFeaturePrefix + "activegate-"
+	annotationFeatureEec        = annotationFeatureActiveGate + "eec-"
+	annotationFeatureStatsd     = annotationFeatureActiveGate + "statsd-"
+)
+
+// FeatureEecResourcesRequests is a feature flag to define CPU or memory requests for the EEC container
+func (dk *DynaKube) FeatureEecResourcesRequests(resourceName corev1.ResourceName) *resource.Quantity {
+	return eecResourceRequirements(dk, "requests-"+resourceName)
+}
+
+// FeatureEecResourcesLimits is a feature flag to define CPU or memory limits for the EEC container
+func (dk *DynaKube) FeatureEecResourcesLimits(resourceName corev1.ResourceName) *resource.Quantity {
+	return eecResourceRequirements(dk, "limits-"+resourceName)
+}
+
+// FeatureStatsdResourcesRequests is a feature flag to define CPU or memory requests for the StatsD container
+func (dk *DynaKube) FeatureStatsdResourcesRequests(resourceName corev1.ResourceName) *resource.Quantity {
+	return statsdResourceRequirements(dk, "requests-"+resourceName)
+}
+
+// FeatureStatsdResourcesLimits is a feature flag to define CPU or memory limits for the StatsD container
+func (dk *DynaKube) FeatureStatsdResourcesLimits(resourceName corev1.ResourceName) *resource.Quantity {
+	return statsdResourceRequirements(dk, "limits-"+resourceName)
+}
+
+//
+//// FeatureResourcesActiveGateEecRequestsCpu is a feature flag to define CPU requests for the EEC container
+//func (dk *DynaKube) FeatureResourcesActiveGateEecRequestsCpu() *resource.Quantity {
+//	return eecResourceRequirements(dk, corev1.ResourceRequestsCPU)
+//}
+//
+//// FeatureResourcesActiveGateEecRequestsMemory is a feature flag to define memory requests for the EEC container
+//func (dk *DynaKube) FeatureResourcesActiveGateEecRequestsMemory() *resource.Quantity {
+//	return eecResourceRequirements(dk, corev1.ResourceRequestsMemory)
+//}
+//
+//// FeatureResourcesActiveGateEecLimitsCpu is a feature flag to define CPU limits for the EEC container
+//func (dk *DynaKube) FeatureResourcesActiveGateEecLimitsCpu() *resource.Quantity {
+//	return eecResourceRequirements(dk, corev1.ResourceLimitsCPU)
+//}
+//
+//// FeatureResourcesActiveGateEecLimitsMemory is a feature flag to define memory limits for the EEC container
+//func (dk *DynaKube) FeatureResourcesActiveGateEecLimitsMemory() *resource.Quantity {
+//	return eecResourceRequirements(dk, corev1.ResourceLimitsMemory)
+//}
+//
+//// FeatureResourcesActiveGateStatsdRequestsCpu is a feature flag to define CPU requests for the StatsD container
+//func (dk *DynaKube) FeatureResourcesActiveGateStatsdRequestsCpu() *resource.Quantity {
+//	return statsdResourceRequirements(dk, corev1.ResourceRequestsCPU)
+//}
+//
+//// FeatureResourcesActiveGateStatsdRequestsMemory is a feature flag to define memory requests for the StatsD container
+//func (dk *DynaKube) FeatureResourcesActiveGateStatsdRequestsMemory() *resource.Quantity {
+//	return statsdResourceRequirements(dk, corev1.ResourceRequestsMemory)
+//}
+//
+//// FeatureResourcesActiveGateStatsdLimitsCpu is a feature flag to define CPU limits for the StatsD container
+//func (dk *DynaKube) FeatureResourcesActiveGateStatsdLimitsCpu() *resource.Quantity {
+//	return statsdResourceRequirements(dk, corev1.ResourceLimitsCPU)
+//}
+//
+//// FeatureResourcesActiveGateStatsdLimitsMemory is a feature flag to define memory limits for the StatsD container
+//func (dk *DynaKube) FeatureResourcesActiveGateStatsdLimitsMemory() *resource.Quantity {
+//	return statsdResourceRequirements(dk, corev1.ResourceLimitsMemory)
+//}
+
+// E.g. "alpha.operator.dynatrace.com/feature-activegate-eec-resources-limits-cpu": "100m"
+func formatResourceName(resourceName corev1.ResourceName) string {
+	return "resources-" + string(resourceName)
+}
+
+func eecResourceRequirements(dk *DynaKube, resourceName corev1.ResourceName) *resource.Quantity {
+	return resourceRequirements(dk, annotationFeatureEec, resourceName)
+}
+
+func statsdResourceRequirements(dk *DynaKube, resourceName corev1.ResourceName) *resource.Quantity {
+	return resourceRequirements(dk, annotationFeatureStatsd, resourceName)
+}
+
+func resourceRequirements(dk *DynaKube, flagPrefix string, resourceName corev1.ResourceName) *resource.Quantity {
+	flagName := flagPrefix + formatResourceName(resourceName)
+
+	val, ok := dk.Annotations[flagName]
+	if !ok {
+		return nil
+	}
+
+	quantity, err := resource.ParseQuantity(val)
+	if err != nil {
+		log.Info("Problem parsing resource requirements for", "flagName", flagName, "val", val, "err", err.Error())
+		return nil
+	}
+
+	return &quantity
+}
+
+// +kubebuilder:object:generate=false
+type ResourceRequirementer interface {
+	Requests(corev1.ResourceName) *resource.Quantity
+	Limits(corev1.ResourceName) *resource.Quantity
+}
+
+func ResourceNames() []corev1.ResourceName {
+	return []corev1.ResourceName{
+		corev1.ResourceCPU, corev1.ResourceMemory,
+	}
+}
+
+func BuildResourceRequirements(resourceRequirementer ResourceRequirementer) corev1.ResourceRequirements {
+	requirements := corev1.ResourceRequirements{
+		Limits:   make(corev1.ResourceList),
+		Requests: make(corev1.ResourceList),
+	}
+
+	for _, resourceName := range ResourceNames() {
+		if quantity := resourceRequirementer.Limits(resourceName); quantity != nil {
+			requirements.Limits[resourceName] = *quantity
+		}
+		if quantity := resourceRequirementer.Requests(resourceName); quantity != nil {
+			requirements.Requests[resourceName] = *quantity
+		}
+	}
+
+	return requirements
+}

--- a/src/api/v1beta1/feature_flags_resources.go
+++ b/src/api/v1beta1/feature_flags_resources.go
@@ -31,47 +31,6 @@ func (dk *DynaKube) FeatureStatsdResourcesLimits(resourceName corev1.ResourceNam
 	return statsdResourceRequirements(dk, "limits-"+resourceName)
 }
 
-//
-//// FeatureResourcesActiveGateEecRequestsCpu is a feature flag to define CPU requests for the EEC container
-//func (dk *DynaKube) FeatureResourcesActiveGateEecRequestsCpu() *resource.Quantity {
-//	return eecResourceRequirements(dk, corev1.ResourceRequestsCPU)
-//}
-//
-//// FeatureResourcesActiveGateEecRequestsMemory is a feature flag to define memory requests for the EEC container
-//func (dk *DynaKube) FeatureResourcesActiveGateEecRequestsMemory() *resource.Quantity {
-//	return eecResourceRequirements(dk, corev1.ResourceRequestsMemory)
-//}
-//
-//// FeatureResourcesActiveGateEecLimitsCpu is a feature flag to define CPU limits for the EEC container
-//func (dk *DynaKube) FeatureResourcesActiveGateEecLimitsCpu() *resource.Quantity {
-//	return eecResourceRequirements(dk, corev1.ResourceLimitsCPU)
-//}
-//
-//// FeatureResourcesActiveGateEecLimitsMemory is a feature flag to define memory limits for the EEC container
-//func (dk *DynaKube) FeatureResourcesActiveGateEecLimitsMemory() *resource.Quantity {
-//	return eecResourceRequirements(dk, corev1.ResourceLimitsMemory)
-//}
-//
-//// FeatureResourcesActiveGateStatsdRequestsCpu is a feature flag to define CPU requests for the StatsD container
-//func (dk *DynaKube) FeatureResourcesActiveGateStatsdRequestsCpu() *resource.Quantity {
-//	return statsdResourceRequirements(dk, corev1.ResourceRequestsCPU)
-//}
-//
-//// FeatureResourcesActiveGateStatsdRequestsMemory is a feature flag to define memory requests for the StatsD container
-//func (dk *DynaKube) FeatureResourcesActiveGateStatsdRequestsMemory() *resource.Quantity {
-//	return statsdResourceRequirements(dk, corev1.ResourceRequestsMemory)
-//}
-//
-//// FeatureResourcesActiveGateStatsdLimitsCpu is a feature flag to define CPU limits for the StatsD container
-//func (dk *DynaKube) FeatureResourcesActiveGateStatsdLimitsCpu() *resource.Quantity {
-//	return statsdResourceRequirements(dk, corev1.ResourceLimitsCPU)
-//}
-//
-//// FeatureResourcesActiveGateStatsdLimitsMemory is a feature flag to define memory limits for the StatsD container
-//func (dk *DynaKube) FeatureResourcesActiveGateStatsdLimitsMemory() *resource.Quantity {
-//	return statsdResourceRequirements(dk, corev1.ResourceLimitsMemory)
-//}
-
 // E.g. "alpha.operator.dynatrace.com/feature-activegate-eec-resources-limits-cpu": "100m"
 func formatResourceName(resourceName corev1.ResourceName) string {
 	return "resources-" + string(resourceName)

--- a/src/api/v1beta1/feature_flags_resources_test.go
+++ b/src/api/v1beta1/feature_flags_resources_test.go
@@ -1,0 +1,71 @@
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var _ ResourceRequirementer = (*testResourceRequirementer)(nil)
+
+type testResourceRequirementer struct {
+	resources corev1.ResourceRequirements
+}
+
+func newTestResourceRequirementer() *testResourceRequirementer {
+	return &testResourceRequirementer{
+		resources: corev1.ResourceRequirements{
+			Limits:   make(corev1.ResourceList),
+			Requests: make(corev1.ResourceList),
+		},
+	}
+}
+
+func (testRequirementer *testResourceRequirementer) Limits(resourceName corev1.ResourceName) *resource.Quantity {
+	if quantity, ok := testRequirementer.resources.Limits[resourceName]; ok {
+		return &quantity
+	}
+	return nil
+}
+
+func (testRequirementer *testResourceRequirementer) Requests(resourceName corev1.ResourceName) *resource.Quantity {
+	if quantity, ok := testRequirementer.resources.Requests[resourceName]; ok {
+		return &quantity
+	}
+	return nil
+}
+
+func TestBuildResourceRequirements(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		testRequirementer := newTestResourceRequirementer()
+		expectedRequests, expectedLimits := &testRequirementer.resources.Requests, &testRequirementer.resources.Limits
+
+		testRequirementer.resources.Requests = corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewScaledQuantity(500, resource.Milli),
+			corev1.ResourceMemory: *resource.NewScaledQuantity(200, resource.Mega),
+		}
+		testRequirementer.resources.Limits = corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewScaledQuantity(1000, resource.Milli),
+		}
+
+		requirements := BuildResourceRequirements(testRequirementer)
+
+		assert.Equal(t, *expectedRequests.Cpu(), *requirements.Requests.Cpu())
+		assert.Equal(t, *expectedRequests.Memory(), *requirements.Requests.Memory())
+		assert.Equal(t, *expectedLimits.Cpu(), *requirements.Limits.Cpu())
+		assert.Empty(t, requirements.Limits[corev1.ResourceMemory])
+	})
+
+	t.Run("empty resource requirements", func(t *testing.T) {
+		testRequirementer := newTestResourceRequirementer()
+
+		requirements := BuildResourceRequirements(testRequirementer)
+
+		assert.Empty(t, requirements.Requests[corev1.ResourceCPU])
+		assert.Empty(t, requirements.Requests[corev1.ResourceMemory])
+		assert.Empty(t, requirements.Limits[corev1.ResourceCPU])
+		assert.Empty(t, requirements.Limits[corev1.ResourceMemory])
+	})
+}

--- a/src/controllers/activegate/reconciler/statefulset/container_eec.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec.go
@@ -3,10 +3,12 @@ package statefulset
 import (
 	"fmt"
 
+	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/internal/consts"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address_of"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -59,6 +61,7 @@ func (eec *ExtensionController) BuildContainer() corev1.Container {
 			TimeoutSeconds:      1,
 		},
 		SecurityContext: eec.buildSecurityContext(),
+		Resources:       eec.buildResourceRequirements(),
 	}
 }
 
@@ -148,4 +151,18 @@ func (eec *ExtensionController) buildSecurityContext() *corev1.SecurityContext {
 			},
 		},
 	}
+}
+
+var _ v1beta1.ResourceRequirementer = (*ExtensionController)(nil)
+
+func (eec *ExtensionController) Limits(resourceName corev1.ResourceName) *resource.Quantity {
+	return eec.stsProperties.FeatureEecResourcesLimits(resourceName)
+}
+
+func (eec *ExtensionController) Requests(resourceName corev1.ResourceName) *resource.Quantity {
+	return eec.stsProperties.FeatureEecResourcesRequests(resourceName)
+}
+
+func (eec *ExtensionController) buildResourceRequirements() corev1.ResourceRequirements {
+	return v1beta1.BuildResourceRequirements(eec)
 }

--- a/src/controllers/activegate/reconciler/statefulset/container_eec.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec.go
@@ -3,7 +3,7 @@ package statefulset
 import (
 	"fmt"
 
-	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/internal/consts"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address_of"
@@ -153,7 +153,7 @@ func (eec *ExtensionController) buildSecurityContext() *corev1.SecurityContext {
 	}
 }
 
-var _ v1beta1.ResourceRequirementer = (*ExtensionController)(nil)
+var _ dynatracev1beta1.ResourceRequirementer = (*ExtensionController)(nil)
 
 func (eec *ExtensionController) Limits(resourceName corev1.ResourceName) *resource.Quantity {
 	return eec.stsProperties.FeatureEecResourcesLimits(resourceName)
@@ -164,5 +164,5 @@ func (eec *ExtensionController) Requests(resourceName corev1.ResourceName) *reso
 }
 
 func (eec *ExtensionController) buildResourceRequirements() corev1.ResourceRequirements {
-	return v1beta1.BuildResourceRequirements(eec)
+	return dynatracev1beta1.BuildResourceRequirements(eec)
 }

--- a/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
@@ -6,20 +6,24 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
+
+func testBuildStsProperties() *statefulSetProperties {
+	instance := buildTestInstance()
+	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
+	return NewStatefulSetProperties(instance, capabilityProperties,
+		"", "", "test-feature", "", "",
+		nil, nil, nil,
+	)
+}
 
 func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 	assertion := assert.New(t)
 	requirement := require.New(t)
 
-	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
-	stsProperties := NewStatefulSetProperties(instance, capabilityProperties,
-		"", "", "test-feature", "", "",
-		nil, nil, nil,
-	)
-
 	t.Run("happy path", func(t *testing.T) {
+		stsProperties := testBuildStsProperties()
 		eec := NewExtensionController(stsProperties)
 		container := eec.BuildContainer()
 
@@ -51,6 +55,7 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 	})
 
 	t.Run("hardened container security context", func(t *testing.T) {
+		stsProperties := testBuildStsProperties()
 		container := NewExtensionController(stsProperties).BuildContainer()
 
 		requirement.NotNil(container.SecurityContext)
@@ -62,6 +67,7 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 	})
 
 	t.Run("volumes vs volume mounts", func(t *testing.T) {
+		stsProperties := testBuildStsProperties()
 		eec := NewExtensionController(stsProperties)
 		statsd := NewStatsd(stsProperties)
 		volumes := buildVolumes(stsProperties, []kubeobjects.ContainerBuilder{eec, statsd})
@@ -70,5 +76,19 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 		for _, volumeMount := range container.VolumeMounts {
 			assertion.Truef(kubeobjects.VolumeIsDefined(volumes, volumeMount.Name), "Expected that volume mount %s has a predefined pod volume", volumeMount.Name)
 		}
+	})
+
+	t.Run("resource requirements from feature flags", func(t *testing.T) {
+		stsProperties := testBuildStsProperties()
+		stsProperties.ObjectMeta.Annotations["alpha.operator.dynatrace.com/feature-activegate-eec-resources-limits-cpu"] = "200m"
+		eec := NewExtensionController(stsProperties)
+
+		container := eec.BuildContainer()
+
+		require.Empty(t, container.Resources.Requests)
+		require.NotEmpty(t, container.Resources.Limits)
+
+		assert.Equal(t, resource.NewScaledQuantity(200, resource.Milli).String(), container.Resources.Limits.Cpu().String())
+		assert.True(t, container.Resources.Limits.Memory().IsZero())
 	})
 }

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd.go
@@ -3,10 +3,12 @@ package statefulset
 import (
 	"fmt"
 
+	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/internal/consts"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address_of"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -67,6 +69,7 @@ func (statsd *Statsd) BuildContainer() corev1.Container {
 			TimeoutSeconds:      1,
 		},
 		SecurityContext: statsd.buildSecurityContext(),
+		Resources:       statsd.buildResourceRequirements(),
 	}
 }
 
@@ -144,4 +147,18 @@ func (statsd *Statsd) buildSecurityContext() *corev1.SecurityContext {
 			},
 		},
 	}
+}
+
+var _ v1beta1.ResourceRequirementer = (*Statsd)(nil)
+
+func (statsd *Statsd) Limits(resourceName corev1.ResourceName) *resource.Quantity {
+	return statsd.stsProperties.FeatureEecResourcesLimits(resourceName)
+}
+
+func (statsd *Statsd) Requests(resourceName corev1.ResourceName) *resource.Quantity {
+	return statsd.stsProperties.FeatureEecResourcesRequests(resourceName)
+}
+
+func (statsd *Statsd) buildResourceRequirements() corev1.ResourceRequirements {
+	return v1beta1.BuildResourceRequirements(statsd)
 }

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd.go
@@ -3,7 +3,7 @@ package statefulset
 import (
 	"fmt"
 
-	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/internal/consts"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address_of"
@@ -149,7 +149,7 @@ func (statsd *Statsd) buildSecurityContext() *corev1.SecurityContext {
 	}
 }
 
-var _ v1beta1.ResourceRequirementer = (*Statsd)(nil)
+var _ dynatracev1beta1.ResourceRequirementer = (*Statsd)(nil)
 
 func (statsd *Statsd) Limits(resourceName corev1.ResourceName) *resource.Quantity {
 	return statsd.stsProperties.FeatureStatsdResourcesLimits(resourceName)
@@ -160,5 +160,5 @@ func (statsd *Statsd) Requests(resourceName corev1.ResourceName) *resource.Quant
 }
 
 func (statsd *Statsd) buildResourceRequirements() corev1.ResourceRequirements {
-	return v1beta1.BuildResourceRequirements(statsd)
+	return dynatracev1beta1.BuildResourceRequirements(statsd)
 }

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd.go
@@ -152,11 +152,11 @@ func (statsd *Statsd) buildSecurityContext() *corev1.SecurityContext {
 var _ v1beta1.ResourceRequirementer = (*Statsd)(nil)
 
 func (statsd *Statsd) Limits(resourceName corev1.ResourceName) *resource.Quantity {
-	return statsd.stsProperties.FeatureEecResourcesLimits(resourceName)
+	return statsd.stsProperties.FeatureStatsdResourcesLimits(resourceName)
 }
 
 func (statsd *Statsd) Requests(resourceName corev1.ResourceName) *resource.Quantity {
-	return statsd.stsProperties.FeatureEecResourcesRequests(resourceName)
+	return statsd.stsProperties.FeatureStatsdResourcesRequests(resourceName)
 }
 
 func (statsd *Statsd) buildResourceRequirements() corev1.ResourceRequirements {

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd_test.go
@@ -7,20 +7,15 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestStatsd_BuildContainerAndVolumes(t *testing.T) {
 	assertion := assert.New(t)
 	requirement := require.New(t)
 
-	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
-	stsProperties := NewStatefulSetProperties(instance, capabilityProperties,
-		"", "", "test-feature", "", "",
-		nil, nil, nil,
-	)
-
 	t.Run("happy path", func(t *testing.T) {
+		stsProperties := testBuildStsProperties()
 		statsd := NewStatsd(stsProperties)
 		container := statsd.BuildContainer()
 
@@ -53,6 +48,7 @@ func TestStatsd_BuildContainerAndVolumes(t *testing.T) {
 	})
 
 	t.Run("hardened container security context", func(t *testing.T) {
+		stsProperties := testBuildStsProperties()
 		container := NewStatsd(stsProperties).BuildContainer()
 
 		requirement.NotNil(container.SecurityContext)
@@ -68,6 +64,7 @@ func TestStatsd_BuildContainerAndVolumes(t *testing.T) {
 	})
 
 	t.Run("volumes vs volume mounts", func(t *testing.T) {
+		stsProperties := testBuildStsProperties()
 		eec := NewExtensionController(stsProperties)
 		statsd := NewStatsd(stsProperties)
 		volumes := buildVolumes(stsProperties, []kubeobjects.ContainerBuilder{eec, statsd})
@@ -76,5 +73,19 @@ func TestStatsd_BuildContainerAndVolumes(t *testing.T) {
 		for _, volumeMount := range container.VolumeMounts {
 			assertion.Truef(kubeobjects.VolumeIsDefined(volumes, volumeMount.Name), "Expected that volume mount %s has a predefined pod volume", volumeMount.Name)
 		}
+	})
+
+	t.Run("resource requirements from feature flags", func(t *testing.T) {
+		stsProperties := testBuildStsProperties()
+		stsProperties.ObjectMeta.Annotations["alpha.operator.dynatrace.com/feature-activegate-statsd-resources-requests-memory"] = "500M"
+		statsd := NewStatsd(stsProperties)
+
+		container := statsd.BuildContainer()
+
+		require.NotEmpty(t, container.Resources.Requests)
+		require.Empty(t, container.Resources.Limits)
+
+		assert.True(t, container.Resources.Requests.Cpu().IsZero())
+		assert.Equal(t, resource.NewScaledQuantity(500, resource.Mega).String(), container.Resources.Requests.Memory().String())
 	})
 }

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -433,8 +433,9 @@ func buildTestInstance() *dynatracev1beta1.DynaKube {
 	replicas := int32(3)
 	return &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      testName,
-			Namespace: testNamespace,
+			Name:        testName,
+			Namespace:   testNamespace,
+			Annotations: make(map[string]string),
 		},
 		Spec: dynatracev1beta1.DynaKubeSpec{
 			APIURL: "https://testing.dev.dynatracelabs.com/api",


### PR DESCRIPTION
This changeset interprets feature flags similar to:
```
  annotations:
    "alpha.operator.dynatrace.com/feature-activegate-statsd-resources-requests-memory": "500M"
```

to corresponding container resource requests or limits.

Valid flags:
- `alpha.operator.dynatrace.com/feature-activegate-statsd-resources-requests-cpu`
- `alpha.operator.dynatrace.com/feature-activegate-statsd-resources-requests-memory`
- `alpha.operator.dynatrace.com/feature-activegate-statsd-resources-limits-cpu`
- `alpha.operator.dynatrace.com/feature-activegate-statsd-resources-limits-memory`
- `alpha.operator.dynatrace.com/feature-activegate-eec-resources-requests-cpu`
- `alpha.operator.dynatrace.com/feature-activegate-eec-resources-requests-memory`
- `alpha.operator.dynatrace.com/feature-activegate-eec-resources-limits-cpu`
- `alpha.operator.dynatrace.com/feature-activegate-eec-resources-limits-memory`
