### PR TITLE
Switched highAvailability mode to true as new default

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -1,4 +1,15 @@
 ---
+# Source: dynatrace-operator/templates/Common/webhook/poddisruptionbudget-webhook.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dynatrace-webhook
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: webhook
+---
 # Source: dynatrace-operator/templates/Common/activegate/serviceaccount-activegate.yaml
 # Copyright 2021 Dynatrace LLC
 
@@ -126,7 +137,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -4036,7 +4046,7 @@ metadata:
     app.kubernetes.io/version: "0.4.2"
     app.kubernetes.io/component: webhook
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 1
   selector:
     matchLabels:
@@ -4055,6 +4065,13 @@ spec:
         internal.dynatrace.com/component: webhook
         internal.dynatrace.com/app: webhook
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: ScheduleAnyway
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: DoNotSchedule
       volumes:
       - emptyDir: {}
         name: certs-dir
@@ -4226,6 +4243,17 @@ webhooks:
     name: webhook.dynatrace.com
     timeoutSeconds: 2
     sideEffects: None
+---
+# Source: dynatrace-operator/templates/Common/webhook/poddisruptionbudget-webhook.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dynatrace-webhook
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: webhook
 ---
 # Source: dynatrace-operator/templates/Common/csi/serviceaccount-csi.yaml
 # Copyright 2021 Dynatrace LLC

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -1,4 +1,15 @@
 ---
+# Source: dynatrace-operator/templates/Common/webhook/poddisruptionbudget-webhook.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dynatrace-webhook
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: webhook
+---
 # Source: dynatrace-operator/templates/Common/activegate/serviceaccount-activegate.yaml
 # Copyright 2021 Dynatrace LLC
 
@@ -137,7 +148,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -4111,7 +4121,7 @@ metadata:
     app.kubernetes.io/version: "0.4.2"
     app.kubernetes.io/component: webhook
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 1
   selector:
     matchLabels:
@@ -4130,6 +4140,13 @@ spec:
         internal.dynatrace.com/component: webhook
         internal.dynatrace.com/app: webhook
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: ScheduleAnyway
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: DoNotSchedule
       volumes:
       - emptyDir: {}
         name: certs-dir
@@ -4516,6 +4533,17 @@ webhooks:
     name: webhook.dynatrace.com
     timeoutSeconds: 2
     sideEffects: None
+---
+# Source: dynatrace-operator/templates/Common/webhook/poddisruptionbudget-webhook.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dynatrace-webhook
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: webhook
 ---
 # Source: dynatrace-operator/templates/Common/csi/serviceaccount-csi.yaml
 # Copyright 2021 Dynatrace LLC

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -2,10 +2,123 @@ suite: test deployment of webhook
 templates:
   - Common/webhook/deployment-webhook.yaml
 tests:
-  - it: should exist
+  - it: should exist with highavailability mode
     set:
       platform: kubernetes
       operator.image: image-name
+      webhook.highAvailability: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: dynatrace-webhook
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/name]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/component]
+          value: webhook
+      - isNotEmpty:
+          path: metadata.labels.[helm.sh/chart]
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 1
+      - equal:
+          path: spec.strategy
+          value:
+            type: RollingUpdate
+      - isNotEmpty:
+          path: spec.selector.matchLabels
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            kubectl.kubernetes.io/default-container: webhook
+      - isNotEmpty:
+          path: spec.template.metadata.labels
+      - equal:
+          path: spec.template.spec
+          value:
+            topologySpreadConstraints:
+              - maxSkew: 1
+                topologyKey: "topology.kubernetes.io/zone"
+                whenUnsatisfiable: ScheduleAnyway
+              - maxSkew: 1
+                topologyKey: "kubernetes.io/hostname"
+                whenUnsatisfiable: DoNotSchedule
+            volumes:
+              - emptyDir: { }
+                name: certs-dir
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: kubernetes.io/arch
+                          operator: In
+                          values:
+                            - amd64
+                            - arm64
+                        - key: kubernetes.io/os
+                          operator: In
+                          values:
+                            - linux
+            containers:
+              - name: webhook
+                args:
+                  - webhook-server
+                  - --certs-dir=/tmp/k8s-webhook-server/serving-certs/
+                image: image-name
+                imagePullPolicy: Always
+                env:
+                  - name: POD_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                readinessProbe:
+                  httpGet:
+                    path: /livez
+                    port: server-port
+                    scheme: HTTPS
+                ports:
+                  - name: server-port
+                    containerPort: 8443
+                resources:
+                  requests:
+                    cpu: 300m
+                    memory: 128Mi
+                  limits:
+                    cpu: 300m
+                    memory: 128Mi
+                volumeMounts:
+                  - name: certs-dir
+                    mountPath: /tmp/k8s-webhook-server/serving-certs/
+                securityContext:
+                  seccompProfile:
+                    type: RuntimeDefault
+                  privileged: false
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  capabilities:
+                    drop: [ "all" ]
+            serviceAccountName: dynatrace-webhook
+
+  - it: should exist (without highavailabilty mode)
+    set:
+      platform: kubernetes
+      operator.image: image-name
+      webhook.highAvailability: false
     asserts:
       - isKind:
           of: Deployment
@@ -106,15 +219,16 @@ tests:
                     drop: ["all"]
             serviceAccountName: dynatrace-webhook
 
-  - it: should not have imagePullSecrets defined in spec
+  - it: should not have imagePullSecrets defined in spec (without highavailabilty mode)
     asserts:
       - isNull:
           path: spec.template.spec.imagePullSecrets
 
-  - it: should exist on olm (but different)
+  - it: should exist on olm (but different and without highavailabilty mode)
     set:
       olm: true
       operator.image: image-name
+      webhook.highAvailability: false
     asserts:
       - isKind:
           of: Deployment

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -39,7 +39,7 @@ webhook:
   limits:
     cpu: 300m
     memory: 128Mi
-  highAvailability: false
+  highAvailability: true
 
 csidriver:
   enabled: false
@@ -52,6 +52,6 @@ csidriver:
 
 securityContextConstraints:
   enabled: true # Only applicable for Openshift
-  
+
 activeGate:
   readOnlyFs: false


### PR DESCRIPTION
# Description
The `highAvailability `flag in the `values.yaml` file in the helm charts is switched to true, which should be the default for now.

## How can this be tested?
Simply switch to this branch, run make manifests and take a look at the `kubernetes.yaml`. Apply it and check for the changed things like `topologySpreadConstraints` in the webhook deployment and so on.


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

