### PR TITLE
Creates the shared image dir so `os.Rename` can work (#1103)

### DIFF
--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -48,6 +48,12 @@ func (installer ImageInstaller) ImageDigest() string {
 func (installer *ImageInstaller) InstallAgent(targetDir string) (bool, error) {
 	log.Info("installing agent from image")
 
+	err := installer.fs.MkdirAll(installer.props.PathResolver.AgentSharedBinaryDirBase(), common.MkDirFileMode)
+	if err != nil {
+		log.Info("failed to create the base shared agent directory", "err", err)
+		return false, errors.WithStack(err)
+	}
+
 	if err := installer.installAgentFromImage(); err != nil {
 		_ = installer.fs.RemoveAll(targetDir)
 		log.Info("failed to install agent from image", "err", err)


### PR DESCRIPTION
# Description
cherry-pick of https://github.com/Dynatrace/dynatrace-operator/pull/1103

## How can this be tested?
same as https://github.com/Dynatrace/dynatrace-operator/pull/1103


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

