### PR TITLE
Creates the shared image dir so `os.Rename` can work

### DIFF
--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -48,6 +48,11 @@ func (installer ImageInstaller) ImageDigest() string {
 func (installer *ImageInstaller) InstallAgent(targetDir string) (bool, error) {
 	log.Info("installing agent from image")
 
+	err := installer.fs.Mkdir(installer.props.PathResolver.AgentSharedBinaryDirBase(), common.MkDirFileMode)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+
 	if err := installer.installAgentFromImage(); err != nil {
 		_ = installer.fs.RemoveAll(targetDir)
 		log.Info("failed to install agent from image", "err", err)

--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -50,7 +50,8 @@ func (installer *ImageInstaller) InstallAgent(targetDir string) (bool, error) {
 
 	err := installer.fs.MkdirAll(installer.props.PathResolver.AgentSharedBinaryDirBase(), common.MkDirFileMode)
 	if err != nil {
-		return false, err
+		log.Info("failed to create the base shared agent directory", "err", err)
+		return false, errors.WithStack(err)
 	}
 
 	if err := installer.installAgentFromImage(); err != nil {

--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -48,9 +48,9 @@ func (installer ImageInstaller) ImageDigest() string {
 func (installer *ImageInstaller) InstallAgent(targetDir string) (bool, error) {
 	log.Info("installing agent from image")
 
-	err := installer.fs.Mkdir(installer.props.PathResolver.AgentSharedBinaryDirBase(), common.MkDirFileMode)
+	err := installer.fs.MkdirAll(installer.props.PathResolver.AgentSharedBinaryDirBase(), common.MkDirFileMode)
 	if err != nil {
-		return false, errors.WithStack(err)
+		return false, err
 	}
 
 	if err := installer.installAgentFromImage(); err != nil {


### PR DESCRIPTION
# Description

The `/data/codemodules` directory is not created, and the `os.Rename` is not smart enough to move a dir from `/data/tmp_zip` to `/data/codemodules/<image-digest>`
This causes that the CSI driver can't finish the download if `codeModulesImage` is used

## How can this be tested?
Deploy the operator on a fresh cluster (where `/data/codemodules` doesn't exist)
and create a Dynakube that uses the CSI driver with `codeModulesImage`


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

