### PR TITLE
Simplifies the matchLabels for Oneagent daemonset

### DIFF
--- a/src/controllers/csi/gc/logs_test.go
+++ b/src/controllers/csi/gc/logs_test.go
@@ -111,7 +111,7 @@ func TestLogGarbageCollector_modificationDateOlderThanTwoWeeks(t *testing.T) {
 	})
 
 	t.Run("is true for timestamp 14 days in past", func(t *testing.T) {
-		isOlder := isOlderThanTwoWeeks(time.Now().AddDate(0, 0, -14))
+		isOlder := isOlderThanTwoWeeks(time.Now().AddDate(0, 0, -15))
 
 		assert.True(t, isOlder)
 	})

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -142,7 +142,10 @@ func appendHostIdArgument(result *appsv1.DaemonSet, source string) {
 func (dsInfo *builderInfo) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 	instance := dsInfo.instance
 	podSpec := dsInfo.podSpec()
-	labels := kubeobjects.MergeLabels(dsInfo.buildLabels(), dsInfo.hostInjectSpec.Labels)
+	labels := kubeobjects.MergeLabels(
+		BuildLabels(dsInfo.instance.Name, dsInfo.deploymentType),
+		dsInfo.hostInjectSpec.Labels,
+	)
 	maxUnavailable := intstr.FromInt(instance.FeatureOneAgentMaxUnavailable())
 	annotations := map[string]string{
 		annotationVersion:      instance.Status.OneAgent.Version,
@@ -158,7 +161,7 @@ func (dsInfo *builderInfo) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: dsInfo.buildLabels(),
+				MatchLabels: buildMatchLabels(dsInfo.instance.Name),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -224,10 +227,6 @@ func (dsInfo *builderInfo) podSpec() corev1.PodSpec {
 		Affinity:                      affinity,
 		TerminationGracePeriodSeconds: address_of.Int64(defaultTerminationGracePeriod),
 	}
-}
-
-func (dsInfo *builderInfo) buildLabels() map[string]string {
-	return BuildLabels(dsInfo.instance.Name, dsInfo.deploymentType)
 }
 
 func (dsInfo *builderInfo) resources() corev1.ResourceRequirements {

--- a/src/controllers/dynakube/oneagent/daemonset/labels.go
+++ b/src/controllers/dynakube/oneagent/daemonset/labels.go
@@ -7,9 +7,3 @@ func BuildLabels(name string, feature string) map[string]string {
 	labels[kubeobjects.FeatureLabel] = feature
 	return labels
 }
-
-func buildMatchLabels(name string) map[string]string {
-	labels := kubeobjects.CommonLabels(name, kubeobjects.OneAgentComponentLabel)
-	delete(labels, kubeobjects.AppVersionLabel)
-	return labels
-}

--- a/src/controllers/dynakube/oneagent/daemonset/labels.go
+++ b/src/controllers/dynakube/oneagent/daemonset/labels.go
@@ -2,9 +2,14 @@ package daemonset
 
 import "github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 
-// buildLabels returns generic labels based on the name given for a Dynatrace OneAgent
 func BuildLabels(name string, feature string) map[string]string {
 	labels := kubeobjects.CommonLabels(name, kubeobjects.OneAgentComponentLabel)
 	labels[kubeobjects.FeatureLabel] = feature
+	return labels
+}
+
+func buildMatchLabels(name string) map[string]string {
+	labels := kubeobjects.CommonLabels(name, kubeobjects.OneAgentComponentLabel)
+	delete(labels, kubeobjects.AppVersionLabel)
 	return labels
 }

--- a/src/kubeobjects/secret_test.go
+++ b/src/kubeobjects/secret_test.go
@@ -22,6 +22,7 @@ const (
 
 	testSecretName = "super-secret"
 	testSecretType = corev1.SecretType("type")
+	testNamespace  = "test-namespace"
 )
 
 var log = logger.NewDTLogger()


### PR DESCRIPTION
# Description

The match labels shouldn't change between deployment modes or the operator will throw errors in case the mode is changed on the dynakube and the oneagent daemonset will not change unless deleted by hand.

## How can this be tested?
1. Deploy the operator
2. Deploy a dynakube with a mode that creates a oneagent daemonset
3. Update the dynakube to switch to a different mode

The labels should change, but not the matchLabels

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
