### PR TITLE
allow for csi tolerations configuration in values.yaml

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -37,6 +37,9 @@ spec:
       labels:
         {{- include "dynatrace-operator.csiLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.csi.tolerations }}
+      tolerations: {{ .Values.csi.tolerations | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         # Used to receive/execute gRPC requests (NodePublishVolume/NodeUnpublishVolume) from kubelet to mount/unmount volumes for a pod
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -64,6 +64,7 @@ csi:
   limits:
     cpu: 300m
     memory: 100Mi
+  tolerations: []
 
 createSecurityContextConstraints: true # Only applicable for Openshift
 


### PR DESCRIPTION
## Description

I have the operator 0.5.0 configured using `applicationMonitoring: true` and `useCSIDriver: true`. Due to how we setup our cluster with 2 node groups (1 for `app` workloads, 1 for `ops` workload) the CSI pods are only scheduled in the `app` due to taints in `ops`. This caused a problem when enabling the monitoring on ingress (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/instrument-ingress-nginx) as the ingress daemonset is configured to have `ops` affinity. Below is the error thrown:

```
MountVolume.SetUp failed for volume "oneagent-bin" : kubernetes.io/csi: mounter.SetUpAt failed to get CSI client: driver name csi.oneagent.dynatrace.com not found in the list of registered 
CSI drivers
```

The update is to allow for CSI tolerations configurations in values.yaml

## How can this be tested?
- Tested in EKS 1.21 on operator and chart 0.5.0 with activegate 1.233.152.20220204-172150
- Also with enabling `applicationMonitoring: true` and `useCSIDriver: true` then running `helm template test . --set apiToken=abc`