### PR TITLE
ActiveGate webserver's CA mounted properly in OneAgents pods

### DIFF
--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -87,7 +87,7 @@ func (dk *DynaKube) KubernetesMonitoringMode() bool {
 	return dk.IsActiveGateMode(KubeMonCapability.DisplayName) || dk.Spec.KubernetesMonitoring.Enabled
 }
 
-func (dk *DynaKube) HasActiveGateTLS() bool {
+func (dk *DynaKube) HasActiveGateCaCert() bool {
 	return dk.ActiveGateMode() && dk.Spec.ActiveGate.TlsSecretName != ""
 }
 

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -1,8 +1,6 @@
 package daemonset
 
 import (
-	"path/filepath"
-
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
@@ -26,14 +24,14 @@ const (
 	// normal oneagent shutdown scenario with some extra time
 	defaultTerminationGracePeriod int64 = 80
 
-	hostRootVolumeName  = "host-root"
-	hostRootVolumeMount = "/mnt/root"
+	hostRootVolumeName      = "host-root"
+	hostRootVolumeMountPath = "/mnt/root"
 
-	certVolumeName  = "certs"
-	certVolumeMount = "/mnt/dynatrace/certs"
+	clusterCaCertVolumeName      = "dynatrace-cluster-ca"
+	clusterCaCertVolumeMountPath = "/mnt/dynatrace/certs"
 
-	OneAgentCustomKeysPath = "/var/lib/dynatrace/oneagent/agent/customkeys"
-	tlsVolumeName          = "tls"
+	activeGateCaCertVolumeName      = "active-gate-ca"
+	activeGateCaCertVolumeMountPath = "/mnt/dynatrace/certs/activegate/"
 
 	csiStorageVolumeName  = "osagent-storage"
 	csiStorageVolumeMount = "/mnt/volume_storage_mount"
@@ -46,10 +44,6 @@ const (
 	ClassicFeature        = "classic"
 	HostMonitoringFeature = "inframon"
 	CloudNativeFeature    = "cloud-native"
-)
-
-var (
-	tlsVolumeMount = filepath.Join(hostRootVolumeMount, OneAgentCustomKeysPath)
 )
 
 type HostMonitoring struct {

--- a/src/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -14,39 +14,38 @@ func prepareVolumeMounts(instance *dynatracev1beta1.DynaKube) []corev1.VolumeMou
 	if instance.NeedsReadOnlyOneAgents() {
 		volumeMounts = append(volumeMounts, getReadOnlyRootMount())
 		volumeMounts = append(volumeMounts, getCSIStorageMount())
-
 	} else {
 		volumeMounts = append(volumeMounts, getRootMount())
 	}
 
 	if instance.Spec.TrustedCAs != "" {
-		volumeMounts = append(volumeMounts, getCertificateMount())
+		volumeMounts = append(volumeMounts, getClusterCaCertVolumeMount())
 	}
 
-	if instance.HasActiveGateTLS() {
-		volumeMounts = append(volumeMounts, getTLSMount())
+	if instance.HasActiveGateCaCert() {
+		volumeMounts = append(volumeMounts, getActiveGateCaCertVolumeMount())
 	}
 	return volumeMounts
 }
 
-func getCertificateMount() corev1.VolumeMount {
+func getClusterCaCertVolumeMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      certVolumeName,
-		MountPath: certVolumeMount,
+		Name:      clusterCaCertVolumeName,
+		MountPath: clusterCaCertVolumeMountPath,
 	}
 }
 
-func getTLSMount() corev1.VolumeMount {
+func getActiveGateCaCertVolumeMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      tlsVolumeName,
-		MountPath: tlsVolumeMount,
+		Name:      activeGateCaCertVolumeName,
+		MountPath: activeGateCaCertVolumeMountPath,
 	}
 }
 
 func getRootMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      hostRootVolumeName,
-		MountPath: hostRootVolumeMount,
+		MountPath: hostRootVolumeMountPath,
 	}
 }
 
@@ -74,8 +73,8 @@ func prepareVolumes(instance *dynatracev1beta1.DynaKube) []corev1.Volume {
 		volumes = append(volumes, getCertificateVolume(instance))
 	}
 
-	if instance.HasActiveGateTLS() {
-		volumes = append(volumes, getTLSVolume(instance))
+	if instance.HasActiveGateCaCert() {
+		volumes = append(volumes, getActiveGateCaCertVolume(instance))
 	}
 
 	return volumes
@@ -83,7 +82,7 @@ func prepareVolumes(instance *dynatracev1beta1.DynaKube) []corev1.Volume {
 
 func getCertificateVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 	return corev1.Volume{
-		Name: certVolumeName,
+		Name: clusterCaCertVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -115,9 +114,9 @@ func getCSIStorageVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 	}
 }
 
-func getTLSVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
+func getActiveGateCaCertVolume(instance *dynatracev1beta1.DynaKube) corev1.Volume {
 	return corev1.Volume{
-		Name: tlsVolumeName,
+		Name: activeGateCaCertVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: instance.Spec.ActiveGate.TlsSecretName,

--- a/src/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -53,7 +53,7 @@ func TestPrepareVolumes(t *testing.T) {
 			},
 		}
 		volumes := prepareVolumes(instance)
-		assert.Contains(t, volumes, getTLSVolume(instance))
+		assert.Contains(t, volumes, getActiveGateCaCertVolume(instance))
 	})
 	t.Run(`doesn't have csi volume`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
@@ -112,7 +112,7 @@ func TestPrepareVolumes(t *testing.T) {
 
 		assert.Contains(t, volumes, getRootVolume())
 		assert.Contains(t, volumes, getCertificateVolume(instance))
-		assert.Contains(t, volumes, getTLSVolume(instance))
+		assert.Contains(t, volumes, getActiveGateCaCertVolume(instance))
 		assert.Contains(t, volumes, getCSIStorageVolume(instance))
 	})
 }
@@ -129,9 +129,9 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		volumeMounts := prepareVolumeMounts(instance)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.NotContains(t, volumeMounts, getCertificateMount())
+		assert.NotContains(t, volumeMounts, getActiveGateCaCertVolumeMount())
 	})
-	t.Run(`has certificate volume mount`, func(t *testing.T) {
+	t.Run(`has cluster certificate volume mount`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				OneAgent: dynatracev1beta1.OneAgentSpec{
@@ -143,9 +143,10 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		volumeMounts := prepareVolumeMounts(instance)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.Contains(t, volumeMounts, getCertificateMount())
+		assert.Contains(t, volumeMounts, getClusterCaCertVolumeMount())
+		assert.NotContains(t, volumeMounts, getActiveGateCaCertVolumeMount())
 	})
-	t.Run(`has tls volume mount`, func(t *testing.T) {
+	t.Run(`has ActiveGate CA volume mount`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				OneAgent: dynatracev1beta1.OneAgentSpec{
@@ -164,7 +165,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		volumeMounts := prepareVolumeMounts(instance)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.Contains(t, volumeMounts, getTLSMount())
+		assert.Contains(t, volumeMounts, getActiveGateCaCertVolumeMount())
 	})
 	t.Run(`doesn't have readonly volume mounts`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
@@ -174,6 +175,12 @@ func TestPrepareVolumeMounts(t *testing.T) {
 				},
 			},
 			Spec: dynatracev1beta1.DynaKubeSpec{
+				ActiveGate: dynatracev1beta1.ActiveGateSpec{
+					TlsSecretName: testName,
+					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+						dynatracev1beta1.RoutingCapability.DisplayName,
+					},
+				},
 				OneAgent: dynatracev1beta1.OneAgentSpec{
 					HostMonitoring: &dynatracev1beta1.HostMonitoringSpec{},
 				},
@@ -183,6 +190,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		volumeMounts := prepareVolumeMounts(instance)
 
 		assert.Contains(t, volumeMounts, getRootMount())
+		assert.Contains(t, volumeMounts, getActiveGateCaCertVolumeMount())
 		assert.NotContains(t, volumeMounts, getCSIStorageMount())
 	})
 	t.Run(`readonly volume not supported on classicFullStack`, func(t *testing.T) {
@@ -225,8 +233,8 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		volumeMounts := dsInfo.podSpec().Containers[0].VolumeMounts
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.Contains(t, volumeMounts, getCertificateMount())
-		assert.Contains(t, volumeMounts, getTLSMount())
+		assert.Contains(t, volumeMounts, getActiveGateCaCertVolumeMount())
+		assert.Contains(t, volumeMounts, getClusterCaCertVolumeMount())
 		assert.Contains(t, volumeMounts, getCSIStorageMount())
 	})
 }

--- a/src/initgeneration/initgeneration.go
+++ b/src/initgeneration/initgeneration.go
@@ -145,7 +145,7 @@ func (g *InitGenerator) prepareScriptForDynaKube(dk *dynatracev1beta1.DynaKube, 
 	}
 
 	var tlsCert string
-	if dk.HasActiveGateTLS() {
+	if dk.HasActiveGateCaCert() {
 		var tlsSecret corev1.Secret
 		if err := g.client.Get(context.TODO(), client.ObjectKey{Name: dk.Spec.ActiveGate.TlsSecretName, Namespace: g.namespace}, &tlsSecret); err != nil {
 			return nil, fmt.Errorf("failed to query tls secret: %w", err)

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -15,7 +15,6 @@ import (
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes"
 	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"
-	oneagent "github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/src/ingestendpoint"
@@ -34,6 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
+
+const oneAgentCustomKeysPath = "/var/lib/dynatrace/oneagent/agent/customkeys"
 
 var podLog = log.WithName("pod")
 
@@ -707,11 +708,11 @@ func updateContainerOneAgent(c *corev1.Container, dk *dynatracev1beta1.DynaKube,
 			MountPath: "/var/lib/dynatrace/oneagent/agent/config/container.conf",
 			SubPath:   fmt.Sprintf("container_%s.conf", c.Name),
 		})
-	if dk.HasActiveGateTLS() {
+	if dk.HasActiveGateCaCert() {
 		c.VolumeMounts = append(c.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      oneAgentShareVolumeName,
-				MountPath: filepath.Join(oneagent.OneAgentCustomKeysPath, "custom.pem"),
+				MountPath: filepath.Join(oneAgentCustomKeysPath, "custom.pem"),
 				SubPath:   "custom.pem",
 			})
 	}


### PR DESCRIPTION
# Description
Backport of https://github.com/Dynatrace/dynatrace-operator/pull/661

OneAgent expects ActiveGate CA cert to be mounted here: `/mnt/dynatrace/certs/activegate/`

## How can this be tested?
1. Create dynakube `cloudNativeFullstack` monitoring enabled
2. `kubectl patch -ndynatrace dynakubes.dynatrace.com dynakube --type=json -p='[{"op":"replace", "path":"/spec/activeGate
/tlsSecretName", "value":"dk-certs"}]'`
3. OneAgent pods should be in Running state eventually


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

