### PR TITLE
Skip cache removal when file does not exist

### DIFF
--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -53,7 +53,8 @@ func (updater *agentUpdater) updateAgent(installedVersion, tenantUUID string, pr
 	targetVersion := updater.getOneAgentVersionFromInstance()
 	targetDir := updater.path.AgentBinaryDirForVersion(tenantUUID, targetVersion)
 
-	if _, err := updater.fs.Stat(targetDir); os.IsNotExist(err) || installedVersion == "" {
+	_, err := updater.fs.Stat(targetDir)
+	if os.IsNotExist(err) || installedVersion == "" {
 		log.Info("updating agent",
 			"target version", targetVersion,
 			"installed version", installedVersion,

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -53,7 +53,7 @@ func (updater *agentUpdater) updateAgent(installedVersion, tenantUUID string, pr
 	targetVersion := updater.getOneAgentVersionFromInstance()
 	targetDir := updater.path.AgentBinaryDirForVersion(tenantUUID, targetVersion)
 
-	if _, err := updater.fs.Stat(targetDir); os.IsNotExist(err) {
+	if _, err := updater.fs.Stat(targetDir); os.IsNotExist(err) || installedVersion == "" {
 		log.Info("updating agent",
 			"target version", targetVersion,
 			"installed version", installedVersion,

--- a/src/controllers/csi/provisioner/processmoduleconfig.go
+++ b/src/controllers/csi/provisioner/processmoduleconfig.go
@@ -55,9 +55,8 @@ func (provisioner *OneAgentProvisioner) getProcessModuleConfig(dtc dtclient.Clie
 }
 
 func (provisioner *OneAgentProvisioner) readProcessModuleConfigCache(tenantUUID string) (*processModuleConfigCache, error) {
-	var processModuleConfig processModuleConfigCache
 	processModuleConfigCacheFile, err := provisioner.fs.Open(provisioner.path.AgentRuxitProcResponseCache(tenantUUID))
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		provisioner.removeProcessModuleConfigCache(tenantUUID)
 		return nil, err
 	}
@@ -76,6 +75,7 @@ func (provisioner *OneAgentProvisioner) readProcessModuleConfigCache(tenantUUID 
 		return nil, errors.Wrapf(err, "error closing file after reading processModuleConfigCache")
 	}
 
+	var processModuleConfig processModuleConfigCache
 	if err := json.Unmarshal(jsonBytes, &processModuleConfig); err != nil {
 		provisioner.removeProcessModuleConfigCache(tenantUUID)
 		return nil, errors.Wrapf(err, "error when unmarshalling processModuleConfigCache")

--- a/src/controllers/csi/provisioner/processmoduleconfig.go
+++ b/src/controllers/csi/provisioner/processmoduleconfig.go
@@ -56,8 +56,10 @@ func (provisioner *OneAgentProvisioner) getProcessModuleConfig(dtc dtclient.Clie
 
 func (provisioner *OneAgentProvisioner) readProcessModuleConfigCache(tenantUUID string) (*processModuleConfigCache, error) {
 	processModuleConfigCacheFile, err := provisioner.fs.Open(provisioner.path.AgentRuxitProcResponseCache(tenantUUID))
-	if err != nil && !os.IsNotExist(err) {
-		provisioner.removeProcessModuleConfigCache(tenantUUID)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			provisioner.removeProcessModuleConfigCache(tenantUUID)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description
Install agent binaries when installed version is `""` (empty), but the `<tenant>/bin/<target version>` directory exists. This means the previous attempt to install agent failed (e.g. OOM during unzip), only created the `bin` folder but did not update the database with the correct version.

## How can this be tested?
Dynakube that needs CSI driver is deployed:
1. CSI driver crashes during unzip (after creating `bin` folder with version)
2. CSI driver restarts and tries to update `ruxitagentproc.conf` without an installed version

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

