### PR TITLE
Set correct connection info

### DIFF
--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -159,7 +159,13 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 
 	var agentUpdater *agentUpdater
 	if dk.CodeModulesImage() != "" {
-		latestProcessModuleConfig = latestProcessModuleConfig.AddConnectionInfo(dk.ConnectionInfo())
+		connectionInfo, err := dtc.GetConnectionInfo()
+		if err != nil {
+			log.Info("could not query connection info")
+			return nil, false, err
+		}
+
+		latestProcessModuleConfig = latestProcessModuleConfig.AddConnectionInfo(connectionInfo)
 		agentUpdater, err = newAgentImageUpdater(ctx, provisioner.fs, provisioner.apiReader, provisioner.path, provisioner.db, provisioner.recorder, dk)
 		if err != nil {
 			log.Error(err, "error when setting up the agent image updater")


### PR DESCRIPTION
# Description

The connection info used in the CSI provisioner was still missing a tenant token.
Since the token must not be stored in the Dynakube status, the connection info is now queried directly from the API.

## How can this be tested?

* Deploy DTO from this branch
* Setup application monitoring dynakube and sample apps
* The `ruxitagentproc.conf` must have a `tenant`, a `serverAddress` and a `tenantToken` property


## Checklist
- [ ] Unit tests have been updated/added
  + the csi provisioner needs to be refactored to allow for sensible unit tests
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

