### PR TITLE
Fix automatic kubernetes api monitoring usage being skipped

### DIFF
--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -348,7 +348,6 @@ func (controller *DynakubeController) reconcileActiveGateCapabilities(dynakubeSt
 				return false
 			}
 			dynakubeState.Update(upd, c.ShortName()+" reconciled")
-			return true
 		} else {
 			sts := appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Description
When using automatic api monitoring, the kubernetes cluster was never registered.

## How can this be tested?
Deploy a Dynakube with the `feature.dynatrace.com/automatic-kubernetes-api-monitoring=true` and the `kubernetes-monitoring` capability enabled.

Request should happen and cluster should show up in the UI.


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

