### PR TITLE
Fix arch used in standalone binary download

### DIFF
--- a/src/standalone/config.go
+++ b/src/standalone/config.go
@@ -28,7 +28,6 @@ const (
 
 	InstallerFlavorEnv = "FLAVOR"
 	InstallerTechEnv   = "TECHNOLOGIES"
-	InstallerArchEnv   = "ARCH"
 
 	K8NodeNameEnv    = "K8S_NODE_NAME"
 	K8PodNameEnv     = "K8S_PODNAME"

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	arch "github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/pkg/errors"
 )
 
@@ -84,7 +83,6 @@ func (env *environment) setOptionalFields() {
 	env.addWorkloadKind()
 	env.addWorkloadName()
 	env.addInstallerUrl()
-	env.addInstallerArch()
 }
 
 func (env *environment) addMode() error {
@@ -121,16 +119,6 @@ func (env *environment) addInstallerTech() error {
 	}
 	env.InstallerTech = strings.Split(technologies, ",")
 	return nil
-}
-
-func (env *environment) addInstallerArch() {
-	archEnv, err := checkEnvVar(InstallerArchEnv)
-	if err != nil {
-		env.InstallerArch = arch.ArchX86
-	} else {
-		env.InstallerArch = archEnv
-	}
-
 }
 
 func (env *environment) addInstallPath() error {

--- a/src/standalone/env_test.go
+++ b/src/standalone/env_test.go
@@ -23,7 +23,6 @@ func TestNewEnv(t *testing.T) {
 		assert.True(t, env.CanFail)
 		assert.NotEmpty(t, env.InstallerFlavor)
 		assert.NotEmpty(t, env.InstallerTech)
-		assert.NotEmpty(t, env.InstallerArch)
 		assert.NotEmpty(t, env.InstallPath)
 		assert.Len(t, env.Containers, 5)
 
@@ -45,7 +44,6 @@ func prepTestEnv(t *testing.T) func() {
 	envs := []string{
 		InstallerFlavorEnv,
 		InstallerTechEnv,
-		InstallerArchEnv,
 		K8NodeNameEnv,
 		K8PodNameEnv,
 		K8PodUIDEnv,

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/Dynatrace/dynatrace-operator/src/arch"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/installer"
 	"github.com/Dynatrace/dynatrace-operator/src/installer/url"
@@ -41,7 +42,7 @@ func NewRunner(fs afero.Fs) (*Runner, error) {
 			Os:           dtclient.OsUnix,
 			Type:         dtclient.InstallerTypePaaS,
 			Flavor:       env.InstallerFlavor,
-			Arch:         env.InstallerArch,
+			Arch:         arch.Arch,
 			Technologies: env.InstallerTech,
 			Version:      url.VersionLatest,
 			Url:          env.InstallerUrl,


### PR DESCRIPTION
# Description

The architecture used in the standalone binary download defaults to `X86` in case the environment variable is missing. Setting this via environment variable also doesn't make sense, since it's easier to load during runtime.

## How can this be tested?
Deploy sample app on ARM node without CSI driver and check injection works correctly.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

