### PR TITLE
Add tolerations and nodeSelectors

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -205,6 +205,12 @@ spec:
           path: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/data
           type: DirectoryOrCreate
         name: dynatrace-oneagent-data-dir
+      {{- if .Values.csidriver.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.csidriver.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.csidriver.tolerations }}
+      tolerations: {{- toYaml .Values.csidriver.tolerations | nindent 8 }}
+      {{- end }}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -121,4 +121,10 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.operator.customPullSecret }}
       {{- end }}
+      {{- if .Values.webhook.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.webhook.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.webhook.tolerations }}
+      tolerations: {{- toYaml .Values.webhook.tolerations | nindent 8 }}
+      {{- end -}}
 {{ end }}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -7,6 +7,30 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should have tolerations if set
+    set:
+      platform: kubernetes
+      csidriver.enabled: true
+      csidriver.tolerations:
+        test-key: test-value
+    asserts:
+    - equal:
+        path: spec.template.spec.tolerations
+        value:
+          test-key: test-value
+
+  - it: should have nodeSelectors if set
+    set:
+      platform: kubernetes
+      csidriver.enabled: true
+      csidriver.nodeSelector:
+        test-key: test-value
+    asserts:
+    - equal:
+        path: spec.template.spec.nodeSelector
+        value:
+          test-key: test-value
+
   - it: should exist in case of CSI enabled
     set:
       operator.image: image-name

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -114,6 +114,28 @@ tests:
                     drop: [ "all" ]
             serviceAccountName: dynatrace-webhook
 
+  - it: should have tolerations if set
+    set:
+      platform: kubernetes
+      webhook.tolerations:
+        test-key: test-value
+    asserts:
+    - equal:
+        path: spec.template.spec.tolerations
+        value:
+          test-key: test-value
+
+  - it: should have nodeSelectors if set
+    set:
+      platform: kubernetes
+      webhook.nodeSelector:
+        test-key: test-value
+    asserts:
+    - equal:
+        path: spec.template.spec.nodeSelector
+        value:
+          test-key: test-value
+
   - it: should exist (without highavailabilty mode)
     set:
       platform: kubernetes

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -32,6 +32,8 @@ operator:
 
 webhook:
   hostNetwork: false
+  nodeSelector: {}
+  tolerations: []
   apparmor: false
   requests:
     cpu: 300m
@@ -43,6 +45,8 @@ webhook:
 
 csidriver:
   enabled: false
+  nodeSelector: {}
+  tolerations: []
   requests:
     cpu: 300m
     memory: 100Mi


### PR DESCRIPTION
# Description

Currently nodeSelector and tolerations can only be set on the operator pod in our helm-chart values file. 
We want to extend that to all other components as well.

## How can this be tested?

Install our helm chart into your cluster, with nodeSelector and tolerations yamls set. It should apply them to our components.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

