### PR TITLE
Uses image for version label for deployed components (if set)

### DIFF
--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -86,8 +86,13 @@ func NewStatefulSetProperties(instance *dynatracev1beta1.DynaKube, capabilityPro
 }
 
 func CreateStatefulSet(stsProperties *statefulSetProperties) (*appsv1.StatefulSet, error) {
+
+	versionLabelValue := stsProperties.Status.ActiveGate.Version
+	if stsProperties.DynaKube.Spec.ActiveGate.Image != "" {
+		versionLabelValue = stsProperties.DynaKube.Spec.ActiveGate.Image
+	}
 	appLabels := kubeobjects.NewAppLabels(kubeobjects.ActiveGateComponentLabel, stsProperties.DynaKube.Name,
-		stsProperties.feature, stsProperties.Status.ActiveGate.Version)
+		stsProperties.feature, versionLabelValue)
 
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset_test.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	testName                 = "test-name"
+	testImage                = "test-image"
 	testNamespace            = "test-namespace"
 	testKey                  = "test-key"
 	testValue                = "test-value"
@@ -42,46 +43,91 @@ func TestNewStatefulSetBuilder(t *testing.T) {
 }
 
 func TestStatefulSetBuilder_Build(t *testing.T) {
-	instance := buildTestInstance()
-	capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
-	sts, err := CreateStatefulSet(NewStatefulSetProperties(instance, capabilityProperties, "", "", testComponentFeature, "", "", nil, nil, nil))
+	t.Run(`build without image`, func(t *testing.T) {
+		instance := buildTestInstance()
+		capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
+		sts, err := CreateStatefulSet(NewStatefulSetProperties(instance, capabilityProperties, "", "", testComponentFeature, "", "", nil, nil, nil))
 
-	expectedLabels := map[string]string{
-		kubeobjects.AppNameLabel:      kubeobjects.ActiveGateComponentLabel,
-		kubeobjects.AppCreatedByLabel: instance.Name,
-		kubeobjects.AppComponentLabel: testComponentFeature,
-		kubeobjects.AppVersionLabel:   testComponentVersion,
-		kubeobjects.AppManagedByLabel: version.AppName,
-	}
-	expectedMatchLabels := map[string]string{
-		kubeobjects.AppNameLabel:      kubeobjects.ActiveGateComponentLabel,
-		kubeobjects.AppCreatedByLabel: instance.Name,
-		kubeobjects.AppManagedByLabel: version.AppName,
-	}
+		expectedLabels := map[string]string{
+			kubeobjects.AppNameLabel:      kubeobjects.ActiveGateComponentLabel,
+			kubeobjects.AppCreatedByLabel: instance.Name,
+			kubeobjects.AppComponentLabel: testComponentFeature,
+			kubeobjects.AppVersionLabel:   testComponentVersion,
+			kubeobjects.AppManagedByLabel: version.AppName,
+		}
+		expectedMatchLabels := map[string]string{
+			kubeobjects.AppNameLabel:      kubeobjects.ActiveGateComponentLabel,
+			kubeobjects.AppCreatedByLabel: instance.Name,
+			kubeobjects.AppManagedByLabel: version.AppName,
+		}
 
-	assert.NoError(t, err)
-	assert.NotNil(t, sts)
-	assert.Equal(t, instance.Name+routingStatefulSetSuffix, sts.Name)
-	assert.Equal(t, instance.Namespace, sts.Namespace)
-	assert.Equal(t, expectedLabels, sts.Labels)
-	assert.Equal(t, instance.Spec.ActiveGate.Replicas, sts.Spec.Replicas)
-	assert.Equal(t, appsv1.ParallelPodManagement, sts.Spec.PodManagementPolicy)
-	assert.Equal(t, metav1.LabelSelector{
-		MatchLabels: expectedMatchLabels,
-	}, *sts.Spec.Selector)
-	assert.NotEqual(t, corev1.PodTemplateSpec{}, sts.Spec.Template)
-	assert.Equal(t, expectedLabels, sts.Spec.Template.Labels)
-	assert.Equal(t, sts.Labels, sts.Spec.Template.Labels)
-	assert.NotEqual(t, corev1.PodSpec{}, sts.Spec.Template.Spec)
-	assert.Contains(t, sts.Annotations, kubeobjects.AnnotationHash)
+		assert.NoError(t, err)
+		assert.NotNil(t, sts)
+		assert.Equal(t, instance.Name+routingStatefulSetSuffix, sts.Name)
+		assert.Equal(t, instance.Namespace, sts.Namespace)
+		assert.Equal(t, expectedLabels, sts.Labels)
+		assert.Equal(t, instance.Spec.ActiveGate.Replicas, sts.Spec.Replicas)
+		assert.Equal(t, appsv1.ParallelPodManagement, sts.Spec.PodManagementPolicy)
+		assert.Equal(t, metav1.LabelSelector{
+			MatchLabels: expectedMatchLabels,
+		}, *sts.Spec.Selector)
+		assert.NotEqual(t, corev1.PodTemplateSpec{}, sts.Spec.Template)
+		assert.Equal(t, expectedLabels, sts.Spec.Template.Labels)
+		assert.Equal(t, sts.Labels, sts.Spec.Template.Labels)
+		assert.NotEqual(t, corev1.PodSpec{}, sts.Spec.Template.Spec)
+		assert.Contains(t, sts.Annotations, kubeobjects.AnnotationHash)
 
-	storedHash := sts.Annotations[kubeobjects.AnnotationHash]
-	sts.Annotations = map[string]string{}
-	hash, err := kubeobjects.GenerateHash(sts)
-	assert.NoError(t, err)
-	assert.Equal(t, storedHash, hash)
+		storedHash := sts.Annotations[kubeobjects.AnnotationHash]
+		sts.Annotations = map[string]string{}
+		hash, err := kubeobjects.GenerateHash(sts)
+		assert.NoError(t, err)
+		assert.Equal(t, storedHash, hash)
+	})
+
+	t.Run(`build while image set`, func(t *testing.T) {
+		instance := buildTestInstanceWithImage()
+		capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
+		sts, err := CreateStatefulSet(NewStatefulSetProperties(instance, capabilityProperties, "", "", testComponentFeature, "", "", nil, nil, nil))
+
+		expectedLabels := map[string]string{
+			kubeobjects.AppNameLabel:      kubeobjects.ActiveGateComponentLabel,
+			kubeobjects.AppCreatedByLabel: instance.Name,
+			kubeobjects.AppComponentLabel: testComponentFeature,
+			kubeobjects.AppVersionLabel:   testImage,
+			kubeobjects.AppManagedByLabel: version.AppName,
+		}
+		expectedMatchLabels := map[string]string{
+			kubeobjects.AppNameLabel:      kubeobjects.ActiveGateComponentLabel,
+			kubeobjects.AppCreatedByLabel: instance.Name,
+			kubeobjects.AppManagedByLabel: version.AppName,
+		}
+
+		assert.NoError(t, err)
+		assert.NotNil(t, sts)
+		assert.Equal(t, instance.Name+routingStatefulSetSuffix, sts.Name)
+		assert.Equal(t, instance.Namespace, sts.Namespace)
+		assert.Equal(t, expectedLabels, sts.Labels)
+		assert.Equal(t, instance.Spec.ActiveGate.Replicas, sts.Spec.Replicas)
+		assert.Equal(t, appsv1.ParallelPodManagement, sts.Spec.PodManagementPolicy)
+		assert.Equal(t, metav1.LabelSelector{
+			MatchLabels: expectedMatchLabels,
+		}, *sts.Spec.Selector)
+		assert.NotEqual(t, corev1.PodTemplateSpec{}, sts.Spec.Template)
+		assert.Equal(t, expectedLabels, sts.Spec.Template.Labels)
+		assert.Equal(t, sts.Labels, sts.Spec.Template.Labels)
+		assert.NotEqual(t, corev1.PodSpec{}, sts.Spec.Template.Spec)
+		assert.Contains(t, sts.Annotations, kubeobjects.AnnotationHash)
+
+		storedHash := sts.Annotations[kubeobjects.AnnotationHash]
+		sts.Annotations = map[string]string{}
+		hash, err := kubeobjects.GenerateHash(sts)
+		assert.NoError(t, err)
+		assert.Equal(t, storedHash, hash)
+	})
 
 	t.Run(`template has annotations`, func(t *testing.T) {
+		instance := buildTestInstance()
+		capabilityProperties := &instance.Spec.ActiveGate.CapabilityProperties
 		sts, _ := CreateStatefulSet(NewStatefulSetProperties(instance, capabilityProperties, "", testValue, "", "", "", nil, nil, nil))
 		assert.Equal(t, map[string]string{
 			annotationActiveGateConfigurationHash: testValue,
@@ -725,6 +771,12 @@ func buildTestInstance() *dynatracev1beta1.DynaKube {
 			},
 		},
 	}
+}
+
+func buildTestInstanceWithImage() *dynatracev1beta1.DynaKube {
+	dynakube := buildTestInstance()
+	dynakube.Spec.ActiveGate.Image = testImage
+	return dynakube
 }
 
 func buildActiveGateMountPoints(statsd bool, readOnly bool, tlsSecret bool) []string {

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -128,8 +128,12 @@ func (dsInfo *builderInfo) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 	instance := dsInfo.instance
 	podSpec := dsInfo.podSpec()
 
+	versionLabelValue := instance.Status.OneAgent.Version
+	if instance.Image() != "" {
+		versionLabelValue = instance.Image()
+	}
 	appLabels := kubeobjects.NewAppLabels(kubeobjects.OneAgentComponentLabel, instance.Name,
-		dsInfo.deploymentType, instance.Status.OneAgent.Version)
+		dsInfo.deploymentType, versionLabelValue)
 	labels := kubeobjects.MergeLabels(
 		appLabels.BuildLabels(),
 		dsInfo.hostInjectSpec.Labels,

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -1,9 +1,12 @@
 package daemonset
 
 import (
+	"strings"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -11,7 +14,8 @@ import (
 )
 
 const (
-	testImage = "test-image"
+	testImage   = "test-image"
+	testVersion = "test-version"
 )
 
 func TestUseImmutableImage(t *testing.T) {
@@ -50,6 +54,92 @@ func TestUseImmutableImage(t *testing.T) {
 		podSpecs := ds.Spec.Template.Spec
 		assert.NotNil(t, podSpecs)
 		assert.Equal(t, testImage, podSpecs.Containers[0].Image)
+	})
+}
+
+func TestLabels(t *testing.T) {
+	feature := strings.ReplaceAll(DeploymentTypeFullStack, "_", "")
+	t.Run(`if image is unset, use version`, func(t *testing.T) {
+		instance := dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testURL,
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					ClassicFullStack: &dynatracev1beta1.HostInjectSpec{},
+				},
+			},
+			Status: dynatracev1beta1.DynaKubeStatus{
+				OneAgent: dynatracev1beta1.OneAgentStatus{
+					VersionStatus: dynatracev1beta1.VersionStatus{
+						Version: testVersion,
+					},
+				},
+			},
+		}
+		expectedLabels := map[string]string{
+			kubeobjects.AppNameLabel:      kubeobjects.OneAgentComponentLabel,
+			kubeobjects.AppCreatedByLabel: instance.Name,
+			kubeobjects.AppComponentLabel: feature,
+			kubeobjects.AppVersionLabel:   testVersion,
+			kubeobjects.AppManagedByLabel: version.AppName,
+		}
+		expectedMatchLabels := map[string]string{
+			kubeobjects.AppNameLabel:      kubeobjects.OneAgentComponentLabel,
+			kubeobjects.AppCreatedByLabel: instance.Name,
+			kubeobjects.AppManagedByLabel: version.AppName,
+		}
+		dsInfo := NewClassicFullStack(&instance, testClusterID)
+		ds, err := dsInfo.BuildDaemonSet()
+		require.NoError(t, err)
+
+		podSpecs := ds.Spec.Template.Spec
+		assert.NotNil(t, podSpecs)
+		assert.Equal(t, instance.ImmutableOneAgentImage(), podSpecs.Containers[0].Image)
+		assert.Equal(t, expectedLabels, ds.Labels)
+		// 		assert.Equal(t, metav1.LabelSelector{
+		// 	MatchLabels: expectedMatchLabels,
+		// }, *sts.Spec.Selector)
+		assert.Equal(t, expectedMatchLabels, ds.Spec.Selector.MatchLabels)
+		assert.Equal(t, expectedLabels, ds.Spec.Template.Labels)
+	})
+	t.Run(`if image is set, set image is used`, func(t *testing.T) {
+		instance := dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testURL,
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					ClassicFullStack: &dynatracev1beta1.HostInjectSpec{
+						Image: testImage,
+					},
+				},
+			},
+		}
+
+		expectedLabels := map[string]string{
+			kubeobjects.AppNameLabel:      kubeobjects.OneAgentComponentLabel,
+			kubeobjects.AppCreatedByLabel: instance.Name,
+			kubeobjects.AppComponentLabel: feature,
+			kubeobjects.AppVersionLabel:   testImage,
+			kubeobjects.AppManagedByLabel: version.AppName,
+		}
+		expectedMatchLabels := map[string]string{
+			kubeobjects.AppNameLabel:      kubeobjects.OneAgentComponentLabel,
+			kubeobjects.AppCreatedByLabel: instance.Name,
+			kubeobjects.AppManagedByLabel: version.AppName,
+		}
+
+		dsInfo := NewClassicFullStack(&instance, testClusterID)
+		ds, err := dsInfo.BuildDaemonSet()
+		require.NoError(t, err)
+
+		podSpecs := ds.Spec.Template.Spec
+		assert.NotNil(t, podSpecs)
+		assert.Equal(t, testImage, podSpecs.Containers[0].Image)
+		assert.Equal(t, expectedLabels, ds.Labels)
+		// 		assert.Equal(t, metav1.LabelSelector{
+		// 	MatchLabels: expectedMatchLabels,
+		// }, *sts.Spec.Selector)
+		assert.Equal(t, expectedMatchLabels, ds.Spec.Selector.MatchLabels)
+		assert.Equal(t, expectedLabels, ds.Spec.Template.Labels)
+
 	})
 }
 


### PR DESCRIPTION
# Description

When setting the version label for components managed by the operator (oneagent and activegate) the latest version on the cluster is used instead of the tag of the image in case an image is used.

Now when an image is used for activegate or oneagent, we use its tag as value for the `app.kubernetes.io/version` label.

## How can this be tested?
Deploy a dynakube where the oneagent/activegate image field is set, and see that the deployed daemonset/statefulset has the correct labels


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly