### PR TITLE
Changes reinvocation policy to be enabled by default

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -91,8 +91,8 @@ func (dk *DynaKube) FeatureOneAgentMaxUnavailable() int {
 	return val
 }
 
-// FeatureDisableWebhookReinvocationPolicy is a feature flag to enable instrumenting missing containers
-// by enabling reinvocation for webhook.
+// FeatureDisableWebhookReinvocationPolicy disables the reinvocation for the Operator's webhooks.
+// This disables instrumenting containers injected by other webhooks following the admission to the Operator's webhook.
 func (dk *DynaKube) FeatureDisableWebhookReinvocationPolicy() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureDisableWebhookReinvocationPolicy) == "true"
 }

--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -56,10 +56,10 @@ const (
 	AnnotationFeatureOneAgentInitialConnectRetry  = AnnotationFeaturePrefix + "oneagent-initial-connect-retry-ms"
 
 	// injection (webhook)
-	AnnotationFeatureEnableWebhookReinvocationPolicy = AnnotationFeaturePrefix + "enable-webhook-reinvocation-policy"
-	AnnotationFeatureIgnoreUnknownState              = AnnotationFeaturePrefix + "ignore-unknown-state"
-	AnnotationFeatureIgnoredNamespaces               = AnnotationFeaturePrefix + "ignored-namespaces"
-	AnnotationFeatureDisableMetadataEnrichment       = AnnotationFeaturePrefix + "disable-metadata-enrichment"
+	AnnotationFeatureDisableWebhookReinvocationPolicy = AnnotationFeaturePrefix + "disable-webhook-reinvocation-policy"
+	AnnotationFeatureIgnoreUnknownState               = AnnotationFeaturePrefix + "ignore-unknown-state"
+	AnnotationFeatureIgnoredNamespaces                = AnnotationFeaturePrefix + "ignored-namespaces"
+	AnnotationFeatureDisableMetadataEnrichment        = AnnotationFeaturePrefix + "disable-metadata-enrichment"
 )
 
 var (
@@ -91,10 +91,10 @@ func (dk *DynaKube) FeatureOneAgentMaxUnavailable() int {
 	return val
 }
 
-// FeatureEnableWebhookReinvocationPolicy is a feature flag to enable instrumenting missing containers
+// FeatureDisableWebhookReinvocationPolicy is a feature flag to enable instrumenting missing containers
 // by enabling reinvocation for webhook.
-func (dk *DynaKube) FeatureEnableWebhookReinvocationPolicy() bool {
-	return dk.getFeatureFlagRaw(AnnotationFeatureEnableWebhookReinvocationPolicy) == "true"
+func (dk *DynaKube) FeatureDisableWebhookReinvocationPolicy() bool {
+	return dk.getFeatureFlagRaw(AnnotationFeatureDisableWebhookReinvocationPolicy) == "true"
 }
 
 // FeatureIgnoreUnknownState is a feature flag that makes the operator inject into applications even when the dynakube is in an UNKNOWN state,

--- a/src/dtclient/agent_tenant_info_test.go
+++ b/src/dtclient/agent_tenant_info_test.go
@@ -53,6 +53,11 @@ func TestTenant(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, tenantInfo)
 
+		// Logging a newline because otherwise the "--- PASS" line is on the same line as the error
+		// logged in GetAgentTenantInfo() which makes IntelliJ / Goland think it has not terminated
+		// which means the tests of this suit are not reported correctly.
+		log.Info("\n")
+
 		assert.Equal(t, "invalid character 'h' in literal true (expecting 'r')", err.Error())
 	})
 }

--- a/src/kubeobjects/consts_test.go
+++ b/src/kubeobjects/consts_test.go
@@ -1,0 +1,18 @@
+package kubeobjects
+
+const (
+	testValue1 = "test-value"
+	testValue2 = "test-alternative-value"
+	testKey1   = "test-key"
+	testKey2   = "test-name"
+
+	testSecretName = "super-secret"
+	testNamespace  = "test-namespace"
+
+	testAppName          = "dynatrace-operator"
+	testAppVersion       = "snapshot"
+	testName             = "test-name"
+	testComponent        = "test-component"
+	testComponentFeature = "test-component-feature"
+	testComponentVersion = "test-component-version"
+)

--- a/src/kubeobjects/env.go
+++ b/src/kubeobjects/env.go
@@ -5,7 +5,7 @@ import corev1 "k8s.io/api/core/v1"
 func FindEnvVar(envVarList []corev1.EnvVar, name string) *corev1.EnvVar {
 	for i, envVar := range envVarList {
 		if envVar.Name == name {
-			// returning reference to env var to ease later manipulation of the same
+			// returning reference to env var to ease later manipulation of it
 			return &envVarList[i]
 		}
 	}

--- a/src/kubeobjects/env.go
+++ b/src/kubeobjects/env.go
@@ -1,0 +1,22 @@
+package kubeobjects
+
+import corev1 "k8s.io/api/core/v1"
+
+func FindEnvVar(envVarList []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i, envVar := range envVarList {
+		if envVar.Name == name {
+			// returning reference to env var to ease later manipulation of the same
+			return &envVarList[i]
+		}
+	}
+	return nil
+}
+
+func EnvVarIsIn(envVars []corev1.EnvVar, envVarToCheck string) bool {
+	for _, envVar := range envVars {
+		if envVar.Name == envVarToCheck {
+			return true
+		}
+	}
+	return false
+}

--- a/src/kubeobjects/env_test.go
+++ b/src/kubeobjects/env_test.go
@@ -1,0 +1,39 @@
+package kubeobjects
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestFindEnvVar(t *testing.T) {
+	envVars := []v1.EnvVar{
+		{Name: testKey1, Value: testAppVersion},
+		{Name: testKey2, Value: testAppName},
+	}
+
+	envVar := FindEnvVar(envVars, testKey1)
+	assert.NotNil(t, envVar)
+	assert.Equal(t, testKey1, envVar.Name)
+	assert.Equal(t, testAppVersion, envVar.Value)
+
+	envVar = FindEnvVar(envVars, testKey2)
+	assert.NotNil(t, envVar)
+	assert.Equal(t, testKey2, envVar.Name)
+	assert.Equal(t, testAppName, envVar.Value)
+
+	envVar = FindEnvVar(envVars, "invalid-key")
+	assert.Nil(t, envVar)
+}
+
+func TestEnvVarIsIn(t *testing.T) {
+	envVars := []v1.EnvVar{
+		{Name: testKey1, Value: testAppVersion},
+		{Name: testKey2, Value: testAppName},
+	}
+
+	assert.True(t, EnvVarIsIn(envVars, testKey1))
+	assert.True(t, EnvVarIsIn(envVars, testKey2))
+	assert.False(t, EnvVarIsIn(envVars, "invalid-key"))
+}

--- a/src/kubeobjects/labels_test.go
+++ b/src/kubeobjects/labels_test.go
@@ -6,15 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	testAppName          = "dynatrace-operator"
-	testAppVersion       = "snapshot"
-	testName             = "test-name"
-	testComponent        = "test-component"
-	testComponentFeature = "test-component-feature"
-	testComponentVersion = "test-component-version"
-)
-
 func TestConstructors(t *testing.T) {
 	appLabels := NewAppLabels(testComponent, testName, testComponentFeature, testComponentVersion)
 	coreLabels := NewCoreLabels(testName, testComponent)

--- a/src/kubeobjects/secret_test.go
+++ b/src/kubeobjects/secret_test.go
@@ -14,16 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-const (
-	testValue1 = "test-value"
-	testValue2 = "test-alternative-value"
-	testKey1   = "test-key"
-	testKey2   = "test-name"
-
-	testSecretName = "super-secret"
-	testNamespace  = "test-namespace"
-)
-
 var log = logger.NewDTLogger()
 
 func TestCreateOrUpdateSecretIfNotExists(t *testing.T) {

--- a/src/kubeobjects/slice.go
+++ b/src/kubeobjects/slice.go
@@ -51,12 +51,3 @@ func PortIsIn(ports []corev1.ContainerPort, portToCheck int32) bool {
 	}
 	return false
 }
-
-func EnvVarIsIn(envVars []corev1.EnvVar, envVarToCheck string) bool {
-	for _, envVar := range envVars {
-		if envVar.Name == envVarToCheck {
-			return true
-		}
-	}
-	return false
-}

--- a/src/mapper/dynakubes.go
+++ b/src/mapper/dynakubes.go
@@ -82,7 +82,7 @@ func (dm DynakubeMapper) mapFromDynakube(nsList *corev1.NamespaceList, dkList *d
 
 	for i := range nsList.Items {
 		namespace := &nsList.Items[i]
-		updated, err = updateNamespace(dm.operatorNs, namespace, dkList)
+		updated, err = updateNamespace(namespace, dkList)
 		if err != nil {
 			return nil, err
 		}

--- a/src/mapper/namespaces.go
+++ b/src/mapper/namespaces.go
@@ -39,5 +39,5 @@ func (nm NamespaceMapper) updateNamespace() (bool, error) {
 		return false, errors.Cause(err)
 	}
 
-	return updateNamespace(nm.operatorNs, nm.targetNs, dkList)
+	return updateNamespace(nm.targetNs, dkList)
 }

--- a/src/webhook/mutation/namespace_mutator.go
+++ b/src/webhook/mutation/namespace_mutator.go
@@ -43,7 +43,7 @@ func (nm *namespaceMutator) InjectClient(clt client.Client) error {
 // 1. ignore the webhook's namespace: this is necessary because if we want to monitor the whole cluster
 //    we would tag our own namespace which would cause the podInjector webhook to inject into our pods which can cause issues. (infra-monitoring pod injected into == bad)
 // 2. if the namespace was updated by the operator => don't do the mapping: we detect this using an annotation, we do this because the operator also does the mapping
-//    but from the dynakube's side (during dynakube reconcile) and we don't want to repeat ourselfs. So we just remove the annotation.
+//    but from the dynakube's side (during dynakube reconcile) and we don't want to repeat ourselves. So we just remove the annotation.
 func (nm *namespaceMutator) Handle(ctx context.Context, request admission.Request) admission.Response {
 	if nm.namespace == request.Namespace {
 		return admission.Patched("")

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -280,19 +280,19 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 }
 
 func (m *podMutator) handleAlreadyInjectedPod(pod *corev1.Pod, dynaKube dynatracev1beta1.DynaKube, injectionInfo *InjectionInfo, req admission.Request) *admission.Response {
-	// are there any injections already?
-	if len(pod.Annotations[dtwebhook.AnnotationDynatraceInjected]) > 0 {
+	if isPodInjected(pod) {
 		if !dynaKube.FeatureDisableWebhookReinvocationPolicy() {
-			log.Info("reinvocation started for pod", "pod", pod.Name, "dynakube", dynaKube.Name)
 			rsp := m.applyReinvocationPolicy(pod, dynaKube, injectionInfo, req)
 			return &rsp
-		} else {
-			log.Info("reinvocation skipped for pod", "pod", pod.Name, "dynakube", dynaKube.Name)
 		}
 		rsp := admission.Patched("")
 		return &rsp
 	}
 	return nil
+}
+
+func isPodInjected(pod *corev1.Pod) bool {
+	return len(pod.Annotations[dtwebhook.AnnotationDynatraceInjected]) > 0
 }
 
 func addToInitContainers(pod *corev1.Pod, installContainer corev1.Container) {

--- a/src/webhook/validation/deprecation_test.go
+++ b/src/webhook/validation/deprecation_test.go
@@ -12,7 +12,7 @@ func TestDeprecationWarning(t *testing.T) {
 	t.Run(`no warning`, func(t *testing.T) {
 		dynakubeMeta := defaultDynakubeObjectMeta
 		dynakubeMeta.Annotations = map[string]string{
-			dynatracev1beta1.AnnotationFeatureEnableWebhookReinvocationPolicy: "true",
+			dynatracev1beta1.AnnotationFeatureDisableWebhookReinvocationPolicy: "true",
 		}
 		dynakube := &dynatracev1beta1.DynaKube{
 			ObjectMeta: dynakubeMeta,
@@ -21,12 +21,12 @@ func TestDeprecationWarning(t *testing.T) {
 			},
 		}
 		assertAllowedResponseWithoutWarnings(t, dynakube)
-		assert.True(t, dynakube.FeatureEnableWebhookReinvocationPolicy())
+		assert.True(t, dynakube.FeatureDisableWebhookReinvocationPolicy())
 	})
 
 	t.Run(`warning present`, func(t *testing.T) {
 		dynakubeMeta := defaultDynakubeObjectMeta
-		split := strings.Split(dynatracev1beta1.AnnotationFeatureEnableWebhookReinvocationPolicy, "/")
+		split := strings.Split(dynatracev1beta1.AnnotationFeatureDisableWebhookReinvocationPolicy, "/")
 		postFix := split[1]
 		dynakubeMeta.Annotations = map[string]string{
 			dynatracev1beta1.DeprecatedFeatureFlagPrefix + postFix: "true",
@@ -38,6 +38,6 @@ func TestDeprecationWarning(t *testing.T) {
 			},
 		}
 		assertAllowedResponseWithWarnings(t, 1, dynakube)
-		assert.True(t, dynakube.FeatureEnableWebhookReinvocationPolicy())
+		assert.True(t, dynakube.FeatureDisableWebhookReinvocationPolicy())
 	})
 }


### PR DESCRIPTION
# Description

Reinvocation of the webhook for already injected pods was disabled by default.
This change enables it by default.

## How can this be tested?

* Create a cluster and install Istio
* Deploy the operator and a dynakube
* Create a test-namespace and label it with `istio-injection=enabled` so that istio injects into pods
* Deploy a sample app
* Pods of your sample app should have an `install-oneagent` init container that includes an environment variable `CONTAINER_X_NAME` with the name of the istio sidecar as a value. E.g. `CONTAINER_2_NAME:      istio-proxy`
* Annotate the dynakube with the `feature.dynatrace.com/disable-webhook-reinvocation-policy: true` annotation
* Delete the pods of your sample app
* Pods of your sample app should have the mentioned environment variable missing

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

