### PR TITLE
Update bundle generation to include onagent unprivileged Serviceaccount

### DIFF
--- a/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
@@ -1,5 +1,5 @@
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift " (include "dynatrace-operator.platformSet" .))}}
-{{- if and (eq .Values.platform "openshift") (eq (include "dynatrace-operator.partial" .) "false") }}
+{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
@@ -1,5 +1,5 @@
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift " (include "dynatrace-operator.platformSet" .))}}
-{{- if and (eq .Values.platform "openshift") (eq (include "dynatrace-operator.partial" .) "false") }}
+{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -154,3 +154,13 @@ Check if platform is set
 {{- end -}}
 {{- end -}}
 
+{{/*
+Exclude Kubernetes manifest not running on OLM
+*/}}
+{{- define "dynatrace-operator.openshiftOrOlm" -}}
+{{- if and (or (eq .Values.platform "openshift") (.Values.olm)) (eq (include "dynatrace-operator.partial" .) "false") -}}
+    {{ default "true" }}
+{{- end -}}
+{{- end -}}
+
+

--- a/config/manifests/bases/dynatrace-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dynatrace-operator.clusterserviceversion.yaml
@@ -634,8 +634,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: General configuration about ActiveGate instances ActiveGate ActiveGateSpec
-          `json:"activeGate,omitempty"`
+      - description: General configuration about ActiveGate instances
         displayName: ActiveGate
         path: activeGate
         x-descriptors:

--- a/config/olm/README.md
+++ b/config/olm/README.md
@@ -12,8 +12,8 @@ Steps:
 1. Get an Openshift cluster that has OLM, and use `oc login` on it
 2. If want you want to test but there is no bundle yet => run `make bundle`
    - example: `make bundle PLATFORM=openshift VERSION=0.6.0`
-3. Run `make test-olm` (with the same args as the `make bundle` + TAG)
-   - example: `make test-olm PLATFORM=openshift VERSION=0.6.0 TAG=test`
+3. Run `make test/olm` (with the same args as the `make bundle` + TAG)
+   - example: `make test/olm PLATFORM=openshift VERSION=0.6.0 TAG=test`
 4. Go to the UI of the Openshift cluster
    - Go to `Operators -> OperatorHub`
    - Search for `Dynatrace`
@@ -71,7 +71,7 @@ First lets understand each part we are creating.
   - Created/managed by the `opm` CLI tool
   - Referenced in the `CatalogSource` resources, which is used by OLM to list what can be installed and do the upgrades when possible.
 
-So `hack/setup_olm_catalog.sh` (used by `make test-olm`) does the following:
+So `hack/setup_olm_catalog.sh` (used by `make test/olm`) does the following:
 1. Creates/pushes `catalog` image for specified bundle
 2. Creates/pushes `index` image (by adding the `catalog` to it)
    - can add a new `catalog` to an existing `index` which creates a new `index`

--- a/hack/build/bundle.sh
+++ b/hack/build/bundle.sh
@@ -3,9 +3,16 @@ set -e
 
 PLATFORM="${1:-openshift}"
 VERSION="${2:-0.0.1}"
-OLM_IMAGE="${3:-registry.connect.redhat.com/dynatrace/dynatrace-operator:v${VERSION}}"
-BUNDLE_CHANNELS="${4:-}"
-BUNDLE_DEFAULT_CHANNEL="${5:-}"
+BUNDLE_CHANNELS="${3:-}"
+BUNDLE_DEFAULT_CHANNEL="${4:-}"
+
+if [ -z "$OLM_IMAGE" ]; then
+  OLM_IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator:v${VERSION}"
+  if [ "${PLATFORM}" == "kubernetes" ]; then
+    OLM_IMAGE="docker.io/dynatrace/dynatrace-operator:v${VERSION}"
+  fi
+fi
+echo "OLM image: ${OLM_IMAGE}"
 
 KUSTOMIZE="$(hack/build/command.sh kustomize 2>/dev/null)"
 if [ -z "${KUSTOMIZE}" ]; then
@@ -20,7 +27,6 @@ if [ -z "${OPERATOR_SDK}" ]; then
 fi
 
 SDK_PARAMS=(
---extra-service-accounts dynatrace-dynakube-oneagent
 --extra-service-accounts dynatrace-dynakube-oneagent-unprivileged
 --extra-service-accounts dynatrace-kubernetes-monitoring
 --extra-service-accounts dynatrace-activegate

--- a/hack/make/bundle.mk
+++ b/hack/make/bundle.mk
@@ -17,7 +17,7 @@ endif
 ## Generates bundle manifests and metadata, then validates generated files
 bundle: OLM=true
 bundle: prerequisites/kustomize manifests/kubernetes manifests/openshift
-	./hack/build/bundle.sh "$(PLATFORM)" "$(VERSION)" "$(OLM_IMAGE)" "$(BUNDLE_CHANNELS)" "$(BUNDLE_DEFAULT_CHANNEL)"
+	./hack/build/bundle.sh "$(PLATFORM)" "$(VERSION)" "$(BUNDLE_CHANNELS)" "$(BUNDLE_DEFAULT_CHANNEL)"
 
 .PHONY: bundle/minimal
 ## Generates bundle manifests and metadata, validates generated files and removes everything but the CSV file


### PR DESCRIPTION
# Description
Add unprivileged oneagent Serviceaccount on Kubernetes and update bundle testing script for Kubernetes.

## How can this be tested?
Generate bundle and deploy on OLM following instructions:
```sh
make bundle PLATFORM=kubernetes OLM_IMAGE=quay.io/dynatrace/dynatrace-operator:snapshot-release-0-7 VERSION=0.7.0 && make test/olm VERSION=0.7.0 PLATFORM=kubernetes TAG=test-0.7.0 CREATE_SUBSCRIPTION=true
```


## Checklist
- [x] PR is labeled accordingly

