### PR TITLE
Fix github action to use correct branch name in ci.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             VERSION="snapshot-$(echo ${GITHUB_HEAD_REF} | sed 's#[^a-zA-Z0-9_-]#-#g')"
           else
             if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         id: prep
         run: |
           if [[ "${{ github.event_name }}" == "pull_request ]]; then
-            VERSION=${GITHUB_HEAD_REF}
+            VERSION="snapshot-$(echo ${GITHUB_HEAD_REF} | sed 's#[^a-zA-Z0-9_-]#-#g')"
           else
             if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
               VERSION="${GITHUB_REF_NAME}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,12 +114,16 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF_NAME}"
-          elif [[ "${GITHUB_REF_NAME}" == "master" ]]; then
-            VERSION="snapshot"
+          if [[ "${{ github.event_name }}" == "pull_request ]]; then
+            VERSION=${GITHUB_HEAD_REF}
           else
-            VERSION="snapshot-$(echo ${GITHUB_REF_NAME} | sed 's#[^a-zA-Z0-9_-]#-#g')"
+            if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+              VERSION="${GITHUB_REF_NAME}"
+            elif [[ "${GITHUB_REF_NAME}" == "master" ]]; then
+              VERSION="snapshot"
+            else
+              VERSION="snapshot-$(echo ${GITHUB_REF_NAME} | sed 's#[^a-zA-Z0-9_-]#-#g')"
+            fi
           fi
 
           LABELS=""


### PR DESCRIPTION
# Description

If Github actions are triggered by PR, the wrong branch name was used. This PR should fix the problem. 

## How can this be tested?

Run the action and check quay for the correct version


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

