### PR TITLE
Add nodeSelector/toleration for deployment-webhook

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -116,4 +116,10 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.operator.customPullSecret }}
       {{- end }}
+      {{- if .Values.operator.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.tolerations }}
+      tolerations: {{- toYaml .Values.operator.tolerations | nindent 8 }}
+      {{- end -}}
 {{ end }}


### PR DESCRIPTION
Problem:
The nodeSelector and tolerations for the dynatrace-webhook can't be configured through the values file.

Change:
Added nodeSelector and tolerations to deployment-webhook.yaml. The values are shared with deployment-operator.yaml
