### PR TITLE
Resource limits in values.yaml not correctly used.

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -87,11 +87,11 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: {{ default "300m" ((.Values.csi).limits).cpu }}
-            memory: {{ default "100Mi" ((.Values.csi).limits).memory }}
+            cpu: {{ default "300m" ((.Values.csidriver).limits).cpu }}
+            memory: {{ default "100Mi" ((.Values.csidriver).limits).memory }}
           requests:
-            cpu: {{ default "300m" ((.Values.csi).requests).cpu }}
-            memory: {{ default "100Mi" ((.Values.csi).requests).memory }}
+            cpu: {{ default "300m" ((.Values.csidriver).requests).cpu }}
+            memory: {{ default "100Mi" ((.Values.csidriver).requests).memory }}
         securityContext:
           runAsUser: 0
           privileged: true # Needed for mountPropagation

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -275,3 +275,24 @@ tests:
       - equal:
           path: spec.template.metadata.labels.testKey
           value: testValue
+
+  - it: should take resource limits from values file
+    set:
+      csidriver.enabled: true
+      csidriver.requests.cpu: 600m
+      csidriver.requests.memory: 200Mi
+      csidriver.limits.cpu: 900m
+      csidriver.limits.memory: 300Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 600m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 200Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 900m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 300Mi


### PR DESCRIPTION
# Description
The Helm chart for the CSI driver daemon set did not correctly use the values file for resource limits.
Fixed Helm chart and added Helm unit test.

## How can this be tested?
- Adopt resource limit values in the values.yaml to some arbitrary values.
- Turn on CSI driver in values.yaml
- Install operator via Helm using the adopted values file.
- Check the installed daemonset manifest, Your values should be used for resource limits.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

