### PR TITLE
Bundle, helm chart & manifest changes to support Power and Z

### DIFF
--- a/assets/samples/kustomization.yaml
+++ b/assets/samples/kustomization.yaml
@@ -1,3 +1,3 @@
 resources:
-  - classicFullStack.yaml
+  - applicationMonitoring.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -115,6 +115,8 @@ spec:
                     values:
                       - amd64
                       - arm64
+                      - ppc64le
+                      - s390x
                   {{- end }}
                   - key: kubernetes.io/os
                     operator: In

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -79,6 +79,8 @@ spec:
                     values:
                       - amd64
                       - arm64
+                      - ppc64le
+                      - s390x
                    {{- end }}
                   - key: kubernetes.io/os
                     operator: In

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -129,6 +129,8 @@ tests:
                           values:
                             - amd64
                             - arm64
+                            - ppc64le
+                            - s390x
                         - key: kubernetes.io/os
                           operator: In
                           values:

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -73,6 +73,8 @@ tests:
                           values:
                             - amd64
                             - arm64
+                            - ppc64le
+                            - s390x
                         - key: kubernetes.io/os
                           operator: In
                           values:
@@ -317,6 +319,8 @@ tests:
                           values:
                             - amd64
                             - arm64
+                            - ppc64le
+                            - s390x
                         - key: kubernetes.io/os
                           operator: In
                           values:

--- a/config/manifests/bases/dynatrace-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dynatrace-operator.clusterserviceversion.yaml
@@ -8,6 +8,11 @@ metadata:
     containerImage: registry.connect.redhat.com/dynatrace/dynatrace-operator
     repository: https://github.com/Dynatrace/dynatrace-operator
     support: Dynatrace
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: dynatrace-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/hack/build/bundle_deploy_ocp.sh
+++ b/hack/build/bundle_deploy_ocp.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+VERSION=$1
+NAMESPACE=${2:-dynatrace}
+REGISTRY=quay.io
+OPERATOR=$REGISTRY/$NAMESPACE/dynatrace-operator:v$VERSION
+BUNDLE=$REGISTRY/$NAMESPACE/dynatrace-operator-bundle:v$VERSION
+INDEX=$REGISTRY/$NAMESPACE/operator-index:v$(date +%Y%m%d)-$(date +%H | sed 's/^0//')
+
+if [[ -z "$VERSION" ]]; then
+	echo "ERROR: Not Enough Arguments."
+	echo "Usage:"
+	echo "  $(basename $0) <version> [namespace]"
+	exit 1
+fi
+
+if [[ -n "$(pwd | grep config$)" ]] && [[ -n "$(dirname $pwd | grep dynatrace-operator$)" ]]; then
+	cd ..
+elif [[ -z "$(pwd | grep dynatrace-operator$)" ]] || [[ ! -f ./Makefile ]]; then
+	echo "ERROR: Must run from the operator project root. Exiting..."
+	exit 2
+fi
+
+OLM_IMAGE=$OPERATOR PLATFORM=openshift VERSION=$VERSION make bundle
+BUNDLE_IMG=$BUNDLE PLATFORM=openshift VERSION=$VERSION make bundle/build
+podman login quay.io
+podman push $BUNDLE
+opm index add --bundles $BUNDLE -t $INDEX
+podman push $INDEX
+
+cat > ${NAMESPACE}-operators.catalogsource.yaml << EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ${NAMESPACE}-operators
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: $INDEX
+  displayName: ${NAMESPACE^} Operators
+  publisher:
+  updateStrategy:
+    registryPoll:
+      interval: 5m
+EOF
+
+echo "Created ./${NAMESPACE}-operators.catalogsource.yaml"
+if [[ -n "$(oc whoami > /dev/null 2>&1 | grep admin)" ]]; then
+	oc apply -f "${NAMESPACE}-operators.catalogsource.yaml"
+else
+	echo "WARNING: You don't appear to be logged into OpenShift as an admin."
+	echo "You must login to OpenShift and run the following command to populate OperatorHub:"
+	echo
+	echo "  oc apply -f ${NAMESPACE}-operators.catalogsource.yaml"
+fi

--- a/hack/build/bundle_deploy_ocp.sh
+++ b/hack/build/bundle_deploy_ocp.sh
@@ -6,19 +6,35 @@ REGISTRY=quay.io
 OPERATOR=$REGISTRY/$NAMESPACE/dynatrace-operator:v$VERSION
 BUNDLE=$REGISTRY/$NAMESPACE/dynatrace-operator-bundle:v$VERSION
 INDEX=$REGISTRY/$NAMESPACE/operator-index:v$(date +%Y%m%d)-$(date +%H | sed 's/^0//')
+PREFIX_REGEXP='^v'
+SEMVER_REGEXP='^([0-9]+\.){2}(\*|[0-9]+)(-.*)?$'
 
-if [[ -z "$VERSION" ]]; then
+if [[ -z $VERSION ]]; then
 	echo "ERROR: Not Enough Arguments."
 	echo "Usage:"
 	echo "  $(basename $0) <version> [namespace]"
 	exit 1
 fi
 
+if [[ $VERSION =~ $PREFIX_REGEXP ]]; then
+	echo "INFO: Stripping prefix 'v' from version argument..."
+	VERSION=$(echo -ne $VERSION | sed -e 's/^v//')
+fi
+
+if [[ $VERSION =~ $SEMVER_REGEXP ]]; then
+	continue
+else
+	echo "ERROR: Version argument must confirm to SemVer 2.0 specification. Exiting..."
+	echo -e "See \033[36mhttps://semver.org\033[00m for more info, but please note that build"
+	echo "tags (+suffix) are not supported in Kubernetes due to DNS naming constraints."
+	exit 2
+fi
+
 if [[ -n "$(pwd | grep config$)" ]] && [[ -n "$(dirname $pwd | grep dynatrace-operator$)" ]]; then
 	cd ..
 elif [[ -z "$(pwd | grep dynatrace-operator$)" ]] || [[ ! -f ./Makefile ]]; then
 	echo "ERROR: Must run from the operator project root. Exiting..."
-	exit 2
+	exit 4
 fi
 
 OLM_IMAGE=$OPERATOR PLATFORM=openshift VERSION=$VERSION make bundle
@@ -28,7 +44,7 @@ podman push $BUNDLE
 opm index add --bundles $BUNDLE -t $INDEX
 podman push $INDEX
 
-cat > ${NAMESPACE}-operators.catalogsource.yaml << EOF
+cat > ${NAMESPACE}-operators.v${VERSION}.catalogsource.yaml << EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -44,12 +60,12 @@ spec:
       interval: 5m
 EOF
 
-echo "Created ./${NAMESPACE}-operators.catalogsource.yaml"
+echo "Created ./${NAMESPACE}-operators.v${VERSION}.catalogsource.yaml"
 if [[ -n "$(oc whoami > /dev/null 2>&1 | grep admin)" ]]; then
-	oc apply -f "${NAMESPACE}-operators.catalogsource.yaml"
+	oc apply -f "${NAMESPACE}-operators.v${VERSION}.catalogsource.yaml"
 else
 	echo "WARNING: You don't appear to be logged into OpenShift as an admin."
 	echo "You must login to OpenShift and run the following command to populate OperatorHub:"
 	echo
-	echo "  oc apply -f ${NAMESPACE}-operators.catalogsource.yaml"
+	echo "  oc apply -f ${NAMESPACE}-operators.v${VERSION}.catalogsource.yaml"
 fi


### PR DESCRIPTION
# Description

This PR is now focused on the helm charts / manifests for the operator, and not the code portion. This will merge _after_ the code portion (#865), once the operator is being built for Power and Z, and support is enabled in Red Hat Partner Connect for externally hosting the multi-arch image.

The motivation behind this is of joint concern to Dynatrace, IBM and Red Hat, to target a growing customer audience that is requesting Dynatrace Operator on the IBM Power and Z platforms.

## How can this be tested?

### Testing Requirements
To test this yourself, you'd need the following:
* An operator image for the respective architecture (either `ppc64le` or `s390x`) built and hosted in a remotely accessible registry
* Operator SDK v1.16.0
* Operator Registry (`opm`) v1.19.5
* The following go binaries:
   * sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0 (required for go 1.18 / generics)
   * sigs.k8s.io/kustomize/kustomize/v3
* Helm v3
* Power or Z-based OpenShift cluster, to be able to test app-only monitoring on the respective platform

### Testing Steps:

You must prepare the bundle, index and catalog source for deployment onto OpenShift with the `bundle_deploy_ocp.sh` script:

```
$ ./hack/build/bundle_deploy_ocp.sh 0.7.0-<arch> <quay-orgname>
```

The above will create and push a bundle image, followed by an index image, to the `<quay-orgname>` with the repository of `dynatrace-operator-bundle:v0.7.0-<arch>` and `operator-index:v<timestamp>-<build#>`, respectively. You will also see a catalog source yaml file named `<quay-orgname>-operators.catalogsource.yaml`, with the respective bundle image and `<quay-orgname>` specified within the catalog source.

To deploy the operator bundle on an OpenShift cluster, first login to OpenShift using `oc login <api-url>` and simply apply the catalog source:

```
oc create -f <quay-orgname>-operators.catalogsource.yaml
```

### Steps to Test
In order to test, install the operator from the web console (I have a script, also) into the `openshift-operators` (All Operators) namespace.

For an application to monitor, I install the IBM OpenLiberty v0.8.1 operator from here (requires building the application container on the specific platform): https://github.com/OpenShift-Z/openliberty-operator-ocpz 

Create the required secret, containing the dynatrace PaaS and API Tokens/Keys into the `openshift-operators` namespace.

By default, the demo application runs in the `openliberty-demo` namespace. I label this namespace with the label `monitor: applicationMonitoring` and deploy the following CR into the `openshift-operators` namespace:

```
apiVersion: dynatrace.com/v1beta1
kind: DynaKube
metadata:
  name: dynakube
  namespace: openshift-operators
spec:
  apiUrl: https://<uuid>.live.dynatrace.com/api

  namespaceSelector:
    matchLabels:
      monitor: applicationMonitoring

  oneAgent:
      useCSIDriver: false
```

You should then see application metrics visible in your Dynatrace Dashboard, for the specified live environment `<uuid>`.

## Checklist
- [x] Unit tests have been updated/added
- [ ] PR is labeled accordingly
- [ ] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)