### PR TITLE
Changes codemodules container.conf file's filemode

### DIFF
--- a/src/standalone/files.go
+++ b/src/standalone/files.go
@@ -8,6 +8,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	onlyReadAllFileMode = 0444
+)
+
 var (
 	baseConfContentFormatString = `[container]
 containerName %s
@@ -112,12 +116,12 @@ func (runner *Runner) createCurlOptionsFile() error {
 }
 
 func (runner *Runner) createConfFile(path string, content string) error {
-	err := runner.fs.MkdirAll(filepath.Dir(path), 0770)
+	err := runner.fs.MkdirAll(filepath.Dir(path), onlyReadAllFileMode)
 	if err != nil {
 		return err
 	}
 
-	file, err := runner.fs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0770)
+	file, err := runner.fs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, onlyReadAllFileMode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Changes the filemode to `0444` so that no matter the user defined in the container or in the security context, everyone can read the `container.conf` created by the standalone init.

## How can this be tested?
Deploy something that injects codemodules.
In an injected sample app check the permissions:
```
$ ls -la /var/lib/dynatrace/oneagent/agent/config/container.conf 
-r--r--r--    1 1006     1006           274 Jun 28 11:12 /var/lib/dynatrace/oneagent/agent/config/container.conf
```

## Checklist
~- [ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

