### PR TITLE
 Fixes OneAgent daemonset not having a separate service account for privileged mode

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1289,12 +1289,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1302,12 +1305,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -1625,12 +1660,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1638,12 +1676,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -2793,12 +2863,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -2806,12 +2879,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1289,15 +1289,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1305,44 +1302,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -1660,15 +1625,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1676,44 +1638,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -2863,15 +2793,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -2879,44 +2806,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -3074,6 +2969,8 @@ spec:
                           type: string
                       type: object
                     type: array
+                  formattedCommunicationEndpoints:
+                    type: string
                   tenantUUID:
                     type: string
                 type: object

--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -59,6 +59,31 @@ metadata:
     app.kubernetes.io/version: "0.8.0"
     app.kubernetes.io/component: activegate
 ---
+# Source: dynatrace-operator/templates/Common/oneagent/serviceaccount-oneagent-privileged.yaml
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-dynakube-oneagent-privileged
+  namespace: dynatrace
+  labels:
+    app.kubernetes.io/name: dynatrace-operator
+    app.kubernetes.io/version: "0.0.0-snapshot"
+    app.kubernetes.io/component: oneagent
+automountServiceAccountToken: false
+---
 # Source: dynatrace-operator/templates/Common/oneagent/serviceaccount-oneagent-unprivileged.yaml
 # Copyright 2021 Dynatrace LLC
 
@@ -138,7 +163,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -1434,12 +1458,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1447,12 +1474,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -1770,12 +1829,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1783,12 +1845,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -2938,12 +3032,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -2951,12 +3048,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with

--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -80,7 +80,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.0.0-snapshot"
+    app.kubernetes.io/version: "0.8.0"
     app.kubernetes.io/component: oneagent
 automountServiceAccountToken: false
 ---
@@ -1458,15 +1458,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1474,44 +1471,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -1829,15 +1794,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1845,44 +1807,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -3032,15 +2962,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -3048,44 +2975,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -3243,6 +3138,8 @@ spec:
                           type: string
                       type: object
                     type: array
+                  formattedCommunicationEndpoints:
+                    type: string
                   tenantUUID:
                     type: string
                 type: object
@@ -4088,7 +3985,7 @@ spec:
             - operator
           # Replace this with the built image name
           image:
-            quay.io/dynatrace/dynatrace-operator:snapshot-release-0-8
+            quay.io/dynatrace/dynatrace-operator:snapshot
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -4240,7 +4137,7 @@ spec:
             # OLM mounts the certificates here, so we reuse it for simplicity
             - --certs-dir=/tmp/k8s-webhook-server/serving-certs/
           image:
-            quay.io/dynatrace/dynatrace-operator:snapshot-release-0-8
+            quay.io/dynatrace/dynatrace-operator:snapshot
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -4663,7 +4560,7 @@ spec:
         # - Needs access to a dedicated folder on the node to persist data, needs to read/write to it.
       - name: driver
         image:
-            quay.io/dynatrace/dynatrace-operator:snapshot-release-0-8
+            quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
         - csi-driver
@@ -4731,7 +4628,7 @@ spec:
         # - Needs access to the registration socket, needs to read/write to it, needs root permissions to do so.
       - name: registrar
         image:
-            quay.io/dynatrace/dynatrace-operator:snapshot-release-0-8
+            quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
         - --csi-address=/csi/csi.sock
@@ -4776,7 +4673,7 @@ spec:
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
       - name: liveness-probe
         image:
-            quay.io/dynatrace/dynatrace-operator:snapshot-release-0-8
+            quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
         - --csi-address=/csi/csi.sock

--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -3972,7 +3972,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
       labels:
         app.kubernetes.io/name: dynatrace-operator
         app.kubernetes.io/version: "0.8.0"

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -59,6 +59,34 @@ metadata:
     app.kubernetes.io/version: "0.8.0"
     app.kubernetes.io/component: activegate
 ---
+# Source: dynatrace-operator/templates/Common/oneagent/serviceaccount-oneagent-privileged.yaml
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-dynakube-oneagent-privileged
+  namespace: dynatrace
+  labels:
+    app.kubernetes.io/name: dynatrace-operator
+    app.kubernetes.io/version: "0.0.0-snapshot"
+    app.kubernetes.io/component: oneagent
+automountServiceAccountToken: false
+imagePullSecrets:
+- name: redhat-connect
+- name: redhat-connect-sso
+---
 # Source: dynatrace-operator/templates/Common/oneagent/serviceaccount-oneagent-unprivileged.yaml
 # Copyright 2021 Dynatrace LLC
 
@@ -1445,12 +1473,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1458,12 +1489,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -1781,12 +1844,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1794,12 +1860,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -2949,12 +3047,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -2962,12 +3063,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -3320,6 +3453,39 @@ rules:
     verbs:
       - get
 ---
+# Source: dynatrace-operator/templates/Common/oneagent/clusterrole-oneagent-privileged.yaml
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dynatrace-dynakube-oneagent-privileged
+  labels:
+    app.kubernetes.io/name: dynatrace-operator
+    app.kubernetes.io/version: "0.0.0-snapshot"
+    app.kubernetes.io/component: oneagent
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - host
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
 # Source: dynatrace-operator/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
 # Copyright 2021 Dynatrace LLC
 
@@ -3563,6 +3729,37 @@ subjects:
   - kind: ServiceAccount
     name: dynatrace-kubernetes-monitoring
     namespace: dynatrace
+---
+# Source: dynatrace-operator/templates/Common/oneagent/clusterrolebinding-oneagent-privileged.yaml
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dynatrace-dynakube-oneagent-privileged
+  labels:
+    app.kubernetes.io/name: dynatrace-operator
+    app.kubernetes.io/version: "0.0.0-snapshot"
+    app.kubernetes.io/component: oneagent
+subjects:
+  - kind: ServiceAccount
+    name: "dynatrace-dynakube-oneagent-privileged"
+    namespace: dynatrace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "dynatrace-dynakube-oneagent-privileged"
 ---
 # Source: dynatrace-operator/templates/Common/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
 # Copyright 2021 Dynatrace LLC
@@ -4403,7 +4600,7 @@ seccompProfiles:
 supplementalGroups:
   type: RunAsAny
 users:
-  - system:serviceaccount:dynatrace:dynatrace-dynakube-oneagent-unprivileged
+  - system:serviceaccount:dynatrace:dynatrace-dynakube-oneagent-privileged
 volumes:
   - "*"
 ---

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -4114,7 +4114,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
       labels:
         app.kubernetes.io/name: dynatrace-operator
         app.kubernetes.io/version: "0.8.0"

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -80,7 +80,7 @@ metadata:
   namespace: dynatrace
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.0.0-snapshot"
+    app.kubernetes.io/version: "0.8.0"
     app.kubernetes.io/component: oneagent
 automountServiceAccountToken: false
 imagePullSecrets:
@@ -177,7 +177,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -1473,15 +1472,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1489,44 +1485,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -1844,15 +1808,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1860,44 +1821,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -3047,15 +2976,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -3063,44 +2989,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -3258,6 +3152,8 @@ spec:
                           type: string
                       type: object
                     type: array
+                  formattedCommunicationEndpoints:
+                    type: string
                   tenantUUID:
                     type: string
                 type: object
@@ -3473,7 +3369,7 @@ metadata:
   name: dynatrace-dynakube-oneagent-privileged
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.0.0-snapshot"
+    app.kubernetes.io/version: "0.8.0"
     app.kubernetes.io/component: oneagent
 rules:
   - apiGroups:
@@ -3750,7 +3646,7 @@ metadata:
   name: dynatrace-dynakube-oneagent-privileged
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: "0.0.0-snapshot"
+    app.kubernetes.io/version: "0.8.0"
     app.kubernetes.io/component: oneagent
 subjects:
   - kind: ServiceAccount
@@ -4231,7 +4127,7 @@ spec:
             - operator
           # Replace this with the built image name
           image:
-            quay.io/dynatrace/dynatrace-operator:snapshot-release-0-8
+            quay.io/dynatrace/dynatrace-operator:snapshot
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -4383,7 +4279,7 @@ spec:
             # OLM mounts the certificates here, so we reuse it for simplicity
             - --certs-dir=/tmp/k8s-webhook-server/serving-certs/
           image:
-            quay.io/dynatrace/dynatrace-operator:snapshot-release-0-8
+            quay.io/dynatrace/dynatrace-operator:snapshot
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -5088,7 +4984,7 @@ spec:
         # - Needs access to a dedicated folder on the node to persist data, needs to read/write to it.
       - name: driver
         image:
-            quay.io/dynatrace/dynatrace-operator:snapshot-release-0-8
+            quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
         - csi-driver
@@ -5156,7 +5052,7 @@ spec:
         # - Needs access to the registration socket, needs to read/write to it, needs root permissions to do so.
       - name: registrar
         image:
-            quay.io/dynatrace/dynatrace-operator:snapshot-release-0-8
+            quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
         - --csi-address=/csi/csi.sock
@@ -5201,7 +5097,7 @@ spec:
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
       - name: liveness-probe
         image:
-            quay.io/dynatrace/dynatrace-operator:snapshot-release-0-8
+            quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
         - --csi-address=/csi/csi.sock

--- a/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
@@ -1298,15 +1298,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1314,44 +1311,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -1669,15 +1634,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1685,44 +1647,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -2872,15 +2802,12 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -2888,44 +2815,12 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
-                        minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
-                          format: int32
-                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            of pods into each bucket. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -3083,6 +2978,8 @@ spec:
                           type: string
                       type: object
                     type: array
+                  formattedCommunicationEndpoints:
+                    type: string
                   tenantUUID:
                     type: string
                 type: object

--- a/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
@@ -1298,12 +1298,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1311,12 +1314,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -1634,12 +1669,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -1647,12 +1685,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -2802,12 +2872,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -2815,12 +2888,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-privileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-privileged.yaml
@@ -1,0 +1,32 @@
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift " (include "dynatrace-operator.platformSet" .))}}
+{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dynatrace-dynakube-oneagent-privileged
+  labels:
+    {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - host
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+{{ end }}

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-privileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-privileged.yaml
@@ -1,0 +1,30 @@
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift " (include "dynatrace-operator.platformSet" .))}}
+{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dynatrace-dynakube-oneagent-privileged
+  labels:
+    {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: "dynatrace-dynakube-oneagent-privileged"
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "dynatrace-dynakube-oneagent-privileged"
+{{ end }}

--- a/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent-privileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent-privileged.yaml
@@ -1,0 +1,29 @@
+{{ $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift" (include "dynatrace-operator.platformSet" .))}}
+{{ if eq (include "dynatrace-operator.partial" .) "false" }}
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-dynakube-oneagent-privileged
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
+automountServiceAccountToken: false
+{{- if eq .Values.platform "openshift"}}
+imagePullSecrets:
+- name: redhat-connect
+- name: redhat-connect-sso
+{{- end }}
+{{ end }}

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -33,12 +33,14 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      {{- if or (.Values.operator).apparmor .Values.operator.annotations}}
       annotations:
       {{- if (.Values.operator).apparmor}}
         container.apparmor.security.beta.kubernetes.io/{{ .Release.Name }}: runtime/default
       {{- end }}
       {{- if .Values.operator.annotations }}
         {{- toYaml .Values.operator.annotations | nindent 8 }}
+      {{- end }}
       {{- end }}
       labels:
         {{- include "dynatrace-operator.operatorLabels" . | nindent 8 }}

--- a/config/helm/chart/default/templates/Openshift/oneagent/securitycontextconstraints-privileged.yaml
+++ b/config/helm/chart/default/templates/Openshift/oneagent/securitycontextconstraints-privileged.yaml
@@ -60,7 +60,7 @@ seccompProfiles:
 supplementalGroups:
   type: RunAsAny
 users:
-  - system:serviceaccount:{{ .Release.Namespace }}:dynatrace-dynakube-oneagent-unprivileged
+  - system:serviceaccount:{{ .Release.Namespace }}:dynatrace-dynakube-oneagent-privileged
 volumes:
   - "*"
 {{ end }}

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -115,7 +115,7 @@ func (dk *DynaKube) NeedsOneAgentProxy() bool {
 }
 
 func (dk *DynaKube) IsOneAgentPrivileged() bool {
-	return dk.FeatureAgentRunPrivileged()
+	return dk.FeatureAgentRunPrivileged() || dk.ClassicFullStackMode()
 }
 
 // ShouldAutoUpdateOneAgent returns true if the Operator should update OneAgent instances automatically.

--- a/src/api/v1beta1/properties_test.go
+++ b/src/api/v1beta1/properties_test.go
@@ -295,3 +295,54 @@ func TestGetRawImageTag(t *testing.T) {
 		require.Equal(t, "", rawTag)
 	})
 }
+
+func TestIsOneAgentPrivileged(t *testing.T) {
+	t.Run("is false by default", func(t *testing.T) {
+		dynakube := DynaKube{}
+
+		assert.False(t, dynakube.IsOneAgentPrivileged())
+	})
+	t.Run("is true when annotation is set to true", func(t *testing.T) {
+		dynakube := DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationFeatureRunOneAgentContainerPrivileged: "true",
+				},
+			},
+		}
+
+		assert.True(t, dynakube.IsOneAgentPrivileged())
+	})
+	t.Run("is false when annotation is set to false", func(t *testing.T) {
+		dynakube := DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationFeatureRunOneAgentContainerPrivileged: "false",
+				},
+			},
+		}
+
+		assert.False(t, dynakube.IsOneAgentPrivileged())
+	})
+	t.Run("is true in classicFullStack mode", func(t *testing.T) {
+		dynakube := DynaKube{
+			Spec: DynaKubeSpec{
+				OneAgent: OneAgentSpec{ClassicFullStack: &HostInjectSpec{}},
+			},
+		}
+
+		assert.True(t, dynakube.IsOneAgentPrivileged())
+
+		dynakube.Annotations = map[string]string{
+			AnnotationFeatureRunOneAgentContainerPrivileged: "false",
+		}
+
+		assert.True(t, dynakube.IsOneAgentPrivileged())
+
+		dynakube.Annotations = map[string]string{
+			AnnotationFeatureRunOneAgentContainerPrivileged: "true",
+		}
+
+		assert.True(t, dynakube.IsOneAgentPrivileged())
+	})
+}

--- a/src/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -23,27 +23,36 @@ const (
 )
 
 func TestArguments(t *testing.T) {
-	instance := dynatracev1beta1.DynaKube{
-		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL: testURL,
-			OneAgent: dynatracev1beta1.OneAgentSpec{
-				ClassicFullStack: &dynatracev1beta1.HostInjectSpec{
-					Args: []string{testValue},
+	t.Run("returns default arguments if hostInjection is nil", func(t *testing.T) {
+		builder := builderInfo{}
+		arguments := builder.arguments()
+		defaultArguments := builder.appendMetadataArgs(appendOperatorVersionArg([]string{}))
+
+		assert.Equal(t, defaultArguments, arguments)
+	})
+	t.Run("classic fullstack", func(t *testing.T) {
+		instance := dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testURL,
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					ClassicFullStack: &dynatracev1beta1.HostInjectSpec{
+						Args: []string{testValue},
+					},
 				},
 			},
-		},
-	}
-	dsInfo := ClassicFullStack{
-		builderInfo{
-			instance:       &instance,
-			hostInjectSpec: instance.Spec.OneAgent.ClassicFullStack,
-			clusterId:      testClusterID,
-		},
-	}
-	podSpecs := dsInfo.podSpec()
-	assert.NotNil(t, podSpecs)
-	assert.NotEmpty(t, podSpecs.Containers)
-	assert.Contains(t, podSpecs.Containers[0].Args, testValue)
+		}
+		dsInfo := ClassicFullStack{
+			builderInfo{
+				instance:       &instance,
+				hostInjectSpec: instance.Spec.OneAgent.ClassicFullStack,
+				clusterId:      testClusterID,
+			},
+		}
+		podSpecs := dsInfo.podSpec()
+		assert.NotNil(t, podSpecs)
+		assert.NotEmpty(t, podSpecs.Containers)
+		assert.Contains(t, podSpecs.Containers[0].Args, testValue)
+	})
 }
 
 func TestPodSpec_Arguments(t *testing.T) {

--- a/src/controllers/dynakube/oneagent/daemonset/env_vars.go
+++ b/src/controllers/dynakube/oneagent/daemonset/env_vars.go
@@ -18,7 +18,12 @@ const (
 )
 
 func (dsInfo *builderInfo) environmentVariables() []corev1.EnvVar {
-	environmentVariables := dsInfo.hostInjectSpec.Env
+	environmentVariables := make([]corev1.EnvVar, 0)
+
+	if dsInfo.hostInjectSpec != nil {
+		environmentVariables = dsInfo.hostInjectSpec.Env
+	}
+
 	envVarMap := envVarsToMap(environmentVariables)
 	envVarMap = setDefaultValueSource(envVarMap, dtNodeName, &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}})
 	envVarMap = setDefaultValue(envVarMap, dtClusterId, dsInfo.clusterId)
@@ -27,7 +32,7 @@ func (dsInfo *builderInfo) environmentVariables() []corev1.EnvVar {
 		envVarMap = dsInfo.setDefaultProxy(envVarMap)
 	}
 
-	if dsInfo.instance.NeedsReadOnlyOneAgents() {
+	if dsInfo.instance != nil && dsInfo.instance.NeedsReadOnlyOneAgents() {
 		envVarMap = setDefaultValue(envVarMap, oneagentReadOnlyMode, "true")
 	}
 

--- a/src/controllers/dynakube/oneagent/daemonset/env_vars_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/env_vars_test.go
@@ -1,1 +1,19 @@
 package daemonset
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestEnvironmentVariables(t *testing.T) {
+	t.Run("returns default values when members are nil", func(t *testing.T) {
+		dsInfo := builderInfo{}
+		envVars := dsInfo.environmentVariables()
+
+		assert.Contains(t, envVars, corev1.EnvVar{Name: dtClusterId, ValueFrom: nil})
+		assert.True(t, kubeobjects.EnvVarIsIn(envVars, dtNodeName))
+	})
+}

--- a/src/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -11,18 +11,18 @@ import (
 func prepareVolumeMounts(instance *dynatracev1beta1.DynaKube) []corev1.VolumeMount {
 	var volumeMounts []corev1.VolumeMount
 
-	if instance.NeedsReadOnlyOneAgents() {
+	if instance != nil && instance.NeedsReadOnlyOneAgents() {
 		volumeMounts = append(volumeMounts, getReadOnlyRootMount())
 		volumeMounts = append(volumeMounts, getCSIStorageMount())
 	} else {
 		volumeMounts = append(volumeMounts, getRootMount())
 	}
 
-	if instance.Spec.TrustedCAs != "" {
+	if instance != nil && instance.Spec.TrustedCAs != "" {
 		volumeMounts = append(volumeMounts, getClusterCaCertVolumeMount())
 	}
 
-	if instance.HasActiveGateCaCert() {
+	if instance != nil && instance.HasActiveGateCaCert() {
 		volumeMounts = append(volumeMounts, getActiveGateCaCertVolumeMount())
 	}
 	return volumeMounts
@@ -64,6 +64,10 @@ func getCSIStorageMount() corev1.VolumeMount {
 
 func prepareVolumes(instance *dynatracev1beta1.DynaKube) []corev1.Volume {
 	volumes := []corev1.Volume{getRootVolume()}
+
+	if instance == nil {
+		return volumes
+	}
 
 	if instance.NeedsReadOnlyOneAgents() {
 		volumes = append(volumes, getCSIStorageVolume(instance))

--- a/src/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -10,6 +10,11 @@ import (
 )
 
 func TestPrepareVolumes(t *testing.T) {
+	t.Run("has defaults if instance is nil", func(t *testing.T) {
+		volumes := prepareVolumes(nil)
+
+		assert.Contains(t, volumes, getRootVolume())
+	})
 	t.Run(`has root volume`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
@@ -117,6 +122,11 @@ func TestPrepareVolumes(t *testing.T) {
 }
 
 func TestPrepareVolumeMounts(t *testing.T) {
+	t.Run("has defaults if instance is nil", func(t *testing.T) {
+		volumeMounts := prepareVolumeMounts(nil)
+
+		assert.Contains(t, volumeMounts, getRootMount())
+	})
 	t.Run(`has root volume mount`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{


### PR DESCRIPTION
# Description

see https://github.com/Dynatrace/dynatrace-operator/pull/993

## How can this be tested?
 
see https://github.com/Dynatrace/dynatrace-operator/pull/993


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

