### PR TITLE
Readds separate proxy key to the init secret

### DIFF
--- a/src/initgeneration/initgeneration.go
+++ b/src/initgeneration/initgeneration.go
@@ -248,6 +248,6 @@ func (g *InitGenerator) createSecretData(config *standalone.SecretConfig) (map[s
 	}
 	return map[string][]byte{
 		standalone.SecretConfigFieldName: jsonContent,
-		dynatracev1beta1.ProxyKey:        []byte(config.Proxy), // needed so that it can be mounted for to the user's pod
+		dynatracev1beta1.ProxyKey:        []byte(config.Proxy), // needed so that it can be mounted to the user's pod without directly reading the secret
 	}, nil
 }

--- a/src/initgeneration/initgeneration.go
+++ b/src/initgeneration/initgeneration.go
@@ -248,5 +248,6 @@ func (g *InitGenerator) createSecretData(config *standalone.SecretConfig) (map[s
 	}
 	return map[string][]byte{
 		standalone.SecretConfigFieldName: jsonContent,
+		dynatracev1beta1.ProxyKey:        []byte(config.Proxy), // needed so that it can be mounted for to the user's pod
 	}, nil
 }

--- a/src/initgeneration/initgeneration_test.go
+++ b/src/initgeneration/initgeneration_test.go
@@ -180,10 +180,14 @@ func TestGenerateForNamespace(t *testing.T) {
 		var initSecret corev1.Secret
 		err = clt.Get(context.TODO(), types.NamespacedName{Name: webhook.SecretConfigName, Namespace: testNamespace.Name}, &initSecret)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(initSecret.Data))
-		sercetConfig, ok := initSecret.Data[standalone.SecretConfigFieldName]
+		assert.Equal(t, 2, len(initSecret.Data))
+		secretConfig, ok := initSecret.Data[standalone.SecretConfigFieldName]
 		assert.True(t, ok)
-		assert.NotNil(t, sercetConfig)
+		assert.NotNil(t, secretConfig)
+		proxy, ok := initSecret.Data[dynatracev1beta1.ProxyKey]
+		assert.True(t, ok)
+		assert.NotNil(t, proxy)
+		assert.Equal(t, testProxy, string(proxy))
 	})
 	t.Run("Add secret for namespace (simple dynakube)", func(t *testing.T) {
 		testNamespace := corev1.Namespace{
@@ -201,10 +205,14 @@ func TestGenerateForNamespace(t *testing.T) {
 		var initSecret corev1.Secret
 		err = clt.Get(context.TODO(), types.NamespacedName{Name: webhook.SecretConfigName, Namespace: testNamespace.Name}, &initSecret)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(initSecret.Data))
-		sercetConfig, ok := initSecret.Data[standalone.SecretConfigFieldName]
+		assert.Equal(t, 2, len(initSecret.Data))
+		secretConfig, ok := initSecret.Data[standalone.SecretConfigFieldName]
 		assert.True(t, ok)
-		assert.NotNil(t, sercetConfig)
+		assert.NotNil(t, secretConfig)
+		proxy, ok := initSecret.Data[dynatracev1beta1.ProxyKey]
+		assert.True(t, ok)
+		assert.NotNil(t, proxy)
+		assert.Empty(t, proxy)
 	})
 }
 
@@ -226,10 +234,14 @@ func TestGenerateForDynakube(t *testing.T) {
 		var initSecret corev1.Secret
 		err = clt.Get(context.TODO(), types.NamespacedName{Name: webhook.SecretConfigName, Namespace: testNamespace.Name}, &initSecret)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(initSecret.Data))
-		sercetConfig, ok := initSecret.Data[standalone.SecretConfigFieldName]
+		assert.Equal(t, 2, len(initSecret.Data))
+		secretConfig, ok := initSecret.Data[standalone.SecretConfigFieldName]
 		assert.True(t, ok)
-		assert.NotNil(t, sercetConfig)
+		assert.NotNil(t, secretConfig)
+		proxy, ok := initSecret.Data[dynatracev1beta1.ProxyKey]
+		assert.True(t, ok)
+		assert.NotNil(t, proxy)
+		assert.Equal(t, testProxy, string(proxy))
 	})
 	t.Run("Add secret for namespace (simple dynakube)", func(t *testing.T) {
 		dk := testDynakubeSimple.DeepCopy()
@@ -248,10 +260,14 @@ func TestGenerateForDynakube(t *testing.T) {
 		var initSecret corev1.Secret
 		err = clt.Get(context.TODO(), types.NamespacedName{Name: webhook.SecretConfigName, Namespace: testNamespace.Name}, &initSecret)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(initSecret.Data))
-		sercetConfig, ok := initSecret.Data[standalone.SecretConfigFieldName]
+		assert.Equal(t, 2, len(initSecret.Data))
+		secretConfig, ok := initSecret.Data[standalone.SecretConfigFieldName]
 		assert.True(t, ok)
-		assert.NotNil(t, sercetConfig)
+		assert.NotNil(t, secretConfig)
+		proxy, ok := initSecret.Data[dynatracev1beta1.ProxyKey]
+		assert.True(t, ok)
+		assert.NotNil(t, proxy)
+		assert.Empty(t, proxy)
 	})
 	t.Run("Add secret to multiple namespaces (simple dynakube)", func(t *testing.T) {
 		dk := testDynakubeSimple.DeepCopy()
@@ -276,16 +292,25 @@ func TestGenerateForDynakube(t *testing.T) {
 		var initSecret corev1.Secret
 		err = clt.Get(context.TODO(), types.NamespacedName{Name: webhook.SecretConfigName, Namespace: testNamespace.Name}, &initSecret)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(initSecret.Data))
-		sercetConfig, ok := initSecret.Data[standalone.SecretConfigFieldName]
+		assert.Equal(t, 2, len(initSecret.Data))
+		secretConfig, ok := initSecret.Data[standalone.SecretConfigFieldName]
 		assert.True(t, ok)
-		assert.NotNil(t, sercetConfig)
+		assert.NotNil(t, secretConfig)
+		proxy, ok := initSecret.Data[dynatracev1beta1.ProxyKey]
+		assert.True(t, ok)
+		assert.NotNil(t, proxy)
+		assert.Empty(t, proxy)
+
 		err = clt.Get(context.TODO(), types.NamespacedName{Name: webhook.SecretConfigName, Namespace: testOtherNamespace.Name}, &initSecret)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(initSecret.Data))
-		sercetConfig, ok = initSecret.Data[standalone.SecretConfigFieldName]
+		assert.Equal(t, 2, len(initSecret.Data))
+		secretConfig, ok = initSecret.Data[standalone.SecretConfigFieldName]
 		assert.True(t, ok)
-		assert.NotNil(t, sercetConfig)
+		assert.NotNil(t, secretConfig)
+		proxy, ok = initSecret.Data[dynatracev1beta1.ProxyKey]
+		assert.True(t, ok)
+		assert.NotNil(t, proxy)
+		assert.Empty(t, proxy)
 	})
 }
 


### PR DESCRIPTION
# Description
The `proxy` field in the init secret was moved under the `config` field (which is a json).
This broke how the webhook injects the `DT_PROXY` envvar to the customer's pod.

And to avoid the need to directly read the secret in the webhook during injection, this adds the `proxy` field back as its separate field.
This duplicates the `proxy` value inside the init secret, however this is a far nicer way than reading the secret for every pod injection.

## How can this be tested?
Use a dynakube that has proxy set, and you can check:
- the `dynatrace-dynakube-config` in the sample app namespace has the `proxy` field
- exec into the sample pod, check if `DT_PROXY` is set
- everything works as normal 


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly