### PR TITLE
Update volume entry if exists

### DIFF
--- a/src/controllers/csi/metadata/sqlite.go
+++ b/src/controllers/csi/metadata/sqlite.go
@@ -49,7 +49,11 @@ const (
 
 	insertVolumeStatement = `
 	INSERT INTO volumes (ID, PodName, Version, TenantUUID)
-	VALUES (?,?,?,?);
+	VALUES (?,?,?,?)
+	ON CONFLICT(ID) DO UPDATE SET
+	  PodName=excluded.PodName,
+	  Version=excluded.Version,
+	  TenantUUID=excluded.TenantUUID;
 	`
 
 	insertOsAgentVolumeStatement = `

--- a/src/controllers/csi/metadata/sqlite_test.go
+++ b/src/controllers/csi/metadata/sqlite_test.go
@@ -159,19 +159,29 @@ func TestInsertVolume(t *testing.T) {
 	db := FakeMemoryDB()
 
 	err := db.InsertVolume(&testVolume1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	row := db.conn.QueryRow(fmt.Sprintf("SELECT * FROM %s WHERE ID = ?;", volumesTableName), testVolume1.VolumeID)
 	var id string
 	var puid string
 	var ver string
 	var tuid string
 	err = row.Scan(&id, &puid, &ver, &tuid)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, id, testVolume1.VolumeID)
 	assert.Equal(t, puid, testVolume1.PodName)
 	assert.Equal(t, ver, testVolume1.Version)
 	assert.Equal(t, tuid, testVolume1.TenantUUID)
-
+	newPodName := "something-else"
+	testVolume1.PodName = newPodName
+	err = db.InsertVolume(&testVolume1)
+	require.NoError(t, err)
+	row = db.conn.QueryRow(fmt.Sprintf("SELECT * FROM %s WHERE ID = ?;", volumesTableName), testVolume1.VolumeID)
+	err = row.Scan(&id, &puid, &ver, &tuid)
+	require.NoError(t, err)
+	assert.Equal(t, id, testVolume1.VolumeID)
+	assert.Equal(t, puid, newPodName)
+	assert.Equal(t, ver, testVolume1.Version)
+	assert.Equal(t, tuid, testVolume1.TenantUUID)
 }
 
 func TestInsertOsAgentVolume(t *testing.T) {


### PR DESCRIPTION
# Description
In some cases (node restart) kubelet might ask to mount a previously mounted volume (volumeID is the same), which causes a clash in the database. 

## How can this be tested?
On node restart everything should work


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

