### PR TITLE
Added feature flag to run oneagent as privileged

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -49,11 +49,12 @@ const (
 	AnnotationFeatureDisableHostsRequests = AnnotationFeaturePrefix + "disable-hosts-requests"
 
 	// oneAgent
-	AnnotationFeatureOneAgentMaxUnavailable       = AnnotationFeaturePrefix + "oneagent-max-unavailable"
-	AnnotationFeatureDisableReadOnlyOneAgent      = AnnotationFeaturePrefix + "disable-oneagent-readonly-host-fs"
-	AnnotationFeatureEnableMultipleOsAgentsOnNode = AnnotationFeaturePrefix + "multiple-osagents-on-node"
-	AnnotationFeatureOneAgentIgnoreProxy          = AnnotationFeaturePrefix + "oneagent-ignore-proxy"
-	AnnotationFeatureOneAgentInitialConnectRetry  = AnnotationFeaturePrefix + "oneagent-initial-connect-retry-ms"
+	AnnotationFeatureOneAgentMaxUnavailable         = AnnotationFeaturePrefix + "oneagent-max-unavailable"
+	AnnotationFeatureDisableReadOnlyOneAgent        = AnnotationFeaturePrefix + "disable-oneagent-readonly-host-fs"
+	AnnotationFeatureEnableMultipleOsAgentsOnNode   = AnnotationFeaturePrefix + "multiple-osagents-on-node"
+	AnnotationFeatureOneAgentIgnoreProxy            = AnnotationFeaturePrefix + "oneagent-ignore-proxy"
+	AnnotationFeatureOneAgentInitialConnectRetry    = AnnotationFeaturePrefix + "oneagent-initial-connect-retry-ms"
+	AnnotationFeatureRunOneAgentContainerPrivileged = AnnotationFeaturePrefix + "oneagent-privileged"
 
 	// injection (webhook)
 	AnnotationFeatureDisableWebhookReinvocationPolicy = AnnotationFeaturePrefix + "disable-webhook-reinvocation-policy"
@@ -219,6 +220,10 @@ func (dk *DynaKube) FeatureAgentInitialConnectRetry() int {
 	}
 
 	return val
+}
+
+func (dk *DynaKube) FeatureAgentRunPrivileged() bool {
+	return dk.getFeatureFlagRaw(AnnotationFeatureRunOneAgentContainerPrivileged) == "true"
 }
 
 func (dk *DynaKube) getFeatureFlagRaw(annotation string) string {

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -114,7 +114,7 @@ func (dk *DynaKube) NeedsOneAgentProxy() bool {
 	return !dk.FeatureOneAgentIgnoreProxy() && dk.hasProxy()
 }
 
-func (dk *DynaKube) OneAgentRunsPrivileged() bool {
+func (dk *DynaKube) IsOneAgentPrivileged() bool {
 	return dk.FeatureAgentRunPrivileged()
 }
 

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -114,6 +114,10 @@ func (dk *DynaKube) NeedsOneAgentProxy() bool {
 	return !dk.FeatureOneAgentIgnoreProxy() && dk.hasProxy()
 }
 
+func (dk *DynaKube) OneAgentRunsPrivileged() bool {
+	return dk.FeatureAgentRunPrivileged()
+}
+
 // ShouldAutoUpdateOneAgent returns true if the Operator should update OneAgent instances automatically.
 func (dk *DynaKube) ShouldAutoUpdateOneAgent() bool {
 	if dk.CloudNativeFullstackMode() {

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -284,5 +284,9 @@ func (dsInfo *builderInfo) unprivilegedSecurityContext() *corev1.SecurityContext
 		securityContext.RunAsUser = &unprivilegedUser
 		securityContext.RunAsGroup = &unprivilegedGroup
 	}
+	runAsPrivileged := true
+	if dsInfo.instance.OneAgentRunsPrivileged() {
+		securityContext.Privileged = &runAsPrivileged
+	}
 	return securityContext
 }


### PR DESCRIPTION
# Description

Added new feature flag which allows the oneagent container to run as privileged

## How can this be tested?
Apply this feature flag and check whether the oneagent container is ran in a privileged context.

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly

