### PR TITLE
Add OpenSSF scorecard workflow

### DIFF
--- a/.github/workflows/openssf-scorecards.yaml
+++ b/.github/workflows/openssf-scorecards.yaml
@@ -1,14 +1,20 @@
 name: Scorecards supply-chain security
+
+# Currently this workflow is failing and should be run only when triggered manually
+# If workflow result is green:
+#    - remove `workflow_dispatch` and uncomment remaining lines 
 on:
-  push:
-    branches:
-      - "*"
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches:
-      - master
-  schedule:
-    - cron: '34 23 * * 0'
+  workflow_dispatch:  
+#   push:
+#     branches:
+#       - master
+#   pull_request:
+#     # The branches below must be a subset of the branches above
+#     branches:
+#       - master
+#   schedule:
+#     - cron: '34 23 * * 0'
+
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/openssf-scorecards.yaml
+++ b/.github/workflows/openssf-scorecards.yaml
@@ -2,7 +2,7 @@ name: Scorecards supply-chain security
 on:
   push:
     branches:
-      - master
+      - "*"
   pull_request:
     # The branches below must be a subset of the branches above
     branches:

--- a/.github/workflows/openssf-scorecards.yaml
+++ b/.github/workflows/openssf-scorecards.yaml
@@ -1,19 +1,12 @@
 name: Scorecards supply-chain security
 
-# Currently this workflow is failing and should be run only when triggered manually
-# If workflow result is green:
-#    - remove `workflow_dispatch` and uncomment remaining lines 
 on:
-  workflow_dispatch:  
-#   push:
-#     branches:
-#       - master
+  push:
+    branches:
+      - master
 #   pull_request:
-#     # The branches below must be a subset of the branches above
 #     branches:
 #       - master
-#   schedule:
-#     - cron: '34 23 * * 0'
 
 
 # Declare default permissions as read only.

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,65 @@
+name: Scorecards supply-chain security
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches:
+      - master
+  schedule:
+    - cron: '34 23 * * 0'
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge. (Upcoming feature)
+      id-token: write
+      # Needs for private repositories.
+      contents: read
+      actions: read
+    
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@3e15ea8318eee9b333819ec77a36aca8d39df13e # v1.1.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) Read-only PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecards on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results. 
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless 
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # v1.0.26
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
# Description
Add OpenSSF scorecard workflow to github actions.
It's triggered manually for the moment. It will be switched to be triggered on `push`, `pull_request` and `schedule` in the next PR.

## How can this be tested?
1. Locally: `act -j analysis`
2. On githbub - verify if CI executes given workflow and its results

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

