### PR TITLE
Fixes codemodules cache not being updated correctly

### DIFF
--- a/src/api/v1beta1/dynakube_status.go
+++ b/src/api/v1beta1/dynakube_status.go
@@ -59,8 +59,9 @@ type DynaKubeStatus struct {
 }
 
 type ConnectionInfoStatus struct {
-	CommunicationHosts []CommunicationHostStatus `json:"communicationHosts,omitempty"`
-	TenantUUID         string                    `json:"tenantUUID,omitempty"`
+	CommunicationHosts              []CommunicationHostStatus `json:"communicationHosts,omitempty"`
+	TenantUUID                      string                    `json:"tenantUUID,omitempty"`
+	FormattedCommunicationEndpoints string                    `json:"formattedCommunicationEndpoints,omitempty"`
 }
 
 type CommunicationHostStatus struct {

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -319,8 +319,9 @@ func (dk *DynaKube) CommunicationHostForClient() dtclient.CommunicationHost {
 
 func (dk *DynaKube) ConnectionInfo() dtclient.ConnectionInfo {
 	return dtclient.ConnectionInfo{
-		CommunicationHosts: dk.CommunicationHosts(),
-		TenantUUID:         dk.Status.ConnectionInfo.TenantUUID,
+		CommunicationHosts:              dk.CommunicationHosts(),
+		TenantUUID:                      dk.Status.ConnectionInfo.TenantUUID,
+		FormattedCommunicationEndpoints: dk.Status.ConnectionInfo.FormattedCommunicationEndpoints,
 	}
 }
 

--- a/src/controllers/dynakube/status/status.go
+++ b/src/controllers/dynakube/status/status.go
@@ -47,8 +47,9 @@ func SetDynakubeStatus(instance *dynatracev1beta1.DynaKube, opts Options) error 
 	communicationHostStatus := dynatracev1beta1.CommunicationHostStatus(communicationHost)
 
 	connectionInfoStatus := dynatracev1beta1.ConnectionInfoStatus{
-		CommunicationHosts: communicationHostsToStatus(connectionInfo.CommunicationHosts),
-		TenantUUID:         connectionInfo.TenantUUID,
+		CommunicationHosts:              communicationHostsToStatus(connectionInfo.CommunicationHosts),
+		TenantUUID:                      connectionInfo.TenantUUID,
+		FormattedCommunicationEndpoints: connectionInfo.FormattedCommunicationEndpoints,
 	}
 
 	instance.Status.KubeSystemUUID = string(uid)

--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -27,22 +27,35 @@ type ProcessModuleProperty struct {
 type ConfMap map[string]map[string]string
 
 func (pmc *ProcessModuleConfig) Add(newProperty ProcessModuleProperty) *ProcessModuleConfig {
-	if newProperty.Value == "" {
-		return pmc
-	}
-
-	var updatedProperties []ProcessModuleProperty
-
-	for _, cachedProperty := range pmc.Properties {
-		if cachedProperty.Key != newProperty.Key {
-			updatedProperties = append(updatedProperties, cachedProperty)
+	for index, cachedProperty := range pmc.Properties {
+		if cachedProperty.Key == newProperty.Key {
+			if newProperty.Value == "" {
+				pmc.removeProperty(index)
+			} else {
+				pmc.updateProperty(index, newProperty)
+			}
+			return pmc
 		}
 	}
 
-	updatedProperties = append(updatedProperties, newProperty)
+	if newProperty.Value != "" {
+		pmc.addProperty(newProperty)
+	}
 
-	pmc.Properties = updatedProperties
 	return pmc
+}
+
+func (pmc *ProcessModuleConfig) addProperty(newProperty ProcessModuleProperty) {
+	pmc.Properties = append(pmc.Properties, newProperty)
+}
+
+func (pmc *ProcessModuleConfig) updateProperty(index int, newProperty ProcessModuleProperty) {
+	pmc.Properties[index].Section = newProperty.Section
+	pmc.Properties[index].Value = newProperty.Value
+}
+
+func (pmc *ProcessModuleConfig) removeProperty(index int) {
+	pmc.Properties = append(pmc.Properties[0:index], pmc.Properties[index+1:]...)
 }
 
 func (pmc *ProcessModuleConfig) AddConnectionInfo(connectionInfo ConnectionInfo) *ProcessModuleConfig {

--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -27,30 +27,21 @@ type ProcessModuleProperty struct {
 type ConfMap map[string]map[string]string
 
 func (pmc *ProcessModuleConfig) Add(newProperty ProcessModuleProperty) *ProcessModuleConfig {
-	if pmc == nil {
-		pmc = &ProcessModuleConfig{}
+	if newProperty.Value == "" {
+		return pmc
 	}
 
-	var newProps []ProcessModuleProperty
-	hasPropertyGroup := false
-	for _, currentProperty := range pmc.Properties {
-		if currentProperty.Key != newProperty.Key {
-			newProps = append(newProps, currentProperty)
-		} else {
-			hasPropertyGroup = true
-			if newProperty.Value == "" {
-				continue
-			} else if newProperty.Value == currentProperty.Value {
-				newProps = append(newProps, currentProperty)
-			} else {
-				newProps = append(pmc.Properties, currentProperty)
-			}
+	var updatedProperties []ProcessModuleProperty
+
+	for _, cachedProperty := range pmc.Properties {
+		if cachedProperty.Key != newProperty.Key {
+			updatedProperties = append(updatedProperties, cachedProperty)
 		}
 	}
-	if !hasPropertyGroup && newProperty.Value != "" {
-		newProps = append(pmc.Properties, newProperty)
-	}
-	pmc.Properties = newProps
+
+	updatedProperties = append(updatedProperties, newProperty)
+
+	pmc.Properties = updatedProperties
 	return pmc
 }
 

--- a/src/dtclient/processmoduleconfig_test.go
+++ b/src/dtclient/processmoduleconfig_test.go
@@ -116,3 +116,7 @@ func TestAddHostGroup(t *testing.T) {
 		assert.Len(t, pmc.Properties, 0)
 	})
 }
+
+func TestAdd(t *testing.T) {
+
+}

--- a/src/dtclient/processmoduleconfig_test.go
+++ b/src/dtclient/processmoduleconfig_test.go
@@ -241,4 +241,46 @@ func TestAdd(t *testing.T) {
 			Value:   "new-value",
 		})
 	})
+	t.Run("fixes broken cache", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+
+		for i := 0; i < 10; i++ {
+			section := fmt.Sprintf("%s-%d", testSection, i)
+			key := fmt.Sprintf("%s-%d", testKey, i)
+			value := fmt.Sprintf("%s-%d", testValue, i)
+
+			processModuleConfig.Add(ProcessModuleProperty{
+				Section: section,
+				Key:     key,
+				Value:   value,
+			})
+		}
+		for i := 0; i < 10; i++ {
+			processModuleConfig.Properties = append(processModuleConfig.Properties, ProcessModuleProperty{
+				Section: testSection,
+				Key:     testKey,
+				Value:   testValue,
+			})
+		}
+
+		require.Len(t, processModuleConfig.Properties, 20)
+
+		processModuleConfig.Add(ProcessModuleProperty{
+			Section: testSection,
+			Key:     testKey,
+			Value:   "new-value",
+		})
+
+		assert.Len(t, processModuleConfig.Properties, 11)
+		assert.Contains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: testSection,
+			Key:     testKey,
+			Value:   "new-value",
+		})
+		assert.NotContains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: testSection,
+			Key:     testKey,
+			Value:   testValue,
+		})
+	})
 }

--- a/src/dtclient/processmoduleconfig_test.go
+++ b/src/dtclient/processmoduleconfig_test.go
@@ -1,6 +1,7 @@
 package dtclient
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -117,6 +118,111 @@ func TestAddHostGroup(t *testing.T) {
 	})
 }
 
-func TestAdd(t *testing.T) {
+const (
+	testSection = "test-section"
+	testKey     = "test-key"
+	testValue   = "test-value"
+)
 
+func TestAdd(t *testing.T) {
+	t.Run("adds properties", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+
+		for i := 0; i < 10; i++ {
+			section := fmt.Sprintf("%s-%d", testSection, i)
+			key := fmt.Sprintf("%s-%d", testKey, i)
+			value := fmt.Sprintf("%s-%d", testValue, i)
+
+			processModuleConfig.Add(ProcessModuleProperty{
+				Section: section,
+				Key:     key,
+				Value:   value,
+			})
+
+			assert.Len(t, processModuleConfig.Properties, i+1)
+			assert.Equal(t, section, processModuleConfig.Properties[i].Section)
+			assert.Equal(t, key, processModuleConfig.Properties[i].Key)
+			assert.Equal(t, value, processModuleConfig.Properties[i].Value)
+		}
+	})
+	t.Run("does not add empty values", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+		processModuleConfig.Add(ProcessModuleProperty{
+			Section: testSection,
+			Key:     testKey,
+			Value:   "",
+		})
+
+		assert.NotContains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: testSection,
+			Key:     testKey,
+			Value:   "",
+		})
+	})
+	t.Run("removes property", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+
+		for i := 0; i < 10; i++ {
+			section := fmt.Sprintf("%s-%d", testSection, i)
+			key := fmt.Sprintf("%s-%d", testKey, i)
+			value := fmt.Sprintf("%s-%d", testValue, i)
+
+			processModuleConfig.Add(ProcessModuleProperty{
+				Section: section,
+				Key:     key,
+				Value:   value,
+			})
+		}
+
+		processModuleConfig.Add(ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "",
+		})
+
+		assert.Len(t, processModuleConfig.Properties, 9)
+		assert.NotContains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "test-value-1",
+		})
+		assert.NotContains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "",
+		})
+	})
+	t.Run("updates property", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+
+		for i := 0; i < 10; i++ {
+			section := fmt.Sprintf("%s-%d", testSection, i)
+			key := fmt.Sprintf("%s-%d", testKey, i)
+			value := fmt.Sprintf("%s-%d", testValue, i)
+
+			processModuleConfig.Add(ProcessModuleProperty{
+				Section: section,
+				Key:     key,
+				Value:   value,
+			})
+		}
+
+		processModuleConfig.Add(ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "new-value",
+		})
+
+		assert.Len(t, processModuleConfig.Properties, 10)
+		assert.NotContains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "test-value-1",
+		})
+		assert.Contains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "new-value",
+		})
+	})
 }

--- a/src/dtclient/processmoduleconfig_test.go
+++ b/src/dtclient/processmoduleconfig_test.go
@@ -159,6 +159,22 @@ func TestAdd(t *testing.T) {
 			Value:   "",
 		})
 	})
+	t.Run("does not add same property multiple times", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+
+		for i := 0; i < 10; i++ {
+			processModuleConfig.Add(ProcessModuleProperty{
+				Section: testSection,
+				Key:     testKey,
+				Value:   testValue,
+			})
+
+			assert.Len(t, processModuleConfig.Properties, 1)
+			assert.Equal(t, testSection, processModuleConfig.Properties[0].Section)
+			assert.Equal(t, testKey, processModuleConfig.Properties[0].Key)
+			assert.Equal(t, testValue, processModuleConfig.Properties[0].Value)
+		}
+	})
 	t.Run("removes property", func(t *testing.T) {
 		processModuleConfig := &ProcessModuleConfig{}
 


### PR DESCRIPTION
# Description

When an Operator =< 0.7.2 is deployed, the cache in `revision.json` is not updated correctly.
Furthermore, the formatted endpoints are never set in the dynakube and therefore not set in the `ruxitagentproc.conf`

This PR fixes handling the cache and extends the Dynakube status with the endpoints

## How can this be tested?

* On a fresh cluster
* Deploy DTO on `release-0.8`
* Deploy an application-only dynakube
* Deploy sample apps
* The `revision.json` should have an or multiple empty `serverAddress` properties
* The Dynakube state should not have an `Formatted Communication Endpoints` property
* Deploy DTO from this branch
* Delete and redeploy Dynakube
* `revision.json` should be fixed
* `Formatted Communication Endpoints` property should exist in the Dynakube status


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

