### PR TITLE
Refactors capabilities into modifiers

### DIFF
--- a/src/api/v1beta1/image_paths.go
+++ b/src/api/v1beta1/image_paths.go
@@ -72,7 +72,7 @@ func (imagePath *statsdImagePath) apiUrl() string {
 }
 
 func (imagePath *statsdImagePath) CustomImagePath() string {
-	if imagePath.dynaKube.IsStatsdCapabilityEnabled() {
+	if imagePath.dynaKube.IsStatsdActiveGateEnabled() {
 		return imagePath.dynaKube.FeatureCustomStatsdImage()
 	}
 	return ""
@@ -95,7 +95,7 @@ func (imagePath *eecImagePath) apiUrl() string {
 }
 
 func (imagePath *eecImagePath) CustomImagePath() string {
-	if imagePath.dynaKube.IsStatsdCapabilityEnabled() {
+	if imagePath.dynaKube.IsStatsdActiveGateEnabled() {
 		return imagePath.dynaKube.FeatureCustomEecImage()
 	}
 	return ""

--- a/src/api/v1beta1/image_paths.go
+++ b/src/api/v1beta1/image_paths.go
@@ -72,7 +72,7 @@ func (imagePath *statsdImagePath) apiUrl() string {
 }
 
 func (imagePath *statsdImagePath) CustomImagePath() string {
-	if imagePath.dynaKube.NeedsStatsd() {
+	if imagePath.dynaKube.IsStatsdCapabilityEnabled() {
 		return imagePath.dynaKube.FeatureCustomStatsdImage()
 	}
 	return ""
@@ -95,7 +95,7 @@ func (imagePath *eecImagePath) apiUrl() string {
 }
 
 func (imagePath *eecImagePath) CustomImagePath() string {
-	if imagePath.dynaKube.NeedsStatsd() {
+	if imagePath.dynaKube.IsStatsdCapabilityEnabled() {
 		return imagePath.dynaKube.FeatureCustomEecImage()
 	}
 	return ""

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -90,11 +90,41 @@ func (dk *DynaKube) IsActiveGateMode(mode CapabilityDisplayName) bool {
 	return false
 }
 
-func (dk *DynaKube) KubernetesMonitoringMode() bool {
+func (dk *DynaKube) ActiveGateServiceAccountOwner() string {
+	if dk.IsKubernetesMonitoringCapabilityEnabled() {
+		return string(KubeMonCapability.DeepCopy().DisplayName)
+	} else {
+		return "activegate"
+	}
+}
+
+func (dk *DynaKube) ActiveGateServiceAccountName() string {
+	return "dynatrace-" + dk.ActiveGateServiceAccountOwner()
+}
+
+func (dk *DynaKube) IsKubernetesMonitoringCapabilityEnabled() bool {
 	return dk.IsActiveGateMode(KubeMonCapability.DisplayName) || dk.Spec.KubernetesMonitoring.Enabled
 }
 
-func (dk *DynaKube) NeedsStatsd() bool {
+func (dk *DynaKube) IsRoutingCapabilityEnabled() bool {
+	return dk.IsActiveGateMode(RoutingCapability.DisplayName) || dk.Spec.Routing.Enabled
+}
+
+func (dk *DynaKube) IsApiCapabilityEnabled() bool {
+	return dk.IsActiveGateMode(DynatraceApiCapability.DisplayName)
+}
+
+func (dk *DynaKube) IsMetricsIngestCapabilityEnabled() bool {
+	return dk.IsActiveGateMode(MetricsIngestCapability.DisplayName)
+}
+
+func (dk *DynaKube) NeedsActiveGateServicePorts() bool {
+	return dk.IsRoutingCapabilityEnabled() ||
+		dk.IsApiCapabilityEnabled() ||
+		dk.IsMetricsIngestCapabilityEnabled()
+}
+
+func (dk *DynaKube) IsStatsdCapabilityEnabled() bool {
 	return dk.IsActiveGateMode(StatsdIngestCapability.DisplayName)
 }
 

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -91,7 +91,7 @@ func (dk *DynaKube) IsActiveGateMode(mode CapabilityDisplayName) bool {
 }
 
 func (dk *DynaKube) ActiveGateServiceAccountOwner() string {
-	if dk.IsKubernetesMonitoringCapabilityEnabled() {
+	if dk.IsKubernetesMonitoringActiveGateEnabled() {
 		return string(KubeMonCapability.DeepCopy().DisplayName)
 	} else {
 		return "activegate"
@@ -102,29 +102,29 @@ func (dk *DynaKube) ActiveGateServiceAccountName() string {
 	return "dynatrace-" + dk.ActiveGateServiceAccountOwner()
 }
 
-func (dk *DynaKube) IsKubernetesMonitoringCapabilityEnabled() bool {
+func (dk *DynaKube) IsKubernetesMonitoringActiveGateEnabled() bool {
 	return dk.IsActiveGateMode(KubeMonCapability.DisplayName) || dk.Spec.KubernetesMonitoring.Enabled
 }
 
-func (dk *DynaKube) IsRoutingCapabilityEnabled() bool {
+func (dk *DynaKube) IsRoutingActiveGateEnabled() bool {
 	return dk.IsActiveGateMode(RoutingCapability.DisplayName) || dk.Spec.Routing.Enabled
 }
 
-func (dk *DynaKube) IsApiCapabilityEnabled() bool {
+func (dk *DynaKube) IsApiActiveGateEnabled() bool {
 	return dk.IsActiveGateMode(DynatraceApiCapability.DisplayName)
 }
 
-func (dk *DynaKube) IsMetricsIngestCapabilityEnabled() bool {
+func (dk *DynaKube) IsMetricsIngestActiveGateEnabled() bool {
 	return dk.IsActiveGateMode(MetricsIngestCapability.DisplayName)
 }
 
 func (dk *DynaKube) NeedsActiveGateServicePorts() bool {
-	return dk.IsRoutingCapabilityEnabled() ||
-		dk.IsApiCapabilityEnabled() ||
-		dk.IsMetricsIngestCapabilityEnabled()
+	return dk.IsRoutingActiveGateEnabled() ||
+		dk.IsApiActiveGateEnabled() ||
+		dk.IsMetricsIngestActiveGateEnabled()
 }
 
-func (dk *DynaKube) IsStatsdCapabilityEnabled() bool {
+func (dk *DynaKube) IsStatsdActiveGateEnabled() bool {
 	return dk.IsActiveGateMode(StatsdIngestCapability.DisplayName)
 }
 

--- a/src/controllers/dynakube/activegate/capability/capability.go
+++ b/src/controllers/dynakube/activegate/capability/capability.go
@@ -119,16 +119,16 @@ func NewRoutingCapability(dk *dynatracev1beta1.DynaKube) *RoutingCapability {
 
 func kubeMonBase() *capabilityBase {
 	c := capabilityBase{
-		shortName: dynatracev1beta1.MetricsIngestCapability.ShortName,
-		argName:   dynatracev1beta1.MetricsIngestCapability.ArgumentName,
+		shortName: dynatracev1beta1.KubeMonCapability.ShortName,
+		argName:   dynatracev1beta1.KubeMonCapability.ArgumentName,
 	}
 	return &c
 }
 
 func routingBase() *capabilityBase {
 	c := capabilityBase{
-		shortName: dynatracev1beta1.MetricsIngestCapability.ShortName,
-		argName:   dynatracev1beta1.MetricsIngestCapability.ArgumentName,
+		shortName: dynatracev1beta1.RoutingCapability.ShortName,
+		argName:   dynatracev1beta1.RoutingCapability.ArgumentName,
 	}
 	return &c
 }

--- a/src/controllers/dynakube/activegate/capability/capability.go
+++ b/src/controllers/dynakube/activegate/capability/capability.go
@@ -1,27 +1,11 @@
 package capability
 
 import (
-	"path/filepath"
 	"regexp"
 	"strings"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
-	corev1 "k8s.io/api/core/v1"
-)
-
-const (
-	trustStoreVolume          = "truststore-volume"
-	k8scrt2jksPath            = "/opt/dynatrace/gateway/k8scrt2jks.sh"
-	activeGateCacertsPath     = "/opt/dynatrace/gateway/jre/lib/security/cacerts"
-	activeGateSslPath         = "/var/lib/dynatrace/gateway/ssl"
-	k8sCertificateFile        = "k8s-local.jks"
-	k8scrt2jksWorkingDir      = "/var/lib/dynatrace/gateway"
-	initContainerTemplateName = "certificate-loader"
-
-	jettyCerts = "server-certs"
-
-	secretsRootDir = "/var/lib/dynatrace/secrets/"
 )
 
 type baseFunc func() *capabilityBase
@@ -34,34 +18,11 @@ var activeGateCapabilities = map[dynatracev1beta1.CapabilityDisplayName]baseFunc
 	dynatracev1beta1.StatsdIngestCapability.DisplayName:  statsdIngestBase,
 }
 
-type AgServicePorts struct {
-	Webserver bool
-	Statsd    bool
-}
-
-func (ports AgServicePorts) HasPorts() bool {
-	return ports.Webserver || ports.Statsd
-}
-
-type Configuration struct {
-	SetDnsEntryPoint       bool
-	SetReadinessPort       bool
-	SetCommunicationPort   bool
-	ServicePorts           AgServicePorts
-	CreateEecRuntimeConfig bool
-	ServiceAccountOwner    string
-}
-
 type Capability interface {
 	Enabled() bool
 	ShortName() string
 	ArgName() string
 	Properties() *dynatracev1beta1.CapabilityProperties
-	Config() Configuration
-	InitContainersTemplates() []corev1.Container
-	ContainerVolumeMounts() []corev1.VolumeMount
-	Volumes() []corev1.Volume
-	ShouldCreateService() bool
 }
 
 type capabilityBase struct {
@@ -69,10 +30,6 @@ type capabilityBase struct {
 	shortName  string
 	argName    string
 	properties *dynatracev1beta1.CapabilityProperties
-	Configuration
-	initContainersTemplates []corev1.Container
-	containerVolumeMounts   []corev1.VolumeMount
-	volumes                 []corev1.Volume
 }
 
 func (c *capabilityBase) Enabled() bool {
@@ -83,32 +40,12 @@ func (c *capabilityBase) Properties() *dynatracev1beta1.CapabilityProperties {
 	return c.properties
 }
 
-func (c *capabilityBase) Config() Configuration {
-	return c.Configuration
-}
-
 func (c *capabilityBase) ShortName() string {
 	return c.shortName
 }
 
 func (c *capabilityBase) ArgName() string {
 	return c.argName
-}
-
-func (c *capabilityBase) ShouldCreateService() bool {
-	return c.ServicePorts.HasPorts()
-}
-
-func (c *capabilityBase) InitContainersTemplates() []corev1.Container {
-	return c.initContainersTemplates
-}
-
-func (c *capabilityBase) ContainerVolumeMounts() []corev1.VolumeMount {
-	return c.containerVolumeMounts
-}
-
-func (c *capabilityBase) Volumes() []corev1.Volume {
-	return c.volumes
 }
 
 func CalculateStatefulSetName(capability Capability, dynakubeName string) string {
@@ -129,30 +66,6 @@ type MultiCapability struct {
 	capabilityBase
 }
 
-func (c *capabilityBase) setTlsConfig(agSpec *dynatracev1beta1.ActiveGateSpec) {
-	if agSpec == nil {
-		return
-	}
-
-	if agSpec.TlsSecretName != "" {
-		c.volumes = append(c.volumes,
-			corev1.Volume{
-				Name: jettyCerts,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: agSpec.TlsSecretName,
-					},
-				},
-			})
-		c.containerVolumeMounts = append(c.containerVolumeMounts,
-			corev1.VolumeMount{
-				ReadOnly:  true,
-				Name:      jettyCerts,
-				MountPath: filepath.Join(secretsRootDir, "tls"),
-			})
-	}
-}
-
 func NewMultiCapability(dk *dynatracev1beta1.DynaKube) *MultiCapability {
 	mc := MultiCapability{
 		capabilityBase{
@@ -160,7 +73,6 @@ func NewMultiCapability(dk *dynatracev1beta1.DynaKube) *MultiCapability {
 		},
 	}
 	if dk == nil || !dk.ActiveGateMode() {
-		mc.ServicePorts.Webserver = true // necessary for cleaning up service if created
 		return &mc
 	}
 	mc.enabled = true
@@ -172,36 +84,9 @@ func NewMultiCapability(dk *dynatracev1beta1.DynaKube) *MultiCapability {
 			continue
 		}
 		capGen := capabilityGenerator()
-
 		capabilityNames = append(capabilityNames, capGen.argName)
-		mc.initContainersTemplates = append(mc.initContainersTemplates, capGen.initContainersTemplates...)
-		mc.containerVolumeMounts = append(mc.containerVolumeMounts, capGen.containerVolumeMounts...)
-		mc.volumes = append(mc.volumes, capGen.volumes...)
-
-		if !mc.ServicePorts.Webserver {
-			mc.ServicePorts.Webserver = capGen.ServicePorts.Webserver
-		}
-		if !mc.ServicePorts.Statsd {
-			mc.ServicePorts.Statsd = capGen.ServicePorts.Statsd
-		}
-		if !mc.CreateEecRuntimeConfig {
-			mc.CreateEecRuntimeConfig = capGen.CreateEecRuntimeConfig
-		}
-		if !mc.SetCommunicationPort {
-			mc.SetCommunicationPort = capGen.SetCommunicationPort
-		}
-		if !mc.SetDnsEntryPoint {
-			mc.SetDnsEntryPoint = capGen.SetDnsEntryPoint
-		}
-		if !mc.SetReadinessPort {
-			mc.SetReadinessPort = capGen.SetReadinessPort
-		}
-		if mc.ServiceAccountOwner == "" {
-			mc.ServiceAccountOwner = capGen.ServiceAccountOwner
-		}
 	}
 	mc.argName = strings.Join(capabilityNames, ",")
-	mc.setTlsConfig(&dk.Spec.ActiveGate)
 	return &mc
 
 }
@@ -234,56 +119,16 @@ func NewRoutingCapability(dk *dynatracev1beta1.DynaKube) *RoutingCapability {
 
 func kubeMonBase() *capabilityBase {
 	c := capabilityBase{
-		shortName: dynatracev1beta1.KubeMonCapability.ShortName,
-		argName:   dynatracev1beta1.KubeMonCapability.ArgumentName,
-		Configuration: Configuration{
-			ServiceAccountOwner: "kubernetes-monitoring",
-		},
-		initContainersTemplates: []corev1.Container{
-			{
-				Name:            initContainerTemplateName,
-				ImagePullPolicy: corev1.PullAlways,
-				WorkingDir:      k8scrt2jksWorkingDir,
-				Command:         []string{"/bin/bash"},
-				Args:            []string{"-c", k8scrt2jksPath},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						ReadOnly:  false,
-						Name:      trustStoreVolume,
-						MountPath: activeGateSslPath,
-					},
-				},
-			},
-		},
-		containerVolumeMounts: []corev1.VolumeMount{{
-			ReadOnly:  true,
-			Name:      trustStoreVolume,
-			MountPath: activeGateCacertsPath,
-			SubPath:   k8sCertificateFile,
-		}},
-		volumes: []corev1.Volume{{
-			Name: trustStoreVolume,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			}},
-		},
+		shortName: dynatracev1beta1.MetricsIngestCapability.ShortName,
+		argName:   dynatracev1beta1.MetricsIngestCapability.ArgumentName,
 	}
 	return &c
 }
 
 func routingBase() *capabilityBase {
 	c := capabilityBase{
-		shortName: dynatracev1beta1.RoutingCapability.ShortName,
-		argName:   dynatracev1beta1.RoutingCapability.ArgumentName,
-		Configuration: Configuration{
-			SetDnsEntryPoint:     true,
-			SetReadinessPort:     true,
-			SetCommunicationPort: true,
-			ServicePorts: AgServicePorts{
-				Webserver: true,
-			},
-			CreateEecRuntimeConfig: false,
-		},
+		shortName: dynatracev1beta1.MetricsIngestCapability.ShortName,
+		argName:   dynatracev1beta1.MetricsIngestCapability.ArgumentName,
 	}
 	return &c
 }
@@ -292,15 +137,6 @@ func metricsIngestBase() *capabilityBase {
 	c := capabilityBase{
 		shortName: dynatracev1beta1.MetricsIngestCapability.ShortName,
 		argName:   dynatracev1beta1.MetricsIngestCapability.ArgumentName,
-		Configuration: Configuration{
-			SetDnsEntryPoint:     true,
-			SetReadinessPort:     true,
-			SetCommunicationPort: true,
-			ServicePorts: AgServicePorts{
-				Webserver: true,
-			},
-			CreateEecRuntimeConfig: false,
-		},
 	}
 	return &c
 }
@@ -309,14 +145,6 @@ func dynatraceApiBase() *capabilityBase {
 	c := capabilityBase{
 		shortName: dynatracev1beta1.DynatraceApiCapability.ShortName,
 		argName:   dynatracev1beta1.DynatraceApiCapability.ArgumentName,
-		Configuration: Configuration{
-			SetDnsEntryPoint:     true,
-			SetReadinessPort:     true,
-			SetCommunicationPort: true,
-			ServicePorts: AgServicePorts{
-				Webserver: true,
-			},
-		},
 	}
 	return &c
 }
@@ -325,15 +153,6 @@ func statsdIngestBase() *capabilityBase {
 	c := capabilityBase{
 		shortName: dynatracev1beta1.StatsdIngestCapability.ShortName,
 		argName:   dynatracev1beta1.StatsdIngestCapability.ArgumentName,
-		Configuration: Configuration{
-			SetDnsEntryPoint:     true,
-			SetReadinessPort:     true,
-			SetCommunicationPort: true,
-			ServicePorts: AgServicePorts{
-				Statsd: true,
-			},
-			CreateEecRuntimeConfig: true,
-		},
 	}
 	return &c
 }

--- a/src/controllers/dynakube/activegate/capability/capability_test.go
+++ b/src/controllers/dynakube/activegate/capability/capability_test.go
@@ -1,587 +1,587 @@
 package capability
 
-import (
-	"reflect"
-	"strings"
-	"testing"
+// import (
+// 	"reflect"
+// 	"strings"
+// 	"testing"
 
-	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
-	v1 "k8s.io/api/core/v1"
-)
+// 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+// 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
+// 	v1 "k8s.io/api/core/v1"
+// )
 
-func Test_capabilityBase_Properties(t *testing.T) {
-	props := &dynatracev1beta1.CapabilityProperties{}
+// func Test_capabilityBase_Properties(t *testing.T) {
+// 	props := &dynatracev1beta1.CapabilityProperties{}
 
-	type fields struct {
-		properties *dynatracev1beta1.CapabilityProperties
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   *dynatracev1beta1.CapabilityProperties
-	}{
-		{
-			name: "properties address is preserved",
-			fields: fields{
-				properties: props,
-			},
-			want: &dynatracev1beta1.CapabilityProperties{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &capabilityBase{
-				properties: tt.fields.properties,
-			}
-			if got := c.Properties(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("capabilityBase.Properties() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 	type fields struct {
+// 		properties *dynatracev1beta1.CapabilityProperties
+// 	}
+// 	tests := []struct {
+// 		name   string
+// 		fields fields
+// 		want   *dynatracev1beta1.CapabilityProperties
+// 	}{
+// 		{
+// 			name: "properties address is preserved",
+// 			fields: fields{
+// 				properties: props,
+// 			},
+// 			want: &dynatracev1beta1.CapabilityProperties{},
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			c := &capabilityBase{
+// 				properties: tt.fields.properties,
+// 			}
+// 			if got := c.Properties(); !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("capabilityBase.Properties() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-func Test_capabilityBase_Configuration(t *testing.T) {
-	conf := Configuration{
-		SetDnsEntryPoint:     false,
-		SetReadinessPort:     false,
-		SetCommunicationPort: true,
-		ServicePorts: AgServicePorts{
-			Webserver: true,
-		},
-		ServiceAccountOwner: "accowner",
-	}
+// func Test_capabilityBase_Configuration(t *testing.T) {
+// 	conf := Configuration{
+// 		SetDnsEntryPoint:     false,
+// 		SetReadinessPort:     false,
+// 		SetCommunicationPort: true,
+// 		ServicePorts: AgServicePorts{
+// 			Webserver: true,
+// 		},
+// 		ServiceAccountOwner: "accowner",
+// 	}
 
-	type fields struct {
-		Configuration Configuration
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   Configuration
-	}{
-		{
-			name: "configuration is correct",
-			fields: fields{
-				Configuration: conf,
-			},
-			want: conf,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &capabilityBase{
-				Configuration: tt.fields.Configuration,
-			}
-			if got := c.Config(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("capabilityBase.Config() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 	type fields struct {
+// 		Configuration Configuration
+// 	}
+// 	tests := []struct {
+// 		name   string
+// 		fields fields
+// 		want   Configuration
+// 	}{
+// 		{
+// 			name: "configuration is correct",
+// 			fields: fields{
+// 				Configuration: conf,
+// 			},
+// 			want: conf,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			c := &capabilityBase{
+// 				Configuration: tt.fields.Configuration,
+// 			}
+// 			if got := c.Config(); !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("capabilityBase.Config() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-func Test_capabilityBase_GetModuleName(t *testing.T) {
-	const expectedModuleName = "some_module"
+// func Test_capabilityBase_GetModuleName(t *testing.T) {
+// 	const expectedModuleName = "some_module"
 
-	type fields struct {
-		moduleName string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{
-			name: "module name is correct",
-			fields: fields{
-				moduleName: expectedModuleName,
-			},
-			want: expectedModuleName,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &capabilityBase{
-				shortName: tt.fields.moduleName,
-			}
-			if got := c.ShortName(); got != tt.want {
-				t.Errorf("capabilityBase.ShortName() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 	type fields struct {
+// 		moduleName string
+// 	}
+// 	tests := []struct {
+// 		name   string
+// 		fields fields
+// 		want   string
+// 	}{
+// 		{
+// 			name: "module name is correct",
+// 			fields: fields{
+// 				moduleName: expectedModuleName,
+// 			},
+// 			want: expectedModuleName,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			c := &capabilityBase{
+// 				shortName: tt.fields.moduleName,
+// 			}
+// 			if got := c.ShortName(); got != tt.want {
+// 				t.Errorf("capabilityBase.ShortName() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-func Test_capabilityBase_GetCapabilityName(t *testing.T) {
-	const expectedCapabilityName = "capability_name"
+// func Test_capabilityBase_GetCapabilityName(t *testing.T) {
+// 	const expectedCapabilityName = "capability_name"
 
-	type fields struct {
-		capabilityName string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{
-			name: "capability name is correct",
-			fields: fields{
-				capabilityName: expectedCapabilityName,
-			},
-			want: expectedCapabilityName,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &capabilityBase{
-				argName: tt.fields.capabilityName,
-			}
-			if got := c.ArgName(); got != tt.want {
-				t.Errorf("capabilityBase.ArgName() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 	type fields struct {
+// 		capabilityName string
+// 	}
+// 	tests := []struct {
+// 		name   string
+// 		fields fields
+// 		want   string
+// 	}{
+// 		{
+// 			name: "capability name is correct",
+// 			fields: fields{
+// 				capabilityName: expectedCapabilityName,
+// 			},
+// 			want: expectedCapabilityName,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			c := &capabilityBase{
+// 				argName: tt.fields.capabilityName,
+// 			}
+// 			if got := c.ArgName(); got != tt.want {
+// 				t.Errorf("capabilityBase.ArgName() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-func TestCalculateStatefulSetName(t *testing.T) {
-	c := NewKubeMonCapability(nil)
-	const instanceName = "testinstance"
+// func TestCalculateStatefulSetName(t *testing.T) {
+// 	c := NewKubeMonCapability(nil)
+// 	const instanceName = "testinstance"
 
-	type args struct {
-		capability   Capability
-		instanceName string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "",
-			args: args{
-				capability:   c,
-				instanceName: instanceName,
-			},
-			want: instanceName + "-" + c.ShortName(),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := CalculateStatefulSetName(tt.args.capability, tt.args.instanceName); got != tt.want {
-				t.Errorf("CalculateStatefulSetName() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 	type args struct {
+// 		capability   Capability
+// 		instanceName string
+// 	}
+// 	tests := []struct {
+// 		name string
+// 		args args
+// 		want string
+// 	}{
+// 		{
+// 			name: "",
+// 			args: args{
+// 				capability:   c,
+// 				instanceName: instanceName,
+// 			},
+// 			want: instanceName + "-" + c.ShortName(),
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			if got := CalculateStatefulSetName(tt.args.capability, tt.args.instanceName); got != tt.want {
+// 				t.Errorf("CalculateStatefulSetName() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-func TestNewKubeMonCapability(t *testing.T) {
-	props := &dynatracev1beta1.CapabilityProperties{}
-	dk := &dynatracev1beta1.DynaKube{
-		Spec: dynatracev1beta1.DynaKubeSpec{
-			KubernetesMonitoring: dynatracev1beta1.KubernetesMonitoringSpec{
-				CapabilityProperties: *props,
-			},
-		},
-	}
+// func TestNewKubeMonCapability(t *testing.T) {
+// 	props := &dynatracev1beta1.CapabilityProperties{}
+// 	dk := &dynatracev1beta1.DynaKube{
+// 		Spec: dynatracev1beta1.DynaKubeSpec{
+// 			KubernetesMonitoring: dynatracev1beta1.KubernetesMonitoringSpec{
+// 				CapabilityProperties: *props,
+// 			},
+// 		},
+// 	}
 
-	type args struct {
-		dynakube *dynatracev1beta1.DynaKube
-	}
-	tests := []struct {
-		name string
-		args args
-		want *KubeMonCapability
-	}{
-		{
-			name: "default",
-			args: args{
-				dynakube: dk,
-			},
-			want: &KubeMonCapability{
-				capabilityBase: capabilityBase{
-					shortName:  dynatracev1beta1.KubeMonCapability.ShortName,
-					argName:    dynatracev1beta1.KubeMonCapability.ArgumentName,
-					properties: props,
-					Configuration: Configuration{
-						ServiceAccountOwner: "kubernetes-monitoring",
-					},
-					initContainersTemplates: []v1.Container{
-						{
-							Name:            initContainerTemplateName,
-							ImagePullPolicy: v1.PullAlways,
-							WorkingDir:      k8scrt2jksWorkingDir,
-							Command:         []string{"/bin/bash"},
-							Args:            []string{"-c", k8scrt2jksPath},
-							VolumeMounts: []v1.VolumeMount{
-								{
-									ReadOnly:  false,
-									Name:      trustStoreVolume,
-									MountPath: activeGateSslPath,
-								},
-							},
-						},
-					},
-					containerVolumeMounts: []v1.VolumeMount{{
-						ReadOnly:  true,
-						Name:      trustStoreVolume,
-						MountPath: activeGateCacertsPath,
-						SubPath:   k8sCertificateFile,
-					}},
-					volumes: []v1.Volume{{
-						Name: trustStoreVolume,
-						VolumeSource: v1.VolumeSource{
-							EmptyDir: &v1.EmptyDirVolumeSource{},
-						},
-					}},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := NewKubeMonCapability(tt.args.dynakube); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewKubeMonCapability() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 	type args struct {
+// 		dynakube *dynatracev1beta1.DynaKube
+// 	}
+// 	tests := []struct {
+// 		name string
+// 		args args
+// 		want *KubeMonCapability
+// 	}{
+// 		{
+// 			name: "default",
+// 			args: args{
+// 				dynakube: dk,
+// 			},
+// 			want: &KubeMonCapability{
+// 				capabilityBase: capabilityBase{
+// 					shortName:  dynatracev1beta1.KubeMonCapability.ShortName,
+// 					argName:    dynatracev1beta1.KubeMonCapability.ArgumentName,
+// 					properties: props,
+// 					Configuration: Configuration{
+// 						ServiceAccountOwner: "kubernetes-monitoring",
+// 					},
+// 					initContainersTemplates: []v1.Container{
+// 						{
+// 							Name:            initContainerTemplateName,
+// 							ImagePullPolicy: v1.PullAlways,
+// 							WorkingDir:      k8scrt2jksWorkingDir,
+// 							Command:         []string{"/bin/bash"},
+// 							Args:            []string{"-c", k8scrt2jksPath},
+// 							VolumeMounts: []v1.VolumeMount{
+// 								{
+// 									ReadOnly:  false,
+// 									Name:      trustStoreVolume,
+// 									MountPath: activeGateSslPath,
+// 								},
+// 							},
+// 						},
+// 					},
+// 					containerVolumeMounts: []v1.VolumeMount{{
+// 						ReadOnly:  true,
+// 						Name:      trustStoreVolume,
+// 						MountPath: activeGateCacertsPath,
+// 						SubPath:   k8sCertificateFile,
+// 					}},
+// 					volumes: []v1.Volume{{
+// 						Name: trustStoreVolume,
+// 						VolumeSource: v1.VolumeSource{
+// 							EmptyDir: &v1.EmptyDirVolumeSource{},
+// 						},
+// 					}},
+// 				},
+// 			},
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			if got := NewKubeMonCapability(tt.args.dynakube); !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("NewKubeMonCapability() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-func TestNewRoutingCapability(t *testing.T) {
+// func TestNewRoutingCapability(t *testing.T) {
 
-	props := &dynatracev1beta1.CapabilityProperties{}
-	dk := &dynatracev1beta1.DynaKube{
-		Spec: dynatracev1beta1.DynaKubeSpec{
-			Routing: dynatracev1beta1.RoutingSpec{
-				CapabilityProperties: *props,
-			},
-		},
-	}
+// 	props := &dynatracev1beta1.CapabilityProperties{}
+// 	dk := &dynatracev1beta1.DynaKube{
+// 		Spec: dynatracev1beta1.DynaKubeSpec{
+// 			Routing: dynatracev1beta1.RoutingSpec{
+// 				CapabilityProperties: *props,
+// 			},
+// 		},
+// 	}
 
-	type args struct {
-		dynakube *dynatracev1beta1.DynaKube
-	}
-	tests := []struct {
-		name string
-		args args
-		want *RoutingCapability
-	}{
-		{
-			name: "default",
-			args: args{
-				dynakube: dk,
-			},
-			want: &RoutingCapability{
-				capabilityBase: capabilityBase{
-					shortName:  dynatracev1beta1.RoutingCapability.ShortName,
-					argName:    dynatracev1beta1.RoutingCapability.ArgumentName,
-					properties: props,
-					Configuration: Configuration{
-						SetDnsEntryPoint:     true,
-						SetReadinessPort:     true,
-						SetCommunicationPort: true,
-						ServiceAccountOwner:  "",
-						ServicePorts: AgServicePorts{
-							Webserver: true,
-						},
-					},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := NewRoutingCapability(tt.args.dynakube); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewRoutingCapability() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 	type args struct {
+// 		dynakube *dynatracev1beta1.DynaKube
+// 	}
+// 	tests := []struct {
+// 		name string
+// 		args args
+// 		want *RoutingCapability
+// 	}{
+// 		{
+// 			name: "default",
+// 			args: args{
+// 				dynakube: dk,
+// 			},
+// 			want: &RoutingCapability{
+// 				capabilityBase: capabilityBase{
+// 					shortName:  dynatracev1beta1.RoutingCapability.ShortName,
+// 					argName:    dynatracev1beta1.RoutingCapability.ArgumentName,
+// 					properties: props,
+// 					Configuration: Configuration{
+// 						SetDnsEntryPoint:     true,
+// 						SetReadinessPort:     true,
+// 						SetCommunicationPort: true,
+// 						ServiceAccountOwner:  "",
+// 						ServicePorts: AgServicePorts{
+// 							Webserver: true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			if got := NewRoutingCapability(tt.args.dynakube); !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("NewRoutingCapability() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-func TestNewMultiCapability(t *testing.T) {
+// func TestNewMultiCapability(t *testing.T) {
 
-	props := &dynatracev1beta1.CapabilityProperties{}
+// 	props := &dynatracev1beta1.CapabilityProperties{}
 
-	type args struct {
-		dynakube *dynatracev1beta1.DynaKube
-	}
-	tests := []struct {
-		name string
-		args args
-		want *MultiCapability
-	}{
-		{
-			name: "empty",
-			args: args{
-				dynakube: &dynatracev1beta1.DynaKube{
-					Spec: dynatracev1beta1.DynaKubeSpec{},
-				},
-			},
-			want: &MultiCapability{
-				capabilityBase: capabilityBase{
-					enabled:   false,
-					shortName: consts.MultiActiveGateName,
-					Configuration: Configuration{
-						ServicePorts: AgServicePorts{
-							Webserver: true,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "just routing",
-			args: args{
-				dynakube: &dynatracev1beta1.DynaKube{
-					Spec: dynatracev1beta1.DynaKubeSpec{
-						ActiveGate: dynatracev1beta1.ActiveGateSpec{
-							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-								dynatracev1beta1.RoutingCapability.DisplayName,
-							},
-						},
-					},
-				},
-			},
-			want: &MultiCapability{
-				capabilityBase: capabilityBase{
-					enabled:    true,
-					shortName:  consts.MultiActiveGateName,
-					argName:    dynatracev1beta1.RoutingCapability.ArgumentName,
-					properties: props,
-					Configuration: Configuration{
-						SetDnsEntryPoint:     true,
-						SetReadinessPort:     true,
-						SetCommunicationPort: true,
-						ServiceAccountOwner:  "",
-						ServicePorts: AgServicePorts{
-							Webserver: true,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "just metrics-ingest",
-			args: args{
-				dynakube: &dynatracev1beta1.DynaKube{
-					Spec: dynatracev1beta1.DynaKubeSpec{
-						ActiveGate: dynatracev1beta1.ActiveGateSpec{
-							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-								dynatracev1beta1.MetricsIngestCapability.DisplayName,
-							},
-						},
-					},
-				},
-			},
-			want: &MultiCapability{
-				capabilityBase: capabilityBase{
-					enabled:    true,
-					shortName:  consts.MultiActiveGateName,
-					argName:    dynatracev1beta1.MetricsIngestCapability.ArgumentName,
-					properties: props,
-					Configuration: Configuration{
-						SetDnsEntryPoint:     true,
-						SetReadinessPort:     true,
-						SetCommunicationPort: true,
-						ServiceAccountOwner:  "",
-						ServicePorts: AgServicePorts{
-							Webserver: true,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "just dynatrace-api",
-			args: args{
-				dynakube: &dynatracev1beta1.DynaKube{
-					Spec: dynatracev1beta1.DynaKubeSpec{
-						ActiveGate: dynatracev1beta1.ActiveGateSpec{
-							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-								dynatracev1beta1.DynatraceApiCapability.DisplayName,
-							},
-						},
-					},
-				},
-			},
-			want: &MultiCapability{
-				capabilityBase: capabilityBase{
-					enabled:    true,
-					shortName:  consts.MultiActiveGateName,
-					argName:    dynatracev1beta1.DynatraceApiCapability.ArgumentName,
-					properties: props,
-					Configuration: Configuration{
-						SetDnsEntryPoint:     true,
-						SetReadinessPort:     true,
-						SetCommunicationPort: true,
-						ServiceAccountOwner:  "",
-						ServicePorts: AgServicePorts{
-							Webserver: true,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "just statsd-ingest",
-			args: args{
-				dynakube: &dynatracev1beta1.DynaKube{
-					Spec: dynatracev1beta1.DynaKubeSpec{
-						ActiveGate: dynatracev1beta1.ActiveGateSpec{
-							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-								dynatracev1beta1.StatsdIngestCapability.DisplayName,
-							},
-						},
-					},
-				},
-			},
-			want: &MultiCapability{
-				capabilityBase: capabilityBase{
-					enabled:    true,
-					shortName:  consts.MultiActiveGateName,
-					argName:    dynatracev1beta1.StatsdIngestCapability.ArgumentName,
-					properties: props,
-					Configuration: Configuration{
-						SetDnsEntryPoint:       true,
-						SetReadinessPort:       true,
-						SetCommunicationPort:   true,
-						CreateEecRuntimeConfig: true,
-						ServiceAccountOwner:    "",
-						ServicePorts: AgServicePorts{
-							Statsd: true,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "just kubemon",
-			args: args{
-				dynakube: &dynatracev1beta1.DynaKube{
-					Spec: dynatracev1beta1.DynaKubeSpec{
-						ActiveGate: dynatracev1beta1.ActiveGateSpec{
-							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-								dynatracev1beta1.KubeMonCapability.DisplayName,
-							},
-						},
-					},
-				},
-			},
-			want: &MultiCapability{
-				capabilityBase: capabilityBase{
-					enabled:    true,
-					shortName:  consts.MultiActiveGateName,
-					argName:    dynatracev1beta1.KubeMonCapability.ArgumentName,
-					properties: props,
-					Configuration: Configuration{
-						ServiceAccountOwner: "kubernetes-monitoring",
-					},
-					initContainersTemplates: []v1.Container{
-						{
-							Name:            initContainerTemplateName,
-							ImagePullPolicy: v1.PullAlways,
-							WorkingDir:      k8scrt2jksWorkingDir,
-							Command:         []string{"/bin/bash"},
-							Args:            []string{"-c", k8scrt2jksPath},
-							VolumeMounts: []v1.VolumeMount{
-								{
-									ReadOnly:  false,
-									Name:      trustStoreVolume,
-									MountPath: activeGateSslPath,
-								},
-							},
-						},
-					},
-					containerVolumeMounts: []v1.VolumeMount{{
-						ReadOnly:  true,
-						Name:      trustStoreVolume,
-						MountPath: activeGateCacertsPath,
-						SubPath:   k8sCertificateFile,
-					}},
-					volumes: []v1.Volume{{
-						Name: trustStoreVolume,
-						VolumeSource: v1.VolumeSource{
-							EmptyDir: &v1.EmptyDirVolumeSource{},
-						},
-					}},
-				},
-			},
-		},
-		{
-			name: "all capability at once",
-			args: args{
-				dynakube: &dynatracev1beta1.DynaKube{
-					Spec: dynatracev1beta1.DynaKubeSpec{
-						ActiveGate: dynatracev1beta1.ActiveGateSpec{
-							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-								dynatracev1beta1.KubeMonCapability.DisplayName,
-								dynatracev1beta1.MetricsIngestCapability.DisplayName,
-								dynatracev1beta1.StatsdIngestCapability.DisplayName,
-								dynatracev1beta1.RoutingCapability.DisplayName,
-								dynatracev1beta1.DynatraceApiCapability.DisplayName,
-							},
-						},
-					},
-				},
-			},
-			want: &MultiCapability{
-				capabilityBase: capabilityBase{
-					enabled:   true,
-					shortName: consts.MultiActiveGateName,
-					argName: strings.Join([]string{
-						dynatracev1beta1.KubeMonCapability.ArgumentName,
-						dynatracev1beta1.MetricsIngestCapability.ArgumentName,
-						dynatracev1beta1.StatsdIngestCapability.ArgumentName,
-						dynatracev1beta1.RoutingCapability.ArgumentName,
-						dynatracev1beta1.DynatraceApiCapability.ArgumentName},
-						","),
-					properties: props,
-					Configuration: Configuration{
-						SetDnsEntryPoint:       true,
-						SetReadinessPort:       true,
-						SetCommunicationPort:   true,
-						CreateEecRuntimeConfig: true,
-						ServiceAccountOwner:    "kubernetes-monitoring",
-						ServicePorts: AgServicePorts{
-							Webserver: true,
-							Statsd:    true,
-						},
-					},
-					initContainersTemplates: []v1.Container{
-						{
-							Name:            initContainerTemplateName,
-							ImagePullPolicy: v1.PullAlways,
-							WorkingDir:      k8scrt2jksWorkingDir,
-							Command:         []string{"/bin/bash"},
-							Args:            []string{"-c", k8scrt2jksPath},
-							VolumeMounts: []v1.VolumeMount{
-								{
-									ReadOnly:  false,
-									Name:      trustStoreVolume,
-									MountPath: activeGateSslPath,
-								},
-							},
-						},
-					},
-					containerVolumeMounts: []v1.VolumeMount{{
-						ReadOnly:  true,
-						Name:      trustStoreVolume,
-						MountPath: activeGateCacertsPath,
-						SubPath:   k8sCertificateFile,
-					}},
-					volumes: []v1.Volume{{
-						Name: trustStoreVolume,
-						VolumeSource: v1.VolumeSource{
-							EmptyDir: &v1.EmptyDirVolumeSource{},
-						},
-					}},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := NewMultiCapability(tt.args.dynakube); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewMultiCapability() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 	type args struct {
+// 		dynakube *dynatracev1beta1.DynaKube
+// 	}
+// 	tests := []struct {
+// 		name string
+// 		args args
+// 		want *MultiCapability
+// 	}{
+// 		{
+// 			name: "empty",
+// 			args: args{
+// 				dynakube: &dynatracev1beta1.DynaKube{
+// 					Spec: dynatracev1beta1.DynaKubeSpec{},
+// 				},
+// 			},
+// 			want: &MultiCapability{
+// 				capabilityBase: capabilityBase{
+// 					enabled:   false,
+// 					shortName: consts.MultiActiveGateName,
+// 					Configuration: Configuration{
+// 						ServicePorts: AgServicePorts{
+// 							Webserver: true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "just routing",
+// 			args: args{
+// 				dynakube: &dynatracev1beta1.DynaKube{
+// 					Spec: dynatracev1beta1.DynaKubeSpec{
+// 						ActiveGate: dynatracev1beta1.ActiveGateSpec{
+// 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+// 								dynatracev1beta1.RoutingCapability.DisplayName,
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			want: &MultiCapability{
+// 				capabilityBase: capabilityBase{
+// 					enabled:    true,
+// 					shortName:  consts.MultiActiveGateName,
+// 					argName:    dynatracev1beta1.RoutingCapability.ArgumentName,
+// 					properties: props,
+// 					Configuration: Configuration{
+// 						SetDnsEntryPoint:     true,
+// 						SetReadinessPort:     true,
+// 						SetCommunicationPort: true,
+// 						ServiceAccountOwner:  "",
+// 						ServicePorts: AgServicePorts{
+// 							Webserver: true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "just metrics-ingest",
+// 			args: args{
+// 				dynakube: &dynatracev1beta1.DynaKube{
+// 					Spec: dynatracev1beta1.DynaKubeSpec{
+// 						ActiveGate: dynatracev1beta1.ActiveGateSpec{
+// 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+// 								dynatracev1beta1.MetricsIngestCapability.DisplayName,
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			want: &MultiCapability{
+// 				capabilityBase: capabilityBase{
+// 					enabled:    true,
+// 					shortName:  consts.MultiActiveGateName,
+// 					argName:    dynatracev1beta1.MetricsIngestCapability.ArgumentName,
+// 					properties: props,
+// 					Configuration: Configuration{
+// 						SetDnsEntryPoint:     true,
+// 						SetReadinessPort:     true,
+// 						SetCommunicationPort: true,
+// 						ServiceAccountOwner:  "",
+// 						ServicePorts: AgServicePorts{
+// 							Webserver: true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "just dynatrace-api",
+// 			args: args{
+// 				dynakube: &dynatracev1beta1.DynaKube{
+// 					Spec: dynatracev1beta1.DynaKubeSpec{
+// 						ActiveGate: dynatracev1beta1.ActiveGateSpec{
+// 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+// 								dynatracev1beta1.DynatraceApiCapability.DisplayName,
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			want: &MultiCapability{
+// 				capabilityBase: capabilityBase{
+// 					enabled:    true,
+// 					shortName:  consts.MultiActiveGateName,
+// 					argName:    dynatracev1beta1.DynatraceApiCapability.ArgumentName,
+// 					properties: props,
+// 					Configuration: Configuration{
+// 						SetDnsEntryPoint:     true,
+// 						SetReadinessPort:     true,
+// 						SetCommunicationPort: true,
+// 						ServiceAccountOwner:  "",
+// 						ServicePorts: AgServicePorts{
+// 							Webserver: true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "just statsd-ingest",
+// 			args: args{
+// 				dynakube: &dynatracev1beta1.DynaKube{
+// 					Spec: dynatracev1beta1.DynaKubeSpec{
+// 						ActiveGate: dynatracev1beta1.ActiveGateSpec{
+// 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+// 								dynatracev1beta1.StatsdIngestCapability.DisplayName,
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			want: &MultiCapability{
+// 				capabilityBase: capabilityBase{
+// 					enabled:    true,
+// 					shortName:  consts.MultiActiveGateName,
+// 					argName:    dynatracev1beta1.StatsdIngestCapability.ArgumentName,
+// 					properties: props,
+// 					Configuration: Configuration{
+// 						SetDnsEntryPoint:       true,
+// 						SetReadinessPort:       true,
+// 						SetCommunicationPort:   true,
+// 						CreateEecRuntimeConfig: true,
+// 						ServiceAccountOwner:    "",
+// 						ServicePorts: AgServicePorts{
+// 							Statsd: true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "just kubemon",
+// 			args: args{
+// 				dynakube: &dynatracev1beta1.DynaKube{
+// 					Spec: dynatracev1beta1.DynaKubeSpec{
+// 						ActiveGate: dynatracev1beta1.ActiveGateSpec{
+// 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+// 								dynatracev1beta1.KubeMonCapability.DisplayName,
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			want: &MultiCapability{
+// 				capabilityBase: capabilityBase{
+// 					enabled:    true,
+// 					shortName:  consts.MultiActiveGateName,
+// 					argName:    dynatracev1beta1.KubeMonCapability.ArgumentName,
+// 					properties: props,
+// 					Configuration: Configuration{
+// 						ServiceAccountOwner: "kubernetes-monitoring",
+// 					},
+// 					initContainersTemplates: []v1.Container{
+// 						{
+// 							Name:            initContainerTemplateName,
+// 							ImagePullPolicy: v1.PullAlways,
+// 							WorkingDir:      k8scrt2jksWorkingDir,
+// 							Command:         []string{"/bin/bash"},
+// 							Args:            []string{"-c", k8scrt2jksPath},
+// 							VolumeMounts: []v1.VolumeMount{
+// 								{
+// 									ReadOnly:  false,
+// 									Name:      trustStoreVolume,
+// 									MountPath: activeGateSslPath,
+// 								},
+// 							},
+// 						},
+// 					},
+// 					containerVolumeMounts: []v1.VolumeMount{{
+// 						ReadOnly:  true,
+// 						Name:      trustStoreVolume,
+// 						MountPath: activeGateCacertsPath,
+// 						SubPath:   k8sCertificateFile,
+// 					}},
+// 					volumes: []v1.Volume{{
+// 						Name: trustStoreVolume,
+// 						VolumeSource: v1.VolumeSource{
+// 							EmptyDir: &v1.EmptyDirVolumeSource{},
+// 						},
+// 					}},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "all capability at once",
+// 			args: args{
+// 				dynakube: &dynatracev1beta1.DynaKube{
+// 					Spec: dynatracev1beta1.DynaKubeSpec{
+// 						ActiveGate: dynatracev1beta1.ActiveGateSpec{
+// 							Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+// 								dynatracev1beta1.KubeMonCapability.DisplayName,
+// 								dynatracev1beta1.MetricsIngestCapability.DisplayName,
+// 								dynatracev1beta1.StatsdIngestCapability.DisplayName,
+// 								dynatracev1beta1.RoutingCapability.DisplayName,
+// 								dynatracev1beta1.DynatraceApiCapability.DisplayName,
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			want: &MultiCapability{
+// 				capabilityBase: capabilityBase{
+// 					enabled:   true,
+// 					shortName: consts.MultiActiveGateName,
+// 					argName: strings.Join([]string{
+// 						dynatracev1beta1.KubeMonCapability.ArgumentName,
+// 						dynatracev1beta1.MetricsIngestCapability.ArgumentName,
+// 						dynatracev1beta1.StatsdIngestCapability.ArgumentName,
+// 						dynatracev1beta1.RoutingCapability.ArgumentName,
+// 						dynatracev1beta1.DynatraceApiCapability.ArgumentName},
+// 						","),
+// 					properties: props,
+// 					Configuration: Configuration{
+// 						SetDnsEntryPoint:       true,
+// 						SetReadinessPort:       true,
+// 						SetCommunicationPort:   true,
+// 						CreateEecRuntimeConfig: true,
+// 						ServiceAccountOwner:    "kubernetes-monitoring",
+// 						ServicePorts: AgServicePorts{
+// 							Webserver: true,
+// 							Statsd:    true,
+// 						},
+// 					},
+// 					initContainersTemplates: []v1.Container{
+// 						{
+// 							Name:            initContainerTemplateName,
+// 							ImagePullPolicy: v1.PullAlways,
+// 							WorkingDir:      k8scrt2jksWorkingDir,
+// 							Command:         []string{"/bin/bash"},
+// 							Args:            []string{"-c", k8scrt2jksPath},
+// 							VolumeMounts: []v1.VolumeMount{
+// 								{
+// 									ReadOnly:  false,
+// 									Name:      trustStoreVolume,
+// 									MountPath: activeGateSslPath,
+// 								},
+// 							},
+// 						},
+// 					},
+// 					containerVolumeMounts: []v1.VolumeMount{{
+// 						ReadOnly:  true,
+// 						Name:      trustStoreVolume,
+// 						MountPath: activeGateCacertsPath,
+// 						SubPath:   k8sCertificateFile,
+// 					}},
+// 					volumes: []v1.Volume{{
+// 						Name: trustStoreVolume,
+// 						VolumeSource: v1.VolumeSource{
+// 							EmptyDir: &v1.EmptyDirVolumeSource{},
+// 						},
+// 					}},
+// 				},
+// 			},
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			if got := NewMultiCapability(tt.args.dynakube); !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("NewMultiCapability() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }

--- a/src/controllers/dynakube/activegate/consts/consts.go
+++ b/src/controllers/dynakube/activegate/consts/consts.go
@@ -19,7 +19,6 @@ const (
 	HttpsContainerPort      = 9999
 	HttpContainerPort       = 9998
 
-	ServiceAccountPrefix     = "dynatrace-"
 	DeploymentTypeActiveGate = "active_gate"
 
 	TenantSecretVolumeName    = "ag-tenant-secret"

--- a/src/controllers/dynakube/activegate/internal/capability/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/capability/reconciler.go
@@ -50,7 +50,7 @@ func (r *Reconciler) Reconcile() (update bool, err error) {
 		}
 	}
 
-	if r.dynakube.IsStatsdCapabilityEnabled() {
+	if r.dynakube.IsStatsdActiveGateEnabled() {
 		update, err = r.createOrUpdateEecConfigMap()
 		if update || err != nil {
 			return update, errors.WithStack(err)

--- a/src/controllers/dynakube/activegate/internal/capability/service.go
+++ b/src/controllers/dynakube/activegate/internal/capability/service.go
@@ -30,7 +30,7 @@ func CreateService(dynakube *dynatracev1beta1.DynaKube, feature string) *corev1.
 		)
 	}
 
-	if dynakube.IsStatsdCapabilityEnabled() {
+	if dynakube.IsStatsdActiveGateEnabled() {
 		ports = append(ports,
 			corev1.ServicePort{
 				Name:       consts.StatsdIngestPortName,

--- a/src/controllers/dynakube/activegate/internal/capability/service.go
+++ b/src/controllers/dynakube/activegate/internal/capability/service.go
@@ -10,10 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func CreateService(dynakube *dynatracev1beta1.DynaKube, feature string, servicePorts capability.AgServicePorts) *corev1.Service {
+func CreateService(dynakube *dynatracev1beta1.DynaKube, feature string) *corev1.Service {
 	var ports []corev1.ServicePort
 
-	if servicePorts.Webserver {
+	if dynakube.NeedsActiveGateServicePorts() {
 		ports = append(ports,
 			corev1.ServicePort{
 				Name:       consts.HttpsServicePortName,
@@ -30,7 +30,7 @@ func CreateService(dynakube *dynatracev1beta1.DynaKube, feature string, serviceP
 		)
 	}
 
-	if servicePorts.Statsd {
+	if dynakube.IsStatsdCapabilityEnabled() {
 		ports = append(ports,
 			corev1.ServicePort{
 				Name:       consts.StatsdIngestPortName,

--- a/src/controllers/dynakube/activegate/internal/capability/service_test.go
+++ b/src/controllers/dynakube/activegate/internal/capability/service_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/version"
@@ -54,9 +53,7 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check service name, labels and selector", func(t *testing.T) {
 		instance := testCreateInstance()
-		service := CreateService(instance, testComponentFeature, capability.AgServicePorts{
-			Webserver: true,
-		})
+		service := CreateService(instance, testComponentFeature)
 
 		assert.NotNil(t, service)
 		assert.Equal(t, instance.Name+"-"+testComponentFeature, service.Name)
@@ -82,15 +79,11 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check AG service if metrics ingest enabled, but not StatsD", func(t *testing.T) {
 		instance := testCreateInstance()
-		desiredPorts := capability.AgServicePorts{
-			Webserver: true,
-		}
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.StatsdIngestCapability, false)
-		require.True(t, !instance.NeedsStatsd())
-		require.True(t, desiredPorts.HasPorts())
+		require.True(t, !instance.IsStatsdCapabilityEnabled())
 
-		service := CreateService(instance, testComponentFeature, desiredPorts)
+		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports
 
 		assert.Contains(t, ports, agHttpsPort, agHttpPort)
@@ -99,16 +92,11 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check AG service if metrics ingest and StatsD enabled", func(t *testing.T) {
 		instance := testCreateInstance()
-		desiredPorts := capability.AgServicePorts{
-			Webserver: true,
-			Statsd:    true,
-		}
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
-		kubeobjects.SwitchCapability(instance, dynatracev1beta1.StatsdIngestCapability, desiredPorts.Statsd)
-		require.True(t, instance.NeedsStatsd())
-		require.True(t, desiredPorts.HasPorts())
+		kubeobjects.SwitchCapability(instance, dynatracev1beta1.StatsdIngestCapability, true)
+		require.True(t, instance.IsStatsdCapabilityEnabled())
 
-		service := CreateService(instance, testComponentFeature, desiredPorts)
+		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports
 
 		assert.Contains(t, ports, agHttpsPort, agHttpPort, statsdPort)
@@ -116,15 +104,11 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check AG service if StatsD enabled, but not metrics ingest", func(t *testing.T) {
 		instance := testCreateInstance()
-		desiredPorts := capability.AgServicePorts{
-			Statsd: true,
-		}
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.MetricsIngestCapability, false)
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.StatsdIngestCapability, true)
-		require.True(t, instance.NeedsStatsd())
-		require.True(t, desiredPorts.HasPorts())
+		require.True(t, instance.IsStatsdCapabilityEnabled())
 
-		service := CreateService(instance, testComponentFeature, desiredPorts)
+		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports
 
 		assert.NotContains(t, ports, agHttpsPort, agHttpPort)
@@ -133,13 +117,11 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check AG service if StatsD and metrics ingest are disabled", func(t *testing.T) {
 		instance := testCreateInstance()
-		desiredPorts := capability.AgServicePorts{}
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.MetricsIngestCapability, false)
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.StatsdIngestCapability, false)
-		require.True(t, !instance.NeedsStatsd())
-		require.False(t, desiredPorts.HasPorts())
+		require.True(t, !instance.IsStatsdCapabilityEnabled())
 
-		service := CreateService(instance, testComponentFeature, desiredPorts)
+		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports
 
 		assert.NotContains(t, ports, agHttpsPort, agHttpPort, statsdPort)

--- a/src/controllers/dynakube/activegate/internal/capability/service_test.go
+++ b/src/controllers/dynakube/activegate/internal/capability/service_test.go
@@ -81,7 +81,7 @@ func TestCreateService(t *testing.T) {
 		instance := testCreateInstance()
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.StatsdIngestCapability, false)
-		require.True(t, !instance.IsStatsdCapabilityEnabled())
+		require.True(t, !instance.IsStatsdActiveGateEnabled())
 
 		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports
@@ -94,7 +94,7 @@ func TestCreateService(t *testing.T) {
 		instance := testCreateInstance()
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.StatsdIngestCapability, true)
-		require.True(t, instance.IsStatsdCapabilityEnabled())
+		require.True(t, instance.IsStatsdActiveGateEnabled())
 
 		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports
@@ -106,7 +106,7 @@ func TestCreateService(t *testing.T) {
 		instance := testCreateInstance()
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.MetricsIngestCapability, false)
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.StatsdIngestCapability, true)
-		require.True(t, instance.IsStatsdCapabilityEnabled())
+		require.True(t, instance.IsStatsdActiveGateEnabled())
 
 		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports
@@ -119,7 +119,7 @@ func TestCreateService(t *testing.T) {
 		instance := testCreateInstance()
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.MetricsIngestCapability, false)
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.StatsdIngestCapability, false)
-		require.True(t, !instance.IsStatsdCapabilityEnabled())
+		require.True(t, !instance.IsStatsdActiveGateEnabled())
 
 		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
@@ -20,12 +20,18 @@ type envModifier interface {
 	getEnvs() []corev1.EnvVar
 }
 
+type initContainerModifier interface {
+	getInitContainers() []corev1.Container
+}
+
 var (
 	log = logger.NewDTLogger().WithName("activegate-statefulset-builder")
 )
 
 func GenerateAllModifiers(dynakube dynatracev1beta1.DynaKube, capability capability.Capability) []builder.Modifier {
 	return []builder.Modifier{
+		NewKubernetesMonitoringModifier(dynakube, capability),
+		NewServicePortModifier(dynakube, capability),
 		NewAuthTokenModifier(dynakube),
 		NewCertificatesModifier(dynakube),
 		NewCustomPropertiesModifier(dynakube, capability),

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/customprops.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/customprops.go
@@ -75,7 +75,7 @@ func (mod CustomPropertiesModifier) hasCustomProperties() bool {
 
 func (mod CustomPropertiesModifier) determineCustomPropertiesSource() string {
 	if mod.capability.Properties().CustomProperties.ValueFrom == "" {
-		return fmt.Sprintf("%s-%s-%s", mod.dynakube.Name, mod.capability.Config().ServiceAccountOwner, customproperties.Suffix)
+		return fmt.Sprintf("%s-%s-%s", mod.dynakube.Name, mod.dynakube.ActiveGateServiceAccountOwner(), customproperties.Suffix)
 	}
 	return mod.capability.Properties().CustomProperties.ValueFrom
 }

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -48,7 +48,7 @@ func NewExtensionControllerModifier(dynakube dynatracev1beta1.DynaKube, capabili
 }
 
 func (eec ExtensionControllerModifier) Enabled() bool {
-	return eec.dynakube.IsStatsdCapabilityEnabled()
+	return eec.dynakube.IsStatsdActiveGateEnabled()
 }
 
 func (eec ExtensionControllerModifier) Modify(sts *appsv1.StatefulSet) {

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -48,7 +48,7 @@ func NewExtensionControllerModifier(dynakube dynatracev1beta1.DynaKube, capabili
 }
 
 func (eec ExtensionControllerModifier) Enabled() bool {
-	return eec.dynakube.NeedsStatsd()
+	return eec.dynakube.IsStatsdCapabilityEnabled()
 }
 
 func (eec ExtensionControllerModifier) Modify(sts *appsv1.StatefulSet) {

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
@@ -1,0 +1,92 @@
+package modifiers
+
+import (
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/capability"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/internal/statefulset/builder"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ volumeModifier = KubernetesMonitoringModifier{}
+var _ volumeMountModifier = KubernetesMonitoringModifier{}
+var _ initContainerModifier = KubernetesMonitoringModifier{}
+var _ builder.Modifier = KubernetesMonitoringModifier{}
+
+const (
+	trustStoreVolume          = "truststore-volume"
+	activeGateCacertsPath     = "/opt/dynatrace/gateway/jre/lib/security/cacerts"
+	k8sCertificateFile        = "k8s-local.jks"
+	k8scrt2jksPath            = "/opt/dynatrace/gateway/k8scrt2jks.sh"
+	activeGateSslPath         = "/var/lib/dynatrace/gateway/ssl"
+	k8scrt2jksWorkingDir      = "/var/lib/dynatrace/gateway"
+	initContainerTemplateName = "certificate-loader"
+)
+
+func NewKubernetesMonitoringModifier(dynakube dynatracev1beta1.DynaKube, capability capability.Capability) KubernetesMonitoringModifier {
+	return KubernetesMonitoringModifier{
+		dynakube:   dynakube,
+		capability: capability,
+	}
+}
+
+type KubernetesMonitoringModifier struct {
+	dynakube   dynatracev1beta1.DynaKube
+	capability capability.Capability
+}
+
+func (mod KubernetesMonitoringModifier) Enabled() bool {
+	return mod.dynakube.IsKubernetesMonitoringCapabilityEnabled()
+}
+
+func (mod KubernetesMonitoringModifier) Modify(sts *appsv1.StatefulSet) {
+	baseContainer := kubeobjects.FindContainerInPodSpec(&sts.Spec.Template.Spec, consts.ActiveGateContainerName)
+	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, mod.getVolumes()...)
+	baseContainer.VolumeMounts = append(baseContainer.VolumeMounts, mod.getVolumeMounts()...)
+	sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers, mod.getInitContainers()...)
+}
+
+func (mod KubernetesMonitoringModifier) getInitContainers() []corev1.Container {
+	return []corev1.Container{
+		{
+			Name:            initContainerTemplateName,
+			Image:           mod.dynakube.ActiveGateImage(),
+			ImagePullPolicy: corev1.PullAlways,
+			WorkingDir:      k8scrt2jksWorkingDir,
+			Command:         []string{"/bin/bash"},
+			Args:            []string{"-c", k8scrt2jksPath},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					ReadOnly:  false,
+					Name:      trustStoreVolume,
+					MountPath: activeGateSslPath,
+				},
+			},
+			Resources: mod.capability.Properties().Resources,
+		},
+	}
+}
+
+func (mod KubernetesMonitoringModifier) getVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: trustStoreVolume,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+}
+
+func (mod KubernetesMonitoringModifier) getVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			ReadOnly:  true,
+			Name:      trustStoreVolume,
+			MountPath: activeGateCacertsPath,
+			SubPath:   k8sCertificateFile,
+		},
+	}
+}

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
@@ -38,7 +38,7 @@ type KubernetesMonitoringModifier struct {
 }
 
 func (mod KubernetesMonitoringModifier) Enabled() bool {
-	return mod.dynakube.IsKubernetesMonitoringCapabilityEnabled()
+	return mod.dynakube.IsKubernetesMonitoringActiveGateEnabled()
 }
 
 func (mod KubernetesMonitoringModifier) Modify(sts *appsv1.StatefulSet) {

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon_test.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon_test.go
@@ -1,0 +1,59 @@
+package modifiers
+
+import (
+	"testing"
+
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/capability"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setKubernetesMonitoringUsage(dynakube *dynatracev1beta1.DynaKube, isUsed bool) {
+	if isUsed {
+		enableKubeMonCapability(dynakube)
+	}
+}
+
+func TestKubernetesMonitoringEnabled(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		setKubernetesMonitoringUsage(&dynakube, true)
+		multiCapability := capability.NewMultiCapability(&dynakube)
+
+		mod := NewKubernetesMonitoringModifier(dynakube, multiCapability)
+
+		assert.True(t, mod.Enabled())
+	})
+
+	t.Run("false", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		setKubernetesMonitoringUsage(&dynakube, false)
+		multiCapability := capability.NewMultiCapability(&dynakube)
+
+		mod := NewKubernetesMonitoringModifier(dynakube, multiCapability)
+
+		assert.False(t, mod.Enabled())
+	})
+}
+
+func TestKubernetesMonitoringModify(t *testing.T) {
+	t.Run("successfully modified", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		setKubernetesMonitoringUsage(&dynakube, true)
+		multiCapability := capability.NewMultiCapability(&dynakube)
+		mod := NewKubernetesMonitoringModifier(dynakube, multiCapability)
+		builder := createBuilderForTesting()
+		expectedVolumes := mod.getVolumes()
+		expectedIniContainers := mod.getInitContainers()
+		expectedVolumeMounts := mod.getVolumeMounts()
+
+		sts := builder.AddModifier(mod).Build()
+
+		require.NotEmpty(t, sts)
+		container := sts.Spec.Template.Spec.Containers[0]
+		isSubset(t, expectedVolumes, sts.Spec.Template.Spec.Volumes)
+		isSubset(t, expectedVolumeMounts, container.VolumeMounts)
+		isSubset(t, expectedIniContainers, sts.Spec.Template.Spec.InitContainers)
+	})
+}

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
@@ -1,0 +1,80 @@
+package modifiers
+
+import (
+	"fmt"
+	"strings"
+
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/capability"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/internal/statefulset/builder"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ envModifier = ServicePortModifier{}
+var _ builder.Modifier = ServicePortModifier{}
+
+func NewServicePortModifier(dynakube dynatracev1beta1.DynaKube, capability capability.Capability) ServicePortModifier {
+	return ServicePortModifier{
+		dynakube:   dynakube,
+		capability: capability,
+	}
+}
+
+type ServicePortModifier struct {
+	dynakube   dynatracev1beta1.DynaKube
+	capability capability.Capability
+}
+
+func (mod ServicePortModifier) Enabled() bool {
+	return mod.dynakube.NeedsActiveGateServicePorts()
+}
+
+func (mod ServicePortModifier) Modify(sts *appsv1.StatefulSet) {
+	baseContainer := kubeobjects.FindContainerInPodSpec(&sts.Spec.Template.Spec, consts.ActiveGateContainerName)
+	baseContainer.ReadinessProbe.HTTPGet.Port = intstr.FromString(consts.HttpsServicePortName)
+	baseContainer.Ports = append(baseContainer.Ports, mod.getPorts()...)
+	baseContainer.Env = append(baseContainer.Env, mod.getEnvs()...)
+}
+
+func (mod ServicePortModifier) getPorts() []corev1.ContainerPort {
+	return []corev1.ContainerPort{
+		{
+			Name:          consts.HttpsServicePortName,
+			ContainerPort: consts.HttpsContainerPort,
+		},
+		{
+			Name:          consts.HttpServicePortName,
+			ContainerPort: consts.HttpContainerPort,
+		},
+	}
+}
+
+func (mod ServicePortModifier) getEnvs() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  consts.EnvDtDnsEntryPoint,
+			Value: mod.buildDNSEntryPoint(),
+		},
+	}
+}
+
+func (mod ServicePortModifier) buildDNSEntryPoint() string {
+	return fmt.Sprintf("https://%s/communication", buildServiceHostName(mod.dynakube.Name, mod.capability.ShortName()))
+}
+
+// buildServiceHostName converts the name returned by BuildServiceName
+// into the variable name which Kubernetes uses to reference the associated service.
+// For more information see: https://kubernetes.io/docs/concepts/services-networking/service/
+func buildServiceHostName(dynakubeName string, module string) string {
+	serviceName :=
+		strings.ReplaceAll(
+			strings.ToUpper(
+				capability.BuildServiceName(dynakubeName, module)),
+			"-", "_")
+
+	return fmt.Sprintf("$(%s_SERVICE_HOST):$(%s_SERVICE_PORT)", serviceName, serviceName)
+}

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport_test.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport_test.go
@@ -1,0 +1,73 @@
+package modifiers
+
+import (
+	"testing"
+
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/capability"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setServicePortUsage(dynakube *dynatracev1beta1.DynaKube, isUsed bool) {
+	if isUsed {
+		dynakube.Spec.ActiveGate.Capabilities = append(dynakube.Spec.ActiveGate.Capabilities, dynatracev1beta1.MetricsIngestCapability.DisplayName)
+	}
+}
+
+func TestServicePortEnabled(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		setServicePortUsage(&dynakube, true)
+		multiCapability := capability.NewMultiCapability(&dynakube)
+
+		mod := NewServicePortModifier(dynakube, multiCapability)
+
+		assert.True(t, mod.Enabled())
+	})
+
+	t.Run("false", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		setServicePortUsage(&dynakube, false)
+		multiCapability := capability.NewMultiCapability(&dynakube)
+
+		mod := NewServicePortModifier(dynakube, multiCapability)
+
+		assert.False(t, mod.Enabled())
+	})
+}
+
+func TestServicePortModify(t *testing.T) {
+	t.Run("successfully modified", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		setServicePortUsage(&dynakube, true)
+		multiCapability := capability.NewMultiCapability(&dynakube)
+		mod := NewServicePortModifier(dynakube, multiCapability)
+		builder := createBuilderForTesting()
+		expectedPorts := mod.getPorts()
+		expectedEnv := mod.getEnvs()
+
+		sts := builder.AddModifier(mod).Build()
+
+		require.NotEmpty(t, sts)
+		container := sts.Spec.Template.Spec.Containers[0]
+		isSubset(t, expectedPorts, container.Ports)
+		isSubset(t, expectedEnv, container.Env)
+		assert.Equal(t, consts.HttpsServicePortName, container.ReadinessProbe.HTTPGet.Port.StrVal)
+	})
+}
+
+func TestBuildServiceNameForDNSEntryPoint(t *testing.T) {
+	actual := buildServiceHostName("test-name", "test-component-feature")
+	assert.NotEmpty(t, actual)
+
+	expected := "$(TEST_NAME_TEST_COMPONENT_FEATURE_SERVICE_HOST):$(TEST_NAME_TEST_COMPONENT_FEATURE_SERVICE_PORT)"
+	assert.Equal(t, expected, actual)
+
+	testStringName := "this---test_string"
+	testStringFeature := "SHOULD--_--PaRsEcORrEcTlY"
+	expected = "$(THIS___TEST_STRING_SHOULD_____PARSECORRECTLY_SERVICE_HOST):$(THIS___TEST_STRING_SHOULD_____PARSECORRECTLY_SERVICE_PORT)"
+	actual = buildServiceHostName(testStringName, testStringFeature)
+	assert.Equal(t, expected, actual)
+}

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd.go
@@ -49,7 +49,7 @@ func NewStatsdModifier(dynakube dynatracev1beta1.DynaKube, capability capability
 }
 
 func (statsd StatsdModifier) Enabled() bool {
-	return statsd.dynakube.IsStatsdCapabilityEnabled()
+	return statsd.dynakube.IsStatsdActiveGateEnabled()
 }
 
 func (statsd StatsdModifier) Modify(sts *appsv1.StatefulSet) {

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd.go
@@ -49,7 +49,7 @@ func NewStatsdModifier(dynakube dynatracev1beta1.DynaKube, capability capability
 }
 
 func (statsd StatsdModifier) Enabled() bool {
-	return statsd.dynakube.NeedsStatsd()
+	return statsd.dynakube.IsStatsdCapabilityEnabled()
 }
 
 func (statsd StatsdModifier) Modify(sts *appsv1.StatefulSet) {
@@ -128,7 +128,7 @@ func (statsd StatsdModifier) buildContainer() corev1.Container {
 		SecurityContext: statsd.buildSecurityContext(),
 		Resources:       statsd.buildResourceRequirements(),
 	}
-	if statsd.capability.Config().SetCommunicationPort {
+	if statsd.dynakube.NeedsActiveGateServicePorts() {
 		container.Ports = []corev1.ContainerPort{
 			{
 				Name:          consts.StatsdIngestTargetPort,

--- a/src/controllers/dynakube/dtclient_reconciler.go
+++ b/src/controllers/dynakube/dtclient_reconciler.go
@@ -134,7 +134,7 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance *dyn
 		tokens[dtclient.DynatraceApiToken].Scopes = append(tokens[dtclient.DynatraceApiToken].Scopes, dtclient.TokenScopeDataExport)
 	}
 
-	if instance.KubernetesMonitoringMode() &&
+	if instance.IsKubernetesMonitoringCapabilityEnabled() &&
 		instance.FeatureAutomaticKubernetesApiMonitoring() {
 		tokens[dtclient.DynatraceApiToken].Scopes = append(tokens[dtclient.DynatraceApiToken].Scopes,
 			dtclient.TokenScopeEntitiesRead,

--- a/src/controllers/dynakube/dtclient_reconciler.go
+++ b/src/controllers/dynakube/dtclient_reconciler.go
@@ -134,7 +134,7 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance *dyn
 		tokens[dtclient.DynatraceApiToken].Scopes = append(tokens[dtclient.DynatraceApiToken].Scopes, dtclient.TokenScopeDataExport)
 	}
 
-	if instance.IsKubernetesMonitoringCapabilityEnabled() &&
+	if instance.IsKubernetesMonitoringActiveGateEnabled() &&
 		instance.FeatureAutomaticKubernetesApiMonitoring() {
 		tokens[dtclient.DynatraceApiToken].Scopes = append(tokens[dtclient.DynatraceApiToken].Scopes,
 			dtclient.TokenScopeEntitiesRead,

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -322,7 +322,7 @@ func (controller *DynakubeController) reconcileActiveGate(ctx context.Context, d
 func (controller *DynakubeController) startApiMonitoring(dynakubeState *status.DynakubeState, dtc dtclient.Client) {
 	if dynakubeState.Instance.Status.KubeSystemUUID != "" &&
 		dynakubeState.Instance.FeatureAutomaticKubernetesApiMonitoring() &&
-		dynakubeState.Instance.KubernetesMonitoringMode() {
+		dynakubeState.Instance.IsKubernetesMonitoringCapabilityEnabled() {
 
 		clusterLabel := dynakubeState.Instance.FeatureAutomaticKubernetesApiMonitoringClusterName()
 		if clusterLabel == "" {

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -322,7 +322,7 @@ func (controller *DynakubeController) reconcileActiveGate(ctx context.Context, d
 func (controller *DynakubeController) startApiMonitoring(dynakubeState *status.DynakubeState, dtc dtclient.Client) {
 	if dynakubeState.Instance.Status.KubeSystemUUID != "" &&
 		dynakubeState.Instance.FeatureAutomaticKubernetesApiMonitoring() &&
-		dynakubeState.Instance.IsKubernetesMonitoringCapabilityEnabled() {
+		dynakubeState.Instance.IsKubernetesMonitoringActiveGateEnabled() {
 
 		clusterLabel := dynakubeState.Instance.FeatureAutomaticKubernetesApiMonitoringClusterName()
 		if clusterLabel == "" {

--- a/src/controllers/dynakube/version/version.go
+++ b/src/controllers/dynakube/version/version.go
@@ -45,11 +45,11 @@ func ReconcileVersions(
 		!dk.FeatureDisableActiveGateUpdates() &&
 		dkState.IsOutdated(dk.Status.ActiveGate.LastUpdateProbeTimestamp, ProbeThreshold)
 
-	needsEecUpdate := dk.IsStatsdCapabilityEnabled() &&
+	needsEecUpdate := dk.IsStatsdActiveGateEnabled() &&
 		!dk.FeatureDisableActiveGateUpdates() &&
 		dkState.IsOutdated(dk.Status.ExtensionController.LastUpdateProbeTimestamp, ProbeThreshold)
 
-	needsStatsdUpdate := dk.IsStatsdCapabilityEnabled() &&
+	needsStatsdUpdate := dk.IsStatsdActiveGateEnabled() &&
 		!dk.FeatureDisableActiveGateUpdates() &&
 		dkState.IsOutdated(dk.Status.Statsd.LastUpdateProbeTimestamp, ProbeThreshold)
 

--- a/src/controllers/dynakube/version/version.go
+++ b/src/controllers/dynakube/version/version.go
@@ -45,11 +45,11 @@ func ReconcileVersions(
 		!dk.FeatureDisableActiveGateUpdates() &&
 		dkState.IsOutdated(dk.Status.ActiveGate.LastUpdateProbeTimestamp, ProbeThreshold)
 
-	needsEecUpdate := dk.NeedsStatsd() &&
+	needsEecUpdate := dk.IsStatsdCapabilityEnabled() &&
 		!dk.FeatureDisableActiveGateUpdates() &&
 		dkState.IsOutdated(dk.Status.ExtensionController.LastUpdateProbeTimestamp, ProbeThreshold)
 
-	needsStatsdUpdate := dk.NeedsStatsd() &&
+	needsStatsdUpdate := dk.IsStatsdCapabilityEnabled() &&
 		!dk.FeatureDisableActiveGateUpdates() &&
 		dkState.IsOutdated(dk.Status.Statsd.LastUpdateProbeTimestamp, ProbeThreshold)
 

--- a/src/ingestendpoint/secret.go
+++ b/src/ingestendpoint/secret.go
@@ -150,7 +150,7 @@ func (g *EndpointSecretGenerator) prepare(ctx context.Context, dk *dynatracev1be
 		}
 	}
 
-	if dk.NeedsStatsd() {
+	if dk.IsStatsdCapabilityEnabled() {
 		if _, err := endpointPropertiesBuilder.WriteString(fmt.Sprintf("%s=%s\n", StatsdUrlSecretField, fields[StatsdUrlSecretField])); err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -182,7 +182,7 @@ func (g *EndpointSecretGenerator) PrepareFields(ctx context.Context, dk *dynatra
 		}
 	}
 
-	if dk.NeedsStatsd() {
+	if dk.IsStatsdCapabilityEnabled() {
 		if statsdUrl, err := statsdIngestUrl(dk); err != nil {
 			return nil, err
 		} else {

--- a/src/ingestendpoint/secret.go
+++ b/src/ingestendpoint/secret.go
@@ -150,7 +150,7 @@ func (g *EndpointSecretGenerator) prepare(ctx context.Context, dk *dynatracev1be
 		}
 	}
 
-	if dk.IsStatsdCapabilityEnabled() {
+	if dk.IsStatsdActiveGateEnabled() {
 		if _, err := endpointPropertiesBuilder.WriteString(fmt.Sprintf("%s=%s\n", StatsdUrlSecretField, fields[StatsdUrlSecretField])); err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -182,7 +182,7 @@ func (g *EndpointSecretGenerator) PrepareFields(ctx context.Context, dk *dynatra
 		}
 	}
 
-	if dk.IsStatsdCapabilityEnabled() {
+	if dk.IsStatsdActiveGateEnabled() {
 		if statsdUrl, err := statsdIngestUrl(dk); err != nil {
 			return nil, err
 		} else {


### PR DESCRIPTION
# Description

Simplifies the `capability` package so it now only has the values necessary to support the current `multiCapability` and the deprecated separate capabilities.
Converted anything possible into modifiers.
Refactored some parts for consistency.

## How can this be tested?
No new feature/behaviour, the activegate creation should work the same as before

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

