### PR TITLE
Fix never invalidated license cache in GitHub actions

### DIFF
--- a/.github/workflows/build-dockerimage.yaml
+++ b/.github/workflows/build-dockerimage.yaml
@@ -41,9 +41,7 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
             ./third_party_licenses
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-build-
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
       - name: Prepare
         run: |
           hack/build/ci/download-go-build-deps.sh

--- a/hack/build/ci/download-go-build-deps.sh
+++ b/hack/build/ci/download-go-build-deps.sh
@@ -2,7 +2,7 @@
 
 # get licenses if no cache exists
 if ! [ -d ./third_party_licenses ]; then
-  go get github.com/google/go-licenses && go-licenses save ./... --save_path third_party_licenses --force
+  go install github.com/google/go-licenses@v1.2.1 && go-licenses save ./... --save_path third_party_licenses --force
 fi
 
 # fetch dependencies


### PR DESCRIPTION
# Description

licenses in our docker image are never updated, as the cache is never invalidated. 

There are 2 problems that caused that behaviour: 
- In our action step where we download the licenses, restore-keys were set. Therefore if no exact cache match was found, our fall back option prevented our bash check (`-d ./third_party_licenses`) to ever become true.
- Installing binaries with `go get` is no longer supported. - Has to be updated to `go install`

## How can this be tested?

Look into the docker image build by our ci and check if the licenses were updated. 

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

