### PR TITLE
Ensure csi driver availability on node scale-down

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -163,6 +163,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -4651,6 +4652,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: provisioner
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app.kubernetes.io/name: dynatrace-operator
         app.kubernetes.io/version: "0.0.0-snapshot"
@@ -4897,6 +4899,9 @@ spec:
           operator: Exists
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoSchedule
+          key: ToBeDeletedByClusterAutoscaler
           operator: Exists
   updateStrategy:
     rollingUpdate:

--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -163,7 +163,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -5075,6 +5075,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: provisioner
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app.kubernetes.io/name: dynatrace-operator
         app.kubernetes.io/version: "0.0.0-snapshot"
@@ -5321,6 +5322,9 @@ spec:
           operator: Exists
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoSchedule
+          key: ToBeDeletedByClusterAutoscaler
           operator: Exists
   updateStrategy:
     rollingUpdate:

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -32,6 +32,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: provisioner
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
         {{- if and (eq (default false .Values.apparmor) true) (ne .Values.platform "openshift") }}
         container.apparmor.security.beta.kubernetes.io/driver: runtime/default
         container.apparmor.security.beta.kubernetes.io/registrar: runtime/default

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -23,6 +23,9 @@ tests:
           - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
             operator: Exists
+          - effect: NoSchedule
+            key: ToBeDeletedByClusterAutoscaler
+            operator: Exists
 
   - it: should have nodeSelectors if set
     set:
@@ -73,6 +76,9 @@ tests:
                   operator: Exists
                 - effect: NoSchedule
                   key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+                - effect: NoSchedule
+                  key: ToBeDeletedByClusterAutoscaler
                   operator: Exists
             containers:
               - args:
@@ -320,6 +326,7 @@ tests:
       - equal:
           path: spec.template.metadata.annotations
           value:
+            cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
             kubectl.kubernetes.io/default-container: provisioner
             testKey: testValue
 

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -58,6 +58,9 @@ csidriver:
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
       operator: Exists
+    - effect: NoSchedule
+      key: ToBeDeletedByClusterAutoscaler
+      operator: Exists
   labels: []
   annotations: []
   requests:


### PR DESCRIPTION
# Description

If a cluster is configured to use auto scaling and a the cluster auto scaler decides to scale down a node, he deletes every pod from the node and afterwards shuts down the node. However he also tries to schedule pods from a deployment for example to another node, but if the old replica can not be deleted because it can not unmount the csi volume it will stay in terminating phase until the node gets deleted and the pod forcefully deleted.  This can be prevented by annotating the CSI Pod with `cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"` for cluster-autoscaler version 1.22+ and for lower versions tolerating the `ToBeDeletedByClusterAutoscaler` taint.

## How can this be tested?

Create a cluster with auto-scalling and create applications to make the autoscaler scale up, afterwards reduce the load of applications and wait for the autoscaler to scale down. The CSI Pod should stay until the node is deleted in order to give other pods that depend on him the possibility to unmount the volume.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)
