### PR TITLE
Update golangcilint to `v1.49`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # v3
         with:
-          version: v1.48
+          version: v1.49
           args: --build-tags integration,containers_image_storage_stub --timeout 300s
 
   prepare:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,21 +15,18 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-  - deadcode
   - gci
   - goimports
   - gosimple
   - govet
   - ineffassign
   - staticcheck
-  - structcheck
   - typecheck
   - unused
-  - varcheck
   - misspell
 
 service:
-  golangci-lint-version: 1.48.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.49.x # use the fixed version to not introduce new linters unexpectedly
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,13 +27,3 @@ linters:
 
 service:
   golangci-lint-version: 1.49.x # use the fixed version to not introduce new linters unexpectedly
-
-issues:
-  exclude-rules:
-    # These are needed because it thinks that FromUnparsedImage can't return nil, however if you go JUST 2 levels down, then you will find several cases when it can be nil
-    - path: src/controllers/dynakube/version/version_image.go
-      linters:
-       - staticcheck
-    - linters:
-        - staticcheck
-      text: "github.com/containers/image/v5/image.FromUnparsedImage never returns a nil interface value"

--- a/src/controllers/dynakube/version/version_image.go
+++ b/src/controllers/dynakube/version/version_image.go
@@ -57,8 +57,6 @@ func GetImageVersion(imageName string, dockerConfig *dockerconfig.DockerConfig) 
 	sourceImage, err := image.FromUnparsedImage(context.TODO(), systemContext, image.UnparsedInstance(imageSource, nil))
 	if err != nil {
 		return ImageVersion{}, err
-	} else if sourceImage == nil {
-		return ImageVersion{}, fmt.Errorf("could not find image: '%s'", transportImageName)
 	}
 
 	inspectedImage, err := sourceImage.Inspect(context.TODO())


### PR DESCRIPTION
# Description

Update golangcilint to `v1.49` and remove unused staticcheck rule.

## How can this be tested?
Linting should work and functionality not change.

## Checklist
- [ ] Unit tests have been updated/added
- [ ] PR is labeled accordingly
- [ ] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

