### PR TITLE
Add abbility to override secret name

### DIFF
--- a/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
@@ -32,7 +32,7 @@ metadata:
 spec:
   apiUrl: {{ required "ApiUrl needs to be set!" .Values.apiUrl }}
 
-  tokens: {{ .Values.name }}
+  tokens: {{ .Values.tokenSecret | default .Values.name }}
 
   {{- if .Values.skipCertCheck }}
   skipCertCheck: {{ .Values.skipCertCheck }}

--- a/config/helm/chart/default/templates/Common/secret.yaml
+++ b/config/helm/chart/default/templates/Common/secret.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.name }}
+  name: {{ .Values.tokenSecret | default .Values.name }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "dynatrace-operator.labels" . | nindent 4 }}


### PR DESCRIPTION
secret with token should be uniform across clusters
forcing it to have same name as cluster in current
setup is a bit of a hurdle when propagating secrets to cluster
via some other automations. Adding ability to override secret name

# Description

Please include the following:
- a summary of the change
- which issue is fixed (if there is one)
- relevant motivation and context

## How can this be tested?
Please include some guiding steps on how to test this change during a review.
- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?


## Checklist
- [ ] Unit tests have been updated/added
- [ ] PR is labeled accordingly

