### PR TITLE
Add tolerations for k8s 1.24 to samples

### DIFF
--- a/config/samples/classicFullStack.yaml
+++ b/config/samples/classicFullStack.yaml
@@ -73,6 +73,9 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
 
       # Optional: resource settings for OneAgent container. Consumption of the OneAgent heavily depends
       # on the workload to monitor; please adjust values accordingly.

--- a/config/samples/cloudNativeFullStack.yaml
+++ b/config/samples/cloudNativeFullStack.yaml
@@ -77,6 +77,9 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
 
       # Optional: resource settings for OneAgent container. Consumption of the OneAgent heavily depends
       # on the workload to monitor; please adjust values accordingly.

--- a/config/samples/hostMonitoring.yaml
+++ b/config/samples/hostMonitoring.yaml
@@ -73,6 +73,9 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
 
       # Optional: resource settings for OneAgent container. Consumption of the OneAgent heavily depends
       # on the workload to monitor; please adjust values accordingly.

--- a/config/samples/multipleDynakubes.yaml
+++ b/config/samples/multipleDynakubes.yaml
@@ -73,6 +73,9 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
   activeGate:
     # Enables listed ActiveGate capabilities
     capabilities:


### PR DESCRIPTION
# Description

Starting with k8s 1.24 nodes will now have two taints (master and control-plane), therefore we need to add both to the samples in order to support k8s 1.24. Read more https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md#design-details

## How can this be tested?
Setup a Cluster with 1.24 and apply one of the changed samples. oneAgent pods should be scheduled on all nodes including master. Also if the k8s version is < 1.24 and only have the `master` taint, they schould also get scheduled on all nodes.


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

