### PR TITLE
Make extractor handle standalone usecase

### DIFF
--- a/src/controllers/csi/provisioner/processmoduleconfig.go
+++ b/src/controllers/csi/provisioner/processmoduleconfig.go
@@ -2,7 +2,7 @@ package csiprovisioner
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
@@ -63,7 +63,7 @@ func (provisioner *OneAgentProvisioner) readProcessModuleConfigCache(tenantUUID 
 		return nil, err
 	}
 
-	jsonBytes, err := ioutil.ReadAll(processModuleConfigCacheFile)
+	jsonBytes, err := io.ReadAll(processModuleConfigCacheFile)
 	if err != nil {
 		if err := processModuleConfigCacheFile.Close(); err != nil {
 			log.Error(errors.WithStack(err), "error closing file after trying to read it")

--- a/src/installer/url/config.go
+++ b/src/installer/url/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	log              = logger.NewDTLogger().WithName("oneagent-url-installer")
+	log = logger.NewDTLogger().WithName("oneagent-url-installer")
 )
 
 const (

--- a/src/installer/url/config.go
+++ b/src/installer/url/config.go
@@ -1,14 +1,11 @@
 package url
 
 import (
-	"path/filepath"
-
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
 )
 
 var (
 	log              = logger.NewDTLogger().WithName("oneagent-url-installer")
-	standaloneBinDir = filepath.Join("mnt", "bin")
 )
 
 const (

--- a/src/installer/url/installer.go
+++ b/src/installer/url/installer.go
@@ -3,6 +3,7 @@ package url
 import (
 	"os"
 
+	"github.com/Dynatrace/dynatrace-operator/src/config"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/installer/symlink"
@@ -92,7 +93,7 @@ func (installer UrlInstaller) installAgentFromUrl(targetDir string) error {
 }
 
 func (installer UrlInstaller) isAlreadyDownloaded(targetDir string) bool {
-	if standaloneBinDir == targetDir {
+	if config.AgentBinDirMount == targetDir {
 		return false
 	}
 	_, err := installer.fs.Stat(targetDir)

--- a/src/installer/url/installer_test.go
+++ b/src/installer/url/installer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/arch"
+	"github.com/Dynatrace/dynatrace-operator/src/config"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/installer/zip"
@@ -204,7 +205,7 @@ func TestIsAlreadyDownloaded(t *testing.T) {
 	})
 	t.Run(`false if standalone`, func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		targetDir := standaloneBinDir
+		targetDir := config.AgentBinDirMount
 		installer := &UrlInstaller{
 			fs:    fs,
 			props: &Properties{},


### PR DESCRIPTION
# Description

`/mnt/bin/` != `mnt/bin/`. This makes the standalone download think the agent is already downloaded.

## How can this be tested?
Deploy `applicationMonitoring` without CSI driver
Deploy sample app


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](/CONTRIBUTING.md)

