### PR TITLE
Added opt-in feature flag AnnotationFeatureEnableActivegateRawImage

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:

--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -39,6 +39,7 @@ const (
 	annotationFeatureCustomEecImage                   = annotationFeaturePrefix + "custom-eec-image"
 	annotationFeatureCustomStatsdImage                = annotationFeaturePrefix + "custom-statsd-image"
 	AnnotationFeatureDisableReadOnlyOneAgent          = annotationFeaturePrefix + "disable-oneagent-readonly-host-fs"
+	AnnotationFeatureEnableActivegateRawImage         = annotationFeaturePrefix + "enable-activegate-raw-image"
 	AnnotationFeatureEnableMultipleOsAgentsOnNode     = annotationFeaturePrefix + "multiple-osagents-on-node"
 )
 
@@ -145,6 +146,14 @@ func (dk *DynaKube) FeatureCustomStatsdImage() string {
 // Defaults to false
 func (dk *DynaKube) FeatureDisableReadOnlyOneAgent() bool {
 	return dk.Annotations[AnnotationFeatureDisableReadOnlyOneAgent] == "true"
+}
+
+// FeatureEnableActivegateRawImage is a feature flag to specify if the operator should
+// fetch from cluster and set in ActiveGet container: tenant UUID, token and communication endpoints
+// instead of using embedded ones in the image
+// Defaults to false
+func (dk *DynaKube) FeatureEnableActivegateRawImage() bool {
+	return dk.Annotations[AnnotationFeatureEnableActivegateRawImage] == "true"
 }
 
 // FeatureEnableMultipleOsAgentsOnNode is a feature flag to enable multiple osagents running on the same host

--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -346,28 +346,8 @@ func buildEnvs(stsProperties *statefulSetProperties) []corev1.EnvVar {
 
 	if stsProperties.DynaKube.FeatureEnableActivegateRawImage() {
 		envs = append(envs,
-			corev1.EnvVar{
-				Name: dtServer,
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: stsProperties.AGTenantSecret(),
-						},
-						Key: activegate.CommunicationEndpointsName,
-					},
-				},
-			},
-			corev1.EnvVar{
-				Name: dtTenant,
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: stsProperties.AGTenantSecret(),
-						},
-						Key: activegate.TenantUuidName,
-					},
-				},
-			})
+			communicationEndpointEnvVar(stsProperties),
+			tenantUuidNameEnvVar(stsProperties))
 	}
 
 	envs = append(envs, stsProperties.Env...)
@@ -380,6 +360,34 @@ func buildEnvs(stsProperties *statefulSetProperties) []corev1.EnvVar {
 	}
 
 	return envs
+}
+
+func tenantUuidNameEnvVar(stsProperties *statefulSetProperties) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: dtTenant,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: stsProperties.AGTenantSecret(),
+				},
+				Key: activegate.TenantUuidName,
+			},
+		},
+	}
+}
+
+func communicationEndpointEnvVar(stsProperties *statefulSetProperties) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: dtServer,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: stsProperties.AGTenantSecret(),
+				},
+				Key: activegate.CommunicationEndpointsName,
+			},
+		},
+	}
 }
 
 func determineServiceAccountName(stsProperties *statefulSetProperties) string {

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -195,7 +195,7 @@ func (controller *DynakubeController) reconcileDynaKube(ctx context.Context, dkS
 		return
 	}
 
-	if dkState.Instance.NeedsActiveGate() {
+	if dkState.Instance.FeatureEnableActivegateRawImage() && dkState.Instance.NeedsActiveGate() {
 		err = activegate.
 			NewTenantSecretReconciler(controller.client, controller.apiReader, controller.scheme, dkState.Instance, dtcReconciler.ApiToken, dtc).
 			Reconcile()


### PR DESCRIPTION
# Description

Added a feature flag called `AnnotationFeatureEnableActivegateRawImage`. (=`false` by default).
It allows customer to opt-in to use raw AG image.

## How can this be tested?
1. Create dynakube with AG spec
2. check if it works with no annotation
3. add `AnnotationFeatureEnableActivegateRawImage = "false"`, operator should work as in point 1
4. change `AnnotationFeatureEnableActivegateRawImage = "true"` and check if `<dynakube>-activegate-tenant-secret` is created and if it's mounted in a pod as:
- token secret: `/var/lib/dynatrace/secrets/tokens/tenant-token`
- env vars: `DT_SERVER`, `DT_TENANT`

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

