### PR TITLE
Add ability to supply custom annotations to DynaKube via values.yaml

### DIFF
--- a/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
@@ -31,6 +31,9 @@ metadata:
     {{- if (.Values.activeGate).readOnlyFs }}
     alpha.operator.dynatrace.com/feature-activegate-readonly-fs: "true"
     {{- end }}
+    {{- range (.Values.activeGate).annotations }}
+    {{ . }}
+    {{- end }}
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -139,6 +139,7 @@ activeGate:
   priorityClassName: ""
   apparmor: false
   readOnlyFs: false
+  annotations: []
 
 # deprecated
 kubernetesMonitoring:


### PR DESCRIPTION
# Description

This will allow users of the helm chart to add annotations to the `DynaKube` object via the helm chart itself.  Among other things, this will allow users to set feature flags such as `alpha.operator.dynatrace.com/feature-automatic-kubernetes-api-monitoring: "true"` via the helm chart, instead of needing to take post-install action.


## How can this be tested?

in the values.yaml under `activeGate.annotations`, provide a list of annotations you would like added to the `DynaKube` object.
```YAML
activeGate:
  capabilities:
  - routing
  - kubernetes-monitoring
  - metrics-ingest
  annotations: 
    - 'alpha.operator.dynatrace.com/disable-metadata-enrichment: "false"'
    - 'alpha.operator.dynatrace.com/feature-automatic-kubernetes-api-monitoring: "true"'
```
perform a `helm template` command with the `--debug` flag, and supply the necessary parameters. 
Search for the DynaKube object and observe the annotations


```YAML
apiVersion: dynatrace.com/v1beta1
kind: DynaKube
metadata:
  annotations:
    alpha.operator.dynatrace.com/disable-metadata-enrichment: "false"
    alpha.operator.dynatrace.com/feature-automatic-kubernetes-api-monitoring: "true"
    helm.sh/hook: post-install,post-upgrade
```

## Checklist
- [ ] Unit tests have been updated/added
- [ ] PR is labeled accordingly

