### PR TITLE
Add priorityClass to CSI Pods

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -4793,4 +4793,4 @@ metadata:
   name: dynatrace-high-priority
 value: 1000000
 globalDefault: false
-description: "This priority class is used for Dynatrace Components with a higher priority"
+description: "This priority class is used for Dynatrace Components in order to make sure they are not evicted in favor of other pods"

--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -4705,6 +4705,7 @@ spec:
       securityContext: {}
       serviceAccountName: dynatrace-oneagent-csi-driver
       terminationGracePeriodSeconds: 30
+      priorityClassName: dynatrace-high-priority
       volumes:
       # This volume is where the registrar registers the plugin with kubelet
       - hostPath:
@@ -4771,3 +4772,25 @@ spec:
   podInfoOnMount: true
   volumeLifecycleModes:
     - Ephemeral
+---
+# Source: dynatrace-operator/templates/Common/csi/priority-class.yaml
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: PriorityClass
+apiVersion: scheduling.k8s.io/v1
+metadata:
+  name: dynatrace-high-priority
+value: 1000000
+globalDefault: false
+description: "This priority class is used for Dynatrace Components with a higher priority"

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -5129,6 +5129,7 @@ spec:
       securityContext: {}
       serviceAccountName: dynatrace-oneagent-csi-driver
       terminationGracePeriodSeconds: 30
+      priorityClassName: dynatrace-high-priority
       volumes:
       # This volume is where the registrar registers the plugin with kubelet
       - hostPath:

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -5196,6 +5196,28 @@ spec:
   volumeLifecycleModes:
     - Ephemeral
 ---
+# Source: dynatrace-operator/templates/Common/csi/priority-class.yaml
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: PriorityClass
+apiVersion: scheduling.k8s.io/v1
+metadata:
+  name: dynatrace-high-priority
+value: 1000000
+globalDefault: false
+description: "This priority class is used for Dynatrace Components with a higher priority"
+---
 # Source: dynatrace-operator/templates/Openshift/csi/securitycontextconstraints-csidriver.yaml
 # Copyright 2021 Dynatrace LLC
 

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -5217,7 +5217,7 @@ metadata:
   name: dynatrace-high-priority
 value: 1000000
 globalDefault: false
-description: "This priority class is used for Dynatrace Components with a higher priority"
+description: "This priority class is used for Dynatrace Components in order to make sure they are not evicted in favor of other pods"
 ---
 # Source: dynatrace-operator/templates/Openshift/csi/securitycontextconstraints-csidriver.yaml
 # Copyright 2021 Dynatrace LLC

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -197,6 +197,7 @@ spec:
       securityContext: {}
       serviceAccountName: dynatrace-oneagent-csi-driver
       terminationGracePeriodSeconds: 30
+      priorityClassName: dynatrace-high-priority
       volumes:
       # This volume is where the registrar registers the plugin with kubelet
       - hostPath:

--- a/config/helm/chart/default/templates/Common/csi/priority-class.yaml
+++ b/config/helm/chart/default/templates/Common/csi/priority-class.yaml
@@ -1,0 +1,24 @@
+{{- include "dynatrace-operator.platformRequired" . }}
+{{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
+
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: PriorityClass
+apiVersion: scheduling.k8s.io/v1
+metadata:
+  name: dynatrace-high-priority
+value: {{ int .Values.csidriver.priorityClassValue }}
+globalDefault: false
+description: "This priority class is used for Dynatrace Components with a higher priority"
+{{- end -}}

--- a/config/helm/chart/default/templates/Common/csi/priority-class.yaml
+++ b/config/helm/chart/default/templates/Common/csi/priority-class.yaml
@@ -20,5 +20,5 @@ metadata:
   name: dynatrace-high-priority
 value: {{ int .Values.csidriver.priorityClassValue }}
 globalDefault: false
-description: "This priority class is used for Dynatrace Components with a higher priority"
+description: "This priority class is used for Dynatrace Components in order to make sure they are not evicted in favor of other pods"
 {{- end -}}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -41,6 +41,7 @@ tests:
       platform: kubernetes
       image: image-name
       csidriver.enabled: true
+      csidriver.priorityClassValue: "1000"
     asserts:
       - isKind:
           of: DaemonSet
@@ -66,6 +67,8 @@ tests:
       - equal:
           path: spec.template.spec
           value:
+            priority: 1000
+            priorityClassName: dynatrace-high-priority
             tolerations:
                 - effect: NoSchedule
                   key: node-role.kubernetes.io/master

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -41,7 +41,6 @@ tests:
       platform: kubernetes
       image: image-name
       csidriver.enabled: true
-      csidriver.priorityClassValue: "1000"
     asserts:
       - isKind:
           of: DaemonSet
@@ -67,7 +66,6 @@ tests:
       - equal:
           path: spec.template.spec
           value:
-            priority: 1000
             priorityClassName: dynatrace-high-priority
             tolerations:
                 - effect: NoSchedule

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -50,6 +50,7 @@ webhook:
 csidriver:
   enabled: false
   nodeSelector: {}
+  priorityClassValue: "1000000"
   tolerations:
     - effect: NoSchedule
       key: node-role.kubernetes.io/master


### PR DESCRIPTION
# Description

Currently our CSI Pod cant be scheduled in certain scenarios, because of lacking resources on the cluster. However if the customer uses a deployment mode, which relies on the CSI Driver Pod to be there and handle volumes, it then leads to the situation that every pod gets the CSI Volume added by the webhook, but the CSI Pod can not handle those requests because he is simply not there. In consequence the application pod, which gets the CSI Volume cannot start and will fail.

Therefor I added a new priorityClass, which is set to a high priority by default, in order to make sure our CSI Pods can be scheduled

## How can this be tested?

- deploy our operator manifests
- check if the CSI Pod has set the correct priorityClass and correct priority


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

