### PR TITLE
[0.7 backport] Fix pod with owner of unknown workload kind

### DIFF
--- a/src/config/enrichment_injection.go
+++ b/src/config/enrichment_injection.go
@@ -1,0 +1,3 @@
+package config
+
+const EnrichmentUnknownWorkload = "UNKNOWN"

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/src/arch"
+	"github.com/Dynatrace/dynatrace-operator/src/config"
 	"github.com/pkg/errors"
 )
 
@@ -233,7 +234,11 @@ func (env *environment) addWorkloadKind() error {
 	if err != nil {
 		return err
 	}
-	env.WorkloadKind = workloadKind
+	if workloadKind == config.EnrichmentUnknownWorkload {
+		env.WorkloadKind = ""
+	} else {
+		env.WorkloadKind = workloadKind
+	}
 	return nil
 }
 
@@ -242,7 +247,11 @@ func (env *environment) addWorkloadName() error {
 	if err != nil {
 		return err
 	}
-	env.WorkloadName = workloadName
+	if workloadName == config.EnrichmentUnknownWorkload {
+		env.WorkloadName = ""
+	} else {
+		env.WorkloadName = workloadName
+	}
 	return nil
 }
 

--- a/src/webhook/mutation/pod_mutator.go
+++ b/src/webhook/mutation/pod_mutator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/src/config"
 	"net/http"
 	"net/url"
 	"os"
@@ -13,6 +12,7 @@ import (
 	"strings"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/config"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes"
 	appvolumes "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver/volumes/app"

--- a/src/webhook/mutation/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator_test.go
@@ -1343,7 +1343,7 @@ func buildResultPod(_ *testing.T, oneAgentFf FeatureFlag, dataIngestFf FeatureFl
 
 		pod.Spec.InitContainers[0].Env = append(pod.Spec.InitContainers[0].Env,
 			corev1.EnvVar{Name: dataIngestInjectedEnvVarName, Value: "true"},
-			corev1.EnvVar{Name: workloadKindEnvVarName, Value: ""},
+			corev1.EnvVar{Name: workloadKindEnvVarName, Value: "Pod"},
 			corev1.EnvVar{Name: workloadNameEnvVarName, Value: "test-pod-12345"},
 		)
 


### PR DESCRIPTION
# Description

See #1074 and #1086 

In case of owner that is not well-known, the kind would be set to Pod, while the name couldn't be set because .metadata.name is empty at this point. The empty kind/name is correct in this case and should not block the init container.

## How can this be tested?
Inject into a pod that has owner reference set to something of unknown kind, i.e. not Deployment, ReplicaSet, ..., but a separate API.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

