### PR TITLE
Installs Helm unittest plugin explicitly (#1001)

### DIFF
--- a/hack/helm/install-unittest-plugin.sh
+++ b/hack/helm/install-unittest-plugin.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+HELM_PLUGINS="$(helm env HELM_PLUGINS)"
+
+architecture="$(uname -m)"
+os="$(uname -s)"
+
+if [[ "${architecture}" == "x86_64" ]]; then
+  ARCH="amd64"
+elif [[ "${architecture}" == "aarch64" ]]; then
+  ARCH="arm64"
+else
+  echo "Unsupported architecture '${architecture}'"
+  exit 1
+fi
+
+if [[ "${os}" == "Linux" ]]; then
+  PLATFORM="linux"
+elif [[ "${os}" == "Darwin" ]]; then
+  PLATFORM="macos"
+else
+  echo "Unsupported operating system '${os}'"
+  exit 1
+fi
+
+
+helm plugin uninstall unittest || true
+curl \
+  -L "https://github.com/quintush/helm-unittest/releases/download/v0.2.8/helm-unittest-${PLATFORM}-${ARCH}-0.2.8.tgz" \
+  -o helm-unittest.tgz
+mkdir -p "${HELM_PLUGINS}/unittest"
+tar xzvf helm-unittest.tgz -C "${HELM_PLUGINS}/unittest"
+rm helm-unittest.tgz

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -7,7 +7,7 @@ endif
 
 ## Installs 'kustomize' if it is missing
 prerequisites/kustomize:
-	hack/build/command.sh kustomize "sigs.k8s.io/kustomize/kustomize/v3@v3.5.4"
+	hack/build/command.sh kustomize "sigs.k8s.io/kustomize/kustomize/v4@latest"
 KUSTOMIZE=$(shell hack/build/command.sh kustomize)
 
 ## Install 'controller-gen' if it is missing
@@ -21,3 +21,6 @@ prerequisites/setup-pre-commit:
 	go install golang.org/x/tools/cmd/goimports@v0.1.10
 	cp ./.github/pre-commit ./.git/hooks/pre-commit
 	chmod +x ./.git/hooks/pre-commit
+
+prerequisites/helm:
+	hack/helm/install-unittest-plugin.sh


### PR DESCRIPTION
(cherry picked from commit 2d98dc3c97413fd57d4a8f4ae3a4b33a99da1f2e)

# Description

See https://github.com/Dynatrace/dynatrace-operator/pull/1001

## How can this be tested?

See https://github.com/Dynatrace/dynatrace-operator/pull/1001


## Checklist
~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

