### PR TITLE
Adds default tolerations for the csi driver

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -137,7 +137,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -4672,6 +4671,13 @@ spec:
           path: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/data
           type: DirectoryOrCreate
         name: dynatrace-oneagent-data-dir
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -148,7 +148,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -4962,6 +4961,13 @@ spec:
           path: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/data
           type: DirectoryOrCreate
         name: dynatrace-oneagent-data-dir
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -7,17 +7,20 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should have tolerations if set
+  - it: should have tolerations by default
     set:
       platform: kubernetes
       csidriver.enabled: true
-      csidriver.tolerations:
-        test-key: test-value
     asserts:
     - equal:
         path: spec.template.spec.tolerations
         value:
-          test-key: test-value
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
 
   - it: should have nodeSelectors if set
     set:
@@ -59,6 +62,13 @@ tests:
       - equal:
           path: spec.template.spec
           value:
+            tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+                  operator: Exists
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/control-plane
+                  operator: Exists
             containers:
               - name: driver
                 image: image-name

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -46,7 +46,13 @@ webhook:
 csidriver:
   enabled: false
   nodeSelector: {}
-  tolerations: []
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Exists
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
   requests:
     cpu: 300m
     memory: 100Mi


### PR DESCRIPTION
# Description

Adds default tolerations for the csi-driver so that they can be scheduled on master nodes.

## How can this be tested?
Try helm install (with csi enabled) and it should deploy the csi-driver with the default tolerations
Try the generated manifests files, it should also deploy the csi-driver with the default tolerations

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly