### PR TITLE
Restrict the token permissions

### DIFF
--- a/.github/workflows/build-dockerimage.yaml
+++ b/.github/workflows/build-dockerimage.yaml
@@ -22,6 +22,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: "^1.18"
   DOCKER_REGISTRY: "quay.io"

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: '34 23 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   PREFLIGHT_VERSION: "1.3.0"
   PREFLIGHT_REPORT_NAME: "preflight.json"

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare properties

--- a/.github/workflows/upload-dockerimage.yaml
+++ b/.github/workflows/upload-dockerimage.yaml
@@ -24,6 +24,9 @@ on:
       docker_repo_password:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   upload_job:
     name: Upload docker image to Registry


### PR DESCRIPTION
# Description
GITHUB_TOKEN permissions should be restricted as much as possible. 

## How can this be tested?
The whole CI should work as always (images published, scans performed).

## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

