### PR TITLE
Update index for `v0.6.0` release

### DIFF
--- a/config/helm/repos/stable/index.yaml
+++ b/config/helm/repos/stable/index.yaml
@@ -2,6 +2,27 @@ apiVersion: v1
 entries:
   dynatrace-operator:
   - apiVersion: v2
+    appVersion: 0.6.0
+    created: '2022-05-06T09:54:25.498445534Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 5740d1d7d1e895d969717a8160d02493224086366282628c0c2e148ca8f80006
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marcell.sevcsik@dynatrace.com
+        name: 0sewa0
+      - email: christoph.muellner@dynatrace.com
+        name: chrismuellner
+      - email: lukas.hinterreiter@dynatrace.com
+        name: luhi-DT
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+      - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.6.0/dynatrace-operator-0.6.0.tgz
+    version: 0.6.0
+  - apiVersion: v2
     appVersion: 0.5.1
     created: '2022-04-07T09:36:15.557655516Z'
     description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
@@ -205,4 +226,4 @@ entries:
     urls:
     - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.1.0.tgz
     version: 0.1.0
-generated: '2022-03-29T09:20:52.729619337Z'
+generated: '2022-05-06T09:54:25.487121387Z'

--- a/config/helm/repos/stable/index.yaml.previous
+++ b/config/helm/repos/stable/index.yaml.previous
@@ -2,6 +2,48 @@ apiVersion: v1
 entries:
   dynatrace-operator:
   - apiVersion: v2
+    appVersion: 0.5.1
+    created: '2022-04-07T09:36:15.557655516Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 10fea82022e0aa2287feafbb37530eff8913dae7cad2fe6f762de4a73b9eaaf9
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+    - email: marcell.sevcsik@dynatrace.com
+      name: 0sewa0
+    - email: christoph.muellner@dynatrace.com
+      name: chrismuellner
+    - email: lukas.hinterreiter@dynatrace.com
+      name: luhi-DT
+    name: dynatrace-operator
+    sources:
+    - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+    - https://github.com/Dynatrace/dynatrace-operator/raw/v0.5.1/config/helm/repos/stable/dynatrace-operator-0.5.1.tgz
+    version: 0.5.1
+  - apiVersion: v2
+    appVersion: 0.5.0
+    created: '2022-03-16T09:20:52.737361919Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: f1059a1e1b08e84537a5210bd6dce072953a197629fe5d21e85a7ceb2235f88c
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+    - email: marcell.sevcsik@dynatrace.com
+      name: 0sewa0
+    - email: christoph.muellner@dynatrace.com
+      name: chrismuellner
+    - email: lukas.hinterreiter@dynatrace.com
+      name: luhi-DT
+    name: dynatrace-operator
+    sources:
+    - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+    - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.5.0.tgz
+    version: 0.5.0
+  - apiVersion: v2
     appVersion: 0.4.2
     created: '2022-02-15T16:50:00.153390163Z'
     description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
@@ -64,4 +106,5 @@ entries:
     urls:
     - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.0.tgz
     version: 0.4.0
-generated: '2022-02-15T16:50:00.144747076Z'
+generated: '2022-03-16T09:20:52.729619337Z'
+


### PR DESCRIPTION
# Description
Upgrade `index.yaml` to include latest version of the helm chart.

## How can this be tested?
Helm upgrade to and install of `v0.6.0` works.

## Checklist
- [x] PR is labeled accordingly

