### PR TITLE
Fixes kubeversion property in Chart.yaml

### DIFF
--- a/config/helm/chart/default/Chart.yaml
+++ b/config/helm/chart/default/Chart.yaml
@@ -20,7 +20,7 @@ home: https://www.dynatrace.com/
 type: application
 version: 0.7.1
 appVersion: 0.7.1
-kubeVersion: ">=1.21"
+kubeVersion: '>=1.21.0-0'
 maintainers:
 - name: 0sewa0
   email: marcell.sevcsik@dynatrace.com


### PR DESCRIPTION
# Description

Adds a dash to the kubeVersion property of the Helm chart to also match version with a build version

## How can this be tested?

Run `make manifests`.
If it succeeds, it works.


## Checklist
~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

