### PR TITLE
Fix activegate service not updating when labels mismatch

### DIFF
--- a/src/controllers/activegate/capability/capability.go
+++ b/src/controllers/activegate/capability/capability.go
@@ -38,7 +38,7 @@ type AgServicePorts struct {
 	Statsd    bool
 }
 
-func (ports AgServicePorts) AtLeastOneEnabled() bool {
+func (ports AgServicePorts) HasPorts() bool {
 	return ports.Webserver || ports.Statsd
 }
 
@@ -95,7 +95,7 @@ func (c *capabilityBase) ArgName() string {
 }
 
 func (c *capabilityBase) ShouldCreateService() bool {
-	return c.ServicePorts.AtLeastOneEnabled()
+	return c.ServicePorts.HasPorts()
 }
 
 // Note:

--- a/src/controllers/activegate/reconciler/capability/service.go
+++ b/src/controllers/activegate/reconciler/capability/service.go
@@ -52,7 +52,7 @@ func createService(instance *dynatracev1beta1.DynaKube, feature string, serviceP
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
-			Selector: coreLabels.BuildMatchLabels(),
+			Selector: buildSelectorLabels(instance.Name),
 			Ports:    ports,
 		},
 	}
@@ -73,4 +73,9 @@ func buildServiceHostName(instanceName string, module string) string {
 			"-", "_")
 
 	return fmt.Sprintf("$(%s_SERVICE_HOST):$(%s_SERVICE_PORT)", serviceName, serviceName)
+}
+
+func buildSelectorLabels(dynakubeName string) map[string]string {
+	appLabels := kubeobjects.NewAppLabels(kubeobjects.ActiveGateComponentLabel, dynakubeName, "", "")
+	return appLabels.BuildMatchLabels()
 }

--- a/src/controllers/activegate/reconciler/capability/service_test.go
+++ b/src/controllers/activegate/reconciler/capability/service_test.go
@@ -62,7 +62,7 @@ func TestCreateService(t *testing.T) {
 
 		expectedLabels := map[string]string{
 			kubeobjects.AppCreatedByLabel: testName,
-			kubeobjects.AppComponentLabel: string(kubeobjects.ActiveGateComponentLabel),
+			kubeobjects.AppComponentLabel: kubeobjects.ActiveGateComponentLabel,
 			kubeobjects.AppNameLabel:      version.AppName,
 			kubeobjects.AppVersionLabel:   version.Version,
 		}
@@ -70,8 +70,8 @@ func TestCreateService(t *testing.T) {
 
 		expectedSelector := map[string]string{
 			kubeobjects.AppCreatedByLabel: testName,
-			kubeobjects.AppComponentLabel: string(kubeobjects.ActiveGateComponentLabel),
-			kubeobjects.AppNameLabel:      version.AppName,
+			kubeobjects.AppManagedByLabel: version.AppName,
+			kubeobjects.AppNameLabel:      kubeobjects.ActiveGateComponentLabel,
 		}
 		serviceSpec := service.Spec
 		assert.Equal(t, corev1.ServiceTypeClusterIP, serviceSpec.Type)
@@ -86,7 +86,7 @@ func TestCreateService(t *testing.T) {
 		testSetCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
 		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, false)
 		require.True(t, !instance.NeedsStatsd())
-		require.True(t, desiredPorts.AtLeastOneEnabled())
+		require.True(t, desiredPorts.HasPorts())
 
 		service := createService(instance, testComponentFeature, desiredPorts)
 		ports := service.Spec.Ports
@@ -104,7 +104,7 @@ func TestCreateService(t *testing.T) {
 		testSetCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
 		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, desiredPorts.Statsd)
 		require.True(t, instance.NeedsStatsd())
-		require.True(t, desiredPorts.AtLeastOneEnabled())
+		require.True(t, desiredPorts.HasPorts())
 
 		service := createService(instance, testComponentFeature, desiredPorts)
 		ports := service.Spec.Ports
@@ -120,7 +120,7 @@ func TestCreateService(t *testing.T) {
 		testSetCapability(instance, dynatracev1beta1.MetricsIngestCapability, false)
 		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, true)
 		require.True(t, instance.NeedsStatsd())
-		require.True(t, desiredPorts.AtLeastOneEnabled())
+		require.True(t, desiredPorts.HasPorts())
 
 		service := createService(instance, testComponentFeature, desiredPorts)
 		ports := service.Spec.Ports
@@ -135,7 +135,7 @@ func TestCreateService(t *testing.T) {
 		testSetCapability(instance, dynatracev1beta1.MetricsIngestCapability, false)
 		testSetCapability(instance, dynatracev1beta1.StatsdIngestCapability, false)
 		require.True(t, !instance.NeedsStatsd())
-		require.False(t, desiredPorts.AtLeastOneEnabled())
+		require.False(t, desiredPorts.HasPorts())
 
 		service := createService(instance, testComponentFeature, desiredPorts)
 		ports := service.Spec.Ports


### PR DESCRIPTION
# Description
(cherrypicked from d938ec45b277a0135aa05d300818fb8474fbca41 in #749 )

## How can this be tested?
Same as #749 

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

