### PR TITLE
Allow to use empty proxy password (backport to release-0.7)

### DIFF
--- a/src/webhook/validation/proxy_url.go
+++ b/src/webhook/validation/proxy_url.go
@@ -55,7 +55,7 @@ func validateProxyUrl(proxyUrl string, parseErrorMessage string, evalErrorMessag
 		return parseErrorMessage
 	} else {
 		password, _ := parsedUrl.User.Password()
-		if !isStringValidForAG(password) {
+		if password != "" && !isStringValidForAG(password) {
 			return evalErrorMessage
 		}
 	}

--- a/src/webhook/validation/proxy_url.go
+++ b/src/webhook/validation/proxy_url.go
@@ -55,7 +55,7 @@ func validateProxyUrl(proxyUrl string, parseErrorMessage string, evalErrorMessag
 		return parseErrorMessage
 	} else {
 		password, _ := parsedUrl.User.Password()
-		if password != "" && !isStringValidForAG(password) {
+		if !isStringValidForAG(password) {
 			return evalErrorMessage
 		}
 	}
@@ -74,6 +74,6 @@ func isStringValidForAG(str string) bool {
 	// ','                 exceptions due to Gateway reader of config files
 	// '&' '=' '+' '%' '\' exceptions due to entrypoint.sh:saveProxyConfiguration
 
-	regex := regexp.MustCompile(`^[!"#$()*\-./0-9:;<>?@A-Z\[\]^_a-z{|}~]+$`)
+	regex := regexp.MustCompile(`^[!"#$()*\-./0-9:;<>?@A-Z\[\]^_a-z{|}~]*$`)
 	return regex.MatchString(str)
 }

--- a/src/webhook/validation/proxy_url_test.go
+++ b/src/webhook/validation/proxy_url_test.go
@@ -17,6 +17,9 @@ const (
 
 	// validEncodedProxyUrl contains no forbidden characters "http://test:password!"#$()*-./:;<>?@[]^_{|}~@proxy-service.dynatrace:3128"
 	validEncodedProxyUrl = "http://test:password!%22%23%24()*-.%2F%3A%3B%3C%3E%3F%40%5B%5D%5E_%7B%7C%7D~@proxy-service.dynatrace:3128"
+
+	// validEncodedProxyUrlNoPassword contains empty password
+	validEncodedProxyUrlNoPassword = "http://test@proxy-service.dynatrace:3128"
 )
 
 func TestInvalidActiveGateProxy(t *testing.T) {
@@ -28,6 +31,20 @@ func TestInvalidActiveGateProxy(t *testing.T) {
 					APIURL: testApiUrl,
 					Proxy: &dynatracev1beta1.DynaKubeProxy{
 						Value:     validEncodedProxyUrl,
+						ValueFrom: "",
+					},
+				},
+			})
+	})
+
+	t.Run(`valid proxy url, no password`, func(t *testing.T) {
+		assertAllowedResponseWithoutWarnings(t,
+			&dynatracev1beta1.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynatracev1beta1.DynaKubeSpec{
+					APIURL: testApiUrl,
+					Proxy: &dynatracev1beta1.DynaKubeProxy{
+						Value:     validEncodedProxyUrlNoPassword,
 						ValueFrom: "",
 					},
 				},


### PR DESCRIPTION
Clients use proxies with empty proxy password. A CR is accepted by the proxy_url validator if proxy password is empty.

How can this be tested?
Use empty password in the Proxy Url (proxy.value, proxy secret) and try to apply your CR - should be accepted.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

