### PR TITLE
Setup automatic dependency updates for go and docker in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "friday"
+    time: "03:00"
+  commit-message:
+    prefix: "Go"
+    include: "scope"
+  labels:
+  - "dependencies"
+
+- package-ecosystem: "docker"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "friday"
+    time: "03:00"
+  commit-message:
+    prefix: "Docker"
+    include: "scope"
+  labels:
+  - "dependencies"


### PR DESCRIPTION
# Description

Dependencies are currently manually updated.
The PR enables dependabot to do that for us.

## How can this be tested?

Fork this PR and start dependabot there.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

