### PR TITLE
Multiple osagents on the same node

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -39,6 +39,7 @@ const (
 	annotationFeatureCustomEecImage                   = annotationFeaturePrefix + "custom-eec-image"
 	annotationFeatureCustomStatsdImage                = annotationFeaturePrefix + "custom-statsd-image"
 	AnnotationFeatureDisableReadOnlyOneAgent          = annotationFeaturePrefix + "disable-oneagent-readonly-host-fs"
+	AnnotationFeatureEnableMultipleOsAgentsOnNode     = annotationFeaturePrefix + "multiple-osagents-on-node"
 )
 
 var (
@@ -144,4 +145,10 @@ func (dk *DynaKube) FeatureCustomStatsdImage() string {
 // Defaults to false
 func (dk *DynaKube) FeatureDisableReadOnlyOneAgent() bool {
 	return dk.Annotations[AnnotationFeatureDisableReadOnlyOneAgent] == "true"
+}
+
+// FeatureEnableMultipleOsAgentsOnNode is a feature flag to enable multiple osagents running on the same host
+// note: it requires volumes enabled
+func (dk *DynaKube) FeatureEnableMultipleOsAgentsOnNode() bool {
+	return dk.Annotations[AnnotationFeatureEnableMultipleOsAgentsOnNode] == "true"
 }

--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -148,7 +148,6 @@ func (dk *DynaKube) FeatureDisableReadOnlyOneAgent() bool {
 }
 
 // FeatureEnableMultipleOsAgentsOnNode is a feature flag to enable multiple osagents running on the same host
-// note: it requires volumes enabled
 func (dk *DynaKube) FeatureEnableMultipleOsAgentsOnNode() bool {
 	return dk.Annotations[AnnotationFeatureEnableMultipleOsAgentsOnNode] == "true"
 }

--- a/src/webhook/validation/config.go
+++ b/src/webhook/validation/config.go
@@ -19,6 +19,7 @@ var validators = []validator{
 	conflictingOneAgentConfiguration,
 	conflictingNodeSelector,
 	conflictingNamespaceSelector,
+	conflictingReadOnlyFilesystemAndMultipleOsAgentsOnNode,
 	noResourcesAvailable,
 }
 

--- a/src/webhook/validation/oneagent.go
+++ b/src/webhook/validation/oneagent.go
@@ -38,8 +38,15 @@ func conflictingOneAgentConfiguration(dv *dynakubeValidator, dynakube *dynatrace
 	return ""
 }
 
+func conflictingReadOnlyFilesystemAndMultipleOsAgentsOnNode(_ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+	if dynakube.FeatureDisableReadOnlyOneAgent() && dynakube.FeatureEnableMultipleOsAgentsOnNode() {
+		return "Multiple OsAgents require readonly host filesystem"
+	}
+	return ""
+}
+
 func conflictingNodeSelector(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
-	if !dynakube.NeedsOneAgent() {
+	if !dynakube.NeedsOneAgent() || dynakube.FeatureEnableMultipleOsAgentsOnNode() {
 		return ""
 	}
 	validDynakubes := &dynatracev1beta1.DynaKubeList{}

--- a/src/webhook/validation/oneagent_test.go
+++ b/src/webhook/validation/oneagent_test.go
@@ -167,7 +167,7 @@ func TestConflictingNodeSelector(t *testing.T) {
 			}, &defaultCSIDaemonSet)
 	})
 	t.Run(`valid dynakube specs with multitenant hostMonitoring`, func(t *testing.T) {
-		assertAllowedResponseWithWarnings(t, 2,
+		assertAllowedResponseWithWarnings(t, 0,
 			newCloudNativeDynakube("dk1", map[string]string{
 				dynatracev1beta1.AnnotationFeatureEnableMultipleOsAgentsOnNode: "true",
 			}, "1"),
@@ -176,7 +176,7 @@ func TestConflictingNodeSelector(t *testing.T) {
 			}, "2"),
 			&defaultCSIDaemonSet)
 
-		assertAllowedResponseWithWarnings(t, 2,
+		assertAllowedResponseWithWarnings(t, 0,
 			newCloudNativeDynakube("dk1", map[string]string{
 				dynatracev1beta1.AnnotationFeatureEnableMultipleOsAgentsOnNode: "true",
 			}, "1"),


### PR DESCRIPTION
# Description

Added a dynakube annotation `alpha.operator.dynatrace.com/feature-multiple-osagents-on-node` allowing multitenant hostMonitoring (defaults to `"false"`).
OneAgent mounts:
* node's root fs as read-only volume
* csi volume as read-write, unique per tenant

If dynakube annotation `alpha.operator.dynatrace.com/feature-multiple-osagents-on-node` == `true`, `nodeSelector` validation is disabled.

## How can this be tested?
2+ dynakube objects with `hostMonitoring` enabled (or `cloudNativeFullStack` with `namespaceSelector` set so that there is no namespace monitored by more than one dynakube).
OneAgent pods are expected to have running status.
Note: currently OneAgent prevents two instances from running on the same host.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

