### PR TITLE
Remove dataingest environment variable from pod injection

### DIFF
--- a/src/ingestendpoint/secret.go
+++ b/src/ingestendpoint/secret.go
@@ -126,8 +126,7 @@ func (g *EndpointSecretGenerator) prepare(ctx context.Context, dk *dynatracev1be
 	}
 
 	data := map[string][]byte{
-		configFile:       endpointBuf.Bytes(),
-		TokenSecretField: []byte(fields[TokenSecretField]),
+		configFile: endpointBuf.Bytes(),
 	}
 	return data, nil
 }

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -227,10 +227,8 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		return *secretResponse
 	}
 
-	dataIngestFields := map[string]string{}
 	if injectionInfo.enabled(DataIngest) {
-		var err error
-		dataIngestFields, err = m.ensureDataIngestSecret(ctx, ns, dkName, dk)
+		err := m.ensureDataIngestSecret(ctx, ns, dkName)
 		if err != nil {
 			return silentErrorResponse(m.currentPodName, err)
 		}
@@ -238,7 +236,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 
 	podLog.Info("injecting into Pod", "name", pod.Name, "generatedName", pod.GenerateName, "namespace", req.Namespace)
 
-	response := m.handleAlreadyInjectedPod(pod, dk, injectionInfo, dataIngestFields, req)
+	response := m.handleAlreadyInjectedPod(pod, dk, injectionInfo, req)
 	if response != nil {
 		return *response
 	}
@@ -267,7 +265,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	decorateInstallContainerWithOneAgent(&installContainer, injectionInfo, flavor, technologies, installPath, installerURL, mode)
 	decorateInstallContainerWithDataIngest(&installContainer, injectionInfo, workloadKind, workloadName)
 
-	updateContainers(pod, injectionInfo, &installContainer, dk, deploymentMetadata, dataIngestFields)
+	updateContainers(pod, injectionInfo, &installContainer, dk, deploymentMetadata)
 
 	addToInitContainers(pod, installContainer)
 
@@ -279,11 +277,11 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	return getResponseForPod(pod, &req)
 }
 
-func (m *podMutator) handleAlreadyInjectedPod(pod *corev1.Pod, dk dynatracev1beta1.DynaKube, injectionInfo *InjectionInfo, dataIngestFields map[string]string, req admission.Request) *admission.Response {
+func (m *podMutator) handleAlreadyInjectedPod(pod *corev1.Pod, dk dynatracev1beta1.DynaKube, injectionInfo *InjectionInfo, req admission.Request) *admission.Response {
 	// are there any injections already?
 	if len(pod.Annotations[dtwebhook.AnnotationDynatraceInjected]) > 0 {
 		if dk.FeatureEnableWebhookReinvocationPolicy() {
-			rsp := m.applyReinvocationPolicy(pod, dk, injectionInfo, dataIngestFields, req)
+			rsp := m.applyReinvocationPolicy(pod, dk, injectionInfo, req)
 			return &rsp
 		}
 		rsp := admission.Patched("")
@@ -296,7 +294,7 @@ func addToInitContainers(pod *corev1.Pod, installContainer corev1.Container) {
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, installContainer)
 }
 
-func updateContainers(pod *corev1.Pod, injectionInfo *InjectionInfo, ic *corev1.Container, dk dynatracev1beta1.DynaKube, deploymentMetadata *deploymentmetadata.DeploymentMetadata, dataIngestFields map[string]string) {
+func updateContainers(pod *corev1.Pod, injectionInfo *InjectionInfo, ic *corev1.Container, dk dynatracev1beta1.DynaKube, deploymentMetadata *deploymentmetadata.DeploymentMetadata) {
 	for i := range pod.Spec.Containers {
 		c := &pod.Spec.Containers[i]
 
@@ -305,7 +303,7 @@ func updateContainers(pod *corev1.Pod, injectionInfo *InjectionInfo, ic *corev1.
 			updateContainerOneAgent(c, &dk, pod, deploymentMetadata)
 		}
 		if injectionInfo.enabled(DataIngest) {
-			updateContainerDataIngest(c, pod, deploymentMetadata, dataIngestFields)
+			updateContainerDataIngest(c, deploymentMetadata)
 		}
 	}
 }
@@ -507,7 +505,7 @@ func (m *podMutator) retrieveWorkload(ctx context.Context, req admission.Request
 	return workloadName, workloadKind, nil
 }
 
-func (m *podMutator) applyReinvocationPolicy(pod *corev1.Pod, dk dynatracev1beta1.DynaKube, injectionInfo *InjectionInfo, dataIngestFields map[string]string, req admission.Request) admission.Response {
+func (m *podMutator) applyReinvocationPolicy(pod *corev1.Pod, dk dynatracev1beta1.DynaKube, injectionInfo *InjectionInfo, req admission.Request) admission.Response {
 	var needsUpdate = false
 	var installContainer *corev1.Container
 	for i := range pod.Spec.Containers {
@@ -562,7 +560,7 @@ func (m *podMutator) applyReinvocationPolicy(pod *corev1.Pod, dk dynatracev1beta
 			podLog.Info("instrumenting missing container", "injectable", "data-ingest", "name", c.Name)
 
 			deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(m.clusterID, deploymentmetadata.DeploymentTypeApplicationMonitoring)
-			updateContainerDataIngest(c, pod, deploymentMetadata, dataIngestFields)
+			updateContainerDataIngest(c, deploymentMetadata)
 
 			needsUpdate = true
 		}
@@ -611,26 +609,21 @@ func (m *podMutator) getNsAndDkName(ctx context.Context, req admission.Request) 
 	return ns, dkName, nil
 }
 
-func (m *podMutator) ensureDataIngestSecret(ctx context.Context, ns corev1.Namespace, dkName string, dk dynatracev1beta1.DynaKube) (map[string]string, error) {
+func (m *podMutator) ensureDataIngestSecret(ctx context.Context, ns corev1.Namespace, dkName string) error {
 	endpointGenerator := dtingestendpoint.NewEndpointSecretGenerator(m.client, m.apiReader, m.namespace)
 
 	var endpointSecret corev1.Secret
 	if err := m.apiReader.Get(ctx, client.ObjectKey{Name: dtingestendpoint.SecretEndpointName, Namespace: ns.Name}, &endpointSecret); k8serrors.IsNotFound(err) {
 		if _, err := endpointGenerator.GenerateForNamespace(ctx, dkName, ns.Name); err != nil {
 			podLog.Error(err, "failed to create the data-ingest endpoint secret before pod injection")
-			return nil, err
+			return err
 		}
 	} else if err != nil {
 		podLog.Error(err, "failed to query the data-ingest endpoint secret before pod injection")
-		return nil, err
+		return err
 	}
 
-	dataIngestFields, err := endpointGenerator.PrepareFields(ctx, &dk)
-	if err != nil {
-		podLog.Error(err, "failed to query the data-ingest endpoint secret before pod injection")
-		return nil, err
-	}
-	return dataIngestFields, nil
+	return nil
 }
 
 func (m *podMutator) getDynakube(ctx context.Context, req admission.Request, dkName string) (dynatracev1beta1.DynaKube, *admission.Response) {
@@ -764,7 +757,7 @@ func addMetadataIfMissing(c *corev1.Container, deploymentMetadata *deploymentmet
 		})
 }
 
-func updateContainerDataIngest(c *corev1.Container, pod *corev1.Pod, deploymentMetadata *deploymentmetadata.DeploymentMetadata, dataIngestFields map[string]string) {
+func updateContainerDataIngest(c *corev1.Container, deploymentMetadata *deploymentmetadata.DeploymentMetadata) {
 	podLog.Info("updating container with missing data ingest enrichment", "containerName", c.Name)
 
 	addMetadataIfMissing(c, deploymentMetadata)
@@ -777,24 +770,6 @@ func updateContainerDataIngest(c *corev1.Container, pod *corev1.Pod, deploymentM
 		corev1.VolumeMount{
 			Name:      dataIngestEndpointVolumeName,
 			MountPath: "/var/lib/dynatrace/enrichment/endpoint",
-		},
-	)
-
-	c.Env = append(c.Env,
-		corev1.EnvVar{
-			Name:  dtingestendpoint.UrlSecretField,
-			Value: dataIngestFields[dtingestendpoint.UrlSecretField],
-		},
-		corev1.EnvVar{
-			Name: dtingestendpoint.TokenSecretField,
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: dtingestendpoint.SecretEndpointName,
-					},
-					Key: dtingestendpoint.TokenSecretField,
-				},
-			},
 		},
 	)
 }

--- a/src/webhook/mutation/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator_test.go
@@ -39,8 +39,6 @@ const (
 	dataIngestToken             = "data-ingest-token"
 )
 
-var defaultInjection = NewInjectionInfo()
-
 func TestInjectionWithMissingOneAgentAPM(t *testing.T) {
 	decoder, err := admission.NewDecoder(scheme.Scheme)
 	require.NoError(t, err)
@@ -92,7 +90,7 @@ func TestInjectionWithMissingOneAgentAPM(t *testing.T) {
 	)
 }
 
-func createPodInjector(_ *testing.T, decoder *admission.Decoder, injectionInfo *InjectionInfo) (*podMutator, *dynatracev1beta1.DynaKube) {
+func createPodInjector(_ *testing.T, decoder *admission.Decoder) (*podMutator, *dynatracev1beta1.DynaKube) {
 	dynakube := &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dynakubeName,
@@ -230,7 +228,7 @@ func impl(t *testing.T, injectionInfo *InjectionInfo) {
 	decoder, err := admission.NewDecoder(scheme.Scheme)
 	require.NoError(t, err)
 
-	inj, instance := createPodInjector(t, decoder, injectionInfo)
+	inj, instance := createPodInjector(t, decoder)
 	err = inj.client.Update(context.TODO(), instance)
 	require.NoError(t, err)
 
@@ -332,7 +330,7 @@ func TestPodInjection(t *testing.T) {
 	decoder, err := admission.NewDecoder(scheme.Scheme)
 	require.NoError(t, err)
 
-	inj, instance := createPodInjector(t, decoder, defaultInjection)
+	inj, instance := createPodInjector(t, decoder)
 	err = inj.client.Update(context.TODO(), instance)
 	require.NoError(t, err)
 
@@ -414,7 +412,7 @@ func TestPodInjectionWithCSI(t *testing.T) {
 	decoder, err := admission.NewDecoder(scheme.Scheme)
 	require.NoError(t, err)
 
-	inj, _ := createPodInjector(t, decoder, defaultInjection)
+	inj, _ := createPodInjector(t, decoder)
 
 	basePod := corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -1351,21 +1349,6 @@ func buildResultPod(_ *testing.T, oneAgentFf FeatureFlag, dataIngestFf FeatureFl
 			corev1.VolumeMount{Name: dataIngestVolumeName, MountPath: standalone.EnrichmentPath},
 		)
 
-		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env,
-			corev1.EnvVar{Name: dtingestendpoint.UrlSecretField, Value: "https://tenant.test-api-url.com/api/v2/metrics/ingest"},
-			corev1.EnvVar{
-				Name: dtingestendpoint.TokenSecretField,
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: dtingestendpoint.SecretEndpointName,
-						},
-						Key: dtingestendpoint.TokenSecretField,
-					},
-				},
-			},
-		)
-
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts,
 			corev1.VolumeMount{Name: dataIngestVolumeName, MountPath: standalone.EnrichmentPath},
 			corev1.VolumeMount{Name: dataIngestEndpointVolumeName, MountPath: "/var/lib/dynatrace/enrichment/endpoint"},
@@ -1416,7 +1399,7 @@ func TestInstrumentThirdPartyContainers(t *testing.T) {
 	decoder, err := admission.NewDecoder(scheme.Scheme)
 	require.NoError(t, err)
 
-	inj, instance := createPodInjector(t, decoder, defaultInjection)
+	inj, instance := createPodInjector(t, decoder)
 
 	// enable feature
 	instance.Annotations = map[string]string{}


### PR DESCRIPTION
# Description

Cherrypick of #566 

## How can this be tested?
When pod is injected by webhook, no metadata enrichment environment variables are added.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

