### PR TITLE
Fix code modules image download loop

### DIFF
--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -133,7 +133,7 @@ func (installer *ImageInstaller) installAgentFromImage() error {
 
 func (installer ImageInstaller) isAlreadyDownloaded(imageDigestEncoded string) bool {
 	sharedDir := installer.props.PathResolver.AgentSharedBinaryDirForImage(installer.props.ImageDigest)
-	if _, err := installer.fs.Stat(sharedDir); !os.IsNotExist(err) {
+	if _, err := installer.fs.Stat(sharedDir); os.IsNotExist(err) {
 		return false
 	}
 	if installer.props.ImageDigest == imageDigestEncoded {


### PR DESCRIPTION
# Description

If the custom code modules image field is set, our CSI driver downloads the oneagent by using the custom docker image. Due to a bug, the image was downloaded on every reconciliation.

## How can this be tested?

Start application monitoring with custom code modules image and check if "image is already installed" is in the log messages of the csi driver pod.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

