### PR TITLE
Fixes Istio reconciliation depending on a token check that depends on Istio reconciliations

### DIFF
--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -112,9 +112,9 @@ func (controller *DynakubeController) Reconcile(ctx context.Context, request rec
 	if updated {
 		dkState.Update(true, "Istio: objects updated")
 		dkState.RequeueAfter = shortUpdateInterval
-	} else {
-		controller.reconcileDynaKube(ctx, dkState, &dkMapper)
 	}
+
+	controller.reconcileDynaKube(ctx, dkState, &dkMapper)
 
 	if dkState.Err != nil {
 		if !dkState.ValidTokens {
@@ -188,6 +188,7 @@ func (controller *DynakubeController) reconcileDynaKube(ctx context.Context, dkS
 		log.Error(err, "failed to check tokens")
 		return
 	}
+
 	dkState.ValidTokens = true
 	if !dtcReconciler.ValidTokens {
 		dkState.ValidTokens = false

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -99,6 +99,9 @@ func (controller *DynakubeController) Reconcile(ctx context.Context, request rec
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	if instance == nil {
+		return reconcile.Result{}, nil
+	}
 
 	// A new mapper is initialized here as well as in getDynakubeOrUnmap because to solve these dependencies
 	// the whole dynakube controller would have to be bulldozed
@@ -143,9 +146,12 @@ func (controller *DynakubeController) getDynakubeOrUnmap(ctx context.Context, na
 
 	if k8serrors.IsNotFound(err) {
 		err = dkMapper.UnmapFromDynaKube()
+		return nil, err
+	} else if err != nil {
+		return nil, err
 	}
 
-	return &dynakube, err
+	return &dynakube, nil
 }
 
 func (controller *DynakubeController) reconcileDynaKube(ctx context.Context, dkState *status.DynakubeState, dkMapper *mapper.DynakubeMapper) {

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -816,3 +816,17 @@ func TestGetDynakube(t *testing.T) {
 		assert.EqualError(t, err, "fake error")
 	})
 }
+
+func TestReconcileIstio(t *testing.T) {
+	fakeClient := fake.NewClient()
+	dynakube := &dynatracev1beta1.DynaKube{}
+	controller := &DynakubeController{
+		client:    fakeClient,
+		apiReader: fakeClient,
+	}
+	updated := controller.reconcileIstio(dynakube)
+
+	assert.False(t, updated)
+
+	// Testing what happens if the flag is enabled is not testable without some bigger refactoring
+}

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -3,8 +3,6 @@ package dynakube
 import (
 	"context"
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/src/mapper"
-	"github.com/pkg/errors"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/agproxysecret"
@@ -15,9 +13,11 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/src/kubesystem"
+	"github.com/Dynatrace/dynatrace-operator/src/mapper"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/src/version"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -3,6 +3,8 @@ package dynakube
 import (
 	"context"
 	"fmt"
+	"github.com/Dynatrace/dynatrace-operator/src/mapper"
+	"github.com/pkg/errors"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/agproxysecret"
@@ -742,4 +744,83 @@ func generateStatefulSetForTesting(name, namespace, feature, kubeSystemUUID stri
 			PodManagementPolicy: "Parallel",
 		},
 	}
+}
+
+type errorClient struct {
+	client.Client
+}
+
+func (clt errorClient) Get(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+	return errors.New("fake error")
+}
+
+func TestGetDynakube(t *testing.T) {
+	t.Run("get dynakube", func(t *testing.T) {
+		fakeClient := fake.NewClient(&dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{},
+				},
+			},
+		})
+		controller := &DynakubeController{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		ctx := context.TODO()
+		dynakube, err := controller.getDynakubeOrUnmap(ctx, testName, testNamespace)
+
+		assert.NotNil(t, dynakube)
+		assert.NoError(t, err)
+
+		assert.Equal(t, testName, dynakube.Name)
+		assert.Equal(t, testNamespace, dynakube.Namespace)
+		assert.NotNil(t, dynakube.Spec.OneAgent.CloudNativeFullStack)
+	})
+	t.Run("unmap if not not found", func(t *testing.T) {
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   testNamespace,
+				Labels: map[string]string{mapper.InstanceLabel: testName},
+			},
+		}
+		fakeClient := fake.NewClient(namespace)
+		controller := &DynakubeController{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		ctx := context.TODO()
+		dynakube, err := controller.getDynakubeOrUnmap(ctx, testName, testNamespace)
+
+		assert.NotNil(t, dynakube)
+		assert.NoError(t, err)
+
+		assert.Equal(t, testName, dynakube.Name)
+		assert.Equal(t, testNamespace, dynakube.Namespace)
+		assert.Nil(t, dynakube.Spec.OneAgent.CloudNativeFullStack)
+
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: testNamespace}, namespace)
+		require.NoError(t, err)
+		assert.NotContains(t, namespace.Labels, mapper.InstanceLabel)
+	})
+	t.Run("return unknown error", func(t *testing.T) {
+		controller := &DynakubeController{
+			client:    errorClient{},
+			apiReader: errorClient{},
+		}
+
+		ctx := context.TODO()
+		dynakube, err := controller.getDynakubeOrUnmap(ctx, testName, testNamespace)
+
+		assert.NotNil(t, dynakube)
+		assert.EqualError(t, err, "fake error")
+
+		assert.Equal(t, testName, dynakube.Name)
+		assert.Equal(t, testNamespace, dynakube.Namespace)
+		assert.Nil(t, dynakube.Spec.OneAgent.CloudNativeFullStack)
+	})
 }

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -796,12 +796,8 @@ func TestGetDynakube(t *testing.T) {
 		ctx := context.TODO()
 		dynakube, err := controller.getDynakubeOrUnmap(ctx, testName, testNamespace)
 
-		assert.NotNil(t, dynakube)
+		assert.Nil(t, dynakube)
 		assert.NoError(t, err)
-
-		assert.Equal(t, testName, dynakube.Name)
-		assert.Equal(t, testNamespace, dynakube.Namespace)
-		assert.Nil(t, dynakube.Spec.OneAgent.CloudNativeFullStack)
 
 		err = fakeClient.Get(ctx, client.ObjectKey{Name: testNamespace}, namespace)
 		require.NoError(t, err)
@@ -816,11 +812,7 @@ func TestGetDynakube(t *testing.T) {
 		ctx := context.TODO()
 		dynakube, err := controller.getDynakubeOrUnmap(ctx, testName, testNamespace)
 
-		assert.NotNil(t, dynakube)
+		assert.Nil(t, dynakube)
 		assert.EqualError(t, err, "fake error")
-
-		assert.Equal(t, testName, dynakube.Name)
-		assert.Equal(t, testNamespace, dynakube.Namespace)
-		assert.Nil(t, dynakube.Spec.OneAgent.CloudNativeFullStack)
 	})
 }

--- a/src/controllers/dynakube/istio/reconciler.go
+++ b/src/controllers/dynakube/istio/reconciler.go
@@ -2,6 +2,7 @@ package istio
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
@@ -58,8 +59,7 @@ func (reconciler *IstioReconciler) initializeIstioClient(config *rest.Config) (i
 
 // ReconcileIstio - runs the istio's reconcile workflow,
 // creating/deleting VS & SE for external communications
-func (reconciler *IstioReconciler) ReconcileIstio(instance *dynatracev1beta1.DynaKube) (updated bool, err error) {
-
+func (reconciler *IstioReconciler) ReconcileIstio(instance *dynatracev1beta1.DynaKube) (bool, error) {
 	enabled, err := CheckIstioEnabled(reconciler.config)
 	if err != nil {
 		return false, fmt.Errorf("istio: failed to verify Istio availability: %w", err)
@@ -70,17 +70,23 @@ func (reconciler *IstioReconciler) ReconcileIstio(instance *dynatracev1beta1.Dyn
 		return false, nil
 	}
 
-	apiHost := instance.CommunicationHostForClient()
-	if upd, err := reconciler.reconcileIstioConfigurations(instance, []dtclient.CommunicationHost{apiHost}, "api-url"); err != nil {
-		return false, fmt.Errorf("istio: error reconciling config for Dynatrace API URL: %w", err)
+	apiHost, err := dtclient.ParseEndpoint(instance.Spec.APIURL)
+	if err != nil {
+		return false, err
+	}
+
+	upd, err := reconciler.reconcileIstioConfigurations(instance, []dtclient.CommunicationHost{apiHost}, "api-url")
+	if err != nil {
+		return false, errors.WithMessage(err, "istio: error reconciling config for Dynatrace API URL")
 	} else if upd {
 		return true, nil
 	}
 
 	// Fetch endpoints via Dynatrace client
 	ci := instance.ConnectionInfo()
-	if upd, err := reconciler.reconcileIstioConfigurations(instance, ci.CommunicationHosts, "communication-endpoint"); err != nil {
-		return false, fmt.Errorf("istio: error reconciling config for Dynatrace communication endpoints: %w", err)
+	upd, err = reconciler.reconcileIstioConfigurations(instance, ci.CommunicationHosts, "communication-endpoint")
+	if err != nil {
+		return false, errors.WithMessage(err, "istio: error reconciling config for Dynatrace communication endpoints:")
 	} else if upd {
 		return true, nil
 	}

--- a/src/controllers/dynakube/istio/reconciler.go
+++ b/src/controllers/dynakube/istio/reconciler.go
@@ -2,12 +2,12 @@ package istio
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/pkg/errors"
 	istioclientset "istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/src/controllers/dynakube/istio/reconciler_test.go
+++ b/src/controllers/dynakube/istio/reconciler_test.go
@@ -80,7 +80,11 @@ func TestController_ReconcileIstio(t *testing.T) {
 	require.NoError(t, err)
 
 	virtualService := buildVirtualService(testVirtualServiceName, DefaultTestNamespace, "localhost", serverUrl.Scheme, uint32(port))
-	instance := &dynatracev1beta1.DynaKube{}
+	instance := &dynatracev1beta1.DynaKube{
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			APIURL: serverUrl.String(),
+		},
+	}
 	reconciler := IstioReconciler{
 		istioClient: fakeistio.NewSimpleClientset(virtualService),
 		scheme:      scheme.Scheme,

--- a/src/dtclient/communication_hosts.go
+++ b/src/dtclient/communication_hosts.go
@@ -22,7 +22,7 @@ type CommunicationHost struct {
 }
 
 func (dtc *dynatraceClient) GetCommunicationHostForClient() (CommunicationHost, error) {
-	return dtc.parseEndpoint(dtc.url)
+	return ParseEndpoint(dtc.url)
 }
 
 func (dtc *dynatraceClient) GetConnectionInfo() (ConnectionInfo, error) {
@@ -64,7 +64,7 @@ func (dtc *dynatraceClient) readResponseForConnectionInfo(response []byte) (Conn
 	formattedCommunicationEndpoints := resp.FormattedCommunicationEndpoints
 
 	for _, s := range resp.CommunicationEndpoints {
-		e, err := dtc.parseEndpoint(s)
+		e, err := ParseEndpoint(s)
 		if err != nil {
 			log.Info("failed to parse communication endpoint", "url", s)
 			continue
@@ -86,7 +86,7 @@ func (dtc *dynatraceClient) readResponseForConnectionInfo(response []byte) (Conn
 	return ci, nil
 }
 
-func (dtc *dynatraceClient) parseEndpoint(s string) (CommunicationHost, error) {
+func ParseEndpoint(s string) (CommunicationHost, error) {
 	u, err := url.ParseRequestURI(s)
 	if err != nil {
 		return CommunicationHost{}, errors.New("failed to parse URL")

--- a/src/dtclient/communication_hosts_test.go
+++ b/src/dtclient/communication_hosts_test.go
@@ -74,10 +74,7 @@ func TestParseEndpoints(t *testing.T) {
 	var err error
 	var ch CommunicationHost
 
-	// Successful parsing
-	dc := &dynatraceClient{}
-
-	ch, err = dc.parseEndpoint("https://example.live.dynatrace.com/communication")
+	ch, err = ParseEndpoint("https://example.live.dynatrace.com/communication")
 	assert.NoError(t, err)
 	assert.Equal(t, CommunicationHost{
 		Protocol: "https",
@@ -85,7 +82,7 @@ func TestParseEndpoints(t *testing.T) {
 		Port:     443,
 	}, ch)
 
-	ch, err = dc.parseEndpoint("https://managedhost.com:9999/here/communication")
+	ch, err = ParseEndpoint("https://managedhost.com:9999/here/communication")
 	assert.NoError(t, err)
 	assert.Equal(t, CommunicationHost{
 		Protocol: "https",
@@ -93,7 +90,7 @@ func TestParseEndpoints(t *testing.T) {
 		Port:     9999,
 	}, ch)
 
-	ch, err = dc.parseEndpoint("https://example.live.dynatrace.com/communication")
+	ch, err = ParseEndpoint("https://example.live.dynatrace.com/communication")
 	assert.NoError(t, err)
 	assert.Equal(t, CommunicationHost{
 		Protocol: "https",
@@ -101,7 +98,7 @@ func TestParseEndpoints(t *testing.T) {
 		Port:     443,
 	}, ch)
 
-	ch, err = dc.parseEndpoint("https://10.0.0.1:8000/communication")
+	ch, err = ParseEndpoint("https://10.0.0.1:8000/communication")
 	assert.NoError(t, err)
 	assert.Equal(t, CommunicationHost{
 		Protocol: "https",
@@ -109,7 +106,7 @@ func TestParseEndpoints(t *testing.T) {
 		Port:     8000,
 	}, ch)
 
-	ch, err = dc.parseEndpoint("http://insecurehost/communication")
+	ch, err = ParseEndpoint("http://insecurehost/communication")
 	assert.NoError(t, err)
 	assert.Equal(t, CommunicationHost{
 		Protocol: "http",
@@ -119,19 +116,19 @@ func TestParseEndpoints(t *testing.T) {
 
 	// Failures
 
-	_, err = dc.parseEndpoint("https://managedhost.com:notaport/here/communication")
+	_, err = ParseEndpoint("https://managedhost.com:notaport/here/communication")
 	assert.Error(t, err)
 
-	_, err = dc.parseEndpoint("example.live.dynatrace.com:80/communication")
+	_, err = ParseEndpoint("example.live.dynatrace.com:80/communication")
 	assert.Error(t, err)
 
-	_, err = dc.parseEndpoint("ftp://randomhost.com:80/communication")
+	_, err = ParseEndpoint("ftp://randomhost.com:80/communication")
 	assert.Error(t, err)
 
-	_, err = dc.parseEndpoint("unix:///some/local/file")
+	_, err = ParseEndpoint("unix:///some/local/file")
 	assert.Error(t, err)
 
-	_, err = dc.parseEndpoint("shouldnotbeparsed")
+	_, err = ParseEndpoint("shouldnotbeparsed")
 	assert.Error(t, err)
 }
 

--- a/src/testing/e2e/integrationtests/istio_integration_test.go
+++ b/src/testing/e2e/integrationtests/istio_integration_test.go
@@ -104,7 +104,7 @@ func TestReconcileOneAgent_ReconcileIstioWithMultipleOneAgentObjects(t *testing.
 	assert.NoError(t, err, "failed to reconcile")
 	_, err = e.Reconciler.Reconcile(context.TODO(), req2)
 	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 8, 8)
+	assertIstioObjects(t, e.Client, 6, 6)
 
 	// Remove two communication endpoints.
 	e.CommunicationHosts = e.CommunicationHosts[2:]
@@ -112,7 +112,7 @@ func TestReconcileOneAgent_ReconcileIstioWithMultipleOneAgentObjects(t *testing.
 	assert.NoError(t, err, "failed to reconcile")
 	_, err = e.Reconciler.Reconcile(context.TODO(), req2)
 	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 4, 4)
+	assertIstioObjects(t, e.Client, 6, 6)
 }
 
 // assertIstioObjects confirms that we have the expected number of ServiceEntry and VirtualService objects, set by ese and evs respectively.

--- a/src/testing/e2e/integrationtests/istio_integration_test.go
+++ b/src/testing/e2e/integrationtests/istio_integration_test.go
@@ -44,13 +44,13 @@ func TestReconcileOneAgent_ReconcileIstio(t *testing.T) {
 	e.CommunicationHosts = append(e.CommunicationHosts, "https://endpoint3.test.com/communication")
 	_, err = e.Reconciler.Reconcile(context.TODO(), req)
 	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 4, 4)
+	assertIstioObjects(t, e.Client, 3, 3)
 
 	// Remove two communication endpoints.
 	e.CommunicationHosts = e.CommunicationHosts[2:]
 	_, err = e.Reconciler.Reconcile(context.TODO(), req)
 	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 2, 2)
+	assertIstioObjects(t, e.Client, 3, 3)
 }
 
 func TestReconcileOneAgent_ReconcileIstioWithMultipleOneAgentObjects(t *testing.T) {


### PR DESCRIPTION
# Description

The Istio reconciliation only start after the tokens have been checked for validity.
The validity check is done using an API call which is blocked if Istio is started in REGISTRY_ONLY mode.

This PR fixes that circular dependency by first reconciling Istio objects if the flag is enabled.
Then reconciling the dynakube custom resource.

## How can this be tested?

* Create a cluster
* Install Istio with outboundTraffic mode being set to REGISTRY_ONLY
* Deploy the operator
* Label dynatrace namespace and test namespaces with `kubectl label namespace <namespace> istio-injection=enabled`
* Apply a Dynakube with the enableIstio flag being set to true
* The logs should show that service entries and virtual services are being created
* One set is created even without tokens for the specified API url
* For other communication hosts, they are created if valid tokens are added as a secret
* Monitored entities should afterwards show up in the UI

On a cluster without Istio and without  the flag being set to true, the Operator should be have as usual

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

