### PR TITLE
Webhook AppArmor annotation fixed

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: webhook
         {{- if (.Values.webhook).apparmor}}
-        container.apparmor.security.beta.kubernetes.io/{{ .Release.Name }}: runtime/default
+        container.apparmor.security.beta.kubernetes.io/webhook: runtime/default
         {{- end }}
       labels:
         dynatrace.com/operator: oneagent


### PR DESCRIPTION
# Description

Helm configuration for Webhook is invalid. AppArmor annotation "container.apparmor.security.beta.kubernetes.io/dynatrace" indicates to non-existent container.The right name is "webhook".

## How can this be tested?
Install DO using helm command. Values.yaml file should contain:
```
webhook:
  apparmor: true
```
## Checklist
- [x] PR is labeled accordingly

