### PR TITLE
Decouple standalone and oneagent csi storage

### DIFF
--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -58,6 +58,13 @@ func (publisher *AppVolumePublisher) PublishVolume(ctx context.Context, volumeCf
 		return nil, err
 	}
 
+	if bindCfg.Version == "" {
+		return nil, status.Error(
+			codes.Unavailable,
+			fmt.Sprintf("version is not yet set, csi-provisioner hasn't finished setup yet for tenant: %s", bindCfg.TenantUUID),
+		)
+	}
+
 	if err := publisher.mountOneAgent(bindCfg, volumeCfg); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to mount oneagent volume: %s", err))
 	}

--- a/src/controllers/csi/metadata/metadata.go
+++ b/src/controllers/csi/metadata/metadata.go
@@ -11,7 +11,7 @@ type Dynakube struct {
 
 // NewDynakube returns a new metadata.Dynakube if all fields are set.
 func NewDynakube(dynakubeName, tenantUUID, latestVersion string) *Dynakube {
-	if tenantUUID == "" || latestVersion == "" || dynakubeName == "" {
+	if tenantUUID == "" || dynakubeName == "" {
 		return nil
 	}
 	return &Dynakube{dynakubeName, tenantUUID, latestVersion}


### PR DESCRIPTION
# Description
The host oneagent csi-storage doesn't get mounted while the standalone agent binary is not downloaded, which is not optimal.

To decouple these two:
The "LatestVersion" field of the Dynakube database entry is not needed for the oneagent-storage,
so now we add the Dynakube entry to the database while the "LatestVersion" is not set.

Therefore we can still stop the mount of the standalone agents if the version not set, 
but we can move forward with mounting the oneagent-storage
 
## How can this be tested?
Deploy cloudNative and see that the host oneagents get there containers created before the standalone binary is donwloaded (sample apps are still waiting).
 Also there is a new error message in the sample app's event while the binary is downloading `version is not yet set, csi-provisioner hasn't finished setup yet for tenant`

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

