### PR TITLE
Adds `lint` target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,10 @@ fmt:
 vet:
 	go vet ./...
 
+tidy: fmt vet
+	gci -w .
+	golangci-lint run --build-tags integration,containers_image_storage_stub --timeout 300s
+
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ fmt:
 vet:
 	go vet ./...
 
-tidy: fmt vet
+lint: fmt vet
 	gci -w .
 	golangci-lint run --build-tags integration,containers_image_storage_stub --timeout 300s
 


### PR DESCRIPTION
I often run linting and formatting steps long before a commit takes shape. This is in particular useful when resolving conflicts during a rebase.

This changeset introduces a Makefile target to group all formatting, vetting and linting:
```
make lint
```