### PR TITLE
Reworks imageInstaller to extract into a shared dir

### DIFF
--- a/src/controllers/csi/metadata/path_resolver.go
+++ b/src/controllers/csi/metadata/path_resolver.go
@@ -42,6 +42,10 @@ func (pr PathResolver) AgentBinaryDirForVersion(tenantUUID string, version strin
 	return filepath.Join(pr.AgentBinaryDir(tenantUUID), version)
 }
 
+func (pr PathResolver) AgentSharedBinaryDirForVersion(version string) string {
+	return filepath.Join(pr.RootDir, "codemodules", version)
+}
+
 func (pr PathResolver) InnerAgentBinaryDirForSymlinkForVersion(tenantUUID string, version string) string {
 	return filepath.Join(pr.AgentBinaryDirForVersion(tenantUUID, version), "agent", "bin", "current")
 }

--- a/src/controllers/csi/metadata/path_resolver.go
+++ b/src/controllers/csi/metadata/path_resolver.go
@@ -46,7 +46,7 @@ func (pr PathResolver) AgentSharedBinaryDirBase() string {
 	return filepath.Join(pr.RootDir, "codemodules")
 }
 
-func (pr PathResolver) AgentSharedBinaryDirForDigest(digest string) string {
+func (pr PathResolver) AgentSharedBinaryDirForImage(digest string) string {
 	return filepath.Join(pr.AgentSharedBinaryDirBase(), digest)
 }
 

--- a/src/controllers/csi/metadata/path_resolver.go
+++ b/src/controllers/csi/metadata/path_resolver.go
@@ -42,8 +42,16 @@ func (pr PathResolver) AgentBinaryDirForVersion(tenantUUID string, version strin
 	return filepath.Join(pr.AgentBinaryDir(tenantUUID), version)
 }
 
-func (pr PathResolver) AgentSharedBinaryDirForVersion(version string) string {
-	return filepath.Join(pr.RootDir, "codemodules", version)
+func (pr PathResolver) AgentSharedBinaryDirBase() string {
+	return filepath.Join(pr.RootDir, "codemodules")
+}
+
+func (pr PathResolver) AgentSharedBinaryDirForDigest(digest string) string {
+	return filepath.Join(pr.AgentSharedBinaryDirBase(), digest)
+}
+
+func (pr PathResolver) AgentConfigDir(tenantUUID string) string {
+	return filepath.Join(pr.EnvDir(tenantUUID), "config")
 }
 
 func (pr PathResolver) InnerAgentBinaryDirForSymlinkForVersion(tenantUUID string, version string) string {

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -44,6 +44,7 @@ func newAgentUpdater(
 	var err error
 	if dk.CodeModulesImage() != "" {
 		agentInstaller, err = setupImageInstaller(ctx, fs, apiReader, certPath, dk)
+		targetDir = path.AgentSharedBinaryDirForVersion(targetVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -99,7 +99,7 @@ func getUrlProperties(version string) *url.Properties {
 	}
 }
 
-func setupImageInstaller(ctx context.Context, fs afero.Fs, path metadata.PathResolver, apiReader client.Reader, certPath, digest string, dynakube *dynatracev1beta1.DynaKube) (installer.Installer, error) {
+func setupImageInstaller(ctx context.Context, fs afero.Fs, pathResolver metadata.PathResolver, apiReader client.Reader, certPath, digest string, dynakube *dynatracev1beta1.DynaKube) (installer.Installer, error) {
 	dockerConfig, err := dockerconfig.NewDockerConfig(ctx, apiReader, *dynakube)
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func setupImageInstaller(ctx context.Context, fs afero.Fs, path metadata.PathRes
 	imageInstaller := image.NewImageInstaller(fs, &image.Properties{
 		ImageUri:     dynakube.CodeModulesImage(),
 		ImageDigest:  digest,
-		PathResolver: path,
+		PathResolver: pathResolver,
 		DockerConfig: *dockerConfig})
 	return imageInstaller, nil
 }

--- a/src/controllers/csi/provisioner/agent_test.go
+++ b/src/controllers/csi/provisioner/agent_test.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	testVersion = "test"
+	testDigest  = "123iamDigest456"
 )
 
 func TestNewAgentUpdater(t *testing.T) {
@@ -348,7 +349,7 @@ func createTestAgentImageUpdater(t *testing.T, dk *dynatracev1beta1.DynaKube, ob
 	fs := afero.NewMemMapFs()
 	rec := record.NewFakeRecorder(10)
 
-	updater, err := newAgentImageUpdater(context.TODO(), fs, fake.NewClient(obj...), path, rec, dk, "TODO")
+	updater, err := newAgentImageUpdater(context.TODO(), fs, fake.NewClient(obj...), path, rec, dk, testDigest)
 	require.NoError(t, err)
 	updater.installer = &installer.InstallerMock{}
 

--- a/src/controllers/csi/provisioner/agent_test.go
+++ b/src/controllers/csi/provisioner/agent_test.go
@@ -65,7 +65,6 @@ func TestUpdateAgent(t *testing.T) {
 
 		currentVersion, err := updater.updateAgent(
 			testVersion,
-			testTenantUUID,
 			&processModuleCache)
 
 		require.NoError(t, err)
@@ -111,7 +110,6 @@ func TestUpdateAgent(t *testing.T) {
 
 		currentVersion, err := updater.updateAgent(
 			testVersion,
-			testTenantUUID,
 			&processModuleCache)
 
 		require.NoError(t, err)
@@ -147,7 +145,6 @@ func TestUpdateAgent(t *testing.T) {
 
 		currentVersion, err := updater.updateAgent(
 			testVersion,
-			testTenantUUID,
 			&processModuleCache)
 
 		require.Error(t, err)
@@ -210,7 +207,6 @@ func TestUpdateAgent(t *testing.T) {
 
 		currentVersion, err := updater.updateAgent(
 			testVersion,
-			testTenantUUID,
 			&processModuleConfig)
 		require.NoError(t, err)
 		assert.Equal(t, tag, currentVersion)
@@ -276,7 +272,6 @@ func TestUpdateAgent(t *testing.T) {
 
 		currentVersion, err := updater.updateAgent(
 			testVersion,
-			testTenantUUID,
 			&processModuleConfig)
 		require.NoError(t, err)
 		assert.Equal(t, tag, currentVersion)
@@ -323,7 +318,6 @@ func updateOneagent(t *testing.T, alreadyInstalled bool) {
 
 	currentVersion, err := updater.updateAgent(
 		"other",
-		testTenantUUID,
 		&processModuleCache)
 
 	require.NoError(t, err)

--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -172,7 +172,7 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 		log.Info("error when setting up the agent updater", "error", err.Error())
 		return nil, false, err
 	}
-	if updatedVersion, err := agentUpdater.updateAgent(dynakubeMetadata.LatestVersion, dynakubeMetadata.TenantUUID, latestProcessModuleConfigCache); err != nil {
+	if updatedVersion, err := agentUpdater.updateAgent(dynakubeMetadata.LatestVersion, latestProcessModuleConfigCache); err != nil {
 		log.Info("error when updating agent", "error", err.Error())
 		// reporting error but not returning it to avoid immediate requeue and subsequently calling the API every few seconds
 		return nil, true, nil

--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -179,14 +179,15 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 		log.Info("error when setting up the agent updater", "error", err.Error())
 		return nil, false, err
 	}
-	if updatedVersion, err := agentUpdater.updateAgent(dynakubeMetadata.LatestVersion, latestProcessModuleConfigCache); err != nil {
+	updatedVersion, err := agentUpdater.updateAgent(dynakubeMetadata.LatestVersion, latestProcessModuleConfigCache)
+	if err != nil {
 		log.Info("error when updating agent", "error", err.Error())
 		// reporting error but not returning it to avoid immediate requeue and subsequently calling the API every few seconds
 		return nil, true, nil
 	} else if updatedVersion != "" {
 		dynakubeMetadata.LatestVersion = updatedVersion
-		imageInstaller, ok := agentUpdater.installer.(*image.ImageInstaller)
-		if ok {
+		imageInstaller, isImageInstaller := agentUpdater.installer.(*image.ImageInstaller)
+		if isImageInstaller {
 			dynakubeMetadata.ImageDigest = imageInstaller.ImageDigest()
 		}
 	}

--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -159,13 +159,7 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 
 	var agentUpdater *agentUpdater
 	if dk.CodeModulesImage() != "" {
-		// TODO: Maybe use the one in the Dynakube ?
-		connectionInfo, err := dtc.GetConnectionInfo()
-		if err != nil {
-			log.Error(err, "error when getting OneAgent connectionInfo")
-			return nil, false, err
-		}
-		latestProcessModuleConfig = latestProcessModuleConfig.AddConnectionInfo(connectionInfo)
+		latestProcessModuleConfig = latestProcessModuleConfig.AddConnectionInfo(dk.ConnectionInfo())
 		agentUpdater, err = newAgentImageUpdater(ctx, provisioner.fs, provisioner.apiReader, provisioner.path, provisioner.recorder, dk, dynakubeMetadata.ImageDigest)
 		if err != nil {
 			log.Error(err, "error when setting up the agent image updater")

--- a/src/controllers/csi/provisioner/events.go
+++ b/src/controllers/csi/provisioner/events.go
@@ -1,0 +1,26 @@
+package csiprovisioner
+
+import (
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+type updaterEventRecorder struct {
+	dynakube *dynatracev1beta1.DynaKube
+	recorder record.EventRecorder
+}
+
+func (event *updaterEventRecorder) sendFailedInstallAgentVersionEvent(version, tenantUUID string) {
+	event.recorder.Eventf(event.dynakube,
+		corev1.EventTypeWarning,
+		failedInstallAgentVersionEvent,
+		"Failed to install agent version: %s to tenant: %s", version, tenantUUID)
+}
+
+func (event *updaterEventRecorder) sendInstalledAgentVersionEvent(version, tenantUUID string) {
+	event.recorder.Eventf(event.dynakube,
+		corev1.EventTypeNormal,
+		installAgentVersionEvent,
+		"Installed agent version: %s to tenant: %s", version, tenantUUID)
+}

--- a/src/installer/common/consts.go
+++ b/src/installer/common/consts.go
@@ -2,4 +2,5 @@ package common
 
 const (
 	AgentConfDirPath = "agent/conf"
+	MkDirFileMode    = 0755
 )

--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -84,7 +84,7 @@ func (installer *ImageInstaller) installAgentFromImage() error {
 	}
 
 	imageDigestEncoded := imageDigest.Encoded()
-	imageCacheDir := filepath.Join(CacheDir, imageDigestEncoded)
+	imageCacheDir := getCacheDirPath(imageDigestEncoded)
 	if installer.isAlreadyDownloaded(imageDigestEncoded, imageCacheDir) {
 		log.Info("image is already installed", "image", image, "digest", imageDigestEncoded)
 		installer.props.ImageDigest = imageDigestEncoded
@@ -132,4 +132,8 @@ func (installer ImageInstaller) isAlreadyDownloaded(imageDigestEncoded string, i
 
 func getImageDigest(systemContext *types.SystemContext, imageReference *types.ImageReference) (digest.Digest, error) {
 	return docker.GetDigest(context.TODO(), systemContext, *imageReference)
+}
+
+func getCacheDirPath(digest string) string {
+	return filepath.Join(CacheDir, digest)
 }

--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -62,7 +62,7 @@ func (installer ImageInstaller) UpdateProcessModuleConfig(targetDir string, proc
 }
 
 func (installer *ImageInstaller) installAgentFromImage() error {
-	defer func() { _ = installer.fs.RemoveAll(CacheDir) }()
+	defer installer.fs.RemoveAll(CacheDir)
 	err := installer.fs.MkdirAll(CacheDir, 0755)
 	if err != nil {
 		log.Info("failed to create cache dir", "err", err)

--- a/src/installer/image/source.go
+++ b/src/installer/image/source.go
@@ -5,20 +5,21 @@ import (
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
+	"github.com/pkg/errors"
 )
 
 func getSourceInfo(cacheDir string, pullInfo Properties) (*types.SystemContext, *types.ImageReference, error) {
 	imageRef, err := parseImageReference(pullInfo.ImageUri)
 	if err != nil {
 		log.Info("failed to parse image reference", "image", pullInfo.ImageUri)
-		return nil, nil, err
+		return nil, nil, errors.WithStack(err)
 	}
 	log.Info("parsed image reference", "imageRef", imageRef)
 
 	sourceRef, err := getSourceReference(imageRef)
 	if err != nil {
 		log.Info("failed to get source reference", "image", pullInfo.ImageUri, "imageRef", imageRef)
-		return nil, nil, err
+		return nil, nil, errors.WithStack(err)
 	}
 	log.Info("got source reference", "image", pullInfo.ImageUri)
 
@@ -29,7 +30,7 @@ func getSourceInfo(cacheDir string, pullInfo Properties) (*types.SystemContext, 
 func parseImageReference(uri string) (reference.Named, error) {
 	ref, err := reference.ParseNormalizedNamed(uri)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	ref = reference.TagNameOnly(ref)
 
@@ -38,7 +39,7 @@ func parseImageReference(uri string) (reference.Named, error) {
 
 func getSourceReference(named reference.Named) (*types.ImageReference, error) {
 	ref, err := docker.NewReference(named)
-	return &ref, err
+	return &ref, errors.WithStack(err)
 }
 
 func buildSourceContext(imageRef reference.Named, cacheDir string, dockerConfig dockerconfig.DockerConfig) *types.SystemContext {

--- a/src/installer/image/unpack.go
+++ b/src/installer/image/unpack.go
@@ -24,7 +24,7 @@ type imagePullInfo struct {
 	destinationRef *types.ImageReference
 }
 
-func (installer *ImageInstaller) extractAgentBinariesFromImage(pullInfo imagePullInfo) error {
+func (installer ImageInstaller) extractAgentBinariesFromImage(pullInfo imagePullInfo) error {
 	manifestBlob, err := copyImageToCache(pullInfo)
 	if err != nil {
 		log.Info("failed to get manifests blob",
@@ -46,7 +46,7 @@ func (installer *ImageInstaller) extractAgentBinariesFromImage(pullInfo imagePul
 
 }
 
-func (installer *ImageInstaller) unmarshalManifestBlob(manifestBlob []byte, imageCacheDir string) ([]*manifest.OCI1, error) {
+func (installer ImageInstaller) unmarshalManifestBlob(manifestBlob []byte, imageCacheDir string) ([]*manifest.OCI1, error) {
 	var manifests []*manifest.OCI1
 
 	switch manifest.GuessMIMEType(manifestBlob) {
@@ -67,7 +67,7 @@ func (installer *ImageInstaller) unmarshalManifestBlob(manifestBlob []byte, imag
 	return manifests, nil
 }
 
-func (installer *ImageInstaller) unpackOciImage(manifests []*manifest.OCI1, imageCacheDir string, targetDir string) error {
+func (installer ImageInstaller) unpackOciImage(manifests []*manifest.OCI1, imageCacheDir string, targetDir string) error {
 	for _, entry := range manifests {
 		for _, layer := range entry.LayerInfos() {
 			switch layer.MediaType {

--- a/src/installer/image/unpack.go
+++ b/src/installer/image/unpack.go
@@ -23,7 +23,7 @@ type imagePullInfo struct {
 	destinationRef *types.ImageReference
 }
 
-func (installer *imageInstaller) extractAgentBinariesFromImage(pullInfo imagePullInfo) error {
+func (installer *ImageInstaller) extractAgentBinariesFromImage(pullInfo imagePullInfo) error {
 	manifestBlob, err := copyImageToCache(pullInfo)
 	if err != nil {
 		log.Info("failed to get manifests blob",
@@ -45,7 +45,7 @@ func (installer *imageInstaller) extractAgentBinariesFromImage(pullInfo imagePul
 
 }
 
-func (installer *imageInstaller) unmarshalManifestBlob(manifestBlob []byte, imageCacheDir string) ([]*manifest.OCI1, error) {
+func (installer *ImageInstaller) unmarshalManifestBlob(manifestBlob []byte, imageCacheDir string) ([]*manifest.OCI1, error) {
 	var manifests []*manifest.OCI1
 
 	switch manifest.GuessMIMEType(manifestBlob) {
@@ -66,7 +66,7 @@ func (installer *imageInstaller) unmarshalManifestBlob(manifestBlob []byte, imag
 	return manifests, nil
 }
 
-func (installer *imageInstaller) unpackOciImage(manifests []*manifest.OCI1, imageCacheDir string, targetDir string) error {
+func (installer *ImageInstaller) unpackOciImage(manifests []*manifest.OCI1, imageCacheDir string, targetDir string) error {
 	for _, entry := range manifests {
 		for _, layer := range entry.LayerInfos() {
 			switch layer.MediaType {

--- a/src/installer/symlink/symlink.go
+++ b/src/installer/symlink/symlink.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )
 
@@ -23,7 +24,7 @@ func CreateSymlinkForCurrentVersionIfNotExists(fs afero.Fs, targetDir string) er
 	relativeSymlinkPath, err = findVersionFromFileSystem(fs, targetBindDir)
 	if err != nil {
 		log.Info("failed to get the version from the filesystem", "targetDir", targetDir)
-		return err
+		return errors.WithStack(err)
 	}
 
 	symlinkTargetPath := filepath.Join(targetBindDir, "current")
@@ -35,7 +36,7 @@ func CreateSymlinkForCurrentVersionIfNotExists(fs afero.Fs, targetDir string) er
 	log.Info("creating symlink", "points-to(relative)", relativeSymlinkPath, "location", symlinkTargetPath)
 	if err := linker.SymlinkIfPossible(relativeSymlinkPath, symlinkTargetPath); err != nil {
 		log.Info("symlinking failed", "version", relativeSymlinkPath)
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }
@@ -58,7 +59,7 @@ func findVersionFromFileSystem(fs afero.Fs, targetDir string) (string, error) {
 		return nil
 	}
 	if err := aferoFs.Walk(targetDir, walkFiles); err != nil && err != iofs.ErrExist {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 	return version, nil
 }

--- a/src/installer/url/download.go
+++ b/src/installer/url/download.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (installer *UrlInstaller) downloadOneAgentFromUrl(tmpFile afero.File) error {
+func (installer UrlInstaller) downloadOneAgentFromUrl(tmpFile afero.File) error {
 	if installer.props.Url != "" {
 		if err := installer.downloadOneAgentViaInstallerUrl(tmpFile); err != nil {
 			return errors.WithStack(err)
@@ -22,7 +22,7 @@ func (installer *UrlInstaller) downloadOneAgentFromUrl(tmpFile afero.File) error
 	return nil
 }
 
-func (installer *UrlInstaller) downloadLatestOneAgent(tmpFile afero.File) error {
+func (installer UrlInstaller) downloadLatestOneAgent(tmpFile afero.File) error {
 	log.Info("downloading latest OneAgent package", "props", installer.props)
 	return installer.dtc.GetLatestAgent(
 		installer.props.Os,
@@ -34,7 +34,7 @@ func (installer *UrlInstaller) downloadLatestOneAgent(tmpFile afero.File) error 
 	)
 }
 
-func (installer *UrlInstaller) downloadOneAgentWithVersion(tmpFile afero.File) error {
+func (installer UrlInstaller) downloadOneAgentWithVersion(tmpFile afero.File) error {
 	log.Info("downloading specific OneAgent package", "version", installer.props.Version)
 	err := installer.dtc.GetAgent(
 		installer.props.Os,
@@ -63,7 +63,7 @@ func (installer *UrlInstaller) downloadOneAgentWithVersion(tmpFile afero.File) e
 	return nil
 }
 
-func (installer *UrlInstaller) downloadOneAgentViaInstallerUrl(tmpFile afero.File) error {
+func (installer UrlInstaller) downloadOneAgentViaInstallerUrl(tmpFile afero.File) error {
 	log.Info("downloading OneAgent package using provided url, all other properties are ignored", "url", installer.props.Url)
 	return installer.dtc.GetAgentViaInstallerUrl(installer.props.Url, tmpFile)
 }

--- a/src/installer/url/download.go
+++ b/src/installer/url/download.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (installer *urlInstaller) downloadOneAgentFromUrl(tmpFile afero.File) error {
+func (installer *UrlInstaller) downloadOneAgentFromUrl(tmpFile afero.File) error {
 	if installer.props.Url != "" {
 		if err := installer.downloadOneAgentViaInstallerUrl(tmpFile); err != nil {
 			return err
@@ -24,7 +24,7 @@ func (installer *urlInstaller) downloadOneAgentFromUrl(tmpFile afero.File) error
 	return nil
 }
 
-func (installer *urlInstaller) downloadLatestOneAgent(tmpFile afero.File) error {
+func (installer *UrlInstaller) downloadLatestOneAgent(tmpFile afero.File) error {
 	log.Info("downloading latest OneAgent package", "props", installer.props)
 	return installer.dtc.GetLatestAgent(
 		installer.props.Os,
@@ -36,7 +36,7 @@ func (installer *urlInstaller) downloadLatestOneAgent(tmpFile afero.File) error 
 	)
 }
 
-func (installer *urlInstaller) downloadOneAgentWithVersion(tmpFile afero.File) error {
+func (installer *UrlInstaller) downloadOneAgentWithVersion(tmpFile afero.File) error {
 	log.Info("downloading specific OneAgent package", "version", installer.props.Version)
 	err := installer.dtc.GetAgent(
 		installer.props.Os,
@@ -63,7 +63,7 @@ func (installer *urlInstaller) downloadOneAgentWithVersion(tmpFile afero.File) e
 	return nil
 }
 
-func (installer *urlInstaller) downloadOneAgentViaInstallerUrl(tmpFile afero.File) error {
+func (installer *UrlInstaller) downloadOneAgentViaInstallerUrl(tmpFile afero.File) error {
 	log.Info("downloading OneAgent package using provided url, all other properties are ignored", "url", installer.props.Url)
 	return installer.dtc.GetAgentViaInstallerUrl(installer.props.Url, tmpFile)
 }

--- a/src/installer/url/download.go
+++ b/src/installer/url/download.go
@@ -1,24 +1,22 @@
 package url
 
 import (
-	"fmt"
-	"strings"
-
+	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )
 
 func (installer *UrlInstaller) downloadOneAgentFromUrl(tmpFile afero.File) error {
 	if installer.props.Url != "" {
 		if err := installer.downloadOneAgentViaInstallerUrl(tmpFile); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	} else if installer.props.Version == VersionLatest {
 		if err := installer.downloadLatestOneAgent(tmpFile); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	} else {
 		if err := installer.downloadOneAgentWithVersion(tmpFile); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 	return nil
@@ -56,9 +54,11 @@ func (installer *UrlInstaller) downloadOneAgentWithVersion(tmpFile afero.File) e
 			installer.props.Arch,
 		)
 		if getVersionsError != nil {
-			return fmt.Errorf("failed to fetch OneAgent version: %w", err)
+			log.Info("failed to get available versions", "err", getVersionsError)
+			return errors.WithStack(getVersionsError)
 		}
-		return fmt.Errorf("failed to fetch OneAgent version: %w, available versions are: %s", err, "[ "+strings.Join(availableVersions, " , ")+" ]")
+		log.Info("failed to download specific OneAgent package", "version", installer.props.Version, "available versions", availableVersions)
+		return errors.WithStack(err)
 	}
 	return nil
 }

--- a/src/installer/url/installer.go
+++ b/src/installer/url/installer.go
@@ -2,6 +2,7 @@ package url
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
+	"github.com/Dynatrace/dynatrace-operator/src/installer/common"
 	"github.com/Dynatrace/dynatrace-operator/src/installer/symlink"
 	"github.com/Dynatrace/dynatrace-operator/src/processmoduleconfig"
 	"github.com/pkg/errors"
@@ -41,7 +42,7 @@ func NewUrlInstaller(fs afero.Fs, dtc dtclient.Client, props *Properties) *UrlIn
 func (installer UrlInstaller) InstallAgent(targetDir string) error {
 	log.Info("installing agent", "target dir", targetDir)
 	installer.props.fillEmptyWithDefaults()
-	err := installer.fs.MkdirAll(targetDir, 0755)
+	err := installer.fs.MkdirAll(targetDir, common.MkDirFileMode)
 	if err != nil {
 		log.Info("failed to create install target dir", "err", err, "targetDir", targetDir)
 		return errors.WithStack(err)

--- a/src/installer/url/installer.go
+++ b/src/installer/url/installer.go
@@ -38,7 +38,7 @@ func NewUrlInstaller(fs afero.Fs, dtc dtclient.Client, props *Properties) *UrlIn
 	}
 }
 
-func (installer *UrlInstaller) InstallAgent(targetDir string) error {
+func (installer UrlInstaller) InstallAgent(targetDir string) error {
 	log.Info("installing agent", "target dir", targetDir)
 	installer.props.fillEmptyWithDefaults()
 	err := installer.fs.MkdirAll(targetDir, 0755)
@@ -54,11 +54,11 @@ func (installer *UrlInstaller) InstallAgent(targetDir string) error {
 	return symlink.CreateSymlinkForCurrentVersionIfNotExists(installer.fs, targetDir)
 }
 
-func (installer *UrlInstaller) UpdateProcessModuleConfig(targetDir string, processModuleConfig *dtclient.ProcessModuleConfig) error {
+func (installer UrlInstaller) UpdateProcessModuleConfig(targetDir string, processModuleConfig *dtclient.ProcessModuleConfig) error {
 	return processmoduleconfig.UpdateProcessModuleConfigInPlace(installer.fs, targetDir, processModuleConfig)
 }
 
-func (installer *UrlInstaller) installAgentFromUrl(targetDir string) error {
+func (installer UrlInstaller) installAgentFromUrl(targetDir string) error {
 	fs := installer.fs
 	tmpFile, err := afero.TempFile(fs, "", "download")
 	if err != nil {

--- a/src/installer/url/installer_test.go
+++ b/src/installer/url/installer_test.go
@@ -43,7 +43,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 		}
 
 		err := installer.installAgentFromUrl("")
-		assert.EqualError(t, err, "failed to create temporary file for download: "+testErrorMessage)
+		assert.EqualError(t, err, testErrorMessage)
 	})
 	t.Run(`error when downloading latest agent`, func(t *testing.T) {
 		fs := afero.NewMemMapFs()
@@ -66,7 +66,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 		}
 
 		err := installer.installAgentFromUrl("")
-		assert.EqualError(t, err, "failed to fetch OneAgent version: "+testErrorMessage)
+		assert.EqualError(t, err, testErrorMessage)
 	})
 	t.Run(`error unzipping file`, func(t *testing.T) {
 		fs := afero.NewMemMapFs()

--- a/src/installer/url/installer_test.go
+++ b/src/installer/url/installer_test.go
@@ -38,7 +38,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 		fs := failFs{
 			Fs: afero.NewMemMapFs(),
 		}
-		installer := &urlInstaller{
+		installer := &UrlInstaller{
 			fs: fs,
 		}
 
@@ -55,7 +55,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 		dtc.
 			On("GetAgentVersions", dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro, mock.AnythingOfType("string")).
 			Return([]string{}, fmt.Errorf(testErrorMessage))
-		installer := &urlInstaller{
+		installer := &UrlInstaller{
 			fs:  fs,
 			dtc: dtc,
 			props: &Properties{
@@ -85,7 +85,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 				require.NoError(t, err)
 			}).
 			Return(nil)
-		installer := &urlInstaller{
+		installer := &UrlInstaller{
 			fs:  fs,
 			dtc: dtc,
 			props: &Properties{
@@ -114,7 +114,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 				require.NoError(t, err)
 			}).
 			Return(nil)
-		installer := &urlInstaller{
+		installer := &UrlInstaller{
 			fs:  fs,
 			dtc: dtc,
 			props: &Properties{
@@ -150,7 +150,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 				require.NoError(t, err)
 			}).
 			Return(nil)
-		installer := &urlInstaller{
+		installer := &UrlInstaller{
 			fs:  fs,
 			dtc: dtc,
 			props: &Properties{
@@ -185,7 +185,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 				require.NoError(t, err)
 			}).
 			Return(nil)
-		installer := &urlInstaller{
+		installer := &UrlInstaller{
 			fs:  fs,
 			dtc: dtc,
 			props: &Properties{

--- a/src/installer/url/unpack.go
+++ b/src/installer/url/unpack.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (installer *UrlInstaller) unpackOneAgentZip(targetDir string, tmpFile afero.File) error {
+func (installer UrlInstaller) unpackOneAgentZip(targetDir string, tmpFile afero.File) error {
 	var fileSize int64
 	if stat, err := tmpFile.Stat(); err == nil {
 		fileSize = stat.Size()

--- a/src/installer/url/unpack.go
+++ b/src/installer/url/unpack.go
@@ -1,9 +1,8 @@
 package url
 
 import (
-	"fmt"
-
 	"github.com/Dynatrace/dynatrace-operator/src/installer/zip"
+	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )
 
@@ -16,7 +15,8 @@ func (installer *UrlInstaller) unpackOneAgentZip(targetDir string, tmpFile afero
 	log.Info("saved OneAgent package", "dest", tmpFile.Name(), "size", fileSize)
 	log.Info("unzipping OneAgent package")
 	if err := zip.ExtractZip(installer.fs, tmpFile, targetDir); err != nil {
-		return fmt.Errorf("failed to unzip file: %w", err)
+		log.Info("failed to unzip OneAgent package", "err", err)
+		return errors.WithStack(err)
 	}
 	log.Info("unzipped OneAgent package")
 	return nil

--- a/src/installer/url/unpack.go
+++ b/src/installer/url/unpack.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (installer *urlInstaller) unpackOneAgentZip(targetDir string, tmpFile afero.File) error {
+func (installer *UrlInstaller) unpackOneAgentZip(targetDir string, tmpFile afero.File) error {
 	var fileSize int64
 	if stat, err := tmpFile.Stat(); err == nil {
 		fileSize = stat.Size()

--- a/src/installer/zip/gzip.go
+++ b/src/installer/zip/gzip.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Dynatrace/dynatrace-operator/src/installer/common"
 	"github.com/klauspost/compress/gzip"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -47,7 +48,7 @@ func ExtractGzip(fs afero.Fs, sourceFilePath, targetDir string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := fs.MkdirAll(target, 0755); err != nil {
+			if err := fs.MkdirAll(target, common.MkDirFileMode); err != nil {
 				return errors.WithStack(err)
 			}
 		case tar.TypeLink:

--- a/src/installer/zip/gzip.go
+++ b/src/installer/zip/gzip.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/klauspost/compress/gzip"
+	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )
 
@@ -18,13 +19,13 @@ func ExtractGzip(fs afero.Fs, sourceFilePath, targetDir string) error {
 
 	reader, err := fs.Open(sourceFilePath)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	defer func() { _ = reader.Close() }()
 
 	gzipReader, err := gzip.NewReader(reader)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	defer func() { _ = gzipReader.Close() }()
 
@@ -34,7 +35,7 @@ func ExtractGzip(fs afero.Fs, sourceFilePath, targetDir string) error {
 		if err == io.EOF {
 			return nil
 		} else if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 
 		target := filepath.Join(targetDir, header.Name)
@@ -47,19 +48,19 @@ func ExtractGzip(fs afero.Fs, sourceFilePath, targetDir string) error {
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if err := fs.MkdirAll(target, 0755); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 		case tar.TypeLink:
 			if err := extractLink(fs, targetDir, target, header); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 		case tar.TypeSymlink:
 			if err := extractSymlink(fs, targetDir, target, header); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 		case tar.TypeReg:
 			if err := extractFile(fs, target, header, tarReader); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 		default:
 			log.Info("skipping special file", "name", header.Name)
@@ -76,7 +77,7 @@ func extractLink(fs afero.Fs, targetDir, target string, header *tar.Header) erro
 	}
 	// Afero doesn't support Link, so we have to use os.Link
 	if err := os.Link(filepath.Join(targetDir, header.Linkname), target); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }
@@ -89,7 +90,7 @@ func extractSymlink(fs afero.Fs, targetDir, target string, header *tar.Header) e
 		return nil
 	}
 	if err := linker.SymlinkIfPossible(header.Linkname, target); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }
@@ -102,11 +103,11 @@ func extractFile(fs afero.Fs, target string, header *tar.Header, tarReader *tar.
 	destinationFile, err := fs.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(mode))
 	defer (func() { _ = destinationFile.Close() })()
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	if _, err := io.Copy(destinationFile, tarReader); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }

--- a/src/installer/zip/gzip.go
+++ b/src/installer/zip/gzip.go
@@ -21,13 +21,13 @@ func ExtractGzip(fs afero.Fs, sourceFilePath, targetDir string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 
 	gzipReader, err := gzip.NewReader(reader)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	defer func() { _ = gzipReader.Close() }()
+	defer gzipReader.Close()
 
 	tarReader := tar.NewReader(gzipReader)
 	for {

--- a/src/installer/zip/zip.go
+++ b/src/installer/zip/zip.go
@@ -30,7 +30,7 @@ func ExtractZip(fs afero.Fs, sourceFile afero.File, targetDir string) error {
 		return errors.WithStack(err)
 	}
 
-	err = fs.MkdirAll(targetDir, 0755)
+	err = fs.MkdirAll(targetDir, common.MkDirFileMode)
 	if err != nil {
 		log.Info("failed to create target directory", "err", err)
 		return errors.WithStack(err)

--- a/src/installer/zip/zip.go
+++ b/src/installer/zip/zip.go
@@ -72,13 +72,13 @@ func extractFileFromZip(fs afero.Fs, targetDir string, file *zip.File) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	defer func() { _ = dstFile.Close() }()
+	defer dstFile.Close()
 
 	srcFile, err := file.Open()
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	defer func() { _ = srcFile.Close() }()
+	defer srcFile.Close()
 
 	_, err = io.Copy(dstFile, srcFile)
 	return errors.WithStack(err)

--- a/src/processmoduleconfig/update.go
+++ b/src/processmoduleconfig/update.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
+	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )
 
@@ -33,7 +34,11 @@ func CreateAgentConfigDir(fs afero.Fs, targetDir, sourceDir string, processModul
 		log.Info("updating ruxitagentproc.conf", "targetDir", targetDir, "sourceDir", sourceDir)
 		sourceProcessModuleConfigPath := filepath.Join(sourceDir, ruxitAgentProcPath)
 		destinationProcessModuleConfigPath := filepath.Join(targetDir, ruxitAgentProcPath)
-		_ = fs.MkdirAll(filepath.Dir(destinationProcessModuleConfigPath), 0755)
+		err := fs.MkdirAll(filepath.Dir(destinationProcessModuleConfigPath), 0755)
+		if err != nil {
+			log.Info("failed to create directory for destination process module config", "path", filepath.Dir(destinationProcessModuleConfigPath))
+			return errors.WithStack(err)
+		}
 		return Update(fs, sourceProcessModuleConfigPath, destinationProcessModuleConfigPath, processModuleConfig.ToMap())
 	}
 	log.Info("no changes to ruxitagentproc.conf, skipping update")

--- a/src/processmoduleconfig/update.go
+++ b/src/processmoduleconfig/update.go
@@ -14,7 +14,7 @@ var (
 	sourceRuxitAgentProcPath = filepath.Join("agent", "conf", "_ruxitagentproc.conf")
 )
 
-func UpdateProcessModuleConfig(fs afero.Fs, targetDir string, processModuleConfig *dtclient.ProcessModuleConfig) error {
+func UpdateProcessModuleConfigInPlace(fs afero.Fs, targetDir string, processModuleConfig *dtclient.ProcessModuleConfig) error {
 	if processModuleConfig != nil {
 		log.Info("updating ruxitagentproc.conf", "targetDir", targetDir)
 		usedProcessModuleConfigPath := filepath.Join(targetDir, ruxitAgentProcPath)
@@ -23,6 +23,18 @@ func UpdateProcessModuleConfig(fs afero.Fs, targetDir string, processModuleConfi
 			return err
 		}
 		return Update(fs, sourceProcessModuleConfigPath, usedProcessModuleConfigPath, processModuleConfig.ToMap())
+	}
+	log.Info("no changes to ruxitagentproc.conf, skipping update")
+	return nil
+}
+
+func CreateAgentConfigDir(fs afero.Fs, targetDir, sourceDir string, processModuleConfig *dtclient.ProcessModuleConfig) error {
+	if processModuleConfig != nil {
+		log.Info("updating ruxitagentproc.conf", "targetDir", targetDir, "sourceDir", sourceDir)
+		sourceProcessModuleConfigPath := filepath.Join(sourceDir, ruxitAgentProcPath)
+		destinationProcessModuleConfigPath := filepath.Join(targetDir, ruxitAgentProcPath)
+		_ = fs.MkdirAll(filepath.Dir(destinationProcessModuleConfigPath), 0755)
+		return Update(fs, sourceProcessModuleConfigPath, destinationProcessModuleConfigPath, processModuleConfig.ToMap())
 	}
 	log.Info("no changes to ruxitagentproc.conf, skipping update")
 	return nil

--- a/src/processmoduleconfig/update_test.go
+++ b/src/processmoduleconfig/update_test.go
@@ -41,7 +41,7 @@ key value
 test test3
 `
 
-	err := UpdateProcessModuleConfig(memFs, "", &testProcessModuleConfig)
+	err := UpdateProcessModuleConfigInPlace(memFs, "", &testProcessModuleConfig)
 	require.NoError(t, err)
 	assertTestConf(t, memFs, ruxitAgentProcPath, expectedUsed)
 	assertTestConf(t, memFs, sourceRuxitAgentProcPath, testRuxitConf)

--- a/src/processmoduleconfig/update_test.go
+++ b/src/processmoduleconfig/update_test.go
@@ -30,10 +30,17 @@ var testProcessModuleConfig = dtclient.ProcessModuleConfig{
 	},
 }
 
-func TestUpdateProcessModuleConfig(t *testing.T) {
-	memFs := afero.NewMemMapFs()
-	prepTestConfFs(memFs)
-	expectedUsed := `
+func TestUpdateProcessModuleConfigInPlace(t *testing.T) {
+	t.Run("no processModuleConfig", func(t *testing.T) {
+		memFs := afero.NewMemMapFs()
+
+		err := UpdateProcessModuleConfigInPlace(memFs, "", nil)
+		require.NoError(t, err)
+	})
+	t.Run("update file", func(t *testing.T) {
+		memFs := afero.NewMemMapFs()
+		prepTestConfFs(memFs)
+		expectedUsed := `
 [general]
 key value
 
@@ -41,10 +48,40 @@ key value
 test test3
 `
 
-	err := UpdateProcessModuleConfigInPlace(memFs, "", &testProcessModuleConfig)
-	require.NoError(t, err)
-	assertTestConf(t, memFs, ruxitAgentProcPath, expectedUsed)
-	assertTestConf(t, memFs, sourceRuxitAgentProcPath, testRuxitConf)
+		err := UpdateProcessModuleConfigInPlace(memFs, "", &testProcessModuleConfig)
+		require.NoError(t, err)
+		assertTestConf(t, memFs, ruxitAgentProcPath, expectedUsed)
+		assertTestConf(t, memFs, sourceRuxitAgentProcPath, testRuxitConf)
+	})
+
+}
+
+func TestCreateAgentConfigDir(t *testing.T) {
+	t.Run("no processModuleConfig", func(t *testing.T) {
+		memFs := afero.NewMemMapFs()
+
+		err := CreateAgentConfigDir(memFs, "", "", nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("create config dir with file", func(t *testing.T) {
+		targetDir := "test"
+		sourceDir := ""
+		memFs := afero.NewMemMapFs()
+		prepTestConfFs(memFs)
+		expectedUsed := `
+[general]
+key value
+
+[test]
+test test3
+`
+
+		err := CreateAgentConfigDir(memFs, targetDir, sourceDir, &testProcessModuleConfig)
+		require.NoError(t, err)
+		assertTestConf(t, memFs, filepath.Join(targetDir, ruxitAgentProcPath), expectedUsed)
+		assertTestConf(t, memFs, filepath.Join(sourceDir, ruxitAgentProcPath), testRuxitConf)
+	})
 }
 
 func TestCheckProcessModuleConfigCopy(t *testing.T) {
@@ -60,6 +97,7 @@ func TestCheckProcessModuleConfigCopy(t *testing.T) {
 
 func prepTestConfFs(fs afero.Fs) {
 	_ = fs.MkdirAll(filepath.Base(sourceRuxitAgentProcPath), 0755)
+	_ = fs.MkdirAll(filepath.Base(ruxitAgentProcPath), 0755)
 	usedConf, _ := fs.OpenFile(ruxitAgentProcPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	_, _ = usedConf.WriteString(testRuxitConf)
 }


### PR DESCRIPTION
# Description

The current way we download/cache and unpack  `codeModulesImage` is not perfect when it comes to node storage usage, as it extracts the image for every tenant.

This PR changes how the provisioner prepares the node for the driver.
The image is downloaded to `/cache/<image-ingest>` and gets unpacked to `data/codemodules/<image-digest>`.
We only download/unpack if the digest changes (or its a new digest), we store the digest in the `dynakubes` table in the metadata database on the node.
After we unpack to `data/codemodules/<image-digest>` then `/cache/<image-ingest>` gets cleaned up as its no longer needed for anything.

Because of the shared nature of the agent "binary" we can't update the `ruxitagentproc.conf` at 
`data/codemodules/<image-digest>`, so we instead create a `data/<tenant>/config/...` where we update/merge the necessary config files.

The driver WILL use `data/codemodules/<image-digest>` + `data/<tenant>/config/...` as 2 of its lowerdirs during mounting the overlayfs volume for user pods.
Therefore `data/<tenant>/config/...` needs to follow the same folder structure as `data/codemodules/<image-digest>`.

## How can this be tested?
Deploy anything that uses the csidriver + `codeModulesImage`, 
then check make sure the csidriver works by: 
- seeing no error in the logs for the provisioner (the driver will not work which is expected)
- check the filesystem for:
  - `data/codemodules/<image-digest>` is a valid oneagent "install"
  - `data/codemodules/<image-digest>/agent/bin/current` is a valid symlink
  - `data/<tenant>/config/agent/conf/ruxitagentproc.conf` is a valid "tenantified" conf file
  - `/cache/<image-ingest>`is cleaned up 



## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

