### PR TITLE
Remove caches from github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: "^1.16"
-      - name: Setup cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-ut-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-ut-
       - name: Download dependencies
         id: depdownload
         run: |

--- a/src/testing/e2e/integrationtests/envutils_test.go
+++ b/src/testing/e2e/integrationtests/envutils_test.go
@@ -43,7 +43,7 @@ func newTestEnvironment() (*ControllerTestEnvironment, error) {
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "..", "config", "crd", "bases"),
 			// ToDo: currently this is the only way to get the CRD - see https://github.com/kubernetes-sigs/controller-runtime/pull/1393
-			filepath.Join(build.Default.GOPATH, "pkg", "mod", "istio.io", "api@v0.0.0-20211020081732-2de5b65af1fe", "kubernetes"),
+			filepath.Join(build.Default.GOPATH, "pkg", "mod", "istio.io", "api@v0.0.0-20220110211529-694b7b802a22", "kubernetes"),
 		},
 	}
 	kubernetesAPIServer := environment.ControlPlane.GetAPIServer()


### PR DESCRIPTION
Our unit-tests use outdated cached packages.

To mitigate this we removed the caches for now.