### PR TITLE
Fix automatic kubernetes api monitoring usage being skipped

### DIFF
--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -348,7 +348,6 @@ func (controller *DynakubeController) reconcileActiveGateCapabilities(dynakubeSt
 				return false
 			}
 			dynakubeState.Update(upd, c.ShortName()+" reconciled")
-			return true
 		} else {
 			sts := appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Description
(cherrypicked from 99d5be36843dad75879e2056fe09c9d925ef962d in #750)

## How can this be tested?
Same as #750 


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

