### PR TITLE
Exclude `metrics-ingest` from samples

### DIFF
--- a/config/samples/applicationMonitoring.yaml
+++ b/config/samples/applicationMonitoring.yaml
@@ -81,7 +81,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-#      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/classicFullStack.yaml
+++ b/config/samples/classicFullStack.yaml
@@ -116,7 +116,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-#      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/cloudNativeFullStack.yaml
+++ b/config/samples/cloudNativeFullStack.yaml
@@ -131,7 +131,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""

--- a/config/samples/hostMonitoring.yaml
+++ b/config/samples/hostMonitoring.yaml
@@ -116,7 +116,6 @@ spec:
     capabilities:
       - routing
       - kubernetes-monitoring
-#      - metrics-ingest
 
     # Optional: to use a custom ActiveGate Docker image.
     image: ""


### PR DESCRIPTION
# Description

Cherry Pick of https://github.com/Dynatrace/dynatrace-operator/pull/693

## How can this be tested?
No tests needed, just documentation changes


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

