### PR TITLE
Create symlink from filesystem instead of latest version on Dynakube

### DIFF
--- a/src/installer/symlink/config.go
+++ b/src/installer/symlink/config.go
@@ -1,0 +1,15 @@
+package symlink
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
+)
+
+const (
+	// example match: 1.239.14.20220325-164521
+	versionRegexp = `^(\d+)\.(\d+)\.(\d+)\.(\d+)-(\d+)$`
+	binDir        = "/agent/bin"
+)
+
+var (
+	log = logger.NewDTLogger().WithName("oneagent-installer-symlink")
+)

--- a/src/installer/symlink/symlink.go
+++ b/src/installer/symlink/symlink.go
@@ -1,0 +1,64 @@
+package symlink
+
+import (
+	iofs "io/fs"
+	"path/filepath"
+	"regexp"
+
+	"github.com/spf13/afero"
+)
+
+func CreateSymlinkForCurrentVersionIfNotExists(fs afero.Fs, targetDir string) error {
+	var relativeSymlinkPath string
+	var err error
+	targetBindDir := filepath.Join(targetDir, binDir)
+
+	// MemMapFs (used for testing) doesn't comply with the Linker interface
+	linker, ok := fs.(afero.Linker)
+	if !ok {
+		log.Info("symlinking not possible", "targetDir", targetDir, "fs", fs)
+		return nil
+	}
+
+	relativeSymlinkPath, err = findVersionFromFileSystem(fs, targetBindDir)
+	if err != nil {
+		log.Info("failed to get the version from the filesystem", "targetDir", targetDir)
+		return err
+	}
+
+	symlinkTargetPath := filepath.Join(targetBindDir, "current")
+	if fileInfo, _ := fs.Stat(symlinkTargetPath); fileInfo != nil {
+		log.Info("symlink already exists", "location", symlinkTargetPath)
+		return nil
+	}
+
+	log.Info("creating symlink", "points-to(relative)", relativeSymlinkPath, "location", symlinkTargetPath)
+	if err := linker.SymlinkIfPossible(relativeSymlinkPath, symlinkTargetPath); err != nil {
+		log.Info("symlinking failed", "version", relativeSymlinkPath)
+		return err
+	}
+	return nil
+}
+
+func findVersionFromFileSystem(fs afero.Fs, targetDir string) (string, error) {
+	var version string
+	aferoFs := afero.Afero{
+		Fs: fs,
+	}
+	walkFiles := func(path string, info iofs.FileInfo, err error) error {
+		if !info.IsDir() {
+			return nil
+		}
+		folderName := filepath.Base(path)
+		if regexp.MustCompile(versionRegexp).Match([]byte(folderName)) {
+			log.Info("found version", "version", folderName)
+			version = folderName
+			return iofs.ErrExist
+		}
+		return nil
+	}
+	if err := aferoFs.Walk(targetDir, walkFiles); err != nil && err != iofs.ErrExist {
+		return "", err
+	}
+	return version, nil
+}

--- a/src/installer/symlink/symlink_test.go
+++ b/src/installer/symlink/symlink_test.go
@@ -1,0 +1,35 @@
+package symlink
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindVersionFromFileSystem(t *testing.T) {
+	testPath := "/test"
+	testVersion := "1.239.14.20220325-164521"
+	t.Run("get version from directory in file system", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		err := fs.MkdirAll(filepath.Join(testPath, testVersion), 0755)
+		require.NoError(t, err)
+
+		version, err := findVersionFromFileSystem(fs, testPath)
+		require.NoError(t, err)
+		assert.Equal(t, testVersion, version)
+	})
+	t.Run("get nothing from file", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		err := fs.MkdirAll(testPath, 0755)
+		require.NoError(t, err)
+		_, err = fs.Create(filepath.Join(testPath, testVersion))
+		require.NoError(t, err)
+
+		version, err := findVersionFromFileSystem(fs, testPath)
+		require.NoError(t, err)
+		assert.Empty(t, version)
+	})
+}


### PR DESCRIPTION
# Description
Inspired by #729 
When there's a mismatch between latest version on the Dynakube and the version of the binaries download, the symlink would point to a different version than existed on the file system.

## How can this be tested?
Check `current` symlink on injected pods and verify it's valid. 

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

