### PR TITLE
Fixes unintentional introduction of DEPLOYED_VIA_OLM environment variable

### DIFF
--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -4129,8 +4129,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: DEPLOYED_VIA_OLM
-              value: "true"
           ports:
             - containerPort: 10080
               name: server-port
@@ -4264,8 +4262,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: DEPLOYED_VIA_OLM
-              value: "true"
           readinessProbe:
             httpGet:
               path: /livez


### PR DESCRIPTION
# Description

Removes the ´DEPLOYED_VIA_OLM` environment variable from normal deployment manifests.

## How can this be tested?

Both `kubernetes-all.yaml` and `openshift-all.yaml` should deploy the Operator and Webhook without the `DEPLOYED_VIA_OLM` environment variable.

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

