### PR TITLE
Only set user/group when csi driver is used

### DIFF
--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -255,7 +255,7 @@ func (dsInfo *builderInfo) imagePullSecrets() []corev1.LocalObjectReference {
 
 func (dsInfo *builderInfo) securityContext() *corev1.SecurityContext {
 	var securityContext corev1.SecurityContext
-	if dsInfo.instance.NeedsReadOnlyOneAgents() || dsInfo.instance.IsOneAgentPrivileged() {
+	if dsInfo.instance.NeedsReadOnlyOneAgents() {
 		securityContext.RunAsNonRoot = address.Of(true)
 		securityContext.RunAsUser = address.Of(int64(1000))
 		securityContext.RunAsGroup = address.Of(int64(1000))

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -193,6 +193,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		assert.Nil(t, securityContext.RunAsUser)
 		assert.Nil(t, securityContext.RunAsGroup)
 		assert.Nil(t, securityContext.RunAsNonRoot)
+		assert.Nil(t, securityContext.Privileged)
 		assert.NotEmpty(t, securityContext.Capabilities)
 	})
 
@@ -222,6 +223,36 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		assert.Equal(t, address.Of(int64(1000)), securityContext.RunAsUser)
 		assert.Equal(t, address.Of(int64(1000)), securityContext.RunAsGroup)
 		assert.Equal(t, address.Of(true), securityContext.RunAsNonRoot)
+		assert.Equal(t, address.Of(true), securityContext.Privileged)
+		assert.Empty(t, securityContext.Capabilities)
+	})
+
+	t.Run(`privileged security context when feature flag is enabled for classic fullstack`, func(t *testing.T) {
+		instance := dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					dynatracev1beta1.AnnotationFeatureRunOneAgentContainerPrivileged: "true",
+				},
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testURL,
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					ClassicFullStack: &dynatracev1beta1.HostInjectSpec{},
+				},
+			},
+		}
+		dsInfo := NewClassicFullStack(&instance, testClusterID)
+		ds, err := dsInfo.BuildDaemonSet()
+		require.NoError(t, err)
+
+		assert.GreaterOrEqual(t, 1, len(ds.Spec.Template.Spec.Containers))
+
+		securityContext := ds.Spec.Template.Spec.Containers[0].SecurityContext
+
+		assert.NotNil(t, securityContext)
+		assert.Nil(t, securityContext.RunAsUser)
+		assert.Nil(t, securityContext.RunAsGroup)
+		assert.Nil(t, securityContext.RunAsNonRoot)
 		assert.Equal(t, address.Of(true), securityContext.Privileged)
 		assert.Empty(t, securityContext.Capabilities)
 	})


### PR DESCRIPTION
# Description
Unprivileged user/group should not be used for classic fullstack.

## How can this be tested?
Deploy classic fullstack and use privileged oneagent feature flag.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

