### PR TITLE
Added ephemeral-storage to operator and webhook pods

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -31,7 +31,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: activegate
 ---
 # Source: dynatrace-operator/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
@@ -55,7 +55,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: activegate
 ---
 # Source: dynatrace-operator/templates/Common/oneagent/serviceaccount-oneagent-unprivileged.yaml
@@ -79,7 +79,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: oneagent
 automountServiceAccountToken: false
 ---
@@ -104,7 +104,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 ---
 # Source: dynatrace-operator/templates/Common/webhook/serviceaccount-webhook.yaml
@@ -128,7 +128,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 ---
 # Source: dynatrace-operator/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -137,6 +137,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -3244,7 +3245,7 @@ metadata:
   name: dynatrace-kubernetes-monitoring
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: activegate
 rules:
   - apiGroups:
@@ -3327,7 +3328,7 @@ metadata:
   name: dynatrace-operator
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 rules:
   - apiGroups:
@@ -3420,7 +3421,7 @@ metadata:
   name: dynatrace-webhook
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 rules:
   - apiGroups:
@@ -3507,7 +3508,7 @@ metadata:
   name: dynatrace-kubernetes-monitoring
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: activegate
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3538,7 +3539,7 @@ metadata:
   name: dynatrace-operator
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 subjects:
   - kind: ServiceAccount
@@ -3569,7 +3570,7 @@ metadata:
   name: dynatrace-webhook
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 subjects:
   - kind: ServiceAccount
@@ -3601,7 +3602,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 rules:
   - apiGroups:
@@ -3761,7 +3762,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 rules:
   - apiGroups:
@@ -3836,7 +3837,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 subjects:
   - kind: ServiceAccount
@@ -3867,7 +3868,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 subjects:
   - kind: ServiceAccount
@@ -3899,12 +3900,12 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 spec:
   selector:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
   ports:
     - port: 443
@@ -3932,7 +3933,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 spec:
   replicas: 1
@@ -3947,7 +3948,7 @@ spec:
       annotations:
       labels:
         app.kubernetes.io/name: dynatrace-operator
-        app.kubernetes.io/version: "0.4.2"
+        app.kubernetes.io/version: "0.6.0"
         app.kubernetes.io/component: operator
         name: dynatrace-operator
     spec:
@@ -3975,9 +3976,11 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
+              ephemeral-storage: "10Mi"
             limits:
               cpu: 100m
               memory: 128Mi
+              ephemeral-storage: "10Mi"
           volumeMounts:
             - name: tmp-cert-dir
               mountPath: /tmp/dynatrace-operator
@@ -4044,7 +4047,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 spec:
   replicas: 2
@@ -4061,7 +4064,7 @@ spec:
         kubectl.kubernetes.io/default-container: webhook
       labels:
         app.kubernetes.io/name: dynatrace-operator
-        app.kubernetes.io/version: "0.4.2"
+        app.kubernetes.io/version: "0.6.0"
         app.kubernetes.io/component: webhook
         internal.dynatrace.com/component: webhook
         internal.dynatrace.com/app: webhook
@@ -4120,9 +4123,11 @@ spec:
             requests:
               cpu: 300m
               memory: 128Mi
+              ephemeral-storage: "10Mi"
             limits:
               cpu: 300m
               memory: 128Mi
+              ephemeral-storage: "10Mi"
           volumeMounts:
             - name: certs-dir
               mountPath: /tmp/k8s-webhook-server/serving-certs/
@@ -4157,7 +4162,7 @@ metadata:
   name: dynatrace-webhook
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 webhooks:
   - name: webhook.pod.dynatrace.com
@@ -4219,7 +4224,7 @@ metadata:
   name: dynatrace-webhook
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 webhooks:
   - admissionReviewVersions:
@@ -4266,7 +4271,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 ---
 # Source: dynatrace-operator/templates/Common/csi/clusterrole-csi.yaml
@@ -4289,7 +4294,7 @@ metadata:
   name: dynatrace-oneagent-csi-driver
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 rules:
   - apiGroups:
@@ -4355,7 +4360,7 @@ metadata:
   name: dynatrace-oneagent-csi-driver
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 subjects:
   - kind: ServiceAccount
@@ -4387,7 +4392,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 rules:
   - apiGroups:
@@ -4450,7 +4455,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 subjects:
   - kind: ServiceAccount
@@ -4480,7 +4485,7 @@ kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
   name: dynatrace-oneagent-csi-driver
   namespace: dynatrace
@@ -4496,7 +4501,7 @@ spec:
         kubectl.kubernetes.io/default-logs-container: driver
       labels:
         app.kubernetes.io/name: dynatrace-operator
-        app.kubernetes.io/version: "0.4.2"
+        app.kubernetes.io/version: "0.6.0"
         app.kubernetes.io/component: csi-driver
         internal.oneagent.dynatrace.com/app: csi-driver
         internal.oneagent.dynatrace.com/component: csi-driver
@@ -4696,7 +4701,7 @@ metadata:
   name: csi.oneagent.dynatrace.com
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 spec:
   attachRequired: false

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -31,7 +31,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: activegate
 ---
 # Source: dynatrace-operator/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
@@ -55,7 +55,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: activegate
 ---
 # Source: dynatrace-operator/templates/Common/oneagent/serviceaccount-oneagent-unprivileged.yaml
@@ -79,7 +79,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: oneagent
 automountServiceAccountToken: false
 imagePullSecrets:
@@ -107,7 +107,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 
 
@@ -136,7 +136,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 imagePullSecrets:
 - name: redhat-connect
@@ -148,6 +148,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -3255,7 +3256,7 @@ metadata:
   name: dynatrace-kubernetes-monitoring
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: activegate
 rules:
   - apiGroups:
@@ -3338,7 +3339,7 @@ metadata:
   name: dynatrace-operator
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 rules:
   - apiGroups:
@@ -3431,7 +3432,7 @@ metadata:
   name: dynatrace-webhook
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 rules:
   - apiGroups:
@@ -3518,7 +3519,7 @@ metadata:
   name: dynatrace-dynakube-oneagent-unprivileged
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: oneagent
 rules:
   - apiGroups:
@@ -3551,7 +3552,7 @@ metadata:
   name: dynatrace-kubernetes-monitoring
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: activegate
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3582,7 +3583,7 @@ metadata:
   name: dynatrace-operator
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 subjects:
   - kind: ServiceAccount
@@ -3613,7 +3614,7 @@ metadata:
   name: dynatrace-webhook
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 subjects:
   - kind: ServiceAccount
@@ -3644,7 +3645,7 @@ metadata:
   name: dynatrace-dynakube-oneagent-unprivileged
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: oneagent
 subjects:
   - kind: ServiceAccount
@@ -3676,7 +3677,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 rules:
   - apiGroups:
@@ -3836,7 +3837,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 rules:
   - apiGroups:
@@ -3911,7 +3912,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 subjects:
   - kind: ServiceAccount
@@ -3942,7 +3943,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 subjects:
   - kind: ServiceAccount
@@ -3974,12 +3975,12 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 spec:
   selector:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
   ports:
     - port: 443
@@ -4007,7 +4008,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 spec:
   replicas: 1
@@ -4022,7 +4023,7 @@ spec:
       annotations:
       labels:
         app.kubernetes.io/name: dynatrace-operator
-        app.kubernetes.io/version: "0.4.2"
+        app.kubernetes.io/version: "0.6.0"
         app.kubernetes.io/component: operator
         name: dynatrace-operator
     spec:
@@ -4050,9 +4051,11 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
+              ephemeral-storage: "10Mi"
             limits:
               cpu: 100m
               memory: 128Mi
+              ephemeral-storage: "10Mi"
           volumeMounts:
             - name: tmp-cert-dir
               mountPath: /tmp/dynatrace-operator
@@ -4119,7 +4122,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 spec:
   replicas: 2
@@ -4136,7 +4139,7 @@ spec:
         kubectl.kubernetes.io/default-container: webhook
       labels:
         app.kubernetes.io/name: dynatrace-operator
-        app.kubernetes.io/version: "0.4.2"
+        app.kubernetes.io/version: "0.6.0"
         app.kubernetes.io/component: webhook
         internal.dynatrace.com/component: webhook
         internal.dynatrace.com/app: webhook
@@ -4195,9 +4198,11 @@ spec:
             requests:
               cpu: 300m
               memory: 128Mi
+              ephemeral-storage: "10Mi"
             limits:
               cpu: 300m
               memory: 128Mi
+              ephemeral-storage: "10Mi"
           volumeMounts:
             - name: certs-dir
               mountPath: /tmp/k8s-webhook-server/serving-certs/
@@ -4232,7 +4237,7 @@ metadata:
   name: dynatrace-webhook
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 webhooks:
   - name: webhook.pod.dynatrace.com
@@ -4344,7 +4349,7 @@ metadata:
   name: dynatrace-dynakube-oneagent-unprivileged
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: oneagent
 allowHostDirVolumePlugin: true
 allowHostIPC: false
@@ -4409,7 +4414,7 @@ metadata:
   name: dynatrace-operator
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 allowPrivilegedContainer: false
 fsGroup:
@@ -4459,7 +4464,7 @@ metadata:
   name: dynatrace-webhook
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: operator
 allowPrivilegedContainer: false
 fsGroup:
@@ -4509,7 +4514,7 @@ metadata:
   name: dynatrace-webhook
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: webhook
 webhooks:
   - admissionReviewVersions:
@@ -4556,7 +4561,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 ---
 # Source: dynatrace-operator/templates/Common/csi/clusterrole-csi.yaml
@@ -4579,7 +4584,7 @@ metadata:
   name: dynatrace-oneagent-csi-driver
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 rules:
   - apiGroups:
@@ -4645,7 +4650,7 @@ metadata:
   name: dynatrace-oneagent-csi-driver
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 subjects:
   - kind: ServiceAccount
@@ -4677,7 +4682,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 rules:
   - apiGroups:
@@ -4740,7 +4745,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 subjects:
   - kind: ServiceAccount
@@ -4770,7 +4775,7 @@ kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
   name: dynatrace-oneagent-csi-driver
   namespace: dynatrace
@@ -4786,7 +4791,7 @@ spec:
         kubectl.kubernetes.io/default-logs-container: driver
       labels:
         app.kubernetes.io/name: dynatrace-operator
-        app.kubernetes.io/version: "0.4.2"
+        app.kubernetes.io/version: "0.6.0"
         app.kubernetes.io/component: csi-driver
         internal.oneagent.dynatrace.com/app: csi-driver
         internal.oneagent.dynatrace.com/component: csi-driver
@@ -4986,7 +4991,7 @@ metadata:
   name: csi.oneagent.dynatrace.com
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 spec:
   attachRequired: false
@@ -5014,7 +5019,7 @@ metadata:
   name: dynatrace-oneagent-csi-driver
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/component: csi-driver
 allowHostDirVolumePlugin: true
 allowHostIPC: true

--- a/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -65,9 +65,11 @@ spec:
             requests:
               cpu: {{ default "50m" ((.Values.operator).requests).cpu }}
               memory: {{ default "64Mi" ((.Values.operator).requests).memory }}
+              ephemeral-storage: "10Mi"
             limits:
               cpu: {{ default "100m" ((.Values.operator).limits).cpu }}
               memory: {{ default "128Mi" ((.Values.operator).limits).memory }}
+              ephemeral-storage: "10Mi"
           volumeMounts:
             - name: tmp-cert-dir
               mountPath: /tmp/dynatrace-operator

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -98,9 +98,11 @@ spec:
             requests:
               cpu: {{ default "300m" ((.Values.webhook).requests).cpu }}
               memory: {{ default "128Mi" ((.Values.webhook).requests).memory }}
+              ephemeral-storage: "10Mi"
             limits:
               cpu: {{ default "300m" ((.Values.webhook).limits).cpu }}
               memory: {{ default "128Mi" ((.Values.webhook).limits).memory }}
+              ephemeral-storage: "10Mi"
           volumeMounts:
             - name: certs-dir
               mountPath: /tmp/k8s-webhook-server/serving-certs/


### PR DESCRIPTION
# Description

Please include the following:
Added ephemeral-storage of 10Mi (as proposed) to the operator and the webhook pod in order for them to have enough storage so they do not get evicted.

## How can this be tested?
Run make deploy and take a look at the pods, there should be the ephemeral-storage now set.


## Checklist
- [x] PR is labeled accordingly

