### PR TITLE
Add `UsesImage` column to Dynakube metadata table

### DIFF
--- a/src/controllers/csi/driver/volumes/app/publisher_test.go
+++ b/src/controllers/csi/driver/volumes/app/publisher_test.go
@@ -185,7 +185,7 @@ func mockPublishedVolume(t *testing.T, publisher *AppVolumePublisher) {
 }
 
 func mockOneAgent(t *testing.T, publisher *AppVolumePublisher) {
-	err := publisher.db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, testAgentVersion))
+	err := publisher.db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, testAgentVersion, false))
 	require.NoError(t, err)
 }
 

--- a/src/controllers/csi/driver/volumes/bind_config_test.go
+++ b/src/controllers/csi/driver/volumes/bind_config_test.go
@@ -32,7 +32,7 @@ func TestNewBindConfig(t *testing.T) {
 
 		db := metadata.FakeMemoryDB()
 
-		db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, testAgentVersion))
+		db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, testAgentVersion, false))
 
 		bindCfg, err := NewBindConfig(context.TODO(), db, volumeCfg)
 

--- a/src/controllers/csi/driver/volumes/host/publisher_test.go
+++ b/src/controllers/csi/driver/volumes/host/publisher_test.go
@@ -148,12 +148,12 @@ func mockPublishedvolume(t *testing.T, publisher *HostVolumePublisher) {
 }
 
 func mockDynakube(t *testing.T, publisher *HostVolumePublisher) {
-	err := publisher.db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, "some-version"))
+	err := publisher.db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, "some-version", false))
 	require.NoError(t, err)
 }
 
 func mockDynakubeWithoutVersion(t *testing.T, publisher *HostVolumePublisher) {
-	err := publisher.db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, ""))
+	err := publisher.db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, "", false))
 	require.NoError(t, err)
 }
 

--- a/src/controllers/csi/metadata/correctness_test.go
+++ b/src/controllers/csi/metadata/correctness_test.go
@@ -6,6 +6,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -58,33 +59,33 @@ func TestCheckStorageCorrectness_PURGE(t *testing.T) {
 	)
 
 	err := CorrectMetadata(client, db)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	vol, err := db.GetVolume(testVolume1.VolumeID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &testVolume1, vol)
 
 	ten, err := db.GetDynakube(testDynakube1.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &testDynakube1, ten)
 
 	// PURGED
 	vol, err = db.GetVolume(testVolume2.VolumeID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, vol)
 
 	// PURGED
 	vol, err = db.GetVolume(testVolume3.VolumeID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, vol)
 
 	// PURGED
 	ten, err = db.GetDynakube(testDynakube2.TenantUUID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, ten)
 
 	// PURGED
 	ten, err = db.GetDynakube(testDynakube3.TenantUUID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, ten)
 }

--- a/src/controllers/csi/metadata/fakes.go
+++ b/src/controllers/csi/metadata/fakes.go
@@ -50,7 +50,6 @@ func emptyMemoryDB() *SqliteAccess {
 func FakeMemoryDB() *SqliteAccess {
 	db := SqliteAccess{}
 	db.Setup(":memory:")
-	_ = db.createTables()
 	return &db
 }
 

--- a/src/controllers/csi/metadata/fakes.go
+++ b/src/controllers/csi/metadata/fakes.go
@@ -9,6 +9,7 @@ var (
 		TenantUUID:    "asc1",
 		LatestVersion: "123",
 		Name:          "dk1",
+		UsesImage:     true,
 	}
 	testDynakube2 = Dynakube{
 		TenantUUID:    "asc2",
@@ -50,6 +51,7 @@ func emptyMemoryDB() *SqliteAccess {
 func FakeMemoryDB() *SqliteAccess {
 	db := SqliteAccess{}
 	db.Setup(":memory:")
+	_ = db.createTables()
 	return &db
 }
 

--- a/src/controllers/csi/metadata/metadata.go
+++ b/src/controllers/csi/metadata/metadata.go
@@ -11,14 +11,15 @@ type Dynakube struct {
 	Name          string `json:"name"`
 	TenantUUID    string `json:"tenantUUID"`
 	LatestVersion string `json:"latestVersion"`
+	UsesImage     bool   `json:"usesImage"`
 }
 
 // NewDynakube returns a new metadata.Dynakube if all fields are set.
-func NewDynakube(dynakubeName, tenantUUID, latestVersion string) *Dynakube {
+func NewDynakube(dynakubeName, tenantUUID, latestVersion string, usesImage bool) *Dynakube {
 	if tenantUUID == "" || dynakubeName == "" {
 		return nil
 	}
-	return &Dynakube{dynakubeName, tenantUUID, latestVersion}
+	return &Dynakube{dynakubeName, tenantUUID, latestVersion, usesImage}
 }
 
 type Volume struct {

--- a/src/controllers/csi/metadata/sqlite.go
+++ b/src/controllers/csi/metadata/sqlite.go
@@ -44,13 +44,13 @@ const (
 	// ALTER
 	dynakubesAlterStatementUsesImageColumn = `
 	ALTER TABLE dynakubes
-	ADD COLUMN uses_image BOOLEAN NOT NULL DEFAULT false;
+	ADD COLUMN UsesImage BOOLEAN NOT NULL DEFAULT false;
 	`
 
 	// INSERT
 	insertDynakubeStatement = `
-	INSERT INTO dynakubes (Name, TenantUUID, LatestVersion)
-	VALUES (?,?,?);
+	INSERT INTO dynakubes (Name, TenantUUID, LatestVersion, UsesImage)
+	VALUES (?,?,?,?);
 	`
 
 	insertVolumeStatement = `
@@ -190,9 +190,9 @@ func (a *SqliteAccess) setupDynakubeTable() error {
 		return fmt.Errorf("couldn't create the table %s, err: %s", dynakubesTableName, err)
 	}
 
-	// errors if column already exists
 	if _, err := a.conn.Exec(dynakubesAlterStatementUsesImageColumn); err != nil {
-		return fmt.Errorf("couldn't add uses image column to table %s, err: %s", dynakubesTableName, err)
+		// statement errors if column already exists, swallow error
+		log.Info("column UsesImage already exists")
 	}
 	return nil
 }
@@ -224,7 +224,7 @@ func (a *SqliteAccess) InsertDynakube(dynakube *Dynakube) error {
 
 // UpdateDynakube updates an existing Dynakube by matching the name
 func (a *SqliteAccess) UpdateDynakube(dynakube *Dynakube) error {
-	err := a.executeStatement(updateDynakubeStatement, dynakube.LatestVersion, dynakube.TenantUUID, dynakube.Name, dynakube.UsesImage)
+	err := a.executeStatement(updateDynakubeStatement, dynakube.LatestVersion, dynakube.TenantUUID, dynakube.UsesImage, dynakube.Name)
 	if err != nil {
 		err = fmt.Errorf("couldn't update dynakube, tenantUUID '%s', latest version '%s', name '%s', uses image '%t', err: %s",
 			dynakube.TenantUUID,

--- a/src/controllers/csi/metadata/sqlite.go
+++ b/src/controllers/csi/metadata/sqlite.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 )
 
 const (
@@ -191,8 +191,11 @@ func (a *SqliteAccess) setupDynakubeTable() error {
 	}
 
 	if _, err := a.conn.Exec(dynakubesAlterStatementUsesImageColumn); err != nil {
-		// statement errors if column already exists, swallow error
-		log.Info("column UsesImage already exists")
+		sqliteError := err.(sqlite3.Error)
+		if sqliteError.Code == sqlite3.ErrError {
+			// generic sql error, column already exists
+			log.Info("column UsesImage already exists")
+		}
 	}
 	return nil
 }

--- a/src/controllers/csi/metadata/sqlite.go
+++ b/src/controllers/csi/metadata/sqlite.go
@@ -192,10 +192,11 @@ func (a *SqliteAccess) setupDynakubeTable() error {
 
 	if _, err := a.conn.Exec(dynakubesAlterStatementUsesImageColumn); err != nil {
 		sqliteError := err.(sqlite3.Error)
-		if sqliteError.Code == sqlite3.ErrError {
-			// generic sql error, column already exists
-			log.Info("column UsesImage already exists")
+		if sqliteError.Code != sqlite3.ErrError {
+			return err
 		}
+		// generic sql error, column already exists
+		log.Info("column UsesImage already exists")
 	}
 	return nil
 }

--- a/src/controllers/csi/provisioner/controller_test.go
+++ b/src/controllers/csi/provisioner/controller_test.go
@@ -356,7 +356,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 	t.Run(`correct directories are created`, func(t *testing.T) {
 		memFs := afero.NewMemMapFs()
 		memDB := metadata.FakeMemoryDB()
-		err := memDB.InsertDynakube(metadata.NewDynakube(dkName, tenantUUID, agentVersion))
+		err := memDB.InsertDynakube(metadata.NewDynakube(dkName, tenantUUID, agentVersion, false))
 		require.NoError(t, err)
 
 		mockClient := &dtclient.MockDynatraceClient{}
@@ -479,14 +479,14 @@ func buildValidApplicationMonitoringSpec(_ *testing.T) *dynatracev1beta1.Applica
 
 func TestProvisioner_CreateDynakube(t *testing.T) {
 	db := metadata.FakeMemoryDB()
-	expectedOtherDynakube := metadata.NewDynakube(otherDkName, tenantUUID, "v1")
+	expectedOtherDynakube := metadata.NewDynakube(otherDkName, tenantUUID, "v1", false)
 	db.InsertDynakube(expectedOtherDynakube)
 	provisioner := &OneAgentProvisioner{
 		db: db,
 	}
 
 	oldDynakube := metadata.Dynakube{}
-	newDynakube := metadata.NewDynakube(dkName, tenantUUID, "v1")
+	newDynakube := metadata.NewDynakube(dkName, tenantUUID, "v1", false)
 
 	err := provisioner.createOrUpdateDynakubeMetadata(oldDynakube, newDynakube)
 	require.NoError(t, err)
@@ -504,15 +504,15 @@ func TestProvisioner_CreateDynakube(t *testing.T) {
 
 func TestProvisioner_UpdateDynakube(t *testing.T) {
 	db := metadata.FakeMemoryDB()
-	oldDynakube := metadata.NewDynakube(dkName, tenantUUID, "v1")
+	oldDynakube := metadata.NewDynakube(dkName, tenantUUID, "v1", false)
 	db.InsertDynakube(oldDynakube)
-	expectedOtherDynakube := metadata.NewDynakube(otherDkName, tenantUUID, "v1")
+	expectedOtherDynakube := metadata.NewDynakube(otherDkName, tenantUUID, "v1", false)
 	db.InsertDynakube(expectedOtherDynakube)
 
 	provisioner := &OneAgentProvisioner{
 		db: db,
 	}
-	newDynakube := metadata.NewDynakube(dkName, "new-uuid", "v2")
+	newDynakube := metadata.NewDynakube(dkName, "new-uuid", "v2", false)
 
 	err := provisioner.createOrUpdateDynakubeMetadata(*oldDynakube, newDynakube)
 	require.NoError(t, err)


### PR DESCRIPTION
# Description
Add new `UsesImage` column to the Dynakube table to be used by CSI server and provisioner. Migration of existing databases to updated schema with new column should happen automatically.

## How can this be tested?
No change in functionality when using the CSI driver:
* existing data is migrated to new schema without data loss
* new value is currently not used, so no changes expected

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

