### PR TITLE
Mark for termination Event was not sent correctly, because of wrong labels on Daemonset

### DIFF
--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -42,6 +42,8 @@ const (
 	dataSourceMetadataMountPoint    = "/mnt/dsmetadata"
 	statsdMetadataMountPoint        = "/opt/dynatrace/remotepluginmodule/agent/datasources/statsd"
 	tenantTokenMountPoint           = "/var/lib/dynatrace/secrets/tokens/tenant-token"
+
+	DeploymentTypeActiveGate = "active_gate"
 )
 
 type statefulSetProperties struct {
@@ -437,7 +439,7 @@ func buildProxyMounts() []corev1.VolumeMount {
 }
 
 func buildEnvs(stsProperties *statefulSetProperties) []corev1.EnvVar {
-	deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(string(stsProperties.kubeSystemUID), deploymentmetadata.DeploymentTypeActiveGate)
+	deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(string(stsProperties.kubeSystemUID), DeploymentTypeActiveGate)
 
 	envs := []corev1.EnvVar{
 		{Name: dtCapabilities, Value: stsProperties.capabilityName},

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -373,7 +373,7 @@ func TestStatefulSet_Volumes(t *testing.T) {
 func TestStatefulSet_Env(t *testing.T) {
 	instance := buildTestInstance()
 	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
-	deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(testUID, deploymentmetadata.DeploymentTypeActiveGate)
+	deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(testUID, DeploymentTypeActiveGate)
 
 	t.Run(`with FeatureEnableActivegateRawImage=true`, func(t *testing.T) {
 		instanceRawImg := instance.DeepCopy()

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -17,9 +17,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/istio"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/status"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/updates"
-	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/src/ingestendpoint"
 	"github.com/Dynatrace/dynatrace-operator/src/initgeneration"
@@ -215,21 +215,21 @@ func (controller *DynakubeController) reconcileDynaKube(ctx context.Context, dkS
 
 	if dkState.Instance.HostMonitoringMode() {
 		upd, err = oneagent.NewOneAgentReconciler(
-			controller.client, controller.apiReader, controller.scheme, dkState.Instance, deploymentmetadata.DeploymentTypeHostMonitoring,
+			controller.client, controller.apiReader, controller.scheme, dkState.Instance, daemonset.DeploymentTypeHostMonitoring,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "infra monitoring reconciled") {
 			return
 		}
 	} else if dkState.Instance.CloudNativeFullstackMode() {
 		upd, err = oneagent.NewOneAgentReconciler(
-			controller.client, controller.apiReader, controller.scheme, dkState.Instance, deploymentmetadata.DeploymentTypeCloudNative,
+			controller.client, controller.apiReader, controller.scheme, dkState.Instance, daemonset.DeploymentTypeCloudNative,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "cloud native infra monitoring reconciled") {
 			return
 		}
 	} else if dkState.Instance.ClassicFullStackMode() {
 		upd, err = oneagent.NewOneAgentReconciler(
-			controller.client, controller.apiReader, controller.scheme, dkState.Instance, deploymentmetadata.DeploymentTypeFullStack,
+			controller.client, controller.apiReader, controller.scheme, dkState.Instance, daemonset.DeploymentTypeFullStack,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "classic fullstack reconciled") {
 			return

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -17,9 +17,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/istio"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/status"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/updates"
+	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/src/ingestendpoint"
 	"github.com/Dynatrace/dynatrace-operator/src/initgeneration"
@@ -215,21 +215,21 @@ func (controller *DynakubeController) reconcileDynaKube(ctx context.Context, dkS
 
 	if dkState.Instance.HostMonitoringMode() {
 		upd, err = oneagent.NewOneAgentReconciler(
-			controller.client, controller.apiReader, controller.scheme, dkState.Instance, daemonset.HostMonitoringFeature,
+			controller.client, controller.apiReader, controller.scheme, dkState.Instance, deploymentmetadata.DeploymentTypeHostMonitoring,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "infra monitoring reconciled") {
 			return
 		}
 	} else if dkState.Instance.CloudNativeFullstackMode() {
 		upd, err = oneagent.NewOneAgentReconciler(
-			controller.client, controller.apiReader, controller.scheme, dkState.Instance, daemonset.CloudNativeFeature,
+			controller.client, controller.apiReader, controller.scheme, dkState.Instance, deploymentmetadata.DeploymentTypeCloudNative,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "cloud native infra monitoring reconciled") {
 			return
 		}
 	} else if dkState.Instance.ClassicFullStackMode() {
 		upd, err = oneagent.NewOneAgentReconciler(
-			controller.client, controller.apiReader, controller.scheme, dkState.Instance, daemonset.ClassicFeature,
+			controller.client, controller.apiReader, controller.scheme, dkState.Instance, deploymentmetadata.DeploymentTypeFullStack,
 		).Reconcile(ctx, dkState)
 		if dkState.Error(err) || dkState.Update(upd, defaultUpdateInterval, "classic fullstack reconciled") {
 			return

--- a/src/controllers/dynakube/oneagent/daemonset/arguments.go
+++ b/src/controllers/dynakube/oneagent/daemonset/arguments.go
@@ -7,6 +7,13 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/version"
 )
 
+const (
+	DeploymentTypeApplicationMonitoring = "application_monitoring"
+	DeploymentTypeFullStack             = "classic_fullstack"
+	DeploymentTypeCloudNative           = "cloud_native_fullstack"
+	DeploymentTypeHostMonitoring        = "host_monitoring"
+)
+
 func (dsInfo *builderInfo) arguments() []string {
 	metadata := deploymentmetadata.NewDeploymentMetadata(dsInfo.clusterId, dsInfo.deploymentType)
 	args := dsInfo.hostInjectSpec.Args

--- a/src/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -121,7 +121,6 @@ func TestPodSpec_Arguments(t *testing.T) {
 				hostInjectSpec: hostInjectSpecs,
 				clusterId:      testClusterID,
 			},
-			HostMonitoringFeature,
 		}
 		daemonset, _ = dsInfo.BuildDaemonSet()
 		podSpecs := daemonset.Spec.Template.Spec

--- a/src/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -67,14 +67,14 @@ func TestPodSpec_Arguments(t *testing.T) {
 			},
 		},
 	}
-	metadata := deploymentmetadata.NewDeploymentMetadata(testClusterID, deploymentmetadata.DeploymentTypeFullStack)
+	metadata := deploymentmetadata.NewDeploymentMetadata(testClusterID, DeploymentTypeFullStack)
 	hostInjectSpecs := &instance.Spec.OneAgent.ClassicFullStack.HostInjectSpec
 	dsInfo := ClassicFullStack{
 		builderInfo{
 			instance:       instance,
 			hostInjectSpec: hostInjectSpecs,
 			clusterId:      testClusterID,
-			deploymentType: deploymentmetadata.DeploymentTypeFullStack,
+			deploymentType: DeploymentTypeFullStack,
 		},
 	}
 
@@ -87,11 +87,12 @@ func TestPodSpec_Arguments(t *testing.T) {
 	}
 	assert.Contains(t, podSpecs.Containers[0].Args, "--set-host-property=OperatorVersion="+version.Version)
 
+	// hardcoded, because a change of consts should not be done
+	assert.Contains(t, podSpecs.Containers[0].Args, "--set-deployment-metadata=orchestration_tech=Operator-classic_fullstack")
 	metadataArgs := metadata.AsArgs()
 	for _, metadataArg := range metadataArgs {
 		assert.Contains(t, podSpecs.Containers[0].Args, metadataArg)
 	}
-
 	t.Run(`has proxy arg`, func(t *testing.T) {
 		instance.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: testValue}
 		podSpecs = dsInfo.podSpec()
@@ -125,5 +126,43 @@ func TestPodSpec_Arguments(t *testing.T) {
 		daemonset, _ = dsInfo.BuildDaemonSet()
 		podSpecs := daemonset.Spec.Template.Spec
 		assert.Contains(t, podSpecs.Containers[0].Args, "--set-host-id-source=k8s-node-name")
+	})
+	t.Run(`is cloudNative`, func(t *testing.T) {
+		instance.Spec.OneAgent = dynatracev1beta1.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
+			HostInjectSpec: dynatracev1beta1.HostInjectSpec{
+				Args: []string{testKey, testValue, testUID},
+			},
+		}}
+		hostInjectSpecs = &instance.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec
+		dsInfo := HostMonitoring{
+			builderInfo{
+				instance:       instance,
+				hostInjectSpec: hostInjectSpecs,
+				clusterId:      testClusterID,
+				deploymentType: DeploymentTypeCloudNative,
+			},
+		}
+		podSpecs = dsInfo.podSpec()
+		// hardcoded, because a change of consts should not be done
+		assert.Contains(t, podSpecs.Containers[0].Args, "--set-deployment-metadata=orchestration_tech=Operator-cloud_native_fullstack")
+	})
+	t.Run(`is hostMonitoring`, func(t *testing.T) {
+		instance.Spec.OneAgent = dynatracev1beta1.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
+			HostInjectSpec: dynatracev1beta1.HostInjectSpec{
+				Args: []string{testKey, testValue, testUID},
+			},
+		}}
+		hostInjectSpecs = &instance.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec
+		dsInfo := HostMonitoring{
+			builderInfo{
+				instance:       instance,
+				hostInjectSpec: hostInjectSpecs,
+				clusterId:      testClusterID,
+				deploymentType: DeploymentTypeHostMonitoring,
+			},
+		}
+		podSpecs = dsInfo.podSpec()
+		// hardcoded, because a change of consts should not be done
+		assert.Contains(t, podSpecs.Containers[0].Args, "--set-deployment-metadata=orchestration_tech=Operator-host_monitoring")
 	})
 }

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -39,10 +39,6 @@ const (
 
 	inframonHostIdSource = "--set-host-id-source=k8s-node-name"
 	classicHostIdSource  = "--set-host-id-source=auto"
-
-	ClassicFeature        = "classic"
-	HostMonitoringFeature = "inframon"
-	CloudNativeFeature    = "cloud-native"
 )
 
 var (
@@ -51,7 +47,6 @@ var (
 
 type HostMonitoring struct {
 	builderInfo
-	feature string
 }
 
 type ClassicFullStack struct {
@@ -77,7 +72,6 @@ func NewHostMonitoring(instance *dynatracev1beta1.DynaKube, clusterId string) Bu
 			clusterId:      clusterId,
 			deploymentType: deploymentmetadata.DeploymentTypeHostMonitoring,
 		},
-		HostMonitoringFeature,
 	}
 }
 
@@ -89,7 +83,6 @@ func NewCloudNativeFullStack(instance *dynatracev1beta1.DynaKube, clusterId stri
 			clusterId:      clusterId,
 			deploymentType: deploymentmetadata.DeploymentTypeCloudNative,
 		},
-		CloudNativeFeature,
 	}
 }
 

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address_of"
 	appsv1 "k8s.io/api/apps/v1"
@@ -70,7 +69,7 @@ func NewHostMonitoring(instance *dynatracev1beta1.DynaKube, clusterId string) Bu
 			instance:       instance,
 			hostInjectSpec: &instance.Spec.OneAgent.HostMonitoring.HostInjectSpec,
 			clusterId:      clusterId,
-			deploymentType: deploymentmetadata.DeploymentTypeHostMonitoring,
+			deploymentType: DeploymentTypeHostMonitoring,
 		},
 	}
 }
@@ -81,7 +80,7 @@ func NewCloudNativeFullStack(instance *dynatracev1beta1.DynaKube, clusterId stri
 			instance:       instance,
 			hostInjectSpec: &instance.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec,
 			clusterId:      clusterId,
-			deploymentType: deploymentmetadata.DeploymentTypeCloudNative,
+			deploymentType: DeploymentTypeCloudNative,
 		},
 	}
 }
@@ -92,7 +91,7 @@ func NewClassicFullStack(instance *dynatracev1beta1.DynaKube, clusterId string) 
 			instance:       instance,
 			hostInjectSpec: &instance.Spec.OneAgent.ClassicFullStack.HostInjectSpec,
 			clusterId:      clusterId,
-			deploymentType: deploymentmetadata.DeploymentTypeFullStack,
+			deploymentType: DeploymentTypeFullStack,
 		},
 	}
 }

--- a/src/controllers/dynakube/oneagent/daemonset/labels_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/labels_test.go
@@ -3,14 +3,13 @@ package daemonset
 import (
 	"testing"
 
-	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildLabels(t *testing.T) {
-	l := BuildLabels("my-name", deploymentmetadata.DeploymentTypeFullStack)
+	l := BuildLabels("my-name", DeploymentTypeFullStack)
 	assert.Equal(t, l[kubeobjects.AppComponentLabel], string(kubeobjects.OneAgentComponentLabel))
 	assert.Equal(t, l[kubeobjects.AppCreatedByLabel], "my-name")
-	assert.Equal(t, l[kubeobjects.FeatureLabel], deploymentmetadata.DeploymentTypeFullStack)
+	assert.Equal(t, l[kubeobjects.FeatureLabel], DeploymentTypeFullStack)
 }

--- a/src/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -103,7 +103,6 @@ func TestPrepareVolumes(t *testing.T) {
 				hostInjectSpec: &instance.Spec.OneAgent.HostMonitoring.HostInjectSpec,
 				clusterId:      "",
 			},
-			HostMonitoringFeature,
 		}
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
@@ -219,7 +218,6 @@ func TestPrepareVolumeMounts(t *testing.T) {
 				hostInjectSpec: &instance.Spec.OneAgent.HostMonitoring.HostInjectSpec,
 				clusterId:      "",
 			},
-			HostMonitoringFeature,
 		}
 
 		volumeMounts := dsInfo.podSpec().Containers[0].VolumeMounts

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler.go
@@ -11,6 +11,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/status"
+	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubesystem"
 	appsv1 "k8s.io/api/apps/v1"
@@ -26,6 +27,7 @@ import (
 const (
 	defaultUpdateInterval = 5 * time.Minute
 	updateEnvVar          = "ONEAGENT_OPERATOR_UPDATE_INTERVAL"
+	oldDsName             = "classic"
 )
 
 // NewOneAgentReconciler initializes a new ReconcileOneAgent instance
@@ -120,7 +122,7 @@ func (r *OneAgentReconciler) reconcileRollout(dkState *status.DynakubeState) (bo
 		// remove old daemonset with feature in name
 		oldClassicDaemonset := &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-%s", r.instance.Name, daemonset.ClassicFeature),
+				Name:      fmt.Sprintf("%s-%s", r.instance.Name, oldDsName),
 				Namespace: r.instance.Namespace,
 			},
 		}
@@ -167,11 +169,11 @@ func (r *OneAgentReconciler) newDaemonSetForCR(dkState *status.DynakubeState, cl
 	var ds *appsv1.DaemonSet
 	var err error
 
-	if r.feature == daemonset.ClassicFeature {
+	if r.feature == deploymentmetadata.DeploymentTypeFullStack {
 		ds, err = daemonset.NewClassicFullStack(dkState.Instance, clusterID).BuildDaemonSet()
-	} else if r.feature == daemonset.HostMonitoringFeature {
+	} else if r.feature == deploymentmetadata.DeploymentTypeHostMonitoring {
 		ds, err = daemonset.NewHostMonitoring(dkState.Instance, clusterID).BuildDaemonSet()
-	} else if r.feature == daemonset.CloudNativeFeature {
+	} else if r.feature == deploymentmetadata.DeploymentTypeCloudNative {
 		ds, err = daemonset.NewCloudNativeFullStack(dkState.Instance, clusterID).BuildDaemonSet()
 	}
 	if err != nil {

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler.go
@@ -11,7 +11,6 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/status"
-	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubesystem"
 	appsv1 "k8s.io/api/apps/v1"
@@ -169,11 +168,11 @@ func (r *OneAgentReconciler) newDaemonSetForCR(dkState *status.DynakubeState, cl
 	var ds *appsv1.DaemonSet
 	var err error
 
-	if r.feature == deploymentmetadata.DeploymentTypeFullStack {
+	if r.feature == daemonset.DeploymentTypeFullStack {
 		ds, err = daemonset.NewClassicFullStack(dkState.Instance, clusterID).BuildDaemonSet()
-	} else if r.feature == deploymentmetadata.DeploymentTypeHostMonitoring {
+	} else if r.feature == daemonset.DeploymentTypeHostMonitoring {
 		ds, err = daemonset.NewHostMonitoring(dkState.Instance, clusterID).BuildDaemonSet()
-	} else if r.feature == deploymentmetadata.DeploymentTypeCloudNative {
+	} else if r.feature == daemonset.DeploymentTypeCloudNative {
 		ds, err = daemonset.NewCloudNativeFullStack(dkState.Instance, clusterID).BuildDaemonSet()
 	}
 	if err != nil {

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/status"
+	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
@@ -84,7 +85,7 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironmentAndDNSPolicy(t *testing.T)
 		apiReader: fakeClient,
 		scheme:    scheme.Scheme,
 		instance:  dynakube,
-		feature:   daemonset.ClassicFeature,
+		feature:   deploymentmetadata.DeploymentTypeFullStack,
 	}
 
 	dkState := status.DynakubeState{Instance: dynakube}
@@ -171,7 +172,7 @@ func TestReconcile_TokensSetCorrectly(t *testing.T) {
 		client:    c,
 		apiReader: c,
 		scheme:    scheme.Scheme,
-		feature:   daemonset.ClassicFeature,
+		feature:   deploymentmetadata.DeploymentTypeFullStack,
 		instance:  &base,
 	}
 
@@ -216,7 +217,7 @@ func TestReconcile_TokensSetCorrectly(t *testing.T) {
 			apiReader: c,
 			scheme:    scheme.Scheme,
 			instance:  &base,
-			feature:   daemonset.ClassicFeature,
+			feature:   deploymentmetadata.DeploymentTypeFullStack,
 		}
 
 		// arrange
@@ -270,7 +271,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 		apiReader: c,
 		scheme:    scheme.Scheme,
 		instance:  &base,
-		feature:   daemonset.ClassicFeature,
+		feature:   deploymentmetadata.DeploymentTypeFullStack,
 	}
 
 	t.Run(`reconileImp Instances set, if autoUpdate is true`, func(t *testing.T) {
@@ -353,7 +354,7 @@ func TestMigrationForDaemonSetWithoutAnnotation(t *testing.T) {
 	dkKey := metav1.ObjectMeta{Name: "my-dynakube", Namespace: "my-namespace"}
 	ds1 := &appsv1.DaemonSet{ObjectMeta: dkKey}
 	r := OneAgentReconciler{
-		feature: daemonset.HostMonitoringFeature,
+		feature: deploymentmetadata.DeploymentTypeHostMonitoring,
 	}
 	dkState := &status.DynakubeState{
 		Instance: &dynatracev1beta1.DynaKube{
@@ -377,7 +378,7 @@ func TestHasSpecChanged(t *testing.T) {
 	runTest := func(msg string, exp bool, mod func(old *dynatracev1beta1.DynaKube, new *dynatracev1beta1.DynaKube)) {
 		t.Run(msg, func(t *testing.T) {
 			r := OneAgentReconciler{
-				feature: daemonset.HostMonitoringFeature,
+				feature: deploymentmetadata.DeploymentTypeHostMonitoring,
 			}
 			key := metav1.ObjectMeta{Name: "my-oneagent", Namespace: "my-namespace"}
 			oldInstance := dynatracev1beta1.DynaKube{
@@ -488,7 +489,7 @@ func TestNewDaemonset_Affinity(t *testing.T) {
 	t.Run(`adds correct affinities`, func(t *testing.T) {
 		versionProvider := &fakeVersionProvider{}
 		r := OneAgentReconciler{
-			feature: daemonset.HostMonitoringFeature,
+			feature: deploymentmetadata.DeploymentTypeHostMonitoring,
 		}
 		dkState := &status.DynakubeState{
 			Instance: newDynaKube(),
@@ -593,7 +594,7 @@ func TestInstanceStatus(t *testing.T) {
 			Labels: map[string]string{
 				"dynatrace.com/component":         "operator",
 				"operator.dynatrace.com/instance": dkName,
-				"operator.dynatrace.com/feature":  daemonset.HostMonitoringFeature,
+				"operator.dynatrace.com/feature":  deploymentmetadata.DeploymentTypeHostMonitoring,
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -615,7 +616,7 @@ func TestInstanceStatus(t *testing.T) {
 		apiReader: fakeClient,
 		scheme:    scheme.Scheme,
 		instance:  dynakube,
-		feature:   daemonset.HostMonitoringFeature,
+		feature:   deploymentmetadata.DeploymentTypeHostMonitoring,
 	}
 
 	upd, err := reconciler.reconcileInstanceStatuses(context.Background(), reconciler.instance)

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -623,7 +623,10 @@ func TestInstanceStatus(t *testing.T) {
 	upd, err := reconciler.reconcileInstanceStatuses(context.Background(), reconciler.instance)
 	assert.NoError(t, err)
 	assert.True(t, upd)
-	assert.NotEmpty(t, dynakube.Status.OneAgent.Instances)
+
+	t.Run("check if oneAgent instances are not empty", func(t *testing.T) {
+		assert.NotEmpty(t, t, dynakube.Status.OneAgent.Instances)
+	})
 
 	upd, err = reconciler.reconcileInstanceStatuses(context.Background(), reconciler.instance)
 	assert.NoError(t, err)

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -623,10 +623,7 @@ func TestInstanceStatus(t *testing.T) {
 	upd, err := reconciler.reconcileInstanceStatuses(context.Background(), reconciler.instance)
 	assert.NoError(t, err)
 	assert.True(t, upd)
-
-	t.Run("check if oneAgent instances are not empty", func(t *testing.T) {
-		assert.NotEmpty(t, t, dynakube.Status.OneAgent.Instances)
-	})
+	assert.NotEmpty(t, t, dynakube.Status.OneAgent.Instances)
 
 	upd, err = reconciler.reconcileInstanceStatuses(context.Background(), reconciler.instance)
 	assert.NoError(t, err)

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -8,7 +8,6 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/status"
-	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
@@ -85,7 +84,7 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironmentAndDNSPolicy(t *testing.T)
 		apiReader: fakeClient,
 		scheme:    scheme.Scheme,
 		instance:  dynakube,
-		feature:   deploymentmetadata.DeploymentTypeFullStack,
+		feature:   daemonset.DeploymentTypeFullStack,
 	}
 
 	dkState := status.DynakubeState{Instance: dynakube}
@@ -172,7 +171,7 @@ func TestReconcile_TokensSetCorrectly(t *testing.T) {
 		client:    c,
 		apiReader: c,
 		scheme:    scheme.Scheme,
-		feature:   deploymentmetadata.DeploymentTypeFullStack,
+		feature:   daemonset.DeploymentTypeFullStack,
 		instance:  &base,
 	}
 
@@ -217,7 +216,7 @@ func TestReconcile_TokensSetCorrectly(t *testing.T) {
 			apiReader: c,
 			scheme:    scheme.Scheme,
 			instance:  &base,
-			feature:   deploymentmetadata.DeploymentTypeFullStack,
+			feature:   daemonset.DeploymentTypeFullStack,
 		}
 
 		// arrange
@@ -271,7 +270,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 		apiReader: c,
 		scheme:    scheme.Scheme,
 		instance:  &base,
-		feature:   deploymentmetadata.DeploymentTypeFullStack,
+		feature:   daemonset.DeploymentTypeFullStack,
 	}
 
 	t.Run(`reconileImp Instances set, if autoUpdate is true`, func(t *testing.T) {
@@ -354,7 +353,7 @@ func TestMigrationForDaemonSetWithoutAnnotation(t *testing.T) {
 	dkKey := metav1.ObjectMeta{Name: "my-dynakube", Namespace: "my-namespace"}
 	ds1 := &appsv1.DaemonSet{ObjectMeta: dkKey}
 	r := OneAgentReconciler{
-		feature: deploymentmetadata.DeploymentTypeHostMonitoring,
+		feature: daemonset.DeploymentTypeHostMonitoring,
 	}
 	dkState := &status.DynakubeState{
 		Instance: &dynatracev1beta1.DynaKube{
@@ -378,7 +377,7 @@ func TestHasSpecChanged(t *testing.T) {
 	runTest := func(msg string, exp bool, mod func(old *dynatracev1beta1.DynaKube, new *dynatracev1beta1.DynaKube)) {
 		t.Run(msg, func(t *testing.T) {
 			r := OneAgentReconciler{
-				feature: deploymentmetadata.DeploymentTypeHostMonitoring,
+				feature: daemonset.DeploymentTypeHostMonitoring,
 			}
 			key := metav1.ObjectMeta{Name: "my-oneagent", Namespace: "my-namespace"}
 			oldInstance := dynatracev1beta1.DynaKube{
@@ -489,7 +488,7 @@ func TestNewDaemonset_Affinity(t *testing.T) {
 	t.Run(`adds correct affinities`, func(t *testing.T) {
 		versionProvider := &fakeVersionProvider{}
 		r := OneAgentReconciler{
-			feature: deploymentmetadata.DeploymentTypeHostMonitoring,
+			feature: daemonset.DeploymentTypeHostMonitoring,
 		}
 		dkState := &status.DynakubeState{
 			Instance: newDynaKube(),
@@ -594,7 +593,7 @@ func TestInstanceStatus(t *testing.T) {
 			Labels: map[string]string{
 				"dynatrace.com/component":         "operator",
 				"operator.dynatrace.com/instance": dkName,
-				"operator.dynatrace.com/feature":  deploymentmetadata.DeploymentTypeHostMonitoring,
+				"operator.dynatrace.com/feature":  daemonset.DeploymentTypeHostMonitoring,
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -616,7 +615,7 @@ func TestInstanceStatus(t *testing.T) {
 		apiReader: fakeClient,
 		scheme:    scheme.Scheme,
 		instance:  dynakube,
-		feature:   deploymentmetadata.DeploymentTypeHostMonitoring,
+		feature:   daemonset.DeploymentTypeHostMonitoring,
 	}
 
 	upd, err := reconciler.reconcileInstanceStatuses(context.Background(), reconciler.instance)

--- a/src/deploymentmetadata/deploymentmetadata.go
+++ b/src/deploymentmetadata/deploymentmetadata.go
@@ -14,12 +14,6 @@ const (
 	keyOperatorScriptVersion = "script_version"
 	keyOrchestratorID        = "orchestrator_id"
 	keyOrchestrationTech     = "orchestration_tech"
-
-	DeploymentTypeApplicationMonitoring = "application_monitoring"
-	DeploymentTypeFullStack             = "classic_fullstack"
-	DeploymentTypeCloudNative           = "cloud_native_fullstack"
-	DeploymentTypeHostMonitoring        = "host_monitoring"
-	DeploymentTypeActiveGate            = "active_gate"
 )
 
 type DeploymentMetadata struct {

--- a/src/deploymentmetadata/deploymentmetadata_test.go
+++ b/src/deploymentmetadata/deploymentmetadata_test.go
@@ -9,12 +9,13 @@ import (
 const (
 	testOrchestratorID = "test-uid"
 
-	testKey   = "test-key"
-	testValue = "test-value"
+	testKey      = "test-key"
+	testValue    = "test-value"
+	testMetaData = "testMetaData"
 )
 
 func newTestDeploymentMetadata(_ *testing.T) *DeploymentMetadata {
-	return NewDeploymentMetadata(testOrchestratorID, DeploymentTypeFullStack)
+	return NewDeploymentMetadata(testOrchestratorID, testMetaData)
 }
 
 func TestNewDeploymentMetadata(t *testing.T) {
@@ -28,7 +29,7 @@ func TestDeploymentMetadata_asArgs(t *testing.T) {
 	labels := deploymentMetadata.AsArgs()
 
 	assert.Equal(t, []string{
-		`--set-deployment-metadata=orchestration_tech=Operator-classic_fullstack`,
+		`--set-deployment-metadata=orchestration_tech=Operator-` + testMetaData,
 		`--set-deployment-metadata=script_version=snapshot`,
 		`--set-deployment-metadata=orchestrator_id=` + testOrchestratorID,
 	}, labels)
@@ -38,14 +39,14 @@ func TestDeploymentMetadata_asString(t *testing.T) {
 	deploymentMetadata := newTestDeploymentMetadata(t)
 	labels := deploymentMetadata.AsString()
 
-	assert.Equal(t, `orchestration_tech=Operator-classic_fullstack;script_version=snapshot;orchestrator_id=`+testOrchestratorID, labels)
+	assert.Equal(t, `orchestration_tech=Operator-`+testMetaData+`;script_version=snapshot;orchestrator_id=`+testOrchestratorID, labels)
 }
 
 func TestDeploymentMetadata_asString_empty_agent(t *testing.T) {
 	deploymentMetadata := newTestDeploymentMetadata(t)
 	labels := deploymentMetadata.AsString()
 
-	assert.Equal(t, `orchestration_tech=Operator-classic_fullstack;script_version=snapshot;orchestrator_id=`+testOrchestratorID, labels)
+	assert.Equal(t, `orchestration_tech=Operator-`+testMetaData+`;script_version=snapshot;orchestrator_id=`+testOrchestratorID, labels)
 }
 
 func TestFormatKeyValue(t *testing.T) {

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -15,6 +15,7 @@ import (
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes"
 	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/src/ingestendpoint"
@@ -376,9 +377,9 @@ func createInstallInitContainerBase(image string, pod *corev1.Pod, failurePolicy
 func (m *podMutator) getDeploymentMetadata(dk dynatracev1beta1.DynaKube) *deploymentmetadata.DeploymentMetadata {
 	var deploymentMetadata *deploymentmetadata.DeploymentMetadata
 	if dk.CloudNativeFullstackMode() {
-		deploymentMetadata = deploymentmetadata.NewDeploymentMetadata(m.clusterID, oneagent.DeploymentTypeCloudNative)
+		deploymentMetadata = deploymentmetadata.NewDeploymentMetadata(m.clusterID, daemonset.DeploymentTypeCloudNative)
 	} else {
-		deploymentMetadata = deploymentmetadata.NewDeploymentMetadata(m.clusterID, oneagent.DeploymentTypeApplicationMonitoring)
+		deploymentMetadata = deploymentmetadata.NewDeploymentMetadata(m.clusterID, daemonset.DeploymentTypeApplicationMonitoring)
 	}
 	return deploymentMetadata
 }
@@ -538,7 +539,7 @@ func (m *podMutator) applyReinvocationPolicy(pod *corev1.Pod, dk dynatracev1beta
 			// container does not have LD_PRELOAD set
 			podLog.Info("instrumenting missing container", "injectable", "oneagent", "name", c.Name)
 
-			deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(m.clusterID, oneagent.DeploymentTypeApplicationMonitoring)
+			deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(m.clusterID, daemonset.DeploymentTypeApplicationMonitoring)
 
 			updateContainerOneAgent(c, &dk, pod, deploymentMetadata)
 
@@ -560,7 +561,7 @@ func (m *podMutator) applyReinvocationPolicy(pod *corev1.Pod, dk dynatracev1beta
 		if diInjectionMissing {
 			podLog.Info("instrumenting missing container", "injectable", "data-ingest", "name", c.Name)
 
-			deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(m.clusterID, oneagent.DeploymentTypeApplicationMonitoring)
+			deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(m.clusterID, daemonset.DeploymentTypeApplicationMonitoring)
 			updateContainerDataIngest(c, deploymentMetadata)
 
 			needsUpdate = true

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -377,9 +377,9 @@ func createInstallInitContainerBase(image string, pod *corev1.Pod, failurePolicy
 func (m *podMutator) getDeploymentMetadata(dk dynatracev1beta1.DynaKube) *deploymentmetadata.DeploymentMetadata {
 	var deploymentMetadata *deploymentmetadata.DeploymentMetadata
 	if dk.CloudNativeFullstackMode() {
-		deploymentMetadata = deploymentmetadata.NewDeploymentMetadata(m.clusterID, deploymentmetadata.DeploymentTypeCloudNative)
+		deploymentMetadata = deploymentmetadata.NewDeploymentMetadata(m.clusterID, oneagent.DeploymentTypeCloudNative)
 	} else {
-		deploymentMetadata = deploymentmetadata.NewDeploymentMetadata(m.clusterID, deploymentmetadata.DeploymentTypeApplicationMonitoring)
+		deploymentMetadata = deploymentmetadata.NewDeploymentMetadata(m.clusterID, oneagent.DeploymentTypeApplicationMonitoring)
 	}
 	return deploymentMetadata
 }
@@ -539,7 +539,7 @@ func (m *podMutator) applyReinvocationPolicy(pod *corev1.Pod, dk dynatracev1beta
 			// container does not have LD_PRELOAD set
 			podLog.Info("instrumenting missing container", "injectable", "oneagent", "name", c.Name)
 
-			deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(m.clusterID, deploymentmetadata.DeploymentTypeApplicationMonitoring)
+			deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(m.clusterID, oneagent.DeploymentTypeApplicationMonitoring)
 
 			updateContainerOneAgent(c, &dk, pod, deploymentMetadata)
 
@@ -561,7 +561,7 @@ func (m *podMutator) applyReinvocationPolicy(pod *corev1.Pod, dk dynatracev1beta
 		if diInjectionMissing {
 			podLog.Info("instrumenting missing container", "injectable", "data-ingest", "name", c.Name)
 
-			deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(m.clusterID, deploymentmetadata.DeploymentTypeApplicationMonitoring)
+			deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(m.clusterID, oneagent.DeploymentTypeApplicationMonitoring)
 			updateContainerDataIngest(c, pod, deploymentMetadata, dataIngestFields)
 
 			needsUpdate = true


### PR DESCRIPTION
## Description

We currently have the problem, that the mark for termination event is not send, because our node cache is not filled with the nodes, where the oneAgent is deployed on. To understand how the node cache is filled, you need to know that we store the instances of a oneAgent pod in the Dynakube-Status. Every 5 Minutes if the DK is reconciled, we query the cluster for oneAgent pods with defined labels on it. If those labels are not matching, then the pods are not received. 

The case was now, that we had a label missmatch and the pods were not correctly stored in the DK Status. Therfore we were not able to query the DK for a node, when a node got reconciled. As a result, the mark for termination Event never got sent.

Why did this happen?
The labels which are set on the daemonset (in detail the feature label) got changed, from the const which was part of the daemonset.go to deploymentmetadata.(feature). The had a slight difference, e.g classic (old label) and classic_fullstack (new label)

## How can this be tested?
To test if everything works no as expected, you can create a DK with classicFullstack, cloudNative or hostMonitoring and check if the Dynakube Object has set the instances of the OneAgent pods correctly. Furthermore to test if the mark for termination event is sent correctly, you can cordon a Node in GKE for example and check if the host has a label in the Dynatrace UI, that it was marked for termination (or check the Operator Logs in the cluster and search for "Sending mark for termination")


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

