### PR TITLE
Update qemu and buildx actions in ci.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ env:
 
 on:
   push:
+    branches:
+      - master
+      - release-*
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
           outputs: type=docker,dest=/tmp/operator-amd64.tar
       - name: Build arm64
         uses: docker/build-push-action@v2
-        if: ${{ contains(github.ref, 'refs/heads/master') || contains(github.ref, 'refs/heads/release-') }}
+        #if: ${{ contains(github.ref, 'refs/heads/master') || contains(github.ref, 'refs/heads/release-') }}
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
           outputs: type=docker,dest=/tmp/operator-amd64.tar
       - name: Build arm64
         uses: docker/build-push-action@v2
-        #if: ${{ contains(github.ref, 'refs/heads/master') || contains(github.ref, 'refs/heads/release-') }}
+        if: ${{ contains(github.ref, 'refs/heads/master') || contains(github.ref, 'refs/heads/release-') }}
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ env:
 
 on:
   push:
-    branches:
-      - "*"
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: amd64
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Set up Golang
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
# Description

ARM builds stopped working in our Github Actions. Upgrading qemu and buildx actions fix this problem. 

Additionally, explicitly trigger push event only on release and master branch.

## How can this be tested?

Look onto arm action step and check if it run successfully.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

