### PR TITLE
Fix check for empty high availability flag

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
     {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
 spec:
-  replicas: {{ (.Values.webhook).highAvailability | ternary 2 1 }}
+  replicas: {{ (default false (.Values.webhook).highAvailability) | ternary 2 1 }}
   revisionHistoryLimit: 1
   selector:
     matchLabels:


### PR DESCRIPTION
# Description
If helm is deployed with `values.yaml` with no `webhook.highAvailability` set, upgrade to `release-0.6` fails.
```
$ helm upgrade dynatrace-operator config/helm/chart/default/ --reuse-values --atomic --namespace dynatrace -v3
Error: UPGRADE FAILED: template: dynatrace-operator/templates/Common/webhook/deployment-webhook.yaml:24:62: executing "dynatrace-operator/templates/Common/webhook/deployment-webhook.yaml" at <1>: invalid value; expected bool
```

## How can this be tested?
1. deploy `release-0.5` - https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/set-up-k8s-monitoring-with-helm
2. `helm upgrade dynatrace-operator config/helm/chart/default/ --reuse-values --atomic --namespace dynatrace`

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

