### PR TITLE
Update agent config during init only in case of installer mode

### DIFF
--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -101,7 +101,18 @@ func (runner *Runner) setHostTenant() error {
 
 func (runner *Runner) installOneAgent() error {
 	log.Info("downloading OneAgent")
-	return runner.installer.InstallAgent(BinDirMount)
+	err := runner.installer.InstallAgent(BinDirMount)
+	if err != nil {
+		return err
+	}
+	processModuleConfig, err := runner.dtclient.GetProcessModuleConfig(0)
+	if err != nil {
+		return err
+	}
+	if err := runner.installer.UpdateProcessModuleConfig(BinDirMount, processModuleConfig); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (runner *Runner) configureInstallation() error {
@@ -121,13 +132,6 @@ func (runner *Runner) configureInstallation() error {
 			if err := runner.propagateTLSCert(); err != nil {
 				return err
 			}
-		}
-		processModuleConfig, err := runner.dtclient.GetProcessModuleConfig(0)
-		if err != nil {
-			return err
-		}
-		if err := runner.installer.UpdateProcessModuleConfig(BinDirMount, processModuleConfig); err != nil {
-			return err
 		}
 	}
 	if runner.env.DataIngestInjected {


### PR DESCRIPTION
If securityContext with user/group is used on a user's pod that we inject a csi volume into, then the standalone-init will fail as it doesn't have the permissions to update the `ruxitagentproc.conf` file.

This happens because the csi-driver creates/updates that file with a different user/group then what the user's pod's securityContext has which is used by the standalone-init.

## How can this be tested?
Have cloud-native and inject into a sample app that has a securityContext with a user/group that is different from the one that the csi-driver is using. The sample app should just work.

For bonus-points: Have app-monitoring WITHOUT csi-driver, deploy the same sample app, check that its running, and check if the `ruxitagentproc.conf` was updated.
  - under `opt/dynatrace/oneagent-paas/agent/conf/` in the injected container, if there is a `_ruxitagentproc.conf` if it was updated


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

