### PR TITLE
Switch back to ubi8-micro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM registry.access.redhat.com/ubi8-minimal:8.6 as dependency-src
 
 RUN  microdnf install util-linux && microdnf clean all
 
-FROM registry.access.redhat.com/ubi9-micro:9.0.0
+FROM registry.access.redhat.com/ubi8-micro:8.6
 
 # operator dependencies
 COPY --from=operator-build /etc/ssl/cert.pem /etc/ssl/cert.pem


### PR DESCRIPTION
# Description

As ubi9-micro has some problems running on specific hardware and together with some container runtimes, we should switch back to ubi8-micro to be on the safe side.

## How can this be tested?
Should work as before and all operator components should run, if they are deployed


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

