### PR TITLE
Remove ZERO WIDTH SPACE characters from the pre-commit script

### DIFF
--- a/.github/pre-commit
+++ b/.github/pre-commit
@@ -44,14 +44,14 @@ if [[ $res -ne 0 ]]; then
     echo "Linting failed"
     exit 2
 fi
-​
+
 # Unit tests
-​
+
 #exec < /dev/tty
 #read -p "Run unit tests[y/n]? " -n 1 -r
 #exec <&-
 REPLY=y
-​
+
 if [[ $REPLY =~ ^[Yy]$ ]]; then
     echo "Run unit tests..."
     go test ./...


### PR DESCRIPTION
## Description

ZERO WIDTH SPACE UTF-8 characters are reported as errors by bash so they are removed. No changes in the script logic.

## How can this be tested?
Linter and unit tests are performed before the actual commit.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

