### PR TITLE
Fixes standalone init and webhook integration

### DIFF
--- a/src/cmd/csi/config.go
+++ b/src/cmd/csi/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log              = logger.NewDTLogger().WithName("csi-launcher")
+	_ = logger.NewDTLogger().WithName("csi-launcher")
 )

--- a/src/cmd/csi/config.go
+++ b/src/cmd/csi/config.go
@@ -1,0 +1,9 @@
+package csi
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
+)
+
+var (
+	log              = logger.NewDTLogger().WithName("csi-launcher")
+)

--- a/src/standalone/config.go
+++ b/src/standalone/config.go
@@ -34,6 +34,7 @@ const (
 	K8PodUIDEnv      = "K8S_PODUID"
 	K8BasePodNameEnv = "K8S_BASEPODNAME"
 	K8NamespaceEnv   = "K8S_NAMESPACE"
+	K8ClusterIDEnv   = "K8S_CLUSTER_ID"
 
 	WorkloadKindEnv = "DT_WORKLOAD_KIND"
 	WorkloadNameEnv = "DT_WORKLOAD_NAME"

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -28,6 +28,7 @@ type environment struct {
 	K8NodeName    string `json:"k8NodeName"`
 	K8PodName     string `json:"k8PodName"`
 	K8PodUID      string `json:"k8BasePodUID"`
+	K8ClusterID   string `json:"k8ClusterID"`
 	K8BasePodName string `json:"k8BasePodName"`
 	K8Namespace   string `json:"k8Namespace"`
 
@@ -74,6 +75,7 @@ func (env *environment) setRequiredFields() error {
 		dataIngestFieldSetters := []func() error{
 			env.addWorkloadKind,
 			env.addWorkloadName,
+			env.addK8ClusterID,
 		}
 		requiredFieldSetters = append(requiredFieldSetters, dataIngestFieldSetters...)
 	}
@@ -197,6 +199,15 @@ func (env *environment) addK8PodUID() error {
 		return err
 	}
 	env.K8PodUID = podUID
+	return nil
+}
+
+func (env *environment) addK8ClusterID() error {
+	clusterID, err := checkEnvVar(K8ClusterIDEnv)
+	if err != nil {
+		return err
+	}
+	env.K8ClusterID = clusterID
 	return nil
 }
 

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -57,27 +57,11 @@ func (env *environment) setRequiredFields() error {
 		env.addCanFail,
 	}
 	if env.OneAgentInjected {
-		oneAgentFieldSetters := []func() error{
-			env.addMode,
-			env.addInstallerTech,
-			env.addInstallPath,
-			env.addContainers,
-			env.addK8NodeName,
-			env.addK8PodName,
-			env.addK8PodUID,
-			env.addK8BasePodName,
-			env.addK8Namespace,
-		}
-		requiredFieldSetters = append(requiredFieldSetters, oneAgentFieldSetters...)
+		requiredFieldSetters = append(requiredFieldSetters, env.getOneAgentFieldSetters()...)
 	}
 
 	if env.DataIngestInjected {
-		dataIngestFieldSetters := []func() error{
-			env.addWorkloadKind,
-			env.addWorkloadName,
-			env.addK8ClusterID,
-		}
-		requiredFieldSetters = append(requiredFieldSetters, dataIngestFieldSetters...)
+		requiredFieldSetters = append(requiredFieldSetters, env.getDataIngestFieldSetters()...)
 	}
 
 	for _, setField := range requiredFieldSetters {
@@ -90,6 +74,28 @@ func (env *environment) setRequiredFields() error {
 		return errors.Errorf("%d envvars missing", len(errs))
 	}
 	return nil
+}
+
+func (env *environment) getOneAgentFieldSetters() []func() error {
+	return []func() error{
+		env.addMode,
+		env.addInstallerTech,
+		env.addInstallPath,
+		env.addContainers,
+		env.addK8NodeName,
+		env.addK8PodName,
+		env.addK8PodUID,
+		env.addK8BasePodName,
+		env.addK8Namespace,
+	}
+}
+
+func (env *environment) getDataIngestFieldSetters() []func() error {
+	return []func() error{
+		env.addWorkloadKind,
+		env.addWorkloadName,
+		env.addK8ClusterID,
+	}
 }
 
 func (env *environment) setOptionalFields() {

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -41,32 +41,44 @@ type environment struct {
 func newEnv() (*environment, error) {
 	log.Info("checking envvars")
 	env := &environment{}
+	env.setOptionalFields()
 	err := env.setRequiredFields()
 	if err != nil {
 		return nil, err
 	}
-	env.setOptionalFields()
 	log.Info("envvars checked", "env", env)
 	return env, nil
 }
 
 func (env *environment) setRequiredFields() error {
 	errs := []error{}
-	fieldSetters := []func() error{
-		env.addMode,
+	requiredFieldSetters := []func() error{
 		env.addCanFail,
-		env.addInstallerTech,
-		env.addInstallPath,
-		env.addContainers,
-		env.addK8NodeName,
-		env.addK8PodName,
-		env.addK8PodUID,
-		env.addK8BasePodName,
-		env.addK8Namespace,
-		env.addOneAgentInjected,
-		env.addDataIngestInjected,
 	}
-	for _, setField := range fieldSetters {
+	if env.OneAgentInjected {
+		oneAgentFieldSetters := []func() error{
+			env.addMode,
+			env.addInstallerTech,
+			env.addInstallPath,
+			env.addContainers,
+			env.addK8NodeName,
+			env.addK8PodName,
+			env.addK8PodUID,
+			env.addK8BasePodName,
+			env.addK8Namespace,
+		}
+		requiredFieldSetters = append(requiredFieldSetters, oneAgentFieldSetters...)
+	}
+
+	if env.DataIngestInjected {
+		dataIngestFieldSetters := []func() error{
+			env.addWorkloadKind,
+			env.addWorkloadName,
+		}
+		requiredFieldSetters = append(requiredFieldSetters, dataIngestFieldSetters...)
+	}
+
+	for _, setField := range requiredFieldSetters {
 		if err := setField(); err != nil {
 			errs = append(errs, err)
 			log.Info(err.Error())
@@ -79,10 +91,10 @@ func (env *environment) setRequiredFields() error {
 }
 
 func (env *environment) setOptionalFields() {
-	env.addWorkloadKind()
-	env.addWorkloadName()
 	env.addInstallerUrl()
 	env.addInstallerFlavor()
+	env.addOneAgentInjected()
+	env.addDataIngestInjected()
 }
 
 func (env *environment) addMode() error {
@@ -144,7 +156,7 @@ func (env *environment) addContainers() error {
 		nameEnv := fmt.Sprintf(ContainerNameEnvTemplate, i)
 		imageEnv := fmt.Sprintf(ContainerImageEnvTemplate, i)
 
-		containeName, err := checkEnvVar(nameEnv)
+		containerName, err := checkEnvVar(nameEnv)
 		if err != nil {
 			return err
 		}
@@ -153,7 +165,7 @@ func (env *environment) addContainers() error {
 			return err
 		}
 		containers = append(containers, containerInfo{
-			Name:  containeName,
+			Name:  containerName,
 			Image: imageName,
 		})
 	}
@@ -206,14 +218,22 @@ func (env *environment) addK8Namespace() error {
 	return nil
 }
 
-func (env *environment) addWorkloadKind() {
-	workloadKind, _ := checkEnvVar(WorkloadKindEnv)
+func (env *environment) addWorkloadKind() error {
+	workloadKind, err := checkEnvVar(WorkloadKindEnv)
+	if err != nil {
+		return err
+	}
 	env.WorkloadKind = workloadKind
+	return nil
 }
 
-func (env *environment) addWorkloadName() {
-	workloadName, _ := checkEnvVar(WorkloadNameEnv)
+func (env *environment) addWorkloadName() error {
+	workloadName, err := checkEnvVar(WorkloadNameEnv)
+	if err != nil {
+		return err
+	}
 	env.WorkloadName = workloadName
+	return nil
 }
 
 func (env *environment) addInstallerUrl() {
@@ -221,22 +241,14 @@ func (env *environment) addInstallerUrl() {
 	env.InstallerUrl = url
 }
 
-func (env *environment) addOneAgentInjected() error {
-	oneAgentInjected, err := checkEnvVar(OneAgentInjectedEnv)
-	if err != nil {
-		return err
-	}
+func (env *environment) addOneAgentInjected() {
+	oneAgentInjected, _ := checkEnvVar(OneAgentInjectedEnv)
 	env.OneAgentInjected = oneAgentInjected == "true"
-	return nil
 }
 
-func (env *environment) addDataIngestInjected() error {
-	dataIngestInjected, err := checkEnvVar(DataIngestInjectedEnv)
-	if err != nil {
-		return err
-	}
+func (env *environment) addDataIngestInjected() {
+	dataIngestInjected, _ := checkEnvVar(DataIngestInjectedEnv)
 	env.DataIngestInjected = dataIngestInjected == "true"
-	return nil
 }
 
 func checkEnvVar(envvar string) (string, error) {

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -42,11 +42,12 @@ type environment struct {
 func newEnv() (*environment, error) {
 	log.Info("checking envvars")
 	env := &environment{}
-	env.setOptionalFields()
+	env.setMutationTypeFields()
 	err := env.setRequiredFields()
 	if err != nil {
 		return nil, err
 	}
+	env.setOptionalFields()
 	log.Info("envvars checked", "env", env)
 	return env, nil
 }
@@ -101,6 +102,9 @@ func (env *environment) getDataIngestFieldSetters() []func() error {
 func (env *environment) setOptionalFields() {
 	env.addInstallerUrl()
 	env.addInstallerFlavor()
+}
+
+func (env *environment) setMutationTypeFields() {
 	env.addOneAgentInjected()
 	env.addDataIngestInjected()
 }

--- a/src/standalone/env_test.go
+++ b/src/standalone/env_test.go
@@ -51,6 +51,7 @@ func prepTestEnv(t *testing.T) func() {
 		K8NamespaceEnv,
 		WorkloadKindEnv,
 		WorkloadNameEnv,
+		K8ClusterIDEnv,
 		InstallPathEnv,
 	}
 	for i := 1; i <= 5; i++ {

--- a/src/standalone/files.go
+++ b/src/standalone/files.go
@@ -86,7 +86,7 @@ func (runner *Runner) createJsonEnrichmentFile() error {
 		runner.env.K8Namespace,
 		runner.env.WorkloadKind,
 		runner.env.WorkloadName,
-		runner.config.ClusterID,
+		runner.env.K8ClusterID,
 	)
 	jsonPath := filepath.Join(EnrichmentPath, fmt.Sprintf(enrichmentFilenameTemplate, "json"))
 
@@ -101,7 +101,7 @@ func (runner *Runner) createPropsEnrichmentFile() error {
 		runner.env.K8Namespace,
 		runner.env.WorkloadKind,
 		runner.env.WorkloadName,
-		runner.config.ClusterID,
+		runner.env.K8ClusterID,
 	)
 	propsPath := filepath.Join(EnrichmentPath, fmt.Sprintf(enrichmentFilenameTemplate, "properties"))
 

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -46,13 +46,13 @@ func NewRunner(fs afero.Fs) (*Runner, error) {
 			fs,
 			client,
 			&url.Properties{
-				Os:           dtclient.OsUnix,
-				Type:         dtclient.InstallerTypePaaS,
-				Flavor:       env.InstallerFlavor,
-				Arch:         arch.Arch,
-				Technologies: env.InstallerTech,
-				TargetVersion:      url.VersionLatest,
-				Url:          env.InstallerUrl,
+				Os:            dtclient.OsUnix,
+				Type:          dtclient.InstallerTypePaaS,
+				Flavor:        env.InstallerFlavor,
+				Arch:          arch.Arch,
+				Technologies:  env.InstallerTech,
+				TargetVersion: url.VersionLatest,
+				Url:           env.InstallerUrl,
 			},
 		)
 	}

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -23,31 +23,39 @@ type Runner struct {
 
 func NewRunner(fs afero.Fs) (*Runner, error) {
 	log.Info("creating standalone runner")
-	config, err := newSecretConfigViaFs(fs)
-	if err != nil {
-		return nil, err
-	}
 	env, err := newEnv()
 	if err != nil {
 		return nil, err
 	}
-	client, err := newDTClientBuilder(config).createClient()
-	if err != nil {
-		return nil, err
+
+	var config *SecretConfig
+	var client dtclient.Client
+	var oneAgentInstaller *url.UrlInstaller
+	if env.OneAgentInjected {
+		config, err = newSecretConfigViaFs(fs)
+		if err != nil {
+			return nil, err
+		}
+
+		client, err := newDTClientBuilder(config).createClient()
+		if err != nil {
+			return nil, err
+		}
+
+		oneAgentInstaller = url.NewUrlInstaller(
+			fs,
+			client,
+			&url.Properties{
+				Os:           dtclient.OsUnix,
+				Type:         dtclient.InstallerTypePaaS,
+				Flavor:       env.InstallerFlavor,
+				Arch:         arch.Arch,
+				Technologies: env.InstallerTech,
+				TargetVersion:      url.VersionLatest,
+				Url:          env.InstallerUrl,
+			},
+		)
 	}
-	oneAgentInstaller := url.NewUrlInstaller(
-		fs,
-		client,
-		&url.Properties{
-			Os:            dtclient.OsUnix,
-			Type:          dtclient.InstallerTypePaaS,
-			Flavor:        env.InstallerFlavor,
-			Arch:          arch.Arch,
-			Technologies:  env.InstallerTech,
-			TargetVersion: url.VersionLatest,
-			Url:           env.InstallerUrl,
-		},
-	)
 	log.Info("standalone runner created successfully")
 	return &Runner{
 		fs:        fs,
@@ -62,15 +70,17 @@ func (runner *Runner) Run() (resultedError error) {
 	log.Info("standalone agent init started")
 	defer runner.consumeErrorIfNecessary(&resultedError)
 
-	if err := runner.setHostTenant(); err != nil {
-		return err
-	}
-
-	if runner.env.Mode == InstallerMode && runner.env.OneAgentInjected {
-		if err := runner.installOneAgent(); err != nil {
+	if runner.env.OneAgentInjected {
+		if err := runner.setHostTenant(); err != nil {
 			return err
 		}
-		log.Info("OneAgent download finished")
+
+		if runner.env.Mode == InstallerMode {
+			if err := runner.installOneAgent(); err != nil {
+				return err
+			}
+			log.Info("OneAgent download finished")
+		}
 	}
 
 	err := runner.configureInstallation()

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -37,7 +37,7 @@ func NewRunner(fs afero.Fs) (*Runner, error) {
 			return nil, err
 		}
 
-		client, err := newDTClientBuilder(config).createClient()
+		client, err = newDTClientBuilder(config).createClient()
 		if err != nil {
 			return nil, err
 		}

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -23,18 +23,49 @@ var testProcessModuleConfig = dtclient.ProcessModuleConfig{
 	},
 }
 
-// TODO: FIX THIS
-// func TestNewRunner(t *testing.T) {
-// 	t.Run(`create runner`, func(t *testing.T) {
-// 		runner := creatTestRunner(t)
-// 		assert.NotNil(t, runner.fs)
-// 		assert.NotNil(t, runner.env)
-// 		assert.NotNil(t, runner.dtclient)
-// 		assert.NotNil(t, runner.config)
-// 		assert.NotNil(t, runner.installer)
-// 		assert.Empty(t, runner.hostTenant)
-// 	})
-// }
+func TestNewRunner(t *testing.T) {
+	fs := prepTestFs(t)
+	t.Run(`create runner with oneagent and data-ingest injection`, func(t *testing.T) {
+		resetEnv := prepCombinedTestEnv(t)
+		runner, err := NewRunner(fs)
+		resetEnv()
+
+		require.NoError(t, err)
+		require.NotNil(t, runner)
+		assert.NotNil(t, runner.fs)
+		assert.NotNil(t, runner.env)
+		assert.NotNil(t, runner.dtclient)
+		assert.NotNil(t, runner.config)
+		assert.NotNil(t, runner.installer)
+		assert.Empty(t, runner.hostTenant)
+	})
+	t.Run(`create runner with only oneagent`, func(t *testing.T) {
+		resetEnv := prepOneAgentTestEnv(t)
+		runner, err := NewRunner(fs)
+		resetEnv()
+
+		require.NoError(t, err)
+		assert.NotNil(t, runner.fs)
+		assert.NotNil(t, runner.env)
+		assert.NotNil(t, runner.dtclient)
+		assert.NotNil(t, runner.config)
+		assert.NotNil(t, runner.installer)
+		assert.Empty(t, runner.hostTenant)
+	})
+	t.Run(`create runner with only data-ingest injection`, func(t *testing.T) {
+		resetEnv := prepDataIngestTestEnv(t)
+		runner, err := NewRunner(fs)
+		resetEnv()
+
+		require.NoError(t, err)
+		assert.NotNil(t, runner.fs)
+		assert.NotNil(t, runner.env)
+		assert.Nil(t, runner.dtclient)
+		assert.Nil(t, runner.config)
+		assert.Nil(t, runner.installer)
+		assert.Empty(t, runner.hostTenant)
+	})
+}
 
 func TestConsumeErrorIfNecessary(t *testing.T) {
 	runner := createMockedRunner(t)
@@ -316,7 +347,7 @@ func TestWriteCurlOptions(t *testing.T) {
 
 func creatTestRunner(t *testing.T) *Runner {
 	fs := prepTestFs(t)
-	resetEnv := prepTestEnv(t)
+	resetEnv := prepCombinedTestEnv(t)
 
 	runner, err := NewRunner(fs)
 	resetEnv()

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -23,17 +23,18 @@ var testProcessModuleConfig = dtclient.ProcessModuleConfig{
 	},
 }
 
-func TestNewRunner(t *testing.T) {
-	t.Run(`create runner`, func(t *testing.T) {
-		runner := creatTestRunner(t)
-		assert.NotNil(t, runner.fs)
-		assert.NotNil(t, runner.env)
-		assert.NotNil(t, runner.dtclient)
-		assert.NotNil(t, runner.config)
-		assert.NotNil(t, runner.installer)
-		assert.Empty(t, runner.hostTenant)
-	})
-}
+// TODO: FIX THIS
+// func TestNewRunner(t *testing.T) {
+// 	t.Run(`create runner`, func(t *testing.T) {
+// 		runner := creatTestRunner(t)
+// 		assert.NotNil(t, runner.fs)
+// 		assert.NotNil(t, runner.env)
+// 		assert.NotNil(t, runner.dtclient)
+// 		assert.NotNil(t, runner.config)
+// 		assert.NotNil(t, runner.installer)
+// 		assert.Empty(t, runner.hostTenant)
+// 	})
+// }
 
 func TestConsumeErrorIfNecessary(t *testing.T) {
 	runner := createMockedRunner(t)

--- a/src/webhook/mutation/pod_mutator/config.go
+++ b/src/webhook/mutation/pod_mutator/config.go
@@ -8,8 +8,6 @@ const (
 	injectEvent          = "Inject"
 	updatePodEvent       = "UpdatePod"
 	missingDynakubeEvent = "MissingDynakube"
-
-	injectionConfigVolumeName = "injection-config"
 )
 
 var (

--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func createInstallInitContainerBase(webhookImage string, pod *corev1.Pod, dynakube dynatracev1beta1.DynaKube) *corev1.Container {
+func createInstallInitContainerBase(webhookImage, clusterID string, pod *corev1.Pod, dynakube dynatracev1beta1.DynaKube) *corev1.Container {
 	return &corev1.Container{
 		Name:            dtwebhook.InstallContainerName,
 		Image:           webhookImage,
@@ -23,6 +23,7 @@ func createInstallInitContainerBase(webhookImage string, pod *corev1.Pod, dynaku
 			{Name: standalone.K8PodNameEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("metadata.name")},
 			{Name: standalone.K8PodUIDEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("metadata.uid")},
 			{Name: standalone.K8BasePodNameEnv, Value: getBasePodName(pod)},
+			{Name: standalone.K8ClusterIDEnv, Value: clusterID},
 			{Name: standalone.K8NamespaceEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("metadata.namespace")},
 			{Name: standalone.K8NodeNameEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("spec.nodeName")},
 		},

--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -27,10 +27,7 @@ func createInstallInitContainerBase(webhookImage string, pod *corev1.Pod, dynaku
 			{Name: standalone.K8NodeNameEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("spec.nodeName")},
 		},
 		SecurityContext: copyUserContainerSecurityContext(pod),
-		VolumeMounts: []corev1.VolumeMount{
-			{Name: injectionConfigVolumeName, MountPath: standalone.ConfigDirMount},
-		},
-		Resources: *dynakube.InitResources(),
+		Resources:       *dynakube.InitResources(),
 	}
 }
 

--- a/src/webhook/mutation/pod_mutator/init_container_test.go
+++ b/src/webhook/mutation/pod_mutator/init_container_test.go
@@ -12,7 +12,8 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		dynakube := getTestDynakube()
 		pod := getTestPod()
 		webhookImage := "test-image"
-		initContainer := createInstallInitContainerBase(webhookImage, pod, *dynakube)
+		clusterID := "id"
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
 		require.NotNil(t, initContainer)
 		assert.Equal(t, initContainer.Image, webhookImage)
 		assert.Equal(t, initContainer.Resources, testResourceRequirements)

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
@@ -47,6 +47,7 @@ func (mutator *OneAgentPodMutator) Mutate(request *dtwebhook.MutationRequest) er
 	mutator.addVolumes(request.Pod, request.DynaKube)
 	mutator.configureInitContainer(request, installerInfo)
 	mutator.mutateUserContainers(request)
+	addInjectionConfigVolumeMount(request.InstallContainer)
 	setInjectedAnnotation(request.Pod)
 	return nil
 }

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
@@ -107,7 +107,7 @@ func TestMutate(t *testing.T) {
 		assert.Equal(t, initialInitContainers, request.Pod.Spec.InitContainers)
 
 		assert.Len(t, request.InstallContainer.Env, 6+(initialContainersLen*2))
-		assert.Len(t, request.InstallContainer.VolumeMounts, 2)
+		assert.Len(t, request.InstallContainer.VolumeMounts, 3)
 	})
 	t.Run("everything turned on, should mutate the pod and init container in the request", func(t *testing.T) {
 		mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
@@ -131,7 +131,7 @@ func TestMutate(t *testing.T) {
 		assert.Equal(t, initialInitContainers, request.Pod.Spec.InitContainers)
 
 		assert.Len(t, request.InstallContainer.Env, 6+(initialContainersLen*2))
-		assert.Len(t, request.InstallContainer.VolumeMounts, 2)
+		assert.Len(t, request.InstallContainer.VolumeMounts, 3)
 	})
 }
 

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/volumes.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/volumes.go
@@ -77,6 +77,12 @@ func addInjectionConfigVolume(pod *corev1.Pod) {
 	)
 }
 
+func addInjectionConfigVolumeMount(container *corev1.Container) {
+	container.VolumeMounts = append(container.VolumeMounts,
+		corev1.VolumeMount{Name: injectionConfigVolumeName, MountPath: standalone.ConfigDirMount},
+	)
+}
+
 func addOneAgentVolumes(pod *corev1.Pod, dynakube dynatracev1beta1.DynaKube) {
 	pod.Spec.Volumes = append(pod.Spec.Volumes,
 		corev1.Volume{


### PR DESCRIPTION
# Description
The injection-info volume was not fully moved to the oneagent-mutator.
Right now the injection-info volume-mount for the init container is defined in the main pod-mutator, which is incorrect.

This causes an error when wanting to only use the dataingest-mutator, as the injection-info volume will not be present.

Furthermore the injection-info's clusterID field is used by the standalone init part of the dataingest mutation, which is not necessary, because that can be set as an env in the webhook.
Doing so the 2 mutators (dataingest and oneagent) can be independent as they were meant to be.

## How can this be tested?
Inject into a:
- pod that has data-ingest disabled
- pod that has oneagent disabled
- pod that has both disabled


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

