### PR TITLE
Remove metrics-ingest from samples as it can cause certificate issues

### DIFF
--- a/config/samples/applicationMonitoring.yaml
+++ b/config/samples/applicationMonitoring.yaml
@@ -81,7 +81,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - metrics-ingest
       - dynatrace-api
 
     # Optional: to use a custom ActiveGate Docker image.

--- a/config/samples/classicFullStack.yaml
+++ b/config/samples/classicFullStack.yaml
@@ -116,7 +116,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - metrics-ingest
       - dynatrace-api
 
     # Optional: to use a custom ActiveGate Docker image.

--- a/config/samples/cloudNativeFullStack.yaml
+++ b/config/samples/cloudNativeFullStack.yaml
@@ -131,7 +131,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - metrics-ingest
       - dynatrace-api
 
     # Optional: to use a custom ActiveGate Docker image.

--- a/config/samples/hostMonitoring.yaml
+++ b/config/samples/hostMonitoring.yaml
@@ -116,7 +116,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - metrics-ingest
       - dynatrace-api
 
     # Optional: to use a custom ActiveGate Docker image.

--- a/config/samples/multipleDynakubes.yaml
+++ b/config/samples/multipleDynakubes.yaml
@@ -77,7 +77,6 @@ spec:
     # Enables listed ActiveGate capabilities
     capabilities:
       - routing
-      - metrics-ingest
       - dynatrace-api
 
     # Amount of replicas of activegate pods


### PR DESCRIPTION
# Description
Samples on GitHub enable metrics-ingest capability by default. This can cause issues as the certificate used for the endpoint is self-signed. Therefore they should not be added by default.

## How can this be tested?
Just documentation changes, no need to test


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

