### PR TITLE
Adds namespace to PodDistruptionBudget

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: dynatrace-webhook
+  namespace: dynatrace
 spec:
   minAvailable: 1
   selector:

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: dynatrace-webhook
+  namespace: dynatrace
 spec:
   minAvailable: 1
   selector:

--- a/config/helm/chart/default/templates/Common/webhook/poddisruptionbudget-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/poddisruptionbudget-webhook.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: dynatrace-webhook
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: 1
   selector:


### PR DESCRIPTION
# Description
PodDistruptionBudget need to be namespaced.

closes #895

## How can this be tested?
Deployed PDB is in the dynatrace namespace (or the one defined in helm)


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

