### PR TITLE
Adds validation that volume storage env setting isn't used in read-only mode

### DIFF
--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -400,3 +400,15 @@ func getRawImageTag(imageURI string) string {
 	splitURI := strings.Split(imageURI, ":")
 	return splitURI[len(splitURI)-1]
 }
+
+func (dk *DynaKube) GetOneAgentEnvironment() []corev1.EnvVar {
+	switch {
+	case dk.CloudNativeFullstackMode():
+		return dk.Spec.OneAgent.CloudNativeFullStack.Env
+	case dk.ClassicFullStackMode():
+		return dk.Spec.OneAgent.ClassicFullStack.Env
+	case dk.HostMonitoringMode():
+		return dk.Spec.OneAgent.HostMonitoring.Env
+	}
+	return []corev1.EnvVar{}
+}

--- a/src/api/v1beta1/properties_test.go
+++ b/src/api/v1beta1/properties_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -344,5 +345,95 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 		}
 
 		assert.True(t, dynakube.IsOneAgentPrivileged())
+	})
+}
+
+func TestGetOneAgentEnvironment(t *testing.T) {
+
+	t.Run("get environment from classicFullstack", func(t *testing.T) {
+		dk := DynaKube{
+			Spec: DynaKubeSpec{
+				OneAgent: OneAgentSpec{
+					ClassicFullStack: &HostInjectSpec{
+						Env: []corev1.EnvVar{
+							{
+								Name:  "classicFullstack",
+								Value: "true",
+							},
+						},
+					},
+				},
+			},
+		}
+		env := dk.GetOneAgentEnvironment()
+
+		require.Len(t, env, 1)
+		assert.Equal(t, "classicFullstack", env[0].Name)
+	})
+
+	t.Run("get environment from hostMonitoring", func(t *testing.T) {
+		dk := DynaKube{
+			Spec: DynaKubeSpec{
+				OneAgent: OneAgentSpec{
+					HostMonitoring: &HostInjectSpec{
+						Env: []corev1.EnvVar{
+							{
+								Name:  "hostMonitoring",
+								Value: "true",
+							},
+						},
+					},
+				},
+			},
+		}
+		env := dk.GetOneAgentEnvironment()
+
+		require.Len(t, env, 1)
+		assert.Equal(t, "hostMonitoring", env[0].Name)
+	})
+
+	t.Run("get environment from cloudNative", func(t *testing.T) {
+		dk := DynaKube{
+			Spec: DynaKubeSpec{
+				OneAgent: OneAgentSpec{
+					CloudNativeFullStack: &CloudNativeFullStackSpec{
+						HostInjectSpec: HostInjectSpec{
+							Env: []corev1.EnvVar{
+								{
+									Name:  "cloudNative",
+									Value: "true",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		env := dk.GetOneAgentEnvironment()
+
+		require.Len(t, env, 1)
+		assert.Equal(t, "cloudNative", env[0].Name)
+	})
+
+	t.Run("get environment from applicationMonitoring", func(t *testing.T) {
+		dk := DynaKube{
+			Spec: DynaKubeSpec{
+				OneAgent: OneAgentSpec{
+					ApplicationMonitoring: &ApplicationMonitoringSpec{},
+				},
+			},
+		}
+		env := dk.GetOneAgentEnvironment()
+
+		require.NotNil(t, env)
+		assert.Len(t, env, 0)
+	})
+
+	t.Run("get environment from unconfigured dynakube", func(t *testing.T) {
+		dk := DynaKube{}
+		env := dk.GetOneAgentEnvironment()
+
+		require.NotNil(t, env)
+		assert.Len(t, env, 0)
 	})
 }

--- a/src/webhook/validation/config.go
+++ b/src/webhook/validation/config.go
@@ -6,6 +6,8 @@ import (
 	"github.com/go-logr/logr"
 )
 
+const oneagentEnableVolumeStorageEnvVarName = "ONEAGENT_ENABLE_VOLUME_STORAGE"
+
 var log = logger.NewDTLogger().WithName("validation-webhook")
 
 type validator func(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string
@@ -24,6 +26,7 @@ var validators = []validator{
 	conflictingReadOnlyFilesystemAndMultipleOsAgentsOnNode,
 	noResourcesAvailable,
 	imageFieldSetWithoutCSIFlag,
+	conflictingOneAgentVolumeStorageSettings,
 }
 
 var warnings = []validator{
@@ -38,6 +41,7 @@ var warnings = []validator{
 	deprecatedFeatureFlagDisableReadOnlyAgent,
 	deprecatedFeatureFlagDisableWebhookReinvocationPolicy,
 	deprecatedFeatureFlagDisableMetadataEnrichment,
+	ineffectiveReadOnlyHostFsFeatureFlag,
 }
 
 func SetLogger(logger logr.Logger) {


### PR DESCRIPTION
# Description
When the OneAgent is deployed with the `ONEAGENT_ENABLE_VOLUME_STORAGE` environment variable set to `true` while being used on a system with a read-only host filesystem, it fails its initialization procedure. Added a validation that this combination is rejected for `cloudNativeFullstack` and hostMonitoring setups. Also added a warning if the feature flag `oneagent-readonly-host-fs` is used in `classicFullstack` where it doesn't have any effects.

## How can this be tested?
- create a `cloudNativeFullstack` configuration with FF `oneagent-readonly-host-fs = true` and `ONEAGENT_ENABLE_VOLUME_STORAGE` env variable added in `oneAgent` spec.
- when applying the config, an error shall be displayed, that this combination is not accepted.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

