### PR TITLE
Makes the deprecated feature-flag warning more precise (#723)

### DIFF
--- a/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/config/helm/chart/default/templates/Common/customresource-dynakube.yaml
@@ -23,13 +23,13 @@ metadata:
     helm.sh/hook: post-install,post-upgrade
     {{- end }}
     {{- if or (and (.Values.hostMonitoring).enabled (.Values.hostMonitoring).disableReadOnly) (and (.Values.cloudNativeFullStack).enabled (.Values.cloudNativeFullStack).disableReadOnly) }}
-    operator.dynatrace.com/feature-disable-oneagent-readonly-host-fs: "true"
+    feature.dynatrace.com/disable-oneagent-readonly-host-fs: "true"
     {{- end }}
     {{- if (.Values.activeGate).apparmor }}
-    alpha.operator.dynatrace.com/feature-activegate-apparmor: "true"
+    feature.dynatrace.com/activegate-apparmor: "true"
     {{- end }}
     {{- if (.Values.activeGate).readOnlyFs }}
-    alpha.operator.dynatrace.com/feature-activegate-readonly-fs: "true"
+    feature.dynatrace.com/activegate-readonly-fs: "true"
     {{- end }}
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}

--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -20,19 +20,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
 )
 
 const (
-	DeprecatedFeatureFlagPrefix = "alpha."
+	DeprecatedFeatureFlagPrefix = "alpha.operator.dynatrace.com/feature-"
 
-	FeatureFlagAnnotationBase = "operator.dynatrace.com/"
-	AnnotationFeaturePrefix   = FeatureFlagAnnotationBase + "feature-"
+	AnnotationFeaturePrefix = "feature.dynatrace.com/"
 
 	// activeGate
 	AnnotationFeatureDisableActiveGateUpdates         = AnnotationFeaturePrefix + "disable-activegate-updates"
-	AnnotationFeatureDisableActivegateRawImage        = AnnotationFeaturePrefix + "disable-activegate-raw-image"
+	AnnotationFeatureDisableActiveGateRawImage        = AnnotationFeaturePrefix + "disable-activegate-raw-image"
 	AnnotationFeatureActiveGateAppArmor               = AnnotationFeaturePrefix + "activegate-apparmor"
 	AnnotationFeatureActiveGateReadOnlyFilesystem     = AnnotationFeaturePrefix + "activegate-readonly-fs"
 	AnnotationFeatureAutomaticKubernetesApiMonitoring = AnnotationFeaturePrefix + "automatic-kubernetes-api-monitoring"
@@ -162,7 +162,7 @@ func (dk *DynaKube) FeatureDisableReadOnlyOneAgent() bool {
 // instead of using embedded ones in the image
 // Defaults to false
 func (dk *DynaKube) FeatureDisableActivegateRawImage() bool {
-	return dk.getFeatureFlagRaw(AnnotationFeatureDisableActivegateRawImage) == "true"
+	return dk.getFeatureFlagRaw(AnnotationFeatureDisableActiveGateRawImage) == "true"
 }
 
 // FeatureEnableMultipleOsAgentsOnNode is a feature flag to enable multiple osagents running on the same host
@@ -184,7 +184,9 @@ func (dk *DynaKube) getFeatureFlagRaw(annotation string) string {
 	if raw, ok := dk.Annotations[annotation]; ok {
 		return raw
 	}
-	if raw, ok := dk.Annotations[DeprecatedFeatureFlagPrefix+annotation]; ok {
+	split := strings.Split(annotation, "/")
+	postFix := split[1]
+	if raw, ok := dk.Annotations[DeprecatedFeatureFlagPrefix+postFix]; ok {
 		return raw
 	}
 	return ""

--- a/src/api/v1beta1/feature_flags_resources.go
+++ b/src/api/v1beta1/feature_flags_resources.go
@@ -31,7 +31,6 @@ func (dk *DynaKube) FeatureStatsdResourcesLimits(resourceName corev1.ResourceNam
 	return statsdResourceRequirements(dk, "limits-"+resourceName)
 }
 
-// E.g. "operator.dynatrace.com/feature-activegate-eec-resources-limits-cpu": "100m"
 func formatResourceName(resourceName corev1.ResourceName) string {
 	return "resources-" + string(resourceName)
 }

--- a/src/controllers/activegate/reconciler/capability/eec_runtime_config.go
+++ b/src/controllers/activegate/reconciler/capability/eec_runtime_config.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const extensionsRuntimeProperties = dynatracev1beta1.FeatureFlagAnnotationBase + "extensions."
+const extensionsRuntimeProperties = dynatracev1beta1.AnnotationFeaturePrefix + "extensions."
 
 type EecRuntimeConfig struct {
 	Revision   int               `json:"revision"`

--- a/src/controllers/activegate/reconciler/capability/eec_runtime_config_test.go
+++ b/src/controllers/activegate/reconciler/capability/eec_runtime_config_test.go
@@ -36,9 +36,9 @@ func testBuildDynaKubeWithAnnotations(instanceName string, statsdEnabled bool, a
 func TestCreateEecConfigMap(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		instance := testBuildDynaKubeWithAnnotations("dynakube", true, map[string]string{
-			"operator.dynatrace.com/extensions.debugExtensionDSstatsddisablenamedalivesignals": "false",
-			"operator.dynatrace.com/extensions.debugExtensionDSstatsdlogoutboundminttraffic":   "true",
-			"operator.dynatrace.com/extensions.debugExtensionDSstatsdcustomloglevel":           "trace",
+			dynatracev1beta1.AnnotationFeaturePrefix + "extensions.debugExtensionDSstatsddisablenamedalivesignals": "false",
+			dynatracev1beta1.AnnotationFeaturePrefix + "extensions.debugExtensionDSstatsdlogoutboundminttraffic":   "true",
+			dynatracev1beta1.AnnotationFeaturePrefix + "extensions.debugExtensionDSstatsdcustomloglevel":           "trace",
 		})
 		runtimeConfig := NewEecRuntimeConfig()
 
@@ -59,8 +59,8 @@ func TestCreateEecConfigMap(t *testing.T) {
 
 	t.Run("no valid EEC runtime properties, StatsD enabled", func(t *testing.T) {
 		instance := testBuildDynaKubeWithAnnotations("dynakube", true, map[string]string{
-			"operator.dynatrace.com/debugExtensionDSstatsdlogoutboundminttraffic": "true",
-			"debugExtensionDSstatsdcustomloglevel":                                "info",
+			dynatracev1beta1.AnnotationFeaturePrefix + "debugExtensionDSstatsdlogoutboundminttraffic": "true",
+			"debugExtensionDSstatsdcustomloglevel":                                                    "info",
 		})
 		runtimeConfig := NewEecRuntimeConfig()
 
@@ -80,7 +80,7 @@ func TestCreateEecConfigMap(t *testing.T) {
 
 	t.Run("valid EEC runtime properties but StatsD disabled", func(t *testing.T) {
 		instance := testBuildDynaKubeWithAnnotations("dynakube", false, map[string]string{
-			"operator.dynatrace.com/extensions.debugExtensiondummylongflag": "17",
+			dynatracev1beta1.AnnotationFeaturePrefix + "extensions.debugExtensiondummylongflag": "17",
 		})
 		runtimeConfig := NewEecRuntimeConfig()
 

--- a/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_eec_test.go
@@ -87,7 +87,7 @@ func TestExtensionController_BuildContainerAndVolumes(t *testing.T) {
 
 	t.Run("resource requirements from feature flags", func(t *testing.T) {
 		stsProperties := testBuildStsProperties()
-		stsProperties.ObjectMeta.Annotations["operator.dynatrace.com/feature-activegate-eec-resources-limits-cpu"] = "200m"
+		stsProperties.ObjectMeta.Annotations[dynatracev1beta1.AnnotationFeaturePrefix+"activegate-eec-resources-limits-cpu"] = "200m"
 		eec := NewExtensionController(stsProperties)
 
 		container := eec.BuildContainer()

--- a/src/controllers/activegate/reconciler/statefulset/container_statsd_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/container_statsd_test.go
@@ -3,6 +3,7 @@ package statefulset
 import (
 	"testing"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/stretchr/testify/assert"
@@ -77,7 +78,7 @@ func TestStatsd_BuildContainerAndVolumes(t *testing.T) {
 
 	t.Run("resource requirements from feature flags", func(t *testing.T) {
 		stsProperties := testBuildStsProperties()
-		stsProperties.ObjectMeta.Annotations["operator.dynatrace.com/feature-activegate-statsd-resources-requests-memory"] = "500M"
+		stsProperties.ObjectMeta.Annotations[dynatracev1beta1.AnnotationFeaturePrefix+"activegate-statsd-resources-requests-memory"] = "500M"
 		statsd := NewStatsd(stsProperties)
 
 		container := statsd.BuildContainer()

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -322,7 +322,7 @@ func TestStatefulSet_Volumes(t *testing.T) {
 	})
 	t.Run(`with FeatureDisableActivegateRawImage=false`, func(t *testing.T) {
 		instanceRawImg := instance.DeepCopy()
-		instanceRawImg.Annotations[dynatracev1beta1.AnnotationFeatureDisableActivegateRawImage] = "false"
+		instanceRawImg.Annotations[dynatracev1beta1.AnnotationFeatureDisableActiveGateRawImage] = "false"
 
 		stsProperties := NewStatefulSetProperties(instanceRawImg, capabilityProperties,
 			"", "", "", "", "",
@@ -395,7 +395,7 @@ func TestStatefulSet_Env(t *testing.T) {
 
 	t.Run(`with FeatureDisableActivegateRawImage=true`, func(t *testing.T) {
 		instanceRawImg := instance.DeepCopy()
-		instanceRawImg.Annotations[dynatracev1beta1.AnnotationFeatureDisableActivegateRawImage] = "true"
+		instanceRawImg.Annotations[dynatracev1beta1.AnnotationFeatureDisableActiveGateRawImage] = "true"
 
 		envVars := buildEnvs(NewStatefulSetProperties(instanceRawImg, capabilityProperties,
 			testUID, "", testFeature, "MSGrouter", "",

--- a/src/controllers/dynakube/dtclient_reconciler_test.go
+++ b/src/controllers/dynakube/dtclient_reconciler_test.go
@@ -188,7 +188,7 @@ func TestReconcileDynatraceClient_TokenValidation(t *testing.T) {
 	t.Run("API token has missing scope for automatic kubernetes api monitoring", func(t *testing.T) {
 		dk := base.DeepCopy()
 		dk.Annotations = map[string]string{
-			"operator.dynatrace.com/feature-automatic-kubernetes-api-monitoring": "true",
+			dynatracev1beta1.AnnotationFeatureAutomaticKubernetesApiMonitoring: "true",
 		}
 		dk.Spec.ActiveGate = dynatracev1beta1.ActiveGateSpec{
 			Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.KubeMonCapability.DisplayName},

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -151,7 +151,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 				Name:      testName,
 				Namespace: testNamespace,
 				Annotations: map[string]string{
-					"operator.dynatrace.com/feature-automatic-kubernetes-api-monitoring": "true",
+					dynatracev1beta1.AnnotationFeatureAutomaticKubernetesApiMonitoring: "true",
 				},
 			},
 			Spec: dynatracev1beta1.DynaKubeSpec{

--- a/src/mapper/dynakube_test.go
+++ b/src/mapper/dynakube_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -112,7 +113,7 @@ func TestMapFromDynakube(t *testing.T) {
 	t.Run("Feature flag for monitoring system namespaces", func(t *testing.T) {
 		dk := createTestDynakubeWithMultipleFeatures("appMonitoring", nil, nil)
 		dk.Annotations = map[string]string{
-			"operator.dynatrace.com/feature-ignored-namespaces": "[]",
+			dynatracev1beta1.AnnotationFeatureIgnoredNamespaces: "[]",
 		}
 		namespace := createNamespace("openshift-something", nil)
 		clt := fake.NewClient(dk, namespace)

--- a/src/mapper/namespaces_test.go
+++ b/src/mapper/namespaces_test.go
@@ -101,7 +101,7 @@ func TestMapFromNamespace(t *testing.T) {
 	t.Run("Feature flag for monitoring system namespaces", func(t *testing.T) {
 		dk := createTestDynakubeWithMultipleFeatures("appMonitoring", nil, nil)
 		dk.Annotations = map[string]string{
-			"operator.dynatrace.com/feature-ignored-namespaces": "[]",
+			dynatracev1beta1.AnnotationFeatureIgnoredNamespaces: "[]",
 		}
 		namespace := createNamespace("openshift-something", nil)
 		clt := fake.NewClient(dk)

--- a/src/webhook/validation/deprecation.go
+++ b/src/webhook/validation/deprecation.go
@@ -15,9 +15,9 @@ func deprecatedFeatureFlagFormat(dv *dynakubeValidator, dynakube *dynatracev1bet
 		return ""
 	}
 
-	deprecatedPrefix := dynatracev1beta1.DeprecatedFeatureFlagPrefix + dynatracev1beta1.FeatureFlagAnnotationBase
+	deprecatedPrefix := dynatracev1beta1.DeprecatedFeatureFlagPrefix
 	if len(dynatracev1beta1.FlagsWithPrefix(dynakube, deprecatedPrefix)) > 0 {
-		return fmt.Sprintf(featureDeprecatedWarningMessage, "'alpha.' prefix not necessary")
+		return fmt.Sprintf(featureDeprecatedWarningMessage, "'alpha.operator.dynatrace.com/feature-' prefix will be replaced with the 'feature.dynatrace.com/' prefix for dynakube feature-flags")
 	}
 
 	return ""

--- a/src/webhook/validation/deprecation_test.go
+++ b/src/webhook/validation/deprecation_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"strings"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
@@ -25,8 +26,10 @@ func TestDeprecationWarning(t *testing.T) {
 
 	t.Run(`warning present`, func(t *testing.T) {
 		dynakubeMeta := defaultDynakubeObjectMeta
+		split := strings.Split(dynatracev1beta1.AnnotationFeatureEnableWebhookReinvocationPolicy, "/")
+		postFix := split[1]
 		dynakubeMeta.Annotations = map[string]string{
-			dynatracev1beta1.DeprecatedFeatureFlagPrefix + dynatracev1beta1.AnnotationFeatureEnableWebhookReinvocationPolicy: "true",
+			dynatracev1beta1.DeprecatedFeatureFlagPrefix + postFix: "true",
 		}
 		dynakube := &dynatracev1beta1.DynaKube{
 			ObjectMeta: dynakubeMeta,


### PR DESCRIPTION
# Description

cherry pick of https://github.com/Dynatrace/dynatrace-operator/pull/723

## How can this be tested?
look at original pr: https://github.com/Dynatrace/dynatrace-operator/pull/723


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

