### PR TITLE
Set `bash` shell as preferred for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = bash
+
 # Running 'make' runs the first rule in the makefile
 # In order to print the help text in this case,
 # 	'default' has been put here even before the includes


### PR DESCRIPTION
# Description

After recent Makefile refactoring, `SHELL = bash` disappeared.
By default `sh` is used and it lacks of bashisms like `source` which is used in e.g. `go/test` target:

```shell
$ make go/test
...                                                                               
source /home/michal/workspace/dynatrace-operator//testbin/setup-envtest.sh; fetch_envtest_tools /home/michal/workspace/dynatrace-operator//testbin; setup_env
test_env /home/michal/workspace/dynatrace-operator//testbin; go test ./... -coverprofile cover.out                                                                         
/bin/sh: 1: source: not found                                                                                                                                                            
/bin/sh: 1: fetch_envtest_tools: not found                                                                                                                                               
/bin/sh: 1: setup_envtest_env: not found                                                                                                                                                 
?       github.com/Dynatrace/dynatrace-operator/src/agproxysecret       [no test files]                                                                                                  
ok      github.com/Dynatrace/dynatrace-operator/src/api/v1alpha1        0.113s  coverage: 7.7% of statements                                                                             
ok      github.com/Dynatrace/dynatrace-operator/src/api/v1beta1 0.048s  coverage: 31.4% of statement
```

Set `SHELL = bash` fixes the issue. 

## How can this be tested?
`make` with any target works properly
e.g.: `make go/test`


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

