### PR TITLE
Standardized CA certificates handling across components

### DIFF
--- a/src/api/v1beta1/dynakube_conversion.go
+++ b/src/api/v1beta1/dynakube_conversion.go
@@ -17,7 +17,7 @@ func (src *DynaKube) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.CustomPullSecret = src.Spec.CustomPullSecret
 	dst.Spec.SkipCertCheck = src.Spec.SkipCertCheck
 	dst.Spec.Proxy = (*v1alpha1.DynaKubeProxy)(src.Spec.Proxy)
-	dst.Spec.TrustedCAs = src.Spec.TrustedCAs
+	dst.Spec.TrustedCAs = src.Spec.ClusterCa
 	dst.Spec.NetworkZone = src.Spec.NetworkZone
 	dst.Spec.EnableIstio = src.Spec.EnableIstio
 
@@ -119,7 +119,7 @@ func (dst *DynaKube) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.CustomPullSecret = src.Spec.CustomPullSecret
 	dst.Spec.SkipCertCheck = src.Spec.SkipCertCheck
 	dst.Spec.Proxy = (*DynaKubeProxy)(src.Spec.Proxy)
-	dst.Spec.TrustedCAs = src.Spec.TrustedCAs
+	dst.Spec.ClusterCa = src.Spec.TrustedCAs
 	dst.Spec.NetworkZone = src.Spec.NetworkZone
 	dst.Spec.EnableIstio = src.Spec.EnableIstio
 

--- a/src/api/v1beta1/dynakube_conversion_test.go
+++ b/src/api/v1beta1/dynakube_conversion_test.go
@@ -18,7 +18,7 @@ const (
 	testToken                     = "test-token"
 	testCustomPullSecret          = "test-custompullsecret"
 	testProxyValue                = "test-proxyvalue"
-	testTrustedCAs                = "test-trustedCAs"
+	testClusterCa                 = "test-clusterCa"
 	testNetworkZone               = "test-networkzone"
 	testOneAgentImage             = "test-oneagent-image"
 	testOneAgentVersion           = "test-oneagent-version"
@@ -77,7 +77,7 @@ func TestConversion_ConvertFrom(t *testing.T) {
 			Proxy: &v1alpha1.DynaKubeProxy{
 				Value: testProxyValue,
 			},
-			TrustedCAs:  testTrustedCAs,
+			TrustedCAs:  testClusterCa,
 			NetworkZone: testNetworkZone,
 			EnableIstio: true,
 
@@ -197,7 +197,7 @@ func TestConversion_ConvertFrom(t *testing.T) {
 	assert.Equal(t, oldDynakube.Spec.SkipCertCheck, convertedDynakube.Spec.SkipCertCheck)
 	assert.Equal(t, oldDynakube.Spec.Proxy.ValueFrom, convertedDynakube.Spec.Proxy.ValueFrom)
 	assert.Equal(t, oldDynakube.Spec.Proxy.Value, convertedDynakube.Spec.Proxy.Value)
-	assert.Equal(t, oldDynakube.Spec.TrustedCAs, convertedDynakube.Spec.TrustedCAs)
+	assert.Equal(t, oldDynakube.Spec.TrustedCAs, convertedDynakube.Spec.ClusterCa)
 	assert.Equal(t, oldDynakube.Spec.NetworkZone, convertedDynakube.Spec.NetworkZone)
 	assert.Equal(t, oldDynakube.Spec.EnableIstio, convertedDynakube.Spec.EnableIstio)
 
@@ -322,7 +322,7 @@ func TestConversion_ConvertTo(t *testing.T) {
 			Proxy: &DynaKubeProxy{
 				Value: testProxyValue,
 			},
-			TrustedCAs:  testTrustedCAs,
+			ClusterCa:   testClusterCa,
 			NetworkZone: testNetworkZone,
 			EnableIstio: true,
 
@@ -421,7 +421,7 @@ func TestConversion_ConvertTo(t *testing.T) {
 	assert.Equal(t, oldDynakube.Spec.SkipCertCheck, convertedDynakube.Spec.SkipCertCheck)
 	assert.Equal(t, oldDynakube.Spec.Proxy.ValueFrom, convertedDynakube.Spec.Proxy.ValueFrom)
 	assert.Equal(t, oldDynakube.Spec.Proxy.Value, convertedDynakube.Spec.Proxy.Value)
-	assert.Equal(t, oldDynakube.Spec.TrustedCAs, convertedDynakube.Spec.TrustedCAs)
+	assert.Equal(t, oldDynakube.Spec.ClusterCa, convertedDynakube.Spec.TrustedCAs)
 	assert.Equal(t, oldDynakube.Spec.NetworkZone, convertedDynakube.Spec.NetworkZone)
 	assert.Equal(t, oldDynakube.Spec.EnableIstio, convertedDynakube.Spec.EnableIstio)
 

--- a/src/api/v1beta1/dynakube_types.go
+++ b/src/api/v1beta1/dynakube_types.go
@@ -104,7 +104,7 @@ type DynaKubeSpec struct {
 	// This property only affects certificates used to communicate with the Dynatrace API.
 	// The property is not applied to the ActiveGate
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Trusted CAs",order=6,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:ConfigMap"}
-	TrustedCAs string `json:"trustedCAs,omitempty"`
+	ClusterCa string `json:"trustedCAs,omitempty"`
 
 	// Optional: Sets Network Zone for OneAgent and ActiveGate pods
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Network Zone",order=7,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -94,7 +94,7 @@ func (dk *DynaKube) NeedsStatsd() bool {
 	return dk.IsActiveGateMode(StatsdIngestCapability.DisplayName)
 }
 
-func (dk *DynaKube) HasActiveGateTLS() bool {
+func (dk *DynaKube) HasActiveGateCustomCa() bool {
 	return dk.ActiveGateMode() && dk.Spec.ActiveGate.TlsSecretName != ""
 }
 

--- a/src/controllers/dynakube/dtclient_builder.go
+++ b/src/controllers/dynakube/dtclient_builder.go
@@ -46,7 +46,7 @@ func NewDynatraceClientProperties(ctx context.Context, apiReader client.Reader, 
 		Namespace:           dk.Namespace,
 		Proxy:               (*DynatraceClientProxy)(dk.Spec.Proxy),
 		NetworkZone:         dk.Spec.NetworkZone,
-		TrustedCerts:        dk.Spec.TrustedCAs,
+		TrustedCerts:        dk.Spec.ClusterCa,
 		SkipCertCheck:       dk.Spec.SkipCertCheck,
 		DisableHostRequests: dk.FeatureDisableHostsRequests(),
 	}, err

--- a/src/controllers/dynakube/dtclient_builder_test.go
+++ b/src/controllers/dynakube/dtclient_builder_test.go
@@ -126,8 +126,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 			}}
 		instance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL:     testEndpoint,
-				TrustedCAs: testKey,
+				APIURL:    testEndpoint,
+				ClusterCa: testKey,
 			}}
 
 		fakeClient := fake.NewClient(instance, &secret)
@@ -136,7 +136,7 @@ func TestBuildDynatraceClient(t *testing.T) {
 			Secret:       &secret,
 			ApiUrl:       instance.Spec.APIURL,
 			Namespace:    testNamespace,
-			TrustedCerts: instance.Spec.TrustedCAs,
+			TrustedCerts: instance.Spec.ClusterCa,
 		}
 		dtc, err := BuildDynatraceClient(dtf)
 
@@ -269,7 +269,7 @@ func TestBuildDynatraceClient(t *testing.T) {
 // 					Certificates: testValue,
 // 				}})
 // 		err = options.appendTrustedCerts(fakeClient, &dynatracev1alpha1.DynaKubeSpec{
-// 			TrustedCAs: testName,
+// 			Ca: testName,
 // 		}, testNamespace)
 
 // 		assert.NoError(t, err)
@@ -283,7 +283,7 @@ func TestBuildDynatraceClient(t *testing.T) {
 
 // 		fakeClient := fake.NewClient()
 // 		err := options.appendTrustedCerts(fakeClient, &dynatracev1alpha1.DynaKubeSpec{
-// 			TrustedCAs: testName,
+// 			Ca: testName,
 // 		}, testNamespace)
 
 // 		assert.Error(t, err)
@@ -297,7 +297,7 @@ func TestBuildDynatraceClient(t *testing.T) {
 // 				},
 // 				Data: map[string]string{}})
 // 		err = options.appendTrustedCerts(fakeClient, &dynatracev1alpha1.DynaKubeSpec{
-// 			TrustedCAs: testName,
+// 			Ca: testName,
 // 		}, testNamespace)
 
 // 		assert.Error(t, err)

--- a/src/controllers/dynakube/dtclient_reconciler.go
+++ b/src/controllers/dynakube/dtclient_reconciler.go
@@ -90,7 +90,7 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance *dyn
 		ApiUrl:              instance.Spec.APIURL,
 		Namespace:           r.ns,
 		NetworkZone:         instance.Spec.NetworkZone,
-		TrustedCerts:        instance.Spec.TrustedCAs,
+		TrustedCerts:        instance.Spec.ClusterCa,
 		SkipCertCheck:       instance.Spec.SkipCertCheck,
 		DisableHostRequests: instance.FeatureDisableHostsRequests(),
 	})

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -24,11 +24,11 @@ const (
 	hostRootVolumeName  = "host-root"
 	hostRootVolumeMount = "/mnt/root"
 
-	trustedCaVolumeName  = "dynatrace-cluster-ca"
-	trustedCaVolumeMount = "/mnt/dynatrace/certs"
+	trustedCaCertVolumeName  = "dynatrace-cluster-ca-cert"
+	trustedCaCertVolumeMount = "/mnt/dynatrace/certs"
 
-	agCaVolumeName  = "active-gate-ca"
-	agCaVolumeMount = "/mnt/dynatrace/certs/activegate/"
+	activeGateCaCertVolumeName  = "active-gate-ca"
+	activeGateCaCertVolumeMount = "/mnt/dynatrace/certs/activegate/"
 
 	csiStorageVolumeName  = "osagent-storage"
 	csiStorageVolumeMount = "/mnt/volume_storage_mount"

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -1,8 +1,6 @@
 package daemonset
 
 import (
-	"path/filepath"
-
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
@@ -26,11 +24,11 @@ const (
 	hostRootVolumeName  = "host-root"
 	hostRootVolumeMount = "/mnt/root"
 
-	certVolumeName  = "certs"
-	certVolumeMount = "/mnt/dynatrace/certs"
+	trustedCaVolumeName  = "dynatrace-cluster-ca"
+	trustedCaVolumeMount = "/mnt/dynatrace/certs"
 
-	OneAgentCustomKeysPath = "/var/lib/dynatrace/oneagent/agent/customkeys"
-	tlsVolumeName          = "tls"
+	agCaVolumeName  = "active-gate-ca"
+	agCaVolumeMount = "/mnt/dynatrace/certs/activegate/"
 
 	csiStorageVolumeName  = "osagent-storage"
 	csiStorageVolumeMount = "/mnt/volume_storage_mount"
@@ -43,10 +41,6 @@ const (
 	ClassicFeature        = "classic"
 	HostMonitoringFeature = "inframon"
 	CloudNativeFeature    = "cloud-native"
-)
-
-var (
-	tlsVolumeMount = filepath.Join(hostRootVolumeMount, OneAgentCustomKeysPath)
 )
 
 type HostMonitoring struct {

--- a/src/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -31,15 +31,15 @@ func prepareVolumeMounts(instance *dynatracev1beta1.DynaKube) []corev1.VolumeMou
 
 func getCertificateMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      certVolumeName,
-		MountPath: certVolumeMount,
+		Name:      trustedCaVolumeName,
+		MountPath: trustedCaVolumeMount,
 	}
 }
 
 func getTLSMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      tlsVolumeName,
-		MountPath: tlsVolumeMount,
+		Name:      agCaVolumeName,
+		MountPath: agCaVolumeMount,
 	}
 }
 
@@ -83,7 +83,7 @@ func prepareVolumes(instance *dynatracev1beta1.DynaKube) []corev1.Volume {
 
 func getCertificateVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 	return corev1.Volume{
-		Name: certVolumeName,
+		Name: trustedCaVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -117,7 +117,7 @@ func getCSIStorageVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 
 func getTLSVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 	return corev1.Volume{
-		Name: tlsVolumeName,
+		Name: agCaVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: instance.Spec.ActiveGate.TlsSecretName,

--- a/src/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -31,15 +31,15 @@ func prepareVolumeMounts(instance *dynatracev1beta1.DynaKube) []corev1.VolumeMou
 
 func getCertificateMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      trustedCaVolumeName,
-		MountPath: trustedCaVolumeMount,
+		Name:      trustedCaCertVolumeName,
+		MountPath: trustedCaCertVolumeMount,
 	}
 }
 
 func getTLSMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      agCaVolumeName,
-		MountPath: agCaVolumeMount,
+		Name:      activeGateCaCertVolumeName,
+		MountPath: activeGateCaCertVolumeMount,
 	}
 }
 
@@ -83,7 +83,7 @@ func prepareVolumes(instance *dynatracev1beta1.DynaKube) []corev1.Volume {
 
 func getCertificateVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 	return corev1.Volume{
-		Name: trustedCaVolumeName,
+		Name: trustedCaCertVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -117,7 +117,7 @@ func getCSIStorageVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 
 func getTLSVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 	return corev1.Volume{
-		Name: agCaVolumeName,
+		Name: activeGateCaCertVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: instance.Spec.ActiveGate.TlsSecretName,

--- a/src/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -19,24 +19,24 @@ func prepareVolumeMounts(instance *dynatracev1beta1.DynaKube) []corev1.VolumeMou
 		volumeMounts = append(volumeMounts, getRootMount())
 	}
 
-	if instance.Spec.TrustedCAs != "" {
-		volumeMounts = append(volumeMounts, getCertificateMount())
+	if instance.Spec.ClusterCa != "" {
+		volumeMounts = append(volumeMounts, getClusterCaCertificateMount())
 	}
 
-	if instance.HasActiveGateTLS() {
-		volumeMounts = append(volumeMounts, getTLSMount())
+	if instance.HasActiveGateCustomCa() {
+		volumeMounts = append(volumeMounts, getActiveGateCaMount())
 	}
 	return volumeMounts
 }
 
-func getCertificateMount() corev1.VolumeMount {
+func getClusterCaCertificateMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      trustedCaCertVolumeName,
 		MountPath: trustedCaCertVolumeMount,
 	}
 }
 
-func getTLSMount() corev1.VolumeMount {
+func getActiveGateCaMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      activeGateCaCertVolumeName,
 		MountPath: activeGateCaCertVolumeMount,
@@ -70,11 +70,11 @@ func prepareVolumes(instance *dynatracev1beta1.DynaKube) []corev1.Volume {
 		volumes = append(volumes, getCSIStorageVolume(instance))
 	}
 
-	if instance.Spec.TrustedCAs != "" {
+	if instance.Spec.ClusterCa != "" {
 		volumes = append(volumes, getCertificateVolume(instance))
 	}
 
-	if instance.HasActiveGateTLS() {
+	if instance.HasActiveGateCustomCa() {
 		volumes = append(volumes, getTLSVolume(instance))
 	}
 
@@ -87,7 +87,7 @@ func getCertificateVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: instance.Spec.TrustedCAs,
+					Name: instance.Spec.ClusterCa,
 				},
 				Items: []corev1.KeyToPath{
 					{

--- a/src/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -26,7 +26,7 @@ func TestPrepareVolumes(t *testing.T) {
 	t.Run(`has certificate volume`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
-				TrustedCAs: testName,
+				ClusterCa: testName,
 				OneAgent: dynatracev1beta1.OneAgentSpec{
 					HostMonitoring: &dynatracev1beta1.HostMonitoringSpec{},
 				},
@@ -40,7 +40,7 @@ func TestPrepareVolumes(t *testing.T) {
 	t.Run(`has tls volume`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
-				TrustedCAs: testName,
+				ClusterCa: testName,
 				ActiveGate: dynatracev1beta1.ActiveGateSpec{
 					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 						dynatracev1beta1.KubeMonCapability.DisplayName,
@@ -85,7 +85,7 @@ func TestPrepareVolumes(t *testing.T) {
 	t.Run(`has all volumes`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
-				TrustedCAs: testName,
+				ClusterCa: testName,
 				OneAgent: dynatracev1beta1.OneAgentSpec{
 					HostMonitoring: &dynatracev1beta1.HostMonitoringSpec{},
 				},
@@ -129,7 +129,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		volumeMounts := prepareVolumeMounts(instance)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.NotContains(t, volumeMounts, getCertificateMount())
+		assert.NotContains(t, volumeMounts, getClusterCaCertificateMount())
 	})
 	t.Run(`has certificate volume mount`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
@@ -137,13 +137,13 @@ func TestPrepareVolumeMounts(t *testing.T) {
 				OneAgent: dynatracev1beta1.OneAgentSpec{
 					HostMonitoring: &dynatracev1beta1.HostMonitoringSpec{},
 				},
-				TrustedCAs: testName,
+				ClusterCa: testName,
 			},
 		}
 		volumeMounts := prepareVolumeMounts(instance)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.Contains(t, volumeMounts, getCertificateMount())
+		assert.Contains(t, volumeMounts, getClusterCaCertificateMount())
 	})
 	t.Run(`has tls volume mount`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
@@ -151,7 +151,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 				OneAgent: dynatracev1beta1.OneAgentSpec{
 					HostMonitoring: &dynatracev1beta1.HostMonitoringSpec{},
 				},
-				TrustedCAs: testName,
+				ClusterCa: testName,
 				ActiveGate: dynatracev1beta1.ActiveGateSpec{
 					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
 						dynatracev1beta1.KubeMonCapability.DisplayName,
@@ -164,7 +164,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		volumeMounts := prepareVolumeMounts(instance)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.Contains(t, volumeMounts, getTLSMount())
+		assert.Contains(t, volumeMounts, getActiveGateCaMount())
 	})
 	t.Run(`doesn't have readonly volume mounts`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
@@ -201,7 +201,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 	t.Run(`has all volume mounts`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
-				TrustedCAs: testName,
+				ClusterCa: testName,
 				OneAgent: dynatracev1beta1.OneAgentSpec{
 					HostMonitoring: &dynatracev1beta1.HostMonitoringSpec{},
 				},
@@ -225,8 +225,8 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		volumeMounts := dsInfo.podSpec().Containers[0].VolumeMounts
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.Contains(t, volumeMounts, getCertificateMount())
-		assert.Contains(t, volumeMounts, getTLSMount())
+		assert.Contains(t, volumeMounts, getClusterCaCertificateMount())
+		assert.Contains(t, volumeMounts, getActiveGateCaMount())
 		assert.Contains(t, volumeMounts, getCSIStorageMount())
 	})
 }

--- a/src/controllers/dynakube/updates/version.go
+++ b/src/controllers/dynakube/updates/version.go
@@ -62,7 +62,7 @@ func ReconcileVersions(
 	}
 
 	dockerCfg := dtversion.DockerConfig{Auths: auths, SkipCertCheck: dk.Spec.SkipCertCheck}
-	if dk.Spec.TrustedCAs != "" {
+	if dk.Spec.ClusterCa != "" {
 		dockerCfg.UseTrustedCerts = saveCustomCAs(cl, *dk)
 		defer func() {
 			_ = os.Remove(path.Join(dtversion.TmpCAPath, dtversion.TmpCAName))
@@ -99,7 +99,7 @@ func ReconcileVersions(
 
 func saveCustomCAs(cl client.Client, dk dynatracev1beta1.DynaKube) bool {
 	certs := &corev1.ConfigMap{}
-	if err := cl.Get(context.TODO(), client.ObjectKey{Namespace: dk.Namespace, Name: dk.Spec.TrustedCAs}, certs); err != nil {
+	if err := cl.Get(context.TODO(), client.ObjectKey{Namespace: dk.Namespace, Name: dk.Spec.ClusterCa}, certs); err != nil {
 		log.Error(err, "failed to load trusted CAs")
 		return false
 	}

--- a/src/initgeneration/config.go
+++ b/src/initgeneration/config.go
@@ -9,7 +9,7 @@ var (
 )
 
 const (
-	trustedCAKey = "certs"
-	proxyKey     = "proxy"
-	tlsCertKey   = "server.crt"
+	clusterCaKey    = "certs"
+	proxyKey        = "proxy"
+	activeGateCaKey = "server.crt"
 )

--- a/src/initgeneration/initgeneration_test.go
+++ b/src/initgeneration/initgeneration_test.go
@@ -25,7 +25,7 @@ var (
 	testTokensName           = "kitchen-sink"
 	testApiUrl               = "https://test-url/api"
 	testProxy                = "testproxy.com"
-	testtrustCAsCM           = "testtrustedCAsConfigMap"
+	testClusterCa            = "testClusterCaConfigMap"
 	testCAValue              = "somecertificate"
 	testTenantUUID           = "abc12345"
 	kubesystemNamespace      = "kube-system"
@@ -38,10 +38,10 @@ var (
 	testDynakubeComplex = &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{Name: testDynakubeComplexName, Namespace: operatorNamespace},
 		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL:     testApiUrl,
-			Proxy:      &dynatracev1beta1.DynaKubeProxy{Value: testProxy},
-			TrustedCAs: testtrustCAsCM,
-			Tokens:     testTokensName,
+			APIURL:    testApiUrl,
+			Proxy:     &dynatracev1beta1.DynaKubeProxy{Value: testProxy},
+			ClusterCa: testClusterCa,
+			Tokens:    testTokensName,
 			OneAgent: dynatracev1beta1.OneAgentSpec{
 				CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
 					HostInjectSpec: dynatracev1beta1.HostInjectSpec{
@@ -113,9 +113,9 @@ var (
 	}
 
 	caConfigMap = &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: testtrustCAsCM, Namespace: operatorNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterCa, Namespace: operatorNamespace},
 		Data: map[string]string{
-			trustedCAKey: testCAValue,
+			clusterCaKey: testCAValue,
 		},
 	}
 
@@ -131,7 +131,7 @@ var (
 
 	testTlsSecretDynakubeComplex = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "testing", Namespace: operatorNamespace},
-		Data:       map[string][]byte{tlsCertKey: []byte("testing")},
+		Data:       map[string][]byte{activeGateCaKey: []byte("testing")},
 	}
 
 	testSecretDynakubeSimple = &corev1.Secret{
@@ -347,7 +347,7 @@ func testForCorrectContent(t *testing.T, secret *corev1.Secret) {
 		ApiToken:        string(secret.Data["apiToken"]),
 		SkipCertCheck:   dk.Spec.SkipCertCheck,
 		Proxy:           testProxy,
-		TrustedCAs:      testCAValue,
+		Ca:              testCAValue,
 		ClusterID:       string(kubesystemUID),
 		TenantUUID:      dk.Status.ConnectionInfo.TenantUUID,
 		MonitoringNodes: imNodes,

--- a/src/standalone/dtclient_builder.go
+++ b/src/standalone/dtclient_builder.go
@@ -60,8 +60,8 @@ func (builder *dtclientBuilder) addNetworkZone() {
 }
 
 func (builder *dtclientBuilder) addTrustedCerts() {
-	if builder.config.TrustedCAs != "" {
-		log.Info("using TrustedCAs, check the secret for more details")
-		builder.options = append(builder.options, dtclient.Certs([]byte(builder.config.TrustedCAs)))
+	if builder.config.Ca != "" {
+		log.Info("using CA, check the secret for more details")
+		builder.options = append(builder.options, dtclient.Certs([]byte(builder.config.Ca)))
 	}
 }

--- a/src/standalone/dtclient_builder_test.go
+++ b/src/standalone/dtclient_builder_test.go
@@ -50,6 +50,6 @@ func complexTestSecretConfigForClient() *SecretConfig {
 		PaasToken:   testPaasToken,
 		Proxy:       testProxy,
 		NetworkZone: testNetworkZone,
-		TrustedCAs:  testTrustedCA,
+		Ca:          testCa,
 	}
 }

--- a/src/standalone/secret.go
+++ b/src/standalone/secret.go
@@ -17,7 +17,7 @@ type SecretConfig struct {
 	PaasToken     string `json:"paasToken"`
 	Proxy         string `json:"proxy"`
 	NetworkZone   string `json:"networkZone"`
-	TrustedCAs    string `json:"trustedCAs"`
+	Ca            string `json:"Ca"`
 	SkipCertCheck bool   `json:"skipCertCheck"`
 
 	// For the injection
@@ -38,8 +38,8 @@ func (secret SecretConfig) logContent() {
 	if secret.PaasToken != "" {
 		secret.PaasToken = "***"
 	}
-	if secret.TrustedCAs != "" {
-		secret.TrustedCAs = "***"
+	if secret.Ca != "" {
+		secret.Ca = "***"
 	}
 	if secret.TlsCert != "" {
 		secret.TlsCert = "***"

--- a/src/standalone/secret_test.go
+++ b/src/standalone/secret_test.go
@@ -18,7 +18,7 @@ const (
 
 	testProxy       = "proxy"
 	testNetworkZone = "zone"
-	testTrustedCA   = "secret"
+	testCa          = "secret"
 
 	testTenantUUID = "test"
 	testNodeName   = "node1"
@@ -33,7 +33,7 @@ var testSecretConfig = SecretConfig{
 	PaasToken:     testPaasToken,
 	Proxy:         testProxy,
 	NetworkZone:   testNetworkZone,
-	TrustedCAs:    testTrustedCA,
+	Ca:            testCa,
 	SkipCertCheck: true,
 	TenantUUID:    testTenantUUID,
 	HasHost:       true,
@@ -59,7 +59,7 @@ func TestNewSecretConfigViaFs(t *testing.T) {
 		assert.Equal(t, testPaasToken, config.PaasToken)
 		assert.Equal(t, testProxy, config.Proxy)
 		assert.Equal(t, testNetworkZone, config.NetworkZone)
-		assert.Equal(t, testTrustedCA, config.TrustedCAs)
+		assert.Equal(t, testCa, config.Ca)
 		assert.True(t, config.SkipCertCheck)
 		assert.Equal(t, testTenantUUID, config.TenantUUID)
 		assert.True(t, config.HasHost)

--- a/src/testing/e2e/dynakubetests/trusted_cas_test.go
+++ b/src/testing/e2e/dynakubetests/trusted_cas_test.go
@@ -16,23 +16,23 @@ import (
 )
 
 // Fails since Operator does not create OneAgent pods when certs are invalid
-func TestTrustedCAs(t *testing.T) {
+func TestClusterCa(t *testing.T) {
 	apiURL, clt := prepareDefaultEnvironment(t)
 	oneAgent := createMinimumViableOneAgent(apiURL)
 
-	trustedCAs := v1.ConfigMap{
+	clusterCa := v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: namespace,
 		},
 		Data: map[string]string{testCertName: testData},
 	}
-	oneAgent.Spec.TrustedCAs = testName
+	oneAgent.Spec.ClusterCa = testName
 
 	// prevent creation of pull secret, which would fail due to the test cert being invalid
 	oneAgent.Spec.CustomPullSecret = testName
 
-	err := clt.Create(context.TODO(), &trustedCAs)
+	err := clt.Create(context.TODO(), &clusterCa)
 	require.NoError(t, err)
 
 	err = clt.Create(context.TODO(), &oneAgent)

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -715,7 +715,7 @@ func updateContainerOneAgent(c *corev1.Container, dk *dynatracev1beta1.DynaKube,
 			MountPath: "/var/lib/dynatrace/oneagent/agent/config/container.conf",
 			SubPath:   fmt.Sprintf(standalone.ContainerConfFilenameTemplate, c.Name),
 		})
-	if dk.HasActiveGateTLS() {
+	if dk.HasActiveGateCustomCa() {
 		c.VolumeMounts = append(c.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      oneAgentShareVolumeName,

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -15,7 +15,6 @@ import (
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes"
 	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"
-	oneagent "github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/src/ingestendpoint"
@@ -35,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
+
+const OneAgentCustomKeysPath = "/var/lib/dynatrace/oneagent/agent/customkeys"
 
 var podLog = log.WithName("pod")
 
@@ -718,7 +719,7 @@ func updateContainerOneAgent(c *corev1.Container, dk *dynatracev1beta1.DynaKube,
 		c.VolumeMounts = append(c.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      oneAgentShareVolumeName,
-				MountPath: filepath.Join(oneagent.OneAgentCustomKeysPath, "custom.pem"),
+				MountPath: filepath.Join(OneAgentCustomKeysPath, "custom.pem"),
 				SubPath:   "custom.pem",
 			})
 	}

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-const OneAgentCustomKeysPath = "/var/lib/dynatrace/oneagent/agent/customkeys"
+const oneAgentCustomKeysPath = "/var/lib/dynatrace/oneagent/agent/customkeys"
 
 var podLog = log.WithName("pod")
 
@@ -719,7 +719,7 @@ func updateContainerOneAgent(c *corev1.Container, dk *dynatracev1beta1.DynaKube,
 		c.VolumeMounts = append(c.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      oneAgentShareVolumeName,
-				MountPath: filepath.Join(OneAgentCustomKeysPath, "custom.pem"),
+				MountPath: filepath.Join(oneAgentCustomKeysPath, "custom.pem"),
 				SubPath:   "custom.pem",
 			})
 	}


### PR DESCRIPTION
# Description

OneAgent uses CA certificates when connecting to Dynatrace Cluster and ActiveGate. These are separate certificates.
Goal of this PR is to make it less confusing for developer to distinguish which certs one is dealing with.

`trusted CA` -> `cluster CA`
`ActiveGate TLS` -> `ActiveGate CA`

`dtclient`:
`trusted CA` -> `CA`

## How can this be tested?
Play with certificates.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

