### PR TITLE
Fixes and improvements to deploy_rhel.sh

### DIFF
--- a/hack/build/deploy_rhel.sh
+++ b/hack/build/deploy_rhel.sh
@@ -2,9 +2,59 @@
 
 if [[ ! "${TAG}" ]]; then
   echo "TAG variable not set"
-  echo "usage: 'make deploy-local TAG=\"<your-image-tag>\"' or 'make deploy-local-easy'"
+  echo "Usage: 'make deploy-local TAG=\"<your-image-tag>\"' or 'make deploy-local-easy'"
+  echo "See '-h' option for help"
   exit 5
 fi
+
+help_opts='^-h$'
+for o in "$@"; do
+	if [[ "$o" =~ $help_opts ]]; then
+		echo "Supported environment variables:"
+		echo "  IMG          Operator image pull spec override"
+		echo "  TAG          Operator image tag (required)"
+		echo "  LOCALBUILD   Do not build in a container (required for multi-arch)"
+		echo "  GOARCH       Desired CPU architecture (amd64|arm64|ppcle64|s390x)"
+		echo "  QUAY_EXPIRY  Days before deleting image from quay (defaults to never)"
+		exit 1
+	fi
+done
+
+function print_err() {
+	ERR_CMD=${ERR_CMD:-"UNKNOWN"}
+	if [[ "${ERR_CMD}" != "UNKNOWN" ]]; then
+		echo "ERROR: \"${ERR_CMD}\" exited abnormally. Aborting..."
+	else
+		echo "ERROR: An unknown error occurred. Aborting..."
+	fi
+}
+
+function check_err() {
+  if [[ "$?" != 0 ]]; then
+	  ERR_CON=$1
+	  case ${ERR_CON} in
+		  GO_BUILD)
+			  ERR_CMD="go build"
+			  print_err
+			  exit 10
+			  ;;
+		  GO_LICENSES)
+			  ERR_CMD="go-licenses save"
+			  print_err
+			  exit 20
+			  ;;
+		  DOCKER_BUILD)
+			  ERR_CMD="docker build"
+			  print_err
+			  exit 40
+			  ;;
+		  *)
+			  print_err
+			  exit 80
+			  ;;
+	  esac
+  fi
+}
 
 commit=$(git rev-parse HEAD)
 build_date="$(date -u +"%Y-%m-%d %H:%M:%S+00:00")"
@@ -16,29 +66,32 @@ go_build_args=(
 base_image="dynatrace-operator"
 out_image="${IMG:-quay.io/dynatrace/dynatrace-operator}:${TAG}"
 
+num_check='^[0-9]+$'
+if [[ -n "${QUAY_EXPIRY}" ]] && [[ "${QUAY_EXPIRY}" =~ ${num_check} ]]; then
+  expiry_args="--label quay.expires-after=${QUAY_EXPIRY}d"
+fi
+
 args="${go_build_args[@]}"
 if [[ "${LOCALBUILD}" ]]; then
   export CGO_ENABLED=1
   export GOOS=linux
   export GOARCH=${GOARCH:-amd64}
 
-  go build -ldflags "$args" -tags exclude_graphdriver_btrfs -o ./build/_output/bin/dynatrace-operator ./src/cmd/operator/
-
-  if [[ "$?" != 0 ]]; then
-	  echo "ERROR: go build exited abnormally. Aborting..."
-	  exit 10
-  fi
-
+  go build -ldflags "${args}" -tags exclude_graphdriver_btrfs -o ./build/_output/bin/dynatrace-operator ./src/cmd/
+  check_err GO_BUILD
+  
   go get github.com/google/go-licenses
   go-licenses save ./... --save_path third_party_licenses --force
+  check_err GO_LICENSES
 
-  docker build . -f ./Dockerfile-localbuild -t "${base_image}" --label "quay.expires-after=14d" --no-cache
+  docker build . -f ./Dockerfile-localbuild -t "${base_image}" ${expiry_args} --no-cache
+  check_err DOCKER_BUILD
 
   rm -rf ./third_party_licenses
 else
   # directory required by docker copy command
   mkdir -p third_party_licenses
-  docker build . -f ./Dockerfile -t "${base_image}" --build-arg "GO_BUILD_ARGS=$args" --label "quay.expires-after=14d" --no-cache
+  docker build . -f ./Dockerfile -t "${base_image}" --build-arg "GO_BUILD_ARGS=${args}" ${expiry_args} --no-cache
   rm -rf third_party_licenses
 fi
 


### PR DESCRIPTION
# Description

This PR fixes #1051 and incorporates the following changes:
* Fixed to track relocated main.go file
* Quay expiry is now optional (defaults to never)
* Added `-h` option for help
* Much improved error checking

## How can this be tested?

On a RHEL 8 or 9 host meeting the installation requirements (see #787 for the full list):
```
$ CC=/usr/bin/gcc LOCALBUILD=1 IMG=quay.io/<your-org>/dynatrace-operator TAG=v0.8.0-test ./hack/build/deploy_rhel.sh
```

## Checklist
- [ ] Unit tests have been updated/added
- [ ] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)
