### PR TITLE
Enables relevant ActiveGate service ports based on capability requirements

### DIFF
--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -94,10 +94,6 @@ func (dk *DynaKube) NeedsStatsd() bool {
 	return dk.IsActiveGateMode(StatsdIngestCapability.DisplayName)
 }
 
-func (dk *DynaKube) NeedsMetricsIngest() bool {
-	return dk.IsActiveGateMode(MetricsIngestCapability.DisplayName)
-}
-
 func (dk *DynaKube) HasActiveGateTLS() bool {
 	return dk.ActiveGateMode() && dk.Spec.ActiveGate.TlsSecretName != ""
 }

--- a/src/controllers/activegate/capability/capability.go
+++ b/src/controllers/activegate/capability/capability.go
@@ -34,12 +34,12 @@ var activeGateCapabilities = map[dynatracev1beta1.CapabilityDisplayName]baseFunc
 }
 
 type AgServicePorts struct {
-	HttpsAndHttp bool
-	Statsd       bool
+	Webserver bool
+	Statsd    bool
 }
 
 func (ports AgServicePorts) AtLeastOneEnabled() bool {
-	return ports.HttpsAndHttp || ports.Statsd
+	return ports.Webserver || ports.Statsd
 }
 
 type Configuration struct {
@@ -163,7 +163,7 @@ func NewMultiCapability(dk *dynatracev1beta1.DynaKube) *MultiCapability {
 		},
 	}
 	if dk == nil || !dk.ActiveGateMode() {
-		mc.ServicePorts.HttpsAndHttp = true // necessary for cleaning up service if created
+		mc.ServicePorts.Webserver = true // necessary for cleaning up service if created
 		return &mc
 	}
 	mc.enabled = true
@@ -181,8 +181,8 @@ func NewMultiCapability(dk *dynatracev1beta1.DynaKube) *MultiCapability {
 		mc.containerVolumeMounts = append(mc.containerVolumeMounts, capGen.containerVolumeMounts...)
 		mc.volumes = append(mc.volumes, capGen.volumes...)
 
-		if !mc.ServicePorts.HttpsAndHttp {
-			mc.ServicePorts.HttpsAndHttp = capGen.ServicePorts.HttpsAndHttp
+		if !mc.ServicePorts.Webserver {
+			mc.ServicePorts.Webserver = capGen.ServicePorts.Webserver
 		}
 		if !mc.ServicePorts.Statsd {
 			mc.ServicePorts.Statsd = capGen.ServicePorts.Statsd
@@ -283,7 +283,7 @@ func routingBase() *capabilityBase {
 			SetReadinessPort:     true,
 			SetCommunicationPort: true,
 			ServicePorts: AgServicePorts{
-				HttpsAndHttp: true,
+				Webserver: true,
 			},
 			CreateEecRuntimeConfig: false,
 		},
@@ -300,7 +300,7 @@ func metricsIngestBase() *capabilityBase {
 			SetReadinessPort:     true,
 			SetCommunicationPort: true,
 			ServicePorts: AgServicePorts{
-				HttpsAndHttp: true,
+				Webserver: true,
 			},
 			CreateEecRuntimeConfig: false,
 		},
@@ -317,7 +317,7 @@ func dynatraceApiBase() *capabilityBase {
 			SetReadinessPort:     true,
 			SetCommunicationPort: true,
 			ServicePorts: AgServicePorts{
-				HttpsAndHttp: true,
+				Webserver: true,
 			},
 		},
 	}

--- a/src/controllers/activegate/capability/capability.go
+++ b/src/controllers/activegate/capability/capability.go
@@ -60,7 +60,7 @@ type Capability interface {
 	InitContainersTemplates() []corev1.Container
 	ContainerVolumeMounts() []corev1.VolumeMount
 	Volumes() []corev1.Volume
-	CreateService() bool
+	ShouldCreateService() bool
 }
 
 type capabilityBase struct {
@@ -94,7 +94,7 @@ func (c *capabilityBase) ArgName() string {
 	return c.argName
 }
 
-func (c *capabilityBase) CreateService() bool {
+func (c *capabilityBase) ShouldCreateService() bool {
 	return c.ServicePorts.AtLeastOneEnabled()
 }
 

--- a/src/controllers/activegate/capability/capability_test.go
+++ b/src/controllers/activegate/capability/capability_test.go
@@ -45,8 +45,10 @@ func Test_capabilityBase_Configuration(t *testing.T) {
 		SetDnsEntryPoint:     false,
 		SetReadinessPort:     false,
 		SetCommunicationPort: true,
-		CreateService:        true,
-		ServiceAccountOwner:  "accowner",
+		ServicePorts: AgServicePorts{
+			HttpsAndHttp: true,
+		},
+		ServiceAccountOwner: "accowner",
 	}
 
 	type fields struct {
@@ -275,8 +277,10 @@ func TestNewRoutingCapability(t *testing.T) {
 						SetDnsEntryPoint:     true,
 						SetReadinessPort:     true,
 						SetCommunicationPort: true,
-						CreateService:        true,
 						ServiceAccountOwner:  "",
+						ServicePorts: AgServicePorts{
+							HttpsAndHttp: true,
+						},
 					},
 				},
 			},
@@ -315,7 +319,9 @@ func TestNewMultiCapability(t *testing.T) {
 					enabled:   false,
 					shortName: MultiActiveGateName,
 					Configuration: Configuration{
-						CreateService: true,
+						ServicePorts: AgServicePorts{
+							HttpsAndHttp: true,
+						},
 					},
 				},
 			},
@@ -343,8 +349,10 @@ func TestNewMultiCapability(t *testing.T) {
 						SetDnsEntryPoint:     true,
 						SetReadinessPort:     true,
 						SetCommunicationPort: true,
-						CreateService:        true,
 						ServiceAccountOwner:  "",
+						ServicePorts: AgServicePorts{
+							HttpsAndHttp: true,
+						},
 					},
 				},
 			},
@@ -372,8 +380,10 @@ func TestNewMultiCapability(t *testing.T) {
 						SetDnsEntryPoint:     true,
 						SetReadinessPort:     true,
 						SetCommunicationPort: true,
-						CreateService:        true,
 						ServiceAccountOwner:  "",
+						ServicePorts: AgServicePorts{
+							HttpsAndHttp: true,
+						},
 					},
 				},
 			},
@@ -401,8 +411,10 @@ func TestNewMultiCapability(t *testing.T) {
 						SetDnsEntryPoint:     true,
 						SetReadinessPort:     true,
 						SetCommunicationPort: true,
-						CreateService:        true,
 						ServiceAccountOwner:  "",
+						ServicePorts: AgServicePorts{
+							HttpsAndHttp: true,
+						},
 					},
 				},
 			},
@@ -430,9 +442,11 @@ func TestNewMultiCapability(t *testing.T) {
 						SetDnsEntryPoint:       true,
 						SetReadinessPort:       true,
 						SetCommunicationPort:   true,
-						CreateService:          true,
 						CreateEecRuntimeConfig: true,
 						ServiceAccountOwner:    "",
+						ServicePorts: AgServicePorts{
+							Statsd: true,
+						},
 					},
 				},
 			},
@@ -523,9 +537,12 @@ func TestNewMultiCapability(t *testing.T) {
 						SetDnsEntryPoint:       true,
 						SetReadinessPort:       true,
 						SetCommunicationPort:   true,
-						CreateService:          true,
 						CreateEecRuntimeConfig: true,
 						ServiceAccountOwner:    "kubernetes-monitoring",
+						ServicePorts: AgServicePorts{
+							HttpsAndHttp: true,
+							Statsd:       true,
+						},
 					},
 					initContainersTemplates: []v1.Container{
 						{

--- a/src/controllers/activegate/capability/capability_test.go
+++ b/src/controllers/activegate/capability/capability_test.go
@@ -46,7 +46,7 @@ func Test_capabilityBase_Configuration(t *testing.T) {
 		SetReadinessPort:     false,
 		SetCommunicationPort: true,
 		ServicePorts: AgServicePorts{
-			HttpsAndHttp: true,
+			Webserver: true,
 		},
 		ServiceAccountOwner: "accowner",
 	}
@@ -279,7 +279,7 @@ func TestNewRoutingCapability(t *testing.T) {
 						SetCommunicationPort: true,
 						ServiceAccountOwner:  "",
 						ServicePorts: AgServicePorts{
-							HttpsAndHttp: true,
+							Webserver: true,
 						},
 					},
 				},
@@ -320,7 +320,7 @@ func TestNewMultiCapability(t *testing.T) {
 					shortName: MultiActiveGateName,
 					Configuration: Configuration{
 						ServicePorts: AgServicePorts{
-							HttpsAndHttp: true,
+							Webserver: true,
 						},
 					},
 				},
@@ -351,7 +351,7 @@ func TestNewMultiCapability(t *testing.T) {
 						SetCommunicationPort: true,
 						ServiceAccountOwner:  "",
 						ServicePorts: AgServicePorts{
-							HttpsAndHttp: true,
+							Webserver: true,
 						},
 					},
 				},
@@ -382,7 +382,7 @@ func TestNewMultiCapability(t *testing.T) {
 						SetCommunicationPort: true,
 						ServiceAccountOwner:  "",
 						ServicePorts: AgServicePorts{
-							HttpsAndHttp: true,
+							Webserver: true,
 						},
 					},
 				},
@@ -413,7 +413,7 @@ func TestNewMultiCapability(t *testing.T) {
 						SetCommunicationPort: true,
 						ServiceAccountOwner:  "",
 						ServicePorts: AgServicePorts{
-							HttpsAndHttp: true,
+							Webserver: true,
 						},
 					},
 				},
@@ -540,8 +540,8 @@ func TestNewMultiCapability(t *testing.T) {
 						CreateEecRuntimeConfig: true,
 						ServiceAccountOwner:    "kubernetes-monitoring",
 						ServicePorts: AgServicePorts{
-							HttpsAndHttp: true,
-							Statsd:       true,
+							Webserver: true,
+							Statsd:    true,
 						},
 					},
 					initContainersTemplates: []v1.Container{

--- a/src/controllers/activegate/reconciler/capability/reconciler.go
+++ b/src/controllers/activegate/reconciler/capability/reconciler.go
@@ -137,7 +137,7 @@ func buildDNSEntryPoint(instance *dynatracev1beta1.DynaKube, moduleName string) 
 }
 
 func (r *Reconciler) Reconcile() (update bool, err error) {
-	if r.CreateService() {
+	if r.ShouldCreateService() {
 		multiCapability := capability.NewMultiCapability(r.Instance)
 		update, err = r.createOrUpdateService(multiCapability.ServicePorts)
 		if update || err != nil {

--- a/src/controllers/activegate/reconciler/capability/reconciler.go
+++ b/src/controllers/activegate/reconciler/capability/reconciler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/internal/events"
 	sts "github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/reconciler/statefulset"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -136,13 +137,9 @@ func buildDNSEntryPoint(instance *dynatracev1beta1.DynaKube, moduleName string) 
 }
 
 func (r *Reconciler) Reconcile() (update bool, err error) {
-	if r.Config().CreateService {
-		update, err = r.createServiceIfNotExists()
-		if update || err != nil {
-			return update, errors.WithStack(err)
-		}
-
-		update, err = r.updateServiceIfOutdated()
+	if r.CreateService() {
+		multiCapability := capability.NewMultiCapability(r.Instance)
+		update, err = r.createOrUpdateService(multiCapability.ServicePorts)
 		if update || err != nil {
 			return update, errors.WithStack(err)
 		}
@@ -159,44 +156,41 @@ func (r *Reconciler) Reconcile() (update bool, err error) {
 	return update, errors.WithStack(err)
 }
 
-func (r *Reconciler) createServiceIfNotExists() (bool, error) {
-	service := createService(r.Instance, r.ShortName())
+func (r *Reconciler) createOrUpdateService(desiredServicePorts capability.AgServicePorts) (bool, error) {
+	desired := createService(r.Instance, r.ShortName(), desiredServicePorts)
+	installed := &corev1.Service{}
 
-	err := r.Get(context.TODO(), client.ObjectKey{Name: service.Name, Namespace: service.Namespace}, service)
-	if err != nil && k8serrors.IsNotFound(err) {
-		log.Info("creating service", "module", r.ShortName())
-		if err := controllerutil.SetControllerReference(r.Instance, service, r.Scheme()); err != nil {
+	err := r.Get(context.TODO(), kubeobjects.Key(desired), installed)
+	if k8serrors.IsNotFound(err) && desiredServicePorts.AtLeastOneEnabled() {
+		log.Info("creating AG service", "module", r.ShortName())
+		if err = controllerutil.SetControllerReference(r.Instance, desired, r.Scheme()); err != nil {
 			return false, errors.WithStack(err)
 		}
 
-		err = r.Create(context.TODO(), service)
+		err = r.Create(context.TODO(), desired)
 		return true, errors.WithStack(err)
 	}
-	return false, errors.WithStack(err)
-}
 
-func (r *Reconciler) updateServiceIfOutdated() (bool, error) {
-	desiredService := createService(r.Instance, r.ShortName())
-	installedService := &corev1.Service{}
+	if err == nil {
+		if r.portsAreOutdated(installed, desired) {
+			desired.Spec.ClusterIP = installed.Spec.ClusterIP
+			desired.ObjectMeta.ResourceVersion = installed.ObjectMeta.ResourceVersion
 
-	if err := r.Get(
-		context.TODO(),
-		client.ObjectKey{Name: desiredService.Name, Namespace: desiredService.Namespace},
-		installedService,
-	); err != nil {
-		return false, errors.WithStack(err)
-	}
-
-	if r.portsAreOutdated(installedService, desiredService) {
-		desiredService.Spec.ClusterIP = installedService.Spec.ClusterIP
-		desiredService.ObjectMeta.ResourceVersion = installedService.ObjectMeta.ResourceVersion
-		err := r.Update(context.TODO(), desiredService)
-		if err != nil {
-			return false, err
+			switch desiredServicePorts.AtLeastOneEnabled() {
+			case true:
+				if err := r.Update(context.TODO(), desired); err != nil {
+					return false, err
+				}
+			case false:
+				if err := r.Delete(context.TODO(), desired); err != nil {
+					return false, err
+				}
+			}
+			return true, nil
 		}
-		return true, nil
 	}
-	return false, nil
+
+	return false, errors.WithStack(err)
 }
 
 func (r *Reconciler) portsAreOutdated(installedService, desiredService *corev1.Service) bool {

--- a/src/controllers/activegate/reconciler/capability/service.go
+++ b/src/controllers/activegate/reconciler/capability/service.go
@@ -12,10 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func createService(instance *dynatracev1beta1.DynaKube, feature string) *corev1.Service {
+func createService(instance *dynatracev1beta1.DynaKube, feature string, servicePorts capability.AgServicePorts) *corev1.Service {
 	var ports []corev1.ServicePort
 
-	if instance.NeedsMetricsIngest() {
+	if servicePorts.HttpsAndHttp {
 		ports = append(ports,
 			corev1.ServicePort{
 				Name:       capability.HttpsServicePortName,
@@ -32,7 +32,7 @@ func createService(instance *dynatracev1beta1.DynaKube, feature string) *corev1.
 		)
 	}
 
-	if instance.NeedsStatsd() {
+	if servicePorts.Statsd {
 		ports = append(ports,
 			corev1.ServicePort{
 				Name:       capability.StatsdIngestPortName,

--- a/src/controllers/activegate/reconciler/capability/service.go
+++ b/src/controllers/activegate/reconciler/capability/service.go
@@ -15,7 +15,7 @@ import (
 func createService(instance *dynatracev1beta1.DynaKube, feature string, servicePorts capability.AgServicePorts) *corev1.Service {
 	var ports []corev1.ServicePort
 
-	if servicePorts.HttpsAndHttp {
+	if servicePorts.Webserver {
 		ports = append(ports,
 			corev1.ServicePort{
 				Name:       capability.HttpsServicePortName,

--- a/src/controllers/activegate/reconciler/capability/service_test.go
+++ b/src/controllers/activegate/reconciler/capability/service_test.go
@@ -51,7 +51,9 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check service name and selector", func(t *testing.T) {
 		instance := testCreateInstance()
-		service := createService(instance, testFeature)
+		service := createService(instance, testFeature, capability.AgServicePorts{
+			HttpsAndHttp: true,
+		})
 
 		assert.NotNil(t, service)
 		assert.Equal(t, instance.Name+"-"+testFeature, service.Name)
@@ -68,11 +70,15 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check AG service if metrics ingest enabled, but not StatsD", func(t *testing.T) {
 		instance := testCreateInstance()
+		desiredPorts := capability.AgServicePorts{
+			HttpsAndHttp: true,
+		}
 		testSetCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
 		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, false)
-		require.True(t, instance.NeedsMetricsIngest() && !instance.NeedsStatsd())
+		require.True(t, !instance.NeedsStatsd())
+		require.True(t, desiredPorts.AtLeastOneEnabled())
 
-		service := createService(instance, testFeature)
+		service := createService(instance, testFeature, desiredPorts)
 		ports := service.Spec.Ports
 
 		assert.Contains(t, ports, agHttpsPort, agHttpPort)
@@ -81,11 +87,16 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check AG service if metrics ingest and StatsD enabled", func(t *testing.T) {
 		instance := testCreateInstance()
+		desiredPorts := capability.AgServicePorts{
+			HttpsAndHttp: true,
+			Statsd:       true,
+		}
 		testSetCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
-		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, true)
-		require.True(t, instance.NeedsMetricsIngest() && instance.NeedsStatsd())
+		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, desiredPorts.Statsd)
+		require.True(t, instance.NeedsStatsd())
+		require.True(t, desiredPorts.AtLeastOneEnabled())
 
-		service := createService(instance, testFeature)
+		service := createService(instance, testFeature, desiredPorts)
 		ports := service.Spec.Ports
 
 		assert.Contains(t, ports, agHttpsPort, agHttpPort, statsdPort)
@@ -93,11 +104,15 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check AG service if StatsD enabled, but not metrics ingest", func(t *testing.T) {
 		instance := testCreateInstance()
+		desiredPorts := capability.AgServicePorts{
+			Statsd: true,
+		}
 		testSetCapability(instance, dynatracev1beta1.MetricsIngestCapability, false)
 		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, true)
-		require.True(t, !instance.NeedsMetricsIngest() && instance.NeedsStatsd())
+		require.True(t, instance.NeedsStatsd())
+		require.True(t, desiredPorts.AtLeastOneEnabled())
 
-		service := createService(instance, testFeature)
+		service := createService(instance, testFeature, desiredPorts)
 		ports := service.Spec.Ports
 
 		assert.NotContains(t, ports, agHttpsPort, agHttpPort)
@@ -106,11 +121,13 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check AG service if StatsD and metrics ingest are disabled", func(t *testing.T) {
 		instance := testCreateInstance()
+		desiredPorts := capability.AgServicePorts{}
 		testSetCapability(instance, dynatracev1beta1.MetricsIngestCapability, false)
 		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, false)
-		require.True(t, !instance.NeedsMetricsIngest() && !instance.NeedsStatsd())
+		require.True(t, !instance.NeedsStatsd())
+		require.False(t, desiredPorts.AtLeastOneEnabled())
 
-		service := createService(instance, testFeature)
+		service := createService(instance, testFeature, desiredPorts)
 		ports := service.Spec.Ports
 
 		assert.NotContains(t, ports, agHttpsPort, agHttpPort, statsdPort)

--- a/src/controllers/activegate/reconciler/capability/service_test.go
+++ b/src/controllers/activegate/reconciler/capability/service_test.go
@@ -52,7 +52,7 @@ func TestCreateService(t *testing.T) {
 	t.Run("check service name and selector", func(t *testing.T) {
 		instance := testCreateInstance()
 		service := createService(instance, testFeature, capability.AgServicePorts{
-			HttpsAndHttp: true,
+			Webserver: true,
 		})
 
 		assert.NotNil(t, service)
@@ -71,7 +71,7 @@ func TestCreateService(t *testing.T) {
 	t.Run("check AG service if metrics ingest enabled, but not StatsD", func(t *testing.T) {
 		instance := testCreateInstance()
 		desiredPorts := capability.AgServicePorts{
-			HttpsAndHttp: true,
+			Webserver: true,
 		}
 		testSetCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
 		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, false)
@@ -88,8 +88,8 @@ func TestCreateService(t *testing.T) {
 	t.Run("check AG service if metrics ingest and StatsD enabled", func(t *testing.T) {
 		instance := testCreateInstance()
 		desiredPorts := capability.AgServicePorts{
-			HttpsAndHttp: true,
-			Statsd:       true,
+			Webserver: true,
+			Statsd:    true,
 		}
 		testSetCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
 		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, desiredPorts.Statsd)

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -332,7 +332,7 @@ func (controller *DynakubeController) reconcileActiveGateCapabilities(dynakubeSt
 				return false
 			}
 
-			if c.Config().CreateService {
+			if c.CreateService() {
 				svc := corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      rcap.BuildServiceName(dynakubeState.Instance.Name, c.ShortName()),

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -332,7 +332,7 @@ func (controller *DynakubeController) reconcileActiveGateCapabilities(dynakubeSt
 				return false
 			}
 
-			if c.CreateService() {
+			if c.ShouldCreateService() {
 				svc := corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      rcap.BuildServiceName(dynakubeState.Instance.Name, c.ShortName()),


### PR DESCRIPTION
# Description

This changeset solves the problem deploying ActiveGate with capabilities which require a `ClusterIP` service (`routing`, `dynatrace-api`) but without `metrics-ingest`. 

Before that, defining `routiung` and/or `dynatrace-api` without `metrics-ingest` caused deployment failure due to AG service not exposing HTTP(S) ports, with stack trace similar to:
```
{"error":"Service \"***-activegate\" is invalid: spec.ports: Required value","level":"error","logger":"main.controller.dynakube","msg":"Reconciler error","name":"***","namespace":"dynatrace","reconciler group":"dynatrace.com","reconciler kind":"DynaKube","stacktrace":"Service \"***-activegate\" is invalid: spec.ports: Required value                                                                    
github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/reconciler/capability.(*Reconciler).createServiceIfNotExists                                                                                               
        /app/src/controllers/activegate/reconciler/capability/reconciler.go:173                                                                                                                                               
github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/reconciler/capability.(*Reconciler).Reconcile                                                                                                              
        /app/src/controllers/activegate/reconciler/capability/reconciler.go:140                                                                                                                                               
github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube.(*DynakubeController).reconcileActiveGateCapabilities                                                                                                        
        /app/src/controllers/dynakube/dynakube_controller.go:320                                                                                                                                                              
github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube.(*DynakubeController).reconcileActiveGate                                                                                                                    
        /app/src/controllers/dynakube/dynakube_controller.go:292                                                                                                                                                              
github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube.(*DynakubeController).reconcileDynaKube                                                                                                                      
        /app/src/controllers/dynakube/dynakube_controller.go:212                                                                                                                                                              
github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube.(*DynakubeController).Reconcile                                                                                                                              
        /app/src/controllers/dynakube/dynakube_controller.go:123                                                                                                                                                              
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile                                                                                                                                                
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114                                                                                                                          
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler                                                                                                                                         
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311                                                                                                                          
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem                                                                                                                                      
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266                                                                                                                          
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2                                                                                                                                            
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227                                                                                                                          
runtime.goexit                                                                                                                                                                                                                
        /usr/local/go/src/runtime/asm_amd64.s:1581    
```

## How can this be tested?
### Automatic
Run or inspect kuttl test scenario [`tests/activegate/routing`](https://github.com/Dynatrace/dynatrace-operator/compare/feature/statsd-ingest--kuttl-tests#diff-32a37812f30c92fa76c5970bf8bcb00e8e632ac3f3c8017b3a5c0d91e4bc07e9).

### Manual
To test the fix, experiment with ActiveGate capabilities making sure that the expected service ports are exposed (and the AG pod is ready):
- if `routing`, `dynatrace-api` and/or `metrics-ingest` capabilities are defined, ports `http` and `https` are exposed in `dynakube-activegate`
- if (and only if) `statsd-ingest` is enabled, port `statsd` is exposed in `dynakube-activegate`
- if `statsd-ingest` and at least one of `routing`, `dynatrace-api` and/or `metrics-ingest` are enabled, all the three ports are exposed (`http`, `https`, `statsd`)
- if ActiveGate is deployed with `kubernetes-monitoring` only, the AG service is not created at all `dynakube-activegate` (or is removed)

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
