### PR TITLE
Updates csi garbage-collector logic to work with images

### DIFF
--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -233,6 +233,7 @@ func (dk *DynaKube) Version() string {
 	return ""
 }
 
+// The dynakube.Version is not take into account when using cloudNative to avoid confusion
 func (dynakube DynaKube) CodeModulesVersion() string {
 	if !dynakube.CloudNativeFullstackMode() && !dynakube.ApplicationMonitoringMode() {
 		return ""
@@ -241,7 +242,7 @@ func (dynakube DynaKube) CodeModulesVersion() string {
 		codeModulesImage := dynakube.CodeModulesImage()
 		return strings.Split(codeModulesImage, ":")[1]
 	}
-	if dynakube.Version() != "" {
+	if dynakube.Version() != "" && !dynakube.CloudNativeFullstackMode() {
 		return dynakube.Version()
 	}
 	return dynakube.Status.LatestAgentVersionUnixPaas

--- a/src/api/v1beta1/properties_test.go
+++ b/src/api/v1beta1/properties_test.go
@@ -233,10 +233,8 @@ func TestCodeModulesVersion(t *testing.T) {
 		dk := DynaKube{
 			Spec: DynaKubeSpec{
 				OneAgent: OneAgentSpec{
-					CloudNativeFullStack: &CloudNativeFullStackSpec{
-						HostInjectSpec: HostInjectSpec{
-							Version: testVersion,
-						},
+					ApplicationMonitoring: &ApplicationMonitoringSpec{
+						Version: testVersion,
 					},
 				},
 			},

--- a/src/controllers/csi/gc/binaries.go
+++ b/src/controllers/csi/gc/binaries.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (gc *CSIGarbageCollector) runBinaryGarbageCollection(tenantUUID string, latestVersion string) {
+func (gc *CSIGarbageCollector) runBinaryGarbageCollection(pinnedVersions pinnedVersionSet, tenantUUID string, latestVersion string) {
 	fs := &afero.Afero{Fs: gc.fs}
 	gcRunsMetric.Inc()
 
@@ -27,7 +27,7 @@ func (gc *CSIGarbageCollector) runBinaryGarbageCollection(tenantUUID string, lat
 
 	for _, version := range storedVersions {
 		shouldDelete := isNotLatestVersion(version, latestVersion) &&
-			shouldDeleteVersion(version, usedVersions)
+			shouldDeleteVersion(version, usedVersions) && !pinnedVersions[version]
 
 		if shouldDelete {
 			binaryPath := gc.path.AgentBinaryDirForVersion(tenantUUID, version)

--- a/src/controllers/csi/gc/binaries.go
+++ b/src/controllers/csi/gc/binaries.go
@@ -27,7 +27,7 @@ func (gc *CSIGarbageCollector) runBinaryGarbageCollection(pinnedVersions pinnedV
 
 	for _, version := range storedVersions {
 		shouldDelete := isNotLatestVersion(version, latestVersion) &&
-			shouldDeleteVersion(version, usedVersions) && !pinnedVersions[version]
+			shouldDeleteVersion(version, usedVersions) && pinnedVersions.isNotPinned(version)
 
 		if shouldDelete {
 			binaryPath := gc.path.AgentBinaryDirForVersion(tenantUUID, version)

--- a/src/controllers/csi/gc/binaries_test.go
+++ b/src/controllers/csi/gc/binaries_test.go
@@ -14,22 +14,98 @@ import (
 )
 
 const (
-	tenantUUID = "asd12345"
-	version_1  = "1"
-	version_2  = "2"
-	version_3  = "3"
-	rootDir    = "/tmp"
+	testTenantUUID = "asd12345"
+	testVersion1   = "1"
+	testVersion2   = "2"
+	testVersion3   = "3"
+	testRootDir    = "/tmp"
 )
 
 var (
-	binaryDir = filepath.Join(rootDir, tenantUUID, "bin")
+	testBinaryDir = filepath.Join(testRootDir, testTenantUUID, "bin")
 )
+
+func TestRunBinaryGarbageCollection(t *testing.T) {
+	t.Run("succeeds when no version present", func(t *testing.T) {
+		resetMetrics()
+		gc := NewMockGarbageCollector()
+
+		gc.runBinaryGarbageCollection(pinnedVersionSet{}, testTenantUUID, testVersion1)
+
+		assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
+		assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
+		assert.Equal(t, float64(0), testutil.ToFloat64(reclaimedMemoryMetric))
+	})
+	t.Run("succeeds when no version available", func(t *testing.T) {
+		resetMetrics()
+		gc := NewMockGarbageCollector()
+		_ = gc.fs.MkdirAll(testBinaryDir, 0770)
+
+		gc.runBinaryGarbageCollection(pinnedVersionSet{}, testTenantUUID, testVersion1)
+
+		assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
+		assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
+		assert.Equal(t, float64(0), testutil.ToFloat64(reclaimedMemoryMetric))
+
+	})
+	t.Run("ignores latest", func(t *testing.T) {
+		resetMetrics()
+		gc := NewMockGarbageCollector()
+		gc.mockUnusedVersions(testVersion1)
+
+		gc.runBinaryGarbageCollection(pinnedVersionSet{}, testTenantUUID, testVersion1)
+
+		assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
+		assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
+		assert.Equal(t, float64(0), testutil.ToFloat64(reclaimedMemoryMetric))
+
+		gc.assertVersionExists(t, testVersion1)
+	})
+	t.Run("remove unused", func(t *testing.T) {
+		resetMetrics()
+		gc := NewMockGarbageCollector()
+		gc.mockUnusedVersions(testVersion1, testVersion2, testVersion3)
+
+		gc.runBinaryGarbageCollection(pinnedVersionSet{}, testTenantUUID, testVersion2)
+
+		assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
+		assert.Equal(t, float64(2), testutil.ToFloat64(foldersRemovedMetric))
+
+		gc.assertVersionNotExists(t, testVersion1, testVersion3)
+	})
+	t.Run("ignore used", func(t *testing.T) {
+		resetMetrics()
+		gc := NewMockGarbageCollector()
+		gc.mockUsedVersions(testVersion1, testVersion2, testVersion3)
+
+		gc.runBinaryGarbageCollection(pinnedVersionSet{}, testTenantUUID, testVersion3)
+
+		assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
+		assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
+		assert.Equal(t, float64(0), testutil.ToFloat64(reclaimedMemoryMetric))
+
+		gc.assertVersionExists(t, testVersion1, testVersion2, testVersion3)
+	})
+	t.Run("ignore set image", func(t *testing.T) {
+		resetMetrics()
+		gc := NewMockGarbageCollector()
+		gc.mockUsedVersions(testVersion1, testVersion2)
+
+		gc.runBinaryGarbageCollection(pinnedVersionSet{testVersion2: true}, testTenantUUID, testVersion1)
+
+		assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
+		assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
+		assert.Equal(t, float64(0), testutil.ToFloat64(reclaimedMemoryMetric))
+
+		gc.assertVersionExists(t, testVersion1, testVersion2)
+	})
+}
 
 func TestBinaryGarbageCollector_getUsedVersions(t *testing.T) {
 	gc := NewMockGarbageCollector()
-	gc.mockUsedVersions(version_1, version_2, version_3)
+	gc.mockUsedVersions(testVersion1, testVersion2, testVersion3)
 
-	usedVersions, err := gc.db.GetUsedVersions(tenantUUID)
+	usedVersions, err := gc.db.GetUsedVersions(testTenantUUID)
 	assert.NoError(t, err)
 
 	assert.NotNil(t, usedVersions)
@@ -37,96 +113,32 @@ func TestBinaryGarbageCollector_getUsedVersions(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestBinaryGarbageCollector_succeedsWhenNoVersionPresent(t *testing.T) {
-	resetMetrics()
-	gc := NewMockGarbageCollector()
-
-	gc.runBinaryGarbageCollection(tenantUUID, version_1)
-
-	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
-	assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
-	assert.Equal(t, float64(0), testutil.ToFloat64(reclaimedMemoryMetric))
-}
-
-func TestBinaryGarbageCollector_succeedsWhenNoVersionsAvailable(t *testing.T) {
-	resetMetrics()
-	gc := NewMockGarbageCollector()
-	_ = gc.fs.MkdirAll(binaryDir, 0770)
-
-	gc.runBinaryGarbageCollection(tenantUUID, version_1)
-
-	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
-	assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
-	assert.Equal(t, float64(0), testutil.ToFloat64(reclaimedMemoryMetric))
-}
-
-func TestBinaryGarbageCollector_ignoresLatest(t *testing.T) {
-	resetMetrics()
-	gc := NewMockGarbageCollector()
-	gc.mockUnusedVersions(version_1)
-
-	gc.runBinaryGarbageCollection(tenantUUID, version_1)
-
-	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
-	assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
-	assert.Equal(t, float64(0), testutil.ToFloat64(reclaimedMemoryMetric))
-
-	gc.assertVersionExists(t, version_1)
-}
-
-func TestBinaryGarbageCollector_removesUnused(t *testing.T) {
-	resetMetrics()
-	gc := NewMockGarbageCollector()
-	gc.mockUnusedVersions(version_1, version_2, version_3)
-
-	gc.runBinaryGarbageCollection(tenantUUID, version_2)
-
-	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
-	assert.Equal(t, float64(2), testutil.ToFloat64(foldersRemovedMetric))
-
-	gc.assertVersionNotExists(t, version_1, version_3)
-}
-
-func TestBinaryGarbageCollector_ignoresUsed(t *testing.T) {
-	resetMetrics()
-	gc := NewMockGarbageCollector()
-	gc.mockUsedVersions(version_1, version_2, version_3)
-
-	gc.runBinaryGarbageCollection(tenantUUID, version_3)
-
-	assert.Equal(t, float64(1), testutil.ToFloat64(gcRunsMetric))
-	assert.Equal(t, float64(0), testutil.ToFloat64(foldersRemovedMetric))
-	assert.Equal(t, float64(0), testutil.ToFloat64(reclaimedMemoryMetric))
-
-	gc.assertVersionExists(t, version_1, version_2, version_3)
-}
-
 func NewMockGarbageCollector() *CSIGarbageCollector {
 	return &CSIGarbageCollector{
-		opts: dtcsi.CSIOptions{RootDir: rootDir},
+		opts: dtcsi.CSIOptions{RootDir: testRootDir},
 		fs:   afero.NewMemMapFs(),
 		db:   metadata.FakeMemoryDB(),
-		path: metadata.PathResolver{RootDir: rootDir},
+		path: metadata.PathResolver{RootDir: testRootDir},
 	}
 }
 
 func (gc *CSIGarbageCollector) mockUnusedVersions(versions ...string) {
-	_ = gc.fs.Mkdir(binaryDir, 0770)
+	_ = gc.fs.Mkdir(testBinaryDir, 0770)
 	for _, version := range versions {
-		_, _ = gc.fs.Create(filepath.Join(binaryDir, version))
+		_, _ = gc.fs.Create(filepath.Join(testBinaryDir, version))
 	}
 }
 func (gc *CSIGarbageCollector) mockUsedVersions(versions ...string) {
-	_ = gc.fs.Mkdir(binaryDir, 0770)
+	_ = gc.fs.Mkdir(testBinaryDir, 0770)
 	for i, version := range versions {
-		_, _ = gc.fs.Create(filepath.Join(binaryDir, version))
-		_ = gc.db.InsertVolume(metadata.NewVolume(fmt.Sprintf("pod%b", i), fmt.Sprintf("volume%b", i), version, tenantUUID))
+		_, _ = gc.fs.Create(filepath.Join(testBinaryDir, version))
+		_ = gc.db.InsertVolume(metadata.NewVolume(fmt.Sprintf("pod%b", i), fmt.Sprintf("volume%b", i), version, testTenantUUID))
 	}
 }
 
 func (gc *CSIGarbageCollector) assertVersionNotExists(t *testing.T, versions ...string) {
 	for _, version := range versions {
-		exists, err := afero.Exists(gc.fs, filepath.Join(binaryDir, version))
+		exists, err := afero.Exists(gc.fs, filepath.Join(testBinaryDir, version))
 		assert.False(t, exists)
 		assert.NoError(t, err)
 	}
@@ -134,7 +146,7 @@ func (gc *CSIGarbageCollector) assertVersionNotExists(t *testing.T, versions ...
 
 func (gc *CSIGarbageCollector) assertVersionExists(t *testing.T, versions ...string) {
 	for _, version := range versions {
-		exists, err := afero.Exists(gc.fs, filepath.Join(binaryDir, version))
+		exists, err := afero.Exists(gc.fs, filepath.Join(testBinaryDir, version))
 		assert.True(t, exists)
 		assert.NoError(t, err)
 	}

--- a/src/controllers/csi/gc/controller.go
+++ b/src/controllers/csi/gc/controller.go
@@ -7,8 +7,6 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/spf13/afero"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,25 +14,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// can contain the tag of the image or the digest, depending on how the user provided the image
+// or the version set for the download
+type pinnedVersionSet map[string]bool
+
 // CSIGarbageCollector removes unused and outdated agent versions
 type CSIGarbageCollector struct {
-	apiReader    client.Reader
-	opts         dtcsi.CSIOptions
-	dtcBuildFunc dynakube.DynatraceClientFunc
-	fs           afero.Fs
-	db           metadata.Access
-	path         metadata.PathResolver
+	apiReader client.Reader
+	opts      dtcsi.CSIOptions
+	fs        afero.Fs
+	db        metadata.Access
+	path      metadata.PathResolver
 }
 
 // NewCSIGarbageCollector returns a new CSIGarbageCollector
 func NewCSIGarbageCollector(apiReader client.Reader, opts dtcsi.CSIOptions, db metadata.Access) *CSIGarbageCollector {
 	return &CSIGarbageCollector{
-		apiReader:    apiReader,
-		opts:         opts,
-		dtcBuildFunc: dynakube.BuildDynatraceClient,
-		fs:           afero.NewOsFs(),
-		db:           db,
-		path:         metadata.PathResolver{RootDir: opts.RootDir},
+		apiReader: apiReader,
+		opts:      opts,
+		fs:        afero.NewOsFs(),
+		db:        db,
+		path:      metadata.PathResolver{RootDir: opts.RootDir},
 	}
 }
 
@@ -48,8 +48,8 @@ func (gc *CSIGarbageCollector) Reconcile(ctx context.Context, request reconcile.
 	log.Info("running OneAgent garbage collection", "namespace", request.Namespace, "name", request.Name)
 	reconcileResult := reconcile.Result{RequeueAfter: 60 * time.Minute}
 
-	var dk dynatracev1beta1.DynaKube
-	if err := gc.apiReader.Get(ctx, request.NamespacedName, &dk); err != nil {
+	var dynakube dynatracev1beta1.DynaKube
+	if err := gc.apiReader.Get(ctx, request.NamespacedName, &dynakube); err != nil {
 		if k8serrors.IsNotFound(err) {
 			log.Info("given DynaKube object not found")
 			return reconcileResult, nil
@@ -59,35 +59,53 @@ func (gc *CSIGarbageCollector) Reconcile(ctx context.Context, request reconcile.
 		return reconcileResult, nil
 	}
 
-	dtp, err := dynakube.NewDynatraceClientProperties(ctx, gc.apiReader, dk)
+	tenantUUID, err := dynakube.TenantUUID()
 	if err != nil {
-		log.Error(err, err.Error())
+		log.Error(err, "failed to get tenantUUID of DynaKube")
+		return reconcileResult, err
+	}
+
+	latestAgentVersion := dynakube.Status.LatestAgentVersionUnixPaas
+	if latestAgentVersion == "" {
+		log.Info("no latest agent version found in dynakube, checking later")
 		return reconcileResult, nil
 	}
 
-	dtc, err := gc.dtcBuildFunc(*dtp)
-	if err != nil {
-		log.Error(err, "failed to create Dynatrace client")
-		return reconcileResult, nil
+	var dynakubeList dynatracev1beta1.DynaKubeList
+	if err := gc.apiReader.List(ctx, &dynakubeList, client.InNamespace(dynakube.Namespace)); err != nil {
+		log.Error(err, "failed to get all DynaKube objects")
+		return reconcileResult, err
 	}
 
-	ci, err := dtc.GetConnectionInfo()
-	if err != nil {
-		log.Info("failed to fetch connection info")
-		return reconcileResult, nil
-	}
-
-	latestAgentVersion, err := dtc.GetLatestAgentVersion(dtclient.OsUnix, dtclient.InstallerTypePaaS)
-	if err != nil {
-		log.Info("failed to query OneAgent version")
-		return reconcileResult, nil
-	}
-
+	pinnedVersions := getAllPinnedVersionsForTenantUUID(tenantUUID, dynakubeList)
 	log.Info("running binary garbage collection")
-	gc.runBinaryGarbageCollection(ci.TenantUUID, latestAgentVersion)
+	gc.runBinaryGarbageCollection(pinnedVersions, tenantUUID, latestAgentVersion)
 
 	log.Info("running log garbage collection")
-	gc.runLogGarbageCollection(ci.TenantUUID)
+	gc.runLogGarbageCollection(tenantUUID)
+
+	log.Info("running image garbage collection")
+	gc.runImageGarbageCollection()
 
 	return reconcileResult, nil
+}
+
+// getAllPinnedVersionsForTenantUUID returns all pinned versions for a given tenantUUID.
+// A pinned version is either the:
+// - image tag/digest set in the dynakube for the csi codeModules
+// - version set for in the dynakube for the csi codeModules. (currently not supported on cloudNative)
+func getAllPinnedVersionsForTenantUUID(tenantUUID string, dynakubes dynatracev1beta1.DynaKubeList) pinnedVersionSet {
+	pinnedImages := make(pinnedVersionSet)
+	for _, dynakube := range dynakubes.Items {
+		uuid, err := dynakube.TenantUUID()
+		if err != nil {
+			log.Error(err, "failed to get tenantUUID of DynaKube")
+			continue
+		}
+		if uuid != tenantUUID {
+			continue
+		}
+		pinnedImages[dynakube.CodeModulesVersion()] = true
+	}
+	return pinnedImages
 }

--- a/src/controllers/csi/gc/controller.go
+++ b/src/controllers/csi/gc/controller.go
@@ -18,6 +18,10 @@ import (
 // or the version set for the download
 type pinnedVersionSet map[string]bool
 
+func (set pinnedVersionSet) isNotPinned(version string) bool {
+	return !set[version]
+}
+
 // CSIGarbageCollector removes unused and outdated agent versions
 type CSIGarbageCollector struct {
 	apiReader client.Reader
@@ -91,9 +95,9 @@ func (gc *CSIGarbageCollector) Reconcile(ctx context.Context, request reconcile.
 }
 
 // getAllPinnedVersionsForTenantUUID returns all pinned versions for a given tenantUUID.
-// A pinned version is either the:
-// - image tag/digest set in the dynakube for the csi codeModules
-// - version set for in the dynakube for the csi codeModules. (currently not supported on cloudNative)
+// A pinned version is either:
+// - the image tag or digest set in the custom resource
+// - the version set in the custom resource if applicationMonitoring is used
 func getAllPinnedVersionsForTenantUUID(tenantUUID string, dynakubes dynatracev1beta1.DynaKubeList) pinnedVersionSet {
 	pinnedImages := make(pinnedVersionSet)
 	for _, dynakube := range dynakubes.Items {

--- a/src/controllers/csi/gc/images.go
+++ b/src/controllers/csi/gc/images.go
@@ -1,0 +1,79 @@
+package csigc
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Dynatrace/dynatrace-operator/src/installer/image"
+	"github.com/spf13/afero"
+)
+
+var maxImageAge = time.Hour * 24 * 14 // 14 days
+
+func (gc *CSIGarbageCollector) runImageGarbageCollection() {
+	imageDirs, _ := getImageCacheDirs(gc.fs)
+	if imageDirs == nil {
+		return
+	}
+
+	imageCachesToDelete := collectUnusedImageCaches(gc.fs, imageDirs)
+
+	deleteImageCaches(gc.fs, imageCachesToDelete)
+}
+
+func getImageCacheDirs(fs afero.Fs) ([]os.FileInfo, error) {
+	imageDirs, err := afero.Afero{Fs: fs}.ReadDir(image.CacheDir)
+	if os.IsNotExist(err) {
+		log.Info("No image cache to clean up")
+		return nil, nil
+	}
+	if err != nil {
+		log.Error(err, "Failed to read image cache directory")
+		return nil, err
+	}
+	return imageDirs, err
+}
+
+func collectUnusedImageCaches(fs afero.Fs, imageDirs []os.FileInfo) []string {
+	var toDelete []string
+	for _, imageDir := range imageDirs {
+		if !imageDir.IsDir() {
+			continue
+		}
+		modificationTime, err := getRelevantModificationTime(fs, imageDir.Name())
+		if err != nil {
+			log.Error(err, "failed to get modification time of image cache", "imageDir", imageDir.Name())
+			continue
+		}
+		if time.Since(modificationTime) > maxImageAge {
+			toDelete = append(toDelete, filepath.Join(image.CacheDir, imageDir.Name()))
+		}
+	}
+	return toDelete
+}
+
+// getRelevantModificationTime returns the last modification time of an image in the cache
+// an image is not a single file but a directory of several files.
+// Most of which don't change when the image is tried to be pulled again.
+// The index.json of the image is a file that is modified in reliable way.(after every pull)
+func getRelevantModificationTime(fs afero.Fs, imageDir string) (time.Time, error) {
+	var modificationTime time.Time
+	indexPath := filepath.Join(image.CacheDir, imageDir, "index.json")
+	indexFileInfo, err := fs.Stat(indexPath)
+	if err != nil {
+		return modificationTime, err
+	}
+	modificationTime = indexFileInfo.ModTime()
+	return modificationTime, err
+}
+
+func deleteImageCaches(fs afero.Fs, imageCaches []string) {
+	for _, dir := range imageCaches {
+		log.Info("Deleting image cache", "dir", dir)
+		err := fs.RemoveAll(dir)
+		if err != nil {
+			log.Error(err, "Failed to delete image cache", "dir", dir)
+		}
+	}
+}

--- a/src/controllers/csi/gc/images_test.go
+++ b/src/controllers/csi/gc/images_test.go
@@ -1,0 +1,57 @@
+package csigc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/src/installer/image"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testImageDigest = "5f50f658891613c752d524b72fc"
+)
+
+func TestGetImageCacheDirs(t *testing.T) {
+	t.Run("no error on empty fs", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		dirs, err := getImageCacheDirs(fs)
+		require.NoError(t, err)
+		assert.Nil(t, dirs)
+	})
+	t.Run("get image cache dirs", func(t *testing.T) {
+		fs := createTestImageCacheDir(t)
+		dirs, err := getImageCacheDirs(fs)
+		require.NoError(t, err)
+		assert.Len(t, dirs, 1)
+	})
+}
+
+func TestDeleteImageCaches(t *testing.T) {
+	t.Run("no panic", func(t *testing.T) {
+		fs := createTestImageCacheDir(t)
+		deleteImageCaches(fs, []string{filepath.Join(image.CacheDir, testImageDigest)})
+		_, err := fs.Stat(filepath.Join(image.CacheDir, testImageDigest))
+		assert.True(t, os.IsNotExist(err))
+	})
+}
+
+func TestGetRelevantModificationTime(t *testing.T) {
+	t.Run("no nil", func(t *testing.T) {
+		fs := createTestImageCacheDir(t)
+		modTime, err := getRelevantModificationTime(fs, testImageDigest)
+		require.NoError(t, err)
+		require.NotNil(t, modTime)
+	})
+}
+
+func createTestImageCacheDir(t *testing.T) afero.Fs {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll(image.CacheDir, 0755))
+	require.NoError(t, fs.Mkdir(filepath.Join(image.CacheDir, testImageDigest), 0755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(image.CacheDir, testImageDigest, "index.json"), []byte("{}"), 0644))
+	return fs
+}

--- a/src/controllers/csi/gc/logs_test.go
+++ b/src/controllers/csi/gc/logs_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 var (
-	logPath    = filepath.Join(rootDir, tenantUUID, "run")
-	technology = "go"
+	testLogPath    = filepath.Join(testRootDir, testTenantUUID, "run")
+	testTechnology = "go"
 )
 
 func TestLogGarbageCollector_noErrorWithoutLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	_ = gc.fs.MkdirAll(logPath, 0770)
-	logs, err := gc.getLogFileInfo(tenantUUID)
+	_ = gc.fs.MkdirAll(testLogPath, 0770)
+	logs, err := gc.getLogFileInfo(testTenantUUID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, &logFileInfo{
@@ -31,9 +31,9 @@ func TestLogGarbageCollector_noErrorWithoutLogs(t *testing.T) {
 
 func TestLogGarbageCollector_emptyLogFileInfoWithNoUnmountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
-	gc.mockMountedVolumeIDPath(version_1)
+	gc.mockMountedVolumeIDPath(testVersion1)
 
-	logs, err := gc.getLogFileInfo(tenantUUID)
+	logs, err := gc.getLogFileInfo(testTenantUUID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, &logFileInfo{
@@ -46,60 +46,60 @@ func TestLogGarbageCollector_emptyLogFileInfoWithNoUnmountedLogs(t *testing.T) {
 func TestLogGarbageCollector_logFileInfo_JustVolumeID_WithUnmountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	gc.mockUnmountedVolumeIDPath(version_1)
+	gc.mockUnmountedVolumeIDPath(testVersion1)
 
-	logs, err := gc.getLogFileInfo(tenantUUID)
+	logs, err := gc.getLogFileInfo(testTenantUUID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), logs.NumberOfFiles)
 	assert.Equal(t, int64(0), logs.OverallSize)
-	assert.Equal(t, version_1, logs.UnusedVolumeIDs[0].Name())
+	assert.Equal(t, testVersion1, logs.UnusedVolumeIDs[0].Name())
 }
 
 func TestLogGarbageCollector_logFileInfo_SingleVolumeID_WithUnmountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	gc.mockUnmountedVolumeIDPath(version_1)
-	gc.mockLogsInPodFolders(5, version_1)
+	gc.mockUnmountedVolumeIDPath(testVersion1)
+	gc.mockLogsInPodFolders(5, testVersion1)
 
-	logs, err := gc.getLogFileInfo(tenantUUID)
+	logs, err := gc.getLogFileInfo(testTenantUUID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(5), logs.NumberOfFiles)
 	assert.Equal(t, int64(0), logs.OverallSize)
-	assert.Equal(t, version_1, logs.UnusedVolumeIDs[0].Name())
+	assert.Equal(t, testVersion1, logs.UnusedVolumeIDs[0].Name())
 }
 
 func TestLogGarbageCollector_logFileInfo_MultipleVolumeIDs_WithUnmountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	gc.mockUnmountedVolumeIDPath(version_1, version_2, version_3)
-	gc.mockLogsInPodFolders(5, version_1, version_2)
+	gc.mockUnmountedVolumeIDPath(testVersion1, testVersion2, testVersion3)
+	gc.mockLogsInPodFolders(5, testVersion1, testVersion2)
 
-	logs, err := gc.getLogFileInfo(tenantUUID)
+	logs, err := gc.getLogFileInfo(testTenantUUID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(10), logs.NumberOfFiles)
 	assert.Equal(t, int64(0), logs.OverallSize)
-	assert.Equal(t, version_1, logs.UnusedVolumeIDs[0].Name())
-	assert.Equal(t, version_2, logs.UnusedVolumeIDs[1].Name())
-	assert.Equal(t, version_3, logs.UnusedVolumeIDs[2].Name())
+	assert.Equal(t, testVersion1, logs.UnusedVolumeIDs[0].Name())
+	assert.Equal(t, testVersion2, logs.UnusedVolumeIDs[1].Name())
+	assert.Equal(t, testVersion3, logs.UnusedVolumeIDs[2].Name())
 }
 
 func TestLogGarbageCollector_logFileInfo_MultipleVolumeIDs_WithUnmountedAndMountedLogs(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	gc.mockMountedVolumeIDPath(version_3)
-	gc.mockUnmountedVolumeIDPath(version_1, version_2)
-	gc.mockLogsInPodFolders(5, version_1, version_2)
+	gc.mockMountedVolumeIDPath(testVersion3)
+	gc.mockUnmountedVolumeIDPath(testVersion1, testVersion2)
+	gc.mockLogsInPodFolders(5, testVersion1, testVersion2)
 
-	logs, err := gc.getLogFileInfo(tenantUUID)
+	logs, err := gc.getLogFileInfo(testTenantUUID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(10), logs.NumberOfFiles)
 	assert.Equal(t, int64(0), logs.OverallSize)
-	assert.Equal(t, version_1, logs.UnusedVolumeIDs[0].Name())
-	assert.Equal(t, version_2, logs.UnusedVolumeIDs[1].Name())
+	assert.Equal(t, testVersion1, logs.UnusedVolumeIDs[0].Name())
+	assert.Equal(t, testVersion2, logs.UnusedVolumeIDs[1].Name())
 	assert.Equal(t, 2, len(logs.UnusedVolumeIDs))
 }
 
@@ -120,32 +120,32 @@ func TestLogGarbageCollector_modificationDateOlderThanTwoWeeks(t *testing.T) {
 func TestLogGarbageCollector_cleanUpSuccessful(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	gc.mockUnmountedVolumeIDPath(version_1, version_2)
-	gc.mockLogsInPodFolders(5, version_1, version_2)
+	gc.mockUnmountedVolumeIDPath(testVersion1, testVersion2)
+	gc.mockLogsInPodFolders(5, testVersion1, testVersion2)
 
-	logs, err := gc.getLogFileInfo(tenantUUID)
+	logs, err := gc.getLogFileInfo(testTenantUUID)
 	assert.NoError(t, err)
 	assert.NotNil(t, logs)
 
 	older := isOlderThanTwoWeeks(logs.UnusedVolumeIDs[0].ModTime())
 	assert.True(t, older)
 
-	gc.tryRemoveLogFolders(logs.UnusedVolumeIDs, tenantUUID)
-	assert.NoDirExists(t, filepath.Join(logPath, logs.UnusedVolumeIDs[0].Name()))
+	gc.tryRemoveLogFolders(logs.UnusedVolumeIDs, testTenantUUID)
+	assert.NoDirExists(t, filepath.Join(testLogPath, logs.UnusedVolumeIDs[0].Name()))
 }
 
 func TestLogGarbageCollector_removeLogsNecessary_filesGetDeleted(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	gc.mockUnmountedVolumeIDPath(version_1, version_2)
-	gc.mockLogsInPodFolders(5, version_1, version_2)
+	gc.mockUnmountedVolumeIDPath(testVersion1, testVersion2)
+	gc.mockLogsInPodFolders(5, testVersion1, testVersion2)
 
-	logs, err := gc.getLogFileInfo(tenantUUID)
+	logs, err := gc.getLogFileInfo(testTenantUUID)
 	assert.NoError(t, err)
 	assert.NotNil(t, logs)
 
-	gc.removeLogsIfNecessary(logs, int64(0), int64(1), tenantUUID)
-	newLogs, err := gc.getLogFileInfo(tenantUUID)
+	gc.removeLogsIfNecessary(logs, int64(0), int64(1), testTenantUUID)
+	newLogs, err := gc.getLogFileInfo(testTenantUUID)
 	assert.NoError(t, err)
 	assert.NotEqual(t, newLogs, logs)
 	assert.Equal(t, newLogs.NumberOfFiles, int64(0))
@@ -154,15 +154,15 @@ func TestLogGarbageCollector_removeLogsNecessary_filesGetDeleted(t *testing.T) {
 func TestLogGarbageCollector_removeLogsNecessary_tooLessFiles(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	gc.mockUnmountedVolumeIDPath(version_1, version_2)
-	gc.mockLogsInPodFolders(5, version_1, version_2)
+	gc.mockUnmountedVolumeIDPath(testVersion1, testVersion2)
+	gc.mockLogsInPodFolders(5, testVersion1, testVersion2)
 
-	logs, err := gc.getLogFileInfo(tenantUUID)
+	logs, err := gc.getLogFileInfo(testTenantUUID)
 	assert.NoError(t, err)
 	assert.NotNil(t, logs)
 
-	gc.removeLogsIfNecessary(logs, int64(0), int64(11), tenantUUID)
-	newLogs, err := gc.getLogFileInfo(tenantUUID)
+	gc.removeLogsIfNecessary(logs, int64(0), int64(11), testTenantUUID)
+	newLogs, err := gc.getLogFileInfo(testTenantUUID)
 	assert.NoError(t, err)
 	assert.Equal(t, newLogs, logs)
 	assert.Equal(t, newLogs.NumberOfFiles, int64(10))
@@ -171,15 +171,15 @@ func TestLogGarbageCollector_removeLogsNecessary_tooLessFiles(t *testing.T) {
 func TestLogGarbageCollector_removeLogsNecessary_FileSizeTooSmall(t *testing.T) {
 	gc := NewMockGarbageCollector()
 
-	gc.mockUnmountedVolumeIDPath(version_1, version_2)
-	gc.mockLogsInPodFolders(5, version_1, version_2)
+	gc.mockUnmountedVolumeIDPath(testVersion1, testVersion2)
+	gc.mockLogsInPodFolders(5, testVersion1, testVersion2)
 
-	logs, err := gc.getLogFileInfo(tenantUUID)
+	logs, err := gc.getLogFileInfo(testTenantUUID)
 	assert.NoError(t, err)
 	assert.NotNil(t, logs)
 
-	gc.removeLogsIfNecessary(logs, int64(10), int64(11), tenantUUID)
-	newLogs, err := gc.getLogFileInfo(tenantUUID)
+	gc.removeLogsIfNecessary(logs, int64(10), int64(11), testTenantUUID)
+	newLogs, err := gc.getLogFileInfo(testTenantUUID)
 	assert.NoError(t, err)
 	assert.Equal(t, newLogs, logs)
 	assert.Equal(t, newLogs.NumberOfFiles, int64(10))
@@ -187,19 +187,19 @@ func TestLogGarbageCollector_removeLogsNecessary_FileSizeTooSmall(t *testing.T) 
 
 func (gc *CSIGarbageCollector) mockMountedVolumeIDPath(volumeIDs ...string) {
 	for _, volumeID := range volumeIDs {
-		_ = gc.fs.MkdirAll(filepath.Join(logPath, volumeID, "mapped", "something"), os.ModePerm)
+		_ = gc.fs.MkdirAll(filepath.Join(testLogPath, volumeID, "mapped", "something"), os.ModePerm)
 	}
 }
 
 func (gc *CSIGarbageCollector) mockUnmountedVolumeIDPath(volumeIDs ...string) {
 	for _, volumeID := range volumeIDs {
-		_ = gc.fs.MkdirAll(filepath.Join(logPath, volumeID, "mapped"), os.ModePerm)
+		_ = gc.fs.MkdirAll(filepath.Join(testLogPath, volumeID, "mapped"), os.ModePerm)
 	}
 }
 
 func (gc *CSIGarbageCollector) mockLogsInPodFolders(nrOfLogFiles int, volumeIDs ...string) {
 	for _, volumeID := range volumeIDs {
-		technologyLogPath := filepath.Join(logPath, volumeID, "var", "log", technology)
+		technologyLogPath := filepath.Join(testLogPath, volumeID, "var", "log", testTechnology)
 		_ = gc.fs.Mkdir(filepath.Join(technologyLogPath), 0770)
 		for i := 0; i < nrOfLogFiles; i++ {
 			_, _ = gc.fs.Create(filepath.Join(technologyLogPath, "logfile"+strconv.Itoa(i)))

--- a/src/controllers/csi/provisioner/agent_test.go
+++ b/src/controllers/csi/provisioner/agent_test.go
@@ -42,10 +42,8 @@ func TestUpdateAgent(t *testing.T) {
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: "https://" + testTenantUUID + ".dynatrace.com",
 				OneAgent: dynatracev1beta1.OneAgentSpec{
-					CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
-						HostInjectSpec: dynatracev1beta1.HostInjectSpec{
-							Version: testVersion,
-						},
+					ApplicationMonitoring: &dynatracev1beta1.ApplicationMonitoringSpec{
+						Version: testVersion,
 					},
 				},
 			},


### PR DESCRIPTION
# Description

The image cache needs to be cleaned up otherwise the we can flood the node's filesystem with many 200MB+ image dirs.

This deletes any cached image that haven't been pulled for 2 weeks.
Every pull for an image changes its `index.json` even if the image was already cached, so its a good indicator of usage.

## How can this be tested?
Well this is kinda hard, as for the "thing" to happen you need to wait for 2 weeks.
What you can do is change the time locally to 10 mins or something, 
build the operator and use it, then create a dynakube that has `codeModulesImage` set.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
