### PR TITLE
Replace the latest oneagent version endpoint to use the versions endpoint

### DIFF
--- a/src/arch/amd.go
+++ b/src/arch/amd.go
@@ -1,0 +1,7 @@
+//go:build amd64
+// +build amd64
+
+package arch
+
+const Arch = ArchX86
+const Flavor = FlavorMultidistro

--- a/src/arch/arm.go
+++ b/src/arch/arm.go
@@ -1,0 +1,7 @@
+//go:build arm64
+// +build arm64
+
+package arch
+
+const Arch = ArchARM
+const Flavor = FlavorDefault

--- a/src/arch/consts.go
+++ b/src/arch/consts.go
@@ -1,0 +1,9 @@
+package arch
+
+const (
+	FlavorDefault     = "default"
+	FlavorMultidistro = "multidistro"
+
+	ArchX86 = "x86"
+	ArchARM = "arm"
+)

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -28,14 +28,6 @@ type agentUpdater struct {
 	recorder      updaterEventRecorder
 }
 
-var installUrlProperties = url.Properties{
-	Os:           dtclient.OsUnix,
-	Type:         dtclient.InstallerTypePaaS,
-	Arch:         arch.Arch,
-	Flavor:       arch.Flavor,
-	Technologies: []string{"all"},
-}
-
 func newAgentUpdater(
 	ctx context.Context,
 	fs afero.Fs,
@@ -57,7 +49,7 @@ func newAgentUpdater(
 			return nil, err
 		}
 	} else {
-		agentInstaller = url.NewUrlInstaller(fs, dtc, &installUrlProperties)
+		agentInstaller = url.NewUrlInstaller(fs, dtc, getUrlProperties(dk.CodeModulesVersion()))
 	}
 	eventRecorder := updaterEventRecorder{
 		recorder: recorder,
@@ -73,6 +65,17 @@ func newAgentUpdater(
 		recorder:      eventRecorder,
 	}, nil
 
+}
+
+func getUrlProperties(version string) *url.Properties {
+	return &url.Properties{
+		Os:           dtclient.OsUnix,
+		Type:         dtclient.InstallerTypePaaS,
+		Arch:         arch.Arch,
+		Flavor:       arch.Flavor,
+		Technologies: []string{"all"},
+		Version:      version,
+	}
 }
 
 func setupImageInstaller(ctx context.Context, fs afero.Fs, apiReader client.Reader, certPath string, dynakube *dynatracev1beta1.DynaKube) (installer.Installer, error) {

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -2,11 +2,11 @@ package csiprovisioner
 
 import (
 	"context"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"os"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/provisioner/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/installer"

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -2,10 +2,10 @@ package csiprovisioner
 
 import (
 	"context"
-	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"os"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"

--- a/src/controllers/csi/provisioner/arch/amd.go
+++ b/src/controllers/csi/provisioner/arch/amd.go
@@ -1,9 +1,0 @@
-//go:build amd64
-// +build amd64
-
-package arch
-
-import "github.com/Dynatrace/dynatrace-operator/src/dtclient"
-
-const Arch = dtclient.ArchX86
-const Flavor = dtclient.FlavorMultidistro

--- a/src/controllers/csi/provisioner/arch/arm.go
+++ b/src/controllers/csi/provisioner/arch/arm.go
@@ -1,9 +1,0 @@
-//go:build arm64
-// +build arm64
-
-package arch
-
-import "github.com/Dynatrace/dynatrace-operator/src/dtclient"
-
-const Arch = dtclient.ArchARM
-const Flavor = dtclient.FlavorDefault

--- a/src/controllers/csi/provisioner/controller_test.go
+++ b/src/controllers/csi/provisioner/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,7 +13,6 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/provisioner/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"

--- a/src/controllers/csi/provisioner/controller_test.go
+++ b/src/controllers/csi/provisioner/controller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"

--- a/src/controllers/dynakube/version/version.go
+++ b/src/controllers/dynakube/version/version.go
@@ -2,7 +2,6 @@ package version
 
 import (
 	"context"
-	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"os"
 	"path"
 	"time"
@@ -10,6 +9,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/status"
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/src/controllers/dynakube/version/version.go
+++ b/src/controllers/dynakube/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"context"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"os"
 	"path"
 	"time"
@@ -120,7 +121,7 @@ func updateImageVersion(
 	}
 
 	if !allowDowngrades && target.Version != "" {
-		if upgrade, err := NeedsUpgradeRaw(target.Version, ver.Version); err != nil {
+		if upgrade, err := version.NeedsUpgradeRaw(target.Version, ver.Version); err != nil {
 			return err
 		} else if !upgrade {
 			return nil

--- a/src/dtclient/agent_version.go
+++ b/src/dtclient/agent_version.go
@@ -30,8 +30,8 @@ func (dtc *dynatraceClient) GetLatestAgentVersion(os, installerType string) (str
 	if err != nil {
 		return "", err
 	}
-	for i := 1; i < len(versions); i++ {
-		versionInfo, err := version.ExtractSemanticVersion(versions[i])
+	for _, rawVersion := range versions[1:] {
+		versionInfo, err := version.ExtractSemanticVersion(rawVersion)
 		if err != nil {
 			return "", err
 		}

--- a/src/dtclient/agent_version.go
+++ b/src/dtclient/agent_version.go
@@ -26,16 +26,16 @@ func (dtc *dynatraceClient) GetLatestAgentVersion(os, installerType string) (str
 		return "", errors.New("no agent versions found")
 	}
 
-	latestVersion, err := version.ExtractVersion(versions[0])
+	latestVersion, err := version.ExtractSemanticVersion(versions[0])
 	if err != nil {
 		return "", err
 	}
 	for i := 1; i < len(versions); i++ {
-		versionInfo, err := version.ExtractVersion(versions[i])
+		versionInfo, err := version.ExtractSemanticVersion(versions[i])
 		if err != nil {
 			return "", err
 		}
-		if version.CompareVersionInfo(versionInfo, latestVersion) > 0 {
+		if version.CompareSemanticVersion(versionInfo, latestVersion) > 0 {
 			latestVersion = versionInfo
 		}
 	}

--- a/src/dtclient/agent_version.go
+++ b/src/dtclient/agent_version.go
@@ -1,7 +1,8 @@
 package dtclient
 
 import (
-	"encoding/json"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"io"
 
 	"github.com/pkg/errors"
@@ -9,26 +10,36 @@ import (
 
 // GetLatestAgentVersion gets the latest agent version for the given OS and installer type.
 func (dtc *dynatraceClient) GetLatestAgentVersion(os, installerType string) (string, error) {
-	if len(os) == 0 || len(installerType) == 0 {
-		return "", errors.New("os or installerType is empty")
+	var flavor string
+	// Default installer type has no "multidistro" flavor
+	// so the default flavor is always needed in that case
+	if installerType == InstallerTypeDefault {
+		flavor = arch.FlavorDefault
+	} else {
+		flavor = arch.Flavor
 	}
-
-	url := dtc.getLatestAgentVersionUrl(os, installerType)
-	resp, err := dtc.makeRequest(url, dynatracePaaSToken)
+	versions, err := dtc.GetAgentVersions(os, installerType, flavor, arch.Arch)
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		//Swallow error, nothing has to be done at this point
-		_ = resp.Body.Close()
-	}()
+	if len(versions) == 0 {
+		return "", errors.New("no agent versions found")
+	}
 
-	responseData, err := dtc.getServerResponseData(resp)
+	latestVersion, err := version.ExtractVersion(versions[0])
 	if err != nil {
 		return "", err
 	}
-
-	return dtc.readResponseForLatestVersion(responseData)
+	for i := 1; i < len(versions); i++ {
+		versionInfo, err := version.ExtractVersion(versions[i])
+		if err != nil {
+			return "", err
+		}
+		if version.CompareVersionInfo(versionInfo, latestVersion) > 0 {
+			latestVersion = versionInfo
+		}
+	}
+	return latestVersion.String(), nil
 }
 
 func (dtc *dynatraceClient) GetEntityIDForIP(ip string) (string, error) {
@@ -45,27 +56,6 @@ func (dtc *dynatraceClient) GetEntityIDForIP(ip string) (string, error) {
 	}
 
 	return hostInfo.entityID, nil
-}
-
-// readLatestVersion reads the agent version from the given server response reader.
-func (dtc *dynatraceClient) readResponseForLatestVersion(response []byte) (string, error) {
-	type jsonResponse struct {
-		LatestAgentVersion string
-	}
-
-	jr := &jsonResponse{}
-	err := json.Unmarshal(response, jr)
-	if err != nil {
-		log.Error(err, "error unmarshalling latest agent version response", "response", string(response))
-		return "", err
-	}
-
-	v := jr.LatestAgentVersion
-	if len(v) == 0 {
-		return "", errors.New("agent version not set")
-	}
-
-	return v, nil
 }
 
 // GetLatestAgent gets the latest agent package for the given OS and installer type.

--- a/src/dtclient/agent_version.go
+++ b/src/dtclient/agent_version.go
@@ -1,10 +1,10 @@
 package dtclient
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/src/arch"
-	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"io"
 
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/pkg/errors"
 )
 
@@ -35,7 +35,7 @@ func (dtc *dynatraceClient) GetLatestAgentVersion(os, installerType string) (str
 		if err != nil {
 			return "", err
 		}
-		if version.CompareSemanticVersion(versionInfo, latestVersion) > 0 {
+		if version.CompareSemanticVersions(versionInfo, latestVersion) > 0 {
 			latestVersion = versionInfo
 		}
 	}

--- a/src/dtclient/agent_version_test.go
+++ b/src/dtclient/agent_version_test.go
@@ -3,6 +3,7 @@ package dtclient
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"net/http"
 	"strings"
 	"testing"
@@ -50,36 +51,6 @@ const (
 	versionedAgentResponse = `zip-content-1.2.3`
 	versionsResponse       = `{ "availableVersions": [ "1.123.1", "1.123.2", "1.123.3", "1.123.4" ] }`
 )
-
-func TestResponseForLatestVersion(t *testing.T) {
-	dc := &dynatraceClient{}
-	readFromString := func(json string) (string, error) {
-		r := []byte(json)
-		return dc.readResponseForLatestVersion(r)
-	}
-
-	{
-		m, err := readFromString(`{"latestAgentVersion": "17"}`)
-		if assert.NoError(t, err) {
-			assert.Equal(t, "17", m)
-		}
-	}
-	{
-		m, err := readFromString(`{"latestAgentVersion": "179.786.861", "extraParam" : "tobeignored"}`)
-		if assert.NoError(t, err) {
-			assert.Equal(t, "179.786.861", m)
-		}
-	}
-	{
-		_, err := readFromString("")
-		assert.Error(t, err, "empty response")
-	}
-	{
-		_, err := readFromString(`{"wrong_json": ["shouldnotbeparsed"]}`)
-		assert.Error(t, err, "invalid data")
-	}
-
-}
 
 func TestGetEntityIDForIP(t *testing.T) {
 	dynatraceServer, _ := createTestDynatraceClient(t, &ipHandler{}, "")
@@ -162,10 +133,10 @@ func testAgentVersionGetLatestAgentVersion(t *testing.T, dynatraceClient Client)
 		assert.Error(t, err, "empty installer type")
 	}
 	{
-		latestAgentVersion, err := dynatraceClient.GetLatestAgentVersion(OsUnix, InstallerTypeDefault)
+		latestAgentVersion, err := dynatraceClient.GetLatestAgentVersion(OsUnix, InstallerTypePaaS)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "17", latestAgentVersion, "latest agent version equals expected version")
+		assert.Equal(t, "1.242.0.20220429-180918", latestAgentVersion, "latest agent version equals expected version")
 	}
 }
 
@@ -186,7 +157,7 @@ func TestGetLatestAgent(t *testing.T) {
 		file, err := afero.TempFile(fs, "client", "installer")
 		require.NoError(t, err)
 
-		err = dtc.GetLatestAgent(OsUnix, InstallerTypePaaS, FlavorMultidistro, "arch", nil, file)
+		err = dtc.GetLatestAgent(OsUnix, InstallerTypePaaS, arch.FlavorMultidistro, "arch", nil, file)
 		require.NoError(t, err)
 
 		resp, err := afero.ReadFile(fs, file.Name())
@@ -198,7 +169,7 @@ func TestGetLatestAgent(t *testing.T) {
 		file, err := afero.TempFile(fs, "client", "installer")
 		require.NoError(t, err)
 
-		err = dtc.GetLatestAgent(OsUnix, InstallerTypePaaS, FlavorMultidistro, "invalid", nil, file)
+		err = dtc.GetLatestAgent(OsUnix, InstallerTypePaaS, arch.FlavorMultidistro, "invalid", nil, file)
 		require.Error(t, err)
 	})
 }
@@ -341,7 +312,19 @@ func handleLatestAgentVersion(request *http.Request, writer http.ResponseWriter)
 	switch request.Method {
 	case "GET":
 		writer.WriteHeader(http.StatusOK)
-		out, _ := json.Marshal(map[string]string{"latestAgentVersion": "17"})
+		out, _ := json.Marshal(
+			map[string][]string{
+				"availableVersions": {
+					"1.241.6.20220422-072953",
+					"1.241.0.20220421-185631",
+					"1.241.15.20220425-161457",
+					"1.242.0.20220429-180918",
+					"1.239.0.20220324-225902",
+					"1.240.0.20220407-234527",
+					"1.242.0.20220429-165750",
+				},
+			},
+		)
 		_, _ = writer.Write(out)
 	default:
 		writeError(writer, http.StatusMethodNotAllowed)

--- a/src/dtclient/agent_version_test.go
+++ b/src/dtclient/agent_version_test.go
@@ -3,12 +3,12 @@ package dtclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/src/dtclient/client.go
+++ b/src/dtclient/client.go
@@ -98,19 +98,6 @@ const (
 	//InstallerTypePaasSh     = "paas-sh"
 )
 
-// Known flavors.
-const (
-	FlavorDefault     = "default"
-	FlavorMusl        = "musl"
-	FlavorMultidistro = "multidistro"
-)
-
-// Known architectures.
-const (
-	ArchX86 = "x86"
-	ArchARM = "arm"
-)
-
 // Known token scopes
 const (
 	TokenScopeInstallerDownload = "InstallerDownload"

--- a/src/dtclient/dynatrace_client_test.go
+++ b/src/dtclient/dynatrace_client_test.go
@@ -148,10 +148,10 @@ func dynatraceServerHandler() http.HandlerFunc {
 }
 
 func handleRequest(request *http.Request, writer http.ResponseWriter) {
-	latestAgentVersion := fmt.Sprintf("/v1/deployment/installer/agent/%s/%s/latest/metainfo", OsUnix, InstallerTypeDefault)
+	agentVersions := fmt.Sprintf("/v1/deployment/installer/agent/versions/%s/%s", OsUnix, InstallerTypePaaS)
 
 	switch request.URL.Path {
-	case latestAgentVersion:
+	case agentVersions:
 		handleLatestAgentVersion(request, writer)
 	case "/v1/entity/infrastructure/hosts":
 		(&ipHandler{}).ServeHTTP(writer, request)

--- a/src/dtclient/endpoints.go
+++ b/src/dtclient/endpoints.go
@@ -19,10 +19,6 @@ func (dtc *dynatraceClient) getAgentVersionsUrl(os, installerType, flavor, arch 
 		dtc.url, os, installerType, flavor, arch)
 }
 
-func (dtc *dynatraceClient) getLatestAgentVersionUrl(os string, installerType string) string {
-	return fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/latest/metainfo", dtc.url, os, installerType)
-}
-
 func (dtc *dynatraceClient) getOneAgentConnectionInfoUrl() string {
 	return fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dtc.url)
 }

--- a/src/installer/url/installer_test.go
+++ b/src/installer/url/installer_test.go
@@ -2,12 +2,12 @@ package url
 
 import (
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/installer/zip"
 	"github.com/spf13/afero"

--- a/src/installer/url/installer_test.go
+++ b/src/installer/url/installer_test.go
@@ -2,6 +2,7 @@ package url
 
 import (
 	"fmt"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"io"
 	"os"
 	"path/filepath"
@@ -48,11 +49,11 @@ func TestInstallAgentFromUrl(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		dtc := &dtclient.MockDynatraceClient{}
 		dtc.
-			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, dtclient.FlavorMultidistro,
+			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), mock.AnythingOfType("*mem.File")).
 			Return(fmt.Errorf(testErrorMessage))
 		dtc.
-			On("GetAgentVersions", dtclient.OsUnix, dtclient.InstallerTypePaaS, dtclient.FlavorMultidistro, mock.AnythingOfType("string")).
+			On("GetAgentVersions", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro, mock.AnythingOfType("string")).
 			Return([]string{}, fmt.Errorf(testErrorMessage))
 		installer := &urlInstaller{
 			fs:  fs,
@@ -60,7 +61,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 			props: &Properties{
 				Os:     dtclient.OsUnix,
 				Type:   dtclient.InstallerTypePaaS,
-				Flavor: dtclient.FlavorMultidistro,
+				Flavor: arch.FlavorMultidistro,
 			},
 		}
 
@@ -72,7 +73,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 
 		dtc := &dtclient.MockDynatraceClient{}
 		dtc.
-			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, dtclient.FlavorMultidistro,
+			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), mock.AnythingOfType("*mem.File")).
 			Run(func(args mock.Arguments) {
 				writer := args.Get(6).(io.Writer)
@@ -90,7 +91,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 			props: &Properties{
 				Os:     dtclient.OsUnix,
 				Type:   dtclient.InstallerTypePaaS,
-				Flavor: dtclient.FlavorMultidistro,
+				Flavor: arch.FlavorMultidistro,
 			},
 		}
 
@@ -101,7 +102,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		dtc := &dtclient.MockDynatraceClient{}
 		dtc.
-			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, dtclient.FlavorMultidistro,
+			On("GetAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), testVersion, mock.AnythingOfType("[]string"), mock.AnythingOfType("*mem.File")).
 			Run(func(args mock.Arguments) {
 				writer := args.Get(6).(io.Writer)
@@ -119,7 +120,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 			props: &Properties{
 				Os:      dtclient.OsUnix,
 				Type:    dtclient.InstallerTypePaaS,
-				Flavor:  dtclient.FlavorMultidistro,
+				Flavor:  arch.FlavorMultidistro,
 				Version: testVersion,
 			},
 		}
@@ -137,7 +138,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		dtc := &dtclient.MockDynatraceClient{}
 		dtc.
-			On("GetLatestAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, dtclient.FlavorMultidistro,
+			On("GetLatestAgent", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), mock.AnythingOfType("*mem.File")).
 			Run(func(args mock.Arguments) {
 				writer := args.Get(5).(io.Writer)
@@ -155,7 +156,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 			props: &Properties{
 				Os:      dtclient.OsUnix,
 				Type:    dtclient.InstallerTypePaaS,
-				Flavor:  dtclient.FlavorMultidistro,
+				Flavor:  arch.FlavorMultidistro,
 				Version: VersionLatest,
 			},
 		}

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -2,11 +2,11 @@ package standalone
 
 import (
 	"fmt"
+	arch "github.com/Dynatrace/dynatrace-operator/src/arch"
 	"os"
 	"strconv"
 	"strings"
 
-	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/pkg/errors"
 )
 
@@ -124,11 +124,11 @@ func (env *environment) addInstallerTech() error {
 }
 
 func (env *environment) addInstallerArch() {
-	arch, err := checkEnvVar(InstallerArchEnv)
+	archEnv, err := checkEnvVar(InstallerArchEnv)
 	if err != nil {
-		env.InstallerArch = dtclient.ArchX86
+		env.InstallerArch = arch.ArchX86
 	} else {
-		env.InstallerArch = arch
+		env.InstallerArch = archEnv
 	}
 
 }

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -2,11 +2,11 @@ package standalone
 
 import (
 	"fmt"
-	arch "github.com/Dynatrace/dynatrace-operator/src/arch"
 	"os"
 	"strconv"
 	"strings"
 
+	arch "github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/pkg/errors"
 )
 

--- a/src/version/semantic.go
+++ b/src/version/semantic.go
@@ -18,12 +18,12 @@ type SemanticVersion struct {
 
 var versionRegex = regexp.MustCompile(`^([\d]+)\.([\d]+)\.([\d]+)\.([\d]+\-[\d]+)$`)
 
-// CompareVersionInfo returns:
+// CompareSemanticVersion returns:
 // 	0: if a == b
 //  n > 0: if a > b
 //  n < 0: if a < b
 //  0 with error: if a == nil || b == nil
-func CompareVersionInfo(a SemanticVersion, b SemanticVersion) int {
+func CompareSemanticVersion(a SemanticVersion, b SemanticVersion) int {
 	if a.major != b.major {
 		return a.major - b.major
 	}
@@ -39,7 +39,7 @@ func CompareVersionInfo(a SemanticVersion, b SemanticVersion) int {
 	return strings.Compare(a.timestamp, b.timestamp)
 }
 
-func ExtractVersion(versionString string) (SemanticVersion, error) {
+func ExtractSemanticVersion(versionString string) (SemanticVersion, error) {
 	version := versionRegex.FindStringSubmatch(versionString)
 
 	if len(version) < 5 {
@@ -71,17 +71,17 @@ func (version SemanticVersion) String() string {
 // NeedsUpgradeRaw parses prev and curr, and returns true when curr is a newer version than prev, or false if they are
 // the same. In case curr is older than prev an error is returned.
 func NeedsUpgradeRaw(prev string, curr string) (bool, error) {
-	parsedPrev, err := ExtractVersion(prev)
+	parsedPrev, err := ExtractSemanticVersion(prev)
 	if err != nil {
 		return false, errors.WithMessage(err, "failed to parse version")
 	}
 
-	parsedCurr, err := ExtractVersion(curr)
+	parsedCurr, err := ExtractSemanticVersion(curr)
 	if err != nil {
 		return false, errors.WithMessage(err, "failed to parse version")
 	}
 
-	comp := CompareVersionInfo(parsedPrev, parsedCurr)
+	comp := CompareSemanticVersion(parsedPrev, parsedCurr)
 	if comp > 0 {
 		return false, errors.Errorf("trying to downgrade from '%s' to '%s'", parsedPrev, parsedCurr)
 	}

--- a/src/version/semantic.go
+++ b/src/version/semantic.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type VersionInfo struct {
+type SemanticVersion struct {
 	major     int
 	minor     int
 	release   int
@@ -23,7 +23,7 @@ var versionRegex = regexp.MustCompile(`^([\d]+)\.([\d]+)\.([\d]+)\.([\d]+\-[\d]+
 //  n > 0: if a > b
 //  n < 0: if a < b
 //  0 with error: if a == nil || b == nil
-func CompareVersionInfo(a VersionInfo, b VersionInfo) int {
+func CompareVersionInfo(a SemanticVersion, b SemanticVersion) int {
 	if a.major != b.major {
 		return a.major - b.major
 	}
@@ -39,33 +39,33 @@ func CompareVersionInfo(a VersionInfo, b VersionInfo) int {
 	return strings.Compare(a.timestamp, b.timestamp)
 }
 
-func ExtractVersion(versionString string) (VersionInfo, error) {
+func ExtractVersion(versionString string) (SemanticVersion, error) {
 	version := versionRegex.FindStringSubmatch(versionString)
 
 	if len(version) < 5 {
-		return VersionInfo{}, fmt.Errorf("version malformed: %s", versionString)
+		return SemanticVersion{}, fmt.Errorf("version malformed: %s", versionString)
 	}
 
 	major, err := strconv.Atoi(version[1])
 	if err != nil {
-		return VersionInfo{}, err
+		return SemanticVersion{}, err
 	}
 
 	minor, err := strconv.Atoi(version[2])
 	if err != nil {
-		return VersionInfo{}, err
+		return SemanticVersion{}, err
 	}
 
 	release, err := strconv.Atoi(version[3])
 	if err != nil {
-		return VersionInfo{}, err
+		return SemanticVersion{}, err
 	}
 
-	return VersionInfo{major, minor, release, version[4]}, nil
+	return SemanticVersion{major, minor, release, version[4]}, nil
 }
 
-func (v VersionInfo) String() string {
-	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.release)
+func (version SemanticVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d.%s", version.major, version.minor, version.release, version.timestamp)
 }
 
 // NeedsUpgradeRaw parses prev and curr, and returns true when curr is a newer version than prev, or false if they are

--- a/src/version/semantic.go
+++ b/src/version/semantic.go
@@ -18,12 +18,12 @@ type SemanticVersion struct {
 
 var versionRegex = regexp.MustCompile(`^([\d]+)\.([\d]+)\.([\d]+)\.([\d]+\-[\d]+)$`)
 
-// CompareSemanticVersion returns:
+// CompareSemanticVersions returns:
 // 	0: if a == b
 //  n > 0: if a > b
 //  n < 0: if a < b
 //  0 with error: if a == nil || b == nil
-func CompareSemanticVersion(a SemanticVersion, b SemanticVersion) int {
+func CompareSemanticVersions(a SemanticVersion, b SemanticVersion) int {
 	if a.major != b.major {
 		return a.major - b.major
 	}
@@ -81,7 +81,7 @@ func NeedsUpgradeRaw(prev string, curr string) (bool, error) {
 		return false, errors.WithMessage(err, "failed to parse version")
 	}
 
-	comp := CompareSemanticVersion(parsedPrev, parsedCurr)
+	comp := CompareSemanticVersions(parsedPrev, parsedCurr)
 	if comp > 0 {
 		return false, errors.Errorf("trying to downgrade from '%s' to '%s'", parsedPrev, parsedCurr)
 	}

--- a/src/version/semantic_test.go
+++ b/src/version/semantic_test.go
@@ -41,10 +41,10 @@ func TestExtractVersion(t *testing.T) {
 	})
 }
 
-func assertIsDefaultVersionInfo(t *testing.T, version VersionInfo, err error) {
+func assertIsDefaultVersionInfo(t *testing.T, version SemanticVersion, err error) {
 	assert.Error(t, err)
 	assert.NotNil(t, version)
-	assert.Equal(t, VersionInfo{
+	assert.Equal(t, SemanticVersion{
 		major:     0,
 		minor:     0,
 		release:   0,
@@ -53,8 +53,8 @@ func assertIsDefaultVersionInfo(t *testing.T, version VersionInfo, err error) {
 }
 
 func TestCompareClusterVersion(t *testing.T) {
-	makeVer := func(major, minor, release int, timestamp string) VersionInfo {
-		return VersionInfo{
+	makeVer := func(major, minor, release int, timestamp string) SemanticVersion {
+		return SemanticVersion{
 			major:     major,
 			minor:     minor,
 			release:   release,

--- a/src/version/semantic_test.go
+++ b/src/version/semantic_test.go
@@ -7,36 +7,36 @@ import (
 )
 
 func TestExtractVersion(t *testing.T) {
-	t.Run("ExtractVersion", func(t *testing.T) {
-		version, err := ExtractVersion("1.203.0.20200908-220956")
+	t.Run("ExtractSemanticVersion", func(t *testing.T) {
+		version, err := ExtractSemanticVersion("1.203.0.20200908-220956")
 		assert.NoError(t, err)
 		assert.NotNil(t, version)
 
-		version, err = ExtractVersion("2.003.0.20200908-220956")
+		version, err = ExtractSemanticVersion("2.003.0.20200908-220956")
 		assert.NoError(t, err)
 		assert.NotNil(t, version)
 
-		version, err = ExtractVersion("1.003.5.20200908-220956")
+		version, err = ExtractSemanticVersion("1.003.5.20200908-220956")
 		assert.NoError(t, err)
 		assert.NotNil(t, version)
 	})
-	t.Run("ExtractVersion fails on malformed version", func(t *testing.T) {
-		version, err := ExtractVersion("1.203")
+	t.Run("ExtractSemanticVersion fails on malformed version", func(t *testing.T) {
+		version, err := ExtractSemanticVersion("1.203")
 		assertIsDefaultVersionInfo(t, version, err)
 
-		version, err = ExtractVersion("2.003.x.20200908-220956")
+		version, err = ExtractSemanticVersion("2.003.x.20200908-220956")
 		assertIsDefaultVersionInfo(t, version, err)
 
-		version, err = ExtractVersion("")
+		version, err = ExtractSemanticVersion("")
 		assertIsDefaultVersionInfo(t, version, err)
 
-		version, err = ExtractVersion("abc")
+		version, err = ExtractSemanticVersion("abc")
 		assertIsDefaultVersionInfo(t, version, err)
 
-		version, err = ExtractVersion("a.bcd.e")
+		version, err = ExtractSemanticVersion("a.bcd.e")
 		assertIsDefaultVersionInfo(t, version, err)
 
-		version, err = ExtractVersion("asdadasdsd.asd1.2.3")
+		version, err = ExtractSemanticVersion("asdadasdsd.asd1.2.3")
 		assertIsDefaultVersionInfo(t, version, err)
 	})
 }
@@ -62,23 +62,23 @@ func TestCompareClusterVersion(t *testing.T) {
 		}
 	}
 
-	t.Run("CompareVersionInfo a == b", func(t *testing.T) {
-		assert.Equal(t, 0, CompareVersionInfo(makeVer(1, 200, 0, ""), makeVer(1, 200, 0, "")))
+	t.Run("CompareSemanticVersion a == b", func(t *testing.T) {
+		assert.Equal(t, 0, CompareSemanticVersion(makeVer(1, 200, 0, ""), makeVer(1, 200, 0, "")))
 	})
 
-	t.Run("CompareVersionInfo a < b", func(t *testing.T) {
-		assert.Less(t, CompareVersionInfo(makeVer(1, 0, 0, ""), makeVer(1, 200, 0, "")), 0)
-		assert.Less(t, CompareVersionInfo(makeVer(0, 0, 0, ""), makeVer(0, 2000, 3000, "")), 0)
-		assert.Less(t, CompareVersionInfo(makeVer(1, 200, 0, ""), makeVer(1, 200, 1, "")), 0)
-		assert.Less(t, CompareVersionInfo(makeVer(1, 200, 0, "0"), makeVer(1, 200, 1, "1")), 0)
+	t.Run("CompareSemanticVersion a < b", func(t *testing.T) {
+		assert.Less(t, CompareSemanticVersion(makeVer(1, 0, 0, ""), makeVer(1, 200, 0, "")), 0)
+		assert.Less(t, CompareSemanticVersion(makeVer(0, 0, 0, ""), makeVer(0, 2000, 3000, "")), 0)
+		assert.Less(t, CompareSemanticVersion(makeVer(1, 200, 0, ""), makeVer(1, 200, 1, "")), 0)
+		assert.Less(t, CompareSemanticVersion(makeVer(1, 200, 0, "0"), makeVer(1, 200, 1, "1")), 0)
 	})
 
-	t.Run("CompareVersionInfo a > b", func(t *testing.T) {
-		assert.Greater(t, CompareVersionInfo(makeVer(1, 200, 0, ""), makeVer(1, 100, 0, "")), 0)
-		assert.Greater(t, CompareVersionInfo(makeVer(2, 0, 0, ""), makeVer(1, 100, 0, "")), 0)
-		assert.Greater(t, CompareVersionInfo(makeVer(1, 201, 0, ""), makeVer(1, 100, 0, "")), 0)
-		assert.Greater(t, CompareVersionInfo(makeVer(1, 0, 0, ""), makeVer(0, 0, 20000, "")), 0)
-		assert.Greater(t, CompareVersionInfo(makeVer(1, 0, 0, "1"), makeVer(1, 0, 0, "0")), 0)
+	t.Run("CompareSemanticVersion a > b", func(t *testing.T) {
+		assert.Greater(t, CompareSemanticVersion(makeVer(1, 200, 0, ""), makeVer(1, 100, 0, "")), 0)
+		assert.Greater(t, CompareSemanticVersion(makeVer(2, 0, 0, ""), makeVer(1, 100, 0, "")), 0)
+		assert.Greater(t, CompareSemanticVersion(makeVer(1, 201, 0, ""), makeVer(1, 100, 0, "")), 0)
+		assert.Greater(t, CompareSemanticVersion(makeVer(1, 0, 0, ""), makeVer(0, 0, 20000, "")), 0)
+		assert.Greater(t, CompareSemanticVersion(makeVer(1, 0, 0, "1"), makeVer(1, 0, 0, "0")), 0)
 	})
 }
 

--- a/src/version/semantic_test.go
+++ b/src/version/semantic_test.go
@@ -62,23 +62,23 @@ func TestCompareClusterVersion(t *testing.T) {
 		}
 	}
 
-	t.Run("CompareSemanticVersion a == b", func(t *testing.T) {
-		assert.Equal(t, 0, CompareSemanticVersion(makeVer(1, 200, 0, ""), makeVer(1, 200, 0, "")))
+	t.Run("CompareSemanticVersions a == b", func(t *testing.T) {
+		assert.Equal(t, 0, CompareSemanticVersions(makeVer(1, 200, 0, ""), makeVer(1, 200, 0, "")))
 	})
 
-	t.Run("CompareSemanticVersion a < b", func(t *testing.T) {
-		assert.Less(t, CompareSemanticVersion(makeVer(1, 0, 0, ""), makeVer(1, 200, 0, "")), 0)
-		assert.Less(t, CompareSemanticVersion(makeVer(0, 0, 0, ""), makeVer(0, 2000, 3000, "")), 0)
-		assert.Less(t, CompareSemanticVersion(makeVer(1, 200, 0, ""), makeVer(1, 200, 1, "")), 0)
-		assert.Less(t, CompareSemanticVersion(makeVer(1, 200, 0, "0"), makeVer(1, 200, 1, "1")), 0)
+	t.Run("CompareSemanticVersions a < b", func(t *testing.T) {
+		assert.Less(t, CompareSemanticVersions(makeVer(1, 0, 0, ""), makeVer(1, 200, 0, "")), 0)
+		assert.Less(t, CompareSemanticVersions(makeVer(0, 0, 0, ""), makeVer(0, 2000, 3000, "")), 0)
+		assert.Less(t, CompareSemanticVersions(makeVer(1, 200, 0, ""), makeVer(1, 200, 1, "")), 0)
+		assert.Less(t, CompareSemanticVersions(makeVer(1, 200, 0, "0"), makeVer(1, 200, 1, "1")), 0)
 	})
 
-	t.Run("CompareSemanticVersion a > b", func(t *testing.T) {
-		assert.Greater(t, CompareSemanticVersion(makeVer(1, 200, 0, ""), makeVer(1, 100, 0, "")), 0)
-		assert.Greater(t, CompareSemanticVersion(makeVer(2, 0, 0, ""), makeVer(1, 100, 0, "")), 0)
-		assert.Greater(t, CompareSemanticVersion(makeVer(1, 201, 0, ""), makeVer(1, 100, 0, "")), 0)
-		assert.Greater(t, CompareSemanticVersion(makeVer(1, 0, 0, ""), makeVer(0, 0, 20000, "")), 0)
-		assert.Greater(t, CompareSemanticVersion(makeVer(1, 0, 0, "1"), makeVer(1, 0, 0, "0")), 0)
+	t.Run("CompareSemanticVersions a > b", func(t *testing.T) {
+		assert.Greater(t, CompareSemanticVersions(makeVer(1, 200, 0, ""), makeVer(1, 100, 0, "")), 0)
+		assert.Greater(t, CompareSemanticVersions(makeVer(2, 0, 0, ""), makeVer(1, 100, 0, "")), 0)
+		assert.Greater(t, CompareSemanticVersions(makeVer(1, 201, 0, ""), makeVer(1, 100, 0, "")), 0)
+		assert.Greater(t, CompareSemanticVersions(makeVer(1, 0, 0, ""), makeVer(0, 0, 20000, "")), 0)
+		assert.Greater(t, CompareSemanticVersions(makeVer(1, 0, 0, "1"), makeVer(1, 0, 0, "0")), 0)
 	})
 }
 

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"net/http"
 	"net/url"
 	"os"
@@ -13,6 +12,7 @@ import (
 	"strings"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes"
 	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"net/http"
 	"net/url"
 	"os"
@@ -17,7 +18,6 @@ import (
 	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/src/deploymentmetadata"
-	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/src/ingestendpoint"
 	"github.com/Dynatrace/dynatrace-operator/src/initgeneration"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
@@ -465,7 +465,7 @@ func (m *podMutator) getBasicData(pod *corev1.Pod) (
 	failurePolicy string,
 	image string,
 ) {
-	flavor = kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFlavor, dtclient.FlavorMultidistro)
+	flavor = kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFlavor, arch.FlavorMultidistro)
 	technologies = url.QueryEscape(kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationTechnologies, "all"))
 	installPath = kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInstallPath, dtwebhook.DefaultInstallPath)
 	installerURL = kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInstallerUrl, "")

--- a/src/webhook/mutation/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator_test.go
@@ -3,12 +3,12 @@ package mutation
 import (
 	"context"
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"sort"
 	"strconv"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes"
 	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"

--- a/src/webhook/mutation/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator_test.go
@@ -3,6 +3,7 @@ package mutation
 import (
 	"context"
 	"fmt"
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"sort"
 	"strconv"
 	"testing"
@@ -1278,7 +1279,7 @@ func buildResultPod(_ *testing.T, oneAgentFf FeatureFlag, dataIngestFf FeatureFl
 	if oaEnabled {
 		pod.Spec.InitContainers[0].Env = append(pod.Spec.InitContainers[0].Env,
 			corev1.EnvVar{Name: oneAgentInjectedEnvVarName, Value: "true"},
-			corev1.EnvVar{Name: standalone.InstallerFlavorEnv, Value: dtclient.FlavorMultidistro},
+			corev1.EnvVar{Name: standalone.InstallerFlavorEnv, Value: arch.FlavorMultidistro},
 			corev1.EnvVar{Name: standalone.InstallerTechEnv, Value: "all"},
 			corev1.EnvVar{Name: standalone.InstallPathEnv, Value: "/opt/dynatrace/oneagent-paas"},
 			corev1.EnvVar{Name: standalone.InstallerUrlEnv, Value: ""},


### PR DESCRIPTION
# Description

based on: https://github.com/Dynatrace/dynatrace-operator/pull/760

## How can this be tested?
same as https://github.com/Dynatrace/dynatrace-operator/pull/760


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

