### PR TITLE
Added flag in values.yaml and added check

### DIFF
--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
@@ -32,6 +32,9 @@ rules:
       - pods/proxy
       - nodes/proxy
       - services
+      {{- if eq (default false .Values.additionalPermissions.pvcMonitoring) true}}
+      - nodes/metrics
+      {{- end }}
     verbs:
       - list
       - watch

--- a/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
@@ -90,3 +90,95 @@ tests:
               - /livez
             verbs:
               - get
+
+  - it: should add additional permissions when flag is enabled
+    set:
+      additionalPermissions.pvcMonitoring: false
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: dynatrace-kubernetes-monitoring
+      - isNotEmpty:
+          path: metadata.labels
+      - isNotEmpty:
+          path: rules
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - nodes
+              - pods
+              - namespaces
+              - replicationcontrollers
+              - events
+              - resourcequotas
+              - pods/proxy
+              - nodes/proxy
+              - services
+              - nodes/metrics
+            verbs:
+              - list
+              - watch
+              - get
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - batch
+            resources:
+              - jobs
+              - cronjobs
+            verbs:
+              - list
+              - watch
+              - get
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - deployments
+              - replicasets
+              - statefulsets
+              - daemonsets
+            verbs:
+              - list
+              - watch
+              - get
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps.openshift.io
+            resources:
+              - deploymentconfigs
+            verbs:
+              - list
+              - watch
+              - get
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - config.openshift.io
+            resources:
+              - clusterversions
+            verbs:
+              - list
+              - watch
+              - get
+      - contains:
+          path: rules
+          content:
+            nonResourceURLs:
+              - /metrics
+              - /version
+              - /readyz
+              - /livez
+            verbs:
+              - get

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -62,3 +62,6 @@ csidriver:
 
 securityContextConstraints:
   enabled: true # Only applicable for Openshift
+
+additionalPermissions:
+  pvcMonitoring: false


### PR DESCRIPTION
# Description

The new PVC monitoring feature for ActiveGate needs an additional permission to work. This permission can be enabled via a flag in the `values.yaml`.

## How can this be tested?

Set the flag to `true` in the `values.yaml`, apply the rendered helm chart and check the clusterrole `dynatrace-kubernetes-monitoring`. In the resources there should now be `nodes/metrics`.


## Checklist
- [x] PR is labeled accordingly

