### PR TITLE
Fixes double insert to dynakube table

### DIFF
--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -124,6 +124,7 @@ func (provisioner *OneAgentProvisioner) Reconcile(ctx context.Context, request r
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	oldDynakube = *dynakube
 
 	if err = provisioner.createCSIDirectories(provisioner.path.EnvDir(dynakube.TenantUUID)); err != nil {
 		log.Error(err, "error when creating csi directories", "path", provisioner.path.EnvDir(dynakube.TenantUUID))


### PR DESCRIPTION
# Description
In case a new dynakube was encountered by the csi driver, it would insert it twice duo to a logic oversight.
This issue flew under the radar as it fixed it self, but still it puts a scary error into the log.

## How can this be tested?
Create a dynakube that is new to the cluster, you should see no errors in the log of the CSI driver

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

