### PR TITLE
Add high availability option for webhook via helm

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -21,7 +21,11 @@ metadata:
   labels:
     {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
 spec:
+  {{- if (.Values.webhook).enableHighAvailability }}
+  replicas: 2
+  {{- else }}
   replicas: 1
+  {{- end}}
   revisionHistoryLimit: 1
   selector:
     matchLabels:
@@ -39,6 +43,15 @@ spec:
         {{- include "dynatrace-operator.webhookLabels" . | nindent 8 }}
         {{- include "dynatrace-operator.webhookSelectorLabels" . | nindent 8 }}
     spec:
+      {{- if (.Values.webhook).enableHighAvailability }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: ScheduleAnyway
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: DoNotSchedule
+      {{- end }}
       volumes:
       - emptyDir: {}
         name: certs-dir

--- a/config/helm/chart/default/templates/Common/webhook/poddisruptionbugdet-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/poddisruptionbugdet-webhook.yaml
@@ -1,0 +1,12 @@
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift " (include "dynatrace-operator.platformSet" .))}}
+{{ if (.Values.webhook).enableHighAvailability }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dynatrace-webhook
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: webhook
+{{ end }}

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -56,6 +56,7 @@ webhook:
   limits:
     cpu: 300m
     memory: 128Mi
+  enableHighAvailability: false
 
 csi:
   requests:


### PR DESCRIPTION
# Description

Introduces a new option for the webhook. The flag is called `enableHighAvailability` and can be found in the `helm charts` in the `values.yaml` file. Changes the replicas of the webhook deployment from 1 to 2 and also introduces a PodDisruptionBudget with `minAvailable` set to 1. Also topologySpreadConstraints are set.

## How can this be tested?
Set the flag to true, render a chart and apply the output file.

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

