### PR TITLE
Replace the latest oneagent version endpoint to use the versions endpoint

### DIFF
--- a/src/arch/consts.go
+++ b/src/arch/consts.go
@@ -1,0 +1,9 @@
+package arch
+
+const (
+	FlavorDefault     = "default"
+	FlavorMultidistro = "multidistro"
+
+	ArchX86 = "x86"
+	ArchARM = "arm"
+)

--- a/src/arch/installer_params_amd.go
+++ b/src/arch/installer_params_amd.go
@@ -1,0 +1,7 @@
+//go:build amd64
+// +build amd64
+
+package arch
+
+const Arch = ArchX86
+const Flavor = FlavorMultidistro

--- a/src/arch/installer_params_arm.go
+++ b/src/arch/installer_params_arm.go
@@ -1,0 +1,7 @@
+//go:build arm64
+// +build arm64
+
+package arch
+
+const Arch = ArchARM
+const Flavor = FlavorDefault

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -4,8 +4,8 @@ import (
 	"os"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/provisioner/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/installer"
 	"github.com/spf13/afero"

--- a/src/controllers/csi/provisioner/arch/amd.go
+++ b/src/controllers/csi/provisioner/arch/amd.go
@@ -1,9 +1,0 @@
-//go:build amd64
-// +build amd64
-
-package arch
-
-import "github.com/Dynatrace/dynatrace-operator/src/dtclient"
-
-const Arch = dtclient.ArchX86
-const Flavor = dtclient.FlavorMultidistro

--- a/src/controllers/csi/provisioner/arch/arm.go
+++ b/src/controllers/csi/provisioner/arch/arm.go
@@ -1,9 +1,0 @@
-//go:build arm64
-// +build arm64
-
-package arch
-
-import "github.com/Dynatrace/dynatrace-operator/src/dtclient"
-
-const Arch = dtclient.ArchARM
-const Flavor = dtclient.FlavorDefault

--- a/src/controllers/csi/provisioner/controller_test.go
+++ b/src/controllers/csi/provisioner/controller_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/provisioner/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"

--- a/src/controllers/dynakube/dtversion/version_info.go
+++ b/src/controllers/dynakube/dtversion/version_info.go
@@ -65,7 +65,7 @@ func ExtractVersion(versionString string) (VersionInfo, error) {
 }
 
 func (v VersionInfo) String() string {
-	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.release)
+	return fmt.Sprintf("%d.%d.%d.%s", v.major, v.minor, v.release, v.timestamp)
 }
 
 // NeedsUpgradeRaw parses prev and curr, and returns true when curr is a newer version than prev, or false if they are

--- a/src/dtclient/client.go
+++ b/src/dtclient/client.go
@@ -98,19 +98,6 @@ const (
 	//InstallerTypePaasSh     = "paas-sh"
 )
 
-// Known flavors.
-const (
-	FlavorDefault     = "default"
-	FlavorMusl        = "musl"
-	FlavorMultidistro = "multidistro"
-)
-
-// Known architectures.
-const (
-	ArchX86 = "x86"
-	ArchARM = "arm"
-)
-
 // Known token scopes
 const (
 	TokenScopeInstallerDownload = "InstallerDownload"

--- a/src/dtclient/dynatrace_client_test.go
+++ b/src/dtclient/dynatrace_client_test.go
@@ -148,10 +148,10 @@ func dynatraceServerHandler() http.HandlerFunc {
 }
 
 func handleRequest(request *http.Request, writer http.ResponseWriter) {
-	latestAgentVersion := fmt.Sprintf("/v1/deployment/installer/agent/%s/%s/latest/metainfo", OsUnix, InstallerTypeDefault)
+	agentVersions := fmt.Sprintf("/v1/deployment/installer/agent/versions/%s/%s", OsUnix, InstallerTypePaaS)
 
 	switch request.URL.Path {
-	case latestAgentVersion:
+	case agentVersions:
 		handleLatestAgentVersion(request, writer)
 	case "/v1/entity/infrastructure/hosts":
 		(&ipHandler{}).ServeHTTP(writer, request)

--- a/src/dtclient/endpoints.go
+++ b/src/dtclient/endpoints.go
@@ -19,10 +19,6 @@ func (dtc *dynatraceClient) getAgentVersionsUrl(os, installerType, flavor, arch 
 		dtc.url, os, installerType, flavor, arch)
 }
 
-func (dtc *dynatraceClient) getLatestAgentVersionUrl(os string, installerType string) string {
-	return fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/latest/metainfo", dtc.url, os, installerType)
-}
-
 func (dtc *dynatraceClient) getOneAgentConnectionInfoUrl() string {
 	return fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dtc.url)
 }

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -64,11 +65,11 @@ func TestInstallAgent(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		dtc := &dtclient.MockDynatraceClient{}
 		dtc.
-			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, dtclient.FlavorMultidistro,
+			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), mock.AnythingOfType("*mem.File")).
 			Return(fmt.Errorf(testErrorMessage))
 		dtc.
-			On("GetAgentVersions", dtclient.OsUnix, dtclient.InstallerTypePaaS, dtclient.FlavorMultidistro, mock.AnythingOfType("string")).
+			On("GetAgentVersions", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro, mock.AnythingOfType("string")).
 			Return([]string{}, fmt.Errorf(testErrorMessage))
 		installer := &OneAgentInstaller{
 			fs:  fs,
@@ -76,7 +77,7 @@ func TestInstallAgent(t *testing.T) {
 			props: InstallerProperties{
 				Os:     dtclient.OsUnix,
 				Type:   dtclient.InstallerTypePaaS,
-				Flavor: dtclient.FlavorMultidistro,
+				Flavor: arch.FlavorMultidistro,
 			},
 		}
 
@@ -88,7 +89,7 @@ func TestInstallAgent(t *testing.T) {
 
 		dtc := &dtclient.MockDynatraceClient{}
 		dtc.
-			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, dtclient.FlavorMultidistro,
+			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), mock.AnythingOfType("*mem.File")).
 			Run(func(args mock.Arguments) {
 				writer := args.Get(6).(io.Writer)
@@ -106,7 +107,7 @@ func TestInstallAgent(t *testing.T) {
 			props: InstallerProperties{
 				Os:     dtclient.OsUnix,
 				Type:   dtclient.InstallerTypePaaS,
-				Flavor: dtclient.FlavorMultidistro,
+				Flavor: arch.FlavorMultidistro,
 			},
 		}
 
@@ -117,7 +118,7 @@ func TestInstallAgent(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		dtc := &dtclient.MockDynatraceClient{}
 		dtc.
-			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, dtclient.FlavorMultidistro,
+			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), testVersion, mock.AnythingOfType("[]string"), mock.AnythingOfType("*mem.File")).
 			Run(func(args mock.Arguments) {
 				writer := args.Get(6).(io.Writer)
@@ -135,7 +136,7 @@ func TestInstallAgent(t *testing.T) {
 			props: InstallerProperties{
 				Os:      dtclient.OsUnix,
 				Type:    dtclient.InstallerTypePaaS,
-				Flavor:  dtclient.FlavorMultidistro,
+				Flavor:  arch.FlavorMultidistro,
 				Version: testVersion,
 			},
 		}
@@ -153,7 +154,7 @@ func TestInstallAgent(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		dtc := &dtclient.MockDynatraceClient{}
 		dtc.
-			On("GetLatestAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, dtclient.FlavorMultidistro,
+			On("GetLatestAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), mock.AnythingOfType("*mem.File")).
 			Run(func(args mock.Arguments) {
 				writer := args.Get(5).(io.Writer)
@@ -171,7 +172,7 @@ func TestInstallAgent(t *testing.T) {
 			props: InstallerProperties{
 				Os:      dtclient.OsUnix,
 				Type:    dtclient.InstallerTypePaaS,
-				Flavor:  dtclient.FlavorMultidistro,
+				Flavor:  arch.FlavorMultidistro,
 				Version: VersionLatest,
 			},
 		}

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/pkg/errors"
 )
 
@@ -124,11 +124,11 @@ func (env *environment) addInstallerTech() error {
 }
 
 func (env *environment) addInstallerArch() {
-	arch, err := checkEnvVar(InstallerArchEnv)
+	archEnv, err := checkEnvVar(InstallerArchEnv)
 	if err != nil {
-		env.InstallerArch = dtclient.ArchX86
+		env.InstallerArch = arch.ArchX86
 	} else {
-		env.InstallerArch = arch
+		env.InstallerArch = archEnv
 	}
 
 }

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -12,12 +12,12 @@ import (
 	"strings"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes"
 	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
-	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/src/ingestendpoint"
 	"github.com/Dynatrace/dynatrace-operator/src/initgeneration"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
@@ -465,7 +465,7 @@ func (m *podMutator) getBasicData(pod *corev1.Pod) (
 	failurePolicy string,
 	image string,
 ) {
-	flavor = kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFlavor, dtclient.FlavorMultidistro)
+	flavor = kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFlavor, arch.FlavorMultidistro)
 	technologies = url.QueryEscape(kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationTechnologies, "all"))
 	installPath = kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInstallPath, dtwebhook.DefaultInstallPath)
 	installerURL = kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInstallerUrl, "")

--- a/src/webhook/mutation/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes"
 	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"
@@ -1278,7 +1279,7 @@ func buildResultPod(_ *testing.T, oneAgentFf FeatureFlag, dataIngestFf FeatureFl
 	if oaEnabled {
 		pod.Spec.InitContainers[0].Env = append(pod.Spec.InitContainers[0].Env,
 			corev1.EnvVar{Name: oneAgentInjectedEnvVarName, Value: "true"},
-			corev1.EnvVar{Name: standalone.InstallerFlavorEnv, Value: dtclient.FlavorMultidistro},
+			corev1.EnvVar{Name: standalone.InstallerFlavorEnv, Value: arch.FlavorMultidistro},
 			corev1.EnvVar{Name: standalone.InstallerTechEnv, Value: "all"},
 			corev1.EnvVar{Name: standalone.InstallPathEnv, Value: "/opt/dynatrace/oneagent-paas"},
 			corev1.EnvVar{Name: standalone.InstallerUrlEnv, Value: ""},


### PR DESCRIPTION
# Description
The latest agent version endpoint we use can't be trusted to give us a version that we can actually download. (it provides the latest version for a different kind of installer).

So instead of that we use the get all versions endpoint and find the latest from that.

## How can this be tested?
Deploy cloudnative on a cluster where
`/deployment/installer/agent/unix/paas/latest/metainfo` returns a version that is not present in 
the output `/deployment​/installer​/agent​/versions​/unix/paas` 
and it shouldn't error anymore.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
