### PR TITLE
Set unprivileged user/group for oneagent securitycontext

### DIFF
--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -254,16 +254,17 @@ func (dsInfo *builderInfo) imagePullSecrets() []corev1.LocalObjectReference {
 }
 
 func (dsInfo *builderInfo) securityContext() *corev1.SecurityContext {
-	if dsInfo.instance.IsOneAgentPrivileged() {
-		runAsPrivileged := true
-		securityContext := &corev1.SecurityContext{
-			Privileged: &runAsPrivileged,
-		}
-		return securityContext
+	var securityContext corev1.SecurityContext
+	if dsInfo.instance.NeedsReadOnlyOneAgents() || dsInfo.instance.IsOneAgentPrivileged() {
+		securityContext.RunAsNonRoot = address.Of(true)
+		securityContext.RunAsUser = address.Of(int64(1000))
+		securityContext.RunAsGroup = address.Of(int64(1000))
 	}
 
-	securityContext := &corev1.SecurityContext{
-		Capabilities: &corev1.Capabilities{
+	if dsInfo.instance.IsOneAgentPrivileged() {
+		securityContext.Privileged = address.Of(true)
+	} else {
+		securityContext.Capabilities = &corev1.Capabilities{
 			Drop: []corev1.Capability{
 				"ALL",
 			},
@@ -284,13 +285,8 @@ func (dsInfo *builderInfo) securityContext() *corev1.SecurityContext {
 				"SYS_PTRACE",
 				"SYS_RESOURCE",
 			},
-		},
+		}
 	}
-	if dsInfo.instance.NeedsReadOnlyOneAgents() {
-		unprivilegedUser := int64(1000)
-		unprivilegedGroup := int64(1000)
-		securityContext.RunAsUser = &unprivilegedUser
-		securityContext.RunAsGroup = &unprivilegedGroup
-	}
-	return securityContext
+
+	return &securityContext
 }

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -140,7 +142,7 @@ func TestResources(t *testing.T) {
 	})
 }
 
-func TestInfraMon_SecurityContext(t *testing.T) {
+func TestHostMonitoring_SecurityContext(t *testing.T) {
 	t.Run(`User and group id set when read only mode is enabled`, func(t *testing.T) {
 		instance := dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
@@ -156,9 +158,71 @@ func TestInfraMon_SecurityContext(t *testing.T) {
 
 		assert.GreaterOrEqual(t, 1, len(ds.Spec.Template.Spec.Containers))
 
-		securityContextConstraints := ds.Spec.Template.Spec.Containers[0].SecurityContext
+		securityContext := ds.Spec.Template.Spec.Containers[0].SecurityContext
 
-		assert.NotNil(t, securityContextConstraints)
-		assert.Nil(t, securityContextConstraints.RunAsNonRoot)
+		assert.NotNil(t, securityContext)
+		assert.Equal(t, address.Of(int64(1000)), securityContext.RunAsUser)
+		assert.Equal(t, address.Of(int64(1000)), securityContext.RunAsGroup)
+		assert.Equal(t, address.Of(true), securityContext.RunAsNonRoot)
+		assert.NotEmpty(t, securityContext.Capabilities)
+	})
+
+	t.Run(`No User and group id set when read only mode is disabled`, func(t *testing.T) {
+		instance := dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					dynatracev1beta1.AnnotationFeatureReadOnlyOneAgent: "false",
+				},
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testURL,
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					HostMonitoring: &dynatracev1beta1.HostInjectSpec{},
+				},
+			},
+		}
+		dsInfo := NewHostMonitoring(&instance, testClusterID)
+		ds, err := dsInfo.BuildDaemonSet()
+		require.NoError(t, err)
+
+		assert.GreaterOrEqual(t, 1, len(ds.Spec.Template.Spec.Containers))
+
+		securityContext := ds.Spec.Template.Spec.Containers[0].SecurityContext
+
+		assert.NotNil(t, securityContext)
+		assert.Nil(t, securityContext.RunAsUser)
+		assert.Nil(t, securityContext.RunAsGroup)
+		assert.Nil(t, securityContext.RunAsNonRoot)
+		assert.NotEmpty(t, securityContext.Capabilities)
+	})
+
+	t.Run(`privileged security context when feature flag is enabled`, func(t *testing.T) {
+		instance := dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					dynatracev1beta1.AnnotationFeatureRunOneAgentContainerPrivileged: "true",
+				},
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testURL,
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					HostMonitoring: &dynatracev1beta1.HostInjectSpec{},
+				},
+			},
+		}
+		dsInfo := NewHostMonitoring(&instance, testClusterID)
+		ds, err := dsInfo.BuildDaemonSet()
+		require.NoError(t, err)
+
+		assert.GreaterOrEqual(t, 1, len(ds.Spec.Template.Spec.Containers))
+
+		securityContext := ds.Spec.Template.Spec.Containers[0].SecurityContext
+
+		assert.NotNil(t, securityContext)
+		assert.Equal(t, address.Of(int64(1000)), securityContext.RunAsUser)
+		assert.Equal(t, address.Of(int64(1000)), securityContext.RunAsGroup)
+		assert.Equal(t, address.Of(true), securityContext.RunAsNonRoot)
+		assert.Equal(t, address.Of(true), securityContext.Privileged)
+		assert.Empty(t, securityContext.Capabilities)
 	})
 }

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -171,7 +171,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		instance := dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					dynatracev1beta1.AnnotationFeatureReadOnlyOneAgent: "false",
+					dynatracev1beta1.AnnotationFeatureDisableReadOnlyOneAgent: "true",
 				},
 			},
 			Spec: dynatracev1beta1.DynaKubeSpec{


### PR DESCRIPTION
# Description
(cherry picked from commit 794e203)

## How can this be tested?
Deploy Oneagent on Cluster with cgroups v2 enabled and verify it works.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

