### PR TITLE
Allows domainless tenant urls

### DIFF
--- a/src/api/v1beta1/properties_test.go
+++ b/src/api/v1beta1/properties_test.go
@@ -140,6 +140,18 @@ func TestTenantUUID(t *testing.T) {
 		)
 	})
 
+	t.Run("happy path (alternative, no domain)", func(t *testing.T) {
+		apiUrl := "https://dynakube-activegate/e/tenant/api/v2/metrics/ingest"
+		expectedTenantId := "tenant"
+
+		actualTenantId, err := tenantUUID(apiUrl)
+
+		assert.NoErrorf(t, err, "Expected that getting tenant id from '%s' will be successful", apiUrl)
+		assert.Equalf(t, expectedTenantId, actualTenantId, "Expected that tenant id of %s is %s, but found %s",
+			apiUrl, expectedTenantId, actualTenantId,
+		)
+	})
+
 	t.Run("missing API URL protocol", func(t *testing.T) {
 		apiUrl := "demo.dev.dynatracelabs.com/api"
 		expectedTenantId := ""

--- a/src/webhook/validation/api_url.go
+++ b/src/webhook/validation/api_url.go
@@ -48,13 +48,13 @@ func isInvalidApiUrl(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube)
 		return errorInvalidApiUrl
 	}
 
-	fqdn := parsedUrl.Hostname()
-	hostnameWithDomains := strings.FieldsFunc(fqdn,
+	hostname := parsedUrl.Hostname()
+	hostnameWithDomains := strings.FieldsFunc(hostname,
 		func(r rune) bool { return r == '.' },
 	)
 
-	if len(hostnameWithDomains) < 2 || len(hostnameWithDomains[0]) == 0 {
-		log.Info("problem getting tenant id from fqdn", "fqdn", fqdn)
+	if len(hostnameWithDomains) < 1 || len(hostnameWithDomains[0]) == 0 {
+		log.Info("invalid hostname in the api url", "hostname", hostname)
 		return errorInvalidApiUrl
 	}
 

--- a/src/webhook/validation/api_url_test.go
+++ b/src/webhook/validation/api_url_test.go
@@ -22,6 +22,18 @@ func TestHasApiUrl(t *testing.T) {
 			},
 		})
 	})
+	t.Run(`valid API URL (no domain)`, func(t *testing.T) {
+		assertAllowedResponse(t, &dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: "https://...tenantid/api",
+			},
+		})
+		assertAllowedResponse(t, &dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: "https://my-in-cluster-activegate/e/<tenant>/api",
+			},
+		})
+	})
 	t.Run(`missing API URL`, func(t *testing.T) {
 		assertDeniedResponse(t, []string{errorNoApiUrl}, &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
@@ -54,13 +66,6 @@ func TestHasApiUrl(t *testing.T) {
 		assertDeniedResponse(t, []string{errorInvalidApiUrl}, &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: "/api",
-			},
-		})
-	})
-	t.Run(`invalid API URL (missing domain)`, func(t *testing.T) {
-		assertDeniedResponse(t, []string{errorInvalidApiUrl}, &dynatracev1beta1.DynaKube{
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: "https://...tenantid/api",
 			},
 		})
 	})


### PR DESCRIPTION
# Description

This changeset fixes webhook API URL validation if tenant URL is defined without domain (it was rejected before and is accepted from now on).

## How can this be tested?
Define a DynaKube with API URL similar to `https://dynakube-activegate/e/tenant/api` (with implicit domain).

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
