### PR TITLE
Add missing shebang; fix hardcoded /bin/bash path

### DIFF
--- a/hack/build/push_image.sh
+++ b/hack/build/push_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ ! "${TAG}" ]]; then
   echo "TAG variable not set"

--- a/hack/build/test.sh
+++ b/hack/build/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ########## Prepare directories for Kubebuilder ##########
 sudo mkdir -p /usr/local/kubebuilder

--- a/hack/do_env_variables_exist.sh
+++ b/hack/do_env_variables_exist.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # check if parameters are set
 if [ -z "$1" ]
 then

--- a/hack/e2e/install-kuttl.sh
+++ b/hack/e2e/install-kuttl.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
   arch=`uname -m`
   ostype=darwin

--- a/hack/helm/google-marketplace/upload_test.sh
+++ b/hack/helm/google-marketplace/upload_test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -eu
 
 gcloud config set project dynatrace-marketplace-dev

--- a/hack/helm/google-marketplace/verify.sh
+++ b/hack/helm/google-marketplace/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/hack/troubleshoot/troubleshoot.sh
+++ b/hack/troubleshoot/troubleshoot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 


### PR DESCRIPTION
# Description
Added missing shebang.
Changed `#!/bin/bash` to `#!/usr/bin/env bash` in shell scripts.

#### Root casue:
When using `zsh`:
```shell
$ make test/kuttl/activegate                                                                                                                                                                                                                                                                                                                 
hack/do_env_variables_exist.sh "APIURL APITOKEN PAASTOKEN"                                                                                                                                                                                                                                                                                                                           
hack/do_env_variables_exist.sh: 10: Bad substitution                                                                                                                                                                                                                                                                                                                                 
make: *** [hack/make/tests/kuttl.mk:7: test/kuttl/check-env-vars] Error 2
```

## How can this be tested?
1. `make test`
2. manually run scripts that are not used in CI

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

