### PR TITLE
Decouple standalone and oneagent csi storage

### DIFF
--- a/src/controllers/csi/driver/volumes/host/publisher.go
+++ b/src/controllers/csi/driver/volumes/host/publisher.go
@@ -55,6 +55,14 @@ func (publisher *HostVolumePublisher) PublishVolume(ctx context.Context, volumeC
 	if err != nil {
 		return nil, err
 	}
+
+	if bindCfg.Version == "" {
+		return nil, status.Error(
+			codes.Unavailable,
+			fmt.Sprintf("version is not yet set, csi-provisioner hasn't finished setup yet for tenant: %s", bindCfg.TenantUUID),
+		)
+	}
+
 	if err := publisher.mountOneAgent(bindCfg.TenantUUID, volumeCfg); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to mount osagent volume: %s", err.Error()))
 	}

--- a/src/controllers/csi/driver/volumes/host/publisher_test.go
+++ b/src/controllers/csi/driver/volumes/host/publisher_test.go
@@ -27,17 +27,30 @@ const (
 )
 
 func TestPublishVolume(t *testing.T) {
-	mounter := mount.NewFakeMounter([]mount.MountPoint{})
-	publisher := newPublisherForTesting(t, mounter)
+	t.Run(`ready dynakube`, func(t *testing.T) {
+		mounter := mount.NewFakeMounter([]mount.MountPoint{})
+		publisher := newPublisherForTesting(t, mounter)
 
-	mockDynakube(t, &publisher)
+		mockDynakube(t, &publisher)
 
-	response, err := publisher.PublishVolume(context.TODO(), createTestVolumeConfig())
+		response, err := publisher.PublishVolume(context.TODO(), createTestVolumeConfig())
 
-	assert.NoError(t, err)
-	assert.NotNil(t, response)
-	assert.NotEmpty(t, mounter.MountPoints)
-	assertReferencesForPublishedVolume(t, &publisher, mounter)
+		require.NoError(t, err)
+		assert.NotNil(t, response)
+		assert.NotEmpty(t, mounter.MountPoints)
+		assertReferencesForPublishedVolume(t, &publisher, mounter)
+	})
+	t.Run(`not ready dynakube`, func(t *testing.T) {
+		mounter := mount.NewFakeMounter([]mount.MountPoint{})
+		publisher := newPublisherForTesting(t, mounter)
+
+		mockNotReadyDynakube(t, &publisher)
+
+		response, err := publisher.PublishVolume(context.TODO(), createTestVolumeConfig())
+
+		assert.Error(t, err)
+		assert.Nil(t, response)
+	})
 }
 
 func TestUnpublishVolume(t *testing.T) {
@@ -133,7 +146,12 @@ func mockPublishedvolume(t *testing.T, publisher *HostVolumePublisher) {
 }
 
 func mockDynakube(t *testing.T, publisher *HostVolumePublisher) {
-	err := publisher.db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, "doesnt-matter"))
+	err := publisher.db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, "some-version"))
+	require.NoError(t, err)
+}
+
+func mockNotReadyDynakube(t *testing.T, publisher *HostVolumePublisher) {
+	err := publisher.db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, ""))
 	require.NoError(t, err)
 }
 

--- a/src/controllers/csi/metadata/metadata.go
+++ b/src/controllers/csi/metadata/metadata.go
@@ -11,7 +11,7 @@ type Dynakube struct {
 
 // NewDynakube returns a new metadata.Dynakube if all fields are set.
 func NewDynakube(dynakubeName, tenantUUID, latestVersion string) *Dynakube {
-	if tenantUUID == "" || latestVersion == "" || dynakubeName == "" {
+	if tenantUUID == "" || dynakubeName == "" {
 		return nil
 	}
 	return &Dynakube{dynakubeName, tenantUUID, latestVersion}

--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -118,6 +118,13 @@ func (provisioner *OneAgentProvisioner) Reconcile(ctx context.Context, request r
 	dynakube.Name = dk.Name
 	dynakube.TenantUUID = dk.ConnectionInfo().TenantUUID
 
+	// Create/update the dynakube entry while `LatestVersion` is not necessarily set
+	// so the host oneagent-storages can be mounted before the standalone agent binaries are ready to be mounted
+	err = provisioner.createOrUpdateDynakube(oldDynakube, dynakube)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	if err = provisioner.createCSIDirectories(provisioner.path.EnvDir(dynakube.TenantUUID)); err != nil {
 		log.Error(err, "error when creating csi directories", "path", provisioner.path.EnvDir(dynakube.TenantUUID))
 		return reconcile.Result{}, errors.WithStack(err)
@@ -141,6 +148,7 @@ func (provisioner *OneAgentProvisioner) Reconcile(ctx context.Context, request r
 		dynakube.LatestVersion = updatedVersion
 	}
 
+	// Set/Update the `LatestVersion` field in the database entry
 	err = provisioner.createOrUpdateDynakube(oldDynakube, dynakube)
 	if err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
# Description

cherry pick of: https://github.com/Dynatrace/dynatrace-operator/pull/629

## How can this be tested?
see original PR


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

