### PR TITLE
Use apiReader in nodes controller where possible

### DIFF
--- a/src/controllers/nodes/cache.go
+++ b/src/controllers/nodes/cache.go
@@ -11,7 +11,7 @@ import (
 // ErrNotFound is returned when entry hasn't been found on the cache.
 var ErrNotFound = errors.New("not found")
 
-// CacheEntry constains information about a Node.
+// CacheEntry contains information about a Node.
 type CacheEntry struct {
 	Instance                 string    `json:"instance"`
 	IPAddress                string    `json:"ip"`
@@ -95,7 +95,7 @@ func (cache *Cache) ContainsKey(key string) bool {
 }
 
 func (cache *Cache) IsCacheOutdated() bool {
-	if lastUpdated, ok := cache.Obj.Annotations[lastUpdatedCacheAnnotiation]; ok {
+	if lastUpdated, ok := cache.Obj.Annotations[lastUpdatedCacheAnnotation]; ok {
 		if lastUpdatedTime, err := time.Parse(time.RFC3339, lastUpdated); err == nil {
 			return lastUpdatedTime.Add(cacheLifetime).Before(time.Now())
 		} else {
@@ -109,7 +109,7 @@ func (cache *Cache) UpdateTimestamp() {
 	if cache.Obj.Annotations == nil {
 		cache.Obj.Annotations = make(map[string]string)
 	}
-	cache.Obj.Annotations[lastUpdatedCacheAnnotiation] = time.Now().Format(time.RFC3339)
+	cache.Obj.Annotations[lastUpdatedCacheAnnotation] = time.Now().Format(time.RFC3339)
 	cache.upd = true
 }
 

--- a/src/controllers/nodes/config.go
+++ b/src/controllers/nodes/config.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	cacheName                   = "dynatrace-node-cache"
-	cacheLifetime               = 10 * time.Minute
-	lastUpdatedCacheAnnotiation = "DTOperatorLastUpdated"
+	cacheName                  = "dynatrace-node-cache"
+	cacheLifetime              = 10 * time.Minute
+	lastUpdatedCacheAnnotation = "DTOperatorLastUpdated"
 )
 
 var (

--- a/src/controllers/nodes/oneagent_dao.go
+++ b/src/controllers/nodes/oneagent_dao.go
@@ -17,7 +17,7 @@ func (controller *NodesController) determineDynakubeForNode(nodeName string) (*d
 
 func (controller *NodesController) getDynakubeList() (*dynatracev1beta1.DynaKubeList, error) {
 	var dynakubeList dynatracev1beta1.DynaKubeList
-	err := controller.client.List(context.TODO(), &dynakubeList, client.InNamespace(controller.podNamespace))
+	err := controller.apiReader.List(context.TODO(), &dynakubeList, client.InNamespace(controller.podNamespace))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description
Replaces all the `client.Get(...)` to use an `apiReader` instead. 
This is necessary because the `client` uses a cache when getting resources which is useful, 
however it does a bad job at keeping that cache up to date, 
which is important for us to act accordingly and also to avoid errors such as:
```
{"level":"info","ts":"2022-06-01T09:06:17.266Z","logger":"nodes-controller","msg":"Removing unfound cached node from cluster","node":"at-k8s-1-21-sd-flc-containerd-worker--i-0a3e305680f9b7abc"}
{"error":"Operation cannot be fulfilled on configmaps \"dynatrace-node-cache\": the object has been modified; please apply your changes to the latest version and try again","level":"error","logger":"main.controller.node","msg":"Reconciler error","name":"at-k8s-1-21-sd-flc-containerd-master--i-0c9e78918ad83e8f5","namespace":"","reconciler group":"","reconciler kind":"Node","stacktrace":"github.com/go-logr/logr.Logger.Error
	/go/pkg/mod/github.com/go-logr/logr@v1.2.2/logr.go:270
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:317
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
```

(Also did a minor refactoring, spelling and fixes)

## How can this be tested?
The bug is not easy to reproduce, that is why it gone unfixed for so long, it happens only rarely and it depends on the cache the `client` uses.

A general test is that you deploy anything that has an OS OneAgent (classicFullstack or cloudNativeFullStack).
Then remove one of the nodes, when that is done in the UI the "bar" should turn to yellow instead of red. 

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

