### PR TITLE
Fixes oneagent privileged flag

### DIFF
--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -255,7 +255,7 @@ func (dsInfo *builderInfo) imagePullSecrets() []corev1.LocalObjectReference {
 
 func (dsInfo *builderInfo) securityContext() *corev1.SecurityContext {
 	var securityContext corev1.SecurityContext
-	if dsInfo.instance.NeedsReadOnlyOneAgents() || dsInfo.instance.IsOneAgentPrivileged() {
+	if dsInfo.instance.NeedsReadOnlyOneAgents() {
 		securityContext.RunAsNonRoot = address.Of(true)
 		securityContext.RunAsUser = address.Of(int64(1000))
 		securityContext.RunAsGroup = address.Of(int64(1000))


### PR DESCRIPTION
# Description
The `feature.dynatrace.com/oneagent-privileged: "true"` flag always added the `runAsUser` and `runAsGroup` that brakes the `classicFullStack` mode

## How can this be tested?
Deploy `classicFullStack` on a cgroup v2 cluster, while having the `feature.dynatrace.com/oneagent-privileged: "true"` feature-flag

## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

