### PR TITLE
Changed direct comparison to 'contains' approach

### DIFF
--- a/troubleshoot/troubleshoot.sh
+++ b/troubleshoot/troubleshoot.sh
@@ -341,7 +341,7 @@ function checkImagePullable {
     image_response_code=$(eval "${check_image}")
     if [[ "$image_response_code" == "200" ]] ; then
       log "image '$oneagent_image' with version '$oneagent_version' exists on registry '$registry'"
-      if [[ "$registry" == "$oneagent_registry" ]] ; then
+      if [[ "$oneagent_registry" == *"$registry"* ]] ; then
         oneagent_image_works=true
       fi
     else
@@ -355,7 +355,7 @@ function checkImagePullable {
     image_response_code=$(eval "${check_image}")
     if [[ "$image_response_code" == "200" ]] ; then
       log "image '$activegate_image' exists on registry '$registry'"
-      if [[ "$registry" == "$activegate_registry" ]] ; then
+      if [[ "$activegate_registry" == *"$registry"* ]] ; then
         activegate_image_works=true
       fi
     else


### PR DESCRIPTION
- The previous comparison was a direct comparison between the registry and the oneagent/activegate registry. This did not work for managed tenants, so I changed the comparison to a 'contains' check, where i check, whether the registry string is contained in the oneagent/activegate registry string.