### PR TITLE
Fix custom activegate labels in Dynakube

### DIFF
--- a/src/controllers/activegate/reconciler/statefulset/statefulset.go
+++ b/src/controllers/activegate/reconciler/statefulset/statefulset.go
@@ -107,7 +107,7 @@ func CreateStatefulSet(stsProperties *statefulSetProperties) (*appsv1.StatefulSe
 			Selector:            &metav1.LabelSelector{MatchLabels: appLabels.BuildMatchLabels()},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: appLabels.BuildLabels(),
+					Labels: stsProperties.buildLabels(appLabels.BuildLabels()),
 					Annotations: map[string]string{
 						annotationActiveGateConfigurationHash: stsProperties.activeGateConfigurationHash,
 					},
@@ -131,6 +131,13 @@ func CreateStatefulSet(stsProperties *statefulSetProperties) (*appsv1.StatefulSe
 
 	sts.ObjectMeta.Annotations[kubeobjects.AnnotationHash] = hash
 	return sts, nil
+}
+
+func (stsProperties *statefulSetProperties) buildLabels(appLabels map[string]string) map[string]string {
+	return kubeobjects.MergeLabels(
+		appLabels,
+		stsProperties.Labels,
+	)
 }
 
 func getContainerBuilders(stsProperties *statefulSetProperties) []kubeobjects.ContainerBuilder {


### PR DESCRIPTION
# Description
Labels defined in `activegate.labels` (or one of the deprecated sections) were not passed to the pods.

## How can this be tested?
Define custom activegate labels and check they are added to the statefulset/pods:
```yaml
...
  activeGate:
    capabilities:
      - routing
      - kubernetes-monitoring
    labels:
      custom: test
```

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

