### PR TITLE
Improve info log when `bin` folder does not exist in CSI driver

### DIFF
--- a/src/controllers/csi/gc/binaries.go
+++ b/src/controllers/csi/gc/binaries.go
@@ -39,9 +39,12 @@ func (gc *CSIGarbageCollector) runBinaryGarbageCollection(tenantUUID string, lat
 }
 
 func (gc *CSIGarbageCollector) getStoredVersions(fs *afero.Afero, tenantUUID string) ([]string, error) {
-	versions := []string{}
+	var versions []string
 	bins, err := fs.ReadDir(gc.path.AgentBinaryDir(tenantUUID))
-	if err != nil {
+	if os.IsNotExist(err) {
+		log.Info("no versions stored")
+		return versions, nil
+	} else if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	for _, bin := range bins {


### PR DESCRIPTION
# Description
Improve log message when the CSI driver never downloaded anything and therefore did not have anything to gargab collect. The log message made it sound like an error occured, even if nothing needed to be done.

## How can this be tested?
For this log to show up:
* operator needs to be running with the CSI driver deployed
* only Dynakubes that don't need the CSI driver need to be on the cluster (e.g. `classicFullStack`)

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

