### PR TITLE
Add feature flag for setting `DT_INITIAL_CONNECT_RETRY_MS` env-var to webhook injected containers

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -51,6 +51,7 @@ const (
 	AnnotationFeatureDisableReadOnlyOneAgent      = AnnotationFeaturePrefix + "disable-oneagent-readonly-host-fs"
 	AnnotationFeatureEnableMultipleOsAgentsOnNode = AnnotationFeaturePrefix + "multiple-osagents-on-node"
 	AnnotationFeatureOneAgentIgnoreProxy          = AnnotationFeaturePrefix + "oneagent-ignore-proxy"
+	AnnotationFeatureOneAgentInitialConnectRetry  = AnnotationFeaturePrefix + "oneagent-initial-connect-retry-ms"
 
 	// injection (webhook)
 	AnnotationFeatureEnableWebhookReinvocationPolicy = AnnotationFeaturePrefix + "enable-webhook-reinvocation-policy"
@@ -190,6 +191,22 @@ func (dk *DynaKube) FeatureOneAgentIgnoreProxy() bool {
 // FeatureActiveGateIgnoreProxy is a feature flag to ignore the proxy for ActiveGate when set in CR
 func (dk *DynaKube) FeatureActiveGateIgnoreProxy() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureActiveGateIgnoreProxy) == "true"
+}
+
+// FeatureAgentInitialConnectRetry is a feature flag to configure startup delay of standalone agents
+func (dk *DynaKube) FeatureAgentInitialConnectRetry() int {
+	raw := dk.getFeatureFlagRaw(AnnotationFeatureOneAgentInitialConnectRetry)
+	if raw == "" {
+		return -1
+	}
+
+	val, err := strconv.Atoi(raw)
+	if err != nil {
+		log.Error(err, "failed to parse agentInitialConnectRetry feature-flag")
+		return -1
+	}
+
+	return val
 }
 
 func (dk *DynaKube) getFeatureFlagRaw(annotation string) string {

--- a/src/webhook/mutation/config.go
+++ b/src/webhook/mutation/config.go
@@ -16,6 +16,8 @@ const (
 	workloadKindEnvVarName = "DT_WORKLOAD_KIND"
 	workloadNameEnvVarName = "DT_WORKLOAD_NAME"
 
+	initialConnectRetryEnvVarName = "DT_INITIAL_CONNECT_RETRY_MS"
+
 	dataIngestVolumeName = "data-ingest-enrichment"
 
 	dataIngestEndpointVolumeName = "data-ingest-endpoint"

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -693,6 +693,7 @@ func updateContainerOneAgent(c *corev1.Container, dk *dynatracev1beta1.DynaKube,
 	installPath := kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInstallPath, dtwebhook.DefaultInstallPath)
 
 	addMetadataIfMissing(c, deploymentMetadata)
+	setInitialConnectRetryIfMissing(c, dk)
 
 	c.VolumeMounts = append(c.VolumeMounts,
 		corev1.VolumeMount{
@@ -751,11 +752,28 @@ func addMetadataIfMissing(c *corev1.Container, deploymentMetadata *deploymentmet
 			return
 		}
 	}
-
 	c.Env = append(c.Env,
 		corev1.EnvVar{
 			Name:  dynatraceMetadataEnvVarName,
 			Value: deploymentMetadata.AsString(),
+		})
+}
+
+func setInitialConnectRetryIfMissing(c *corev1.Container, dynaKube *dynatracev1beta1.DynaKube) {
+	if dynaKube.FeatureAgentInitialConnectRetry() < 0 {
+		return
+	}
+
+	for _, v := range c.Env {
+		if v.Name == initialConnectRetryEnvVarName{
+			return
+		}
+	}
+
+	c.Env = append(c.Env,
+		corev1.EnvVar{
+			Name:  initialConnectRetryEnvVarName,
+			Value: strconv.Itoa(dynaKube.FeatureAgentInitialConnectRetry()),
 		})
 }
 

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -765,7 +765,7 @@ func setInitialConnectRetryIfMissing(c *corev1.Container, dynaKube *dynatracev1b
 	}
 
 	for _, v := range c.Env {
-		if v.Name == initialConnectRetryEnvVarName{
+		if v.Name == initialConnectRetryEnvVarName {
 			return
 		}
 	}

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -747,7 +747,7 @@ func updateContainerOneAgent(c *corev1.Container, dk *dynatracev1beta1.DynaKube,
 }
 
 func addMetadataIfMissing(c *corev1.Container, deploymentMetadata *deploymentmetadata.DeploymentMetadata) {
-	if envVarExists(c.Env, dynatraceMetadataEnvVarName) {
+	if kubeobjects.EnvVarIsIn(c.Env, dynatraceMetadataEnvVarName) {
 		return
 	}
 
@@ -759,7 +759,7 @@ func addMetadataIfMissing(c *corev1.Container, deploymentMetadata *deploymentmet
 }
 
 func setInitialConnectRetryIfMissing(c *corev1.Container, dynaKube *dynatracev1beta1.DynaKube) {
-	if dynaKube.FeatureAgentInitialConnectRetry() < 0 || envVarExists(c.Env, initialConnectRetryEnvVarName) {
+	if dynaKube.FeatureAgentInitialConnectRetry() < 0 || kubeobjects.EnvVarIsIn(c.Env, initialConnectRetryEnvVarName) {
 		return
 	}
 
@@ -798,15 +798,6 @@ func getResponseForPod(pod *corev1.Pod, req *admission.Request) admission.Respon
 
 func fieldEnvVar(key string) *corev1.EnvVarSource {
 	return &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: key}}
-}
-
-func envVarExists(envVars []corev1.EnvVar, checkedVar string) bool {
-	for _, v := range envVars {
-		if v.Name == checkedVar {
-			return true
-		}
-	}
-	return false
 }
 
 func silentErrorResponse(podName string, err error) admission.Response {

--- a/src/webhook/mutation/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator_test.go
@@ -1404,7 +1404,9 @@ func TestInstrumentThirdPartyContainers(t *testing.T) {
 
 	// enable feature
 	instance.Annotations = map[string]string{}
+	connectRetryValue := "6000"
 	instance.Annotations[dynatracev1beta1.AnnotationFeatureEnableWebhookReinvocationPolicy] = "true"
+	instance.Annotations[dynatracev1beta1.AnnotationFeatureOneAgentInitialConnectRetry] = connectRetryValue
 	err = inj.client.Update(context.TODO(), instance)
 	require.NoError(t, err)
 
@@ -1488,6 +1490,9 @@ func TestInstrumentThirdPartyContainers(t *testing.T) {
 
 	// check updated pod
 	require.Equal(t, "DT_DEPLOYMENT_METADATA", updPod.Spec.Containers[1].Env[0].Name)
+
+	require.Equal(t, "DT_INITIAL_CONNECT_RETRY_MS", updPod.Spec.Containers[1].Env[1].Name)
+	require.Equal(t, connectRetryValue, updPod.Spec.Containers[1].Env[1].Value)
 
 	var updInstallContainer = updPod.Spec.InitContainers[0]
 


### PR DESCRIPTION
# Description

In order to support istio, we need to give customer the possibility to set `DT_INITIAL_CONNECT_RETRY_MS` via the webhook to their containers, in order to delay the startup of the agent. It was decided that it should be a feature flag, rather than tightly coupling it with the `enableIstio` field in the CR. Therefore I introduced the `feature.dynatrace.com/oneagent-initial-connect-retry-ms` feature flag, where customers can set the preferred value.

## How can this be tested?
Create a Dynakube (either with applicationMonitoring or cloudNative) and add the annotation `feature.dynatrace.com/oneagent-initial-connect-retry-ms: "<value>"` to it. Any pod which is injected now should get the env var `DT_INITIAL_CONNECT_RETRY_MS` set to its containers, with the according value.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

