### PR TITLE
Bump go version to ^1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.18"
+          go-version: "^1.18.1"
       - name: Setup cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  GO_VERSION: "^1.18"
+
 on:
   push:
     branches:
@@ -53,7 +56,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.18.1"
+          go-version: ${{ env.GO_VERSION }}
       - name: Download dependencies
         id: depdownload
         run: |
@@ -97,7 +100,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.18.1"
+          go-version: ${{ env.GO_VERSION }}
       - name: Setup cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.16"
+          go-version: "^1.18.1"
       - name: Download dependencies
         id: depdownload
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.17"
+          go-version: "^1.18"
       - name: Setup cache
         uses: actions/cache@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.18-alpine AS operator-build
 
 RUN apk update --no-cache && \
-    apk add --no-cache gcc musl-dev btrfs-progs-dev lvm2-dev device-mapper-static && \
+    apk add --no-cache gcc musl-dev btrfs-progs-dev lvm2-dev device-mapper-static git && \
     rm -rf /var/cache/apk/*
 
 ARG GO_BUILD_ARGS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine AS operator-build
+FROM golang:1.18-alpine AS operator-build
 
 RUN apk update --no-cache && \
     apk add --no-cache gcc musl-dev btrfs-progs-dev lvm2-dev device-mapper-static && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Dynatrace/dynatrace-operator
 
-go 1.17
+go 1.18
 
 require (
 	github.com/container-storage-interface/spec v1.5.0


### PR DESCRIPTION
# Description
Follow-up of https://github.com/Dynatrace/dynatrace-operator/pull/651

go version is set to 1.18.1.
Some problems with linters may occur when using generics. It should be addressed when working with generics.


## How can this be tested?
- build image
- execute unit tests


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

