### PR TITLE
Fix check for protected branch status

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,7 +136,7 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Build image
-        if: matrix.platform != 'arm64' || github.ref_protected == 'true'
+        if: matrix.platform != 'arm64' || github.ref_protected
         uses: ./.github/actions/build-image
         with:
           platform: ${{ matrix.platform }}
@@ -163,7 +163,7 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Upload Image
-        if: matrix.platform != 'arm64' || github.ref_protected == 'true'
+        if: matrix.platform != 'arm64' || github.ref_protected
         uses: ./.github/actions/upload-image
         with:
           platform: ${{ matrix.platform }}
@@ -177,7 +177,7 @@ jobs:
     needs: [prepare, push]
     runs-on: ubuntu-latest
     env:
-      COMBINED: ${{ github.ref_protected == 'true' }}
+      COMBINED: ${{ github.ref_protected }}
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3


### PR DESCRIPTION
# Description
`github.ref_protected` is a `boolean` and not a `string`.

## How can this be tested?
CI has to trigger on protected branch, like master or release branches.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

