### PR TITLE
Revert ossf action to `v1.1.2`

### DIFF
--- a/.github/workflows/openssf-scorecards.yaml
+++ b/.github/workflows/openssf-scorecards.yaml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@13ec8c77e8a5dae7e0a0d47bde3e3004df15d34f # v2.0.0
+        uses: ossf/scorecard-action@ce330fde6b1a5c9c75b417e7efc510b822a35564 # v1.1.2
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
# Description

Latest release of `ossf/scorecard-action` is broken: https://github.com/ossf/scorecard-action/issues/856

## How can this be tested?
-


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

