### PR TITLE
Fix `activegate.customproperties.value` when multi line string is used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.43.0
+          version: v1.45.2
           args: --build-tags integration,containers_image_storage_stub --timeout 300s
 
   builddockerimage:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,4 +19,4 @@ linters:
   - misspell
 
 service:
-  golangci-lint-version: 1.43.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.45.x # use the fixed version to not introduce new linters unexpectedly

--- a/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
@@ -110,8 +110,7 @@ spec:
       {{- if (.Values.activeGate.customProperties).value }}
       value: |
 {{ (.Values.activeGate.customProperties).value | indent 8 }}
-      {{- end }}
-      {{- if (.Values.activeGate.customProperties).valueFrom }}
+      {{- else if (.Values.activeGate.customProperties).valueFrom }}
       valueFrom: {{ .Values.activeGate.customProperties.valueFrom }}
       {{- end }}
     {{- end }}

--- a/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
@@ -106,11 +106,12 @@ spec:
     {{- end }}
 
     {{- if .Values.activeGate.customProperties }}
-      {{- if .Values.activeGate.customProperties.value }}
     customProperties:
-      value: {{ .Values.activeGate.customProperties.value }}
-      {{- else if .Values.activeGate.customProperties.valueFrom }}
-    customProperties:
+      {{- if (.Values.activeGate.customProperties).value }}
+      value: |
+{{ (.Values.activeGate.customProperties).value | indent 8 }}
+      {{- end }}
+      {{- if (.Values.activeGate.customProperties).valueFrom }}
       valueFrom: {{ .Values.activeGate.customProperties.valueFrom }}
       {{- end }}
     {{- end }}

--- a/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_activegate_test.yaml
+++ b/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_activegate_test.yaml
@@ -96,9 +96,9 @@ tests:
       - equal:
           path: spec.activeGate.customProperties.value
           value: |
-        test-value
+            test-value
 
-  - it: "should add routing customProperties value if set and enabled"
+  - it: "should add routing customProperties multi-line value if set and enabled"
     set:
       apiUrl: test-api-url
       apiToken: test-api-token
@@ -120,8 +120,8 @@ tests:
       - equal:
           path: spec.activeGate.customProperties.value
           value: |
-        [test-value]
-        key=value
+            [test-value]
+            key=value
 
   - it: "should add routing customProperties valueFrom if set and enabled"
     set:

--- a/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_activegate_test.yaml
+++ b/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_activegate_test.yaml
@@ -96,7 +96,7 @@ tests:
       - equal:
           path: spec.activeGate.customProperties.value
           value: |
-            test-value
+        test-value
 
   - it: "should add routing customProperties value if set and enabled"
     set:
@@ -110,7 +110,8 @@ tests:
           - metrics-ingest
         customProperties:
           value: |
-            test-value
+            [test-value]
+            key=value
     asserts:
       - isNotNull:
           path: spec.activeGate.customProperties
@@ -119,7 +120,8 @@ tests:
       - equal:
           path: spec.activeGate.customProperties.value
           value: |
-            test-value
+        [test-value]
+        key=value
 
   - it: "should add routing customProperties valueFrom if set and enabled"
     set:

--- a/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_activegate_test.yaml
+++ b/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_activegate_test.yaml
@@ -95,6 +95,51 @@ tests:
           path: spec.activeGate.customProperties.valueFrom
       - equal:
           path: spec.activeGate.customProperties.value
+          value: |
+            test-value
+
+  - it: "should add routing customProperties value if set and enabled"
+    set:
+      apiUrl: test-api-url
+      apiToken: test-api-token
+      paasToken: test-paas-token
+      activeGate:
+        capabilities:
+          - kubernetes-monitoring
+          - routing
+          - metrics-ingest
+        customProperties:
+          value: |
+            test-value
+    asserts:
+      - isNotNull:
+          path: spec.activeGate.customProperties
+      - isNull:
+          path: spec.activeGate.customProperties.valueFrom
+      - equal:
+          path: spec.activeGate.customProperties.value
+          value: |
+            test-value
+
+  - it: "should add routing customProperties valueFrom if set and enabled"
+    set:
+      apiUrl: test-api-url
+      apiToken: test-api-token
+      paasToken: test-paas-token
+      activeGate:
+        capabilities:
+          - kubernetes-monitoring
+          - routing
+          - metrics-ingest
+        customProperties:
+          valueFrom: test-value
+    asserts:
+      - isNotNull:
+          path: spec.activeGate.customProperties
+      - isNull:
+          path: spec.activeGate.customProperties.value
+      - equal:
+          path: spec.activeGate.customProperties.valueFrom
           value: test-value
 
   - it: "should add routing customProperties valueFrom if set and enabled"

--- a/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_activegate_test.yaml
+++ b/config/helm/chart/default/tests/Common/customresource-modules/customresource-dynakube_activegate_test.yaml
@@ -185,7 +185,8 @@ tests:
           path: spec.activeGate.customProperties.valueFrom
       - equal:
           path: spec.activeGate.customProperties.value
-          value: test-value
+          value: |
+            test-value
 
   - it: "should add routing resource if set and enabled"
     set:

--- a/src/dtclient/client_test.go
+++ b/src/dtclient/client_test.go
@@ -81,5 +81,5 @@ func TestCerts(t *testing.T) {
 	certs := Certs(nil)
 	assert.NotNil(t, certs)
 	certs(&dtc)
-	assert.Equal(t, [][]uint8{}, transport.TLSClientConfig.RootCAs.Subjects())
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
 }


### PR DESCRIPTION
# Description
When using a multi line string for `customproperties.value` in the values file, invalid yaml was generated by helm.

## How can this be tested?
Use a values file that contains a multi line string in this section:
```yaml
activeGate:
  capabilities:
  - kubernetes-monitoring
  customProperties:
    value: |
      [kubernetes_monitoring]
      key=value
```
Run the following command:
```
helm install dynatrace-operator config/helm/chart/default -f values.yaml --create-namespace -n dynatrace --dry-run
```

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

