### PR TITLE
Moves the customPullSecret to the root of the values files

### DIFF
--- a/config/helm/chart/default/questions.yml
+++ b/config/helm/chart/default/questions.yml
@@ -18,7 +18,7 @@ questions:
     type: string
     group: "Global Configuration"
 
-  - variable: operator.customPullSecret
+  - variable: customPullSecret
     label: "Set a custom pull secret for operator image"
     description: "Set a custom pull secret for the operator image"
     default: ""

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -215,6 +215,10 @@ spec:
         # A volume for the driver to write temporary files to
       - name: tmp-dir
         emptyDir: {}
+      {{- if .Values.customPullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.customPullSecret }}
+      {{- end }}
       {{- if .Values.csidriver.nodeSelector }}
       nodeSelector: {{- toYaml .Values.csidriver.nodeSelector | nindent 8 }}
       {{- end }}

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -116,9 +116,9 @@ spec:
         - emptyDir: { }
           name: tmp-cert-dir
       serviceAccountName: {{ .Release.Name }}
-      {{- if .Values.operator.customPullSecret }}
+      {{- if .Values.customPullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.operator.customPullSecret }}
+        - name: {{ .Values.customPullSecret }}
       {{- end }}
       {{- if .Values.operator.nodeSelector }}
       nodeSelector: {{- toYaml .Values.operator.nodeSelector | nindent 8 }}

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -121,9 +121,9 @@ spec:
       {{- if (.Values.webhook).hostNetwork }}
       hostNetwork: true
       {{- end }}
-      {{- if .Values.operator.customPullSecret }}
+      {{- if .Values.customPullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.operator.customPullSecret }}
+        - name: {{ .Values.customPullSecret }}
       {{- end }}
       {{- if .Values.webhook.nodeSelector }}
       nodeSelector: {{- toYaml .Values.webhook.nodeSelector | nindent 8 }}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -231,3 +231,11 @@ tests:
               - emptyDir: { }
                 name: tmp-dir
 
+  - it: should have imagePullSecrets defined in spec
+    set:
+      customPullSecret: pull-secret
+      csidriver.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: pull-secret

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -273,7 +273,7 @@ tests:
   - it: should have imagePullSecrets defined in spec
     set:
       platform: openshift
-      operator.customPullSecret: pull-secret
+      customPullSecret: pull-secret
     asserts:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -368,3 +368,11 @@ tests:
                           operator: In
                           values:
                             - linux
+
+  - it: should have imagePullSecrets defined in spec
+    set:
+      customPullSecret: pull-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: pull-secret

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -16,10 +16,10 @@
 platform: "kubernetes"
 
 image: ""
+customPullSecret: ""
 installCRD: false
 
 operator:
-  customPullSecret: ""
   nodeSelector: {}
   tolerations: []
   apparmor: false

--- a/config/helm/schema.yaml
+++ b/config/helm/schema.yaml
@@ -195,12 +195,12 @@ properties:
     type: string
     x-google-marketplace:
       type: DEPLOYER_IMAGE
-
-  operator.customPullSecret:
+  customPullSecret:
     type: string
     title: Custom pull secret
     description: If the Operator image is in a private registry, the name of the appropriate pull secret can be set here
     default: ""
+
   operator.apparmor:
     type: boolean
     title: Enables AppArmor for Operator


### PR DESCRIPTION
# Description

`customPullSecret` moved to the root and is used for every deployment that the helmchart deploys

closes https://github.com/Dynatrace/helm-charts/pull/190

## How can this be tested?
Set `values.customPullSecret`, then see if the deployment of the operator and webhook + the daemonset of the csi-driver uses it.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

