### PR TITLE
Fix data-ingests's `endpoint.properties` secret handling

### DIFF
--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -174,6 +174,7 @@ func (dk *DynaKube) NeedsCSIDriver() bool {
 func (dk *DynaKube) NeedAppInjection() bool {
 	return dk.CloudNativeFullstackMode() || dk.ApplicationMonitoringMode()
 }
+
 func (dk *DynaKube) Image() string {
 	if dk.ClassicFullStackMode() {
 		return dk.Spec.OneAgent.ClassicFullStack.Image

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -264,21 +264,15 @@ func (controller *DynakubeController) reconcileDynaKube(ctx context.Context, dkS
 		}
 		dkState.Update(upd, "new init secret created")
 
-		if !dkState.Instance.FeatureDisableMetadataEnrichment() {
-			upd, err = endpointSecretGenerator.GenerateForDynakube(ctx, dkState.Instance)
-			if dkState.Error(err) {
-				return
-			}
-			dkState.Update(upd, "new data-ingest endpoint secret created")
-		} else {
-			err = endpointSecretGenerator.RemoveEndpointSecrets(ctx, dkState.Instance)
-			if dkState.Error(err) {
-				return
-			}
+		upd, err = endpointSecretGenerator.GenerateForDynakube(ctx, dkState.Instance)
+		if dkState.Error(err) {
+			return
 		}
+		dkState.Update(upd, "new data-ingest endpoint secret created")
+
 		if dkState.Instance.ApplicationMonitoringMode() {
 			dkState.Instance.Status.SetPhase(dynatracev1beta1.Running)
-			dkState.Update(true, "application monitoring reconciled")
+			dkState.Update(upd, "application monitoring reconciled")
 		}
 	} else {
 		if err := dkMapper.UnmapFromDynaKube(); err != nil {

--- a/src/ingestendpoint/secret.go
+++ b/src/ingestendpoint/secret.go
@@ -167,10 +167,10 @@ func (g *EndpointSecretGenerator) PrepareFields(ctx context.Context, dk *dynatra
 			fields[MetricsTokenSecretField] = string(token)
 		}
 
-		if diUrl, err := dataIngestUrl(dk); err != nil {
+		if dataIngestUrl, err := dataIngestUrlFor(dk); err != nil {
 			return nil, err
 		} else {
-			fields[MetricsUrlSecretField] = diUrl
+			fields[MetricsUrlSecretField] = dataIngestUrl
 		}
 	}
 
@@ -185,7 +185,7 @@ func (g *EndpointSecretGenerator) PrepareFields(ctx context.Context, dk *dynatra
 	return fields, nil
 }
 
-func dataIngestUrl(dk *dynatracev1beta1.DynaKube) (string, error) {
+func dataIngestUrlFor(dk *dynatracev1beta1.DynaKube) (string, error) {
 	if dk.IsActiveGateMode(dynatracev1beta1.MetricsIngestCapability.DisplayName) {
 		return metricsIngestUrlForClusterActiveGate(dk)
 	} else if len(dk.Spec.APIURL) > 0 {

--- a/src/ingestendpoint/secret_test.go
+++ b/src/ingestendpoint/secret_test.go
@@ -70,18 +70,18 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), dynakubeName, namespace1)
 			assert.NoError(t, err)
 			assert.Equal(t, false, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`data-ingest endpoint secret created and token updated`, func(t *testing.T) {
@@ -94,9 +94,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 
 		updateTestSecret(t, fakeClient)
@@ -106,9 +106,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, updatedTokenDataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedTokenDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`data-ingest endpoint secret created and apiUrl updated`, func(t *testing.T) {
@@ -121,9 +121,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 
 		updateTestDynakube(t, fakeClient)
@@ -133,9 +133,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, updatedApiUrlDataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 
@@ -147,10 +147,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, dataIngestSecretWithMetrics)
-
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
@@ -165,8 +164,8 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
 		}
 
 		updateTestSecret(t, fakeClient)
@@ -175,11 +174,11 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, updatedTokenDataIngestSecretWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, updatedTokenDataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedTokenDataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, updatedTokenDataIngestSecretWithMetrics)
 		}
 
-		checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+		checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 	})
 	t.Run(`data-ingest endpoint secret created in all namespaces and apiUrl updated`, func(t *testing.T) {
 		fakeClient := buildTestClientBeforeGenerate(buildTestDynakube())
@@ -190,9 +189,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			newInstance := updatedTestDynakube()
@@ -200,9 +199,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, newInstance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, updatedApiUrlDataIngestSecretWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, updatedApiUrlDataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`data-ingest endpoint secret created (local AG) in all namespaces and apiUrl updated`, func(t *testing.T) {
@@ -216,8 +215,8 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
 		}
 		{
 			newInstance := updatedTestDynakubeWithDataIngestCapability([]dynatracev1beta1.CapabilityDisplayName{
@@ -228,10 +227,10 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, newInstance, fakeClient)
 			assert.Equal(t, false, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAgWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAgWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAgWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAgWithMetrics)
 
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`metrics-ingest with statsd endpoint secret created (local AG) in all namespaces and apiUrl updated`, func(t *testing.T) {
@@ -247,9 +246,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretLocalAGWithMetricsAndStatsd)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, dataIngestSecretLocalAGWithMetricsAndStatsd)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetricsAndStatsd)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetricsAndStatsd)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			newInstance := updatedTestDynakubeWithDataIngestCapability([]dynatracev1beta1.CapabilityDisplayName{
@@ -261,9 +260,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, newInstance, fakeClient)
 			assert.Equal(t, false, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`StatsD ingest URL is added/removed to endpoint properties when statsd-ingest capability is added/removed`, func(t *testing.T) {
@@ -278,9 +277,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 
 		{
@@ -293,9 +292,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, newInstance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			newerInstance := updatedTestDynakubeWithDataIngestCapability([]dynatracev1beta1.CapabilityDisplayName{
@@ -306,9 +305,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, newerInstance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			unchangedInstance := updatedTestDynakubeWithDataIngestCapability([]dynatracev1beta1.CapabilityDisplayName{
@@ -319,9 +318,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, unchangedInstance, fakeClient)
 			assert.Equal(t, false, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`No ingestion is enabled (statsd capability is not enabled, disable-metadata-enrichment feature flag is set true)`, func(t *testing.T) {
@@ -336,9 +335,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName}, emptyFile)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName}, emptyFile)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespaceDynatrace, SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, emptyFile)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, emptyFile)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 }
@@ -360,8 +359,8 @@ func TestRemoveEndpointSecrets(t *testing.T) {
 	err := endpointSecretGenerator.RemoveEndpointSecrets(context.TODO(), dk)
 	require.NoError(t, err)
 
-	checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespace1, SecretEndpointName})
-	checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{namespace2, SecretEndpointName})
+	checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName})
+	checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
 
 }
 

--- a/src/ingestendpoint/secret_test.go
+++ b/src/ingestendpoint/secret_test.go
@@ -16,126 +16,126 @@ import (
 )
 
 const (
-	paasToken              = "test-paas-token"
-	apiToken               = "test-api-token"
-	dataIngestToken        = "test-data-ingest-token"
-	updatedDataIngestToken = "updated-test-data-ingest-token"
+	testPaasToken              = "test-paas-token"
+	testApiToken               = "test-api-token"
+	testDataIngestToken        = "test-data-ingest-token"
+	testUpdatedDataIngestToken = "updated-test-data-ingest-token"
 
-	apiUrl        = "https://tenant.test/api"
-	updatedApiUrl = "https://tenant.updated-test/api"
+	testApiUrl        = "https://tenant.test/api"
+	testUpdatedApiUrl = "https://tenant.updated-test/api"
 
-	dataIngestSecretWithMetrics = `DT_METRICS_INGEST_URL=https://tenant.test/api/v2/metrics/ingest
+	testDataIngestSecretWithMetrics = `DT_METRICS_INGEST_URL=https://tenant.test/api/v2/metrics/ingest
 DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
 `
-	updatedTokenDataIngestSecretWithMetrics = `DT_METRICS_INGEST_URL=https://tenant.test/api/v2/metrics/ingest
+	testUpdatedTokenDataIngestSecretWithMetrics = `DT_METRICS_INGEST_URL=https://tenant.test/api/v2/metrics/ingest
 DT_METRICS_INGEST_API_TOKEN=updated-test-data-ingest-token
 `
-	updatedApiUrlDataIngestSecretWithMetrics = `DT_METRICS_INGEST_URL=https://tenant.updated-test/api/v2/metrics/ingest
+	testUpdatedApiUrlDataIngestSecretWithMetrics = `DT_METRICS_INGEST_URL=https://tenant.updated-test/api/v2/metrics/ingest
 DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
 `
 
-	dataIngestSecretLocalAGWithMetrics = `DT_METRICS_INGEST_URL=https://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
+	testDataIngestSecretLocalAGWithMetrics = `DT_METRICS_INGEST_URL=https://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
 DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
 `
-	updatedApiUrlDataIngestSecretLocalAgWithMetrics = `DT_METRICS_INGEST_URL=https://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
+	testUpdatedApiUrlDataIngestSecretLocalAgWithMetrics = `DT_METRICS_INGEST_URL=https://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
 DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
 `
 
-	dataIngestSecretLocalAGWithMetricsAndStatsd = `DT_METRICS_INGEST_URL=https://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
-DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
-DT_STATSD_INGEST_URL=dynakube-activegate.dynatrace:18125
-`
-
-	updatedApiUrlDataIngestSecretLocalAGWithStatsd = `DT_METRICS_INGEST_URL=https://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
+	testDataIngestSecretLocalAGWithMetricsAndStatsd = `DT_METRICS_INGEST_URL=https://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
 DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
 DT_STATSD_INGEST_URL=dynakube-activegate.dynatrace:18125
 `
-	emptyFile = ``
 
-	namespace1 = "test-namespace-one"
-	namespace2 = "test-namespace-two"
+	testUpdatedApiUrlDataIngestSecretLocalAGWithStatsd = `DT_METRICS_INGEST_URL=https://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
+DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
+DT_STATSD_INGEST_URL=dynakube-activegate.dynatrace:18125
+`
+	testEmptyFile = ``
 
-	namespaceDynatrace = "dynatrace"
-	dynakubeName       = "dynakube"
+	testNamespace1 = "test-namespace-one"
+	testNamespace2 = "test-namespace-two"
+
+	testNamespaceDynatrace = "dynatrace"
+	testDynakubeName       = "dynakube"
 )
 
 func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 	t.Run(`data-ingest endpoint secret created but not updated`, func(t *testing.T) {
 		instance := buildTestDynakube()
 		fakeClient := buildTestClientBeforeGenerate(instance)
-		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, namespaceDynatrace)
+		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		{
-			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), dynakubeName, namespace1)
+			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), testDynakubeName, testNamespace1)
 			assert.NoError(t, err)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
-			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), dynakubeName, namespace1)
+			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), testDynakubeName, testNamespace1)
 			assert.NoError(t, err)
 			assert.Equal(t, false, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`data-ingest endpoint secret created and token updated`, func(t *testing.T) {
 		instance := buildTestDynakube()
 		fakeClient := buildTestClientBeforeGenerate(instance)
-		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, namespaceDynatrace)
+		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		{
-			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), dynakubeName, namespace1)
+			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), testDynakubeName, testNamespace1)
 			assert.NoError(t, err)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 
 		updateTestSecret(t, fakeClient)
 
 		{
-			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), dynakubeName, namespace1)
+			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), testDynakubeName, testNamespace1)
 			assert.NoError(t, err)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedTokenDataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testUpdatedTokenDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`data-ingest endpoint secret created and apiUrl updated`, func(t *testing.T) {
 		instance := buildTestDynakube()
 		fakeClient := buildTestClientBeforeGenerate(instance)
-		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, namespaceDynatrace)
+		endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		{
-			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), dynakubeName, namespace1)
+			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), testDynakubeName, testNamespace1)
 			assert.NoError(t, err)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 
 		updateTestDynakube(t, fakeClient)
 
 		{
-			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), dynakubeName, namespace1)
+			upd, err := endpointSecretGenerator.GenerateForNamespace(context.TODO(), testDynakubeName, testNamespace1)
 			assert.NoError(t, err)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testUpdatedApiUrlDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 
@@ -147,9 +147,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
@@ -164,8 +164,8 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testDataIngestSecretWithMetrics)
 		}
 
 		updateTestSecret(t, fakeClient)
@@ -174,11 +174,11 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedTokenDataIngestSecretWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, updatedTokenDataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testUpdatedTokenDataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testUpdatedTokenDataIngestSecretWithMetrics)
 		}
 
-		checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+		checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 	})
 	t.Run(`data-ingest endpoint secret created in all namespaces and apiUrl updated`, func(t *testing.T) {
 		fakeClient := buildTestClientBeforeGenerate(buildTestDynakube())
@@ -189,9 +189,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			newInstance := updatedTestDynakube()
@@ -199,9 +199,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, newInstance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testUpdatedApiUrlDataIngestSecretWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testUpdatedApiUrlDataIngestSecretWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`data-ingest endpoint secret created (local AG) in all namespaces and apiUrl updated`, func(t *testing.T) {
@@ -215,8 +215,8 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretLocalAGWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testDataIngestSecretLocalAGWithMetrics)
 		}
 		{
 			newInstance := updatedTestDynakubeWithDataIngestCapability([]dynatracev1beta1.CapabilityDisplayName{
@@ -227,10 +227,10 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, newInstance, fakeClient)
 			assert.Equal(t, false, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAgWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAgWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testUpdatedApiUrlDataIngestSecretLocalAgWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testUpdatedApiUrlDataIngestSecretLocalAgWithMetrics)
 
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`metrics-ingest with statsd endpoint secret created (local AG) in all namespaces and apiUrl updated`, func(t *testing.T) {
@@ -246,9 +246,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetricsAndStatsd)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetricsAndStatsd)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretLocalAGWithMetricsAndStatsd)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testDataIngestSecretLocalAGWithMetricsAndStatsd)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			newInstance := updatedTestDynakubeWithDataIngestCapability([]dynatracev1beta1.CapabilityDisplayName{
@@ -260,9 +260,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, newInstance, fakeClient)
 			assert.Equal(t, false, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testUpdatedApiUrlDataIngestSecretLocalAGWithStatsd)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testUpdatedApiUrlDataIngestSecretLocalAGWithStatsd)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`StatsD ingest URL is added/removed to endpoint properties when statsd-ingest capability is added/removed`, func(t *testing.T) {
@@ -277,9 +277,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretLocalAGWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testDataIngestSecretLocalAGWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 
 		{
@@ -292,9 +292,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, newInstance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, updatedApiUrlDataIngestSecretLocalAGWithStatsd)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testUpdatedApiUrlDataIngestSecretLocalAGWithStatsd)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testUpdatedApiUrlDataIngestSecretLocalAGWithStatsd)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			newerInstance := updatedTestDynakubeWithDataIngestCapability([]dynatracev1beta1.CapabilityDisplayName{
@@ -305,9 +305,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, newerInstance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretLocalAGWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testDataIngestSecretLocalAGWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 		{
 			unchangedInstance := updatedTestDynakubeWithDataIngestCapability([]dynatracev1beta1.CapabilityDisplayName{
@@ -318,9 +318,9 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, unchangedInstance, fakeClient)
 			assert.Equal(t, false, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, dataIngestSecretLocalAGWithMetrics)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testDataIngestSecretLocalAGWithMetrics)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testDataIngestSecretLocalAGWithMetrics)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 	t.Run(`No ingestion is enabled (statsd capability is not enabled, disable-metadata-enrichment feature flag is set true)`, func(t *testing.T) {
@@ -335,15 +335,15 @@ func TestGenerateDataIngestSecret_ForDynakube(t *testing.T) {
 			upd := testGenerateEndpointsSecret(t, instance, fakeClient)
 			assert.Equal(t, true, upd)
 
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName}, emptyFile)
-			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName}, emptyFile)
-			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespaceDynatrace, Name: SecretEndpointName})
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName}, testEmptyFile)
+			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName}, testEmptyFile)
+			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: SecretEndpointName})
 		}
 	})
 }
 
 func testGenerateEndpointsSecret(t *testing.T, instance *dynatracev1beta1.DynaKube, fakeClient client.Client) bool {
-	endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, namespaceDynatrace)
+	endpointSecretGenerator := NewEndpointSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 	upd, err := endpointSecretGenerator.GenerateForDynakube(context.TODO(), instance)
 	assert.NoError(t, err)
@@ -359,8 +359,8 @@ func TestRemoveEndpointSecrets(t *testing.T) {
 	err := endpointSecretGenerator.RemoveEndpointSecrets(context.TODO(), dk)
 	require.NoError(t, err)
 
-	checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace1, Name: SecretEndpointName})
-	checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: namespace2, Name: SecretEndpointName})
+	checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: SecretEndpointName})
+	checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: SecretEndpointName})
 
 }
 
@@ -384,13 +384,13 @@ func checkTestSecretDoesntExist(t *testing.T, fakeClient client.Client, secretNa
 func updateTestSecret(t *testing.T, fakeClient client.Client) {
 	updatedSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dynakubeName,
-			Namespace: namespaceDynatrace,
+			Name:      testDynakubeName,
+			Namespace: testNamespaceDynatrace,
 		},
 		Data: map[string][]byte{
-			"apiToken":        []byte(apiToken),
-			"paasToken":       []byte(paasToken),
-			"dataIngestToken": []byte(updatedDataIngestToken),
+			"apiToken":        []byte(testApiToken),
+			"paasToken":       []byte(testPaasToken),
+			"dataIngestToken": []byte(testUpdatedDataIngestToken),
 		},
 	}
 
@@ -401,11 +401,11 @@ func updateTestSecret(t *testing.T, fakeClient client.Client) {
 func updatedTestDynakube() *dynatracev1beta1.DynaKube {
 	return &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dynakubeName,
-			Namespace: namespaceDynatrace,
+			Name:      testDynakubeName,
+			Namespace: testNamespaceDynatrace,
 		},
 		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL: updatedApiUrl,
+			APIURL: testUpdatedApiUrl,
 		},
 	}
 }
@@ -413,24 +413,24 @@ func updatedTestDynakube() *dynatracev1beta1.DynaKube {
 func updatedTestDynakubeWithDataIngestCapability(capabilities []dynatracev1beta1.CapabilityDisplayName) *dynatracev1beta1.DynaKube {
 	return &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dynakubeName,
-			Namespace: namespaceDynatrace,
+			Name:      testDynakubeName,
+			Namespace: testNamespaceDynatrace,
 		},
 		Spec: dynatracev1beta1.DynaKubeSpec{
 			ActiveGate: dynatracev1beta1.ActiveGateSpec{
 				Capabilities: capabilities,
 			},
-			APIURL: updatedApiUrl,
+			APIURL: testUpdatedApiUrl,
 		},
 	}
 }
 
 func updateTestDynakube(t *testing.T, fakeClient client.Client) {
 	var dk dynatracev1beta1.DynaKube
-	err := fakeClient.Get(context.TODO(), client.ObjectKey{Name: dynakubeName, Namespace: namespaceDynatrace}, &dk)
+	err := fakeClient.Get(context.TODO(), client.ObjectKey{Name: testDynakubeName, Namespace: testNamespaceDynatrace}, &dk)
 	assert.NoError(t, err)
 
-	dk.Spec.APIURL = updatedApiUrl
+	dk.Spec.APIURL = testUpdatedApiUrl
 
 	err = fakeClient.Update(context.TODO(), &dk)
 	assert.NoError(t, err)
@@ -439,11 +439,11 @@ func updateTestDynakube(t *testing.T, fakeClient client.Client) {
 func buildTestDynakube() *dynatracev1beta1.DynaKube {
 	return &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dynakubeName,
-			Namespace: namespaceDynatrace,
+			Name:      testDynakubeName,
+			Namespace: testNamespaceDynatrace,
 		},
 		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL: apiUrl,
+			APIURL: testApiUrl,
 		},
 	}
 }
@@ -451,14 +451,14 @@ func buildTestDynakube() *dynatracev1beta1.DynaKube {
 func buildTestDynakubeWithDataIngestCapability(capabilities []dynatracev1beta1.CapabilityDisplayName) *dynatracev1beta1.DynaKube {
 	return &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dynakubeName,
-			Namespace: namespaceDynatrace,
+			Name:      testDynakubeName,
+			Namespace: testNamespaceDynatrace,
 		},
 		Spec: dynatracev1beta1.DynaKubeSpec{
 			ActiveGate: dynatracev1beta1.ActiveGateSpec{
 				Capabilities: capabilities,
 			},
-			APIURL: apiUrl,
+			APIURL: testApiUrl,
 		},
 	}
 }
@@ -467,12 +467,12 @@ func buildTestClientBeforeGenerate(dk *dynatracev1beta1.DynaKube) client.Client 
 	return fake.NewClient(dk,
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: namespaceDynatrace,
+				Name: testNamespaceDynatrace,
 			},
 		},
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace1,
+				Name: testNamespace1,
 				Labels: map[string]string{
 					mapper.InstanceLabel: dk.Name,
 				},
@@ -480,7 +480,7 @@ func buildTestClientBeforeGenerate(dk *dynatracev1beta1.DynaKube) client.Client 
 		},
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace2,
+				Name: testNamespace2,
 				Labels: map[string]string{
 					mapper.InstanceLabel: dk.Name,
 				},
@@ -489,12 +489,12 @@ func buildTestClientBeforeGenerate(dk *dynatracev1beta1.DynaKube) client.Client 
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      dk.Tokens(),
-				Namespace: namespaceDynatrace,
+				Namespace: testNamespaceDynatrace,
 			},
 			Data: map[string][]byte{
-				"apiToken":        []byte(apiToken),
-				"paasToken":       []byte(paasToken),
-				"dataIngestToken": []byte(dataIngestToken),
+				"apiToken":        []byte(testApiToken),
+				"paasToken":       []byte(testPaasToken),
+				"dataIngestToken": []byte(testDataIngestToken),
 			},
 		})
 }
@@ -503,12 +503,12 @@ func buildTestClientAfterGenerate(dk *dynatracev1beta1.DynaKube) client.Client {
 	return fake.NewClient(dk,
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: namespaceDynatrace,
+				Name: testNamespaceDynatrace,
 			},
 		},
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace1,
+				Name: testNamespace1,
 				Labels: map[string]string{
 					mapper.InstanceLabel: dk.Name,
 				},
@@ -516,7 +516,7 @@ func buildTestClientAfterGenerate(dk *dynatracev1beta1.DynaKube) client.Client {
 		},
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace2,
+				Name: testNamespace2,
 				Labels: map[string]string{
 					mapper.InstanceLabel: dk.Name,
 				},
@@ -524,8 +524,8 @@ func buildTestClientAfterGenerate(dk *dynatracev1beta1.DynaKube) client.Client {
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      namespace1,
-				Namespace: namespaceDynatrace,
+				Name:      testNamespace1,
+				Namespace: testNamespaceDynatrace,
 			},
 			Data: map[string][]byte{
 				"doesn't": []byte("matter"),
@@ -533,8 +533,8 @@ func buildTestClientAfterGenerate(dk *dynatracev1beta1.DynaKube) client.Client {
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      namespace2,
-				Namespace: namespaceDynatrace,
+				Name:      testNamespace2,
+				Namespace: testNamespaceDynatrace,
 			},
 			Data: map[string][]byte{
 				"doesn't": []byte("matter"),
@@ -543,12 +543,12 @@ func buildTestClientAfterGenerate(dk *dynatracev1beta1.DynaKube) client.Client {
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      dk.Tokens(),
-				Namespace: namespaceDynatrace,
+				Namespace: testNamespaceDynatrace,
 			},
 			Data: map[string][]byte{
-				"apiToken":        []byte(apiToken),
-				"paasToken":       []byte(paasToken),
-				"dataIngestToken": []byte(dataIngestToken),
+				"apiToken":        []byte(testApiToken),
+				"paasToken":       []byte(testPaasToken),
+				"dataIngestToken": []byte(testDataIngestToken),
 			},
 		})
 }


### PR DESCRIPTION
# Description
1. Secret `dynatrace-data-ingest-endpoint` is now always generated nevertheless which ingestions are enabled.
If no ingestion is enabled, secret's data contains an empty string, as expected.

2. Fixed bug causing permanent reconciliation which was caused by comparing `nil` and an empty map, assuming it's equal.

# How can this be tested?
Check if `dynatrace-data-ingest-endpoint` secret in `deafult` namespace contains expected content.

Dynakubes to be used:
1. default one, with no annotation
2. with AG `statsd-ingest` capability enabled

Maniulate dynakubes with:
1. `k -ndynatrace annotate dynakubes.dynatrace.com dk --overwrite feature.dynatrace.com/disable-metadata-enrichment=false` - no change should be observed
2. `k -ndynatrace annotate dynakubes.dynatrace.com dk --overwrite feature.dynatrace.com/disable-metadata-enrichment=true` - metrics ingest URL and token should be removed from the secret data

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

