### PR TITLE
Adds google-autopilot as a new platform to helm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ config/deploy/kustomization.yaml
 
 /.run/
 config/deploy/kubernetes/kubernetes.yaml
-config/deploy/kubernetes/gke-autopilot.yaml
+config/deploy/kubernetes/google-autopilot.yaml
 config/deploy/kubernetes/kubernetes-csi.yaml
 config/deploy/kubernetes/kubernetes-olm.yaml
 config/deploy/openshift/openshift.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ config/deploy/kustomization.yaml
 
 /.run/
 config/deploy/kubernetes/kubernetes.yaml
+config/deploy/kubernetes/gke-autopilot.yaml
 config/deploy/kubernetes/kubernetes-csi.yaml
 config/deploy/kubernetes/kubernetes-olm.yaml
 config/deploy/openshift/openshift.yaml

--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -4002,6 +4002,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
             capabilities:
               drop: ["all"]
       affinity:
@@ -4133,6 +4135,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
             capabilities:
               drop: ["all"]
       serviceAccountName: dynatrace-webhook
@@ -4551,7 +4555,7 @@ spec:
           runAsUser: 0
           privileged: true # Needed for mountPropagation
           allowPrivilegeEscalation: true # Needed for privileged
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
@@ -4568,6 +4572,8 @@ spec:
         - mountPath: /data
           mountPropagation: Bidirectional
           name: dynatrace-oneagent-data-dir
+        - mountPath: /tmp
+          name: tmp-dir
         # Used to make a gRPC request (GetPluginInfo()) to the driver to get driver name and driver contain
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
         # Used for registering the driver with kubelet
@@ -4602,7 +4608,7 @@ spec:
         securityContext:
           runAsUser: 0
           privileged: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
@@ -4613,6 +4619,8 @@ spec:
           name: plugin-dir
         - mountPath: /registration
           name: registration-dir
+        - mountPath: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com
+          name: lockfile-dir
         # Used to make a gRPC request (Probe()) to the driver to check if its running
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
       - name: liveness-probe
@@ -4637,7 +4645,7 @@ spec:
           runAsUser: 0
           privileged: false
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
@@ -4657,10 +4665,10 @@ spec:
           type: Directory
         name: registration-dir
         # This volume is where the socket for kubelet->driver communication is done
-      - hostPath:
+      - name: plugin-dir
+        hostPath:
           path: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com
           type: DirectoryOrCreate
-        name: plugin-dir
         # This volume is where the driver mounts volumes
       - hostPath:
           path: /var/lib/kubelet/pods
@@ -4671,6 +4679,12 @@ spec:
           path: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/data
           type: DirectoryOrCreate
         name: dynatrace-oneagent-data-dir
+        # Used by the registrar to create its lockfile
+      - name: lockfile-dir
+        emptyDir: {}
+        # A volume for the driver to write temporary files to
+      - name: tmp-dir
+        emptyDir: {}
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -3318,6 +3318,39 @@ rules:
     verbs:
       - get
 ---
+# Source: dynatrace-operator/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dynatrace-dynakube-oneagent-unprivileged
+  labels:
+    app.kubernetes.io/name: dynatrace-operator
+    app.kubernetes.io/version: "0.0.0-snapshot"
+    app.kubernetes.io/component: oneagent
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - host
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
 # Source: dynatrace-operator/templates/Common/operator/clusterrole-operator.yaml
 # Copyright 2021 Dynatrace LLC
 
@@ -3498,39 +3531,6 @@ rules:
     verbs:
       - get
 ---
-# Source: dynatrace-operator/templates/Openshift/oneagent/clusterrole-oneagent-unprivileged.yaml
-# Copyright 2021 Dynatrace LLC
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#     http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: dynatrace-dynakube-oneagent-unprivileged
-  labels:
-    app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.0.0-snapshot"
-    app.kubernetes.io/component: oneagent
-rules:
-  - apiGroups:
-      - security.openshift.io
-    resourceNames:
-      - host
-      - privileged
-    resources:
-      - securitycontextconstraints
-    verbs:
-      - use
----
 # Source: dynatrace-operator/templates/Common/kubernetes-monitoring/clusterrolebinding-kubernetes-monitoring.yaml
 # Copyright 2021 Dynatrace LLC
 
@@ -3561,6 +3561,37 @@ subjects:
   - kind: ServiceAccount
     name: dynatrace-kubernetes-monitoring
     namespace: dynatrace
+---
+# Source: dynatrace-operator/templates/Common/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dynatrace-dynakube-oneagent-unprivileged
+  labels:
+    app.kubernetes.io/name: dynatrace-operator
+    app.kubernetes.io/version: "0.0.0-snapshot"
+    app.kubernetes.io/component: oneagent
+subjects:
+  - kind: ServiceAccount
+    name: dynatrace-dynakube-oneagent-unprivileged
+    namespace: dynatrace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dynatrace-dynakube-oneagent-unprivileged
 ---
 # Source: dynatrace-operator/templates/Common/operator/clusterrolebinding-operator.yaml
 # Copyright 2021 Dynatrace LLC
@@ -3623,37 +3654,6 @@ roleRef:
   kind: ClusterRole
   name: dynatrace-webhook
   apiGroup: rbac.authorization.k8s.io
----
-# Source: dynatrace-operator/templates/Openshift/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
-# Copyright 2021 Dynatrace LLC
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#     http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: dynatrace-dynakube-oneagent-unprivileged
-  labels:
-    app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.0.0-snapshot"
-    app.kubernetes.io/component: oneagent
-subjects:
-  - kind: ServiceAccount
-    name: dynatrace-dynakube-oneagent-unprivileged
-    namespace: dynatrace
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: dynatrace-dynakube-oneagent-unprivileged
 ---
 # Source: dynatrace-operator/templates/Common/operator/role-operator.yaml
 # Copyright 2021 Dynatrace LLC
@@ -4077,6 +4077,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
             capabilities:
               drop: ["all"]
       affinity:
@@ -4208,6 +4210,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
             capabilities:
               drop: ["all"]
       serviceAccountName: dynatrace-webhook
@@ -4841,7 +4845,7 @@ spec:
           runAsUser: 0
           privileged: true # Needed for mountPropagation
           allowPrivilegeEscalation: true # Needed for privileged
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
@@ -4858,6 +4862,8 @@ spec:
         - mountPath: /data
           mountPropagation: Bidirectional
           name: dynatrace-oneagent-data-dir
+        - mountPath: /tmp
+          name: tmp-dir
         # Used to make a gRPC request (GetPluginInfo()) to the driver to get driver name and driver contain
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
         # Used for registering the driver with kubelet
@@ -4892,7 +4898,7 @@ spec:
         securityContext:
           runAsUser: 0
           privileged: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
@@ -4903,6 +4909,8 @@ spec:
           name: plugin-dir
         - mountPath: /registration
           name: registration-dir
+        - mountPath: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com
+          name: lockfile-dir
         # Used to make a gRPC request (Probe()) to the driver to check if its running
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
       - name: liveness-probe
@@ -4927,7 +4935,7 @@ spec:
           runAsUser: 0
           privileged: false
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
@@ -4947,10 +4955,10 @@ spec:
           type: Directory
         name: registration-dir
         # This volume is where the socket for kubelet->driver communication is done
-      - hostPath:
+      - name: plugin-dir
+        hostPath:
           path: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com
           type: DirectoryOrCreate
-        name: plugin-dir
         # This volume is where the driver mounts volumes
       - hostPath:
           path: /var/lib/kubelet/pods
@@ -4961,6 +4969,12 @@ spec:
           path: /var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/data
           type: DirectoryOrCreate
         name: dynatrace-oneagent-data-dir
+        # Used by the registrar to create its lockfile
+      - name: lockfile-dir
+        emptyDir: {}
+        # A volume for the driver to write temporary files to
+      - name: tmp-dir
+        emptyDir: {}
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master

--- a/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -101,11 +101,13 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
+                  {{- if ne .Values.platform "google-autopilot"}}
                   - key: kubernetes.io/arch
                     operator: In
                     values:
                       - amd64
                       - arm64
+                  {{- end }}
                   - key: kubernetes.io/os
                     operator: In
                     values:

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -56,11 +56,13 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
+                    {{- if ne .Values.platform "google-autopilot"}}
                   - key: kubernetes.io/arch
                     operator: In
                     values:
                       - amd64
                       - arm64
+                   {{- end }}
                   - key: kubernetes.io/os
                     operator: In
                     values:

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -149,7 +149,7 @@ Check if we are generating only a part of the yamls
 Check if platform is set
 */}}
 {{- define "dynatrace-operator.platformSet" -}}
-{{- if or (eq .Values.platform "kubernetes") (eq .Values.platform "openshift") (eq .Values.platform "google") -}}
+{{- if or (eq .Values.platform "kubernetes") (eq .Values.platform "openshift") (eq .Values.platform "google") (eq .Values.platform "google-autopilot") -}}
     {{ default "set" }}
 {{- end -}}
 {{- end -}}

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -285,3 +285,19 @@ tests:
     asserts:
       - isNull:
           path: spec.template.spec.imagePullSecrets
+
+  - it: should have only OS node affinity on GKE Autopilot
+    set:
+      platform: google-autopilot
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity
+          value:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: kubernetes.io/os
+                          operator: In
+                          values:
+                            - linux

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -352,3 +352,19 @@ tests:
                   capabilities:
                     drop: ["all"]
             serviceAccountName: dynatrace-webhook
+
+  - it: should have only OS node affinity on GKE Autopilot
+    set:
+      platform: google-autopilot
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity
+          value:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: kubernetes.io/os
+                          operator: In
+                          values:
+                            - linux

--- a/hack/make/manifests/config.mk
+++ b/hack/make/manifests/config.mk
@@ -11,6 +11,7 @@ HELM_CRD_DIR=$(HELM_TEMPLATES_DIR)/Common/crd/
 MANIFESTS_DIR=config/deploy/
 
 KUBERNETES_CORE_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes.yaml
+KUBERNETES_AUTOPILOT_YAML=$(MANIFESTS_DIR)kubernetes/gke-autopilot.yaml
 KUBERNETES_CSIDRIVER_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-csi.yaml
 KUBERNETES_OLM_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-olm.yaml
 KUBERNETES_ALL_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-all.yaml

--- a/hack/make/manifests/config.mk
+++ b/hack/make/manifests/config.mk
@@ -11,7 +11,7 @@ HELM_CRD_DIR=$(HELM_TEMPLATES_DIR)/Common/crd/
 MANIFESTS_DIR=config/deploy/
 
 KUBERNETES_CORE_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes.yaml
-KUBERNETES_AUTOPILOT_YAML=$(MANIFESTS_DIR)kubernetes/gke-autopilot.yaml
+KUBERNETES_AUTOPILOT_YAML=$(MANIFESTS_DIR)kubernetes/google-autopilot.yaml
 KUBERNETES_CSIDRIVER_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-csi.yaml
 KUBERNETES_OLM_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-olm.yaml
 KUBERNETES_ALL_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-all.yaml

--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -19,8 +19,17 @@ manifests/kubernetes/core: manifests/crd/helm prerequisites/kustomize
 			--set olm="${OLM}" \
 			--set image="$(MASTER_IMAGE)" > "$(KUBERNETES_CORE_YAML)"
 
+manifests/kubernetes/autopilot: manifests/crd/helm prerequisites/kustomize
+	helm template dynatrace-operator config/helm/chart/default \
+			--namespace dynatrace \
+			--set installCRD=true \
+			--set platform="google-autopilot" \
+			--set manifests=true \
+			--set olm="${OLM}" \
+			--set image="$(MASTER_IMAGE)" > "$(KUBERNETES_AUTOPILOT_YAML)"
+
 ## Generates a manifest for Kubernetes including a CRD, a CSI driver deployment and a OLM version
-manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi
+manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi manifests/kubernetes/autopilot
 	cp "$(KUBERNETES_CORE_YAML)" "$(KUBERNETES_OLM_YAML)"
 	cat "$(KUBERNETES_CORE_YAML)" "$(KUBERNETES_CSIDRIVER_YAML)" > "$(KUBERNETES_ALL_YAML)"
 


### PR DESCRIPTION
# Description

In gke autopilot version 1.23x the `nodeAffinity` specifying the arch for the node is very picky, and only supports a single value which is `amd64` so having it would just complicate things.
So on gke-autopilot we will not have them.

Added `google-autopilot` as a new possible platform, if used no `nodeAffinity` will be set for checking the arch.

## How can this be tested?
Deploy to a `rapid` channel autopilot cluster, while setting the platform to `google-autopilot`. (remember autopilot doesn't support CSI driver)


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

