### PR TITLE
Changes csidriver containers to use read-only filesystem

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -87,7 +87,7 @@ spec:
           runAsUser: 0
           privileged: true # Needed for mountPropagation
           allowPrivilegeEscalation: true # Needed for privileged
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
@@ -104,6 +104,8 @@ spec:
         - mountPath: /data
           mountPropagation: Bidirectional
           name: dynatrace-oneagent-data-dir
+        - mountPath: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/tmp
+          name: tmp-dir
         # Used to make a gRPC request (GetPluginInfo()) to the driver to get driver name and driver contain
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
         # Used for registering the driver with kubelet
@@ -137,7 +139,7 @@ spec:
         securityContext:
           runAsUser: 0
           privileged: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
@@ -148,6 +150,8 @@ spec:
           name: plugin-dir
         - mountPath: /registration
           name: registration-dir
+        - mountPath: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com
+          name: lockfile-dir
         # Used to make a gRPC request (Probe()) to the driver to check if its running
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
       - name: liveness-probe
@@ -171,7 +175,7 @@ spec:
           runAsUser: 0
           privileged: false
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
@@ -191,10 +195,10 @@ spec:
           type: Directory
         name: registration-dir
         # This volume is where the socket for kubelet->driver communication is done
-      - hostPath:
+      - name: plugin-dir
+        hostPath:
           path: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com
           type: DirectoryOrCreate
-        name: plugin-dir
         # This volume is where the driver mounts volumes
       - hostPath:
           path: /var/lib/kubelet/pods
@@ -205,6 +209,12 @@ spec:
           path: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/data
           type: DirectoryOrCreate
         name: dynatrace-oneagent-data-dir
+        # Used by the registrar to create its lockfile
+      - name: lockfile-dir
+        emptyDir: {}
+        # A volume for the driver to write temporary files to
+      - name: tmp-dir
+        emptyDir: {}
       {{- if .Values.csidriver.nodeSelector }}
       nodeSelector: {{- toYaml .Values.csidriver.nodeSelector | nindent 8 }}
       {{- end }}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -114,7 +114,7 @@ tests:
                   runAsUser: 0
                   privileged: true
                   allowPrivilegeEscalation: true
-                  readOnlyRootFilesystem: false
+                  readOnlyRootFilesystem: true
                   runAsNonRoot: false
                   seccompProfile:
                     type: RuntimeDefault
@@ -131,6 +131,8 @@ tests:
                   - mountPath: /data
                     mountPropagation: Bidirectional
                     name: dynatrace-oneagent-data-dir
+                  - mountPath: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/tmp
+                    name: tmp-dir
               - name: registrar
                 image: image-name
                 imagePullPolicy: Always
@@ -160,7 +162,7 @@ tests:
                 securityContext:
                   runAsUser: 0
                   privileged: false
-                  readOnlyRootFilesystem: false
+                  readOnlyRootFilesystem: true
                   runAsNonRoot: false
                   seccompProfile:
                     type: RuntimeDefault
@@ -171,6 +173,8 @@ tests:
                     name: plugin-dir
                   - mountPath: /registration
                     name: registration-dir
+                  - mountPath: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com
+                    name: lockfile-dir
               - name: liveness-probe
                 image: image-name
                 imagePullPolicy: Always
@@ -192,7 +196,7 @@ tests:
                   runAsUser: 0
                   privileged: false
                   allowPrivilegeEscalation: false
-                  readOnlyRootFilesystem: false
+                  readOnlyRootFilesystem: true
                   runAsNonRoot: false
                   seccompProfile:
                     type: RuntimeDefault
@@ -222,3 +226,8 @@ tests:
                   path: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/data
                   type: DirectoryOrCreate
                 name: dynatrace-oneagent-data-dir
+              - emptyDir: { }
+                name: lockfile-dir
+              - emptyDir: { }
+                name: tmp-dir
+


### PR DESCRIPTION
# Description

The containers of the CSI driver were using a write-able filesystem.
These changes lock the containers root filesystem to be read-only.
An ephemeral storage volume is mounted at the points where some components need to write transient data.

## How can this be tested?

* Deploy the Operator with the CSI driver
* Exec into containers of a CSI driver pod
* Navigate to any place __excluding__
   *  `/csi`
   * `/registration`
   * `/var/lib/kubelet/plugins/csi.oneagent.dynatrace.com`
   * These directories are mounted volumes that do have write permissions
* Try to create a file, e.g.: `touch test.txt`
* An error should occur, e.g.: `touch: cannot touch 'test': Read-only file system`
* Use a mode that uses the CSI driver such as cloud-native fullstack or app-only.
* Injection should work as usual
* CSI driver should download binaries as usual


## Checklist
~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

