### PR TITLE
Remove deprecation warning from gci and errors from pre-commit script.

### DIFF
--- a/.github/pre-commit
+++ b/.github/pre-commit
@@ -31,7 +31,7 @@ else
     for file in $STAGED_GO_FILES; do
         gofmt -w $file
         goimports -w $file
-        gci -w $file
+        gci write $file
         ## add any potential changes from our formatting to the
         ## commit
         git add $file

--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -10,7 +10,7 @@ go/vet:
 
 ## Lints the go code
 go/lint: go/fmt go/vet
-	gci -w .
+	gci write .
 	golangci-lint run --build-tags integration,containers_image_storage_stub --timeout 300s
 
 ## Runs go unit tests and writes the coverprofile to cover.out


### PR DESCRIPTION
# Description
Using flags for `gci` calls is deprecated. Subcommands should be used. Altered all calls to `gci` makefiles and pre-commit hook. No logic changed.

## Checklist
- [ n/a] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

