### PR TITLE
Revert pre-generation of Kubernetes ME Id

### DIFF
--- a/src/dtclient/kubernetes_settings.go
+++ b/src/dtclient/kubernetes_settings.go
@@ -2,11 +2,8 @@ package dtclient
 
 import (
 	"bytes"
-	"encoding/binary"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -94,15 +91,7 @@ func (dtc *dynatraceClient) CreateOrUpdateKubernetesSetting(name, kubeSystemUUID
 		},
 	}
 
-	if scope == "" {
-		var meID, err = generateKubernetesMEIdentifier(kubeSystemUUID)
-		if err != nil {
-			return "", err
-		}
-		if meID != "" {
-			body[0].Scope = meID
-		}
-	} else {
+	if scope != "" {
 		body[0].Scope = scope
 	}
 
@@ -267,16 +256,4 @@ func handleErrorArrayResponseFromAPI(response []byte, statusCode int) error {
 
 		return fmt.Errorf(sb.String())
 	}
-}
-
-func generateKubernetesMEIdentifier(kubeSystemUUID string) (string, error) {
-	var hasher = fnv.New64()
-	_, err := hasher.Write([]byte(kubeSystemUUID))
-	if err != nil {
-		return "", err
-	}
-	var hash = hasher.Sum64()
-	byteHash := make([]byte, 8)
-	binary.LittleEndian.PutUint64(byteHash, hash)
-	return "KUBERNETES_CLUSTER-" + strings.ToUpper(hex.EncodeToString(byteHash)), nil
 }

--- a/src/dtclient/kubernetes_settings_test.go
+++ b/src/dtclient/kubernetes_settings_test.go
@@ -258,20 +258,6 @@ func TestDynatraceClient_CreateOrUpdateKubernetesSetting(t *testing.T) {
 	})
 }
 
-func TestDynatraceClient_generateKubernetesMEIdentifier(t *testing.T) {
-	t.Run(`Generate monitored entity id from kube-system uid`, func(t *testing.T) {
-		// arrange
-		var expected = "KUBERNETES_CLUSTER-4FA1F797E44DFBC0"
-
-		// act
-		var actual, err = generateKubernetesMEIdentifier("b51a38b1-2619-436a-9c0a-b0fb214a0fa9")
-
-		// assert
-		assert.NoError(t, err)
-		assert.EqualValues(t, expected, actual)
-	})
-}
-
 func createMonitoredEntitiesForTesting() []MonitoredEntity {
 	return []MonitoredEntity{
 		{EntityId: "KUBERNETES_CLUSTER-0E30FE4BF2007587", DisplayName: "operator test entity 1", LastSeenTms: 1639483869085},


### PR DESCRIPTION
# Description

Revert pre-generation of Kubernetes ME Id introduced in #569 because this check is already done on the cluster.

## How can this be tested?
Dynakube with automatic api monitoring enabled should correctly register the Kubernetes Cluster to Dynatrace.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

