### PR TITLE
SecurityContext added to ActiveGate container

### DIFF
--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -3903,6 +3903,54 @@ webhooks:
     admissionReviewVersions: [ "v1beta1", "v1" ]
     sideEffects: None
 ---
+# Source: dynatrace-operator/templates/Openshift/activegate/securitycontextconstraints.yaml
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: dynatrace-activegate
+allowPrivilegedContainer: false
+fsGroup:
+  type: RunAsAny
+priority: 1
+readOnlyRootFilesystem: false
+
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - "*"
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:dynatrace:dynatrace-activegate
+  - system:serviceaccount:dynatrace:dynatrace-kubernetes-monitoring
+volumes:
+  - "*"
+
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowedFlexVolumes: null
+defaultAddCapabilities: []
+---
 # Source: dynatrace-operator/templates/Openshift/oneagent/securitycontextconstraints-unprivileged.yaml
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
@@ -25,10 +25,10 @@ metadata:
     {{- if or (and (.Values.hostMonitoring).enabled (.Values.hostMonitoring).disableReadOnly) (and (.Values.cloudNativeFullStack).enabled (.Values.cloudNativeFullStack).disableReadOnly) }}
     alpha.operator.dynatrace.com/feature-disable-oneagent-readonly-host-fs: "true"
     {{- end }}
-    {{- if (eq (default false .Values.activeGate.apparmor) true) }}
+    {{- if (.Values.activeGate).apparmor }}
     alpha.operator.dynatrace.com/feature-activegate-apparmor: "true"
     {{- end }}
-    {{- if (eq (default false .Values.activeGate.readOnlyFs) true) }}
+    {{- if (.Values.activeGate).readOnlyFs }}
     alpha.operator.dynatrace.com/feature-activegate-readonly-fs: "true"
     {{- end }}
   name: {{ .Values.name }}

--- a/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
@@ -25,6 +25,12 @@ metadata:
     {{- if or (and (.Values.hostMonitoring).enabled (.Values.hostMonitoring).disableReadOnly) (and (.Values.cloudNativeFullStack).enabled (.Values.cloudNativeFullStack).disableReadOnly) }}
     alpha.operator.dynatrace.com/feature-disable-oneagent-readonly-host-fs: "true"
     {{- end }}
+    {{- if (eq (default false .Values.activeGate.apparmor) true) }}
+    alpha.operator.dynatrace.com/feature-activegate-apparmor: "true"
+    {{- end }}
+    {{- if (eq (default false .Values.activeGate.readOnlyFs) true) }}
+    alpha.operator.dynatrace.com/feature-activegate-readonly-fs: "true"
+    {{- end }}
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/config/helm/chart/default/templates/Openshift/activegate/securitycontextconstraints.yaml
+++ b/config/helm/chart/default/templates/Openshift/activegate/securitycontextconstraints.yaml
@@ -1,0 +1,52 @@
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift " (include "dynatrace-operator.platformSet" .))}}
+{{- if and (eq .Values.platform "openshift") (.Values.createSecurityContextConstraints) (eq (include "dynatrace-operator.partial" .) "false")}}
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: dynatrace-activegate
+allowPrivilegedContainer: false
+fsGroup:
+  type: RunAsAny
+priority: 1
+{{- if (.Values.activeGate).readOnlyFs }}
+readOnlyRootFilesystem: true
+{{ else }}
+readOnlyRootFilesystem: false
+{{ end }}
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - "*"
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:dynatrace-activegate
+  - system:serviceaccount:{{ .Release.Namespace }}:dynatrace-kubernetes-monitoring
+volumes:
+  - "*"
+
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowedFlexVolumes: null
+defaultAddCapabilities: []
+{{ end }}

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -135,6 +135,8 @@ activeGate:
   labels: {}
   env: []
   tlsSecretName: ""
+  apparmor: false
+  readOnlyFs: false
 
 # deprecated
 kubernetesMonitoring:

--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -41,6 +41,8 @@ const (
 	AnnotationFeatureDisableReadOnlyOneAgent          = annotationFeaturePrefix + "disable-oneagent-readonly-host-fs"
 	AnnotationFeatureEnableActivegateRawImage         = annotationFeaturePrefix + "enable-activegate-raw-image"
 	AnnotationFeatureEnableMultipleOsAgentsOnNode     = annotationFeaturePrefix + "multiple-osagents-on-node"
+	AnnotationFeatureAgReadOnlyFilesystem             = annotationFeaturePrefix + "activegate-readonly-fs"
+	AnnotationFeatureAgAppArmor                       = annotationFeaturePrefix + "activegate-apparmor"
 )
 
 var (
@@ -159,4 +161,14 @@ func (dk *DynaKube) FeatureEnableActivegateRawImage() bool {
 // FeatureEnableMultipleOsAgentsOnNode is a feature flag to enable multiple osagents running on the same host
 func (dk *DynaKube) FeatureEnableMultipleOsAgentsOnNode() bool {
 	return dk.Annotations[AnnotationFeatureEnableMultipleOsAgentsOnNode] == "true"
+}
+
+// FeatureAgReadOnlyFilesystem is a feature flag to enable RO mounted filesystem in ActiveGate container
+func (dk *DynaKube) FeatureAgReadOnlyFilesystem() bool {
+	return dk.Annotations[AnnotationFeatureAgReadOnlyFilesystem] == "true"
+}
+
+// FeatureAgAppArmor is a feature flag to enable AppArmor in ActiveGate container
+func (dk *DynaKube) FeatureAgAppArmor() bool {
+	return dk.Annotations[AnnotationFeatureAgAppArmor] == "true"
 }

--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -163,12 +163,12 @@ func (dk *DynaKube) FeatureEnableMultipleOsAgentsOnNode() bool {
 	return dk.Annotations[AnnotationFeatureEnableMultipleOsAgentsOnNode] == "true"
 }
 
-// FeatureAgReadOnlyFilesystem is a feature flag to enable RO mounted filesystem in ActiveGate container
-func (dk *DynaKube) FeatureAgReadOnlyFilesystem() bool {
+// FeatureActiveGateReadOnlyFilesystem is a feature flag to enable RO mounted filesystem in ActiveGate container
+func (dk *DynaKube) FeatureActiveGateReadOnlyFilesystem() bool {
 	return dk.Annotations[AnnotationFeatureAgReadOnlyFilesystem] == "true"
 }
 
-// FeatureAgAppArmor is a feature flag to enable AppArmor in ActiveGate container
-func (dk *DynaKube) FeatureAgAppArmor() bool {
+// FeatureActiveGateAppArmor is a feature flag to enable AppArmor in ActiveGate container
+func (dk *DynaKube) FeatureActiveGateAppArmor() bool {
 	return dk.Annotations[AnnotationFeatureAgAppArmor] == "true"
 }

--- a/src/controllers/activegate/capability/config.go
+++ b/src/controllers/activegate/capability/config.go
@@ -3,6 +3,18 @@ package capability
 const (
 	ActiveGateContainerName = "activegate"
 
+	ActiveGateGatewayConfigVolumeName = "ag-lib-gateway-config"
+	ActiveGateGatewayTempVolumeName   = "ag-lib-gateway-temp"
+	ActiveGateGatewayDataVolumeName   = "ag-lib-gateway-data"
+	ActiveGateLogVolumeName           = "ag-log-gateway"
+	ActiveGateTmpVolumeName           = "ag-tmp-gateway"
+
+	ActiveGateGatewayConfigMountPoint = "/var/lib/dynatrace/gateway/config"
+	ActiveGateGatewayTempMountPoint   = "/var/lib/dynatrace/gateway/temp"
+	ActiveGateGatewayDataMountPoint   = "/var/lib/dynatrace/gateway/data"
+	ActiveGateLogMountPoint           = "/var/log/dynatrace/gateway"
+	ActiveGateTmpMountPoint           = "/var/tmp/dynatrace/gateway"
+
 	HttpsServicePortName = "https"
 	HttpsServicePort     = 443
 	HttpServicePortName  = "http"

--- a/src/controllers/activegate/reconciler/statefulset/container_eec.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec.go
@@ -21,8 +21,6 @@ const extensionsRuntimeDir = "/var/lib/dynatrace/remotepluginmodule/agent/conf/r
 const activeGateInternalCommunicationPort = 9999
 
 const (
-	eecAuthToken = "auth-tokens"
-
 	dataSourceStartupArguments = "eec-ds-shared"
 	dataSourceAuthToken        = "dsauthtokendir"
 	eecLogs                    = "extensions-logs"
@@ -74,12 +72,6 @@ func (eec *ExtensionController) BuildContainer() corev1.Container {
 
 func (eec *ExtensionController) BuildVolumes() []corev1.Volume {
 	volumes := []corev1.Volume{
-		{
-			Name: eecAuthToken,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		},
 		{
 			Name: dataSourceStartupArguments,
 			VolumeSource: corev1.VolumeSource{
@@ -148,7 +140,7 @@ func (eec *ExtensionController) buildCommand() []string {
 
 func (eec *ExtensionController) buildVolumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
-		{Name: eecAuthToken, MountPath: activeGateConfigDir},
+		{Name: capability.ActiveGateGatewayConfigVolumeName, ReadOnly: true, MountPath: capability.ActiveGateGatewayConfigMountPoint},
 		{Name: dataSourceStartupArguments, MountPath: dataSourceStartupArgsMountPoint},
 		{Name: dataSourceAuthToken, MountPath: dataSourceAuthTokenMountPoint},
 		{Name: dataSourceMetadata, MountPath: statsdMetadataMountPoint, ReadOnly: true},

--- a/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
@@ -3,6 +3,7 @@ package statefulset
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,7 +38,7 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 		}
 
 		for _, mountPath := range []string{
-			activeGateConfigDir,
+			capability.ActiveGateGatewayConfigMountPoint,
 			dataSourceStartupArgsMountPoint,
 			dataSourceAuthTokenMountPoint,
 			statsdMetadataMountPoint,
@@ -46,6 +47,10 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 		} {
 			assertion.Truef(kubeobjects.MountPathIsIn(container.VolumeMounts, mountPath), "Expected that EEC container defines mount point %s", mountPath)
 		}
+
+		assert.Truef(t, kubeobjects.MountPathIs(container.VolumeMounts, capability.ActiveGateGatewayConfigMountPoint, kubeobjects.ReadOnlyMountPath),
+			"Expected that ActiveGate container mount point %s is mounted ReadOnly", capability.ActiveGateGatewayConfigMountPoint,
+		)
 
 		for _, envVar := range []string{
 			envTenantId, envServerUrl, envEecIngestPort,

--- a/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
@@ -3,6 +3,7 @@ package statefulset
 import (
 	"testing"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/stretchr/testify/assert"
@@ -48,7 +49,7 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 			assertion.Truef(kubeobjects.MountPathIsIn(container.VolumeMounts, mountPath), "Expected that EEC container defines mount point %s", mountPath)
 		}
 
-		assert.Truef(t, kubeobjects.MountPathIs(container.VolumeMounts, capability.ActiveGateGatewayConfigMountPoint, kubeobjects.ReadOnlyMountPath),
+		assert.Truef(t, kubeobjects.MountPathIsReadOnlyOrReadWrite(container.VolumeMounts, capability.ActiveGateGatewayConfigMountPoint, kubeobjects.ReadOnlyMountPath),
 			"Expected that ActiveGate container mount point %s is mounted ReadOnly", capability.ActiveGateGatewayConfigMountPoint,
 		)
 
@@ -73,6 +74,7 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 
 	t.Run("volumes vs volume mounts", func(t *testing.T) {
 		stsProperties := testBuildStsProperties()
+		stsProperties.Spec.ActiveGate.Capabilities = append(stsProperties.Spec.ActiveGate.Capabilities, dynatracev1beta1.StatsdIngestCapability.DisplayName)
 		eec := NewExtensionController(stsProperties)
 		statsd := NewStatsd(stsProperties)
 		volumes := buildVolumes(stsProperties, []kubeobjects.ContainerBuilder{eec, statsd})

--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address_of"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,8 +24,9 @@ const (
 	serviceAccountPrefix   = "dynatrace-"
 	tenantSecretVolumeName = "ag-tenant-secret"
 
-	annotationVersion         = dynatracev1beta1.InternalFlagPrefix + "version"
-	annotationCustomPropsHash = dynatracev1beta1.InternalFlagPrefix + "custom-properties-hash"
+	annotationVersion                     = dynatracev1beta1.InternalFlagPrefix + "version"
+	annotationCustomPropsHash             = dynatracev1beta1.InternalFlagPrefix + "custom-properties-hash"
+	annotationActiveGateContainerAppArmor = "container.apparmor.security.beta.kubernetes.io/" + capability.ActiveGateContainerName
 
 	dtServer             = "DT_SERVER"
 	dtTenant             = "DT_TENANT"
@@ -35,7 +37,6 @@ const (
 	dtGroup              = "DT_GROUP"
 	dtDeploymentMetadata = "DT_DEPLOYMENT_METADATA"
 
-	activeGateConfigDir             = "/var/lib/dynatrace/gateway/config"
 	dataSourceStartupArgsMountPoint = "/mnt/dsexecargs"
 	dataSourceAuthTokenMountPoint   = "/var/lib/dynatrace/remotepluginmodule/agent/runtime/datasources"
 	dataSourceMetadataMountPoint    = "/mnt/dsmetadata"
@@ -103,6 +104,10 @@ func CreateStatefulSet(stsProperties *statefulSetProperties) (*appsv1.StatefulSe
 				Spec: buildTemplateSpec(stsProperties),
 			},
 		}}
+
+	if stsProperties.DynaKube.FeatureAgAppArmor() {
+		sts.Spec.Template.ObjectMeta.Annotations[annotationActiveGateContainerAppArmor] = "runtime/default"
+	}
 
 	for _, onAfterCreateListener := range stsProperties.OnAfterCreateListener {
 		onAfterCreateListener(sts)
@@ -179,6 +184,11 @@ func buildContainers(stsProperties *statefulSetProperties, extraContainerBuilder
 }
 
 func buildActiveGateContainer(stsProperties *statefulSetProperties) corev1.Container {
+	readOnlyFs := false
+	if stsProperties.FeatureAgReadOnlyFilesystem() {
+		readOnlyFs = true
+	}
+
 	return corev1.Container{
 		Name:            capability.ActiveGateContainerName,
 		Image:           stsProperties.DynaKube.ActiveGateImage(),
@@ -197,6 +207,20 @@ func buildActiveGateContainer(stsProperties *statefulSetProperties) corev1.Conta
 			InitialDelaySeconds: 90,
 			PeriodSeconds:       15,
 			FailureThreshold:    3,
+		},
+		SecurityContext: &corev1.SecurityContext{
+			Privileged:               address_of.Bool(false),
+			AllowPrivilegeEscalation: address_of.Bool(false),
+			ReadOnlyRootFilesystem:   &readOnlyFs,
+			RunAsNonRoot:             address_of.Bool(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"all",
+				},
+			},
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 		},
 	}
 }
@@ -243,6 +267,44 @@ func buildVolumes(stsProperties *statefulSetProperties, extraContainerBuilders [
 		volumes = append(volumes, buildProxyVolumes()...)
 	}
 
+	volumes = append(volumes, buildActiveGateVolumes()...)
+
+	return volumes
+}
+
+func buildActiveGateVolumes() []corev1.Volume {
+	volumes := []corev1.Volume{
+		{
+			Name: capability.ActiveGateGatewayConfigVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: capability.ActiveGateGatewayTempVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: capability.ActiveGateGatewayDataVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: capability.ActiveGateLogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: capability.ActiveGateTmpVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
 	return volumes
 }
 
@@ -280,7 +342,6 @@ func buildVolumeMounts(stsProperties *statefulSetProperties) []corev1.VolumeMoun
 
 	if stsProperties.NeedsStatsd() {
 		volumeMounts = append(volumeMounts,
-			corev1.VolumeMount{Name: eecAuthToken, MountPath: activeGateConfigDir},
 			corev1.VolumeMount{Name: eecLogs, MountPath: extensionsLogsDir + "/eec", ReadOnly: true},
 			corev1.VolumeMount{Name: dataSourceStatsdLogs, MountPath: extensionsLogsDir + "/statsd", ReadOnly: true},
 		)
@@ -302,6 +363,39 @@ func buildVolumeMounts(stsProperties *statefulSetProperties) []corev1.VolumeMoun
 		)
 	}
 
+	volumeMounts = append(volumeMounts, buildActiveGateVolumeMounts()...)
+
+	return volumeMounts
+}
+
+func buildActiveGateVolumeMounts() []corev1.VolumeMount {
+	volumeMounts := []corev1.VolumeMount{
+		{
+			ReadOnly:  false,
+			Name:      capability.ActiveGateGatewayConfigVolumeName,
+			MountPath: capability.ActiveGateGatewayConfigMountPoint,
+		},
+		{
+			ReadOnly:  false,
+			Name:      capability.ActiveGateGatewayTempVolumeName,
+			MountPath: capability.ActiveGateGatewayTempMountPoint,
+		},
+		{
+			ReadOnly:  false,
+			Name:      capability.ActiveGateGatewayDataVolumeName,
+			MountPath: capability.ActiveGateGatewayDataMountPoint,
+		},
+		{
+			ReadOnly:  false,
+			Name:      capability.ActiveGateLogVolumeName,
+			MountPath: capability.ActiveGateLogMountPoint,
+		},
+		{
+			ReadOnly:  false,
+			Name:      capability.ActiveGateTmpVolumeName,
+			MountPath: capability.ActiveGateTmpMountPoint,
+		},
+	}
 	return volumeMounts
 }
 

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -289,7 +289,6 @@ func TestStatefulSet_Volumes(t *testing.T) {
 		volumes := buildVolumes(stsProperties, getContainerBuilders(stsProperties))
 		expectedSecretName := instance.Name + "-router-" + customproperties.Suffix
 
-		require.Equal(t, 2, len(volumes))
 		require.Equal(t, 1, len(volumes))
 
 		customPropertiesVolume, err := kubeobjects.GetVolumeByName(volumes, customproperties.VolumeName)
@@ -312,7 +311,6 @@ func TestStatefulSet_Volumes(t *testing.T) {
 		volumes := buildVolumes(stsProperties, getContainerBuilders(stsProperties))
 		expectedSecretName := testKey
 
-		require.Equal(t, 2, len(volumes))
 		require.Equal(t, 1, len(volumes))
 
 		customPropertiesVolume, err := kubeobjects.GetVolumeByName(volumes, customproperties.VolumeName)

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -101,9 +101,6 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 	}
 
 	checkVolumeMounts := func(expected bool, templateSpec *corev1.PodSpec) {
-		assert.Equalf(t, expected, kubeobjects.VolumeIsDefined(templateSpec.Volumes, "auth-tokens"),
-			"Expected that volume mount %s has a predefined pod volume", "auth-tokens",
-		)
 		assert.Equalf(t, expected, kubeobjects.VolumeIsDefined(templateSpec.Volumes, dataSourceMetadata),
 			"Expected that volume mount %s has a predefined pod volume", dataSourceMetadata,
 		)
@@ -147,31 +144,128 @@ func TestStatefulSet_TemplateSpec(t *testing.T) {
 }
 
 func TestStatefulSet_Container(t *testing.T) {
-	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
-	stsProperties := NewStatefulSetProperties(instance, capabilityProperties,
-		"", "", "", "", "", nil, nil, nil)
-	extraContainerBuilders := getContainerBuilders(stsProperties)
-	containers := buildContainers(stsProperties, extraContainerBuilders)
-	activeGateContainer := containers[0]
+	checkCoreProperties := func(activeGateContainer *corev1.Container, dynakube *dynatracev1beta1.DynaKube) {
+		assert.Equal(t, capability.ActiveGateContainerName, activeGateContainer.Name)
+		assert.Equal(t, dynakube.ActiveGateImage(), activeGateContainer.Image)
+		assert.Empty(t, activeGateContainer.Resources)
+		assert.Equal(t, corev1.PullAlways, activeGateContainer.ImagePullPolicy)
+		assert.NotEmpty(t, activeGateContainer.Env)
+		assert.Empty(t, activeGateContainer.Args)
+	}
 
-	assert.Equal(t, capability.ActiveGateContainerName, activeGateContainer.Name)
-	assert.Equal(t, instance.ActiveGateImage(), activeGateContainer.Image)
-	assert.Empty(t, activeGateContainer.Resources)
-	assert.Equal(t, corev1.PullAlways, activeGateContainer.ImagePullPolicy)
-	assert.NotEmpty(t, activeGateContainer.Env)
-	assert.Empty(t, activeGateContainer.Args)
+	checkSecurityProperties := func(activeGateContainer *corev1.Container, readOnlyFs bool) {
+		assert.Equal(t, *activeGateContainer.SecurityContext.Privileged, false)
+		assert.Equal(t, *activeGateContainer.SecurityContext.AllowPrivilegeEscalation, false)
+		assert.Equal(t, *activeGateContainer.SecurityContext.ReadOnlyRootFilesystem, readOnlyFs)
+		assert.Equal(t, *activeGateContainer.SecurityContext.RunAsNonRoot, true)
+		assert.Equal(t, activeGateContainer.SecurityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
+		assert.Equal(t, len(activeGateContainer.SecurityContext.Capabilities.Drop), 1)
+		assert.Equal(t, activeGateContainer.SecurityContext.Capabilities.Drop[0], corev1.Capability("all"))
+	}
 
-	assert.Equalf(t, instance.NeedsStatsd(), kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, activeGateConfigDir),
-		"Expected that ActiveGate container defines mount point %s if and only if StatsD ingest is enabled", activeGateConfigDir,
-	)
-	assert.Equalf(t, instance.NeedsStatsd(), kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, extensionsLogsDir+"/eec"),
-		"Expected that ActiveGate container defines mount point %s if and only if StatsD ingest is enabled", extensionsLogsDir+"/eec",
-	)
-	assert.Equalf(t, instance.NeedsStatsd(), kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, extensionsLogsDir+"/statsd"),
-		"Expected that ActiveGate container defines mount point %s if and only if StatsD ingest is enabled", extensionsLogsDir+"/statsd",
-	)
-	assert.NotNil(t, activeGateContainer.ReadinessProbe)
+	checkVolumes := func(activeGateContainer *corev1.Container, dynakube *dynatracev1beta1.DynaKube, directories []string) {
+		for _, directory := range directories {
+			assert.Truef(t, kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, directory),
+				"Expected that ActiveGate container defines mount point %s", directory,
+			)
+			assert.Truef(t, kubeobjects.MountPathIs(activeGateContainer.VolumeMounts, directory, kubeobjects.ReadWriteMountPath),
+				"Expected that ActiveGate container mount point %s is mounted ReadWrite", directory,
+			)
+		}
+
+		assert.Equalf(t, dynakube.NeedsStatsd(), kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, extensionsLogsDir+"/eec"),
+			"Expected that ActiveGate container defines mount point %s if and only if StatsD ingest is enabled", extensionsLogsDir+"/eec",
+		)
+		assert.Equalf(t, dynakube.NeedsStatsd(), kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, extensionsLogsDir+"/statsd"),
+			"Expected that ActiveGate container defines mount point %s if and only if StatsD ingest is enabled", extensionsLogsDir+"/statsd",
+		)
+	}
+
+	checkAnnotations := func(sts *appsv1.StatefulSet, exists bool) {
+		if exists {
+			assert.Truef(t, sts.Spec.Template.ObjectMeta.Annotations[annotationActiveGateContainerAppArmor] == "runtime/default",
+				"'%s' is invalid (%s)", annotationActiveGateContainerAppArmor, sts.Spec.Template.ObjectMeta.Annotations[annotationActiveGateContainerAppArmor])
+		} else {
+			_, ok := sts.Spec.Template.ObjectMeta.Annotations[annotationActiveGateContainerAppArmor]
+			assert.Falsef(t, ok, "'%s'found)", annotationActiveGateContainerAppArmor)
+		}
+	}
+
+	t.Run("DynaKube with RW filesystem and AppArmor disabled", func(t *testing.T) {
+		instance := buildTestInstance()
+		capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
+		stsProperties := NewStatefulSetProperties(instance, capabilityProperties,
+			"", "", "", "", "", nil, nil, nil)
+		sts, err := CreateStatefulSet(stsProperties)
+		assert.Nil(t, err)
+		extraContainerBuilders := getContainerBuilders(stsProperties)
+		containers := buildContainers(stsProperties, extraContainerBuilders)
+		activeGateContainer := containers[0]
+
+		checkCoreProperties(&activeGateContainer, instance)
+		checkSecurityProperties(&activeGateContainer, false)
+		checkVolumes(&activeGateContainer, instance, buildActiveGateVolumeDirectories(false))
+		checkAnnotations(sts, false)
+		assert.NotNil(t, activeGateContainer.ReadinessProbe)
+	})
+
+	t.Run("DynaKube with RW filesystem and AppArmor enabled", func(t *testing.T) {
+		instance := buildTestInstance()
+		instance.Annotations[dynatracev1beta1.AnnotationFeatureAgAppArmor] = "true"
+		capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
+		stsProperties := NewStatefulSetProperties(instance, capabilityProperties,
+			"", "", "", "", "", nil, nil, nil)
+		sts, err := CreateStatefulSet(stsProperties)
+		assert.Nil(t, err)
+		extraContainerBuilders := getContainerBuilders(stsProperties)
+		containers := buildContainers(stsProperties, extraContainerBuilders)
+		activeGateContainer := containers[0]
+
+		checkCoreProperties(&activeGateContainer, instance)
+		checkSecurityProperties(&activeGateContainer, false)
+		checkVolumes(&activeGateContainer, instance, buildActiveGateVolumeDirectories(false))
+		checkAnnotations(sts, true)
+		assert.NotNil(t, activeGateContainer.ReadinessProbe)
+	})
+
+	t.Run("DynaKube with RO filesystem and AppArmor disabled", func(t *testing.T) {
+		instance := buildTestInstance()
+		instance.Annotations[dynatracev1beta1.AnnotationFeatureAgReadOnlyFilesystem] = "true"
+		capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
+		stsProperties := NewStatefulSetProperties(instance, capabilityProperties,
+			"", "", "", "", "", nil, nil, nil)
+		sts, err := CreateStatefulSet(stsProperties)
+		assert.Nil(t, err)
+		extraContainerBuilders := getContainerBuilders(stsProperties)
+		containers := buildContainers(stsProperties, extraContainerBuilders)
+		activeGateContainer := containers[0]
+
+		checkCoreProperties(&activeGateContainer, instance)
+		checkSecurityProperties(&activeGateContainer, true)
+		checkVolumes(&activeGateContainer, instance, buildActiveGateVolumeDirectories(true))
+		checkAnnotations(sts, false)
+		assert.NotNil(t, activeGateContainer.ReadinessProbe)
+	})
+
+	t.Run("DynaKube with RO filesystem and AppArmor enabled", func(t *testing.T) {
+		instance := buildTestInstance()
+		instance.Annotations[dynatracev1beta1.AnnotationFeatureAgReadOnlyFilesystem] = "true"
+		instance.Annotations[dynatracev1beta1.AnnotationFeatureAgAppArmor] = "true"
+		capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
+		stsProperties := NewStatefulSetProperties(instance, capabilityProperties,
+			"", "", "", "", "", nil, nil, nil)
+		sts, err := CreateStatefulSet(stsProperties)
+		assert.Nil(t, err)
+		extraContainerBuilders := getContainerBuilders(stsProperties)
+		containers := buildContainers(stsProperties, extraContainerBuilders)
+		activeGateContainer := containers[0]
+
+		checkCoreProperties(&activeGateContainer, instance)
+		checkSecurityProperties(&activeGateContainer, true)
+		checkVolumes(&activeGateContainer, instance, buildActiveGateVolumeDirectories(true))
+		checkAnnotations(sts, true)
+		assert.NotNil(t, activeGateContainer.ReadinessProbe)
+	})
 }
 
 func TestStatefulSet_Volumes(t *testing.T) {
@@ -509,5 +603,21 @@ func buildTestInstance() *dynatracev1beta1.DynaKube {
 				},
 			},
 		},
+	}
+}
+
+func buildActiveGateVolumeDirectories(readOnly bool) []string {
+	if readOnly {
+		return []string{
+			capability.ActiveGateGatewayConfigMountPoint,
+			capability.ActiveGateGatewayTempMountPoint,
+			capability.ActiveGateGatewayDataMountPoint,
+			capability.ActiveGateLogMountPoint,
+			capability.ActiveGateTmpMountPoint,
+		}
+	} else {
+		return []string{
+			capability.ActiveGateGatewayConfigMountPoint,
+		}
 	}
 }

--- a/src/kubeobjects/slice.go
+++ b/src/kubeobjects/slice.go
@@ -16,9 +16,9 @@ func MountPathIsIn(volumeMounts []corev1.VolumeMount, mountPathToCheck string) b
 	return false
 }
 
-func MountPathIs(volumeMounts []corev1.VolumeMount, mountPathToCheck string, readOnly bool) bool {
+func MountPathIsReadOnlyOrReadWrite(volumeMounts []corev1.VolumeMount, mountPathToCheck string, mode bool) bool {
 	for _, volMount := range volumeMounts {
-		if volMount.MountPath == mountPathToCheck && volMount.ReadOnly == readOnly {
+		if volMount.MountPath == mountPathToCheck && volMount.ReadOnly == mode {
 			return true
 		}
 	}

--- a/src/kubeobjects/slice.go
+++ b/src/kubeobjects/slice.go
@@ -2,9 +2,23 @@ package kubeobjects
 
 import corev1 "k8s.io/api/core/v1"
 
+const (
+	ReadOnlyMountPath  = true
+	ReadWriteMountPath = false
+)
+
 func MountPathIsIn(volumeMounts []corev1.VolumeMount, mountPathToCheck string) bool {
 	for _, volMount := range volumeMounts {
 		if volMount.MountPath == mountPathToCheck {
+			return true
+		}
+	}
+	return false
+}
+
+func MountPathIs(volumeMounts []corev1.VolumeMount, mountPathToCheck string, readOnly bool) bool {
+	for _, volMount := range volumeMounts {
+		if volMount.MountPath == mountPathToCheck && volMount.ReadOnly == readOnly {
 			return true
 		}
 	}


### PR DESCRIPTION
All changes related to ActiveGate container:
1) the root filesystem is mounted ReadOnly.
2) security context added:
>  privileged: false
>  allowPrivilegeEscalation: false
>  readOnlyRootFilesystem: true *
>  runAsNonRoot: true
>  capabilities:
>    drop: ["all"]
* enabled by "alpha.operator.dynatrace.com/feature-activegate-readonly-fs":"true" annotation 
3) seccompProfile is set to:
>    type: RuntimeDefault 
4)  AppArmor is enabled via AG pod annotation *
>  container.apparmor.security.beta.kubernetes.io/activegate: runtime/default 
* enabled by "alpha.operator.dynatrace.com/feature-activegate-apparmor":"true" annotation 