### PR TITLE
Add redhat preflight workflow

### DIFF
--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -1,0 +1,33 @@
+name: preflight
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      registry:
+        required: true
+        type: string
+      repository:
+        required: true
+        type: string
+
+env:
+  PREFLIGHT_VERSION: "1.3.0"
+  PROJECT_ID: "ospid-37afb7f1-4eea-4feb-9125-9d57526bf5ab"
+  IMAGE_TAG: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.version }}-${{ inputs.platform }}
+
+jobs:
+  preflight:
+    name: Run preflight on image
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run preflight on image
+      run: |
+        hack/build/ci/preflight.sh "${{ env.PREFLIGHT_VERSION }}" "${{ env.IMAGE_TAG }}"

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -18,7 +18,7 @@ on:
 
 env:
   PREFLIGHT_VERSION: "1.3.0"
-  PROJECT_ID: "ospid-37afb7f1-4eea-4feb-9125-9d57526bf5ab"
+  PREFLIGHT_REPORT_NAME: "preflight.json"
   IMAGE_TAG: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.version }}-${{ inputs.platform }}
 
 jobs:
@@ -30,4 +30,9 @@ jobs:
       uses: actions/checkout@v2
     - name: Run preflight on image
       run: |
-        hack/build/ci/preflight.sh "${{ env.PREFLIGHT_VERSION }}" "${{ env.IMAGE_TAG }}"
+        hack/build/ci/preflight.sh "${{ env.PREFLIGHT_VERSION }}" "${{ env.IMAGE_TAG }}" "${{ env.PREFLIGHT_REPORT_NAME }}"
+    - name: Upload reports
+      uses: actions/upload-artifact@v3
+      with:
+        name: preflight-report
+        path: ${{ env.PREFLIGHT_REPORT_NAME }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -24,7 +24,7 @@ jobs:
 
   # Workflow needs to build docker images again as separate workflows don't have access to others artifacts
   # https://github.com/actions/download-artifact/issues/3
-  build-amd:
+  build-amd64:
     name: Build amd image
     uses: ./.github/workflows/build-dockerimage.yaml
     needs: [prepare]
@@ -46,10 +46,34 @@ jobs:
       labels: ${{ needs.prepare.outputs.labels }}
       image-tag: ${{ needs.prepare.outputs.version }}
 
+  push-quay:
+    name: Push to quay
+    needs: [prepare, build-amd64]
+    uses: ./.github/workflows/upload-dockerimage.yaml
+    with:
+      platform: amd64
+      labels: ${{ needs.prepare.outputs.labels }}
+      version: ${{ needs.prepare.outputs.version }}
+      registry: quay.io
+      repository: dynatrace/dynatrace-operator
+    secrets:
+      docker_repo_username: ${{ secrets.QUAY_USERNAME }}
+      docker_repo_password: ${{ secrets.QUAY_PASSWORD }}
+
+  preflight:
+    name: Validate image with RedHat's preflight tool
+    needs: [prepare, push-quay]
+    uses: ./.github/workflows/preflight.yaml
+    with:
+      platform: amd64
+      version: ${{ needs.prepare.outputs.version }}
+      registry: quay.io
+      repository: dynatrace/dynatrace-operator
+
   push-dockerhub-amd:
     name: Push amd image to Dockerhub
     uses: ./.github/workflows/upload-dockerimage.yaml
-    needs: [prepare, build-amd]
+    needs: [prepare, build-amd64, preflight]
     with:
       platform: amd64
       labels: ${{ needs.prepare.outputs.labels }}
@@ -63,7 +87,7 @@ jobs:
   push-dockerhub-arm:
     name: Push arm image to Dockerhub
     uses: ./.github/workflows/upload-dockerimage.yaml
-    needs: [prepare, build-arm]
+    needs: [prepare, build-arm, preflight]
     with:
      platform: arm64
      labels: ${{ needs.prepare.outputs.labels }}
@@ -77,7 +101,7 @@ jobs:
 #  push-gcr-amd:
 #    name: Push amd image to GCR
 #    uses: ./.github/workflows/upload-dockerimage.yaml
-#    needs: [prepare, build-amd]
+#    needs: [prepare, build-amd64, preflight]
 #    with:
 #      platform: amd64
 #      labels: ${{ needs.prepare.outputs.labels }}
@@ -91,7 +115,7 @@ jobs:
 #  push-gcr-arm:
 #    name: Push arm image to GCR
 #    uses: ./.github/workflows/upload-dockerimage.yaml
-#    needs: [prepare, build-arm]
+#    needs: [prepare, build-arm, preflight]
 #    with:
 #      platform: arm64
 #      labels: ${{ needs.prepare.outputs.labels }}
@@ -105,7 +129,7 @@ jobs:
 #  push-rhcc-amd:
 #    name: Push amd image to RHCC
 #    uses: ./.github/workflows/upload-dockerimage.yaml
-#    needs: [prepare, build-amd]
+#    needs: [prepare, build-amd64, preflight]
 #    with:
 #      platform: amd64
 #      labels: ${{ needs.prepare.outputs.labels }}

--- a/.github/workflows/upload-dockerimage.yaml
+++ b/.github/workflows/upload-dockerimage.yaml
@@ -47,4 +47,4 @@ jobs:
           path: /tmp
       - name: Upload image to Registry
         run: |
-          hack/build/ci/upload-docker-image.sh "${{ inputs.platform }}" "${SOURCE_IMAGE_TAG}" "${TARGET_IMAGE_TAG}"
+          hack/build/ci/upload-docker-image.sh "${{ inputs.platform }}" "${TARGET_IMAGE_TAG}"

--- a/hack/build/ci/preflight.sh
+++ b/hack/build/ci/preflight.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -xe
+
+readonly PREFLIGHT_VERSION="${1}"
+readonly IMAGE_TAG="${2}"
+readonly PREFLIGHT_REPORT_NAME="${3}"
+
+readonly PREFLIGHT_EXECUTABLE="preflight-linux-amd64"
+readonly PREFLIGHT_LOG="preflight.log"
+
+download_preflight() {
+  curl -LO "https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/${PREFLIGHT_VERSION}/${PREFLIGHT_EXECUTABLE}"
+  sudo chmod +x "${PREFLIGHT_EXECUTABLE}"
+}
+
+check_image() {
+  ./"${PREFLIGHT_EXECUTABLE}" check container "${IMAGE_TAG}" 1> "${PREFLIGHT_REPORT_NAME}" 2> "${PREFLIGHT_LOG}"
+  echo "${PREFLIGHT_EXECUTABLE} returned ${?}"
+  cat "${PREFLIGHT_LOG}"
+  grep "Preflight result: PASSED" "${PREFLIGHT_LOG}" || exit 1
+}
+
+
+download_preflight
+check_image

--- a/hack/build/ci/upload-docker-image.sh
+++ b/hack/build/ci/upload-docker-image.sh
@@ -13,6 +13,11 @@ readonly targetImageTag=${2}
 readonly imageTarPath="/tmp/operator-${platform}.tar"
 
 docker load -i "${imageTarPath}"
+
+# $docker load -i /tmp/alipine.tar
+# Loaded image: alpine:latest
+#
+# we're interested in "alpine:latest", that's field=3
 srcImageTag=$(docker load -i "${imageTarPath}" | cut -d' ' -f3)
 
 docker load --input "${imageTarPath}"

--- a/hack/build/ci/upload-docker-image.sh
+++ b/hack/build/ci/upload-docker-image.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
-if [ -z "$3" ]
+set -x
+
+if [ -z "$2" ]
 then
-  echo "Usage: $0 <platform> <source_image> <target_image>"
+  echo "Usage: $0 <platform> <targetImageTag>"
   exit 1
 fi
 
-platform=$1
-source_image=$2
-target_image=$3
+readonly platform=${1}
+readonly targetImageTag=${2}
+readonly imageTarPath="/tmp/operator-${platform}.tar"
 
-docker load --input "/tmp/operator-${platform}.tar"
-docker tag "${source_image}" "${target_image}"
-docker push "${target_image}"
+docker load -i "${imageTarPath}"
+srcImageTag=$(docker load -i "${imageTarPath}" | cut -d' ' -f3)
+
+docker load --input "${imageTarPath}"
+docker tag "${srcImageTag}" "${targetImageTag}"
+docker push "${targetImageTag}"


### PR DESCRIPTION
# Description
Adds github reusable workflow with image verification using RedHat preflight tool.
~~If test is passed, results are uploaded to RedHat.~~ - create a new PR to add this feature

`preflight` workflow is now required to success in `Publish images` workflow before images are pushed.

Refactored `upload-docker-image.sh` - now it doesn't need `SOURCE_IMAGE_TAG` parameter.

## How can this be tested?
- check if github action workflow `preflight` output reflects image state

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

