### PR TITLE
Removes unnecessary wiring around image build on CI

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -10,9 +10,6 @@ inputs:
   go-linker-args:
     description: The linker args for the go compiler
     required: true
-  cgo-cflags:
-    description: The cgo cflags for the go compiler
-    required: true
   labels:
     description: The labels for the built image
     required: true
@@ -48,7 +45,6 @@ runs:
         builder: ${{ steps.buildx.outputs.name }}
         build-args: |
           GO_LINKER_ARGS=${{ inputs.go-linker-args }}
-          CGO_CFLAGS=${{ inputs.cgo-cflags }}
         context: .
         file: ./Dockerfile
         platforms: linux/${{ inputs.platform }}

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -4,9 +4,6 @@ inputs:
   platform:
     description: The platform for which the image will be built
     required: true
-  go-linker-args:
-    description: The linker args for the go compiler
-    required: true
   labels:
     description: The labels for the built image
     required: true
@@ -24,6 +21,11 @@ runs:
       uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
       with:
         go-version-file: "${{ github.workspace }}/go.mod"
+    - name: Prepare build parameters
+      id: prep
+      shell: bash
+      run: |
+        hack/build/ci/prepare-build-variables.sh
     - name: Setup cache
       uses: actions/cache@a7c34adf76222e77931dedbf4a45b2e4648ced19 # v3
       with:
@@ -32,7 +34,7 @@ runs:
           ~/.cache/go-build
           ./third_party_licenses
         key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
-    - name: Prepare
+    - name: Download go build dependencies
       shell: bash
       run: |
         hack/build/ci/download-go-build-deps.sh
@@ -41,7 +43,7 @@ runs:
       with:
         builder: ${{ steps.buildx.outputs.name }}
         build-args: |
-          GO_LINKER_ARGS=${{ inputs.go-linker-args }}
+          GO_LINKER_ARGS=${{ steps.prep.outputs.go_linker_args }}
         context: .
         file: ./Dockerfile
         platforms: linux/${{ inputs.platform }}

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -4,9 +4,6 @@ inputs:
   platform:
     description: The platform for which the image will be built
     required: true
-  go-version:
-    description: The go version used during the build
-    required: true
   go-linker-args:
     description: The linker args for the go compiler
     required: true
@@ -26,7 +23,7 @@ runs:
     - name: Set up Golang
       uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
       with:
-        go-version: ${{ inputs.go-version }}
+        go-version-file: "${{ github.workspace }}/go.mod"
     - name: Setup cache
       uses: actions/cache@a7c34adf76222e77931dedbf4a45b2e4648ced19 # v3
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,6 @@ jobs:
       labels: ${{ steps.prep.outputs.docker_image_labels }}
       version: ${{ steps.prep.outputs.docker_image_tag }}
       go-linker-args: ${{ steps.prep.outputs.go_linker_args }}
-      cgo-cflags: ${{ steps.prep.outputs.cgo_cflags }}
       go-version: ${{ steps.prepenv.outputs.goversion }}
       registry: ${{ steps.prepenv.outputs.registry }}
       repository: ${{ steps.prepenv.outputs.repository }}
@@ -142,7 +141,6 @@ jobs:
           platform: ${{ matrix.platform }}
           go-version: ${{ needs.prepare.outputs.go-version }}
           go-linker-args: ${{ needs.prepare.outputs.go-linker-args }}
-          cgo-cflags: ${{ needs.prepare.outputs.cgo-cflags }}
           labels: ${{ needs.prepare.outputs.labels }}
           image-tag: ${{ needs.prepare.outputs.version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,7 +136,7 @@ jobs:
         if: matrix.platform != 'arm64' || github.ref_protected == 'true'
         uses: ./.github/actions/build-image
         with:
-          platform: amd64
+          platform: ${{ matrix.platform }}
           labels: ${{ needs.prepare.outputs.labels }}
           image-tag: ${{ needs.prepare.outputs.version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,6 @@ jobs:
     outputs:
       labels: ${{ steps.prep.outputs.docker_image_labels }}
       version: ${{ steps.prep.outputs.docker_image_tag }}
-      go-linker-args: ${{ steps.prep.outputs.go_linker_args }}
       registry: ${{ steps.prepenv.outputs.registry }}
       repository: ${{ steps.prepenv.outputs.repository }}
 
@@ -138,7 +137,6 @@ jobs:
         uses: ./.github/actions/build-image
         with:
           platform: amd64
-          go-linker-args: ${{ needs.prepare.outputs.go-linker-args }}
           labels: ${{ needs.prepare.outputs.labels }}
           image-tag: ${{ needs.prepare.outputs.version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "${{ github.workspace }}/go.mod"
       - name: Download dependencies
         id: depdownload
         run: |
@@ -75,11 +75,11 @@ jobs:
     name: Run linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+      - uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
+        with:
+          go-version-file: "${{ github.workspace }}/go.mod"
       - name: Download dependencies
         id: depdownload
         run: |
@@ -114,7 +114,6 @@ jobs:
       labels: ${{ steps.prep.outputs.docker_image_labels }}
       version: ${{ steps.prep.outputs.docker_image_tag }}
       go-linker-args: ${{ steps.prep.outputs.go_linker_args }}
-      go-version: ${{ steps.prepenv.outputs.goversion }}
       registry: ${{ steps.prepenv.outputs.registry }}
       repository: ${{ steps.prepenv.outputs.repository }}
 
@@ -138,8 +137,7 @@ jobs:
         if: matrix.platform != 'arm64' || github.ref_protected == 'true'
         uses: ./.github/actions/build-image
         with:
-          platform: ${{ matrix.platform }}
-          go-version: ${{ needs.prepare.outputs.go-version }}
+          platform: amd64
           go-linker-args: ${{ needs.prepare.outputs.go-linker-args }}
           labels: ${{ needs.prepare.outputs.labels }}
           image-tag: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -24,7 +24,6 @@ jobs:
       labels: ${{ steps.prep.outputs.docker_image_labels }}
       version: ${{ steps.prep.outputs.docker_image_tag }}
       go-linker-args: ${{ steps.prep.outputs.go_linker_args }}
-      go-version: "1.19"
 
   build:
     name: Build images
@@ -40,7 +39,6 @@ jobs:
         uses: ./.github/actions/build-image
         with:
           platform: ${{ matrix.platform }}
-          go-version: ${{ needs.prepare.outputs.go-version }}
           go-linker-args: ${{ needs.prepare.outputs.go-linker-args }}
           labels: ${{ needs.prepare.outputs.labels }}
           image-tag: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -24,7 +24,6 @@ jobs:
       labels: ${{ steps.prep.outputs.docker_image_labels }}
       version: ${{ steps.prep.outputs.docker_image_tag }}
       go-linker-args: ${{ steps.prep.outputs.go_linker_args }}
-      cgo-cflags: ${{ steps.prep.outputs.cgo_cflags }}
       go-version: "1.19"
 
   build:
@@ -43,7 +42,6 @@ jobs:
           platform: ${{ matrix.platform }}
           go-version: ${{ needs.prepare.outputs.go-version }}
           go-linker-args: ${{ needs.prepare.outputs.go-linker-args }}
-          cgo-cflags: ${{ needs.prepare.outputs.cgo-cflags }}
           labels: ${{ needs.prepare.outputs.labels }}
           image-tag: ${{ needs.prepare.outputs.version }}
 

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -23,7 +23,6 @@ jobs:
     outputs:
       labels: ${{ steps.prep.outputs.docker_image_labels }}
       version: ${{ steps.prep.outputs.docker_image_tag }}
-      go-linker-args: ${{ steps.prep.outputs.go_linker_args }}
 
   build:
     name: Build images
@@ -39,7 +38,6 @@ jobs:
         uses: ./.github/actions/build-image
         with:
           platform: ${{ matrix.platform }}
-          go-linker-args: ${{ needs.prepare.outputs.go-linker-args }}
           labels: ${{ needs.prepare.outputs.labels }}
           image-tag: ${{ needs.prepare.outputs.version }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 # move previously cached go modules to gopath
 RUN if [ -d ./mod ]; then mkdir -p ${GOPATH}/pkg && [ -d mod ] && mv ./mod ${GOPATH}/pkg; fi;
 
-RUN CGO_ENABLED=1 CGO_CFLAGS="${CGO_CFLAGS}" go build -ldflags="${GO_LINKER_ARGS}" -o ./build/_output/bin/dynatrace-operator ./src/cmd/
+RUN CGO_ENABLED=1 CGO_CFLAGS="-O2 -Wno-return-local-addr" go build -ldflags="${GO_LINKER_ARGS}" -o ./build/_output/bin/dynatrace-operator ./src/cmd/
 
 FROM registry.access.redhat.com/ubi9-minimal:9.0.0 as dependency-src
 

--- a/hack/build/ci/prepare-build-variables.sh
+++ b/hack/build/ci/prepare-build-variables.sh
@@ -21,7 +21,6 @@ createDockerImageLabels() {
 }
 
 setBuildRelatedVariables() {
-  echo ::set-output name=cgo_cflags::"${cgo_cflags}"
   echo ::set-output name=go_linker_args::"${go_linker_args}"
   echo ::set-output name=docker_image_labels::"${docker_image_labels}"
   echo ::set-output name=docker_image_tag::"${docker_image_tag}"
@@ -31,6 +30,5 @@ setBuildRelatedVariables() {
 docker_image_tag=$(createDockerImageTag)
 docker_image_labels=$(createDockerImageLabels)
 go_linker_args=$(hack/build/create_go_linker_args.sh "${docker_image_tag}" "${GITHUB_SHA}")
-cgo_cflags=$(hack/build/create_cgo_cflags.sh)
 setBuildRelatedVariables
 

--- a/hack/build/create_cgo_cflags.sh
+++ b/hack/build/create_cgo_cflags.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-cgo_cflags=(
-  "-O2"
-  "-Wno-return-local-addr"
-)
-echo "${cgo_cflags[*]}"

--- a/hack/build/push_image.sh
+++ b/hack/build/push_image.sh
@@ -8,13 +8,11 @@ fi
 
 commit=$(git rev-parse HEAD)
 go_linker_args=$(hack/build/create_go_linker_args.sh "${TAG}" "${commit}")
-cgo_cflags=$(hack/build/create_cgo_cflags.sh)
 base_image="dynatrace-operator"
 out_image="${IMG:-quay.io/dynatrace/dynatrace-operator}:${TAG}"
 
 if [[ "${LOCALBUILD}" ]]; then
   export CGO_ENABLED=1
-  export CGO_CFLAGS="${cgo_cflags}"
   export GOOS=linux
   export GOARCH=amd64
 
@@ -31,7 +29,6 @@ else
   mkdir -p third_party_licenses
   docker build . -f ./Dockerfile -t "${base_image}" \
     --build-arg "GO_LINKER_ARGS=${go_linker_args}" \
-    --build-arg "CGO_CFLAGS=${cgo_cflags}" \
     --label "quay.expires-after=14d" \
     --no-cache
   rm -rf third_party_licenses


### PR DESCRIPTION
# Description
Too complex wiring between actions makes them difficult to understand.

To make it easier to work with, following parameters usage is changed:
- `CGO_CFLAGS` - embedded in Dockerfile, there is no need to make it configurable
- `go-version` - deduced from `go.mod` file instead of explicitly declaring it as input parameter
- `GO_LINKER_ARGS` - moved to `build-image` action, so now there is no need to pass it's value through multiple actions

## How can this be tested?
- CI
- locally `make build`


## Checklist
~- [ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

