### PR TITLE
Fixes missing "crd:" prefix for crd options

### DIFF
--- a/hack/make/manifests/config.mk
+++ b/hack/make/manifests/config.mk
@@ -1,4 +1,4 @@
-CRD_OPTIONS ?= "crdVersions=v1"
+CRD_OPTIONS ?= "crd:crdVersions=v1"
 OLM ?= false
 
 DYNATRACE_OPERATOR_CRD_YAML=dynatrace-operator-crd.yaml


### PR DESCRIPTION
# Description

`controller-gen` produces an error that `crdVersions` is not recognized.
This is due to the prefix `crd:` missing.

## How can this be tested?

`make install` must run successfully

## Checklist
~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly

