### PR TITLE
Add ClusterRoles for OLM activegate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ endif
 SERVICE_ACCOUNTS=--extra-service-accounts dynatrace-dynakube-oneagent
 SERVICE_ACCOUNTS+=--extra-service-accounts dynatrace-dynakube-oneagent-unprivileged
 SERVICE_ACCOUNTS+=--extra-service-accounts dynatrace-kubernetes-monitoring
+SERVICE_ACCOUNTS+=--extra-service-accounts dynatrace-activegate
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle

--- a/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
@@ -1,0 +1,35 @@
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift" (include "dynatrace-operator.platformSet" .))}}
+{{- if eq (default false .Values.olm) true}}
+{{ if eq (include "dynatrace-operator.partial" .) "false" }}
+
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dynatrace-activegate
+  labels:
+  {{- include "dynatrace-operator.activegateLabels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - host
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+{{- end -}}
+{{- end -}}

--- a/config/helm/chart/default/templates/Common/activegate/clusterrolebinding-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/clusterrolebinding-activegate.yaml
@@ -1,0 +1,32 @@
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift" (include "dynatrace-operator.platformSet" .))}}
+{{- if eq (default false .Values.olm) true}}
+{{ if eq (include "dynatrace-operator.partial" .) "false" }}
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dynatrace-activegate
+  labels:
+    {{- include "dynatrace-operator.activegateLabels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: dynatrace-activegate
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: dynatrace-activegate
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}
+{{- end -}}

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
@@ -79,4 +79,15 @@ rules:
       - /livez
     verbs:
       - get
+  {{- if eq (default false .Values.olm) true}}
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - host
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
# Description

ActiveGate need new SecurityContextConstraints, but just linking the ServiceAccount with the SCCs is not enough to have the corresponding permissions, when generating the CSV. Therefore if a an activeGate is deployed via OperatorHub, the statefulset cannot create pods, as it violates SCCs. ClusterRole and RoleBinding for dynatrace-activegate SA are only created if generated for OLM.

## How can this be tested?
```
make bundle VERSION=0.X.X PLATFORM=openshift
```
Should also include now SCCs for `dynatrace-activegate` and `dynatrace-kubernetes-monitoring`


## Checklist
- [x] PR is labeled accordingly

