### PR TITLE
Fixes using wrong tag for immutable image when version is set

### DIFF
--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -232,12 +232,27 @@ func (dk *DynaKube) ImmutableOneAgentImage() string {
 	}
 
 	tag := "latest"
-	if ver := dk.Version(); ver != "" {
-		tag = ver
+	if version := dk.Version(); version != "" {
+		truncatedVersion := truncateBuildDate(version)
+		tag = truncatedVersion
 	}
 
 	registry := buildImageRegistry(dk.Spec.APIURL)
 	return fmt.Sprintf("%s/linux/oneagent:%s", registry, tag)
+}
+
+func truncateBuildDate(version string) string {
+	const versionSeperator = "."
+	const buildDateIndex = 3
+
+	if strings.Count(version, versionSeperator) >= buildDateIndex {
+		splitVersion := strings.Split(version, versionSeperator)
+		truncatedVersion := strings.Join(splitVersion[:buildDateIndex], versionSeperator)
+
+		return truncatedVersion
+	}
+
+	return version
 }
 
 // Tokens returns the name of the Secret to be used for tokens.

--- a/src/api/v1beta1/properties_test.go
+++ b/src/api/v1beta1/properties_test.go
@@ -96,6 +96,27 @@ func TestOneAgentImage(t *testing.T) {
 		dk := DynaKube{Spec: DynaKubeSpec{OneAgent: OneAgentSpec{ClassicFullStack: &HostInjectSpec{Image: customImg}}}}
 		assert.Equal(t, customImg, dk.ImmutableOneAgentImage())
 	})
+
+	t.Run(`OneAgentImage with custom version truncates build date`, func(t *testing.T) {
+		version := "1.239.14.20220325-164521"
+		expectedImage := "test-endpoint/linux/oneagent:1.239.14"
+
+		dynakube := DynaKube{
+			Spec: DynaKubeSpec{
+				APIURL: testAPIURL,
+				OneAgent: OneAgentSpec{
+					CloudNativeFullStack: &CloudNativeFullStackSpec{
+						HostInjectSpec: HostInjectSpec{
+							Version: version,
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, expectedImage, dynakube.ImmutableOneAgentImage())
+		assert.Equal(t, version, dynakube.Version())
+	})
 }
 
 func TestOneAgentDaemonsetName(t *testing.T) {


### PR DESCRIPTION
# Description

## Summary

This PR truncates the build date of a supplied OneAgent version when used as a tag for the immutable image.
It implements the change for the `ImmutableOneAgentImage()` DynaKube property.

## Which issue is fixed

When the OneAgent version is set in the custom resource and the CSI driver is used, the image cannot be pulled since the version has the wrong format for the image.

The CSI driver expects the version to be in a format like "1.231.288.20220218-170442". If the version is not in this format, the CSI driver cannot download it from the API since the version has to include the build date.

However, the same version field is used to overwrite the version tag for the oneagent images that are used. These image tags do not contain the build date.
Therefore, the version can only be correct for either the API or the Image tag.

## How can this be tested?

### Environment necessary

Fresh Kubernetes cluster

### Recreating the error

On a fresh cluster,  
create the dynatrace namespace,  
deploy the operator from the master branch or use the 0.5 release,  
create the dynakube secret,  
modify a sample to use cloud native full stack and set the version field to a valid version, e.g., the one described above,  
watch the pods fail due to a image pull back off error,  
modify the sample to use a version without the build date and apply,  
watch the pods be created successfully, however the CSI driver will fail in the logs due to the version being invalid

### Confirming the fix

On a fresh cluster,  
create the dynatrace namespace,  
deploy the operator from fix/truncate-version-build-date branch,  
create the dynakube secret,  
modify a sample to use cloud native full stack and set the version field to a valid version, e.g., the one described above,  
the pods should start successfully, the version tag should be the same as the one in the CR but without the build date,  
the CSI driver does not show error logs regarding the version

## Checklist
- [X] Unit tests have been updated/added
- [X] PR is labeled accordingly

