### PR TITLE
Check `fork` flag on `pull_request` event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name != 'pull_request' ||
-      github.pull_request.head.repo.full_name == github.pull_request.head.base.full_name
+      github.pull_request.head.repo.fork == false
     needs: [tests, linting, builddockerimage]
     env:
       IMAGE_QUAY: quay.io/dynatrace/dynatrace-operator


### PR DESCRIPTION
# Description
Comparing `repo.full_name` was not viable, so we check the `repo.fork` flag to find out if the event was fired from a fork.

## How can this be tested?
Pull Request is created to this repository from a fork.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

