### PR TITLE
Removes duplicate manifest recources

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -4245,17 +4245,6 @@ webhooks:
     timeoutSeconds: 2
     sideEffects: None
 ---
-# Source: dynatrace-operator/templates/Common/webhook/poddisruptionbudget-webhook.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: dynatrace-webhook
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: webhook
----
 # Source: dynatrace-operator/templates/Common/csi/serviceaccount-csi.yaml
 # Copyright 2021 Dynatrace LLC
 

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -3766,6 +3766,7 @@ rules:
       - watch
       - create
       - update
+      - delete
   - apiGroups:
       - ""
     resources:
@@ -4533,17 +4534,6 @@ webhooks:
     name: webhook.dynatrace.com
     timeoutSeconds: 2
     sideEffects: None
----
-# Source: dynatrace-operator/templates/Common/webhook/poddisruptionbudget-webhook.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: dynatrace-webhook
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: webhook
 ---
 # Source: dynatrace-operator/templates/Common/csi/serviceaccount-csi.yaml
 # Copyright 2021 Dynatrace LLC

--- a/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:


### PR DESCRIPTION
# Description

The webhook's `PodDistruptionBudget` is present 2 times in the manifests, causing an error when trying to apply it.

## How can this be tested?
`k apply -f config/deploy/kubernetes/kubernetes-all.yaml` should work (same for the openshift one)


## Checklist
- [x] PR is labeled accordingly

