### PR TITLE
Add feature flag to opt-into injection per pod 

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -86,6 +86,7 @@ const (
 
 	AnnotationFeatureIgnoreUnknownState = AnnotationFeaturePrefix + "ignore-unknown-state"
 	AnnotationFeatureIgnoredNamespaces  = AnnotationFeaturePrefix + "ignored-namespaces"
+	AnnotationFeatureAutomaticInjection = AnnotationFeaturePrefix + "automatic-injection"
 )
 
 var (
@@ -173,6 +174,13 @@ func (dk *DynaKube) FeatureAutomaticKubernetesApiMonitoringClusterName() string 
 // FeatureDisableMetadataEnrichment is a feature flag to disable metadata enrichment,
 func (dk *DynaKube) FeatureDisableMetadataEnrichment() bool {
 	return dk.getDisableFlagWithDeprecatedAnnotation(AnnotationFeatureMetadataEnrichment, AnnotationFeatureDisableMetadataEnrichment)
+}
+
+// FeatureAutomaticInjection controls OneAgent is injected to pods in selected namespaces automatically ("automatic-injection=true" or flag not set)
+// or if pods need to be opted-in one by one ("automatic-injection=false")
+func (dk *DynaKube) FeatureEnableAutomaticInjection() bool {
+	autoInjectionFlag := dk.getFeatureFlagRaw(AnnotationFeatureAutomaticInjection)
+	return autoInjectionFlag == "true" || len(autoInjectionFlag) == 0
 }
 
 // FeatureUseActiveGateImageForStatsd is a feature flag that makes the operator use ActiveGate image when initializing Extension Controller and Statsd containers

--- a/src/mapper/namespaces.go
+++ b/src/mapper/namespaces.go
@@ -32,12 +32,12 @@ func (nm NamespaceMapper) MapFromNamespace() (bool, error) {
 }
 
 func (nm NamespaceMapper) updateNamespace() (bool, error) {
-	dkList := &dynatracev1beta1.DynaKubeList{}
-	err := nm.client.List(nm.ctx, dkList)
+	deployedDynakubes := &dynatracev1beta1.DynaKubeList{}
+	err := nm.client.List(nm.ctx, deployedDynakubes)
 
 	if err != nil {
 		return false, errors.Cause(err)
 	}
 
-	return updateNamespace(nm.targetNs, dkList)
+	return updateNamespace(nm.targetNs, deployedDynakubes)
 }

--- a/src/mapper/namespaces_test.go
+++ b/src/mapper/namespaces_test.go
@@ -46,7 +46,7 @@ func TestMapFromNamespace(t *testing.T) {
 		assert.Equal(t, 2, len(nm.targetNs.Labels))
 	})
 
-	t.Run("Error, 2 dynakube point to same namespace", func(t *testing.T) {
+	t.Run("Error, 2 dynakubes point to same namespace", func(t *testing.T) {
 		dk2 := createTestDynakubeWithAppInject("appMonitoring-2", labels, nil)
 		clt := fake.NewClient(dk, dk2)
 		nm := NewNamespaceMapper(context.TODO(), clt, clt, "dynatrace", namespace)

--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator.go
@@ -27,8 +27,10 @@ func NewDataIngestPodMutator(webhookNamespace string, client client.Client, apiR
 }
 
 func (mutator *DataIngestPodMutator) Enabled(request *dtwebhook.BaseRequest) bool {
-	enabledOnPod := kubeobjects.GetFieldBool(request.Pod.Annotations, dtwebhook.AnnotationDataIngestInject, true)
+	enabledOnPod := kubeobjects.GetFieldBool(request.Pod.Annotations, dtwebhook.AnnotationDataIngestInject,
+		request.DynaKube.FeatureEnableAutomaticInjection())
 	enabledOnDynakube := !request.DynaKube.FeatureDisableMetadataEnrichment()
+
 	return enabledOnPod && enabledOnDynakube
 }
 

--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator_test.go
@@ -48,6 +48,24 @@ func TestEnabled(t *testing.T) {
 
 		require.True(t, enabled)
 	})
+	t.Run("off by feature flag", func(t *testing.T) {
+		mutator := createTestPodMutator(nil)
+		request := createTestMutationRequest(nil, nil)
+		request.DynaKube.Annotations = map[string]string{dynatracev1beta1.AnnotationFeatureAutomaticInjection: "false"}
+
+		enabled := mutator.Enabled(request.BaseRequest)
+
+		require.False(t, enabled)
+	})
+	t.Run("on with feature flag", func(t *testing.T) {
+		mutator := createTestPodMutator(nil)
+		request := createTestMutationRequest(nil, nil)
+		request.DynaKube.Annotations = map[string]string{dynatracev1beta1.AnnotationFeatureAutomaticInjection: "true"}
+
+		enabled := mutator.Enabled(request.BaseRequest)
+
+		require.True(t, enabled)
+	})
 }
 
 func TestInjected(t *testing.T) {

--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -56,6 +56,6 @@ func getBasePodName(pod *corev1.Pod) string {
 	return basePodName
 }
 
-func attachInitContainerToPod(pod *corev1.Pod, initContainer *corev1.Container) {
+func addInitContainerToPod(pod *corev1.Pod, initContainer *corev1.Container) {
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *initContainer)
 }

--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -56,6 +56,6 @@ func getBasePodName(pod *corev1.Pod) string {
 	return basePodName
 }
 
-func addToInitContainers(pod *corev1.Pod, initContainer *corev1.Container) {
+func attachInitContainerToPod(pod *corev1.Pod, initContainer *corev1.Container) {
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *initContainer)
 }

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
@@ -30,7 +30,7 @@ func NewOneAgentPodMutator(image, clusterID, webhookNamespace string, client cli
 }
 
 func (mutator *OneAgentPodMutator) Enabled(request *dtwebhook.BaseRequest) bool {
-	return kubeobjects.GetFieldBool(request.Pod.Annotations, dtwebhook.AnnotationOneAgentInject, true)
+	return kubeobjects.GetFieldBool(request.Pod.Annotations, dtwebhook.AnnotationOneAgentInject, request.DynaKube.FeatureEnableAutomaticInjection())
 }
 
 func (mutator *OneAgentPodMutator) Injected(request *dtwebhook.BaseRequest) bool {

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
@@ -40,6 +40,24 @@ func TestEnabled(t *testing.T) {
 
 		require.True(t, enabled)
 	})
+	t.Run("off by feature flag", func(t *testing.T) {
+		mutator := createTestPodMutator(nil)
+		request := createTestMutationRequest(nil, nil)
+		request.DynaKube.Annotations = map[string]string{dynatracev1beta1.AnnotationFeatureAutomaticInjection: "false"}
+
+		enabled := mutator.Enabled(request.BaseRequest)
+
+		require.False(t, enabled)
+	})
+	t.Run("on with feature flag", func(t *testing.T) {
+		mutator := createTestPodMutator(nil)
+		request := createTestMutationRequest(nil, nil)
+		request.DynaKube.Annotations = map[string]string{dynatracev1beta1.AnnotationFeatureAutomaticInjection: "true"}
+
+		enabled := mutator.Enabled(request.BaseRequest)
+
+		require.True(t, enabled)
+	})
 }
 
 func TestInjected(t *testing.T) {

--- a/src/webhook/mutation/pod_mutator/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator/pod_mutator.go
@@ -111,7 +111,8 @@ func (webhook *podMutatorWebhook) handlePodMutation(mutationRequest *dtwebhook.M
 		log.Info("no mutation is enabled")
 		return nil
 	}
-	attachInitContainerToPod(mutationRequest.Pod, mutationRequest.InstallContainer)
+
+	addInitContainerToPod(mutationRequest.Pod, mutationRequest.InstallContainer)
 	webhook.recorder.sendPodInjectEvent()
 	setDynatraceInjectedAnnotation(mutationRequest)
 	return nil

--- a/src/webhook/mutation/pod_mutator/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator/pod_mutator.go
@@ -111,7 +111,7 @@ func (webhook *podMutatorWebhook) handlePodMutation(mutationRequest *dtwebhook.M
 		log.Info("no mutation is enabled")
 		return nil
 	}
-	addToInitContainers(mutationRequest.Pod, mutationRequest.InstallContainer)
+	attachInitContainerToPod(mutationRequest.Pod, mutationRequest.InstallContainer)
 	webhook.recorder.sendPodInjectEvent()
 	setDynatraceInjectedAnnotation(mutationRequest)
 	return nil

--- a/src/webhook/mutator.go
+++ b/src/webhook/mutator.go
@@ -20,7 +20,7 @@ type PodMutator interface {
 	Mutate(request *MutationRequest) error
 
 	// Reinvocation mutates the pod of the given ReinvocationRequest.
-	// It only mutates the parts of the pod that hasn't been mutated yet. (example: another webhook mutated the pod after our webhook was executed)
+	// It only mutates the parts of the pod that haven't been mutated yet. (example: another webhook mutated the pod after our webhook was executed)
 	Reinvoke(request *ReinvocationRequest) bool
 }
 


### PR DESCRIPTION
# Description
Added feature flag `feature.dynatrace.com/automatic-injection` to disable automatic injection for a dynakube. If set to `false`, pods nominated for injection need to be manually annotated with `oneagent.dynatrace.com/inject=true`. Default value for the feature flag is `true`.

## How can this be tested?
- Set the annotation `feature.dynatrace.com/automatic-injection: "false"` on a dynakube
- Create a pod or restart one in a namespace that is associated with the used dynakube
- Check that there is no injection happening on the pod.
- Add the annotation `oneagent.dynatrace.com/inject: "true"` to the pod spec and make sure the pod restarts
- Check that there is injection happening on the pod.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

