### PR TITLE
Fix publish images action

### DIFF
--- a/.github/actions/preflight/action.yaml
+++ b/.github/actions/preflight/action.yaml
@@ -32,7 +32,7 @@ runs:
   steps:
   - name: Checkout
     uses: actions/checkout@v2
-  - name: Login to Registry to create docker-config.json
+  - name: Login to Registry
     uses: docker/login-action@v1
     with:
       registry: ${{ inputs.registry }}
@@ -43,7 +43,7 @@ runs:
     env:
       RHCC_APITOKEN: ${{ inputs.pyxis-api-token }}
       RHCC_PROJECT_ID: ${{ inputs.redhat-project-id }}
-      PREFLIGHT_VERSION: "1.3.0"
+      PREFLIGHT_VERSION: "1.3.4"
       IMAGE_URI: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.version }}
     run: |
       hack/build/ci/preflight.sh "${{ env.PREFLIGHT_VERSION }}" "${{ env.IMAGE_URI}}" "${{ inputs.report-name }}"

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Push ${{matrix.platform}} to ${{matrix.registry-name}}
         uses: ./.github/actions/upload-image
-        if: ${{ matrix.registry-name != "rhcc" && matrix.platform != "arm64" }}
+        if: matrix.registry-name != 'rhcc' && matrix.platform != 'arm64'
         with:
           platform: ${{matrix.platform}}
           labels: ${{ needs.prepare.outputs.labels }}
@@ -112,7 +112,7 @@ jobs:
           repository-username: ${{ secrets[matrix.username] }}
           repository-password: ${{ secrets[matrix.password] }}
       - name: Run preflight
-        if: ${{ matrix.registry-name == "rhcc" && matrix.platform == "amd64" }}
+        if: matrix.registry-name == 'rhcc' && matrix.platform == 'amd64'
         uses: ./.github/actions/preflight
         with:
           version: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -87,13 +87,13 @@ jobs:
             repository: dynatrace/dynatrace-operator
             username: RHCC_USERNAME
             password: RHCC_PASSWORD
-          - registry: gcr
-            url: gcr.io
+          - registry-name: gcr
+            registry-url: gcr.io
             repository: dynatrace-marketplace-prod/dynatrace-operator
             username: GCR_USERNAME
             password: GCR_JSON_KEY
-          - registry: dockerhub
-            url: docker.io
+          - registry-name: dockerhub
+            registry-url: docker.io
             repository: dynatrace/dynatrace-operator
             username: DOCKERHUB_USERNAME
             password: DOCKERHUB_PASSWORD

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -117,7 +117,7 @@ jobs:
         with:
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{matrix.registry-url}}
-          repository: ${{matrix.repository}}
+          repository: ${{ secrets[matrix.repository] }}
           report-name: "preflight.json"
           redhat-project-id: ${{ secrets.REDHAT_PROJECT_ID }}
           pyxis-api-token: ${{ secrets.PYXIS_API_TOKEN }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -125,9 +125,9 @@ jobs:
           rhcc-password: ${{ secrets[matrix.password] }}
 
   manifest:
-    name: Create Dockerhub manifests
+    name: Create manifests
     environment: Release
-    needs: [prepare, push-dockerhub-amd, push-dockerhub-arm]
+    needs: [prepare, push]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -84,17 +84,17 @@ jobs:
         include:
           - registry-name: rhcc
             registry-url: scan.connect.redhat.com
-            repository: dynatrace/dynatrace-operator
+            repository: RHCC_REPOSITORY
             username: RHCC_USERNAME
             password: RHCC_PASSWORD
           - registry-name: gcr
             registry-url: gcr.io
-            repository: dynatrace-marketplace-prod/dynatrace-operator
+            repository: GCR_REPOSITORY
             username: GCR_USERNAME
             password: GCR_JSON_KEY
           - registry-name: dockerhub
             registry-url: docker.io
-            repository: dynatrace/dynatrace-operator
+            repository: DOCKERHUB_REPOSITORY
             username: DOCKERHUB_USERNAME
             password: DOCKERHUB_PASSWORD
     steps:
@@ -104,11 +104,11 @@ jobs:
         uses: ./.github/actions/upload-image
         if: matrix.registry-name != 'rhcc' || ( matrix.registry-name == 'rhcc' && matrix.platform == 'amd64' )
         with:
-          platform: ${{matrix.platform}}
+          platform: ${{ matrix.platform }}
           labels: ${{ needs.prepare.outputs.labels }}
           version: ${{ needs.prepare.outputs.version }}
-          registry: ${{matrix.registry-url}}
-          repository: ${{matrix.repository}}
+          registry: ${{ matrix.registry-url }}
+          repository: ${{ secrets[matrix.repository] }}
           repository-username: ${{ secrets[matrix.username] }}
           repository-password: ${{ secrets[matrix.password] }}
       - name: Run preflight
@@ -135,12 +135,12 @@ jobs:
         include:
           - registry: gcr
             url: gcr.io
-            repository: dynatrace-marketplace-prod/dynatrace-operator
+            repository: GCR_REPOSITORY
             username: GCR_USERNAME
             password: GCR_JSON_KEY
           - registry: dockerhub
             url: docker.io
-            repository: dynatrace/dynatrace-operator
+            repository: DOCKERHUB_REPOSITORY
             username: DOCKERHUB_USERNAME
             password: DOCKERHUB_PASSWORD
     steps:
@@ -151,7 +151,7 @@ jobs:
         with:
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{ matrix.url }}
-          repository: ${{ matrix.repository }}
+          repository: ${{ secrets[matrix.repository] }}
           combined: true
           repository-username: ${{ secrets[matrix.username] }}
           repository-password: ${{ secrets[matrix.password] }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         platform: [amd64, arm64]
-        registry: [rhcc, gcr, dockerhub]
+        registry-name: [rhcc, gcr, dockerhub]
         include:
           - registry-name: rhcc
             registry-url: scan.connect.redhat.com
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Push ${{matrix.platform}} to ${{matrix.registry-name}}
         uses: ./.github/actions/upload-image
-        if: matrix.registry-name != 'rhcc' && matrix.platform != 'arm64'
+        if: matrix.registry-name != 'rhcc' || ( matrix.registry-name == 'rhcc' && matrix.platform == 'amd64' )
         with:
           platform: ${{matrix.platform}}
           labels: ${{ needs.prepare.outputs.labels }}

--- a/hack/build/ci/preflight.sh
+++ b/hack/build/ci/preflight.sh
@@ -15,7 +15,9 @@ download_preflight() {
 }
 
 check_image() {
-  ./"${PREFLIGHT_EXECUTABLE}" check container "${IMAGE_TAG}" 1> "${PREFLIGHT_REPORT_NAME}" 2> "${PREFLIGHT_LOG}"
+  ./"${PREFLIGHT_EXECUTABLE}" check container "${IMAGE_TAG}" \
+    --docker-config="${HOME}/.docker/config.json" \
+    1> "${PREFLIGHT_REPORT_NAME}" 2> "${PREFLIGHT_LOG}"
   echo "${PREFLIGHT_EXECUTABLE} returned ${?}"
   cat "${PREFLIGHT_LOG}"
   grep "Preflight result: PASSED" "${PREFLIGHT_LOG}" || exit 1

--- a/hack/build/ci/preflight.sh
+++ b/hack/build/ci/preflight.sh
@@ -22,7 +22,10 @@ check_image() {
 }
 
 submit_report() {
-   ./"${PREFLIGHT_EXECUTABLE}" check container "${IMAGE_TAG}" --submit --pyxis-api-token="${RHCC_APITOKEN}" --certification-project-id="${RHCC_PROJECT_ID}"
+  ./"${PREFLIGHT_EXECUTABLE}" check container "${IMAGE_TAG}" \
+    --pyxis-api-token="${RHCC_APITOKEN}" --certification-project-id="${RHCC_PROJECT_ID}" \
+    --docker-config="${HOME}/.docker/config.json" \
+    --submit
 }
 
 download_preflight


### PR DESCRIPTION
# Description

During the last release some smaller issues came up which were fixed:
- missing docker config for preflight
- incorrect repository for RHCC image
- incorrect matrix usage for push action

## How can this be tested?
Trigger the publish images action by creating a tag (e.g. on a fork) and have all the secrets available.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

