### PR TITLE
Check for fork correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name != 'pull_request' ||
-      github.pull_request.head.repo.fork == false
+      !github.event.pull_request.head.repo.fork
     needs: [tests, linting, builddockerimage]
     env:
       IMAGE_QUAY: quay.io/dynatrace/dynatrace-operator


### PR DESCRIPTION
# Description
Push image step should not trigger on `pull_request`. Check was implemented incorrectly in #743

## How can this be tested?
Pull request should not trigger push image.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

