### PR TITLE
Adds extra check for empty node names + merge fix

### DIFF
--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -81,7 +81,7 @@ func (installAgentCfg *installAgentConfig) updateAgent(installedVersion, tenantU
 			installAgentVersionEvent,
 			"Set new agent version: %s to tenant: %s", targetVersion, tenantUUID)
 		log.Info("updating ruxitagentproc.conf on new set version")
-		if err := installAgentCfg.updateProcessModuleConfig(installedVersion, targetDir, latestProcessModuleConfigCache.ProcessModuleConfig); err != nil {
+		if err := installAgentCfg.updateProcessModuleConfig(targetVersion, tenantUUID, latestProcessModuleConfigCache.ProcessModuleConfig); err != nil {
 			return "", err
 		}
 		return targetVersion, nil

--- a/src/initgeneration/init.sh.test-sample
+++ b/src/initgeneration/init.sh.test-sample
@@ -20,6 +20,10 @@ cluster_id="42"
 has_host="true"
 tls_cert="testing"
 
+if [[ "${K8S_NODE_NAME}" == "" ]]; then
+	K8S_NODE_NAME="EMPTY"
+fi
+
 declare -A im_nodes
 im_nodes=(
   ["node1"]="abc12345"

--- a/src/initgeneration/init.sh.tmpl
+++ b/src/initgeneration/init.sh.tmpl
@@ -20,6 +20,10 @@ cluster_id="{{.ClusterID}}"
 has_host="{{.HasHost}}"
 tls_cert="{{.TlsCert}}"
 
+if [[ "${K8S_NODE_NAME}" == "" ]]; then
+	K8S_NODE_NAME="EMPTY"
+fi
+
 declare -A im_nodes
 im_nodes=(
   {{- range $node, $tenant := .IMNodes}}

--- a/src/initgeneration/initgeneration.go
+++ b/src/initgeneration/initgeneration.go
@@ -197,20 +197,22 @@ func (g *InitGenerator) getInfraMonitoringNodes(dk *dynatracev1beta1.DynaKube) (
 		for _, node := range nodeInf.nodes {
 			nodeLabels := labels.Set(node.Labels)
 			if nodeSelector.Matches(nodeLabels) {
+				key := handleEmptyNodeName(node.Name)
 				if tenantUUID != "" {
-					nodeInf.imNodes[node.Name] = tenantUUID
+					nodeInf.imNodes[key] = tenantUUID
 				} else if !dk.FeatureIgnoreUnknownState() {
-					delete(nodeInf.imNodes, node.Name)
+					delete(nodeInf.imNodes, key)
 				}
 			}
 		}
 		imNodes = nodeInf.imNodes
 	} else {
 		for nodeName := range dk.Status.OneAgent.Instances {
+			key := handleEmptyNodeName(nodeName)
 			if tenantUUID != "" {
-				imNodes[nodeName] = tenantUUID
+				imNodes[key] = tenantUUID
 			} else if !dk.FeatureIgnoreUnknownState() {
-				delete(imNodes, nodeName)
+				delete(imNodes, key)
 			}
 		}
 	}
@@ -249,4 +251,11 @@ func (s *script) generate() (map[string][]byte, error) {
 	}
 
 	return data, nil
+}
+
+func handleEmptyNodeName(nodeName string) string {
+	if nodeName == "" {
+		return "EMPTY"
+	}
+	return nodeName
 }


### PR DESCRIPTION
# Description
There is this weird issue, when the nodeName is ""(empty string) which breaks the init.sh, I added a small fix for that. (even though I couldn't reproduce this issue.) 

Also fixes an issue cause by the merge/cherrypick that messed up some paths in the csi driver.

## How can this be tested?
Deploy and CSI driver should work (mount volumes)


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

