### PR TITLE
Set uid and gid explicitly in operator and webhook deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,4 +62,4 @@ RUN  /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
-USER ${USER_UID}
+USER ${USER_UID}:${USER_UID}

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -104,7 +104,7 @@ spec:
         - mountPath: /data
           mountPropagation: Bidirectional
           name: dynatrace-oneagent-data-dir
-        - mountPath: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/tmp
+        - mountPath: /tmp
           name: tmp-dir
         # Used to make a gRPC request (GetPluginInfo()) to the driver to get driver name and driver contain
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -92,6 +92,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
             capabilities:
               drop: ["all"]
       affinity:

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -111,6 +111,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
             capabilities:
               drop: ["all"]
       serviceAccountName: dynatrace-webhook

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -131,7 +131,7 @@ tests:
                   - mountPath: /data
                     mountPropagation: Bidirectional
                     name: dynatrace-oneagent-data-dir
-                  - mountPath: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/tmp
+                  - mountPath: /tmp
                     name: tmp-dir
               - name: registrar
                 image: image-name

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -84,6 +84,8 @@ tests:
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
+                  runAsUser: 1001
+                  runAsGroup: 1001
                   capabilities:
                     drop: ["all"]
             affinity:
@@ -219,6 +221,8 @@ tests:
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
+                  runAsUser: 1001
+                  runAsGroup: 1001
                   capabilities:
                     drop: ["all"]
             affinity:

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -110,6 +110,8 @@ tests:
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
+                  runAsUser: 1001
+                  runAsGroup: 1001
                   capabilities:
                     drop: [ "all" ]
             serviceAccountName: dynatrace-webhook
@@ -237,6 +239,8 @@ tests:
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
+                  runAsUser: 1001
+                  runAsGroup: 1001
                   capabilities:
                     drop: ["all"]
             serviceAccountName: dynatrace-webhook
@@ -343,6 +347,8 @@ tests:
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
+                  runAsUser: 1001
+                  runAsGroup: 1001
                   capabilities:
                     drop: ["all"]
             serviceAccountName: dynatrace-webhook


### PR DESCRIPTION
# Description

We want to run our operator and webhook with the same UID and GID specified in our dockerfile. 
Therefore the IDs are explicitly set in our deployments. 
Setting them in our CSI driver is not possible due to required privileges for accessing the CSI driver sockets.

Additionally fixed wrong /tmp path for CSI driver

## How can this be tested?

Deploy the operator in the cluster, exec into operator/webhook pod and check the UID and GID.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

