### PR TITLE
Include prereleases in chart version

### DIFF
--- a/config/helm/chart/default/Chart.yaml
+++ b/config/helm/chart/default/Chart.yaml
@@ -20,7 +20,7 @@ home: https://www.dynatrace.com/
 type: application
 version: 0.0.0-snapshot
 appVersion: 0.0.0-snapshot
-kubeVersion: '>=1.21'
+kubeVersion: '>=1.21.0-0'
 maintainers:
 - name: 0sewa0
   email: marcell.sevcsik@dynatrace.com


### PR DESCRIPTION
# Description
Using `>=1.21` does not include pre releases, https://github.com/helm/helm/issues/3810

## How can this be tested?
Install helm chart on Cluster using `x.x.x-x` version.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

