### PR TITLE
Add response to log metadata in dtclient

### DIFF
--- a/src/controllers/csi/provisioner/processmoduleconfig.go
+++ b/src/controllers/csi/provisioner/processmoduleconfig.go
@@ -2,6 +2,7 @@ package csiprovisioner
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -40,7 +41,7 @@ func (provisioner *OneAgentProvisioner) getProcessModuleConfig(dtc dtclient.Clie
 		}
 		return latestProcessModuleConfig, storedHash, nil
 	} else if err != nil {
-		return nil, storedHash, err
+		return nil, storedHash, fmt.Errorf("error reading process module config cache: %v", err)
 	}
 	storedHash = storedProcessModuleConfig.Hash
 	latestProcessModuleConfig, err := dtc.GetProcessModuleConfig(storedProcessModuleConfig.Revision)

--- a/src/dtclient/activegate_tenant_info.go
+++ b/src/dtclient/activegate_tenant_info.go
@@ -35,7 +35,6 @@ func (dtc *dynatraceClient) GetActiveGateTenantInfo() (*ActiveGateTenantInfo, er
 
 	tenantInfo, err := dtc.readResponseForActiveGateTenantInfo(data)
 	if err != nil {
-		log.Error(err, err.Error())
 		return nil, err
 	}
 	if len(tenantInfo.Endpoints) == 0 {
@@ -49,8 +48,8 @@ func (dtc *dynatraceClient) readResponseForActiveGateTenantInfo(response []byte)
 	agTenantInfo := &ActiveGateTenantInfo{}
 	err := json.Unmarshal(response, agTenantInfo)
 	if err != nil {
-		log.Error(err, "error unmarshalling json response")
-		return nil, errors.WithStack(err)
+		log.Error(err, "error unmarshalling activegate tenant info", "response", string(response))
+		return nil, err
 	}
 
 	return agTenantInfo, nil

--- a/src/dtclient/agent_tenant_info.go
+++ b/src/dtclient/agent_tenant_info.go
@@ -36,7 +36,6 @@ func (dtc *dynatraceClient) GetAgentTenantInfo() (*AgentTenantInfo, error) {
 
 	tenantInfo, err := dtc.readResponseForTenantInfo(data)
 	if err != nil {
-		log.Error(err, err.Error())
 		return nil, errors.WithStack(err)
 	}
 	if len(tenantInfo.Endpoints) <= 0 {
@@ -57,8 +56,8 @@ func (dtc *dynatraceClient) readResponseForTenantInfo(response []byte) (*AgentTe
 	jr := &jsonResponse{}
 	err := json.Unmarshal(response, jr)
 	if err != nil {
-		log.Error(err, "error unmarshalling json response")
-		return nil, errors.WithStack(err)
+		log.Error(err, "unable to unmarshal tenant info response")
+		return nil, err
 	}
 
 	return &AgentTenantInfo{

--- a/src/dtclient/agent_version.go
+++ b/src/dtclient/agent_version.go
@@ -56,7 +56,7 @@ func (dtc *dynatraceClient) readResponseForLatestVersion(response []byte) (strin
 	jr := &jsonResponse{}
 	err := json.Unmarshal(response, jr)
 	if err != nil {
-		log.Error(err, "error unmarshalling json response")
+		log.Error(err, "error unmarshalling latest agent version response", "response", string(response))
 		return "", err
 	}
 

--- a/src/dtclient/communication_hosts.go
+++ b/src/dtclient/communication_hosts.go
@@ -51,7 +51,7 @@ func (dtc *dynatraceClient) readResponseForConnectionInfo(response []byte) (Conn
 	resp := jsonResponse{}
 	err := json.Unmarshal(response, &resp)
 	if err != nil {
-		log.Error(err, "error unmarshalling json response")
+		log.Error(err, "error unmarshalling connection info response", "response", string(response))
 		return ConnectionInfo{}, err
 	}
 

--- a/src/dtclient/dynatrace_client.go
+++ b/src/dtclient/dynatrace_client.go
@@ -197,7 +197,7 @@ func (dtc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 	var hostInfoResponses []hostInfoResponse
 	err := json.Unmarshal(response, &hostInfoResponses)
 	if err != nil {
-		log.Error(err, "error unmarshalling json response")
+		log.Error(err, "error unmarshalling json response", "response", string(response))
 		return errors.WithStack(err)
 	}
 

--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -131,7 +131,7 @@ func (dtc *dynatraceClient) readResponseForProcessModuleConfig(response []byte) 
 	resp := ProcessModuleConfig{}
 	err := json.Unmarshal(response, &resp)
 	if err != nil {
-		log.Error(err, "error unmarshalling processmoduleconfig response: %s", string(response))
+		log.Error(err, "error unmarshalling processmoduleconfig response", "response", string(response))
 		return nil, err
 	}
 

--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -77,7 +77,7 @@ func (dtc *dynatraceClient) GetProcessModuleConfig(prevRevision uint) (*ProcessM
 		return &ProcessModuleConfig{}, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error making get request to dynatrace api: %w", err)
+		return nil, fmt.Errorf("error while requesting process module config: %v", err)
 	}
 	defer func() {
 		//Swallow error, nothing has to be done at this point
@@ -131,7 +131,7 @@ func (dtc *dynatraceClient) readResponseForProcessModuleConfig(response []byte) 
 	resp := ProcessModuleConfig{}
 	err := json.Unmarshal(response, &resp)
 	if err != nil {
-		log.Error(err, "error unmarshalling json response")
+		log.Error(err, "error unmarshalling processmoduleconfig response: %s", string(response))
 		return nil, err
 	}
 

--- a/src/dtclient/token.go
+++ b/src/dtclient/token.go
@@ -63,7 +63,8 @@ func (dtc *dynatraceClient) readResponseForTokenScopes(response []byte) (TokenSc
 	}
 
 	if err := json.Unmarshal(response, &jr); err != nil {
-		return nil, fmt.Errorf("error unmarshalling json response: %w", err)
+		log.Error(err, "unable to unmarshal token scopes response", "response", string(response))
+		return nil, err
 	}
 
 	return jr.Scopes, nil


### PR DESCRIPTION
# Description

If a request to the tenant fails, because the response is malformed, we can't see the actual response from the tenant in the debug logs, which makes this hard to debug. 

Therefore this PR adds the response to failed request error messages.

## How can this be tested?

Cause a malformed response from the tenant => The malformed requests should show up in the log now.

## Checklist
- [x] Unit tests have been updated/added
- [ ] PR is labeled accordingly

