### PR TITLE
Improve yamls generation in Makefile 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,12 +83,15 @@ tags
 config/deploy/kustomization.yaml
 
 /.run/
-/config/deploy/kubernetes/kubernetes.yaml
-/config/deploy/kubernetes/kubernetes-csi.yaml
-/config/deploy/kubernetes/kubernetes-olm.yaml
-/config/deploy/openshift/openshift.yaml
-/config/deploy/openshift/openshift-csi.yaml
-/config/deploy/openshift/openshift-olm.yaml
+config/deploy/kubernetes/kubernetes-crd.yaml
+config/deploy/kubernetes/kubernetes-csidriver.yaml
+config/deploy/kubernetes/kubernetes-others.yaml
+onfig/deploy/kubernetes/kubernetes-olm.yaml
+config/deploy/openshift/openshift-crd.yaml
+config/deploy/openshift/openshift-csidriver.yaml
+config/deploy/openshift/openshift-others.yaml
+onfig/deploy/openshift/openshift-olm.yaml
+
 
 .vscode
 

--- a/.gitignore
+++ b/.gitignore
@@ -83,11 +83,11 @@ tags
 config/deploy/kustomization.yaml
 
 /.run/
-config/deploy/kubernetes/kubernetes-crd.yaml
+config/deploy/kubernetes/kubernetes.yaml
 config/deploy/kubernetes/kubernetes-csidriver.yaml
 config/deploy/kubernetes/kubernetes-others.yaml
 config/deploy/kubernetes/kubernetes-olm.yaml
-config/deploy/openshift/openshift-crd.yaml
+config/deploy/openshift/openshift.yaml
 config/deploy/openshift/openshift-csidriver.yaml
 config/deploy/openshift/openshift-others.yaml
 config/deploy/openshift/openshift-olm.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -86,11 +86,11 @@ config/deploy/kustomization.yaml
 config/deploy/kubernetes/kubernetes-crd.yaml
 config/deploy/kubernetes/kubernetes-csidriver.yaml
 config/deploy/kubernetes/kubernetes-others.yaml
-onfig/deploy/kubernetes/kubernetes-olm.yaml
+config/deploy/kubernetes/kubernetes-olm.yaml
 config/deploy/openshift/openshift-crd.yaml
 config/deploy/openshift/openshift-csidriver.yaml
 config/deploy/openshift/openshift-others.yaml
-onfig/deploy/openshift/openshift-olm.yaml
+config/deploy/openshift/openshift-olm.yaml
 
 
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,9 @@ manifests-crd: generate-crd controller-gen kustomize
 		--set autoCreateSecret=false \
 		--set operator.image="$(MASTER_IMAGE)" > "$(KUBERNETES_OTHERS_YAML)"
 
-	sed -i "/app.kubernetes.io\/managed-by/d" "$(KUBERNETES_OTHERS_YAML)" 
-	sed -i "/helm.sh/d" "$(KUBERNETES_OTHERS_YAML)" 
+	grep -v 'app.kubernetes.io/managed-by' "$(KUBERNETES_OTHERS_YAML)"  > config/deploy/kubernetes/tmp.yaml
+	grep -v 'helm.sh' config/deploy/kubernetes/tmp.yaml > "$(KUBERNETES_OTHERS_YAML)"
+	rm config/deploy/kubernetes/tmp.yaml
 
 	$(KUSTOMIZE) build config/crd | cat - "$(KUBERNETES_OTHERS_YAML)" > "$(KUBERNETES_CRD_YAML)"
 
@@ -156,8 +157,9 @@ manifests-k8s-csidriver:
 		--set autoCreateSecret=false \
 		--set operator.image="$(MASTER_IMAGE)" > "$(KUBERNETES_CSIDRIVER_YAML)"
 
-	sed -i "/app.kubernetes.io\/managed-by/d" "$(KUBERNETES_CSIDRIVER_YAML)" 
-	sed -i "/helm.sh/d" "$(KUBERNETES_CSIDRIVER_YAML)" 
+	grep -v 'app.kubernetes.io/managed-by' "$(KUBERNETES_CSIDRIVER_YAML)"  > config/deploy/kubernetes/tmp.yaml
+	grep -v 'helm.sh' config/deploy/kubernetes/tmp.yaml > "$(KUBERNETES_CSIDRIVER_YAML)"
+	rm config/deploy/kubernetes/tmp.yaml
 
 manifests-ocp: manifests-ocp-crd manifests-ocp-csidriver
 	cp "$(OPENSHIFT_CRD_YAML)" "$(OPENSHIFT_OLM_YAML)"
@@ -177,8 +179,9 @@ manifests-ocp-crd: generate-crd controller-gen kustomize
 		--set createSecurityContextConstraints="true" \
 		--set operator.image="$(MASTER_IMAGE)" > "$(OPENSHIFT_OTHERS_YAML)"
 
-	sed -i "/app.kubernetes.io\/managed-by/d" "$(OPENSHIFT_OTHERS_YAML)"
-	sed -i "/helm.sh/d" "$(OPENSHIFT_OTHERS_YAML)" 
+	grep -v 'app.kubernetes.io/managed-by' "$(OPENSHIFT_OTHERS_YAML)"  > config/deploy/kubernetes/tmp.yaml
+	grep -v 'helm.sh' config/deploy/kubernetes/tmp.yaml > "$(OPENSHIFT_OTHERS_YAML)"
+	rm config/deploy/kubernetes/tmp.yaml
 
 	$(KUSTOMIZE) build config/crd | cat - "$(OPENSHIFT_OTHERS_YAML)" > "$(OPENSHIFT_CRD_YAML)"
 
@@ -194,9 +197,10 @@ manifests-ocp-csidriver:
 		--set createSecurityContextConstraints="true" \
 		--set operator.image="$(MASTER_IMAGE)" > "$(OPENSHIFT_CSIDRIVER_YAML)"
 
-	sed -i "/app.kubernetes.io\/managed-by/d" "$(OPENSHIFT_CSIDRIVER_YAML)" 
-	sed -i "/helm.sh/d" "$(OPENSHIFT_CSIDRIVER_YAML)" 
-
+	grep -v 'app.kubernetes.io/managed-by' "$(OPENSHIFT_CSIDRIVER_YAML)"  > config/deploy/kubernetes/tmp.yaml
+	grep -v 'helm.sh' config/deploy/kubernetes/tmp.yaml > "$(OPENSHIFT_CSIDRIVER_YAML)"
+	rm config/deploy/kubernetes/tmp.yaml
+	
 
 # Run go fmt against code
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -123,11 +123,11 @@ push-tagged-image: push-image
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: manifests-k8s manifests-ocp
 
-manifests-k8s: manifests-k8s-crd manifests-k8s-csidriver
+manifests-k8s: manifests-crd manifests-k8s-csidriver
 	cp "$(KUBERNETES_CRD_YAML)" "$(KUBERNETES_OLM_YAML)"
 	cat "$(KUBERNETES_CRD_YAML)" "$(KUBERNETES_CSIDRIVER_YAML)" > "$(KUBERNETES_ALL_YAML)"
 
-manifests-k8s-crd: generate-crd controller-gen kustomize
+manifests-crd: generate-crd controller-gen kustomize
 	# Create directories for manifests if they do not exist
 	mkdir -p config/deploy/kubernetes
 
@@ -158,7 +158,6 @@ manifests-k8s-csidriver:
 
 	sed -i "/app.kubernetes.io\/managed-by/d" "$(KUBERNETES_CSIDRIVER_YAML)" 
 	sed -i "/helm.sh/d" "$(KUBERNETES_CSIDRIVER_YAML)" 
-
 
 manifests-ocp: manifests-ocp-crd manifests-ocp-csidriver
 	cp "$(OPENSHIFT_CRD_YAML)" "$(OPENSHIFT_OLM_YAML)"

--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:


### PR DESCRIPTION
## Description
Basic refactoring of Makefile around yamls generation

- use variables
- remove temp variables
- better targets granularity
- ~`grep -v` replaced with `sed`~
- more descriptive yaml filenames
- no more overriding of `kubernetes.yaml`

## How can this be tested?
`make manifests`

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

