### PR TITLE
Removes admission.Errored responses from podmutator webhook

### DIFF
--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -601,7 +601,11 @@ func (m *podMutator) getNsAndDkName(ctx context.Context, req admission.Request) 
 
 	dkName, ok := ns.Labels[mapper.InstanceLabel]
 	if !ok {
-		rsp = silentErrorResponse(m.currentPodName, fmt.Errorf("no DynaKube instance set for namespace: %s", req.Namespace))
+		if kubesystem.DeployedViaOLM() {
+			rsp = admission.Patched("")
+		} else {
+			rsp = silentErrorResponse(m.currentPodName, fmt.Errorf("no DynaKube instance set for namespace: %s", req.Namespace))
+		}
 		return corev1.Namespace{}, "", &rsp
 	}
 	return ns, dkName, nil

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -814,7 +814,6 @@ func fieldEnvVar(key string) *corev1.EnvVarSource {
 
 func silentErrorResponse(podName string, err error) admission.Response {
 	rsp := admission.Patched("")
-	message := fmt.Sprintf("Failed to inject into pod: %s because %s", podName, err.Error())
-	rsp.Result.Message = message
+	rsp.Result.Message = fmt.Sprintf("Failed to inject into pod: %s because %s", podName, err.Error())
 	return rsp
 }

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -104,15 +104,16 @@ func registerHealthzEndpoint(mgr manager.Manager) {
 
 // podMutator injects the OneAgent into Pods
 type podMutator struct {
-	client     client.Client
-	metaClient client.Client
-	apiReader  client.Reader
-	decoder    *admission.Decoder
-	image      string
-	namespace  string
-	apmExists  bool
-	clusterID  string
-	recorder   record.EventRecorder
+	client         client.Client
+	metaClient     client.Client
+	apiReader      client.Reader
+	decoder        *admission.Decoder
+	image          string
+	namespace      string
+	apmExists      bool
+	clusterID      string
+	currentPodName string
+	recorder       record.EventRecorder
 }
 
 func findRootOwnerOfPod(ctx context.Context, clt client.Client, pod *corev1.Pod, namespace string) (string, string, error) {
@@ -193,6 +194,10 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	if rsp != nil {
 		return *rsp
 	}
+	m.currentPodName = pod.Name
+	defer func() {
+		m.currentPodName = ""
+	}()
 
 	injectionInfo := NewInjectionInfoForPod(pod)
 	if !injectionInfo.anyEnabled() {
@@ -227,7 +232,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		var err error
 		dataIngestFields, err = m.ensureDataIngestSecret(ctx, ns, dkName, dk)
 		if err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
+			return silentErrorResponse(m.currentPodName, err)
 		}
 	}
 
@@ -495,7 +500,7 @@ func (m *podMutator) retrieveWorkload(ctx context.Context, req admission.Request
 		var err error
 		workloadName, workloadKind, err = findRootOwnerOfPod(ctx, m.metaClient, pod, req.Namespace)
 		if err != nil {
-			rsp = admission.Errored(http.StatusInternalServerError, err)
+			rsp = silentErrorResponse(m.currentPodName, err)
 			return "", "", &rsp
 		}
 	}
@@ -579,7 +584,7 @@ func (m *podMutator) getPod(req admission.Request) (*corev1.Pod, *admission.Resp
 	err := m.decoder.Decode(req, pod)
 	if err != nil {
 		podLog.Error(err, "Failed to decode the request for pod injection")
-		rsp := admission.Errored(http.StatusBadRequest, err)
+		rsp := silentErrorResponse(req.Name, err)
 		return nil, &rsp
 	}
 	return pod, nil
@@ -590,13 +595,13 @@ func (m *podMutator) getNsAndDkName(ctx context.Context, req admission.Request) 
 
 	if err := m.client.Get(ctx, client.ObjectKey{Name: req.Namespace}, &ns); err != nil {
 		podLog.Error(err, "Failed to query the namespace before pod injection")
-		rsp = admission.Errored(http.StatusInternalServerError, err)
+		rsp = silentErrorResponse(m.currentPodName, err)
 		return corev1.Namespace{}, "", &rsp
 	}
 
 	dkName, ok := ns.Labels[mapper.InstanceLabel]
 	if !ok {
-		rsp = admission.Errored(http.StatusInternalServerError, fmt.Errorf("no DynaKube instance set for namespace: %s", req.Namespace))
+		rsp = silentErrorResponse(m.currentPodName, fmt.Errorf("no DynaKube instance set for namespace: %s", req.Namespace))
 		return corev1.Namespace{}, "", &rsp
 	}
 	return ns, dkName, nil
@@ -634,11 +639,11 @@ func (m *podMutator) getDynakube(ctx context.Context, req admission.Request, dkN
 			corev1.EventTypeWarning,
 			missingDynakubeEvent,
 			template, req.Namespace, dkName)
-		rsp = admission.Errored(http.StatusBadRequest, fmt.Errorf(
+		rsp = silentErrorResponse(m.currentPodName, fmt.Errorf(
 			template, req.Namespace, dkName))
 		return dynatracev1beta1.DynaKube{}, &rsp
 	} else if err != nil {
-		rsp = admission.Errored(http.StatusInternalServerError, err)
+		rsp = silentErrorResponse(m.currentPodName, err)
 		return dynatracev1beta1.DynaKube{}, &rsp
 	}
 	return dk, nil
@@ -651,12 +656,12 @@ func (m *podMutator) ensureInitSecret(ctx context.Context, ns corev1.Namespace, 
 	if err := m.apiReader.Get(ctx, client.ObjectKey{Name: dtwebhook.SecretConfigName, Namespace: ns.Name}, &initSecret); k8serrors.IsNotFound(err) {
 		if _, err := initgeneration.NewInitGenerator(m.client, m.apiReader, m.namespace).GenerateForNamespace(ctx, dk, ns.Name); err != nil {
 			podLog.Error(err, "Failed to create the init secret before pod injection")
-			rsp = admission.Errored(http.StatusBadRequest, err)
+			rsp = silentErrorResponse(m.currentPodName, err)
 			return &rsp
 		}
 	} else if err != nil {
 		podLog.Error(err, "failed to query the init secret before pod injection")
-		rsp = admission.Errored(http.StatusBadRequest, err)
+		rsp = silentErrorResponse(m.currentPodName, err)
 		return &rsp
 	}
 	return nil
@@ -794,11 +799,18 @@ func updateContainerDataIngest(c *corev1.Container, pod *corev1.Pod, deploymentM
 func getResponseForPod(pod *corev1.Pod, req *admission.Request) admission.Response {
 	marshaledPod, err := json.MarshalIndent(pod, "", "  ")
 	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, err)
+		return silentErrorResponse(pod.Name, err)
 	}
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 }
 
 func fieldEnvVar(key string) *corev1.EnvVarSource {
 	return &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: key}}
+}
+
+func silentErrorResponse(podName string, err error) admission.Response {
+	rsp := admission.Patched("")
+	message := fmt.Sprintf("Failed to inject into pod: %s because %s", podName, err.Error())
+	rsp.Result.Message = message
+	return rsp
 }

--- a/src/webhook/mutation/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator_test.go
@@ -79,8 +79,8 @@ func TestInjectionWithMissingOneAgentAPM(t *testing.T) {
 	}
 	resp := inj.Handle(context.TODO(), req)
 	require.NoError(t, resp.Complete(req))
-	require.False(t, resp.Allowed)
-	require.Equal(t, resp.Result.Message, "namespace 'test-namespace' is assigned to DynaKube instance 'dynakube' but doesn't exist")
+	require.True(t, resp.Allowed)
+	require.Equal(t, resp.Result.Message, "Failed to inject into pod: test-pod-123456 because namespace 'test-namespace' is assigned to DynaKube instance 'dynakube' but doesn't exist")
 	t_utils.AssertEvents(t,
 		inj.recorder.(*record.FakeRecorder).Events,
 		t_utils.Events{


### PR DESCRIPTION
# Description

On OLM the namespaceSelector in the `MutatingWebhookConfiguration` is ignored. This leads to the Webhook intercepting Pod Creation for every pod in the Cluster, independent of the namespaceSelector in the Dynakube and the corresponding label on the namespace managed by the Operator.
The failurePolicy is set to ignore, with a timeout of 2s, but since the Webhook returns an error response before the 2s are up, the pod is blocked from being created.


## How can this be tested?
No matter what, the webhook will not stop the scheduling of a pod because of an error, instead the error's text should be in the message.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

