### PR TITLE
Add image field to DynaKube where CSI Driver is used

### DIFF
--- a/src/api/v1beta1/oneagent_types.go
+++ b/src/api/v1beta1/oneagent_types.go
@@ -29,6 +29,10 @@ type OneAgentSpec struct {
 }
 
 type CloudNativeFullStackSpec struct {
+	// Optional: the Dynatrace installer container image
+	// Defaults to the registry on the tenant for both Kubernetes and for OpenShift
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=12,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	Image string `json:"image,omitempty"`
 
 	// Optional: If specified, indicates the OneAgent version to use
 	// Defaults to latest
@@ -114,6 +118,11 @@ type HostInjectSpec struct {
 
 type ApplicationMonitoringSpec struct {
 	AppInjectionSpec `json:",inline"`
+
+	// Optional: the Dynatrace installer container image
+	// Defaults to the registry on the tenant for both Kubernetes and for OpenShift
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=12,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	Image string `json:"image,omitempty"`
 
 	// Optional: If specified, indicates the OneAgent version to use
 	// Defaults to latest

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -166,6 +166,10 @@ func (dk *DynaKube) Image() string {
 		return dk.Spec.OneAgent.ClassicFullStack.Image
 	} else if dk.HostMonitoringMode() {
 		return dk.Spec.OneAgent.HostMonitoring.Image
+	} else if dk.CloudNativeFullstackMode() {
+		return dk.Spec.OneAgent.CloudNativeFullStack.Image
+	} else if dk.ApplicationMonitoringMode() && dk.NeedsCSIDriver() {
+		return dk.Spec.OneAgent.ApplicationMonitoring.Image
 	}
 	return ""
 }

--- a/src/webhook/validation/config.go
+++ b/src/webhook/validation/config.go
@@ -21,6 +21,7 @@ var validators = []validator{
 	conflictingNamespaceSelector,
 	conflictingReadOnlyFilesystemAndMultipleOsAgentsOnNode,
 	noResourcesAvailable,
+	imageFieldSetWithoutCSIFlag,
 }
 
 var warnings = []validator{

--- a/src/webhook/validation/oneagent.go
+++ b/src/webhook/validation/oneagent.go
@@ -11,6 +11,7 @@ import (
 const (
 	errorConflictingOneagentMode = `The DynaKube's specification tries to use multiple oneagent modes at the same time, which is not supported.
 `
+	errorImageFieldSetWithoutCSIFlag = `The DynaKube's specification tries to enable ApplicationMonitoring mode and get the respective image, but the CSI driver is not enabled.`
 
 	errorNodeSelectorConflict = `The DynaKube's specification tries to specify a nodeSelector conflicts with an another Dynakube's nodeSelector, which is not supported.
 The conflicting Dynakube: %s
@@ -65,6 +66,15 @@ func conflictingNodeSelector(dv *dynakubeValidator, dynakube *dynatracev1beta1.D
 				log.Info("requested dynakube has conflicting nodeSelector", "name", dynakube.Name, "namespace", dynakube.Namespace)
 				return fmt.Sprintf(errorNodeSelectorConflict, item.Name)
 			}
+		}
+	}
+	return ""
+}
+
+func imageFieldSetWithoutCSIFlag(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+	if dynakube.ApplicationMonitoringMode() && !dynakube.NeedsCSIDriver() {
+		if len(dynakube.Spec.OneAgent.ApplicationMonitoring.Image) > 0 {
+			return errorImageFieldSetWithoutCSIFlag
 		}
 	}
 	return ""

--- a/src/webhook/validation/oneagent_test.go
+++ b/src/webhook/validation/oneagent_test.go
@@ -261,13 +261,14 @@ func TestConflictingNodeSelector(t *testing.T) {
 func TestImageFieldSetWithoutCSIFlag(t *testing.T) {
 	t.Run(`spec with appMon enabled and image name`, func(t *testing.T) {
 		useCSIDriver := true
+		testImage := "testImage"
 		assertAllowedResponseWithoutWarnings(t, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,
 				OneAgent: dynatracev1beta1.OneAgentSpec{
 					ApplicationMonitoring: &dynatracev1beta1.ApplicationMonitoringSpec{
-						Image:        "testImage",
+						Image:        testImage,
 						UseCSIDriver: &useCSIDriver,
 					},
 				},
@@ -277,13 +278,14 @@ func TestImageFieldSetWithoutCSIFlag(t *testing.T) {
 
 	t.Run(`spec with appMon enabled, useCSIDriver not enabled but image set`, func(t *testing.T) {
 		useCSIDriver := false
+		testImage := "testImage"
 		assertDeniedResponse(t, []string{errorImageFieldSetWithoutCSIFlag}, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,
 				OneAgent: dynatracev1beta1.OneAgentSpec{
 					ApplicationMonitoring: &dynatracev1beta1.ApplicationMonitoringSpec{
-						Image:        "testimage",
+						Image:        testImage,
 						UseCSIDriver: &useCSIDriver,
 					},
 				},

--- a/src/webhook/validation/oneagent_test.go
+++ b/src/webhook/validation/oneagent_test.go
@@ -257,3 +257,38 @@ func TestConflictingNodeSelector(t *testing.T) {
 			&defaultCSIDaemonSet)
 	})
 }
+
+func TestImageFieldSetWithoutCSIFlag(t *testing.T) {
+	t.Run(`spec with appMon enabled and image name`, func(t *testing.T) {
+		useCSIDriver := true
+		assertAllowedResponseWithoutWarnings(t, &dynatracev1beta1.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					ApplicationMonitoring: &dynatracev1beta1.ApplicationMonitoringSpec{
+						Image:        "testImage",
+						UseCSIDriver: &useCSIDriver,
+					},
+				},
+			},
+		}, &defaultCSIDaemonSet)
+	})
+
+	t.Run(`spec with appMon enabled, useCSIDriver not enabled but image set`, func(t *testing.T) {
+		useCSIDriver := false
+		assertDeniedResponse(t, []string{errorImageFieldSetWithoutCSIFlag}, &dynatracev1beta1.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					ApplicationMonitoring: &dynatracev1beta1.ApplicationMonitoringSpec{
+						Image:        "testimage",
+						UseCSIDriver: &useCSIDriver,
+					},
+				},
+			},
+		}, &defaultCSIDaemonSet)
+	})
+
+}


### PR DESCRIPTION
# Description

Added an image field to applicationMontioring mode and to cloudNativeFullstack mode. Regarding applicationMonitoring also added a little validation, which should ensure that there can not be a image set, if useCSIDriver is not enabled.

## How can this be tested?

Try to apply a dynakube for example where applicationMonitoring is enabled, useCSIDriver is not enabled but there is an image set.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
