### PR TITLE
Update index for v0.7.0 release

### DIFF
--- a/config/helm/repos/stable/index.yaml
+++ b/config/helm/repos/stable/index.yaml
@@ -9,18 +9,18 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marcell.sevcsik@dynatrace.com
-        name: 0sewa0
-      - email: christoph.muellner@dynatrace.com
-        name: chrismuellner
-      - email: lukas.hinterreiter@dynatrace.com
-        name: luhi-DT
+    - email: marcell.sevcsik@dynatrace.com
+      name: 0sewa0
+    - email: christoph.muellner@dynatrace.com
+      name: chrismuellner
+    - email: lukas.hinterreiter@dynatrace.com
+      name: luhi-DT
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/dynatrace-operator
+    - https://github.com/Dynatrace/dynatrace-operator
     type: application
     urls:
-      - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.7.0/dynatrace-operator-0.7.0.tgz
+    - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.7.0/dynatrace-operator-0.7.0.tgz
     version: 0.7.0
   - apiVersion: v2
     appVersion: 0.6.0
@@ -30,18 +30,18 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marcell.sevcsik@dynatrace.com
-        name: 0sewa0
-      - email: christoph.muellner@dynatrace.com
-        name: chrismuellner
-      - email: lukas.hinterreiter@dynatrace.com
-        name: luhi-DT
+    - email: marcell.sevcsik@dynatrace.com
+      name: 0sewa0
+    - email: christoph.muellner@dynatrace.com
+      name: chrismuellner
+    - email: lukas.hinterreiter@dynatrace.com
+      name: luhi-DT
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/dynatrace-operator
+    - https://github.com/Dynatrace/dynatrace-operator
     type: application
     urls:
-      - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.6.0/dynatrace-operator-0.6.0.tgz
+    - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.6.0/dynatrace-operator-0.6.0.tgz
     version: 0.6.0
   - apiVersion: v2
     appVersion: 0.5.1
@@ -51,18 +51,18 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marcell.sevcsik@dynatrace.com
-        name: 0sewa0
-      - email: christoph.muellner@dynatrace.com
-        name: chrismuellner
-      - email: lukas.hinterreiter@dynatrace.com
-        name: luhi-DT
+    - email: marcell.sevcsik@dynatrace.com
+      name: 0sewa0
+    - email: christoph.muellner@dynatrace.com
+      name: chrismuellner
+    - email: lukas.hinterreiter@dynatrace.com
+      name: luhi-DT
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/dynatrace-operator
+    - https://github.com/Dynatrace/dynatrace-operator
     type: application
     urls:
-      - https://github.com/Dynatrace/dynatrace-operator/raw/v0.5.1/config/helm/repos/stable/dynatrace-operator-0.5.1.tgz
+    - https://github.com/Dynatrace/dynatrace-operator/raw/v0.5.1/config/helm/repos/stable/dynatrace-operator-0.5.1.tgz
     version: 0.5.1
   - apiVersion: v2
     appVersion: 0.5.0
@@ -72,18 +72,18 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marcell.sevcsik@dynatrace.com
-        name: 0sewa0
-      - email: christoph.muellner@dynatrace.com
-        name: chrismuellner
-      - email: lukas.hinterreiter@dynatrace.com
-        name: luhi-DT
+    - email: marcell.sevcsik@dynatrace.com
+      name: 0sewa0
+    - email: christoph.muellner@dynatrace.com
+      name: chrismuellner
+    - email: lukas.hinterreiter@dynatrace.com
+      name: luhi-DT
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/dynatrace-operator
+    - https://github.com/Dynatrace/dynatrace-operator
     type: application
     urls:
-      - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.5.0.tgz
+    - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.5.0.tgz
     version: 0.5.0
   - apiVersion: v2
     appVersion: 0.4.2
@@ -93,18 +93,18 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marcell.sevcsik@dynatrace.com
-        name: 0sewa0
-      - email: christoph.muellner@dynatrace.com
-        name: chrismuellner
-      - email: lukas.hinterreiter@dynatrace.com
-        name: luhi-DT
+    - email: marcell.sevcsik@dynatrace.com
+      name: 0sewa0
+    - email: christoph.muellner@dynatrace.com
+      name: chrismuellner
+    - email: lukas.hinterreiter@dynatrace.com
+      name: luhi-DT
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/dynatrace-operator
+    - https://github.com/Dynatrace/dynatrace-operator
     type: application
     urls:
-      - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.2.tgz
+    - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.2.tgz
     version: 0.4.2
   - apiVersion: v2
     appVersion: 0.4.1
@@ -114,18 +114,18 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marcell.sevcsik@dynatrace.com
-        name: 0sewa0
-      - email: christoph.muellner@dynatrace.com
-        name: chrismuellner
-      - email: lukas.hinterreiter@dynatrace.com
-        name: luhi-DT
+    - email: marcell.sevcsik@dynatrace.com
+      name: 0sewa0
+    - email: christoph.muellner@dynatrace.com
+      name: chrismuellner
+    - email: lukas.hinterreiter@dynatrace.com
+      name: luhi-DT
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/dynatrace-operator
+    - https://github.com/Dynatrace/dynatrace-operator
     type: application
     urls:
-      - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.1.tgz
+    - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.1.tgz
     version: 0.4.1
   - apiVersion: v2
     appVersion: 0.4.0
@@ -135,18 +135,18 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marcell.sevcsik@dynatrace.com
-        name: 0sewa0
-      - email: christoph.muellner@dynatrace.com
-        name: chrismuellner
-      - email: lukas.hinterreiter@dynatrace.com
-        name: luhi-DT
+    - email: marcell.sevcsik@dynatrace.com
+      name: 0sewa0
+    - email: christoph.muellner@dynatrace.com
+      name: chrismuellner
+    - email: lukas.hinterreiter@dynatrace.com
+      name: luhi-DT
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/dynatrace-operator
+    - https://github.com/Dynatrace/dynatrace-operator
     type: application
     urls:
-      - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.0.tgz
+    - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v2
     appVersion: 0.3.0
@@ -156,16 +156,16 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marco.mader@dynatrace.com
-        name: DTMad
-      - email: michael.mayr@dynatrace.com
-        name: mmayr-at
+    - email: marco.mader@dynatrace.com
+      name: DTMad
+    - email: michael.mayr@dynatrace.com
+      name: mmayr-at
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/helm-charts
+    - https://github.com/Dynatrace/helm-charts
     type: application
     urls:
-      - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.3.0.tgz
+    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v2
     appVersion: 0.2.3
@@ -175,16 +175,16 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marco.mader@dynatrace.com
-        name: DTMad
-      - email: michael.mayr@dynatrace.com
-        name: mmayr-at
+    - email: marco.mader@dynatrace.com
+      name: DTMad
+    - email: michael.mayr@dynatrace.com
+      name: mmayr-at
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/helm-charts
+    - https://github.com/Dynatrace/helm-charts
     type: application
     urls:
-      - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.3.tgz
+    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.3.tgz
     version: 0.2.3
   - apiVersion: v2
     appVersion: 0.2.2
@@ -194,16 +194,16 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marco.mader@dynatrace.com
-        name: DTMad
-      - email: michael.mayr@dynatrace.com
-        name: mmayr-at
+    - email: marco.mader@dynatrace.com
+      name: DTMad
+    - email: michael.mayr@dynatrace.com
+      name: mmayr-at
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/helm-charts
+    - https://github.com/Dynatrace/helm-charts
     type: application
     urls:
-      - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.2.tgz
+    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.2.tgz
     version: 0.2.2
   - apiVersion: v2
     appVersion: 0.2.1
@@ -213,18 +213,18 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marco.mader@dynatrace.com
-        name: DTMad
-      - email: luis.garcia@dynatrace.com
-        name: lrgar
-      - email: michael.mayr@dynatrace.com
-        name: mmayr-at
+    - email: marco.mader@dynatrace.com
+      name: DTMad
+    - email: luis.garcia@dynatrace.com
+      name: lrgar
+    - email: michael.mayr@dynatrace.com
+      name: mmayr-at
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/helm-charts
+    - https://github.com/Dynatrace/helm-charts
     type: application
     urls:
-      - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.1.tgz
+    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v2
     appVersion: 0.1.0
@@ -234,17 +234,17 @@ entries:
     home: https://www.dynatrace.com/
     icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
     maintainers:
-      - email: marco.mader@dynatrace.com
-        name: DTMad
-      - email: luis.garcia@dynatrace.com
-        name: lrgar
-      - email: michael.mayr@dynatrace.com
-        name: mmayr-at
+    - email: marco.mader@dynatrace.com
+      name: DTMad
+    - email: luis.garcia@dynatrace.com
+      name: lrgar
+    - email: michael.mayr@dynatrace.com
+      name: mmayr-at
     name: dynatrace-operator
     sources:
-      - https://github.com/Dynatrace/helm-charts
+    - https://github.com/Dynatrace/helm-charts
     type: application
     urls:
-      - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.1.0.tgz
+    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.1.0.tgz
     version: 0.1.0
 generated: '2022-06-23T13:39:10.103570024Z'

--- a/config/helm/repos/stable/index.yaml
+++ b/config/helm/repos/stable/index.yaml
@@ -1,250 +1,250 @@
 apiVersion: v1
 entries:
   dynatrace-operator:
-    - apiVersion: v2
-      appVersion: 0.7.0
-      created: '2022-06-23T13:39:10.105364309Z'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: 5cc26c8129371389f351530a848b89df4d7627e7f86f58393cc3ce383a1550cd
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marcell.sevcsik@dynatrace.com
-          name: 0sewa0
-        - email: christoph.muellner@dynatrace.com
-          name: chrismuellner
-        - email: lukas.hinterreiter@dynatrace.com
-          name: luhi-DT
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/dynatrace-operator
-      type: application
-      urls:
-        - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.7.0/dynatrace-operator-0.7.0.tgz
-      version: 0.7.0
-    - apiVersion: v2
-      appVersion: 0.6.0
-      created: '2022-05-06T09:54:25.498445534Z'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: 5740d1d7d1e895d969717a8160d02493224086366282628c0c2e148ca8f80006
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marcell.sevcsik@dynatrace.com
-          name: 0sewa0
-        - email: christoph.muellner@dynatrace.com
-          name: chrismuellner
-        - email: lukas.hinterreiter@dynatrace.com
-          name: luhi-DT
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/dynatrace-operator
-      type: application
-      urls:
-        - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.6.0/dynatrace-operator-0.6.0.tgz
-      version: 0.6.0
-    - apiVersion: v2
-      appVersion: 0.5.1
-      created: '2022-04-07T09:36:15.557655516Z'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: 10fea82022e0aa2287feafbb37530eff8913dae7cad2fe6f762de4a73b9eaaf9
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marcell.sevcsik@dynatrace.com
-          name: 0sewa0
-        - email: christoph.muellner@dynatrace.com
-          name: chrismuellner
-        - email: lukas.hinterreiter@dynatrace.com
-          name: luhi-DT
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/dynatrace-operator
-      type: application
-      urls:
-        - https://github.com/Dynatrace/dynatrace-operator/raw/v0.5.1/config/helm/repos/stable/dynatrace-operator-0.5.1.tgz
-      version: 0.5.1
-    - apiVersion: v2
-      appVersion: 0.5.0
-      created: '2022-03-16T09:20:52.737361919Z'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: f1059a1e1b08e84537a5210bd6dce072953a197629fe5d21e85a7ceb2235f88c
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marcell.sevcsik@dynatrace.com
-          name: 0sewa0
-        - email: christoph.muellner@dynatrace.com
-          name: chrismuellner
-        - email: lukas.hinterreiter@dynatrace.com
-          name: luhi-DT
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/dynatrace-operator
-      type: application
-      urls:
-        - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.5.0.tgz
-      version: 0.5.0
-    - apiVersion: v2
-      appVersion: 0.4.2
-      created: '2022-02-15T16:50:00.153390163Z'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: bd5ec00b917d84157bbc0a2676581979dc7c7f56728703436731a3cf94be7165
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marcell.sevcsik@dynatrace.com
-          name: 0sewa0
-        - email: christoph.muellner@dynatrace.com
-          name: chrismuellner
-        - email: lukas.hinterreiter@dynatrace.com
-          name: luhi-DT
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/dynatrace-operator
-      type: application
-      urls:
-        - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.2.tgz
-      version: 0.4.2
-    - apiVersion: v2
-      appVersion: 0.4.1
-      created: '2022-02-01T13:14:01.982041685Z'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: c343ea54012d0a1c6680e69320ebc6335beb05b1c8c3d91e7eba081579bf8728
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marcell.sevcsik@dynatrace.com
-          name: 0sewa0
-        - email: christoph.muellner@dynatrace.com
-          name: chrismuellner
-        - email: lukas.hinterreiter@dynatrace.com
-          name: luhi-DT
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/dynatrace-operator
-      type: application
-      urls:
-        - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.1.tgz
-      version: 0.4.1
-    - apiVersion: v2
-      appVersion: 0.4.0
-      created: '2022-01-25T12:25:43.110745598Z'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: 2e7bbc3b1424db289776d6b5fd839c1bd924ea20d9629e5cfdf4f8b1b2c12dec
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marcell.sevcsik@dynatrace.com
-          name: 0sewa0
-        - email: christoph.muellner@dynatrace.com
-          name: chrismuellner
-        - email: lukas.hinterreiter@dynatrace.com
-          name: luhi-DT
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/dynatrace-operator
-      type: application
-      urls:
-        - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.0.tgz
-      version: 0.4.0
-    - apiVersion: v2
-      appVersion: 0.3.0
-      created: '2021-11-30T13:25:32.738491282+01:00'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: fc762f753413ec0624661fca5dda0e381af07ba7e2e0f2d56733462529a430b7
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marco.mader@dynatrace.com
-          name: DTMad
-        - email: michael.mayr@dynatrace.com
-          name: mmayr-at
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/helm-charts
-      type: application
-      urls:
-        - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.3.0.tgz
-      version: 0.3.0
-    - apiVersion: v2
-      appVersion: 0.2.3
-      created: '2021-09-27T12:21:54.707256263+02:00'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: 7b4ec16f6531f1a455ddb64f1516c3282befe9b69699382e9eb5d2eb4854b1f0
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marco.mader@dynatrace.com
-          name: DTMad
-        - email: michael.mayr@dynatrace.com
-          name: mmayr-at
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/helm-charts
-      type: application
-      urls:
-        - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.3.tgz
-      version: 0.2.3
-    - apiVersion: v2
-      appVersion: 0.2.2
-      created: '2021-08-25T09:45:58.393115+02:00'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: 13dbc0238a4d91a43db5e9d346e36dac4bab29b91467c1c02660f3d6a6c27152
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marco.mader@dynatrace.com
-          name: DTMad
-        - email: michael.mayr@dynatrace.com
-          name: mmayr-at
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/helm-charts
-      type: application
-      urls:
-        - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.2.tgz
-      version: 0.2.2
-    - apiVersion: v2
-      appVersion: 0.2.1
-      created: '2021-04-12T09:35:02.568665+02:00'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: 2e495df7fbf756f6bfbd813e0a70fd51237ef731e778fc58ed3e9ab32b001980
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marco.mader@dynatrace.com
-          name: DTMad
-        - email: luis.garcia@dynatrace.com
-          name: lrgar
-        - email: michael.mayr@dynatrace.com
-          name: mmayr-at
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/helm-charts
-      type: application
-      urls:
-        - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.1.tgz
-      version: 0.2.1
-    - apiVersion: v2
-      appVersion: 0.1.0
-      created: '2021-01-25T13:54:44.810522+01:00'
-      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-      digest: ea946772001f6b1fd45dcb25b014d05bead1de06e21952a85a5ecd6a664567c1
-      home: https://www.dynatrace.com/
-      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-      maintainers:
-        - email: marco.mader@dynatrace.com
-          name: DTMad
-        - email: luis.garcia@dynatrace.com
-          name: lrgar
-        - email: michael.mayr@dynatrace.com
-          name: mmayr-at
-      name: dynatrace-operator
-      sources:
-        - https://github.com/Dynatrace/helm-charts
-      type: application
-      urls:
-        - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.1.0.tgz
-      version: 0.1.0
+  - apiVersion: v2
+    appVersion: 0.7.0
+    created: '2022-06-23T13:39:10.105364309Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 5cc26c8129371389f351530a848b89df4d7627e7f86f58393cc3ce383a1550cd
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marcell.sevcsik@dynatrace.com
+        name: 0sewa0
+      - email: christoph.muellner@dynatrace.com
+        name: chrismuellner
+      - email: lukas.hinterreiter@dynatrace.com
+        name: luhi-DT
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+      - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.7.0/dynatrace-operator-0.7.0.tgz
+    version: 0.7.0
+  - apiVersion: v2
+    appVersion: 0.6.0
+    created: '2022-05-06T09:54:25.498445534Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 5740d1d7d1e895d969717a8160d02493224086366282628c0c2e148ca8f80006
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marcell.sevcsik@dynatrace.com
+        name: 0sewa0
+      - email: christoph.muellner@dynatrace.com
+        name: chrismuellner
+      - email: lukas.hinterreiter@dynatrace.com
+        name: luhi-DT
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+      - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.6.0/dynatrace-operator-0.6.0.tgz
+    version: 0.6.0
+  - apiVersion: v2
+    appVersion: 0.5.1
+    created: '2022-04-07T09:36:15.557655516Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 10fea82022e0aa2287feafbb37530eff8913dae7cad2fe6f762de4a73b9eaaf9
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marcell.sevcsik@dynatrace.com
+        name: 0sewa0
+      - email: christoph.muellner@dynatrace.com
+        name: chrismuellner
+      - email: lukas.hinterreiter@dynatrace.com
+        name: luhi-DT
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+      - https://github.com/Dynatrace/dynatrace-operator/raw/v0.5.1/config/helm/repos/stable/dynatrace-operator-0.5.1.tgz
+    version: 0.5.1
+  - apiVersion: v2
+    appVersion: 0.5.0
+    created: '2022-03-16T09:20:52.737361919Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: f1059a1e1b08e84537a5210bd6dce072953a197629fe5d21e85a7ceb2235f88c
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marcell.sevcsik@dynatrace.com
+        name: 0sewa0
+      - email: christoph.muellner@dynatrace.com
+        name: chrismuellner
+      - email: lukas.hinterreiter@dynatrace.com
+        name: luhi-DT
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+      - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.5.0.tgz
+    version: 0.5.0
+  - apiVersion: v2
+    appVersion: 0.4.2
+    created: '2022-02-15T16:50:00.153390163Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: bd5ec00b917d84157bbc0a2676581979dc7c7f56728703436731a3cf94be7165
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marcell.sevcsik@dynatrace.com
+        name: 0sewa0
+      - email: christoph.muellner@dynatrace.com
+        name: chrismuellner
+      - email: lukas.hinterreiter@dynatrace.com
+        name: luhi-DT
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+      - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.2.tgz
+    version: 0.4.2
+  - apiVersion: v2
+    appVersion: 0.4.1
+    created: '2022-02-01T13:14:01.982041685Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: c343ea54012d0a1c6680e69320ebc6335beb05b1c8c3d91e7eba081579bf8728
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marcell.sevcsik@dynatrace.com
+        name: 0sewa0
+      - email: christoph.muellner@dynatrace.com
+        name: chrismuellner
+      - email: lukas.hinterreiter@dynatrace.com
+        name: luhi-DT
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+      - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.1.tgz
+    version: 0.4.1
+  - apiVersion: v2
+    appVersion: 0.4.0
+    created: '2022-01-25T12:25:43.110745598Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 2e7bbc3b1424db289776d6b5fd839c1bd924ea20d9629e5cfdf4f8b1b2c12dec
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marcell.sevcsik@dynatrace.com
+        name: 0sewa0
+      - email: christoph.muellner@dynatrace.com
+        name: chrismuellner
+      - email: lukas.hinterreiter@dynatrace.com
+        name: luhi-DT
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+      - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.0.tgz
+    version: 0.4.0
+  - apiVersion: v2
+    appVersion: 0.3.0
+    created: '2021-11-30T13:25:32.738491282+01:00'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: fc762f753413ec0624661fca5dda0e381af07ba7e2e0f2d56733462529a430b7
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marco.mader@dynatrace.com
+        name: DTMad
+      - email: michael.mayr@dynatrace.com
+        name: mmayr-at
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/helm-charts
+    type: application
+    urls:
+      - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.3.0.tgz
+    version: 0.3.0
+  - apiVersion: v2
+    appVersion: 0.2.3
+    created: '2021-09-27T12:21:54.707256263+02:00'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 7b4ec16f6531f1a455ddb64f1516c3282befe9b69699382e9eb5d2eb4854b1f0
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marco.mader@dynatrace.com
+        name: DTMad
+      - email: michael.mayr@dynatrace.com
+        name: mmayr-at
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/helm-charts
+    type: application
+    urls:
+      - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.3.tgz
+    version: 0.2.3
+  - apiVersion: v2
+    appVersion: 0.2.2
+    created: '2021-08-25T09:45:58.393115+02:00'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 13dbc0238a4d91a43db5e9d346e36dac4bab29b91467c1c02660f3d6a6c27152
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marco.mader@dynatrace.com
+        name: DTMad
+      - email: michael.mayr@dynatrace.com
+        name: mmayr-at
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/helm-charts
+    type: application
+    urls:
+      - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.2.tgz
+    version: 0.2.2
+  - apiVersion: v2
+    appVersion: 0.2.1
+    created: '2021-04-12T09:35:02.568665+02:00'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 2e495df7fbf756f6bfbd813e0a70fd51237ef731e778fc58ed3e9ab32b001980
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marco.mader@dynatrace.com
+        name: DTMad
+      - email: luis.garcia@dynatrace.com
+        name: lrgar
+      - email: michael.mayr@dynatrace.com
+        name: mmayr-at
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/helm-charts
+    type: application
+    urls:
+      - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.1.tgz
+    version: 0.2.1
+  - apiVersion: v2
+    appVersion: 0.1.0
+    created: '2021-01-25T13:54:44.810522+01:00'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: ea946772001f6b1fd45dcb25b014d05bead1de06e21952a85a5ecd6a664567c1
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marco.mader@dynatrace.com
+        name: DTMad
+      - email: luis.garcia@dynatrace.com
+        name: lrgar
+      - email: michael.mayr@dynatrace.com
+        name: mmayr-at
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/helm-charts
+    type: application
+    urls:
+      - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.1.0.tgz
+    version: 0.1.0
 generated: '2022-06-23T13:39:10.103570024Z'

--- a/config/helm/repos/stable/index.yaml
+++ b/config/helm/repos/stable/index.yaml
@@ -1,229 +1,250 @@
 apiVersion: v1
 entries:
   dynatrace-operator:
-  - apiVersion: v2
-    appVersion: 0.6.0
-    created: '2022-05-06T09:54:25.498445534Z'
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: 5740d1d7d1e895d969717a8160d02493224086366282628c0c2e148ca8f80006
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-      - email: marcell.sevcsik@dynatrace.com
-        name: 0sewa0
-      - email: christoph.muellner@dynatrace.com
-        name: chrismuellner
-      - email: lukas.hinterreiter@dynatrace.com
-        name: luhi-DT
-    name: dynatrace-operator
-    sources:
-      - https://github.com/Dynatrace/dynatrace-operator
-    type: application
-    urls:
-      - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.6.0/dynatrace-operator-0.6.0.tgz
-    version: 0.6.0
-  - apiVersion: v2
-    appVersion: 0.5.1
-    created: '2022-04-07T09:36:15.557655516Z'
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: 10fea82022e0aa2287feafbb37530eff8913dae7cad2fe6f762de4a73b9eaaf9
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-    - email: marcell.sevcsik@dynatrace.com
-      name: 0sewa0
-    - email: christoph.muellner@dynatrace.com
-      name: chrismuellner
-    - email: lukas.hinterreiter@dynatrace.com
-      name: luhi-DT
-    name: dynatrace-operator
-    sources:
-    - https://github.com/Dynatrace/dynatrace-operator
-    type: application
-    urls:
-    - https://github.com/Dynatrace/dynatrace-operator/raw/v0.5.1/config/helm/repos/stable/dynatrace-operator-0.5.1.tgz
-    version: 0.5.1
-  - apiVersion: v2
-    appVersion: 0.5.0
-    created: '2022-03-16T09:20:52.737361919Z'
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: f1059a1e1b08e84537a5210bd6dce072953a197629fe5d21e85a7ceb2235f88c
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-    - email: marcell.sevcsik@dynatrace.com
-      name: 0sewa0
-    - email: christoph.muellner@dynatrace.com
-      name: chrismuellner
-    - email: lukas.hinterreiter@dynatrace.com
-      name: luhi-DT
-    name: dynatrace-operator
-    sources:
-    - https://github.com/Dynatrace/dynatrace-operator
-    type: application
-    urls:
-    - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.5.0.tgz
-    version: 0.5.0
-  - apiVersion: v2
-    appVersion: 0.4.2
-    created: '2022-02-15T16:50:00.153390163Z'
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: bd5ec00b917d84157bbc0a2676581979dc7c7f56728703436731a3cf94be7165
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-    - email: marcell.sevcsik@dynatrace.com
-      name: 0sewa0
-    - email: christoph.muellner@dynatrace.com
-      name: chrismuellner
-    - email: lukas.hinterreiter@dynatrace.com
-      name: luhi-DT
-    name: dynatrace-operator
-    sources:
-    - https://github.com/Dynatrace/dynatrace-operator
-    type: application
-    urls:
-    - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.2.tgz
-    version: 0.4.2
-  - apiVersion: v2
-    appVersion: 0.4.1
-    created: '2022-02-01T13:14:01.982041685Z'
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: c343ea54012d0a1c6680e69320ebc6335beb05b1c8c3d91e7eba081579bf8728
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-    - email: marcell.sevcsik@dynatrace.com
-      name: 0sewa0
-    - email: christoph.muellner@dynatrace.com
-      name: chrismuellner
-    - email: lukas.hinterreiter@dynatrace.com
-      name: luhi-DT
-    name: dynatrace-operator
-    sources:
-    - https://github.com/Dynatrace/dynatrace-operator
-    type: application
-    urls:
-    - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.1.tgz
-    version: 0.4.1
-  - apiVersion: v2
-    appVersion: 0.4.0
-    created: '2022-01-25T12:25:43.110745598Z'
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: 2e7bbc3b1424db289776d6b5fd839c1bd924ea20d9629e5cfdf4f8b1b2c12dec
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-    - email: marcell.sevcsik@dynatrace.com
-      name: 0sewa0
-    - email: christoph.muellner@dynatrace.com
-      name: chrismuellner
-    - email: lukas.hinterreiter@dynatrace.com
-      name: luhi-DT
-    name: dynatrace-operator
-    sources:
-    - https://github.com/Dynatrace/dynatrace-operator
-    type: application
-    urls:
-    - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.0.tgz
-    version: 0.4.0
-  - apiVersion: v2
-    appVersion: 0.3.0
-    created: "2021-11-30T13:25:32.738491282+01:00"
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: fc762f753413ec0624661fca5dda0e381af07ba7e2e0f2d56733462529a430b7
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-    - email: marco.mader@dynatrace.com
-      name: DTMad
-    - email: michael.mayr@dynatrace.com
-      name: mmayr-at
-    name: dynatrace-operator
-    sources:
-    - https://github.com/Dynatrace/helm-charts
-    type: application
-    urls:
-    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.3.0.tgz
-    version: 0.3.0
-  - apiVersion: v2
-    appVersion: 0.2.3
-    created: "2021-09-27T12:21:54.707256263+02:00"
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: 7b4ec16f6531f1a455ddb64f1516c3282befe9b69699382e9eb5d2eb4854b1f0
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-    - email: marco.mader@dynatrace.com
-      name: DTMad
-    - email: michael.mayr@dynatrace.com
-      name: mmayr-at
-    name: dynatrace-operator
-    sources:
-    - https://github.com/Dynatrace/helm-charts
-    type: application
-    urls:
-    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.3.tgz
-    version: 0.2.3
-  - apiVersion: v2
-    appVersion: 0.2.2
-    created: "2021-08-25T09:45:58.393115+02:00"
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: 13dbc0238a4d91a43db5e9d346e36dac4bab29b91467c1c02660f3d6a6c27152
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-    - email: marco.mader@dynatrace.com
-      name: DTMad
-    - email: michael.mayr@dynatrace.com
-      name: mmayr-at
-    name: dynatrace-operator
-    sources:
-    - https://github.com/Dynatrace/helm-charts
-    type: application
-    urls:
-    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.2.tgz
-    version: 0.2.2
-  - apiVersion: v2
-    appVersion: 0.2.1
-    created: "2021-04-12T09:35:02.568665+02:00"
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: 2e495df7fbf756f6bfbd813e0a70fd51237ef731e778fc58ed3e9ab32b001980
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-    - email: marco.mader@dynatrace.com
-      name: DTMad
-    - email: luis.garcia@dynatrace.com
-      name: lrgar
-    - email: michael.mayr@dynatrace.com
-      name: mmayr-at
-    name: dynatrace-operator
-    sources:
-    - https://github.com/Dynatrace/helm-charts
-    type: application
-    urls:
-    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.1.tgz
-    version: 0.2.1
-  - apiVersion: v2
-    appVersion: 0.1.0
-    created: "2021-01-25T13:54:44.810522+01:00"
-    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
-    digest: ea946772001f6b1fd45dcb25b014d05bead1de06e21952a85a5ecd6a664567c1
-    home: https://www.dynatrace.com/
-    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
-    maintainers:
-    - email: marco.mader@dynatrace.com
-      name: DTMad
-    - email: luis.garcia@dynatrace.com
-      name: lrgar
-    - email: michael.mayr@dynatrace.com
-      name: mmayr-at
-    name: dynatrace-operator
-    sources:
-    - https://github.com/Dynatrace/helm-charts
-    type: application
-    urls:
-    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.1.0.tgz
-    version: 0.1.0
-generated: '2022-05-06T09:54:25.487121387Z'
+    - apiVersion: v2
+      appVersion: 0.7.0
+      created: '2022-06-23T13:39:10.105364309Z'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: 5cc26c8129371389f351530a848b89df4d7627e7f86f58393cc3ce383a1550cd
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marcell.sevcsik@dynatrace.com
+          name: 0sewa0
+        - email: christoph.muellner@dynatrace.com
+          name: chrismuellner
+        - email: lukas.hinterreiter@dynatrace.com
+          name: luhi-DT
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/dynatrace-operator
+      type: application
+      urls:
+        - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.7.0/dynatrace-operator-0.7.0.tgz
+      version: 0.7.0
+    - apiVersion: v2
+      appVersion: 0.6.0
+      created: '2022-05-06T09:54:25.498445534Z'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: 5740d1d7d1e895d969717a8160d02493224086366282628c0c2e148ca8f80006
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marcell.sevcsik@dynatrace.com
+          name: 0sewa0
+        - email: christoph.muellner@dynatrace.com
+          name: chrismuellner
+        - email: lukas.hinterreiter@dynatrace.com
+          name: luhi-DT
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/dynatrace-operator
+      type: application
+      urls:
+        - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.6.0/dynatrace-operator-0.6.0.tgz
+      version: 0.6.0
+    - apiVersion: v2
+      appVersion: 0.5.1
+      created: '2022-04-07T09:36:15.557655516Z'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: 10fea82022e0aa2287feafbb37530eff8913dae7cad2fe6f762de4a73b9eaaf9
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marcell.sevcsik@dynatrace.com
+          name: 0sewa0
+        - email: christoph.muellner@dynatrace.com
+          name: chrismuellner
+        - email: lukas.hinterreiter@dynatrace.com
+          name: luhi-DT
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/dynatrace-operator
+      type: application
+      urls:
+        - https://github.com/Dynatrace/dynatrace-operator/raw/v0.5.1/config/helm/repos/stable/dynatrace-operator-0.5.1.tgz
+      version: 0.5.1
+    - apiVersion: v2
+      appVersion: 0.5.0
+      created: '2022-03-16T09:20:52.737361919Z'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: f1059a1e1b08e84537a5210bd6dce072953a197629fe5d21e85a7ceb2235f88c
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marcell.sevcsik@dynatrace.com
+          name: 0sewa0
+        - email: christoph.muellner@dynatrace.com
+          name: chrismuellner
+        - email: lukas.hinterreiter@dynatrace.com
+          name: luhi-DT
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/dynatrace-operator
+      type: application
+      urls:
+        - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.5.0.tgz
+      version: 0.5.0
+    - apiVersion: v2
+      appVersion: 0.4.2
+      created: '2022-02-15T16:50:00.153390163Z'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: bd5ec00b917d84157bbc0a2676581979dc7c7f56728703436731a3cf94be7165
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marcell.sevcsik@dynatrace.com
+          name: 0sewa0
+        - email: christoph.muellner@dynatrace.com
+          name: chrismuellner
+        - email: lukas.hinterreiter@dynatrace.com
+          name: luhi-DT
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/dynatrace-operator
+      type: application
+      urls:
+        - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.2.tgz
+      version: 0.4.2
+    - apiVersion: v2
+      appVersion: 0.4.1
+      created: '2022-02-01T13:14:01.982041685Z'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: c343ea54012d0a1c6680e69320ebc6335beb05b1c8c3d91e7eba081579bf8728
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marcell.sevcsik@dynatrace.com
+          name: 0sewa0
+        - email: christoph.muellner@dynatrace.com
+          name: chrismuellner
+        - email: lukas.hinterreiter@dynatrace.com
+          name: luhi-DT
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/dynatrace-operator
+      type: application
+      urls:
+        - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.1.tgz
+      version: 0.4.1
+    - apiVersion: v2
+      appVersion: 0.4.0
+      created: '2022-01-25T12:25:43.110745598Z'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: 2e7bbc3b1424db289776d6b5fd839c1bd924ea20d9629e5cfdf4f8b1b2c12dec
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marcell.sevcsik@dynatrace.com
+          name: 0sewa0
+        - email: christoph.muellner@dynatrace.com
+          name: chrismuellner
+        - email: lukas.hinterreiter@dynatrace.com
+          name: luhi-DT
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/dynatrace-operator
+      type: application
+      urls:
+        - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.0.tgz
+      version: 0.4.0
+    - apiVersion: v2
+      appVersion: 0.3.0
+      created: '2021-11-30T13:25:32.738491282+01:00'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: fc762f753413ec0624661fca5dda0e381af07ba7e2e0f2d56733462529a430b7
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marco.mader@dynatrace.com
+          name: DTMad
+        - email: michael.mayr@dynatrace.com
+          name: mmayr-at
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/helm-charts
+      type: application
+      urls:
+        - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.3.0.tgz
+      version: 0.3.0
+    - apiVersion: v2
+      appVersion: 0.2.3
+      created: '2021-09-27T12:21:54.707256263+02:00'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: 7b4ec16f6531f1a455ddb64f1516c3282befe9b69699382e9eb5d2eb4854b1f0
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marco.mader@dynatrace.com
+          name: DTMad
+        - email: michael.mayr@dynatrace.com
+          name: mmayr-at
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/helm-charts
+      type: application
+      urls:
+        - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.3.tgz
+      version: 0.2.3
+    - apiVersion: v2
+      appVersion: 0.2.2
+      created: '2021-08-25T09:45:58.393115+02:00'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: 13dbc0238a4d91a43db5e9d346e36dac4bab29b91467c1c02660f3d6a6c27152
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marco.mader@dynatrace.com
+          name: DTMad
+        - email: michael.mayr@dynatrace.com
+          name: mmayr-at
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/helm-charts
+      type: application
+      urls:
+        - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.2.tgz
+      version: 0.2.2
+    - apiVersion: v2
+      appVersion: 0.2.1
+      created: '2021-04-12T09:35:02.568665+02:00'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: 2e495df7fbf756f6bfbd813e0a70fd51237ef731e778fc58ed3e9ab32b001980
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marco.mader@dynatrace.com
+          name: DTMad
+        - email: luis.garcia@dynatrace.com
+          name: lrgar
+        - email: michael.mayr@dynatrace.com
+          name: mmayr-at
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/helm-charts
+      type: application
+      urls:
+        - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.1.tgz
+      version: 0.2.1
+    - apiVersion: v2
+      appVersion: 0.1.0
+      created: '2021-01-25T13:54:44.810522+01:00'
+      description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+      digest: ea946772001f6b1fd45dcb25b014d05bead1de06e21952a85a5ecd6a664567c1
+      home: https://www.dynatrace.com/
+      icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+      maintainers:
+        - email: marco.mader@dynatrace.com
+          name: DTMad
+        - email: luis.garcia@dynatrace.com
+          name: lrgar
+        - email: michael.mayr@dynatrace.com
+          name: mmayr-at
+      name: dynatrace-operator
+      sources:
+        - https://github.com/Dynatrace/helm-charts
+      type: application
+      urls:
+        - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.1.0.tgz
+      version: 0.1.0
+generated: '2022-06-23T13:39:10.103570024Z'

--- a/config/helm/repos/stable/index.yaml.previous
+++ b/config/helm/repos/stable/index.yaml.previous
@@ -2,6 +2,27 @@ apiVersion: v1
 entries:
   dynatrace-operator:
   - apiVersion: v2
+    appVersion: 0.6.0
+    created: '2022-05-06T09:54:25.498445534Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 5740d1d7d1e895d969717a8160d02493224086366282628c0c2e148ca8f80006
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+      - email: marcell.sevcsik@dynatrace.com
+        name: 0sewa0
+      - email: christoph.muellner@dynatrace.com
+        name: chrismuellner
+      - email: lukas.hinterreiter@dynatrace.com
+        name: luhi-DT
+    name: dynatrace-operator
+    sources:
+      - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+      - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.6.0/dynatrace-operator-0.6.0.tgz
+    version: 0.6.0
+  - apiVersion: v2
     appVersion: 0.5.1
     created: '2022-04-07T09:36:15.557655516Z'
     description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
@@ -106,5 +127,103 @@ entries:
     urls:
     - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.0.tgz
     version: 0.4.0
-generated: '2022-03-16T09:20:52.729619337Z'
-
+  - apiVersion: v2
+    appVersion: 0.3.0
+    created: "2021-11-30T13:25:32.738491282+01:00"
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: fc762f753413ec0624661fca5dda0e381af07ba7e2e0f2d56733462529a430b7
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+    - email: marco.mader@dynatrace.com
+      name: DTMad
+    - email: michael.mayr@dynatrace.com
+      name: mmayr-at
+    name: dynatrace-operator
+    sources:
+    - https://github.com/Dynatrace/helm-charts
+    type: application
+    urls:
+    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.3.0.tgz
+    version: 0.3.0
+  - apiVersion: v2
+    appVersion: 0.2.3
+    created: "2021-09-27T12:21:54.707256263+02:00"
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 7b4ec16f6531f1a455ddb64f1516c3282befe9b69699382e9eb5d2eb4854b1f0
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+    - email: marco.mader@dynatrace.com
+      name: DTMad
+    - email: michael.mayr@dynatrace.com
+      name: mmayr-at
+    name: dynatrace-operator
+    sources:
+    - https://github.com/Dynatrace/helm-charts
+    type: application
+    urls:
+    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.3.tgz
+    version: 0.2.3
+  - apiVersion: v2
+    appVersion: 0.2.2
+    created: "2021-08-25T09:45:58.393115+02:00"
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 13dbc0238a4d91a43db5e9d346e36dac4bab29b91467c1c02660f3d6a6c27152
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+    - email: marco.mader@dynatrace.com
+      name: DTMad
+    - email: michael.mayr@dynatrace.com
+      name: mmayr-at
+    name: dynatrace-operator
+    sources:
+    - https://github.com/Dynatrace/helm-charts
+    type: application
+    urls:
+    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.2.tgz
+    version: 0.2.2
+  - apiVersion: v2
+    appVersion: 0.2.1
+    created: "2021-04-12T09:35:02.568665+02:00"
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: 2e495df7fbf756f6bfbd813e0a70fd51237ef731e778fc58ed3e9ab32b001980
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+    - email: marco.mader@dynatrace.com
+      name: DTMad
+    - email: luis.garcia@dynatrace.com
+      name: lrgar
+    - email: michael.mayr@dynatrace.com
+      name: mmayr-at
+    name: dynatrace-operator
+    sources:
+    - https://github.com/Dynatrace/helm-charts
+    type: application
+    urls:
+    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.2.1.tgz
+    version: 0.2.1
+  - apiVersion: v2
+    appVersion: 0.1.0
+    created: "2021-01-25T13:54:44.810522+01:00"
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: ea946772001f6b1fd45dcb25b014d05bead1de06e21952a85a5ecd6a664567c1
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+    - email: marco.mader@dynatrace.com
+      name: DTMad
+    - email: luis.garcia@dynatrace.com
+      name: lrgar
+    - email: michael.mayr@dynatrace.com
+      name: mmayr-at
+    name: dynatrace-operator
+    sources:
+    - https://github.com/Dynatrace/helm-charts
+    type: application
+    urls:
+    - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.1.0.tgz
+    version: 0.1.0
+generated: '2022-05-06T09:54:25.487121387Z'


### PR DESCRIPTION
# Description
Upgrade `index.yaml` to include latest version of the helm chart.

## How can this be tested?
Helm upgrade to and install of `v0.7.0` works.

## Checklist
- [x] PR is labeled accordingly


