### PR TITLE
Adapt makefile to generate correct names for csi manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,10 +84,10 @@ config/deploy/kustomization.yaml
 
 /.run/
 config/deploy/kubernetes/kubernetes.yaml
-config/deploy/kubernetes/kubernetes-csidriver.yaml
+config/deploy/kubernetes/kubernetes-csi.yaml
 config/deploy/kubernetes/kubernetes-olm.yaml
 config/deploy/openshift/openshift.yaml
-config/deploy/openshift/openshift-csidriver.yaml
+config/deploy/openshift/openshift-csi.yaml
 config/deploy/openshift/openshift-olm.yaml
 config/deploy/kubernetes/dynatrace-operator-crd.yaml
 

--- a/hack/build/bundle.sh
+++ b/hack/build/bundle.sh
@@ -56,7 +56,7 @@ sed "s/bundle/${VERSION}/" "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfil
 mv "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile.output" "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile"
 awk '/operators.operatorframework.io.metrics.project_layout/ { print; print "  operators.operatorframework.io.bundle.channel.default.v1: alpha"; next }1' "./config/olm/${PLATFORM}/${VERSION}/metadata/annotations.yaml" >  "./config/olm/${PLATFORM}/${VERSION}/metadata/annotations.yaml.output"
 mv "./config/olm/${PLATFORM}/${VERSION}/metadata/annotations.yaml.output" "./config/olm/${PLATFORM}/${VERSION}/metadata/annotations.yaml"
-awk '/operators.operatorframework.io.${VERSION}.mediatype.v1/ { print "LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha"; print; next }1' "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile" > "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile.output"
+awk "/operators.operatorframework.io.${VERSION}.mediatype.v1/ { print \"LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha\"; print; next }1" "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile" > "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile.output"
 mv "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile.output" "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile"
 grep -v '# Labels for testing.' "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile" > "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile.output"
 mv "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile.output" "./config/olm/${PLATFORM}/bundle-${VERSION}.Dockerfile"

--- a/hack/make/manifests/config.mk
+++ b/hack/make/manifests/config.mk
@@ -11,11 +11,11 @@ HELM_CRD_DIR=$(HELM_TEMPLATES_DIR)/Common/crd/
 MANIFESTS_DIR=config/deploy/
 
 KUBERNETES_CORE_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes.yaml
-KUBERNETES_CSIDRIVER_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-csidriver.yaml
+KUBERNETES_CSIDRIVER_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-csi.yaml
 KUBERNETES_OLM_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-olm.yaml
 KUBERNETES_ALL_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-all.yaml
 
 OPENSHIFT_CORE_YAML=$(MANIFESTS_DIR)openshift/openshift.yaml
-OPENSHIFT_CSIDRIVER_YAML=$(MANIFESTS_DIR)openshift/openshift-csidriver.yaml
+OPENSHIFT_CSIDRIVER_YAML=$(MANIFESTS_DIR)openshift/openshift-csi.yaml
 OPENSHIFT_OLM_YAML=$(MANIFESTS_DIR)openshift/openshift-olm.yaml
 OPENSHIFT_ALL_YAML=$(MANIFESTS_DIR)openshift/openshift-all.yaml

--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -6,7 +6,7 @@
 
 ## Generates a manifest for Kubernetes solely for a CSI driver deployment
 manifests/kubernetes/csi:
-	# Generate kubernetes-csidriver.yaml
+	# Generate kubernetes-csi.yaml
 	helm template dynatrace-operator config/helm/chart/default \
 		--namespace dynatrace \
 		--set partial="csi" \


### PR DESCRIPTION
# Description
The makefile generated wrong manifest names for kubernetes-csi.yaml and openshift-csi.yaml. This is especially important for the release pipeline and the attached manifests for it.

## How can this be tested?
`make manifest` should generate the two files with the right name


## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

