### PR TITLE
Sign images on release

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -22,46 +22,44 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # v2
-      - name: Set up Golang
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
-        with:
-          go-version: ${{ inputs.go-version }}
-      - name: Setup cache
-        uses: actions/cache@a7c34adf76222e77931dedbf4a45b2e4648ced19 # v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ./third_party_licenses
-          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
-      - name: Prepare
-        shell: bash
-        run: |
-          hack/build/ci/download-go-build-deps.sh
-      - name: Build target
-        uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94 # v3
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          build-args: |
-            GO_LINKER_ARGS=${{ inputs.go-linker-args }}
-            CGO_CFLAGS=${{ inputs.cgo-cflags }}
-          context: .
-          file: ./Dockerfile
-          platforms: linux/${{ inputs.platform }}
-          push: false
-          tags: operator-${{ inputs.platform }}:${{ inputs.image-tag }}
-          labels: ${{ inputs.labels }}
-          outputs: type=docker,dest=/tmp/operator-${{ inputs.platform }}.tar
-      - name: Upload artifact
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3
-        with:
-          name: operator-${{ inputs.platform }}
-          path: /tmp/operator-${{ inputs.platform }}.tar
-          retention-days: 1
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # v2
+    - name: Set up Golang
+      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
+      with:
+        go-version: ${{ inputs.go-version }}
+    - name: Setup cache
+      uses: actions/cache@a7c34adf76222e77931dedbf4a45b2e4648ced19 # v3
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ./third_party_licenses
+        key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
+    - name: Prepare
+      shell: bash
+      run: |
+        hack/build/ci/download-go-build-deps.sh
+    - name: Build target
+      uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94 # v3
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
+        build-args: |
+          GO_LINKER_ARGS=${{ inputs.go-linker-args }}
+          CGO_CFLAGS=${{ inputs.cgo-cflags }}
+        context: .
+        file: ./Dockerfile
+        platforms: linux/${{ inputs.platform }}
+        push: false
+        tags: operator-${{ inputs.platform }}:${{ inputs.image-tag }}
+        labels: ${{ inputs.labels }}
+        outputs: type=docker,dest=/tmp/operator-${{ inputs.platform }}.tar
+    - name: Upload artifact
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3
+      with:
+        name: operator-${{ inputs.platform }}
+        path: /tmp/operator-${{ inputs.platform }}.tar
+        retention-days: 1
 

--- a/.github/actions/create-manifests/action.yaml
+++ b/.github/actions/create-manifests/action.yaml
@@ -13,26 +13,12 @@ inputs:
   combined:
     description: Should it create a combined manifests for amd64 and arm64 builds
     required: true
-  repository-username:
-    description: The username to access the registry/repository
-    required: true
-  repository-password:
-    description: The password to access the registry/repository
-    required: true
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
-    - name: Login to Quay
-      uses:  docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2
-      with:
-        registry: ${{ inputs.registry }}
-        username: ${{ inputs.repository-username }}
-        password: ${{ inputs.repository-password }}
     - name: Create manifest
       env:
-        IMAGE_QUAY: ${{ inputs.registry }}/${{ inputs.repository }}
+        IMAGE: ${{ inputs.registry }}/${{ inputs.repository }}
       shell: bash
       run: |
-        hack/build/ci/create-manifest.sh "${IMAGE_QUAY}" "${{ inputs.version }}" ${{ inputs.combined }}
+        hack/build/ci/create-manifest.sh "${IMAGE}" "${{ inputs.version }}" ${{ inputs.combined }}

--- a/.github/actions/preflight/action.yaml
+++ b/.github/actions/preflight/action.yaml
@@ -19,25 +19,10 @@ inputs:
   pyxis-api-token:
     description: The pyxis api token
     required: true
-  rhcc-username:
-    description: The username to access rhcc
-    required: true
-  rhcc-password:
-    description: The password to access rhcc
-    required: true
-
 
 runs:
   using: "composite"
   steps:
-  - name: Checkout
-    uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
-  - name: Login to Registry
-    uses:  docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2
-    with:
-      registry: ${{ inputs.registry }}
-      username: ${{ inputs.rhcc-username }}
-      password: ${{ inputs.rhcc-password }}
   - name: Run preflight on image
     shell: bash
     env:

--- a/.github/actions/sign-image/action.yaml
+++ b/.github/actions/sign-image/action.yaml
@@ -1,0 +1,31 @@
+name: Sign Image
+description: Signs the operator docker image
+inputs:
+  image:
+    description: full image tag that will be signed
+    required: true
+  signing-key:
+    description: private signing key
+    required: true
+  signing-password:
+    description: password for private signing key
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@b3413d484cc23cf8778c3d2aa361568d4eb54679 # v2.5.1
+    - name: Sign image with a key
+      shell: bash
+      run: |
+        cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+      env:
+        TAGS: ${{ inputs.image }}
+        COSIGN_PRIVATE_KEY: ${{ inputs.signing-key }}
+        COSIGN_PASSWORD: ${{ inputs.signing-password }}
+    - name: Sign the images with GitHub OIDC Token
+      shell: bash
+      run: cosign sign ${TAGS}
+      env:
+        TAGS: ${{ inputs.image }}
+        COSIGN_EXPERIMENTAL: "true"

--- a/.github/actions/upload-image/action.yaml
+++ b/.github/actions/upload-image/action.yaml
@@ -16,23 +16,9 @@ inputs:
   repository:
     description: The repository in the registry where the image is uploaded
     required: true
-  repository-username:
-    description: The username to access the registry/repository
-    required: true
-  repository-password:
-    description: The password to access the registry/repository
-    required: true
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
-    - name: Login to Registry
-      uses:  docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2
-      with:
-        registry: ${{ inputs.registry }}
-        username: ${{ inputs.repository-username }}
-        password: ${{ inputs.repository-password }}
     - name: Download artifact
       uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
-      - name: build-image
+      - name: Login to Registry
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build image
         uses: ./.github/actions/build-image
         with:
           platform: amd64
@@ -143,8 +149,6 @@ jobs:
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{ needs.prepare.outputs.registry }}
           repository: ${{ needs.prepare.outputs.repository }}
-          repository-username: ${{ secrets.QUAY_USERNAME }}
-          repository-password: ${{ secrets.QUAY_PASSWORD }}
       - name: Create Manifests
         uses: ./.github/actions/create-manifests
         with:
@@ -152,8 +156,6 @@ jobs:
           registry: ${{ needs.prepare.outputs.registry }}
           repository: ${{ needs.prepare.outputs.repository }}
           combined: false
-          repository-username: ${{ secrets.QUAY_USERNAME }}
-          repository-password: ${{ secrets.QUAY_PASSWORD }}
 
   build-arm64:
     name: Build arm64 docker image
@@ -195,6 +197,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+      - name: Login to Registry
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
       - name: Create Manifests
         uses: ./.github/actions/create-manifests
         with:
@@ -202,5 +210,3 @@ jobs:
           registry: ${{ needs.prepare.outputs.registry }}
           repository: ${{ needs.prepare.outputs.repository }}
           combined: true
-          repository-username: ${{ secrets.QUAY_USERNAME }}
-          repository-password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -123,7 +123,7 @@ jobs:
             username: GCR_USERNAME
             password: GCR_JSON_KEY
           - registry: dockerhub
-            url: quay.io
+            url: docker.io
             repository: DOCKERHUB_REPOSITORY
             username: DOCKERHUB_USERNAME
             password: DOCKERHUB_PASSWORD

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -91,7 +91,7 @@ jobs:
           registry: ${{ matrix.url }}
           repository: ${{ secrets[matrix.repository] }}
       - name: Run preflight
-        if: matrix.registry-name == 'rhcc' && matrix.platform == 'amd64'
+        if: matrix.registry == 'rhcc' && matrix.platform == 'amd64'
         uses: ./.github/actions/preflight
         with:
          version: ${{ needs.prepare.outputs.version }}
@@ -101,7 +101,7 @@ jobs:
          redhat-project-id: ${{ secrets.REDHAT_PROJECT_ID }}
          pyxis-api-token: ${{ secrets.PYXIS_API_TOKEN }}
       - name: Create manifests for ${{matrix.registry}}
-        if: matrix.registry-name != 'rhcc'
+        if: matrix.registry != 'rhcc'
         uses: ./.github/actions/sign-image
         with:
           image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}-${{ matrix.platform }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -7,9 +7,9 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
-
   prepare:
     name: Prepare properties
     runs-on: ubuntu-latest
@@ -27,36 +27,20 @@ jobs:
       cgo-cflags: ${{ steps.prep.outputs.cgo_cflags }}
       go-version: "1.19"
 
-  # Workflow needs to build docker images again as separate workflows don't have access to others artifacts
-  # https://github.com/actions/download-artifact/issues/3
-  build-amd64:
-    name: Build image amd64
+  build:
+    name: Build images
     runs-on: ubuntu-latest
     needs: [prepare]
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
       - name: build-image
         uses: ./.github/actions/build-image
         with:
-          platform: amd64
-          go-version: ${{ needs.prepare.outputs.go-version }}
-          go-linker-args: ${{ needs.prepare.outputs.go-linker-args }}
-          cgo-cflags: ${{ needs.prepare.outputs.cgo-cflags }}
-          labels: ${{ needs.prepare.outputs.labels }}
-          image-tag: ${{ needs.prepare.outputs.version }}
-
-  build-arm64:
-    name: Build image arm64
-    runs-on: ubuntu-latest
-    needs: [prepare]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
-      - name: Build Image
-        uses: ./.github/actions/build-image
-        with:
-          platform: arm64
+          platform: ${{ matrix.platform }}
           go-version: ${{ needs.prepare.outputs.go-version }}
           go-linker-args: ${{ needs.prepare.outputs.go-linker-args }}
           cgo-cflags: ${{ needs.prepare.outputs.cgo-cflags }}
@@ -66,31 +50,37 @@ jobs:
   push:
     name: Push images
     environment: Release
-    needs: [prepare, build-arm64, build-amd64]
+    needs: [prepare, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
         platform: [amd64, arm64]
-        registry-name: [rhcc, gcr, dockerhub]
+        registry: [gcr, dockerhub]
         include:
-          - registry-name: rhcc
-            registry-url: scan.connect.redhat.com
-            repository: RHCC_REPOSITORY
-            username: RHCC_USERNAME
-            password: RHCC_PASSWORD
-          - registry-name: gcr
-            registry-url: gcr.io
-            repository: GCR_REPOSITORY
-            username: GCR_USERNAME
-            password: GCR_JSON_KEY
-          - registry-name: dockerhub
-            registry-url: docker.io
-            repository: DOCKERHUB_REPOSITORY
-            username: DOCKERHUB_USERNAME
-            password: DOCKERHUB_PASSWORD
+        - registry: rhcc
+          url: scan.connect.redhat.com
+          repository: RHCC_REPOSITORY
+          username: RHCC_USERNAME
+          password: RHCC_PASSWORD
+        - registry: gcr
+          url: gcr.io
+          repository: GCR_REPOSITORY
+          username: GCR_USERNAME
+          password: GCR_JSON_KEY
+        - registry: dockerhub
+          url: docker.io
+          repository: DOCKERHUB_REPOSITORY
+          username: DOCKERHUB_USERNAME
+          password: DOCKERHUB_PASSWORD
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+      - name: Login to Registry
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2
+        with:
+          registry: ${{ matrix.url }}
+          username: ${{ secrets[matrix.username] }}
+          password: ${{ secrets[matrix.password] }}
       - name: Push ${{matrix.platform}} to ${{matrix.registry-name}}
         uses: ./.github/actions/upload-image
         if: matrix.registry-name != 'rhcc' || ( matrix.registry-name == 'rhcc' && matrix.platform == 'amd64' )
@@ -98,22 +88,25 @@ jobs:
           platform: ${{ matrix.platform }}
           labels: ${{ needs.prepare.outputs.labels }}
           version: ${{ needs.prepare.outputs.version }}
-          registry: ${{ matrix.registry-url }}
+          registry: ${{ matrix.url }}
           repository: ${{ secrets[matrix.repository] }}
-          repository-username: ${{ secrets[matrix.username] }}
-          repository-password: ${{ secrets[matrix.password] }}
       - name: Run preflight
         if: matrix.registry-name == 'rhcc' && matrix.platform == 'amd64'
         uses: ./.github/actions/preflight
         with:
-          version: ${{ needs.prepare.outputs.version }}
-          registry: ${{matrix.registry-url}}
-          repository: ${{ secrets[matrix.repository] }}
-          report-name: "preflight.json"
-          redhat-project-id: ${{ secrets.REDHAT_PROJECT_ID }}
-          pyxis-api-token: ${{ secrets.PYXIS_API_TOKEN }}
-          rhcc-username: ${{ secrets[matrix.username] }}
-          rhcc-password: ${{ secrets[matrix.password] }}
+         version: ${{ needs.prepare.outputs.version }}
+         registry: ${{ matrix.url }}
+         repository: ${{ secrets[matrix.repository] }}
+         report-name: "preflight.json"
+         redhat-project-id: ${{ secrets.REDHAT_PROJECT_ID }}
+         pyxis-api-token: ${{ secrets.PYXIS_API_TOKEN }}
+      - name: Create manifests for ${{matrix.registry}}
+        if: matrix.registry-name != 'rhcc'
+        uses: ./.github/actions/sign-image
+        with:
+          image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}-${{ matrix.platform }}
+          signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          signing-password: ${{ secrets.COSIGN_PASSWORD }}
 
   manifest:
     name: Create manifests
@@ -130,13 +123,19 @@ jobs:
             username: GCR_USERNAME
             password: GCR_JSON_KEY
           - registry: dockerhub
-            url: docker.io
+            url: quay.io
             repository: DOCKERHUB_REPOSITORY
             username: DOCKERHUB_USERNAME
             password: DOCKERHUB_PASSWORD
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+      - name: Login to Registry
+        uses:  docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2
+        with:
+          registry: ${{ matrix.url }}
+          username: ${{ secrets[matrix.username] }}
+          password: ${{ secrets[matrix.password] }}
       - name: Create manifests for ${{matrix.registry}}
         uses: ./.github/actions/create-manifests
         with:
@@ -144,5 +143,9 @@ jobs:
           registry: ${{ matrix.url }}
           repository: ${{ secrets[matrix.repository] }}
           combined: true
-          repository-username: ${{ secrets[matrix.username] }}
-          repository-password: ${{ secrets[matrix.password] }}
+      - name: Sign manifests for ${{matrix.registry}}
+        uses: ./.github/actions/sign-image
+        with:
+          image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}
+          signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          signing-password: ${{ secrets.COSIGN_PASSWORD }}


### PR DESCRIPTION
# Description
Images pushed to Dockerhub and GCR are signed using `cosign` both with a private key and the experimental keyless way ([cosign docs](https://docs.sigstore.dev/cosign/sign)).


## How can this be tested?
Push a tag and watch action trigger, see [fork for working example](https://github.com/chrismuellner/dynatrace-operator/actions/workflows/publish-images.yaml).

CI should still work, checkout/login actions were moved out of composite action because of duplication. 

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

