### PR TITLE
Fixes codemodules cache not being updated correctly (#1008)

### DIFF
--- a/src/api/v1beta1/dynakube_status.go
+++ b/src/api/v1beta1/dynakube_status.go
@@ -59,8 +59,9 @@ type DynaKubeStatus struct {
 }
 
 type ConnectionInfoStatus struct {
-	CommunicationHosts []CommunicationHostStatus `json:"communicationHosts,omitempty"`
-	TenantUUID         string                    `json:"tenantUUID,omitempty"`
+	CommunicationHosts              []CommunicationHostStatus `json:"communicationHosts,omitempty"`
+	TenantUUID                      string                    `json:"tenantUUID,omitempty"`
+	FormattedCommunicationEndpoints string                    `json:"formattedCommunicationEndpoints,omitempty"`
 }
 
 type CommunicationHostStatus struct {

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -319,8 +319,9 @@ func (dk *DynaKube) CommunicationHostForClient() dtclient.CommunicationHost {
 
 func (dk *DynaKube) ConnectionInfo() dtclient.ConnectionInfo {
 	return dtclient.ConnectionInfo{
-		CommunicationHosts: dk.CommunicationHosts(),
-		TenantUUID:         dk.Status.ConnectionInfo.TenantUUID,
+		CommunicationHosts:              dk.CommunicationHosts(),
+		TenantUUID:                      dk.Status.ConnectionInfo.TenantUUID,
+		FormattedCommunicationEndpoints: dk.Status.ConnectionInfo.FormattedCommunicationEndpoints,
 	}
 }
 

--- a/src/controllers/dynakube/status/status.go
+++ b/src/controllers/dynakube/status/status.go
@@ -47,8 +47,9 @@ func SetDynakubeStatus(instance *dynatracev1beta1.DynaKube, opts Options) error 
 	communicationHostStatus := dynatracev1beta1.CommunicationHostStatus(communicationHost)
 
 	connectionInfoStatus := dynatracev1beta1.ConnectionInfoStatus{
-		CommunicationHosts: communicationHostsToStatus(connectionInfo.CommunicationHosts),
-		TenantUUID:         connectionInfo.TenantUUID,
+		CommunicationHosts:              communicationHostsToStatus(connectionInfo.CommunicationHosts),
+		TenantUUID:                      connectionInfo.TenantUUID,
+		FormattedCommunicationEndpoints: connectionInfo.FormattedCommunicationEndpoints,
 	}
 
 	instance.Status.KubeSystemUUID = string(uid)

--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -27,31 +27,58 @@ type ProcessModuleProperty struct {
 type ConfMap map[string]map[string]string
 
 func (pmc *ProcessModuleConfig) Add(newProperty ProcessModuleProperty) *ProcessModuleConfig {
-	if pmc == nil {
-		pmc = &ProcessModuleConfig{}
-	}
+	pmc.fixBrokenCache()
 
-	var newProps []ProcessModuleProperty
-	hasPropertyGroup := false
-	for _, currentProperty := range pmc.Properties {
-		if currentProperty.Key != newProperty.Key {
-			newProps = append(newProps, currentProperty)
-		} else {
-			hasPropertyGroup = true
+	for index, cachedProperty := range pmc.Properties {
+		if cachedProperty.Key == newProperty.Key {
 			if newProperty.Value == "" {
-				continue
-			} else if newProperty.Value == currentProperty.Value {
-				newProps = append(newProps, currentProperty)
+				pmc.removeProperty(index)
 			} else {
-				newProps = append(pmc.Properties, currentProperty)
+				pmc.updateProperty(index, newProperty)
 			}
+			return pmc
 		}
 	}
-	if !hasPropertyGroup && newProperty.Value != "" {
-		newProps = append(pmc.Properties, newProperty)
+
+	if newProperty.Value != "" {
+		pmc.addProperty(newProperty)
 	}
-	pmc.Properties = newProps
+
 	return pmc
+}
+
+// fixBrokenCache fixes a cache that might have been broken by previous versions
+// Older operator versions handled the cache wrong and multiplied properties on an update
+// instead of updating it.
+// The fixed algorithm in Add cannot handle this broken cache without this function
+// It adds every property first to a map using the property's key, to make them distinct
+// Then collects the now distinct properties and updates the cache
+func (pmc *ProcessModuleConfig) fixBrokenCache() {
+	properties := make([]ProcessModuleProperty, 0, len(pmc.Properties))
+	propertyMap := make(map[string]ProcessModuleProperty)
+
+	for _, property := range pmc.Properties {
+		propertyMap[property.Key] = property
+	}
+
+	for _, value := range propertyMap {
+		properties = append(properties, value)
+	}
+
+	pmc.Properties = properties
+}
+
+func (pmc *ProcessModuleConfig) addProperty(newProperty ProcessModuleProperty) {
+	pmc.Properties = append(pmc.Properties, newProperty)
+}
+
+func (pmc *ProcessModuleConfig) updateProperty(index int, newProperty ProcessModuleProperty) {
+	pmc.Properties[index].Section = newProperty.Section
+	pmc.Properties[index].Value = newProperty.Value
+}
+
+func (pmc *ProcessModuleConfig) removeProperty(index int) {
+	pmc.Properties = append(pmc.Properties[0:index], pmc.Properties[index+1:]...)
 }
 
 func (pmc *ProcessModuleConfig) AddConnectionInfo(connectionInfo ConnectionInfo) *ProcessModuleConfig {

--- a/src/dtclient/processmoduleconfig_test.go
+++ b/src/dtclient/processmoduleconfig_test.go
@@ -1,6 +1,7 @@
 package dtclient
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -114,5 +115,172 @@ func TestAddHostGroup(t *testing.T) {
 		result := pmc.AddHostGroup("")
 		assert.NotNil(t, result)
 		assert.Len(t, pmc.Properties, 0)
+	})
+}
+
+const (
+	testSection = "test-section"
+	testKey     = "test-key"
+	testValue   = "test-value"
+)
+
+func TestAdd(t *testing.T) {
+	t.Run("adds properties", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+
+		for i := 0; i < 10; i++ {
+			section := fmt.Sprintf("%s-%d", testSection, i)
+			key := fmt.Sprintf("%s-%d", testKey, i)
+			value := fmt.Sprintf("%s-%d", testValue, i)
+
+			processModuleConfig.Add(ProcessModuleProperty{
+				Section: section,
+				Key:     key,
+				Value:   value,
+			})
+
+			assert.Len(t, processModuleConfig.Properties, i+1)
+			assert.Equal(t, section, processModuleConfig.Properties[i].Section)
+			assert.Equal(t, key, processModuleConfig.Properties[i].Key)
+			assert.Equal(t, value, processModuleConfig.Properties[i].Value)
+		}
+	})
+	t.Run("does not add empty values", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+		processModuleConfig.Add(ProcessModuleProperty{
+			Section: testSection,
+			Key:     testKey,
+			Value:   "",
+		})
+
+		assert.NotContains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: testSection,
+			Key:     testKey,
+			Value:   "",
+		})
+	})
+	t.Run("does not add same property multiple times", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+
+		for i := 0; i < 10; i++ {
+			processModuleConfig.Add(ProcessModuleProperty{
+				Section: testSection,
+				Key:     testKey,
+				Value:   testValue,
+			})
+
+			assert.Len(t, processModuleConfig.Properties, 1)
+			assert.Equal(t, testSection, processModuleConfig.Properties[0].Section)
+			assert.Equal(t, testKey, processModuleConfig.Properties[0].Key)
+			assert.Equal(t, testValue, processModuleConfig.Properties[0].Value)
+		}
+	})
+	t.Run("removes property", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+
+		for i := 0; i < 10; i++ {
+			section := fmt.Sprintf("%s-%d", testSection, i)
+			key := fmt.Sprintf("%s-%d", testKey, i)
+			value := fmt.Sprintf("%s-%d", testValue, i)
+
+			processModuleConfig.Add(ProcessModuleProperty{
+				Section: section,
+				Key:     key,
+				Value:   value,
+			})
+		}
+
+		processModuleConfig.Add(ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "",
+		})
+
+		assert.Len(t, processModuleConfig.Properties, 9)
+		assert.NotContains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "test-value-1",
+		})
+		assert.NotContains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "",
+		})
+	})
+	t.Run("updates property", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+
+		for i := 0; i < 10; i++ {
+			section := fmt.Sprintf("%s-%d", testSection, i)
+			key := fmt.Sprintf("%s-%d", testKey, i)
+			value := fmt.Sprintf("%s-%d", testValue, i)
+
+			processModuleConfig.Add(ProcessModuleProperty{
+				Section: section,
+				Key:     key,
+				Value:   value,
+			})
+		}
+
+		processModuleConfig.Add(ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "new-value",
+		})
+
+		assert.Len(t, processModuleConfig.Properties, 10)
+		assert.NotContains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "test-value-1",
+		})
+		assert.Contains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: "test-section-1",
+			Key:     "test-key-1",
+			Value:   "new-value",
+		})
+	})
+	t.Run("fixes broken cache", func(t *testing.T) {
+		processModuleConfig := &ProcessModuleConfig{}
+
+		for i := 0; i < 10; i++ {
+			section := fmt.Sprintf("%s-%d", testSection, i)
+			key := fmt.Sprintf("%s-%d", testKey, i)
+			value := fmt.Sprintf("%s-%d", testValue, i)
+
+			processModuleConfig.Add(ProcessModuleProperty{
+				Section: section,
+				Key:     key,
+				Value:   value,
+			})
+		}
+		for i := 0; i < 10; i++ {
+			processModuleConfig.Properties = append(processModuleConfig.Properties, ProcessModuleProperty{
+				Section: testSection,
+				Key:     testKey,
+				Value:   testValue,
+			})
+		}
+
+		require.Len(t, processModuleConfig.Properties, 20)
+
+		processModuleConfig.Add(ProcessModuleProperty{
+			Section: testSection,
+			Key:     testKey,
+			Value:   "new-value",
+		})
+
+		assert.Len(t, processModuleConfig.Properties, 11)
+		assert.Contains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: testSection,
+			Key:     testKey,
+			Value:   "new-value",
+		})
+		assert.NotContains(t, processModuleConfig.Properties, ProcessModuleProperty{
+			Section: testSection,
+			Key:     testKey,
+			Value:   testValue,
+		})
 	})
 }


### PR DESCRIPTION
# Description

see https://github.com/Dynatrace/dynatrace-operator/pull/1008

## How can this be tested?

see https://github.com/Dynatrace/dynatrace-operator/pull/1008

N.B.: the `master` version of the Operator instead of `release-0.8` must be used since this fix is already merged in `release-0.8`


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

