### PR TITLE
Readds the version log to the top of the logs

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/standalone"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/webhook"
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -71,6 +72,7 @@ func rootCommand(_ *cobra.Command, _ []string) error {
 }
 
 func main() {
+	version.LogVersion()
 	ctrl.SetLogger(log)
 	cmd := newRootCommand()
 


### PR DESCRIPTION
# Description
The operator is missing the fist log line in all of our pods, which usually printed the commit hash, operator version and other infos.

## How can this be tested?
Deploy, then check first line in the log to be something like:
```
{"level":"info","ts":"2022-08-03T12:24:32.051Z","logger":"dynatrace-operator-version","msg":"dynatrace-operator","version":"v0.7.2","gitCommit":"ed89e3e390eb12a49ca2d21de08b4c33ede49a09","buildDate":"2022-07-13T07:51:51+00:00","goVersion":"go
1.18.4","platform":"linux/amd64"} 
```


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

