### PR TITLE
Fixes codemodules install permissions

### DIFF
--- a/src/cmd/standalone/standalone.go
+++ b/src/cmd/standalone/standalone.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/standalone"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -18,7 +19,7 @@ func NewStandaloneCommand() *cobra.Command {
 }
 
 func startStandAloneInit(_ *cobra.Command, _ []string) error {
-	// TODO: make the code below testable and test it, but in another ticket because otherwise adding the other commands will take a week
+	unix.Umask(0000)
 	standaloneRunner, err := standalone.NewRunner(afero.NewOsFs())
 	if err != nil {
 		return err

--- a/src/installer/zip/zip.go
+++ b/src/installer/zip/zip.go
@@ -54,12 +54,13 @@ func extractFileFromZip(fs afero.Fs, targetDir string, file *zip.File) error {
 	}
 
 	mode := file.Mode()
-	if isAgentConfFile(file.Name) {
-		mode = common.ReadWriteAllFileMode
-	}
 
 	if file.FileInfo().IsDir() {
 		return fs.MkdirAll(path, mode)
+	}
+
+	if isAgentConfFile(file.Name) {
+		mode = common.ReadWriteAllFileMode
 	}
 
 	if err := fs.MkdirAll(filepath.Dir(path), mode); err != nil {


### PR DESCRIPTION
# Description
Installing codemodules without the CSI driver had multiple problems.
1. The unix mask 0000 was only set in the CSI driver (we should set the mask in the standalone init aswell)
2. Modifying the `agent/conf` dir's filemode caused permissions errors for creating files inside it. (so we should only modify the filemode inside the dir)

## How can this be tested?
Deploy codemodules with and without the csi-driver.
Check that no error happens during install, and check that the filemode on in the `.../agent/conf` is the following:
```
drwxr-xr-x 3 1001 1001   4096 Jul  4 15:23 .
drwxr-xr-x 7 1001 1001   4096 Jul  4 15:23 ..
-rw-r--r-- 1 1001 1001   3420 Jul  4 15:23 _ruxitagentproc.conf (if codeModulesImage is used, this is not present)
drwxrwxrwx 3 1001 1001   4096 Jul  4 15:23 runtime
-rw-rw-rw- 1 1001 1001   5059 Jul  4 15:23 ruxitagentproc.conf
-rw-rw-rw- 1 1001 1001   6137 Jul  4 15:23 ruxitserver.pem
-rw-rw-rw- 1 1001 1001 215352 Jul  4 15:23 ruxitserverfull.pem
```


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

