### PR TITLE
Fix error masking in standalone runner

### DIFF
--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -57,32 +57,32 @@ func NewRunner(fs afero.Fs) (*Runner, error) {
 	}, nil
 }
 
-func (runner *Runner) Run() error {
+func (runner *Runner) Run() (resultedError error) {
 	log.Info("standalone agent init started")
-	var err error
-	defer runner.consumeErrorIfNecessary(&err)
+	defer runner.consumeErrorIfNecessary(&resultedError)
 
-	if err = runner.setHostTenant(); err != nil {
+	if err := runner.setHostTenant(); err != nil {
 		return err
 	}
 
 	if runner.env.Mode == InstallerMode && runner.env.OneAgentInjected {
-		if err = runner.installOneAgent(); err != nil {
+		if err := runner.installOneAgent(); err != nil {
 			return err
 		}
 		log.Info("OneAgent download finished")
 	}
-	err = runner.configureInstallation()
+
+	err := runner.configureInstallation()
 	if err == nil {
 		log.Info("standalone agent init completed")
 	}
 	return err
 }
 
-func (runner *Runner) consumeErrorIfNecessary(err *error) {
-	if !runner.env.CanFail && err != nil {
-		log.Error(*err, "This error has been masked to not fail the container.")
-		*err = nil
+func (runner *Runner) consumeErrorIfNecessary(resultedError *error) {
+	if !runner.env.CanFail && *resultedError != nil {
+		log.Error(*resultedError, "This error has been masked to not fail the container.")
+		*resultedError = nil
 	}
 }
 

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -36,22 +36,27 @@ func TestNewRunner(t *testing.T) {
 }
 
 func TestConsumeErrorIfNecessary(t *testing.T) {
-	runner := createMockedRunner(t)
-	t.Run(`consume error`, func(t *testing.T) {
+	t.Run(`no error thrown`, func(t *testing.T) {
+		runner := createMockedRunner(t)
 		runner.env.CanFail = false
-		err := fmt.Errorf("TESTING")
-
-		runner.consumeErrorIfNecessary(&err)
-		assert.NoError(t, err)
+		err := runner.Run()
+		assert.Nil(t, err)
 	})
-	t.Run(`NOT consume error`, func(t *testing.T) {
+	t.Run(`error thrown, but consume error`, func(t *testing.T) {
+		runner := createMockedRunner(t)
+		runner.env.K8NodeName = "" // create artificial error
+		runner.env.CanFail = false
+		err := runner.Run()
+		require.NoError(t, err)
+		assert.Nil(t, err)
+	})
+	t.Run(`error thrown, but don't consume error`, func(t *testing.T) {
+		runner := createMockedRunner(t)
+		runner.env.K8NodeName = "" // create artificial error
 		runner.env.CanFail = true
-		err := fmt.Errorf("TESTING")
-
-		runner.consumeErrorIfNecessary(&err)
-		assert.Error(t, err)
+		err := runner.Run()
+		assert.NotNil(t, err)
 	})
-
 }
 
 func TestSetHostTenant(t *testing.T) {

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -36,22 +36,19 @@ func TestNewRunner(t *testing.T) {
 }
 
 func TestConsumeErrorIfNecessary(t *testing.T) {
+	runner := createMockedRunner(t)
 	t.Run(`no error thrown`, func(t *testing.T) {
-		runner := createMockedRunner(t)
 		runner.env.CanFail = false
 		err := runner.Run()
 		assert.Nil(t, err)
 	})
 	t.Run(`error thrown, but consume error`, func(t *testing.T) {
-		runner := createMockedRunner(t)
 		runner.env.K8NodeName = "" // create artificial error
 		runner.env.CanFail = false
 		err := runner.Run()
-		require.NoError(t, err)
 		assert.Nil(t, err)
 	})
 	t.Run(`error thrown, but don't consume error`, func(t *testing.T) {
-		runner := createMockedRunner(t)
 		runner.env.K8NodeName = "" // create artificial error
 		runner.env.CanFail = true
 		err := runner.Run()


### PR DESCRIPTION
# Description
Currently our error masking within the standalone runner is broken. The runner always logs that an error has been masked even though there is no error. This happened because, in the check for masking the error `consumeErrorIfNecessary()`, we do not check for the error itself but for the pointer, which is never nil. Additionally the defer function set the wrong variable to nil because `defer` runs a function **after** the return statement but **before** the function is actually returned, thus enabling modify returned results, but only named return results can be accessed normally. This caused that the error was set to nil, but not actual returned error, because go already evaluated the return result.

More here: https://stackoverflow.com/questions/48680222/what-is-the-difference-between-named-return-value-and-normal-return-value

## How can this be tested?
**Before this PR**
Deploy cloudNative or applicationMonitoring on a cluster and deploy sample apps. If you now check the logs of the initContainer, you can see the error log at the end of the run. Additionally if an error happens within the run and the failure policy is set to `silent`, the sample app would crash, because the initContainer is not finished successfully. 

**After this PR**
Deploy cloudNative or applicationMonitoring on a cluster and deploy sample apps. If you now check the logs of the initContainer, should not see any false error log anymore. Additionally if an error happens within the run and the failure policy is set to `silent`, the sample app is not crashing anymore and the initContainer finishes with 0 even though there was an error. 

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

