### PR TITLE
Use kind "Pod" when owner reference is empty

### DIFF
--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/workload.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/workload.go
@@ -52,9 +52,6 @@ func findRootOwnerOfPod(ctx context.Context, clt client.Client, pod *corev1.Pod,
 
 func findRootOwner(ctx context.Context, clt client.Client, partialObjectMetadata *metav1.PartialObjectMetadata) (workloadInfo, error) {
 	if len(partialObjectMetadata.ObjectMeta.OwnerReferences) == 0 {
-		if partialObjectMetadata.Kind == "Pod" {
-			partialObjectMetadata.Kind = ""
-		}
 		return *newWorkloadInfo(partialObjectMetadata), nil
 	}
 

--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/workload_test.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/workload_test.go
@@ -84,6 +84,25 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 	})
 }
 
+func TestFindRootOwner(t *testing.T) {
+	ctx := context.TODO()
+	clt := fake.NewClient()
+	metadata := metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testPodName,
+		},
+	}
+
+	workload, err := findRootOwner(ctx, clt, &metadata)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Pod", workload.kind)
+	assert.Equal(t, testPodName, workload.name)
+}
+
 func createTestWorkloadInfo() *workloadInfo {
 	return &workloadInfo{
 		kind: "test",


### PR DESCRIPTION
(cherry picked from commit 72799e66a44908e4c2bd00494717aa6db6a4b5d7)

# Description

See https://github.com/Dynatrace/dynatrace-operator/pull/988

## How can this be tested?

See https://github.com/Dynatrace/dynatrace-operator/pull/988

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

