### PR TITLE
Improves isAlreadyDownloaded for ImageInstaller

### DIFF
--- a/src/controllers/csi/metadata/fakes.go
+++ b/src/controllers/csi/metadata/fakes.go
@@ -68,4 +68,6 @@ func (f *FakeFailDB) GetAllUsedVersions() (map[string]bool, error) { return nil,
 
 func (f *FakeFailDB) GetUsedImageDigests() (map[string]bool, error) { return nil, sql.ErrTxDone }
 
-func (f *FakeFailDB) GetDynakubeNamesForImageDigest(imageDigest string) ([]string, error)  { return nil, sql.ErrTxDone }
+func (f *FakeFailDB) GetDynakubeNamesForImageDigest(imageDigest string) ([]string, error) {
+	return nil, sql.ErrTxDone
+}

--- a/src/controllers/csi/metadata/fakes.go
+++ b/src/controllers/csi/metadata/fakes.go
@@ -68,6 +68,6 @@ func (f *FakeFailDB) GetAllUsedVersions() (map[string]bool, error) { return nil,
 
 func (f *FakeFailDB) GetUsedImageDigests() (map[string]bool, error) { return nil, sql.ErrTxDone }
 
-func (f *FakeFailDB) GetDynakubeNamesForImageDigest(imageDigest string) ([]string, error) {
-	return nil, sql.ErrTxDone
+func (f *FakeFailDB) IsImageDigestUsed(imageDigest string) (bool, error) {
+	return false, sql.ErrTxDone
 }

--- a/src/controllers/csi/metadata/fakes.go
+++ b/src/controllers/csi/metadata/fakes.go
@@ -67,3 +67,5 @@ func (f *FakeFailDB) GetUsedVersions(tenantUUID string) (map[string]bool, error)
 func (f *FakeFailDB) GetAllUsedVersions() (map[string]bool, error) { return nil, sql.ErrTxDone }
 
 func (f *FakeFailDB) GetUsedImageDigests() (map[string]bool, error) { return nil, sql.ErrTxDone }
+
+func (f *FakeFailDB) GetDynakubeNamesForImageDigest(imageDigest string) ([]string, error)  { return nil, sql.ErrTxDone }

--- a/src/controllers/csi/metadata/metadata.go
+++ b/src/controllers/csi/metadata/metadata.go
@@ -76,7 +76,7 @@ type Access interface {
 	GetUsedVersions(tenantUUID string) (map[string]bool, error)
 	GetAllUsedVersions() (map[string]bool, error)
 	GetUsedImageDigests() (map[string]bool, error)
-	GetDynakubeNamesForImageDigest(imageDigest string) ([]string, error)
+	IsImageDigestUsed(imageDigest string) (bool, error)
 }
 
 type AccessOverview struct {

--- a/src/controllers/csi/metadata/metadata.go
+++ b/src/controllers/csi/metadata/metadata.go
@@ -76,6 +76,7 @@ type Access interface {
 	GetUsedVersions(tenantUUID string) (map[string]bool, error)
 	GetAllUsedVersions() (map[string]bool, error)
 	GetUsedImageDigests() (map[string]bool, error)
+	GetDynakubeNamesForImageDigest(imageDigest string) ([]string, error)
 }
 
 type AccessOverview struct {

--- a/src/controllers/csi/metadata/sqlite_test.go
+++ b/src/controllers/csi/metadata/sqlite_test.go
@@ -426,6 +426,35 @@ func TestGetUsedImageDigests(t *testing.T) {
 	assert.True(t, digests[testDynakube2.ImageDigest])
 }
 
+func TestGetDynakubeNamesForImageDigest(t *testing.T) {
+	db := FakeMemoryDB()
+
+	dynakubeNames, err := db.GetDynakubeNamesForImageDigest("test")
+	require.NoError(t, err)
+	require.Empty(t, dynakubeNames)
+
+	testDynakube1 := createTestDynakube(1)
+	err = db.InsertDynakube(&testDynakube1)
+	require.NoError(t, err)
+
+	dynakubeNames, err = db.GetDynakubeNamesForImageDigest(testDynakube1.ImageDigest)
+	require.NoError(t, err)
+	require.Len(t, dynakubeNames, 1)
+
+	copyDynakube := testDynakube1
+	copyDynakube.Name = "copy"
+	err = db.InsertDynakube(&copyDynakube)
+	require.NoError(t, err)
+
+	testDynakube2 := createTestDynakube(2)
+	err = db.InsertDynakube(&testDynakube2)
+	require.NoError(t, err)
+
+	dynakubeNames, err = db.GetDynakubeNamesForImageDigest(testDynakube1.ImageDigest)
+	require.NoError(t, err)
+	require.Len(t, dynakubeNames, 2)
+}
+
 func TestGetPodNames(t *testing.T) {
 	testVolume1 := createTestVolume(1)
 	testVolume2 := createTestVolume(2)

--- a/src/controllers/csi/metadata/sqlite_test.go
+++ b/src/controllers/csi/metadata/sqlite_test.go
@@ -426,33 +426,20 @@ func TestGetUsedImageDigests(t *testing.T) {
 	assert.True(t, digests[testDynakube2.ImageDigest])
 }
 
-func TestGetDynakubeNamesForImageDigest(t *testing.T) {
+func TestIsImageDigestUsed(t *testing.T) {
 	db := FakeMemoryDB()
 
-	dynakubeNames, err := db.GetDynakubeNamesForImageDigest("test")
+	isUsed, err := db.IsImageDigestUsed("test")
 	require.NoError(t, err)
-	require.Empty(t, dynakubeNames)
+	require.False(t, isUsed)
 
 	testDynakube1 := createTestDynakube(1)
 	err = db.InsertDynakube(&testDynakube1)
 	require.NoError(t, err)
 
-	dynakubeNames, err = db.GetDynakubeNamesForImageDigest(testDynakube1.ImageDigest)
+	isUsed, err = db.IsImageDigestUsed(testDynakube1.ImageDigest)
 	require.NoError(t, err)
-	require.Len(t, dynakubeNames, 1)
-
-	copyDynakube := testDynakube1
-	copyDynakube.Name = "copy"
-	err = db.InsertDynakube(&copyDynakube)
-	require.NoError(t, err)
-
-	testDynakube2 := createTestDynakube(2)
-	err = db.InsertDynakube(&testDynakube2)
-	require.NoError(t, err)
-
-	dynakubeNames, err = db.GetDynakubeNamesForImageDigest(testDynakube1.ImageDigest)
-	require.NoError(t, err)
-	require.Len(t, dynakubeNames, 2)
+	require.True(t, isUsed)
 }
 
 func TestGetPodNames(t *testing.T) {

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -120,6 +120,7 @@ func setupImageInstaller(ctx context.Context, fs afero.Fs, apiReader client.Read
 	imageInstaller := image.NewImageInstaller(fs, &image.Properties{
 		ImageUri:     dynakube.CodeModulesImage(),
 		PathResolver: pathResolver,
+		Metadata:     db,
 		DockerConfig: *dockerConfig})
 	return imageInstaller, nil
 }

--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -60,14 +60,14 @@ func newAgentImageUpdater(
 	fs afero.Fs,
 	apiReader client.Reader,
 	path metadata.PathResolver,
+	db metadata.Access,
 	recorder record.EventRecorder,
-	dk *dynatracev1beta1.DynaKube,
-	digest string) (*agentUpdater, error) {
+	dk *dynatracev1beta1.DynaKube) (*agentUpdater, error) {
 
 	tenantUUID := dk.ConnectionInfo().TenantUUID
 	certPath := path.ImageCertPath(tenantUUID)
 
-	agentInstaller, err := setupImageInstaller(ctx, fs, path, apiReader, certPath, digest, dk)
+	agentInstaller, err := setupImageInstaller(ctx, fs, apiReader, path, db, certPath, dk)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func getUrlProperties(targetVersion, previousVersion string) *url.Properties {
 	}
 }
 
-func setupImageInstaller(ctx context.Context, fs afero.Fs, pathResolver metadata.PathResolver, apiReader client.Reader, certPath, digest string, dynakube *dynatracev1beta1.DynaKube) (installer.Installer, error) {
+func setupImageInstaller(ctx context.Context, fs afero.Fs, apiReader client.Reader, pathResolver metadata.PathResolver, db metadata.Access, certPath string, dynakube *dynatracev1beta1.DynaKube) (installer.Installer, error) {
 	dockerConfig := dockerconfig.NewDockerConfig(apiReader, *dynakube)
 	if dynakube.Spec.CustomPullSecret != "" {
 		err := dockerConfig.SetupAuths(ctx)
@@ -119,7 +119,6 @@ func setupImageInstaller(ctx context.Context, fs afero.Fs, pathResolver metadata
 
 	imageInstaller := image.NewImageInstaller(fs, &image.Properties{
 		ImageUri:     dynakube.CodeModulesImage(),
-		ImageDigest:  digest,
 		PathResolver: pathResolver,
 		DockerConfig: *dockerConfig})
 	return imageInstaller, nil

--- a/src/controllers/csi/provisioner/agent_test.go
+++ b/src/controllers/csi/provisioner/agent_test.go
@@ -334,8 +334,9 @@ func createTestAgentImageUpdater(t *testing.T, dk *dynatracev1beta1.DynaKube, ob
 	path := metadata.PathResolver{RootDir: "test"}
 	fs := afero.NewMemMapFs()
 	rec := record.NewFakeRecorder(10)
+	db := metadata.FakeMemoryDB()
 
-	updater, err := newAgentImageUpdater(context.TODO(), fs, fake.NewClient(obj...), path, rec, dk, testDigest)
+	updater, err := newAgentImageUpdater(context.TODO(), fs, fake.NewClient(obj...), path, db, rec, dk)
 	require.NoError(t, err)
 	updater.installer = &installer.InstallerMock{}
 

--- a/src/controllers/csi/provisioner/agent_test.go
+++ b/src/controllers/csi/provisioner/agent_test.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	testVersion = "test"
-	testDigest  = "123iamDigest456"
 )
 
 func TestNewAgentUpdater(t *testing.T) {

--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -160,7 +160,7 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 	var agentUpdater *agentUpdater
 	if dk.CodeModulesImage() != "" {
 		latestProcessModuleConfig = latestProcessModuleConfig.AddConnectionInfo(dk.ConnectionInfo())
-		agentUpdater, err = newAgentImageUpdater(ctx, provisioner.fs, provisioner.apiReader, provisioner.path, provisioner.recorder, dk, dynakubeMetadata.ImageDigest)
+		agentUpdater, err = newAgentImageUpdater(ctx, provisioner.fs, provisioner.apiReader, provisioner.path, provisioner.db, provisioner.recorder, dk,)
 		if err != nil {
 			log.Error(err, "error when setting up the agent image updater")
 			return nil, false, err

--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -160,7 +160,7 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 	var agentUpdater *agentUpdater
 	if dk.CodeModulesImage() != "" {
 		latestProcessModuleConfig = latestProcessModuleConfig.AddConnectionInfo(dk.ConnectionInfo())
-		agentUpdater, err = newAgentImageUpdater(ctx, provisioner.fs, provisioner.apiReader, provisioner.path, provisioner.db, provisioner.recorder, dk,)
+		agentUpdater, err = newAgentImageUpdater(ctx, provisioner.fs, provisioner.apiReader, provisioner.path, provisioner.db, provisioner.recorder, dk)
 		if err != nil {
 			log.Error(err, "error when setting up the agent image updater")
 			return nil, false, err

--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -143,7 +143,7 @@ func (installer ImageInstaller) isAlreadyDownloaded(imageDigestEncoded string) (
 	if _, err := installer.fs.Stat(sharedDir); os.IsNotExist(err) {
 		return false, nil
 	} else if err != nil {
-		return false, err
+		return false, errors.WithStack(err)
 	}
 
 	dynakubeNames, err := installer.props.Metadata.GetDynakubeNamesForImageDigest(imageDigestEncoded)

--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -20,9 +20,10 @@ import (
 
 type Properties struct {
 	ImageUri     string
-	ImageDigest  string
 	DockerConfig dockerconfig.DockerConfig
 	PathResolver metadata.PathResolver
+	Metadata     metadata.Access
+	imageDigest  string
 }
 
 func NewImageInstaller(fs afero.Fs, props *Properties) *ImageInstaller {
@@ -38,7 +39,7 @@ type ImageInstaller struct {
 }
 
 func (installer ImageInstaller) ImageDigest() string {
-	return installer.props.ImageDigest
+	return installer.props.imageDigest
 }
 
 func (installer *ImageInstaller) InstallAgent(targetDir string) (bool, error) {
@@ -56,7 +57,7 @@ func (installer *ImageInstaller) InstallAgent(targetDir string) (bool, error) {
 		return false, errors.WithStack(err)
 	}
 
-	sharedDir := installer.props.PathResolver.AgentSharedBinaryDirForImage(installer.props.ImageDigest)
+	sharedDir := installer.props.PathResolver.AgentSharedBinaryDirForImage(installer.props.imageDigest)
 	if err := symlink.CreateSymlinkForCurrentVersionIfNotExists(installer.fs, sharedDir); err != nil {
 		_ = installer.fs.RemoveAll(targetDir)
 		_ = installer.fs.RemoveAll(sharedDir)
@@ -67,7 +68,7 @@ func (installer *ImageInstaller) InstallAgent(targetDir string) (bool, error) {
 }
 
 func (installer ImageInstaller) UpdateProcessModuleConfig(targetDir string, processModuleConfig *dtypes.ProcessModuleConfig) error {
-	sourceDir := installer.props.PathResolver.AgentSharedBinaryDirForImage(installer.props.ImageDigest)
+	sourceDir := installer.props.PathResolver.AgentSharedBinaryDirForImage(installer.props.imageDigest)
 	return processmoduleconfig.CreateAgentConfigDir(installer.fs, targetDir, sourceDir, processModuleConfig)
 }
 
@@ -93,9 +94,14 @@ func (installer *ImageInstaller) installAgentFromImage() error {
 	}
 
 	imageDigestEncoded := imageDigest.Encoded()
-	if installer.isAlreadyDownloaded(imageDigestEncoded) {
+	isDownloaded, err := installer.isAlreadyDownloaded(imageDigestEncoded)
+	if err != nil {
+		log.Info("failed to determine state of download", "digest", imageDigestEncoded)
+		return errors.WithStack(err)
+	}
+	if isDownloaded {
 		log.Info("image is already installed", "image", image, "digest", imageDigestEncoded)
-		installer.props.ImageDigest = imageDigestEncoded
+		installer.props.imageDigest = imageDigestEncoded
 		return nil
 	}
 
@@ -127,19 +133,28 @@ func (installer *ImageInstaller) installAgentFromImage() error {
 		log.Info("failed to extract agent binaries from image", "image", image, "imageCacheDir", imageCacheDir)
 		return errors.WithStack(err)
 	}
-	installer.props.ImageDigest = imageDigestEncoded
+	installer.props.imageDigest = imageDigestEncoded
 	return nil
 }
 
-func (installer ImageInstaller) isAlreadyDownloaded(imageDigestEncoded string) bool {
-	sharedDir := installer.props.PathResolver.AgentSharedBinaryDirForImage(installer.props.ImageDigest)
+func (installer ImageInstaller) isAlreadyDownloaded(imageDigestEncoded string) (bool, error) {
+	sharedDir := installer.props.PathResolver.AgentSharedBinaryDirForImage(installer.props.imageDigest)
+
 	if _, err := installer.fs.Stat(sharedDir); os.IsNotExist(err) {
-		return false
+		return false, nil
+	} else if err != nil {
+		return false, err
 	}
-	if installer.props.ImageDigest == imageDigestEncoded {
-		return true
+
+	dynakubeNames, err := installer.props.Metadata.GetDynakubeNamesForImageDigest(imageDigestEncoded)
+	if err != nil {
+		return false, err
 	}
-	return false
+
+	if len(dynakubeNames) > 0 {
+		return true, nil
+	}
+	return false, nil
 }
 
 func getImageDigest(systemContext *types.SystemContext, imageReference *types.ImageReference) (digest.Digest, error) {

--- a/src/installer/image/installer_test.go
+++ b/src/installer/image/installer_test.go
@@ -1,0 +1,80 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAlreadyDownloaded(t *testing.T) {
+	imageDigest := "test"
+	pathResolver := metadata.PathResolver{}
+
+	t.Run(`returns early if path doesn't exist`, func(t *testing.T) {
+		installer := ImageInstaller{
+			fs: afero.NewMemMapFs(),
+			props: &Properties{
+				PathResolver: pathResolver,
+			},
+		}
+		isDownloaded, err := installer.isAlreadyDownloaded(imageDigest)
+		require.NoError(t, err)
+		assert.False(t, isDownloaded)
+	})
+	t.Run(`checks metadata if path already exists, no entry => previous download failed`, func(t *testing.T) {
+		installer := ImageInstaller{
+			fs: testFileSystemWithSharedDirPresent(pathResolver, imageDigest),
+			props: &Properties{
+				PathResolver: pathResolver,
+				Metadata: metadata.FakeMemoryDB(),
+			},
+		}
+		isDownloaded, err := installer.isAlreadyDownloaded(imageDigest)
+		require.NoError(t, err)
+		assert.False(t, isDownloaded)
+	})
+	t.Run(`checks metadata if path already exists, entry => previous download succeeded`, func(t *testing.T) {
+		installer := ImageInstaller{
+			fs: testFileSystemWithSharedDirPresent(pathResolver, imageDigest),
+			props: &Properties{
+				PathResolver: pathResolver,
+				Metadata: testMetadataWithImageDigestPresent(imageDigest),
+			},
+		}
+		isDownloaded, err := installer.isAlreadyDownloaded(imageDigest)
+		require.NoError(t, err)
+		assert.True(t, isDownloaded)
+	})
+	t.Run(`fail db`, func(t *testing.T) {
+		installer := ImageInstaller{
+			fs: testFileSystemWithSharedDirPresent(pathResolver, imageDigest),
+			props: &Properties{
+				PathResolver: pathResolver,
+				Metadata: &metadata.FakeFailDB{},
+			},
+		}
+		isDownloaded, err := installer.isAlreadyDownloaded(imageDigest)
+		require.Error(t, err)
+		assert.False(t, isDownloaded)
+	})
+}
+
+func testFileSystemWithSharedDirPresent(pathResolver metadata.PathResolver, imageDigest string) afero.Fs {
+	fs := afero.NewMemMapFs()
+	fs.MkdirAll(pathResolver.AgentSharedBinaryDirForImage(imageDigest), 0777)
+	return fs
+}
+
+func testMetadataWithImageDigestPresent(imageDigest string) metadata.Access {
+	db := metadata.FakeMemoryDB()
+	db.InsertDynakube(&metadata.Dynakube{
+		Name: "test",
+		TenantUUID: "test",
+		LatestVersion: "test",
+		ImageDigest: imageDigest,
+	})
+	return db
+}

--- a/src/installer/image/installer_test.go
+++ b/src/installer/image/installer_test.go
@@ -29,7 +29,7 @@ func TestIsAlreadyDownloaded(t *testing.T) {
 			fs: testFileSystemWithSharedDirPresent(pathResolver, imageDigest),
 			props: &Properties{
 				PathResolver: pathResolver,
-				Metadata: metadata.FakeMemoryDB(),
+				Metadata:     metadata.FakeMemoryDB(),
 			},
 		}
 		isDownloaded, err := installer.isAlreadyDownloaded(imageDigest)
@@ -41,7 +41,7 @@ func TestIsAlreadyDownloaded(t *testing.T) {
 			fs: testFileSystemWithSharedDirPresent(pathResolver, imageDigest),
 			props: &Properties{
 				PathResolver: pathResolver,
-				Metadata: testMetadataWithImageDigestPresent(imageDigest),
+				Metadata:     testMetadataWithImageDigestPresent(imageDigest),
 			},
 		}
 		isDownloaded, err := installer.isAlreadyDownloaded(imageDigest)
@@ -53,7 +53,7 @@ func TestIsAlreadyDownloaded(t *testing.T) {
 			fs: testFileSystemWithSharedDirPresent(pathResolver, imageDigest),
 			props: &Properties{
 				PathResolver: pathResolver,
-				Metadata: &metadata.FakeFailDB{},
+				Metadata:     &metadata.FakeFailDB{},
 			},
 		}
 		isDownloaded, err := installer.isAlreadyDownloaded(imageDigest)
@@ -71,10 +71,10 @@ func testFileSystemWithSharedDirPresent(pathResolver metadata.PathResolver, imag
 func testMetadataWithImageDigestPresent(imageDigest string) metadata.Access {
 	db := metadata.FakeMemoryDB()
 	db.InsertDynakube(&metadata.Dynakube{
-		Name: "test",
-		TenantUUID: "test",
+		Name:          "test",
+		TenantUUID:    "test",
 		LatestVersion: "test",
-		ImageDigest: imageDigest,
+		ImageDigest:   imageDigest,
 	})
 	return db
 }


### PR DESCRIPTION
# Description

The `ImageInstaller`'s check  `isAlreadyDownloaded` didn't consider that there might have been other `Dynakubes` that have already downloaded the image, which caused unnecessary downloads.

## How can this be tested?
Have 2 Dynakubes, both use the same `codeModulesImage`.
1. Dynakube gets reconciled by the csi-driver provisioner ==> image gets downloaded
2. Dynakube gets reconciled by the csi-driver provisioner ==> image DOESN'T get downloaded, because its already present

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

