### PR TITLE
Fix phase field not updating

### DIFF
--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -32,7 +32,7 @@ const (
 	PullSecretSuffix   = "-pull-secret"
 	TenantSecretSuffix = "-activegate-tenant-secret"
 
-	PodNameOSAgent = "oneagent"
+	PodNameOsAgent = "oneagent"
 )
 
 // NeedsActiveGate returns true when a feature requires ActiveGate instances.
@@ -66,7 +66,7 @@ func (dk *DynaKube) NeedsOneAgent() bool {
 }
 
 func (dk *DynaKube) OneAgentDaemonsetName() string {
-	return fmt.Sprintf("%s-%s", dk.Name, PodNameOSAgent)
+	return fmt.Sprintf("%s-%s", dk.Name, PodNameOsAgent)
 }
 
 func (dk *DynaKube) DeprecatedActiveGateMode() bool {

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +62,10 @@ func (dk *DynaKube) ClassicFullStackMode() bool {
 // NeedsOneAgent returns true when a feature requires OneAgent instances.
 func (dk *DynaKube) NeedsOneAgent() bool {
 	return dk.ClassicFullStackMode() || dk.CloudNativeFullstackMode() || dk.HostMonitoringMode()
+}
+
+func (dk *DynaKube) OneAgentDaemonsetName() string {
+	return fmt.Sprintf("%s-%s", dk.Name, daemonset.PodNameOSAgent)
 }
 
 func (dk *DynaKube) DeprecatedActiveGateMode() bool {

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +31,8 @@ const (
 	// PullSecretSuffix is the suffix appended to the DynaKube name to n.
 	PullSecretSuffix   = "-pull-secret"
 	TenantSecretSuffix = "-activegate-tenant-secret"
+
+	PodNameOSAgent = "oneagent"
 )
 
 // NeedsActiveGate returns true when a feature requires ActiveGate instances.
@@ -65,7 +66,7 @@ func (dk *DynaKube) NeedsOneAgent() bool {
 }
 
 func (dk *DynaKube) OneAgentDaemonsetName() string {
-	return fmt.Sprintf("%s-%s", dk.Name, daemonset.PodNameOSAgent)
+	return fmt.Sprintf("%s-%s", dk.Name, PodNameOSAgent)
 }
 
 func (dk *DynaKube) DeprecatedActiveGateMode() bool {

--- a/src/api/v1beta1/properties_test.go
+++ b/src/api/v1beta1/properties_test.go
@@ -98,6 +98,15 @@ func TestOneAgentImage(t *testing.T) {
 	})
 }
 
+func TestOneAgentDaemonsetName(t *testing.T) {
+	instance := &DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testName,
+		},
+	}
+	assert.Equal(t, "test-name-oneagent", instance.OneAgentDaemonsetName())
+}
+
 func TestTokens(t *testing.T) {
 	testName := "test-name"
 	testValue := "test-value"

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -272,7 +272,7 @@ func (controller *DynakubeController) reconcileDynaKube(ctx context.Context, dkS
 }
 
 func (controller *DynakubeController) removeOneAgentDaemonSet(dkState *status.DynakubeState) {
-	ds := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: dkState.Instance.Name + "-" + daemonset.PodNameOSAgent, Namespace: dkState.Instance.Namespace}}
+	ds := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: dkState.Instance.OneAgentDaemonsetName(), Namespace: dkState.Instance.Namespace}}
 	if err := controller.ensureDeleted(&ds); dkState.Error(err) {
 		return
 	}

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -8,7 +8,6 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/capability"
 	rcap "github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/reconciler/capability"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/kubesystem"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
@@ -221,7 +220,7 @@ func TestRemoveOneAgentDaemonset(t *testing.T) {
 			},
 			&appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      testName + "-" + daemonset.PodNameOSAgent,
+					Name:      testName + "-" + dynatracev1beta1.PodNameOSAgent,
 					Namespace: testNamespace,
 				},
 			},
@@ -244,7 +243,7 @@ func TestRemoveOneAgentDaemonset(t *testing.T) {
 
 		var daemonSet appsv1.DaemonSet
 
-		err = controller.client.Get(context.TODO(), client.ObjectKey{Name: (testName + "-" + daemonset.PodNameOSAgent), Namespace: testNamespace}, &daemonSet)
+		err = controller.client.Get(context.TODO(), client.ObjectKey{Name: (testName + "-" + dynatracev1beta1.PodNameOSAgent), Namespace: testNamespace}, &daemonSet)
 
 		assert.Error(t, err)
 	})

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -220,7 +220,7 @@ func TestRemoveOneAgentDaemonset(t *testing.T) {
 			},
 			&appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      testName + "-" + dynatracev1beta1.PodNameOSAgent,
+					Name:      instance.OneAgentDaemonsetName(),
 					Namespace: testNamespace,
 				},
 			},
@@ -243,7 +243,7 @@ func TestRemoveOneAgentDaemonset(t *testing.T) {
 
 		var daemonSet appsv1.DaemonSet
 
-		err = controller.client.Get(context.TODO(), client.ObjectKey{Name: (testName + "-" + dynatracev1beta1.PodNameOSAgent), Namespace: testNamespace}, &daemonSet)
+		err = controller.client.Get(context.TODO(), client.ObjectKey{Name: (instance.OneAgentDaemonsetName()), Namespace: testNamespace}, &daemonSet)
 
 		assert.Error(t, err)
 	})

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -1,7 +1,6 @@
 package daemonset
 
 import (
-	"fmt"
 	"path/filepath"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
@@ -117,7 +116,7 @@ func (dsInfo *HostMonitoring) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 		return nil, err
 	}
 
-	result.Name = fmt.Sprintf("%s-%s", dsInfo.instance.Name, PodNameOSAgent)
+	result.Name = dsInfo.instance.OneAgentDaemonsetName()
 	result.Labels[labelFeature] = dsInfo.feature
 	result.Spec.Selector.MatchLabels[labelAgentType] = labelAgentTypeValue
 	result.Spec.Template.Labels[labelFeature] = dsInfo.feature
@@ -137,7 +136,7 @@ func (dsInfo *ClassicFullStack) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 		return nil, err
 	}
 
-	result.Name = fmt.Sprintf("%s-%s", dsInfo.instance.Name, PodNameOSAgent)
+	result.Name = dsInfo.instance.OneAgentDaemonsetName()
 	result.Labels[labelFeature] = ClassicFeature
 	result.Spec.Selector.MatchLabels[labelAgentType] = labelAgentTypeValue
 	result.Spec.Template.Labels[labelFeature] = ClassicFeature

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -44,8 +44,6 @@ const (
 	inframonHostIdSource = "--set-host-id-source=k8s-node-name"
 	classicHostIdSource  = "--set-host-id-source=auto"
 
-	PodNameOSAgent = "oneagent"
-
 	ClassicFeature        = "classic"
 	HostMonitoringFeature = "inframon"
 	CloudNativeFeature    = "cloud-native"

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler.go
@@ -224,7 +224,7 @@ func getInstanceStatuses(pods []corev1.Pod) (map[string]dynatracev1beta1.OneAgen
 func (r *OneAgentReconciler) determineDynaKubePhase(instance *dynatracev1beta1.DynaKube) (bool, error) {
 	var phaseChanged bool
 	dsActual := &appsv1.DaemonSet{}
-	instanceName := fmt.Sprintf("%s-%s", instance.Name, r.feature)
+	instanceName := fmt.Sprintf("%s-%s", instance.OneAgentDaemonsetName())
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instanceName, Namespace: instance.Namespace}, dsActual)
 
 	if k8serrors.IsNotFound(err) {

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler.go
@@ -224,7 +224,7 @@ func getInstanceStatuses(pods []corev1.Pod) (map[string]dynatracev1beta1.OneAgen
 func (r *OneAgentReconciler) determineDynaKubePhase(instance *dynatracev1beta1.DynaKube) (bool, error) {
 	var phaseChanged bool
 	dsActual := &appsv1.DaemonSet{}
-	instanceName := fmt.Sprintf("%s-%s", instance.OneAgentDaemonsetName())
+	instanceName := instance.OneAgentDaemonsetName()
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instanceName, Namespace: instance.Namespace}, dsActual)
 
 	if k8serrors.IsNotFound(err) {

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -92,10 +92,10 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironmentAndDNSPolicy(t *testing.T)
 	assert.NoError(t, err)
 
 	dsActual := &appsv1.DaemonSet{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: dkName + "-" + dynatracev1beta1.PodNameOSAgent, Namespace: namespace}, dsActual)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: dynakube.OneAgentDaemonsetName(), Namespace: namespace}, dsActual)
 	assert.NoError(t, err, "failed to get DaemonSet")
 	assert.Equal(t, namespace, dsActual.Namespace, "wrong namespace")
-	assert.Equal(t, dkName+"-"+dynatracev1beta1.PodNameOSAgent, dsActual.GetObjectMeta().GetName(), "wrong name")
+	assert.Equal(t, dynakube.OneAgentDaemonsetName(), dsActual.GetObjectMeta().GetName(), "wrong name")
 	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, dsActual.Spec.Template.Spec.DNSPolicy, "wrong policy")
 	mock.AssertExpectationsForObjects(t, dtClient)
 }

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -92,10 +92,10 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironmentAndDNSPolicy(t *testing.T)
 	assert.NoError(t, err)
 
 	dsActual := &appsv1.DaemonSet{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: dkName + "-" + daemonset.PodNameOSAgent, Namespace: namespace}, dsActual)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: dkName + "-" + dynatracev1beta1.PodNameOSAgent, Namespace: namespace}, dsActual)
 	assert.NoError(t, err, "failed to get DaemonSet")
 	assert.Equal(t, namespace, dsActual.Namespace, "wrong namespace")
-	assert.Equal(t, dkName+"-"+daemonset.PodNameOSAgent, dsActual.GetObjectMeta().GetName(), "wrong name")
+	assert.Equal(t, dkName+"-"+dynatracev1beta1.PodNameOSAgent, dsActual.GetObjectMeta().GetName(), "wrong name")
 	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, dsActual.Spec.Template.Spec.DNSPolicy, "wrong policy")
 	mock.AssertExpectationsForObjects(t, dtClient)
 }

--- a/src/testing/e2e/integrationtests/envutils_test.go
+++ b/src/testing/e2e/integrationtests/envutils_test.go
@@ -104,14 +104,16 @@ func (e *ControllerTestEnvironment) Stop() error {
 	return e.server.Stop()
 }
 
-func (e *ControllerTestEnvironment) AddOneAgent(n string, s *dynatracev1beta1.DynaKubeSpec) error {
-	return e.Client.Create(context.TODO(), &dynatracev1beta1.DynaKube{
+func (e *ControllerTestEnvironment) AddOneAgent(n string, s *dynatracev1beta1.DynaKubeSpec) (*dynatracev1beta1.DynaKube, error) {
+	instance := &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      n,
 			Namespace: DefaultTestNamespace,
 		},
 		Spec: *s,
-	})
+	}
+
+	return instance, e.Client.Create(context.TODO(), instance)
 }
 
 func newReconciliationRequest(oaName string) reconcile.Request {

--- a/src/testing/e2e/integrationtests/oneagent_controller_integration_test.go
+++ b/src/testing/e2e/integrationtests/oneagent_controller_integration_test.go
@@ -22,13 +22,14 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironment(t *testing.T) {
 
 	defer e.Stop()
 
-	e.AddOneAgent(oaName, &dynatracev1beta1.DynaKubeSpec{
+	instance, err := e.AddOneAgent(oaName, &dynatracev1beta1.DynaKubeSpec{
 		APIURL: DefaultTestAPIURL,
 		Tokens: "token-test",
 		OneAgent: dynatracev1beta1.OneAgentSpec{
 			ClassicFullStack: &dynatracev1beta1.ClassicFullStackSpec{},
 		},
 	})
+	assert.NoError(t, err)
 
 	_, err = e.Reconciler.Reconcile(context.TODO(), newReconciliationRequest(oaName))
 	assert.NoError(t, err, "error reconciling")
@@ -36,10 +37,10 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironment(t *testing.T) {
 	// Check if deamonset has been created and has correct namespace and name.
 	dsActual := &appsv1.DaemonSet{}
 
-	err = e.Client.Get(context.TODO(), types.NamespacedName{Name: oaName + "-" + dynatracev1beta1.PodNameOSAgent, Namespace: DefaultTestNamespace}, dsActual)
+	err = e.Client.Get(context.TODO(), types.NamespacedName{Name: instance.OneAgentDaemonsetName(), Namespace: DefaultTestNamespace}, dsActual)
 	assert.NoError(t, err, "failed to get daemonset")
 
 	assert.Equal(t, DefaultTestNamespace, dsActual.Namespace, "wrong namespace")
-	assert.Equal(t, oaName+"-"+dynatracev1beta1.PodNameOSAgent, dsActual.GetObjectMeta().GetName(), "wrong name")
+	assert.Equal(t, instance.OneAgentDaemonsetName(), dsActual.GetObjectMeta().GetName(), "wrong name")
 	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, dsActual.Spec.Template.Spec.DNSPolicy, "DNS policy should ClusterFirst by default")
 }

--- a/src/testing/e2e/integrationtests/oneagent_controller_integration_test.go
+++ b/src/testing/e2e/integrationtests/oneagent_controller_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,10 +36,10 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironment(t *testing.T) {
 	// Check if deamonset has been created and has correct namespace and name.
 	dsActual := &appsv1.DaemonSet{}
 
-	err = e.Client.Get(context.TODO(), types.NamespacedName{Name: oaName + "-" + daemonset.PodNameOSAgent, Namespace: DefaultTestNamespace}, dsActual)
+	err = e.Client.Get(context.TODO(), types.NamespacedName{Name: oaName + "-" + dynatracev1beta1.PodNameOSAgent, Namespace: DefaultTestNamespace}, dsActual)
 	assert.NoError(t, err, "failed to get daemonset")
 
 	assert.Equal(t, DefaultTestNamespace, dsActual.Namespace, "wrong namespace")
-	assert.Equal(t, oaName+"-"+daemonset.PodNameOSAgent, dsActual.GetObjectMeta().GetName(), "wrong name")
+	assert.Equal(t, oaName+"-"+dynatracev1beta1.PodNameOSAgent, dsActual.GetObjectMeta().GetName(), "wrong name")
 	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, dsActual.Spec.Template.Spec.DNSPolicy, "DNS policy should ClusterFirst by default")
 }


### PR DESCRIPTION
# Description
The oneagent reconciler references the wrong daemonset and therefore never updates the phase field.

## How can this be tested?
Deploy full stack monitoring and watch the phase field. => Should be "Running" after dynakube reconciliation.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

