### PR TITLE
Renamed helm-chart platform value google-marketplace to gke-marketplace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ config/deploy/kustomization.yaml
 
 /.run/
 config/deploy/kubernetes/kubernetes.yaml
-config/deploy/kubernetes/google-autopilot.yaml
+config/deploy/kubernetes/gke-autopilot.yaml
 config/deploy/kubernetes/kubernetes-csi.yaml
 config/deploy/kubernetes/kubernetes-olm.yaml
 config/deploy/openshift/openshift.yaml

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -108,7 +108,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  {{- if ne .Values.platform "google-autopilot"}}
+                  {{- if ne .Values.platform "gke-autopilot"}}
                   - key: kubernetes.io/arch
                     operator: In
                     values:

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -73,7 +73,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                    {{- if ne .Values.platform "google-autopilot"}}
+                    {{- if ne .Values.platform "gke-autopilot"}}
                   - key: kubernetes.io/arch
                     operator: In
                     values:

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -149,7 +149,7 @@ Check if we are generating only a part of the yamls
 Check if platform is set
 */}}
 {{- define "dynatrace-operator.platformSet" -}}
-{{- if or (eq .Values.platform "kubernetes") (eq .Values.platform "openshift") (eq .Values.platform "google-marketplace") (eq .Values.platform "google-autopilot") -}}
+{{- if or (eq .Values.platform "kubernetes") (eq .Values.platform "openshift") (eq .Values.platform "google-marketplace") (eq .Values.platform "gke-autopilot") -}}
     {{ default "set" }}
 {{- end -}}
 {{- end -}}
@@ -167,5 +167,5 @@ Exclude Kubernetes manifest not running on OLM
 Check if the platform is set
 */}}
 {{- define "dynatrace-operator.platformRequired" -}}
-{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift, google-marketplace, or google-autopilot" (include "dynatrace-operator.platformSet" .))}}
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift, google-marketplace, or gke-autopilot" (include "dynatrace-operator.platformSet" .))}}
 {{- end -}}

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -23,9 +23,9 @@ tests:
       - hasDocuments:
           count: 1
 
-  - it: should exist if platform is set to google-autopilot
+  - it: should exist if platform is set to gke-autopilot
     set:
-      platform: google-autopilot
+      platform: gke-autopilot
     asserts:
       - hasDocuments:
           count: 1
@@ -322,7 +322,7 @@ tests:
 
   - it: should have only OS node affinity on GKE Autopilot
     set:
-      platform: google-autopilot
+      platform: gke-autopilot
     asserts:
       - equal:
           path: spec.template.spec.affinity

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -370,7 +370,7 @@ tests:
 
   - it: should have only OS node affinity on GKE Autopilot
     set:
-      platform: google-autopilot
+      platform: gke-autopilot
     asserts:
       - equal:
           path: spec.template.spec.affinity

--- a/config/helm/chart/default/tests/Google/application_test.yaml
+++ b/config/helm/chart/default/tests/Google/application_test.yaml
@@ -23,9 +23,9 @@ tests:
       - hasDocuments:
           count: 1
 
-  - it: should not exist if platform is set to google-autopilot
+  - it: should not exist if platform is set to gke-autopilot
     set:
-      platform: google-autopilot
+      platform: gke-autopilot
     asserts:
       - hasDocuments:
           count: 0

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# may be set to "kubernetes", "openshift", or "google-marketplace"
+# may be set to "kubernetes", "openshift", or "gke-autopilot"
 platform: "kubernetes"
 
 image: ""

--- a/hack/make/deploy/gcr.mk
+++ b/hack/make/deploy/gcr.mk
@@ -6,4 +6,4 @@ deploy/gke/deployer:
 ## Deploys the operator using a snapshot deployer image for an autopilot GKE cluster
 deploy/autopilot/deployer:
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/application/master/deploy/kube-app-manager-aio.yaml
-	./hack/gcr/deploy.sh ":snapshot-${SNAPSHOT_SUFFIX}" "google-autopilot"
+	./hack/gcr/deploy.sh ":snapshot-${SNAPSHOT_SUFFIX}" "gke-autopilot"

--- a/hack/make/deploy/gcr.mk
+++ b/hack/make/deploy/gcr.mk
@@ -4,6 +4,6 @@ deploy/gke/deployer:
 	./hack/gcr/deploy.sh ":snapshot-${SNAPSHOT_SUFFIX}"
 
 ## Deploys the operator using a snapshot deployer image for an autopilot GKE cluster
-deploy/autopilot/deployer:
+deploy/gke-autopilot/deployer:
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/application/master/deploy/kube-app-manager-aio.yaml
 	./hack/gcr/deploy.sh ":snapshot-${SNAPSHOT_SUFFIX}" "gke-autopilot"

--- a/hack/make/manifests/config.mk
+++ b/hack/make/manifests/config.mk
@@ -11,7 +11,7 @@ HELM_CRD_DIR=$(HELM_TEMPLATES_DIR)/Common/crd/
 MANIFESTS_DIR=config/deploy/
 
 KUBERNETES_CORE_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes.yaml
-KUBERNETES_AUTOPILOT_YAML=$(MANIFESTS_DIR)kubernetes/google-autopilot.yaml
+KUBERNETES_AUTOPILOT_YAML=$(MANIFESTS_DIR)kubernetes/gke-autopilot.yaml
 KUBERNETES_CSIDRIVER_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-csi.yaml
 KUBERNETES_OLM_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-olm.yaml
 KUBERNETES_ALL_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-all.yaml

--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -9,7 +9,7 @@ manifests/kubernetes/csi:
 		--set olm="${OLM}" \
 		--set image="$(MASTER_IMAGE)" > "$(KUBERNETES_CSIDRIVER_YAML)"
 
-## Generates an Kubernetes manifest with a CRD
+## Generates a Kubernetes manifest with a CRD
 manifests/kubernetes/core: manifests/crd/helm prerequisites/kustomize
 	helm template dynatrace-operator config/helm/chart/default \
 			--namespace dynatrace \
@@ -19,11 +19,12 @@ manifests/kubernetes/core: manifests/crd/helm prerequisites/kustomize
 			--set olm="${OLM}" \
 			--set image="$(MASTER_IMAGE)" > "$(KUBERNETES_CORE_YAML)"
 
-manifests/kubernetes/autopilot: manifests/crd/helm prerequisites/kustomize
+## Generates a Kubernetes manifest with a CRD for gke-autopilot
+manifests/kubernetes/gke-autopilot: manifests/crd/helm prerequisites/kustomize
 	helm template dynatrace-operator config/helm/chart/default \
 			--namespace dynatrace \
 			--set installCRD=true \
-			--set platform="google-autopilot" \
+			--set platform="gke-autopilot" \
 			--set manifests=true \
 			--set olm="${OLM}" \
 			--set image="$(MASTER_IMAGE)" > "$(KUBERNETES_AUTOPILOT_YAML)"

--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -30,7 +30,7 @@ manifests/kubernetes/gke-autopilot: manifests/crd/helm prerequisites/kustomize
 			--set image="$(MASTER_IMAGE)" > "$(KUBERNETES_AUTOPILOT_YAML)"
 
 ## Generates a manifest for Kubernetes including a CRD, a CSI driver deployment and a OLM version
-manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi manifests/kubernetes/autopilot
+manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi manifests/kubernetes/gke-autopilot
 	cp "$(KUBERNETES_CORE_YAML)" "$(KUBERNETES_OLM_YAML)"
 	cat "$(KUBERNETES_CORE_YAML)" "$(KUBERNETES_CSIDRIVER_YAML)" > "$(KUBERNETES_ALL_YAML)"
 


### PR DESCRIPTION
# Description

Changing "google-marketplace" to "gke-marketplace".

## How can this be tested?

- Run  `make manifests/kubernetes/gke-autopilot` and check if correct manifest are generated


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

