### PR TITLE
Fix nil panic introduced by installer rework

### DIFF
--- a/src/controllers/csi/provisioner/processmoduleconfig.go
+++ b/src/controllers/csi/provisioner/processmoduleconfig.go
@@ -47,7 +47,7 @@ func (provisioner *OneAgentProvisioner) getProcessModuleConfig(dtc dtclient.Clie
 	if err != nil {
 		return nil, storedHash, err
 	}
-	if latestProcessModuleConfig != nil {
+	if latestProcessModuleConfig != nil && !latestProcessModuleConfig.IsEmpty() {
 		return latestProcessModuleConfig, storedHash, nil
 	}
 	return storedProcessModuleConfig.ProcessModuleConfig, storedHash, nil

--- a/src/dtclient/processmoduleconfig_test.go
+++ b/src/dtclient/processmoduleconfig_test.go
@@ -42,10 +42,11 @@ func TestSpecialProcessModuleConfigRequestStatus(t *testing.T) {
 	dc := &dynatraceClient{}
 	require.NotNil(t, dc)
 
-	assert.True(t, dc.specialProcessModuleConfigRequestStatus(&http.Response{StatusCode: http.StatusNotModified}))
-	assert.True(t, dc.specialProcessModuleConfigRequestStatus(&http.Response{StatusCode: http.StatusNotFound}))
-	assert.False(t, dc.specialProcessModuleConfigRequestStatus(&http.Response{StatusCode: http.StatusOK}))
-	assert.False(t, dc.specialProcessModuleConfigRequestStatus(&http.Response{StatusCode: http.StatusInternalServerError}))
+	assert.True(t, dc.checkProcessModuleConfigRequestStatus(nil))
+	assert.True(t, dc.checkProcessModuleConfigRequestStatus(&http.Response{StatusCode: http.StatusNotModified}))
+	assert.True(t, dc.checkProcessModuleConfigRequestStatus(&http.Response{StatusCode: http.StatusNotFound}))
+	assert.False(t, dc.checkProcessModuleConfigRequestStatus(&http.Response{StatusCode: http.StatusOK}))
+	assert.False(t, dc.checkProcessModuleConfigRequestStatus(&http.Response{StatusCode: http.StatusInternalServerError}))
 }
 
 func TestReadResponseForProcessModuleConfig(t *testing.T) {


### PR DESCRIPTION
# Description
this bug was introduced when the extraction/rework of the installer in the csi driver happend. If the processmoduleconfig endpoint is not present on the tenant we would get a nil panic in the csi provisioner no matter what. 

## How can this be tested?
In a new cluster, with a tenant that doesn't have the processmoduleconfig endpoint, deploy cloudNative, the csi driver should not panic and should mount the volume successfully. (if hostGroup is used it should be added to the ruxitagentproc.conf)


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

