### PR TITLE
Adds Calico policies

### DIFF
--- a/assets/calico/activegate-policy.yaml
+++ b/assets/calico/activegate-policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-activegate-pods
+  namespace: dynatrace
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: activegate
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+  - from:
+    # from any ip
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    # from activegate ports
+    - protocol: TCP
+      port: 9999   
+    - protocol: TCP
+      port: 9998    
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 80
+  egress:
+  # Allow DNS lookup 
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow external traffic for e.g. Cluster API requests
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        # blocks private ips, i.e. blocks Pod to Pod communication
+        - 10.0.0.0/8
+        - 192.168.0.0/16
+        - 172.16.0.0/12
+    ports: []

--- a/assets/calico/agent-policy-external-only.yaml
+++ b/assets/calico/agent-policy-external-only.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-agent-traffic
+spec:
+  podSelector:
+    matchLabels:
+      app: myapp
+  policyTypes:
+    - Egress
+  egress:
+  # Allow DNS lookup 
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow external traffic for e.g. Cluster API requests
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        # blocks private ips, i.e. blocks Pod to Pod communication
+        - 10.0.0.0/8
+        - 192.168.0.0/16
+        - 172.16.0.0/12
+    ports: []

--- a/assets/calico/agent-policy.yaml
+++ b/assets/calico/agent-policy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-agent-traffic
+spec:
+  podSelector:
+    matchLabels:
+      app: myapp
+  policyTypes:
+    - Egress
+  egress:
+  # Allow DNS lookup 
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow external traffic for e.g. Cluster API requests
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports: []

--- a/assets/calico/dynatrace-policies.yaml
+++ b/assets/calico/dynatrace-policies.yaml
@@ -1,0 +1,84 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dynatrace-pods
+  namespace: dynatrace
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: dynatrace-operator
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+  - from:
+    # from any ip
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    # from webhook ports
+    - protocol: TCP
+      port: 8383   
+    - protocol: TCP
+      port: 8384
+    - protocol: TCP
+      port: 8443
+    - protocol: TCP
+      port: 443
+    # from operator ports
+    - protocol: TCP
+      port: 8080
+    - protocol: TCP
+      port: 10080
+    - protocol: TCP
+      port: 80
+    # from oneagent ports
+    - protocol: TCP
+      port: 50000
+      endPort: 50005
+  egress:
+  - to:
+    # to any ip
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    # to webhook ports
+    - protocol: TCP
+      port: 8383   
+    - protocol: TCP
+      port: 8384
+    - protocol: TCP
+      port: 8443
+    - protocol: TCP
+      port: 443    
+    # to operator ports
+    - protocol: TCP
+      port: 8080
+    - protocol: TCP
+      port: 10080
+    - protocol: TCP
+      port: 80
+    # to oneagent ports
+    - protocol: TCP
+      port: 50000
+      endPort: 50005
+  # Allow DNS lookup 
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow external traffic for e.g. Cluster API requests
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        # blocks private ips, i.e. blocks Pod to Pod communication
+        - 10.0.0.0/8
+        - 192.168.0.0/16
+        - 172.16.0.0/12
+    ports: []


### PR DESCRIPTION
# Description

Adds policies that make the Operator behave in case a deny-all network policy is in place.

## How can this be tested?

* Setup a cluster an enable Calico
* Apply a deny-all policy
* Deploy the operator
* Everything should fail
* Apply the policies
* Everything should start to work

## Checklist
~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

