### PR TITLE
`AnnotationFeatureEnableActivegateRawImage` defaults to `true`

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -160,9 +160,9 @@ func (dk *DynaKube) FeatureDisableReadOnlyOneAgent() bool {
 // FeatureEnableActivegateRawImage is a feature flag to specify if the operator should
 // fetch from cluster and set in ActiveGet container: tenant UUID, token and communication endpoints
 // instead of using embedded ones in the image
-// Defaults to false
+// Defaults to true
 func (dk *DynaKube) FeatureEnableActivegateRawImage() bool {
-	return dk.getFeatureFlagRaw(AnnotationFeatureEnableActivegateRawImage) == "true"
+	return dk.getFeatureFlagRaw(AnnotationFeatureEnableActivegateRawImage) != "false"
 }
 
 // FeatureEnableMultipleOsAgentsOnNode is a feature flag to enable multiple osagents running on the same host

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -335,7 +335,10 @@ func TestStatefulSet_Volumes(t *testing.T) {
 		volumes := buildVolumes(stsProperties, getContainerBuilders(stsProperties))
 		expectedSecretName := instance.Name + "-router-" + customproperties.Suffix
 
-		require.Equal(t, 1, len(volumes))
+		require.Equal(t, 2, len(volumes))
+
+		_, err := kubeobjects.GetVolumeByName(volumes, tenantSecretVolumeName)
+		assert.NoError(t, err)
 
 		customPropertiesVolume, err := kubeobjects.GetVolumeByName(volumes, customproperties.VolumeName)
 		assert.NoError(t, err)
@@ -357,7 +360,10 @@ func TestStatefulSet_Volumes(t *testing.T) {
 		volumes := buildVolumes(stsProperties, getContainerBuilders(stsProperties))
 		expectedSecretName := testKey
 
-		require.Equal(t, 1, len(volumes))
+		require.Equal(t, 2, len(volumes))
+
+		_, err := kubeobjects.GetVolumeByName(volumes, tenantSecretVolumeName)
+		assert.NoError(t, err)
 
 		customPropertiesVolume, err := kubeobjects.GetVolumeByName(volumes, customproperties.VolumeName)
 		assert.NoError(t, err)
@@ -375,9 +381,9 @@ func TestStatefulSet_Env(t *testing.T) {
 	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 	deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(testUID, deploymentmetadata.DeploymentTypeActiveGate)
 
-	t.Run(`with FeatureEnableActivegateRawImage=true`, func(t *testing.T) {
+	t.Run(`with FeatureEnableActivegateRawImage=false`, func(t *testing.T) {
 		instanceRawImg := instance.DeepCopy()
-		instanceRawImg.Annotations[dynatracev1beta1.AnnotationFeatureEnableActivegateRawImage] = "true"
+		instanceRawImg.Annotations[dynatracev1beta1.AnnotationFeatureEnableActivegateRawImage] = "false"
 
 		envVars := buildEnvs(NewStatefulSetProperties(instanceRawImg, capabilityProperties,
 			testUID, "", testFeature, "MSGrouter", "",
@@ -385,28 +391,6 @@ func TestStatefulSet_Env(t *testing.T) {
 		))
 
 		expectedEnvVars := []corev1.EnvVar{
-			{
-				Name: dtServer,
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: instanceRawImg.Name + dynatracev1beta1.TenantSecretSuffix,
-						},
-						Key: activegate.CommunicationEndpointsName,
-					},
-				},
-			},
-			{
-				Name: dtTenant,
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: instanceRawImg.Name + dynatracev1beta1.TenantSecretSuffix,
-						},
-						Key: activegate.TenantUuidName,
-					},
-				},
-			},
 			{Name: dtCapabilities, Value: "MSGrouter"},
 			{Name: dtIdSeedNamespace, Value: instanceRawImg.Namespace},
 			{Name: dtIdSeedClusterId, Value: testUID},
@@ -424,6 +408,28 @@ func TestStatefulSet_Env(t *testing.T) {
 		))
 
 		expectedEnvVars := []corev1.EnvVar{
+			{
+				Name: dtServer,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: instance.Name + dynatracev1beta1.TenantSecretSuffix,
+						},
+						Key: activegate.CommunicationEndpointsName,
+					},
+				},
+			},
+			{
+				Name: dtTenant,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: instance.Name + dynatracev1beta1.TenantSecretSuffix,
+						},
+						Key: activegate.TenantUuidName,
+					},
+				},
+			},
 			{Name: dtCapabilities, Value: "MSGrouter"},
 			{Name: dtIdSeedNamespace, Value: instance.Namespace},
 			{Name: dtIdSeedClusterId, Value: testUID},
@@ -432,7 +438,6 @@ func TestStatefulSet_Env(t *testing.T) {
 		}
 
 		assert.ElementsMatch(t, expectedEnvVars, envVars)
-
 	})
 	t.Run(`with networkzone`, func(t *testing.T) {
 		instance := buildTestInstance()


### PR DESCRIPTION
# Description
ActiveGate image contains embedded metadata containing connection info. 
It's about to change, images will be generic and connection info must be provided by dynatrace-operator via mounted volume.

therefore `operator.dynatrace.com/feature-enable-activegate-raw-image` defaults to `true`

## How can this be tested?
Following dynakubes should deploy ActiveGate correctly (== `running` state)
1. connection info fetched by dynatrace-operator and mounted into AG pods:
```
apiVersion: dynatrace.com/v1beta1
kind: DynaKube
metadata:
  name: dk
  namespace: dynatrace
spec:
  apiUrl: <api_url>
  activeGate:
    capabilities:
    - kubernetes-monitoring
```
```
apiVersion: dynatrace.com/v1beta1
kind: DynaKube
metadata:
  name: dk
  namespace: dynatrace
  annotations:
    operator.dynatrace.com/feature-enable-activegate-raw-image: "true"
spec:
  apiUrl: <api_url>
  activeGate:
    capabilities:
    - kubernetes-monitoring
```
2. connection info taken from the image
```
apiVersion: dynatrace.com/v1beta1
kind: DynaKube
metadata:
  name: dk
  namespace: dynatrace
  annotations:
    operator.dynatrace.com/feature-enable-activegate-raw-image: "false"
spec:
  apiUrl: <api_url>
  activeGate:
    capabilities:
    - kubernetes-monitoring
```


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

