### PR TITLE
Added labels and annotations for helm

### DIFF
--- a/config/helm/chart/default/templates/Common/activegate/serviceaccount-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/serviceaccount-activegate.yaml
@@ -20,4 +20,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.activegateLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: dynatrace-operator
+    meta.helm.sh/release-namespace: dynatrace
 {{ end }}

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
@@ -19,5 +19,9 @@ metadata:
   name: dynatrace-kubernetes-monitoring
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/managed-by: Helm
     {{- include "dynatrace-operator.activegateLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace}}
 {{ end }}

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
@@ -19,7 +19,6 @@ metadata:
   name: dynatrace-kubernetes-monitoring
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/managed-by: Helm
     {{- include "dynatrace-operator.activegateLabels" . | nindent 4 }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-privileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-privileged.yaml
@@ -19,6 +19,9 @@ metadata:
   name: dynatrace-dynakube-oneagent-privileged
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
+  annotations:
+      meta.helm.sh/release-name: {{ .Release.Name }}
+      meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - security.openshift.io

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
@@ -19,6 +19,9 @@ metadata:
   name: dynatrace-dynakube-oneagent-unprivileged
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
+  annotations:
+      meta.helm.sh/release-name: {{ .Release.Name }}
+      meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - security.openshift.io

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-privileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-privileged.yaml
@@ -19,6 +19,9 @@ metadata:
   name: dynatrace-dynakube-oneagent-privileged
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace}}
 subjects:
   - kind: ServiceAccount
     name: "dynatrace-dynakube-oneagent-privileged"

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
@@ -16,6 +16,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: dynatrace-dynakube-oneagent-unprivileged
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
   annotations:

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
@@ -16,9 +16,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: dynatrace-dynakube-oneagent-unprivileged
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace}}
+
 subjects:
   - kind: ServiceAccount
     name: dynatrace-dynakube-oneagent-unprivileged

--- a/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent-privileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent-privileged.yaml
@@ -20,6 +20,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace}}
+
 automountServiceAccountToken: false
 {{- if eq .Values.platform "openshift"}}
 imagePullSecrets:

--- a/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent-unprivileged.yaml
@@ -20,6 +20,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace}}
+
 automountServiceAccountToken: false
 {{- if eq .Values.platform "openshift"}}
 imagePullSecrets:

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -23,6 +23,9 @@ metadata:
   {{- if .Values.operator.labels }}
       {{- toYaml .Values.operator.labels | nindent 4 }}
   {{- end }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1

--- a/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
@@ -19,6 +19,9 @@ metadata:
   name: dynatrace-webhook
   labels:
     {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/config/helm/chart/default/templates/Common/webhook/clusterrolebinding-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/clusterrolebinding-webhook.yaml
@@ -19,6 +19,9 @@ metadata:
   name: dynatrace-webhook
   labels:
     {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: dynatrace-webhook

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -23,6 +23,9 @@ metadata:
   {{- if .Values.webhook.labels }}
       {{- toYaml .Values.webhook.labels | nindent 4 }}
   {{- end }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ (default false (.Values.webhook).highAvailability) | ternary 2 1 }}
   revisionHistoryLimit: 1

--- a/config/helm/chart/default/templates/Common/webhook/mutatingwebhookconfiguration.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/mutatingwebhookconfiguration.yaml
@@ -19,6 +19,9 @@ metadata:
   name: dynatrace-webhook
   labels:
   {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 webhooks:
   - name: webhook.pod.dynatrace.com
     reinvocationPolicy: IfNeeded

--- a/config/helm/chart/default/templates/Common/webhook/poddisruptionbudget-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/poddisruptionbudget-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
   name: dynatrace-webhook
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/managed-by: Helm
+  {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace}}

--- a/config/helm/chart/default/templates/Common/webhook/poddisruptionbudget-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/poddisruptionbudget-webhook.yaml
@@ -5,6 +5,13 @@ kind: PodDisruptionBudget
 metadata:
   name: dynatrace-webhook
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace}}
+
+
 spec:
   minAvailable: 1
   selector:

--- a/config/helm/chart/default/templates/Common/webhook/role-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/role-webhook.yaml
@@ -20,6 +20,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
+  annotations:
+      meta.helm.sh/release-name: {{ .Release.Name }}
+      meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/config/helm/chart/default/templates/Common/webhook/service.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/service.yaml
@@ -20,6 +20,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 spec:
   selector:
   {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}

--- a/config/helm/chart/default/templates/Common/webhook/serviceaccount-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/serviceaccount-webhook.yaml
@@ -20,6 +20,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 {{- if eq .Values.platform "openshift" }}
 imagePullSecrets:
 - name: redhat-connect

--- a/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
@@ -19,6 +19,9 @@ metadata:
   name: dynatrace-webhook
   labels:
   {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 webhooks:
   - admissionReviewVersions:
       - v1

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -35,6 +35,7 @@ Common labels
 */}}
 {{- define "dynatrace-operator.commonLabels" -}}
 {{ include "dynatrace-operator.futureSelectorLabels" . }}
+app.kubernetes.io/managed-by: Helm
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}


### PR DESCRIPTION
# Description
This change added the following:

`app.kubernetes.io/managed-by: Helm` to the *dynatrace-operator.commonLabels* definition

and annotations for `meta.helm.sh/release-name` and `meta.helm.sh/release-namespace` to individual yaml files.

## Issue I'm trying to fix:

When redeploying the application via helm, helm complains if specific labels and annoations are missing from resources it is trying to update, for example:

`Error: rendered manifests contain a resource that already exists. Unable to continue with install: ValidatingWebhookConfiguration "dynatrace-webhook" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "dynatrace-operator"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "dynatrace"`

## Motivation

I'm using Terraform helm_release to manage the deployment of the dynatrace-operator to kubernetes. The initial installation goes well, but updates fail.


## How can this be tested?
To test deploy the dynatrace-operator via helm; make a change to a value, and try to redeploy

## Checklist
- [ ] Unit tests have been updated/added
- [ ] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

