### PR TITLE
Fix arm build on protected branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,10 +119,13 @@ jobs:
       registry: ${{ steps.prepenv.outputs.registry }}
       repository: ${{ steps.prepenv.outputs.repository }}
 
-  build-amd64:
-    name: Build amd64 docker image
-    needs: [prepare, tests, linting]
+  build:
+    name: Build images
     runs-on: ubuntu-latest
+    needs: [prepare]
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
@@ -133,67 +136,49 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Build image
+        if: matrix.platform != 'arm64' || github.ref_protected == 'true'
         uses: ./.github/actions/build-image
         with:
-          platform: amd64
+          platform: ${{ matrix.platform }}
           go-version: ${{ needs.prepare.outputs.go-version }}
           go-linker-args: ${{ needs.prepare.outputs.go-linker-args }}
           cgo-cflags: ${{ needs.prepare.outputs.cgo-cflags }}
           labels: ${{ needs.prepare.outputs.labels }}
           image-tag: ${{ needs.prepare.outputs.version }}
-      - name: Upload Image
-        uses: ./.github/actions/upload-image
-        with:
-          platform: amd64
-          labels: ${{ needs.prepare.outputs.labels }}
-          version: ${{ needs.prepare.outputs.version }}
-          registry: ${{ needs.prepare.outputs.registry }}
-          repository: ${{ needs.prepare.outputs.repository }}
-      - name: Create Manifests
-        uses: ./.github/actions/create-manifests
-        with:
-          version: ${{ needs.prepare.outputs.version }}
-          registry: ${{ needs.prepare.outputs.registry }}
-          repository: ${{ needs.prepare.outputs.repository }}
-          combined: false
 
-  build-arm64:
-    name: Build arm64 docker image
-    needs: [prepare, tests, linting]
-    if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'refs/heads/master') || contains(github.ref, 'refs/heads/release-') }}
+  push:
+    name: Push images
     runs-on: ubuntu-latest
+    needs: [prepare, build]
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
-      - name: build-image
-        uses: ./.github/actions/build-image
+      - name: Login to Registry
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2
         with:
-          platform: arm64
-          go-version: ${{ needs.prepare.outputs.go-version }}
-          go-linker-args: ${{ needs.prepare.outputs.go-linker-args }}
-          cgo-cflags: ${{ needs.prepare.outputs.cgo-cflags }}
-          labels: ${{ needs.prepare.outputs.labels }}
-          image-tag: ${{ needs.prepare.outputs.version }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
       - name: Upload Image
+        if: matrix.platform != 'arm64' || github.ref_protected == 'true'
         uses: ./.github/actions/upload-image
         with:
-          platform: arm64
+          platform: ${{ matrix.platform }}
           labels: ${{ needs.prepare.outputs.labels }}
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{ needs.prepare.outputs.registry }}
           repository: ${{ needs.prepare.outputs.repository }}
-          repository-username: ${{ secrets.QUAY_USERNAME }}
-          repository-password: ${{ secrets.QUAY_PASSWORD }}
 
-  create-manifest-for-combined-images:
-    name: Combine images
-    needs: [prepare, build-arm64, build-amd64]
+  manifest:
+    name: Create manifest
+    needs: [prepare, push]
     runs-on: ubuntu-latest
-    if: |
-      (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) &&
-      (contains(github.ref, 'refs/tags/v') || contains(github.ref, 'refs/heads/master') || contains(github.ref, 'refs/heads/release-'))
     env:
       IMAGE_QUAY: ${{ needs.prepare.outputs.registry }}/${{ needs.prepare.outputs.repository }}
+      COMBINED: ${{ matrix.platform != 'arm64' || github.ref_protected == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
@@ -209,4 +194,4 @@ jobs:
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{ needs.prepare.outputs.registry }}
           repository: ${{ needs.prepare.outputs.repository }}
-          combined: true
+          combined: ${{ COMBINED }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,7 +177,6 @@ jobs:
     needs: [prepare, push]
     runs-on: ubuntu-latest
     env:
-      IMAGE_QUAY: ${{ needs.prepare.outputs.registry }}/${{ needs.prepare.outputs.repository }}
       COMBINED: ${{ matrix.platform != 'arm64' || github.ref_protected == 'true' }}
     steps:
       - name: Checkout
@@ -194,4 +193,4 @@ jobs:
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{ needs.prepare.outputs.registry }}
           repository: ${{ needs.prepare.outputs.repository }}
-          combined: ${{ COMBINED }}
+          combined: ${ COMBINED }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,7 +177,7 @@ jobs:
     needs: [prepare, push]
     runs-on: ubuntu-latest
     env:
-      COMBINED: ${{ matrix.platform != 'arm64' || github.ref_protected == 'true' }}
+      COMBINED: ${{ github.ref_protected == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
@@ -193,4 +193,4 @@ jobs:
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{ needs.prepare.outputs.registry }}
           repository: ${{ needs.prepare.outputs.repository }}
-          combined: ${ COMBINED }
+          combined: ${{ env.COMBINED }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,7 @@ jobs:
   build:
     name: Build images
     runs-on: ubuntu-latest
-    needs: [prepare]
+    needs: [prepare, tests, linting]
     strategy:
       matrix:
         platform: [amd64, arm64]

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
-      - name: build-image
+      - name: Build image
         uses: ./.github/actions/build-image
         with:
           platform: ${{ matrix.platform }}
@@ -81,9 +81,9 @@ jobs:
           registry: ${{ matrix.url }}
           username: ${{ secrets[matrix.username] }}
           password: ${{ secrets[matrix.password] }}
-      - name: Push ${{matrix.platform}} to ${{matrix.registry-name}}
+      - name: Push ${{matrix.platform}} to ${{matrix.registry}}
         uses: ./.github/actions/upload-image
-        if: matrix.registry-name != 'rhcc' || ( matrix.registry-name == 'rhcc' && matrix.platform == 'amd64' )
+        if: matrix.registry != 'rhcc' || ( matrix.registry == 'rhcc' && matrix.platform == 'amd64' )
         with:
           platform: ${{ matrix.platform }}
           labels: ${{ needs.prepare.outputs.labels }}
@@ -100,7 +100,7 @@ jobs:
          report-name: "preflight.json"
          redhat-project-id: ${{ secrets.REDHAT_PROJECT_ID }}
          pyxis-api-token: ${{ secrets.PYXIS_API_TOKEN }}
-      - name: Create manifests for ${{matrix.registry}}
+      - name: Sign image for ${{matrix.registry}}
         if: matrix.registry != 'rhcc'
         uses: ./.github/actions/sign-image
         with:


### PR DESCRIPTION
# Description

Change `ci.yaml` to similar matrix based structure as `publish-images.yaml`:
- reuse build action for amd/arm
- separate push/manifest jobs
- only push arm image and combined manifest on protected branches (release + master)

## How can this be tested?
CI should run correctly on all branches!

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

