### PR TITLE
Improves isAlreadyDownloaded check

### DIFF
--- a/src/controllers/csi/provisioner/agent_test.go
+++ b/src/controllers/csi/provisioner/agent_test.go
@@ -64,7 +64,6 @@ func TestUpdateAgent(t *testing.T) {
 			Return(nil)
 
 		currentVersion, err := updater.updateAgent(
-			testVersion,
 			&processModuleCache)
 
 		require.NoError(t, err)
@@ -112,7 +111,6 @@ func TestUpdateAgent(t *testing.T) {
 		_ = updater.fs.MkdirAll(targetDir, 0755)
 
 		currentVersion, err := updater.updateAgent(
-			testVersion,
 			&processModuleCache)
 
 		require.NoError(t, err)
@@ -147,7 +145,6 @@ func TestUpdateAgent(t *testing.T) {
 			Return(false, fmt.Errorf("BOOM"))
 
 		currentVersion, err := updater.updateAgent(
-			testVersion,
 			&processModuleCache)
 
 		require.Error(t, err)
@@ -209,7 +206,6 @@ func TestUpdateAgent(t *testing.T) {
 			Return(nil)
 
 		currentVersion, err := updater.updateAgent(
-			testVersion,
 			&processModuleConfig)
 		require.NoError(t, err)
 		assert.Equal(t, tag, currentVersion)
@@ -274,7 +270,6 @@ func TestUpdateAgent(t *testing.T) {
 			Return(nil)
 
 		currentVersion, err := updater.updateAgent(
-			testVersion,
 			&processModuleConfig)
 		require.NoError(t, err)
 		assert.Equal(t, tag, currentVersion)
@@ -316,7 +311,6 @@ func testUpdateOneagent(t *testing.T, alreadyInstalled bool) {
 	}
 
 	currentVersion, err := updater.updateAgent(
-		"other",
 		&processModuleCache)
 
 	require.NoError(t, err)
@@ -329,7 +323,7 @@ func createTestAgentUrlUpdater(t *testing.T, dk *dynatracev1beta1.DynaKube) *age
 	fs := afero.NewMemMapFs()
 	rec := record.NewFakeRecorder(10)
 
-	updater, err := newAgentUrlUpdater(context.TODO(), fs, &mockedClient, path, rec, dk)
+	updater, err := newAgentUrlUpdater(context.TODO(), fs, &mockedClient, testVersion, path, rec, dk)
 	require.NoError(t, err)
 	updater.installer = &installer.InstallerMock{}
 

--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -166,7 +166,7 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 			return nil, false, err
 		}
 	} else {
-		agentUpdater, err = newAgentUrlUpdater(ctx, provisioner.fs, dtc, provisioner.path, provisioner.recorder, dk)
+		agentUpdater, err = newAgentUrlUpdater(ctx, provisioner.fs, dtc, dynakubeMetadata.LatestVersion, provisioner.path, provisioner.recorder, dk)
 		if err != nil {
 			log.Info("error when setting up the agent url updater", "error", err.Error())
 			return nil, false, err
@@ -179,7 +179,7 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 		log.Info("error when setting up the agent updater", "error", err.Error())
 		return nil, false, err
 	}
-	updatedVersion, err := agentUpdater.updateAgent(dynakubeMetadata.LatestVersion, latestProcessModuleConfigCache)
+	updatedVersion, err := agentUpdater.updateAgent(latestProcessModuleConfigCache)
 	if err != nil {
 		log.Info("error when updating agent", "error", err.Error())
 		// reporting error but not returning it to avoid immediate requeue and subsequently calling the API every few seconds

--- a/src/installer/url/download.go
+++ b/src/installer/url/download.go
@@ -10,7 +10,7 @@ func (installer UrlInstaller) downloadOneAgentFromUrl(tmpFile afero.File) error 
 		if err := installer.downloadOneAgentViaInstallerUrl(tmpFile); err != nil {
 			return errors.WithStack(err)
 		}
-	} else if installer.props.Version == VersionLatest {
+	} else if installer.props.TargetVersion == VersionLatest {
 		if err := installer.downloadLatestOneAgent(tmpFile); err != nil {
 			return errors.WithStack(err)
 		}
@@ -35,13 +35,13 @@ func (installer UrlInstaller) downloadLatestOneAgent(tmpFile afero.File) error {
 }
 
 func (installer UrlInstaller) downloadOneAgentWithVersion(tmpFile afero.File) error {
-	log.Info("downloading specific OneAgent package", "version", installer.props.Version)
+	log.Info("downloading specific OneAgent package", "version", installer.props.TargetVersion)
 	err := installer.dtc.GetAgent(
 		installer.props.Os,
 		installer.props.Type,
 		installer.props.Flavor,
 		installer.props.Arch,
-		installer.props.Version,
+		installer.props.TargetVersion,
 		installer.props.Technologies,
 		tmpFile,
 	)
@@ -57,7 +57,7 @@ func (installer UrlInstaller) downloadOneAgentWithVersion(tmpFile afero.File) er
 			log.Info("failed to get available versions", "err", getVersionsError)
 			return errors.WithStack(getVersionsError)
 		}
-		log.Info("failed to download specific OneAgent package", "version", installer.props.Version, "available versions", availableVersions)
+		log.Info("failed to download specific OneAgent package", "version", installer.props.TargetVersion, "available versions", availableVersions)
 		return errors.WithStack(err)
 	}
 	return nil

--- a/src/installer/url/installer.go
+++ b/src/installer/url/installer.go
@@ -12,13 +12,14 @@ import (
 )
 
 type Properties struct {
-	Os           string
-	Arch         string
-	Type         string
-	Flavor       string
-	Version      string
-	Technologies []string
-	Url          string // if this is set all settings before it will be ignored
+	Os              string
+	Arch            string
+	Type            string
+	Flavor          string
+	TargetVersion   string
+	PreviousVersion string
+	Technologies    []string
+	Url             string // if this is set all settings before it will be ignored
 }
 
 func (props *Properties) fillEmptyWithDefaults() {
@@ -91,7 +92,7 @@ func (installer UrlInstaller) installAgentFromUrl(targetDir string) error {
 }
 
 func (installer UrlInstaller) isAlreadyDownloaded(targetDir string) bool {
-	if standaloneBinDir == targetDir {
+	if standaloneBinDir == targetDir || installer.props.PreviousVersion == "" {
 		return false
 	}
 	_, err := installer.fs.Stat(targetDir)

--- a/src/installer/url/installer_test.go
+++ b/src/installer/url/installer_test.go
@@ -118,10 +118,10 @@ func TestInstallAgentFromUrl(t *testing.T) {
 			fs:  fs,
 			dtc: dtc,
 			props: &Properties{
-				Os:      dtclient.OsUnix,
-				Type:    dtclient.InstallerTypePaaS,
-				Flavor:  arch.FlavorMultidistro,
-				Version: testVersion,
+				Os:            dtclient.OsUnix,
+				Type:          dtclient.InstallerTypePaaS,
+				Flavor:        arch.FlavorMultidistro,
+				TargetVersion: testVersion,
 			},
 		}
 
@@ -154,10 +154,10 @@ func TestInstallAgentFromUrl(t *testing.T) {
 			fs:  fs,
 			dtc: dtc,
 			props: &Properties{
-				Os:      dtclient.OsUnix,
-				Type:    dtclient.InstallerTypePaaS,
-				Flavor:  arch.FlavorMultidistro,
-				Version: VersionLatest,
+				Os:            dtclient.OsUnix,
+				Type:          dtclient.InstallerTypePaaS,
+				Flavor:        arch.FlavorMultidistro,
+				TargetVersion: VersionLatest,
 			},
 		}
 
@@ -201,5 +201,39 @@ func TestInstallAgentFromUrl(t *testing.T) {
 		assert.NotNil(t, info)
 		assert.False(t, info.IsDir())
 		assert.Equal(t, int64(25), info.Size())
+	})
+}
+
+func TestIsAlreadyDownloaded(t *testing.T) {
+	t.Run(`true if exits and not standalone and previous set`, func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		targetDir := "test/test"
+		fs.MkdirAll(targetDir, 0666)
+		installer := &UrlInstaller{
+			fs: fs,
+			props: &Properties{
+				PreviousVersion: "test",
+			},
+		}
+		assert.True(t, installer.isAlreadyDownloaded(targetDir))
+	})
+	t.Run(`false if standalone`, func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		targetDir := standaloneBinDir
+		installer := &UrlInstaller{
+			fs:    fs,
+			props: &Properties{},
+		}
+		assert.False(t, installer.isAlreadyDownloaded(targetDir))
+	})
+	t.Run(`false if previous not set`, func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		targetDir := "test/test"
+		fs.MkdirAll(targetDir, 0666)
+		installer := &UrlInstaller{
+			fs:    fs,
+			props: &Properties{},
+		}
+		assert.False(t, installer.isAlreadyDownloaded(targetDir))
 	})
 }

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -39,13 +39,13 @@ func NewRunner(fs afero.Fs) (*Runner, error) {
 		fs,
 		client,
 		&url.Properties{
-			Os:           dtclient.OsUnix,
-			Type:         dtclient.InstallerTypePaaS,
-			Flavor:       env.InstallerFlavor,
-			Arch:         arch.Arch,
-			Technologies: env.InstallerTech,
-			Version:      url.VersionLatest,
-			Url:          env.InstallerUrl,
+			Os:            dtclient.OsUnix,
+			Type:          dtclient.InstallerTypePaaS,
+			Flavor:        env.InstallerFlavor,
+			Arch:          arch.Arch,
+			Technologies:  env.InstallerTech,
+			TargetVersion: url.VersionLatest,
+			Url:           env.InstallerUrl,
 		},
 	)
 	log.Info("standalone runner created successfully")


### PR DESCRIPTION
# Description

Bug: 
1. csi-provisioner tries to download version X
2. create targetDir for version X
3. gets OOM killed
4. retries, but "targetDir for version X" already exists ==> doesn't retry

## How can this be tested?
1. Reduce csi-driver's resource limits, so it gets OOM killed
2. After an OOM, check if the provisioner created the directory `/data/<tenant>/bin/<version>`, make sure its empty
3. Raise the csi-driver's resource limits, so it doesn't get OOM killed
4. The csi-driver should download the targetVersion X (`/data/<tenant>/bin/<version>` is no longer empty, and sample starts up)


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

