### PR TITLE
Fix failing ActiveGate deployment on Google Autopilot

### DIFF
--- a/src/controllers/dynakube/activegate/capability/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/capability/reconciler_test.go
@@ -3,7 +3,6 @@ package capability
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
@@ -11,6 +10,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/src/kubesystem"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/src/controllers/dynakube/activegate/statefulset/affinity.go
+++ b/src/controllers/dynakube/activegate/statefulset/affinity.go
@@ -20,7 +20,7 @@ func affinityWithoutArch() *corev1.Affinity {
 		NodeAffinity: &corev1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					{},
+					kubernetesOsSelectorTerm(),
 				},
 			},
 		},
@@ -37,5 +37,11 @@ func affinityNodeSelectorTerms() []corev1.NodeSelectorTerm {
 func kubernetesArchOsSelectorTerm() corev1.NodeSelectorTerm {
 	return corev1.NodeSelectorTerm{
 		MatchExpressions: kubeobjects.AffinityNodeRequirement(),
+	}
+}
+
+func kubernetesOsSelectorTerm() corev1.NodeSelectorTerm {
+	return corev1.NodeSelectorTerm{
+		MatchExpressions: kubeobjects.AffinityNodeRequirementWithoutArch(),
 	}
 }

--- a/src/controllers/dynakube/activegate/statefulset/affinity.go
+++ b/src/controllers/dynakube/activegate/statefulset/affinity.go
@@ -15,6 +15,18 @@ func affinity() *corev1.Affinity {
 	}
 }
 
+func affinityWithoutArch() *corev1.Affinity {
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{},
+				},
+			},
+		},
+	}
+}
+
 func affinityNodeSelectorTerms() []corev1.NodeSelectorTerm {
 	nodeSelectorTerms := []corev1.NodeSelectorTerm{
 		kubernetesArchOsSelectorTerm(),

--- a/src/controllers/dynakube/activegate/statefulset/affinity.go
+++ b/src/controllers/dynakube/activegate/statefulset/affinity.go
@@ -5,7 +5,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func affinity() *corev1.Affinity {
+func Affinity() *corev1.Affinity {
 	return &corev1.Affinity{
 		NodeAffinity: &corev1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
@@ -15,7 +15,7 @@ func affinity() *corev1.Affinity {
 	}
 }
 
-func affinityWithoutArch() *corev1.Affinity {
+func AffinityWithoutArch() *corev1.Affinity {
 	return &corev1.Affinity{
 		NodeAffinity: &corev1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{

--- a/src/controllers/dynakube/activegate/statefulset/affinity_test.go
+++ b/src/controllers/dynakube/activegate/statefulset/affinity_test.go
@@ -1,8 +1,9 @@
 package statefulset
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAffinity(t *testing.T) {

--- a/src/controllers/dynakube/activegate/statefulset/affinity_test.go
+++ b/src/controllers/dynakube/activegate/statefulset/affinity_test.go
@@ -1,15 +1,27 @@
 package statefulset
 
 import (
-	"testing"
-
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestAffinity(t *testing.T) {
-	affinitySpec := affinity()
-	nodeSelectorTerms := affinitySpec.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	t.Run("default selector terms", func(t *testing.T) {
+		affinitySpec := affinity()
+		nodeSelectorTerms := affinitySpec.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 
-	assert.Equal(t, 1, len(nodeSelectorTerms))
-	assert.Contains(t, nodeSelectorTerms, kubernetesArchOsSelectorTerm())
+		assert.Equal(t, 1, len(nodeSelectorTerms))
+		assert.Contains(t, nodeSelectorTerms, kubernetesArchOsSelectorTerm())
+	})
+	t.Run("affinity without OS term", func(t *testing.T) {
+		affinitySpec := affinityWithoutArch()
+
+		assert.NotNil(t, affinitySpec)
+
+		nodeSelectorTerms := affinitySpec.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+
+		assert.Equal(t, 1, len(nodeSelectorTerms))
+		assert.Contains(t, nodeSelectorTerms, kubeobjects.AffinityNodeRequirement())
+	})
 }

--- a/src/controllers/dynakube/activegate/statefulset/affinity_test.go
+++ b/src/controllers/dynakube/activegate/statefulset/affinity_test.go
@@ -1,7 +1,6 @@
 package statefulset
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -22,6 +21,6 @@ func TestAffinity(t *testing.T) {
 		nodeSelectorTerms := affinitySpec.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 
 		assert.Equal(t, 1, len(nodeSelectorTerms))
-		assert.Contains(t, nodeSelectorTerms, kubeobjects.AffinityNodeRequirement())
+		assert.Contains(t, nodeSelectorTerms, kubernetesOsSelectorTerm())
 	})
 }

--- a/src/controllers/dynakube/activegate/statefulset/affinity_test.go
+++ b/src/controllers/dynakube/activegate/statefulset/affinity_test.go
@@ -7,14 +7,14 @@ import (
 
 func TestAffinity(t *testing.T) {
 	t.Run("default selector terms", func(t *testing.T) {
-		affinitySpec := affinity()
+		affinitySpec := Affinity()
 		nodeSelectorTerms := affinitySpec.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 
 		assert.Equal(t, 1, len(nodeSelectorTerms))
 		assert.Contains(t, nodeSelectorTerms, kubernetesArchOsSelectorTerm())
 	})
 	t.Run("affinity without OS term", func(t *testing.T) {
-		affinitySpec := affinityWithoutArch()
+		affinitySpec := AffinityWithoutArch()
 
 		assert.NotNil(t, affinitySpec)
 

--- a/src/controllers/dynakube/activegate/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/statefulset/statefulset.go
@@ -147,7 +147,7 @@ func buildTemplateSpec(stsProperties *statefulSetProperties) corev1.PodSpec {
 		InitContainers:     buildInitContainers(stsProperties),
 		NodeSelector:       stsProperties.CapabilityProperties.NodeSelector,
 		ServiceAccountName: determineServiceAccountName(stsProperties),
-		Affinity:           affinity(),
+		Affinity:           Affinity(),
 		Tolerations:        stsProperties.Tolerations,
 		Volumes:            buildVolumes(stsProperties, extraContainerBuilders),
 		ImagePullSecrets: []corev1.LocalObjectReference{

--- a/src/kubeobjects/affinity.go
+++ b/src/kubeobjects/affinity.go
@@ -19,17 +19,29 @@ func AffinityNodeRequirementWithARM64() []corev1.NodeSelectorRequirement {
 	return affinityNodeRequirementsForArches(amd64, arm64)
 }
 
+func AffinityNodeRequirementWithoutArch() []corev1.NodeSelectorRequirement {
+	return []corev1.NodeSelectorRequirement{linuxRequirement()}
+}
+
 func affinityNodeRequirementsForArches(arches ...string) []corev1.NodeSelectorRequirement {
 	return []corev1.NodeSelectorRequirement{
-		{
-			Key:      kubernetesArch,
-			Operator: corev1.NodeSelectorOpIn,
-			Values:   arches,
-		},
-		{
-			Key:      kubernetesOS,
-			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{linux},
-		},
+		archRequirement(arches...),
+		linuxRequirement(),
+	}
+}
+
+func archRequirement(arches ...string) corev1.NodeSelectorRequirement {
+	return corev1.NodeSelectorRequirement{
+		Key:      kubernetesArch,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   arches,
+	}
+}
+
+func linuxRequirement() corev1.NodeSelectorRequirement {
+	return corev1.NodeSelectorRequirement{
+		Key:      kubernetesOS,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{linux},
 	}
 }

--- a/src/kubeobjects/affinity_test.go
+++ b/src/kubeobjects/affinity_test.go
@@ -7,7 +7,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const nodeSelectorRequirements = 2
+const (
+	nodeSelectorRequirements = 2
+
+	testArch1 = "arch1"
+	testArch2 = "arch2"
+)
 
 func TestAffinityNodeRequirement(t *testing.T) {
 	assert.Equal(t, AffinityNodeRequirement(), affinityNodeRequirementsForArches(amd64))
@@ -18,10 +23,39 @@ func TestAffinityNodeRequirement(t *testing.T) {
 	assert.Contains(t, AffinityNodeRequirementWithARM64(), linuxRequirement())
 }
 
-func linuxRequirement() corev1.NodeSelectorRequirement {
-	return corev1.NodeSelectorRequirement{
+func TestLinuxRequirement(t *testing.T) {
+	expectedRequirement := corev1.NodeSelectorRequirement{
 		Key:      kubernetesOS,
 		Operator: corev1.NodeSelectorOpIn,
 		Values:   []string{linux},
 	}
+
+	assert.Equal(t, expectedRequirement, linuxRequirement())
+}
+
+func TestArchRequirement(t *testing.T) {
+	expectedRequirement := corev1.NodeSelectorRequirement{
+		Key:      kubernetesArch,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{testArch1},
+	}
+
+	assert.Equal(t, expectedRequirement, archRequirement(testArch1))
+
+	expectedRequirement = corev1.NodeSelectorRequirement{
+		Key:      kubernetesArch,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{testArch1, testArch2},
+	}
+
+	assert.Equal(t, expectedRequirement, archRequirement(testArch1, testArch2))
+}
+
+func TestAffinityNodeRequirementWithoutArch(t *testing.T) {
+	expectedAffinity := []corev1.NodeSelectorRequirement{
+		linuxRequirement(),
+	}
+	affinity := AffinityNodeRequirementWithoutArch()
+
+	assert.Equal(t, expectedAffinity, affinity)
 }


### PR DESCRIPTION
# Description

On the latest gke autopilot, the ActiveGate deployment fails.
This is due to the stateful set including node selectors for the architecture, which are not allowed on GKE Autopilot as of Kubernetes 1.23 available in the rapid channel.

This changes retries deploying the ActiveGate without the mentioned node selector if the first deployment fails.

## How can this be tested?

* Create an Autopilot cluster using the Rapid channel
* Deploy the Operator
* Deploy a Dynakube CR with an ActiveGate
* The ActiveGate should be deployed correctly without the node selector concerning the architecture


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

