### PR TITLE
Add separate config/binary directory when using code modules image

### DIFF
--- a/src/controllers/csi/config.go
+++ b/src/controllers/csi/config.go
@@ -21,14 +21,18 @@ import (
 )
 
 const (
-	DataPath             = "/data"
-	DriverName           = "csi.oneagent.dynatrace.com"
-	AgentBinaryDir       = "bin"
-	AgentRunDir          = "run"
+	DataPath       = "/data"
+	DriverName     = "csi.oneagent.dynatrace.com"
+	AgentBinaryDir = "bin"
+	AgentRunDir    = "run"
+
 	OverlayMappedDirPath = "mapped"
 	OverlayVarDirPath    = "var"
 	OverlayWorkDirPath   = "work"
-	DaemonSetName        = "dynatrace-oneagent-csi-driver"
+	SharedAgentBinDir    = "codemodules"
+	SharedAgentConfigDir = "config"
+
+	DaemonSetName = "dynatrace-oneagent-csi-driver"
 )
 
 var MetadataAccessPath = filepath.Join(DataPath, "csi.db")

--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -143,7 +143,7 @@ func (publisher *AppVolumePublisher) buildLowerDir(bindCfg *csivolumes.BindConfi
 		}
 	}
 
-	return strings.Join(directories, ",")
+	return strings.Join(directories, ":")
 }
 
 func (publisher *AppVolumePublisher) mountOneAgent(bindCfg *csivolumes.BindConfig, volumeCfg *csivolumes.VolumeConfig) error {

--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -53,8 +53,8 @@ type AppVolumePublisher struct {
 	path    metadata.PathResolver
 }
 
-func (publisher *AppVolumePublisher) PublishVolume(ctx context.Context, volumeCfg *csivolumes.VolumeConfig) (*csi.NodePublishVolumeResponse, error) {
-	bindCfg, err := csivolumes.NewBindConfig(ctx, publisher.db, volumeCfg)
+func (publisher *AppVolumePublisher) PublishVolume(_ context.Context, volumeCfg *csivolumes.VolumeConfig) (*csi.NodePublishVolumeResponse, error) {
+	bindCfg, err := csivolumes.NewBindConfig(publisher.db, volumeCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -138,8 +138,8 @@ func (publisher *AppVolumePublisher) buildLowerDir(bindCfg *csivolumes.BindConfi
 		}
 	} else {
 		directories = []string{
-			publisher.path.AgentSharedBinaryDirForImage(bindCfg.ImageDigest),
 			publisher.path.AgentConfigDir(bindCfg.TenantUUID),
+			publisher.path.AgentSharedBinaryDirForImage(bindCfg.ImageDigest),
 		}
 	}
 

--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -138,8 +138,8 @@ func (publisher *AppVolumePublisher) buildLowerDir(bindCfg *csivolumes.BindConfi
 		}
 	} else {
 		directories = []string{
-			publisher.path.AgentSharedBinary(bindCfg.Version),
-			publisher.path.AgentSharedConfig(bindCfg.TenantUUID),
+			publisher.path.AgentSharedBinaryDirForImage(bindCfg.ImageDigest),
+			publisher.path.AgentConfigDir(bindCfg.TenantUUID),
 		}
 	}
 

--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -130,12 +130,6 @@ func (publisher *AppVolumePublisher) fireVolumeUnpublishedMetric(volume metadata
 	}
 }
 
-type MountOptionsBuilder struct {
-	tenantUUID   string
-	bindCfg      *csivolumes.BindConfig
-	pathResolver metadata.PathResolver
-}
-
 func (publisher *AppVolumePublisher) buildLowerDir(bindCfg *csivolumes.BindConfig) string {
 	var directories []string
 	if bindCfg.ImageDigest == "" {

--- a/src/controllers/csi/driver/volumes/app/publisher_test.go
+++ b/src/controllers/csi/driver/volumes/app/publisher_test.go
@@ -73,7 +73,7 @@ func TestPublishVolume(t *testing.T) {
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Device)
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Type)
 		assert.Equal(t, []string{
-			"lowerdir=/data/codemodules/1.2-3,/data/a-tenant-uuid/config",
+			"lowerdir=/codemodules/sha256:123456789,/a-tenant-uuid/config",
 			"upperdir=/a-tenant-uuid/run/a-volume/var",
 			"workdir=/a-tenant-uuid/run/a-volume/work"},
 			mounter.MountPoints[0].Opts)

--- a/src/controllers/csi/driver/volumes/app/publisher_test.go
+++ b/src/controllers/csi/driver/volumes/app/publisher_test.go
@@ -73,7 +73,7 @@ func TestPublishVolume(t *testing.T) {
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Device)
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Type)
 		assert.Equal(t, []string{
-			"lowerdir=/codemodules/sha256:123456789,/a-tenant-uuid/config",
+			"lowerdir=/codemodules/sha256:123456789:/a-tenant-uuid/config",
 			"upperdir=/a-tenant-uuid/run/a-volume/var",
 			"workdir=/a-tenant-uuid/run/a-volume/work"},
 			mounter.MountPoints[0].Opts)

--- a/src/controllers/csi/driver/volumes/app/publisher_test.go
+++ b/src/controllers/csi/driver/volumes/app/publisher_test.go
@@ -73,7 +73,7 @@ func TestPublishVolume(t *testing.T) {
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Device)
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Type)
 		assert.Equal(t, []string{
-			"lowerdir=/codemodules/sha256:123456789:/a-tenant-uuid/config",
+			"lowerdir=/a-tenant-uuid/config:/codemodules/sha256:123456789",
 			"upperdir=/a-tenant-uuid/run/a-volume/var",
 			"workdir=/a-tenant-uuid/run/a-volume/work"},
 			mounter.MountPoints[0].Opts)

--- a/src/controllers/csi/driver/volumes/bind_config.go
+++ b/src/controllers/csi/driver/volumes/bind_config.go
@@ -10,12 +10,13 @@ import (
 )
 
 type BindConfig struct {
-	TenantUUID string
-	Version    string
+	TenantUUID  string
+	Version     string
+	ImageDigest string
 }
 
 func NewBindConfig(
-	ctx context.Context,
+	_ context.Context,
 	access metadata.Access,
 	volumeCfg *VolumeConfig) (*BindConfig, error) {
 
@@ -27,7 +28,8 @@ func NewBindConfig(
 		return nil, status.Error(codes.Unavailable, fmt.Sprintf("dynakube (%s) is missing from metadata database", volumeCfg.DynakubeName))
 	}
 	return &BindConfig{
-		TenantUUID: dynakube.TenantUUID,
-		Version:    dynakube.LatestVersion,
+		TenantUUID:  dynakube.TenantUUID,
+		Version:     dynakube.LatestVersion,
+		ImageDigest: dynakube.ImageDigest,
 	}, nil
 }

--- a/src/controllers/csi/driver/volumes/bind_config.go
+++ b/src/controllers/csi/driver/volumes/bind_config.go
@@ -1,7 +1,6 @@
 package csivolumes
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
@@ -15,10 +14,7 @@ type BindConfig struct {
 	ImageDigest string
 }
 
-func NewBindConfig(
-	_ context.Context,
-	access metadata.Access,
-	volumeCfg *VolumeConfig) (*BindConfig, error) {
+func NewBindConfig(access metadata.Access, volumeCfg *VolumeConfig) (*BindConfig, error) {
 
 	dynakube, err := access.GetDynakube(volumeCfg.DynakubeName)
 	if err != nil {

--- a/src/controllers/csi/driver/volumes/bind_config_test.go
+++ b/src/controllers/csi/driver/volumes/bind_config_test.go
@@ -1,7 +1,6 @@
 package csivolumes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
@@ -20,7 +19,7 @@ func TestNewBindConfig(t *testing.T) {
 			DynakubeName: testDynakubeName,
 		}
 
-		bindCfg, err := NewBindConfig(context.TODO(), metadata.FakeMemoryDB(), volumeCfg)
+		bindCfg, err := NewBindConfig(metadata.FakeMemoryDB(), volumeCfg)
 
 		assert.Error(t, err)
 		assert.Nil(t, bindCfg)
@@ -34,7 +33,7 @@ func TestNewBindConfig(t *testing.T) {
 
 		db.InsertDynakube(metadata.NewDynakube(testDynakubeName, testTenantUUID, testAgentVersion, ""))
 
-		bindCfg, err := NewBindConfig(context.TODO(), db, volumeCfg)
+		bindCfg, err := NewBindConfig(db, volumeCfg)
 
 		expected := BindConfig{
 			TenantUUID: testTenantUUID,

--- a/src/controllers/csi/driver/volumes/host/publisher.go
+++ b/src/controllers/csi/driver/volumes/host/publisher.go
@@ -50,8 +50,8 @@ type HostVolumePublisher struct {
 	path    metadata.PathResolver
 }
 
-func (publisher *HostVolumePublisher) PublishVolume(ctx context.Context, volumeCfg *csivolumes.VolumeConfig) (*csi.NodePublishVolumeResponse, error) {
-	bindCfg, err := csivolumes.NewBindConfig(ctx, publisher.db, volumeCfg)
+func (publisher *HostVolumePublisher) PublishVolume(_ context.Context, volumeCfg *csivolumes.VolumeConfig) (*csi.NodePublishVolumeResponse, error) {
+	bindCfg, err := csivolumes.NewBindConfig(publisher.db, volumeCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/src/controllers/csi/metadata/path_resolver.go
+++ b/src/controllers/csi/metadata/path_resolver.go
@@ -65,3 +65,11 @@ func (pr PathResolver) OverlayVarDir(tenantUUID string, volumeId string) string 
 func (pr PathResolver) OverlayWorkDir(tenantUUID string, volumeId string) string {
 	return filepath.Join(pr.AgentRunDirForVolume(tenantUUID, volumeId), dtcsi.OverlayWorkDirPath)
 }
+
+func (pr PathResolver) AgentSharedBinary(version string) string {
+	return filepath.Join(dtcsi.DataPath, dtcsi.SharedAgentBinDir, version)
+}
+
+func (pr PathResolver) AgentSharedConfig(tenantUUID string) string {
+	return filepath.Join(dtcsi.DataPath, tenantUUID, dtcsi.SharedAgentConfigDir)
+}

--- a/src/controllers/csi/metadata/path_resolver.go
+++ b/src/controllers/csi/metadata/path_resolver.go
@@ -43,7 +43,7 @@ func (pr PathResolver) AgentBinaryDirForVersion(tenantUUID string, version strin
 }
 
 func (pr PathResolver) AgentSharedBinaryDirBase() string {
-	return filepath.Join(pr.RootDir, "codemodules")
+	return filepath.Join(pr.RootDir, dtcsi.SharedAgentBinDir)
 }
 
 func (pr PathResolver) AgentSharedBinaryDirForImage(digest string) string {
@@ -51,7 +51,7 @@ func (pr PathResolver) AgentSharedBinaryDirForImage(digest string) string {
 }
 
 func (pr PathResolver) AgentConfigDir(tenantUUID string) string {
-	return filepath.Join(pr.EnvDir(tenantUUID), "config")
+	return filepath.Join(pr.EnvDir(tenantUUID), dtcsi.SharedAgentConfigDir)
 }
 
 func (pr PathResolver) InnerAgentBinaryDirForSymlinkForVersion(tenantUUID string, version string) string {
@@ -76,12 +76,4 @@ func (pr PathResolver) OverlayVarDir(tenantUUID string, volumeId string) string 
 
 func (pr PathResolver) OverlayWorkDir(tenantUUID string, volumeId string) string {
 	return filepath.Join(pr.AgentRunDirForVolume(tenantUUID, volumeId), dtcsi.OverlayWorkDirPath)
-}
-
-func (pr PathResolver) AgentSharedBinary(version string) string {
-	return filepath.Join(dtcsi.DataPath, dtcsi.SharedAgentBinDir, version)
-}
-
-func (pr PathResolver) AgentSharedConfig(tenantUUID string) string {
-	return filepath.Join(dtcsi.DataPath, tenantUUID, dtcsi.SharedAgentConfigDir)
 }


### PR DESCRIPTION
# Description
Adapt OverlayFS creation when image digest is used:
- Binary directory pointing to image tag
- Config directory pointing to tenant specific configuration

## How can this be tested?
Using changes in #834 to add `ImageDigest` to database when used the lowerdir is setup correctly:
- both binary and config are passed to the `mount` command


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly

