### PR TITLE
Refactors test objects from being global variables to being created in functions

### DIFF
--- a/src/controllers/csi/metadata/correctness_test.go
+++ b/src/controllers/csi/metadata/correctness_test.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"fmt"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
@@ -10,6 +11,98 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func createTestDynakube(index int) Dynakube {
+	return Dynakube{
+		TenantUUID:    fmt.Sprintf("asc%d", index),
+		LatestVersion: fmt.Sprintf("%d", 123*index),
+		Name:          fmt.Sprintf("dk%d", index),
+		ImageDigest:   fmt.Sprintf("sha256:%d", 123*index),
+	}
+}
+
+func createTestVolume(index int) Volume {
+	return Volume{
+		VolumeID:   fmt.Sprintf("vol-%d", index),
+		PodName:    fmt.Sprintf("pod%d", index),
+		Version:    createTestDynakube(index).LatestVersion,
+		TenantUUID: createTestDynakube(index).TenantUUID,
+	}
+}
+
+func TestCreateTestDynakube(t *testing.T) {
+	// Check instantiation
+	dynakube0 := createTestDynakube(0)
+
+	assert.Equal(t, "asc0", dynakube0.TenantUUID)
+	assert.Equal(t, "0", dynakube0.LatestVersion)
+	assert.Equal(t, "dk0", dynakube0.Name)
+	assert.Equal(t, "sha256:0", dynakube0.ImageDigest)
+
+	dynakube1 := createTestDynakube(1)
+
+	assert.Equal(t, "asc1", dynakube1.TenantUUID)
+	assert.Equal(t, "123", dynakube1.LatestVersion)
+	assert.Equal(t, "dk1", dynakube1.Name)
+	assert.Equal(t, "sha256:123", dynakube1.ImageDigest)
+
+	dynakube2 := createTestDynakube(2)
+
+	assert.Equal(t, "asc2", dynakube2.TenantUUID)
+	assert.Equal(t, "246", dynakube2.LatestVersion)
+	assert.Equal(t, "dk2", dynakube2.Name)
+	assert.Equal(t, "sha256:246", dynakube2.ImageDigest)
+
+	// Check that they are not references of each other
+	dynakube0.Name = "new-name"
+	newDynakube0 := createTestDynakube(0)
+
+	assert.NotEqual(t, dynakube0.Name, newDynakube0.Name)
+	assert.Equal(t, "dk0", newDynakube0.Name)
+
+	newDynakube0 = createTestDynakube(0)
+	dynakube0.Name = "new-name"
+
+	assert.NotEqual(t, dynakube0.Name, newDynakube0.Name)
+	assert.Equal(t, "dk0", newDynakube0.Name)
+}
+
+func TestCreateTestVolume(t *testing.T) {
+	// Check instantiation
+	volume0 := createTestVolume(0)
+
+	assert.Equal(t, "vol-0", volume0.VolumeID)
+	assert.Equal(t, "pod0", volume0.PodName)
+	assert.Equal(t, "0", volume0.Version)
+	assert.Equal(t, "asc0", volume0.TenantUUID)
+
+	volume1 := createTestVolume(1)
+
+	assert.Equal(t, "vol-1", volume1.VolumeID)
+	assert.Equal(t, "pod1", volume1.PodName)
+	assert.Equal(t, "123", volume1.Version)
+	assert.Equal(t, "asc1", volume1.TenantUUID)
+
+	volume2 := createTestVolume(2)
+
+	assert.Equal(t, "vol-2", volume2.VolumeID)
+	assert.Equal(t, "pod2", volume2.PodName)
+	assert.Equal(t, "246", volume2.Version)
+	assert.Equal(t, "asc2", volume2.TenantUUID)
+
+	// Check that they are not references of each other
+	volume0.PodName = "new-name"
+	newVolume0 := createTestVolume(0)
+
+	assert.NotEqual(t, volume0.PodName, newVolume0.PodName)
+	assert.Equal(t, "pod0", newVolume0.PodName)
+
+	newVolume0 = createTestVolume(0)
+	volume0.PodName = "new-name"
+
+	assert.NotEqual(t, volume0.PodName, newVolume0.PodName)
+	assert.Equal(t, "pod0", newVolume0.PodName)
+}
 
 func TestCheckStorageCorrectness_FreshDB(t *testing.T) {
 	// db without tables
@@ -30,6 +123,8 @@ func TestCheckStorageCorrectness_EmptyDB(t *testing.T) {
 }
 
 func TestCheckStorageCorrectness_DoNothing(t *testing.T) {
+	testVolume1 := createTestVolume(1)
+	testDynakube1 := createTestDynakube(1)
 	db := FakeMemoryDB()
 	db.InsertVolume(&testVolume1)
 	client := fake.NewClient(
@@ -46,6 +141,14 @@ func TestCheckStorageCorrectness_DoNothing(t *testing.T) {
 }
 
 func TestCheckStorageCorrectness_PURGE(t *testing.T) {
+	testVolume1 := createTestVolume(1)
+	testVolume2 := createTestVolume(2)
+	testVolume3 := createTestVolume(3)
+
+	testDynakube1 := createTestDynakube(1)
+	testDynakube2 := createTestDynakube(2)
+	testDynakube3 := createTestDynakube(3)
+
 	db := FakeMemoryDB()
 	db.InsertVolume(&testVolume1)
 	db.InsertVolume(&testVolume2)

--- a/src/controllers/csi/metadata/fakes.go
+++ b/src/controllers/csi/metadata/fakes.go
@@ -4,44 +4,6 @@ import (
 	"database/sql"
 )
 
-var (
-	testDynakube1 = Dynakube{
-		TenantUUID:    "asc1",
-		LatestVersion: "123",
-		Name:          "dk1",
-		ImageDigest:   "sha256:123",
-	}
-	testDynakube2 = Dynakube{
-		TenantUUID:    "asc2",
-		LatestVersion: "223",
-		Name:          "dk2",
-	}
-	testDynakube3 = Dynakube{
-		TenantUUID:    "asc3",
-		LatestVersion: "323",
-		Name:          "dk3",
-	}
-
-	testVolume1 = Volume{
-		VolumeID:   "vol-1",
-		PodName:    "pod1",
-		Version:    testDynakube1.LatestVersion,
-		TenantUUID: testDynakube1.TenantUUID,
-	}
-	testVolume2 = Volume{
-		VolumeID:   "vol-2",
-		PodName:    "pod2",
-		Version:    testDynakube2.LatestVersion,
-		TenantUUID: testDynakube2.TenantUUID,
-	}
-	testVolume3 = Volume{
-		VolumeID:   "vol-3",
-		PodName:    "pod3",
-		Version:    testDynakube3.LatestVersion,
-		TenantUUID: testDynakube3.TenantUUID,
-	}
-)
-
 func emptyMemoryDB() *SqliteAccess {
 	db := SqliteAccess{}
 	_ = db.connect(sqliteDriverName, ":memory:")

--- a/src/controllers/csi/metadata/sqlite_test.go
+++ b/src/controllers/csi/metadata/sqlite_test.go
@@ -64,6 +64,8 @@ func TestCreateTables(t *testing.T) {
 }
 
 func TestInsertDynakube(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
+
 	db := FakeMemoryDB()
 
 	err := db.InsertDynakube(&testDynakube1)
@@ -81,6 +83,7 @@ func TestInsertDynakube(t *testing.T) {
 }
 
 func TestGetDynakube_Empty(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
 	db := FakeMemoryDB()
 
 	gt, err := db.GetDynakube(testDynakube1.TenantUUID)
@@ -89,6 +92,7 @@ func TestGetDynakube_Empty(t *testing.T) {
 }
 
 func TestGetDynakube(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
 	db := FakeMemoryDB()
 	err := db.InsertDynakube(&testDynakube1)
 	require.NoError(t, err)
@@ -99,6 +103,7 @@ func TestGetDynakube(t *testing.T) {
 }
 
 func TestUpdateDynakube(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
 	db := FakeMemoryDB()
 	err := db.InsertDynakube(&testDynakube1)
 	require.NoError(t, err)
@@ -120,6 +125,9 @@ func TestUpdateDynakube(t *testing.T) {
 }
 
 func TestGetTenantsToDynakubes(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
+	testDynakube2 := createTestDynakube(2)
+
 	db := FakeMemoryDB()
 	err := db.InsertDynakube(&testDynakube1)
 	require.NoError(t, err)
@@ -134,6 +142,9 @@ func TestGetTenantsToDynakubes(t *testing.T) {
 }
 
 func TestGetAllDynakubes(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
+	testDynakube2 := createTestDynakube(2)
+
 	db := FakeMemoryDB()
 	err := db.InsertDynakube(&testDynakube1)
 	require.NoError(t, err)
@@ -146,6 +157,9 @@ func TestGetAllDynakubes(t *testing.T) {
 }
 
 func TestGetAllVolumes(t *testing.T) {
+	testVolume1 := createTestVolume(1)
+	testVolume2 := createTestVolume(2)
+
 	db := FakeMemoryDB()
 	err := db.InsertVolume(&testVolume1)
 	require.NoError(t, err)
@@ -158,6 +172,9 @@ func TestGetAllVolumes(t *testing.T) {
 }
 
 func TestGetAllOsAgentVolumes(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
+	testDynakube2 := createTestDynakube(2)
+
 	now := time.Now()
 	osVolume1 := OsAgentVolume{
 		VolumeID:     "vol-1",
@@ -183,6 +200,9 @@ func TestGetAllOsAgentVolumes(t *testing.T) {
 }
 
 func TestDeleteDynakube(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
+	testDynakube2 := createTestDynakube(2)
+
 	db := FakeMemoryDB()
 	err := db.InsertDynakube(&testDynakube1)
 	require.NoError(t, err)
@@ -198,6 +218,7 @@ func TestDeleteDynakube(t *testing.T) {
 }
 
 func TestGetVolume_Empty(t *testing.T) {
+	testVolume1 := createTestVolume(1)
 	db := FakeMemoryDB()
 
 	vo, err := db.GetVolume(testVolume1.PodName)
@@ -206,6 +227,7 @@ func TestGetVolume_Empty(t *testing.T) {
 }
 
 func TestInsertVolume(t *testing.T) {
+	testVolume1 := createTestVolume(1)
 	db := FakeMemoryDB()
 
 	err := db.InsertVolume(&testVolume1)
@@ -235,6 +257,7 @@ func TestInsertVolume(t *testing.T) {
 }
 
 func TestInsertOsAgentVolume(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
 	db := FakeMemoryDB()
 
 	now := time.Now()
@@ -261,6 +284,7 @@ func TestInsertOsAgentVolume(t *testing.T) {
 }
 
 func TestGetOsAgentVolumeViaVolumeID(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
 	db := FakeMemoryDB()
 
 	now := time.Now()
@@ -283,6 +307,7 @@ func TestGetOsAgentVolumeViaVolumeID(t *testing.T) {
 }
 
 func TestGetOsAgentVolumeViaTennatUUID(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
 	db := FakeMemoryDB()
 
 	now := time.Now()
@@ -304,6 +329,7 @@ func TestGetOsAgentVolumeViaTennatUUID(t *testing.T) {
 }
 
 func TestUpdateOsAgentVolume(t *testing.T) {
+	testDynakube1 := createTestDynakube(1)
 	db := FakeMemoryDB()
 
 	now := time.Now()
@@ -330,6 +356,7 @@ func TestUpdateOsAgentVolume(t *testing.T) {
 }
 
 func TestGetVolume(t *testing.T) {
+	testVolume1 := createTestVolume(1)
 	db := FakeMemoryDB()
 	err := db.InsertVolume(&testVolume1)
 	require.NoError(t, err)
@@ -340,6 +367,7 @@ func TestGetVolume(t *testing.T) {
 }
 
 func TestGetUsedVersions(t *testing.T) {
+	testVolume1 := createTestVolume(1)
 	db := FakeMemoryDB()
 	err := db.InsertVolume(&testVolume1)
 	testVolume11 := testVolume1
@@ -357,6 +385,9 @@ func TestGetUsedVersions(t *testing.T) {
 }
 
 func TestGetPodNames(t *testing.T) {
+	testVolume1 := createTestVolume(1)
+	testVolume2 := createTestVolume(2)
+
 	db := FakeMemoryDB()
 	err := db.InsertVolume(&testVolume1)
 	require.NoError(t, err)
@@ -371,6 +402,9 @@ func TestGetPodNames(t *testing.T) {
 }
 
 func TestDeleteVolume(t *testing.T) {
+	testVolume1 := createTestVolume(1)
+	testVolume2 := createTestVolume(2)
+
 	db := FakeMemoryDB()
 	err := db.InsertVolume(&testVolume1)
 	require.NoError(t, err)

--- a/src/controllers/csi/provisioner/controller_test.go
+++ b/src/controllers/csi/provisioner/controller_test.go
@@ -244,6 +244,9 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		assert.EqualError(t, err, "failed to create directory "+filepath.Join(tenantUUID)+": "+errorMsg)
 		assert.NotNil(t, result)
 		assert.Equal(t, reconcile.Result{}, result)
+
+		// Logging newline so go test can parse the output correctly
+		log.Info("")
 	})
 	t.Run(`error getting latest agent version`, func(t *testing.T) {
 		memFs := afero.NewMemMapFs()

--- a/src/webhook/mutation/pod_mutator/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/pod_mutator_test.go
@@ -72,6 +72,9 @@ func TestHandle(t *testing.T) {
 		assert.Nil(t, response.Patches)
 		sadMutator.(*dtwebhook.PodMutatorMock).AssertNumberOfCalls(t, "Enabled", 1)
 		sadMutator.(*dtwebhook.PodMutatorMock).AssertNumberOfCalls(t, "Mutate", 1)
+
+		// Logging newline so go test can parse the output correctly
+		log.Info("")
 	})
 }
 


### PR DESCRIPTION
# Description

Refactors test objects to be created by functions instead of being stored in global variables.
This change breaks up dependencies between tests.

## How can this be tested?

Since these changes do not affect production code, if the unit tests run through and everyone is happy with the changes, it just works.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

