### PR TITLE
Reworks dockerConfig auth setup

### DIFF
--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -100,9 +100,12 @@ func getUrlProperties(version string) *url.Properties {
 }
 
 func setupImageInstaller(ctx context.Context, fs afero.Fs, pathResolver metadata.PathResolver, apiReader client.Reader, certPath, digest string, dynakube *dynatracev1beta1.DynaKube) (installer.Installer, error) {
-	dockerConfig, err := dockerconfig.NewDockerConfig(ctx, apiReader, *dynakube)
-	if err != nil {
-		return nil, err
+	dockerConfig := dockerconfig.NewDockerConfig(apiReader, *dynakube)
+	if dynakube.Spec.CustomPullSecret != "" {
+		err := dockerConfig.SetupAuths(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if dynakube.Spec.TrustedCAs != "" {
 		err := dockerConfig.SaveCustomCAs(ctx, afero.Afero{Fs: fs}, certPath)

--- a/src/controllers/dynakube/version/version.go
+++ b/src/controllers/dynakube/version/version.go
@@ -58,7 +58,8 @@ func ReconcileVersions(
 	}
 
 	caCertPath := path.Join(TmpCAPath, TmpCAName)
-	dockerConfig, err := dockerconfig.NewDockerConfig(ctx, apiReader, *dkState.Instance)
+	dockerConfig := dockerconfig.NewDockerConfig(apiReader, *dkState.Instance)
+	err := dockerConfig.SetupAuths(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/src/dockerconfig/docker_config.go
+++ b/src/dockerconfig/docker_config.go
@@ -3,10 +3,10 @@ package dockerconfig
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
+	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,47 +25,30 @@ type DockerAuth struct {
 	Password string `json:"password"`
 }
 
-func NewDockerConfig(ctx context.Context, apiReader client.Reader, dynakube dynatracev1beta1.DynaKube) (*DockerConfig, error) {
+func NewDockerConfig(apiReader client.Reader, dynakube dynatracev1beta1.DynaKube) *DockerConfig {
+	dockerConfig := DockerConfig{
+		ApiReader:     apiReader,
+		Auths:         make(map[string]DockerAuth),
+		Dynakube:      &dynakube,
+		SkipCertCheck: dynakube.Spec.SkipCertCheck,
+	}
+	return &dockerConfig
+}
+
+func (config *DockerConfig) SetupAuths(ctx context.Context) error {
 	var pullSecret corev1.Secret
-	if err := apiReader.Get(ctx, client.ObjectKey{Name: dynakube.PullSecret(), Namespace: dynakube.Namespace}, &pullSecret); err != nil {
-		log.Info("failed to load pull secret", "dynakube", dynakube.Name)
-		return nil, err
+	err := config.ApiReader.Get(ctx, client.ObjectKey{Name: config.Dynakube.PullSecret(), Namespace: config.Dynakube.Namespace}, &pullSecret)
+	if err != nil {
+		log.Info("failed to load pull secret", "dynakube", config.Dynakube.Name)
+		return errors.WithStack(err)
 	}
 	dockerAuths, err := parseDockerAuthsFromSecret(&pullSecret)
 	if err != nil {
-		log.Info("failed to parse pull secret content", "dynakube", dynakube.Name)
-		return nil, err
+		log.Info("failed to parse pull secret content", "dynakube", config.Dynakube.Name)
+		return err
 	}
-
-	dockerConfig := DockerConfig{
-		ApiReader:     apiReader,
-		Dynakube:      &dynakube,
-		Auths:         dockerAuths,
-		SkipCertCheck: dynakube.Spec.SkipCertCheck,
-	}
-	return &dockerConfig, nil
-
-}
-
-func parseDockerAuthsFromSecret(secret *corev1.Secret) (map[string]DockerAuth, error) {
-	if secret == nil {
-		return nil, fmt.Errorf("given secret is nil")
-	}
-
-	config, hasConfig := secret.Data[".dockerconfigjson"]
-	if !hasConfig {
-		return nil, fmt.Errorf("could not find any docker config in image pull secret")
-	}
-
-	var dockerConf struct {
-		Auths map[string]DockerAuth `json:"auths"`
-	}
-	err := json.Unmarshal(config, &dockerConf)
-	if err != nil {
-		return nil, err
-	}
-
-	return dockerConf.Auths, nil
+	config.Auths = dockerAuths
+	return nil
 }
 
 func (config *DockerConfig) SaveCustomCAs(
@@ -76,15 +59,36 @@ func (config *DockerConfig) SaveCustomCAs(
 	certs := &corev1.ConfigMap{}
 	if err := config.ApiReader.Get(ctx, client.ObjectKey{Namespace: config.Dynakube.Namespace, Name: config.Dynakube.Spec.TrustedCAs}, certs); err != nil {
 		log.Info("failed to load trusted CAs")
-		return err
+		return errors.WithStack(err)
 	}
 	if certs.Data[dtclient.CustomCertificatesConfigMapKey] == "" {
-		return fmt.Errorf("failed to extract certificate configmap field: missing field certs")
+		return errors.New("failed to extract certificate configmap field: missing field certs")
 	}
 	if err := fs.WriteFile(path, []byte(certs.Data[dtclient.CustomCertificatesConfigMapKey]), 0666); err != nil {
 		log.Info("failed to save custom certificates")
-		return err
+		return errors.WithStack(err)
 	}
 	config.TrustedCertsPath = path
 	return nil
+}
+
+func parseDockerAuthsFromSecret(secret *corev1.Secret) (map[string]DockerAuth, error) {
+	if secret == nil {
+		return nil, errors.New("given secret is nil")
+	}
+
+	config, hasConfig := secret.Data[".dockerconfigjson"]
+	if !hasConfig {
+		return nil, errors.New("could not find any docker config in image pull secret")
+	}
+
+	var dockerConf struct {
+		Auths map[string]DockerAuth `json:"auths"`
+	}
+	err := json.Unmarshal(config, &dockerConf)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return dockerConf.Auths, nil
 }

--- a/src/dockerconfig/docker_config.go
+++ b/src/dockerconfig/docker_config.go
@@ -16,7 +16,6 @@ type DockerConfig struct {
 	ApiReader        client.Reader
 	Dynakube         *dynatracev1beta1.DynaKube
 	Auths            map[string]DockerAuth
-	SkipCertCheck    bool
 	TrustedCertsPath string
 }
 
@@ -27,10 +26,9 @@ type DockerAuth struct {
 
 func NewDockerConfig(apiReader client.Reader, dynakube dynatracev1beta1.DynaKube) *DockerConfig {
 	dockerConfig := DockerConfig{
-		ApiReader:     apiReader,
-		Auths:         make(map[string]DockerAuth),
-		Dynakube:      &dynakube,
-		SkipCertCheck: dynakube.Spec.SkipCertCheck,
+		ApiReader: apiReader,
+		Auths:     make(map[string]DockerAuth),
+		Dynakube:  &dynakube,
 	}
 	return &dockerConfig
 }
@@ -72,9 +70,16 @@ func (config *DockerConfig) SaveCustomCAs(
 	return nil
 }
 
+func (config DockerConfig) SkipCertCheck() bool {
+	if config.Dynakube == nil {
+		return false
+	}
+	return config.Dynakube.Spec.SkipCertCheck
+}
+
 func parseDockerAuthsFromSecret(secret *corev1.Secret) (map[string]DockerAuth, error) {
 	if secret == nil {
-		return nil, errors.New("given secret is nil")
+		return nil, errors.New("pull secret is nil, parsing not possible")
 	}
 
 	config, hasConfig := secret.Data[".dockerconfigjson"]

--- a/src/dockerconfig/docker_config_test.go
+++ b/src/dockerconfig/docker_config_test.go
@@ -31,7 +31,7 @@ func TestNewDockerConfig(t *testing.T) {
 		assert.NotNil(t, dockerConfig.Auths)
 		assert.Empty(t, dockerConfig.Auths)
 		assert.Equal(t, apiReader, dockerConfig.ApiReader)
-		assert.False(t, dockerConfig.SkipCertCheck)
+		assert.False(t, dockerConfig.SkipCertCheck())
 	})
 	t.Run("empty skipCertCheck", func(t *testing.T) {
 		dynakube := dynatracev1beta1.DynaKube{
@@ -45,7 +45,7 @@ func TestNewDockerConfig(t *testing.T) {
 		assert.NotNil(t, dockerConfig.Auths)
 		assert.Empty(t, dockerConfig.Auths)
 		assert.Equal(t, apiReader, dockerConfig.ApiReader)
-		assert.True(t, dockerConfig.SkipCertCheck)
+		assert.True(t, dockerConfig.SkipCertCheck())
 	})
 }
 

--- a/src/dockerconfig/system_context.go
+++ b/src/dockerconfig/system_context.go
@@ -15,7 +15,7 @@ func MakeSystemContext(dockerReference reference.Named, dockerConfig *DockerConf
 
 	var systemContext types.SystemContext
 
-	if dockerConfig.SkipCertCheck {
+	if dockerConfig.SkipCertCheck() {
 		systemContext.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
 	}
 	if dockerConfig.TrustedCertsPath != "" {


### PR DESCRIPTION
# Description
The `NewDockerConfig` constructor will not setup the `Auths`, that is done in `SetupAuths` method.
This is a small optimisation so in case something needs the dockerConfig but requires no authentication, we will no longer force to use the default pull secret. (Also its nicer for testing)

## How can this be tested?
When you use `codeModulesImage` that points to a registry that doesn't need `customPullSecret`, it should work


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

