### PR TITLE
Add RW volume for AG tls certificate

### DIFF
--- a/src/controllers/activegate/capability/config.go
+++ b/src/controllers/activegate/capability/config.go
@@ -6,12 +6,14 @@ const (
 	ActiveGateGatewayConfigVolumeName = "ag-lib-gateway-config"
 	ActiveGateGatewayTempVolumeName   = "ag-lib-gateway-temp"
 	ActiveGateGatewayDataVolumeName   = "ag-lib-gateway-data"
+	ActiveGateGatewaySslVolumeName    = "ag-lib-gateway-ssl"
 	ActiveGateLogVolumeName           = "ag-log-gateway"
 	ActiveGateTmpVolumeName           = "ag-tmp-gateway"
 
 	ActiveGateGatewayConfigMountPoint = "/var/lib/dynatrace/gateway/config"
 	ActiveGateGatewayTempMountPoint   = "/var/lib/dynatrace/gateway/temp"
 	ActiveGateGatewayDataMountPoint   = "/var/lib/dynatrace/gateway/data"
+	ActiveGateGatewaySslMountPoint    = "/var/lib/dynatrace/gateway/ssl"
 	ActiveGateLogMountPoint           = "/var/log/dynatrace/gateway"
 	ActiveGateTmpMountPoint           = "/var/tmp/dynatrace/gateway"
 

--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -310,7 +310,19 @@ func buildActiveGateVolumes(stsProperties *statefulSetProperties) []corev1.Volum
 				},
 			},
 		)
+
+		if stsProperties.HasActiveGateCaCert() {
+			volumes = append(volumes,
+				corev1.Volume{
+					Name: capability.ActiveGateGatewaySslVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			)
+		}
 	}
+
 	return volumes
 }
 
@@ -405,6 +417,16 @@ func buildActiveGateVolumeMounts(stsProperties *statefulSetProperties) []corev1.
 				Name:      capability.ActiveGateTmpVolumeName,
 				MountPath: capability.ActiveGateTmpMountPoint,
 			})
+
+		if stsProperties.HasActiveGateCaCert() {
+			volumeMounts = append(volumeMounts,
+				corev1.VolumeMount{
+					ReadOnly:  false,
+					Name:      capability.ActiveGateGatewaySslVolumeName,
+					MountPath: capability.ActiveGateGatewaySslMountPoint,
+				},
+			)
+		}
 	}
 	return volumeMounts
 }

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -215,7 +215,7 @@ func TestStatefulSet_Container(t *testing.T) {
 	}
 
 	checkVolumes := func(activeGateContainer *corev1.Container, dynakube *dynatracev1beta1.DynaKube) {
-		for _, directory := range buildActiveGateMountPoints(dynakube.NeedsStatsd(), dynakube.FeatureActiveGateReadOnlyFilesystem()) {
+		for _, directory := range buildActiveGateMountPoints(dynakube.NeedsStatsd(), dynakube.FeatureActiveGateReadOnlyFilesystem(), dynakube.HasActiveGateCaCert()) {
 			assert.Truef(t, kubeobjects.MountPathIsIn(activeGateContainer.VolumeMounts, directory),
 				"Expected that ActiveGate container defines mount point %s", directory,
 			)
@@ -242,13 +242,16 @@ func TestStatefulSet_Container(t *testing.T) {
 		}
 	}
 
-	test := func(ro bool, statsd bool) {
+	test := func(ro bool, statsd bool, tlsSecret bool) {
 		instance := buildTestInstance()
 		if ro {
 			instance.Annotations[dynatracev1beta1.AnnotationFeatureActiveGateReadOnlyFilesystem] = "true"
 		}
 		if statsd {
 			instance.Spec.ActiveGate.Capabilities = append(instance.Spec.ActiveGate.Capabilities, dynatracev1beta1.StatsdIngestCapability.DisplayName)
+		}
+		if tlsSecret {
+			instance.Spec.ActiveGate.TlsSecretName = "secret"
 		}
 		capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 		stsProperties := NewStatefulSetProperties(instance, capabilityProperties,
@@ -267,19 +270,23 @@ func TestStatefulSet_Container(t *testing.T) {
 	}
 
 	t.Run("DynaKube with RW filesystem and StatsD disabled", func(t *testing.T) {
-		test(false, false)
+		test(false, false, false)
 	})
 
 	t.Run("DynaKube with RW filesystem and StatsD enabled", func(t *testing.T) {
-		test(false, true)
+		test(false, true, false)
 	})
 
 	t.Run("DynaKube with RO filesystem and StatsD disabled", func(t *testing.T) {
-		test(true, false)
+		test(true, false, false)
 	})
 
 	t.Run("DynaKube with RO filesystem and StatsD enabled", func(t *testing.T) {
-		test(true, true)
+		test(true, true, false)
+	})
+
+	t.Run("DynaKube with RO filesystem, StatsD enabled and tlsSecret set", func(t *testing.T) {
+		test(true, true, true)
 	})
 
 	t.Run("DynaKube with AppArmor enabled", func(t *testing.T) {
@@ -642,7 +649,7 @@ func buildTestInstance() *dynatracev1beta1.DynaKube {
 	}
 }
 
-func buildActiveGateMountPoints(statsd bool, readOnly bool) []string {
+func buildActiveGateMountPoints(statsd bool, readOnly bool, tlsSecret bool) []string {
 	var mountPoints []string
 	if readOnly || statsd {
 		mountPoints = append(mountPoints, capability.ActiveGateGatewayConfigMountPoint)
@@ -653,6 +660,10 @@ func buildActiveGateMountPoints(statsd bool, readOnly bool) []string {
 			capability.ActiveGateGatewayDataMountPoint,
 			capability.ActiveGateLogMountPoint,
 			capability.ActiveGateTmpMountPoint)
+
+		if tlsSecret {
+			mountPoints = append(mountPoints, capability.ActiveGateGatewaySslMountPoint)
+		}
 	}
 	return mountPoints
 }


### PR DESCRIPTION
AG fails to start if RO filesystem is enabled and custom TLS secret is set. In such a case new RW volume is mounted on /var/lib/dynatrace/gateway/ssl directory and the launching script of AG image is able to copy the certificate to the 'ssl' directory.

## How can this be tested?
-create tls secret `kubectl -n dynatrace create secret generic dk-cert --from-file=server.p12=cert.p12` 
-add it to your CR
```
spec:
  activegate:
    tlsSecretName: dk-cert
```
- check out AG logs `kctl logs pod/<your CR name>-activegate-0`
- the following message is reported at the very beginning of the log
```
Copying /var/lib/dynatrace/secrets//tls/server.p12 certificate file to /var/lib/dynatrace/gateway/ssl/server.p12
```

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

