### PR TITLE
Improve logs for `ruxitagentproc.conf` cache deletion

### DIFF
--- a/src/controllers/csi/provisioner/processmoduleconfig.go
+++ b/src/controllers/csi/provisioner/processmoduleconfig.go
@@ -55,10 +55,11 @@ func (provisioner *OneAgentProvisioner) getProcessModuleConfig(dtc dtclient.Clie
 }
 
 func (provisioner *OneAgentProvisioner) readProcessModuleConfigCache(tenantUUID string) (*processModuleConfigCache, error) {
-	var processModuleConfig processModuleConfigCache
 	processModuleConfigCacheFile, err := provisioner.fs.Open(provisioner.path.AgentRuxitProcResponseCache(tenantUUID))
 	if err != nil {
-		provisioner.removeProcessModuleConfigCache(tenantUUID)
+		if !os.IsNotExist(err) {
+			provisioner.removeProcessModuleConfigCache(tenantUUID)
+		}
 		return nil, err
 	}
 
@@ -76,6 +77,7 @@ func (provisioner *OneAgentProvisioner) readProcessModuleConfigCache(tenantUUID 
 		return nil, errors.Wrapf(err, "error closing file after reading processModuleConfigCache")
 	}
 
+	var processModuleConfig processModuleConfigCache
 	if err := json.Unmarshal(jsonBytes, &processModuleConfig); err != nil {
 		provisioner.removeProcessModuleConfigCache(tenantUUID)
 		return nil, errors.Wrapf(err, "error when unmarshalling processModuleConfigCache")


### PR DESCRIPTION
# Description
When removing invalid `revision.json` files the file is deleted even if it doesn't exist. Connected to #754 

## How can this be tested?
Similar as #754 

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

