### PR TITLE
Remove preview warning from CSI driver

### DIFF
--- a/src/webhook/validation/config.go
+++ b/src/webhook/validation/config.go
@@ -23,7 +23,6 @@ var validators = []validator{
 }
 
 var warnings = []validator{
-	oneAgentModePreviewWarning,
 	metricIngestPreviewWarning,
 	statsdIngestPreviewWarning,
 	missingActiveGateMemoryLimit,

--- a/src/webhook/validation/csi_daemonset_test.go
+++ b/src/webhook/validation/csi_daemonset_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMissingCSIDaemonSet(t *testing.T) {
 	t.Run(`valid cloud-native dynakube specs`, func(t *testing.T) {
-		assertAllowedResponseWithWarnings(t, 2, &dynatracev1beta1.DynaKube{
+		assertAllowedResponseWithoutWarnings(t, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,
@@ -33,7 +33,7 @@ func TestMissingCSIDaemonSet(t *testing.T) {
 
 	t.Run(`valid application-monitoring via csi dynakube specs`, func(t *testing.T) {
 		useCSIDriver := true
-		assertAllowedResponseWithWarnings(t, 2, &dynatracev1beta1.DynaKube{
+		assertAllowedResponseWithoutWarnings(t, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,

--- a/src/webhook/validation/oneagent_test.go
+++ b/src/webhook/validation/oneagent_test.go
@@ -109,7 +109,7 @@ func TestConflictingNodeSelector(t *testing.T) {
 				},
 			}, &defaultCSIDaemonSet)
 
-		assertAllowedResponseWithWarnings(t, 2,
+		assertAllowedResponseWithoutWarnings(t,
 			&dynatracev1beta1.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "conflict2",

--- a/src/webhook/validation/preview.go
+++ b/src/webhook/validation/preview.go
@@ -12,10 +12,7 @@ const (
 )
 
 func oneAgentModePreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
-	if dynakube.CloudNativeFullstackMode() {
-		log.Info("DynaKube with cloudNativeFullStack was applied, warning was provided.")
-		return fmt.Sprintf(featurePreviewWarningMessage, "cloudNativeFullStack")
-	} else if dynakube.ApplicationMonitoringMode() && dynakube.NeedsCSIDriver() {
+	if dynakube.ApplicationMonitoringMode() && !dynakube.NeedsCSIDriver() {
 		log.Info("DynaKube with applicationMonitoring was applied, warning was provided.")
 		return fmt.Sprintf(featurePreviewWarningMessage, "applicationMonitoring")
 	}

--- a/src/webhook/validation/preview.go
+++ b/src/webhook/validation/preview.go
@@ -11,14 +11,6 @@ const (
 	basePreviewWarning           = "PREVIEW features are NOT production ready and you may run into bugs."
 )
 
-func oneAgentModePreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
-	if dynakube.ApplicationMonitoringMode() && !dynakube.NeedsCSIDriver() {
-		log.Info("DynaKube with applicationMonitoring was applied, warning was provided.")
-		return fmt.Sprintf(featurePreviewWarningMessage, "applicationMonitoring")
-	}
-	return ""
-}
-
 func metricIngestPreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.IsActiveGateMode(dynatracev1beta1.MetricsIngestCapability.DisplayName) {
 		log.Info("DynaKube with metrics-ingest was applied, warning was provided.")

--- a/src/webhook/validation/preview_test.go
+++ b/src/webhook/validation/preview_test.go
@@ -18,19 +18,4 @@ func TestPreviewWarning(t *testing.T) {
 			},
 		})
 	})
-
-	t.Run(`warning present`, func(t *testing.T) {
-		useCSIDriver := true
-		assertAllowedResponseWithWarnings(t, 2, &dynatracev1beta1.DynaKube{
-			ObjectMeta: defaultDynakubeObjectMeta,
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-				OneAgent: dynatracev1beta1.OneAgentSpec{
-					ApplicationMonitoring: &dynatracev1beta1.ApplicationMonitoringSpec{
-						UseCSIDriver: &useCSIDriver,
-					},
-				},
-			},
-		}, &defaultCSIDaemonSet)
-	})
 }

--- a/src/webhook/validation/validation_test.go
+++ b/src/webhook/validation/validation_test.go
@@ -61,7 +61,7 @@ var dummyNamespace2 = corev1.Namespace{
 func TestDynakubeValidator_Handle(t *testing.T) {
 	t.Run(`valid dynakube specs`, func(t *testing.T) {
 
-		assertAllowedResponseWithWarnings(t, 4, &dynatracev1beta1.DynaKube{
+		assertAllowedResponseWithWarnings(t, 3, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,


### PR DESCRIPTION
# Description

- Removed the preview warnings in every deployment mode where the csi driver is inclued (i.e. cloudNativeFullstack, applicationMonitoring)

## How can this be tested?
- Apply a dynakube which either uses cloudNativeFullstack or applicationMonitoring with CSIDriver. Other than before, there will not pop up a preview warning message


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

