### PR TITLE
Rename `.Values.operator.image` to `.Values.image`

### DIFF
--- a/config/helm/chart/default/questions.yml
+++ b/config/helm/chart/default/questions.yml
@@ -11,7 +11,7 @@ questions:
     type: boolean
     group: "Global Configuration"
 
-  - variable: operator.image
+  - variable: image
     label: "Set a custom image for operator components"
     description: "Set a custom image for operator. Defaults to docker.io/dynatrace/dynatrace-operator"
     default: ""

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -113,8 +113,6 @@ Check if default image is used
 {{- define "dynatrace-operator.image" -}}
 {{- if .Values.image -}}
 	{{- printf "%s" .Values.image -}}
-{{- else if .Values.operator.image -}} # Left in for backwards compativility
-	{{- printf "%s" .Values.operator.image -}}
 {{- else -}}
 	{{- if eq .Values.platform "google" -}}
     	{{- printf "%s:%s" "gcr.io/dynatrace-marketplace-prod/dynatrace-operator" "{{ .Chart.AppVersion }}" }}

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -111,7 +111,9 @@ app.kubernetes.io/component: oneagent
 Check if default image is used
 */}}
 {{- define "dynatrace-operator.image" -}}
-{{- if .Values.operator.image -}}
+{{- if .Values.image -}}
+	{{- printf "%s" .Values.image -}}
+{{- else if .Values.operator.image -}} # Left in for backwards compativility
 	{{- printf "%s" .Values.operator.image -}}
 {{- else -}}
 	{{- if eq .Values.platform "google" -}}

--- a/config/helm/chart/default/tests/Common/csi/clusterrole-csi_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/clusterrole-csi_test.yaml
@@ -9,7 +9,7 @@ tests:
 
   - it: should be built correctly with CSI enabled
     set:
-      operator.image: image-name
+      image: image-name
       csidriver.enabled: true
     asserts:
       - isAPIVersion:
@@ -24,7 +24,7 @@ tests:
 
   - it: should have the correct rules
     set:
-      operator.image: image-name
+      image: image-name
       csidriver.enabled: true
     asserts:
       - equal:

--- a/config/helm/chart/default/tests/Common/csi/clusterrolebinding-csi_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/clusterrolebinding-csi_test.yaml
@@ -9,7 +9,7 @@ tests:
 
   - it: should be built correctly with CSI enabled
     set:
-      operator.image: image-name
+      image: image-name
       csidriver.enabled: true
     asserts:
       - isAPIVersion:

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -33,7 +33,7 @@ tests:
 
   - it: should exist in case of CSI enabled
     set:
-      operator.image: image-name
+      image: image-name
       csidriver.enabled: true
     asserts:
       - isKind:
@@ -51,7 +51,7 @@ tests:
 
   - it: should create correct spec for template of daemonset spec
     set:
-      operator.image: image-name
+      image: image-name
       csidriver.enabled: true
     asserts:
       - isNotEmpty:

--- a/config/helm/chart/default/tests/Common/csi/role-csi_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/role-csi_test.yaml
@@ -9,7 +9,7 @@ tests:
 
   - it: should be built correctly with CSI enabled
     set:
-      operator.image: image-name
+      image: image-name
       csidriver.enabled: true
     asserts:
       - isAPIVersion:
@@ -27,7 +27,7 @@ tests:
 
   - it: should have correct rules
     set:
-      operator.image: image-name
+      image: image-name
       csidriver.enabled: true
     asserts:
       - equal:

--- a/config/helm/chart/default/tests/Common/csi/rolebinding-csi_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/rolebinding-csi_test.yaml
@@ -9,7 +9,7 @@ tests:
 
   - it: should be built correctly with CSI enabled
     set:
-      operator.image: image-name
+      image: image-name
       csidriver.enabled: true
     asserts:
       - isAPIVersion:

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -5,7 +5,7 @@ tests:
   - it: should exist
     set:
       platform: kubernetes
-      operator.image: image-name
+      image: image-name
     asserts:
       - isKind:
           of: Deployment
@@ -140,7 +140,7 @@ tests:
   - it: should exist
     set:
       platform: openshift
-      operator.image: image-name
+      image: image-name
     asserts:
       - isKind:
           of: Deployment

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -5,7 +5,7 @@ tests:
   - it: should exist with highavailability mode
     set:
       platform: kubernetes
-      operator.image: image-name
+      image: image-name
       webhook.highAvailability: true
     asserts:
       - isKind:
@@ -139,7 +139,7 @@ tests:
   - it: should exist (without highavailabilty mode)
     set:
       platform: kubernetes
-      operator.image: image-name
+      image: image-name
       webhook.highAvailability: false
     asserts:
       - isKind:
@@ -249,7 +249,7 @@ tests:
   - it: should exist on olm (but different and without highavailabilty mode)
     set:
       olm: true
-      operator.image: image-name
+      image: image-name
       webhook.highAvailability: false
     asserts:
       - isKind:

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -15,10 +15,10 @@
 # may be set to "kubernetes", "openshift", "google"
 platform: "kubernetes"
 
+image: ""
 installCRD: false
 
 operator:
-  image: ""
   customPullSecret: ""
   nodeSelector: {}
   tolerations: []

--- a/config/helm/schema.yaml
+++ b/config/helm/schema.yaml
@@ -101,7 +101,7 @@ x-google-marketplace:
   images:
     ? ''
     : properties:
-        operator.image:
+        image:
           type: FULL
   deployerServiceAccount:
     description: 'Service account used to configure the Dynatrace Operator'
@@ -205,8 +205,8 @@ properties:
     type: boolean
     title: Enables AppArmor for Operator
     description: |
-      AppArmor is a security system for Linux. 
-      If a cluster supports AppArmor the Operator uses it if it is enabled here. 
+      AppArmor is a security system for Linux.
+      If a cluster supports AppArmor the Operator uses it if it is enabled here.
       If it is not supported by a cluster it must not be enabled.
     default: false
   operator.requests.cpu:
@@ -234,15 +234,15 @@ properties:
     type: boolean
     title: Webhook uses Host network
     description: |
-      Allows the webhook to connect with and use the same network as the node. 
+      Allows the webhook to connect with and use the same network as the node.
       May alleviate issues with container network interfaces (CNI).
     default: false
   webhook.apparmor:
     type: boolean
     title: Enables AppArmor for Webhook
     description: |
-      AppArmor is a security system for Linux. 
-      If a cluster supports AppArmor the Webhook uses it if it is enabled here. 
+      AppArmor is a security system for Linux.
+      If a cluster supports AppArmor the Webhook uses it if it is enabled here.
       If it is not supported by a cluster it must not be enabled.
     default: false
   webhook.requests.cpu:
@@ -269,7 +269,7 @@ properties:
   webhook.limits.memory:
     type: string
     title: Webhook Memory limit
-    description: | 
+    description: |
       The amount of memory allocation to which the cluster may limit the Webhook.
       It is recommended for the memory limits to be the same as the memory requests.
     default: 128Mi

--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -13,7 +13,7 @@ manifests/kubernetes/csi:
 		--set platform="kubernetes" \
 		--set manifests=true \
 		--set olm="${OLM}" \
-		--set operator.image="$(MASTER_IMAGE)" > "$(KUBERNETES_CSIDRIVER_YAML)"
+		--set image="$(MASTER_IMAGE)" > "$(KUBERNETES_CSIDRIVER_YAML)"
 
 ## Generates an Kubernetes manifest with a CRD
 manifests/kubernetes/core: manifests/crd/helm prerequisites/kustomize
@@ -23,7 +23,7 @@ manifests/kubernetes/core: manifests/crd/helm prerequisites/kustomize
 			--set platform="kubernetes" \
 			--set manifests=true \
 			--set olm="${OLM}" \
-			--set operator.image="$(MASTER_IMAGE)" > "$(KUBERNETES_CORE_YAML)"
+			--set image="$(MASTER_IMAGE)" > "$(KUBERNETES_CORE_YAML)"
 
 ## Generates a manifest for Kubernetes including a CRD, a CSI driver deployment and a OLM version
 manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi

--- a/hack/make/manifests/openshift.mk
+++ b/hack/make/manifests/openshift.mk
@@ -13,7 +13,7 @@ manifests/openshift/csi:
 		--set manifests=true \
 		--set olm="${OLM}" \
 		--set createSecurityContextConstraints="true" \
-		--set operator.image="$(MASTER_IMAGE)" > "$(OPENSHIFT_CSIDRIVER_YAML)"
+		--set image="$(MASTER_IMAGE)" > "$(OPENSHIFT_CSIDRIVER_YAML)"
 
 ## Generates an OpenShift manifest with a CRD
 manifests/openshift/core: manifests/crd/helm prerequisites/kustomize
@@ -24,7 +24,7 @@ manifests/openshift/core: manifests/crd/helm prerequisites/kustomize
 		--set manifests=true \
 		--set olm="${OLM}" \
 		--set createSecurityContextConstraints="true" \
-		--set operator.image="$(MASTER_IMAGE)" > "$(OPENSHIFT_CORE_YAML)"
+		--set image="$(MASTER_IMAGE)" > "$(OPENSHIFT_CORE_YAML)"
 
 ## Generates a manifest for OpenShift including a CRD and a CSI driver deployment
 manifests/openshift: manifests/openshift/core manifests/openshift/csi


### PR DESCRIPTION
# Description
Setting the `image` for the deployments when using helm now is less weird, as the while you already could set the `image` for the deployments, you had to do it with `operator.image` which is a bit confusing when it also updates the image used by the CSI and webhook.

## How can this be tested?
Set the `image` field when deploying(or generating yamls) via helm, then check that it was used in the deployments/daemonset.

Also try what is described in https://github.com/Dynatrace/dynatrace-operator/blob/master/config/helm/README.md.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
