### PR TITLE
Makes apparmor setting more flexible in helm

### DIFF
--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -31,7 +31,7 @@ spec:
   template:
     metadata:
       annotations:
-      {{- if and (eq (default false .Values.apparmor) true) (ne .Values.platform "openshift") }}
+      {{- if and (eq (default false (.Values.operator).apparmor) true)}}
         container.apparmor.security.beta.kubernetes.io/{{ .Release.Name }}: runtime/default
       {{- end }}
       labels:

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -31,7 +31,7 @@ spec:
   template:
     metadata:
       annotations:
-      {{- if and (eq (default false (.Values.operator).apparmor) true)}}
+      {{- if (.Values.operator).apparmor}}
         container.apparmor.security.beta.kubernetes.io/{{ .Release.Name }}: runtime/default
       {{- end }}
       labels:

--- a/config/helm/chart/default/templates/Common/operator/role-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/role-operator.yaml
@@ -121,6 +121,7 @@ rules:
       - services
     verbs:
       - create
+      - update
       - delete
       - get
       - list

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -33,9 +33,9 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: webhook
-       {{- if and (eq (default false .Values.apparmor) true) (ne .Values.platform "openshift") }}
+        {{- if and (eq (default false (.Values.webhook).apparmor) true)}}
         container.apparmor.security.beta.kubernetes.io/{{ .Release.Name }}: runtime/default
-      {{- end }}
+        {{- end }}
       labels:
         dynatrace.com/operator: oneagent
         internal.dynatrace.com/component: webhook

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -33,7 +33,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: webhook
-        {{- if and (eq (default false (.Values.webhook).apparmor) true)}}
+        {{- if (.Values.webhook).apparmor}}
         container.apparmor.security.beta.kubernetes.io/{{ .Release.Name }}: runtime/default
         {{- end }}
       labels:

--- a/config/helm/chart/default/tests/Common/operator/role-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/role-operator_test.yaml
@@ -117,6 +117,7 @@ tests:
                 - services
               verbs:
                 - create
+                - update
                 - delete
                 - get
                 - list

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -25,7 +25,6 @@ proxy: ""
 trustedCAs: ""
 networkZone: ""
 enableIstio: false
-apparmor: false
 
 # Only works for applicationMonitoring and cloudNativeFullStack
 namespaceSelector: {}
@@ -40,6 +39,7 @@ operator:
   customPullSecret: ""
   nodeSelector: {}
   tolerations: []
+  apparmor: false
   requests:
     cpu: 50m
     memory: 64Mi
@@ -49,6 +49,7 @@ operator:
 
 webhook:
   hostNetwork: false
+  apparmor: false
   requests:
     cpu: 300m
     memory: 128Mi


### PR DESCRIPTION
# Description
apparmor setting now can be turned on/off per deployment in helm

## How can this be tested?
.Values.operator.apparmor: true should only set the apparmor annotation on the operator deployment
same for the webhook


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

