### PR TITLE
Make provisioner to get tenantUUID from url

### DIFF
--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -361,7 +361,7 @@ func tenantUUID(apiUrl string) (string, error) {
 
 	}
 
-	return "", fmt.Errorf("problem getting tenant id from API URL '%s'", apiUrl)
+	return "", errors.Errorf("problem getting tenant id from API URL '%s'", apiUrl)
 }
 
 func (dk *DynaKube) HostGroup() string {

--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -209,7 +209,7 @@ func (provisioner *OneAgentProvisioner) handleMetadata(ctx context.Context, dk *
 		oldDynakubeMetadata = *dynakubeMetadata
 	}
 
-	tenantUUID, err:= dk.TenantUUID()
+	tenantUUID, err := dk.TenantUUID()
 	if err != nil {
 		return nil, metadata.Dynakube{}, err
 	}

--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -91,11 +91,6 @@ func (provisioner *OneAgentProvisioner) Reconcile(ctx context.Context, request r
 		return reconcile.Result{RequeueAfter: longRequeueDuration}, provisioner.db.DeleteDynakube(ctx, request.Name)
 	}
 
-	if dk.ConnectionInfo().TenantUUID == "" {
-		log.Info("DynaKube instance has not been reconciled yet and some values usually cached are missing, retrying in a few seconds")
-		return reconcile.Result{RequeueAfter: shortRequeueDuration}, nil
-	}
-
 	// creates a dt client and checks tokens exist for the given dynakube
 	dtc, err := buildDtc(provisioner, ctx, dk)
 	if err != nil {
@@ -214,9 +209,14 @@ func (provisioner *OneAgentProvisioner) handleMetadata(ctx context.Context, dk *
 		oldDynakubeMetadata = *dynakubeMetadata
 	}
 
+	tenantUUID, err:= dk.TenantUUID()
+	if err != nil {
+		return nil, metadata.Dynakube{}, err
+	}
+
 	dynakubeMetadata = metadata.NewDynakube(
 		dk.Name,
-		dk.ConnectionInfo().TenantUUID,
+		tenantUUID,
 		oldDynakubeMetadata.LatestVersion,
 		oldDynakubeMetadata.ImageDigest,
 		dk.FeatureMaxFailedCsiMountAttempts())

--- a/src/controllers/csi/provisioner/controller_test.go
+++ b/src/controllers/csi/provisioner/controller_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	testAPIURL = "http://test-uid/api"
+	testAPIURL   = "http://test-uid/api"
 	tenantUUID   = "test-uid"
 	dkName       = "dynakube-test"
 	otherDkName  = "other-dk"

--- a/src/controllers/csi/provisioner/controller_test.go
+++ b/src/controllers/csi/provisioner/controller_test.go
@@ -28,10 +28,11 @@ import (
 )
 
 const (
+	testAPIURL = "http://test-uid/api"
+	tenantUUID   = "test-uid"
 	dkName       = "dynakube-test"
 	otherDkName  = "other-dk"
 	errorMsg     = "test-error"
-	tenantUUID   = "test-uid"
 	agentVersion = "12345"
 	testZip      = `UEsDBAoAAAAAAKh0p1JsLSFnGQAAABkAAAAIABwAdGVzdC50eHRVVAkAA3w0lWATB55gdXgLAAEE6AMAAAToAwAAeW91IGZvdW5kIHRoZSBlYXN0ZXIgZWdnClBLAwQKAAAAAADAOa5SAAAAAAAAAAAAAAAABQAcAHRlc3QvVVQJAAMXB55gHQeeYHV4CwABBOgDAAAE6AMAAFBLAwQKAAAAAACodKdSbC0hZxkAAAAZAAAADQAcAHRlc3QvdGVzdC50eHRVVAkAA3w0lWATB55gdXgLAAEE6AMAAAToAwAAeW91IGZvdW5kIHRoZSBlYXN0ZXIgZWdnClBLAwQKAAAAAADCOa5SAAAAAAAAAAAAAAAACgAcAHRlc3QvdGVzdC9VVAkAAxwHnmAgB55gdXgLAAEE6AMAAAToAwAAUEsDBAoAAAAAAKh0p1JsLSFnGQAAABkAAAASABwAdGVzdC90ZXN0L3Rlc3QudHh0VVQJAAN8NJVgHAeeYHV4CwABBOgDAAAE6AMAAHlvdSBmb3VuZCB0aGUgZWFzdGVyIGVnZwpQSwMECgAAAAAA2zquUgAAAAAAAAAAAAAAAAYAHABhZ2VudC9VVAkAAy4JnmAxCZ5gdXgLAAEE6AMAAAToAwAAUEsDBAoAAAAAAOI6rlIAAAAAAAAAAAAAAAALABwAYWdlbnQvY29uZi9VVAkAAzgJnmA+CZ5gdXgLAAEE6AMAAAToAwAAUEsDBAoAAAAAAKh0p1JsLSFnGQAAABkAAAATABwAYWdlbnQvY29uZi90ZXN0LnR4dFVUCQADfDSVYDgJnmB1eAsAAQToAwAABOgDAAB5b3UgZm91bmQgdGhlIGVhc3RlciBlZ2cKUEsBAh4DCgAAAAAAqHSnUmwtIWcZAAAAGQAAAAgAGAAAAAAAAQAAAKSBAAAAAHRlc3QudHh0VVQFAAN8NJVgdXgLAAEE6AMAAAToAwAAUEsBAh4DCgAAAAAAwDmuUgAAAAAAAAAAAAAAAAUAGAAAAAAAAAAQAO1BWwAAAHRlc3QvVVQFAAMXB55gdXgLAAEE6AMAAAToAwAAUEsBAh4DCgAAAAAAqHSnUmwtIWcZAAAAGQAAAA0AGAAAAAAAAQAAAKSBmgAAAHRlc3QvdGVzdC50eHRVVAUAA3w0lWB1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAADCOa5SAAAAAAAAAAAAAAAACgAYAAAAAAAAABAA7UH6AAAAdGVzdC90ZXN0L1VUBQADHAeeYHV4CwABBOgDAAAE6AMAAFBLAQIeAwoAAAAAAKh0p1JsLSFnGQAAABkAAAASABgAAAAAAAEAAACkgT4BAAB0ZXN0L3Rlc3QvdGVzdC50eHRVVAUAA3w0lWB1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAADbOq5SAAAAAAAAAAAAAAAABgAYAAAAAAAAABAA7UGjAQAAYWdlbnQvVVQFAAMuCZ5gdXgLAAEE6AMAAAToAwAAUEsBAh4DCgAAAAAA4jquUgAAAAAAAAAAAAAAAAsAGAAAAAAAAAAQAO1B4wEAAGFnZW50L2NvbmYvVVQFAAM4CZ5gdXgLAAEE6AMAAAToAwAAUEsBAh4DCgAAAAAAqHSnUmwtIWcZAAAAGQAAABMAGAAAAAAAAQAAAKSBKAIAAGFnZW50L2NvbmYvdGVzdC50eHRVVAUAA3w0lWB1eAsAAQToAwAABOgDAABQSwUGAAAAAAgACACKAgAAjgIAAAAA`
 )
@@ -159,13 +160,9 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 						Name: dkName,
 					},
 					Spec: dynatracev1beta1.DynaKubeSpec{
+						APIURL: testAPIURL,
 						OneAgent: dynatracev1beta1.OneAgentSpec{
 							ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
-						},
-					},
-					Status: dynatracev1beta1.DynaKubeStatus{
-						ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-							TenantUUID: tenantUUID,
 						},
 					},
 				},
@@ -185,13 +182,9 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 						Name: dkName,
 					},
 					Spec: dynatracev1beta1.DynaKubeSpec{
+						APIURL: testAPIURL,
 						OneAgent: dynatracev1beta1.OneAgentSpec{
 							ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
-						},
-					},
-					Status: dynatracev1beta1.DynaKubeStatus{
-						ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-							TenantUUID: tenantUUID,
 						},
 					},
 				},
@@ -211,38 +204,6 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		assert.NotNil(t, result)
 		assert.Equal(t, reconcile.Result{}, result)
 	})
-	t.Run(`error when querying dynatrace client for connection info`, func(t *testing.T) {
-		mockClient := &dtclient.MockDynatraceClient{}
-		mockClient.On("GetConnectionInfo").Return(dtclient.ConnectionInfo{}, fmt.Errorf(errorMsg))
-
-		provisioner := &OneAgentProvisioner{
-			apiReader: fake.NewClient(
-				&dynatracev1beta1.DynaKube{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: dkName,
-					},
-					Spec: dynatracev1beta1.DynaKubeSpec{
-						OneAgent: dynatracev1beta1.OneAgentSpec{
-							ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
-						},
-					},
-				},
-				&v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: dkName,
-					},
-				},
-			),
-			dtcBuildFunc: func(dynakube.DynatraceClientProperties) (dtclient.Client, error) {
-				return mockClient, nil
-			},
-		}
-		result, err := provisioner.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: dkName}})
-
-		assert.NoError(t, err)
-		assert.NotNil(t, result)
-		assert.Equal(t, reconcile.Result{RequeueAfter: 15 * time.Second}, result)
-	})
 	t.Run(`error creating directories`, func(t *testing.T) {
 		errorfs := &mkDirAllErrorFs{
 			Fs: afero.NewMemMapFs(),
@@ -258,13 +219,9 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 						Name: dkName,
 					},
 					Spec: dynatracev1beta1.DynaKubeSpec{
+						APIURL: testAPIURL,
 						OneAgent: dynatracev1beta1.OneAgentSpec{
 							ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
-						},
-					},
-					Status: dynatracev1beta1.DynaKubeStatus{
-						ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-							TenantUUID: tenantUUID,
 						},
 					},
 				},
@@ -314,13 +271,9 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 						Name: dkName,
 					},
 					Spec: dynatracev1beta1.DynaKubeSpec{
+						APIURL: testAPIURL,
 						OneAgent: dynatracev1beta1.OneAgentSpec{
 							ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
-						},
-					},
-					Status: dynatracev1beta1.DynaKubeStatus{
-						ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-							TenantUUID: tenantUUID,
 						},
 					},
 				},
@@ -368,13 +321,9 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 						Name: dkName,
 					},
 					Spec: dynatracev1beta1.DynaKubeSpec{
+						APIURL: testAPIURL,
 						OneAgent: dynatracev1beta1.OneAgentSpec{
 							ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
-						},
-					},
-					Status: dynatracev1beta1.DynaKubeStatus{
-						ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-							TenantUUID: tenantUUID,
 						},
 					},
 				},
@@ -431,15 +380,10 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 						Name: dkName,
 					},
 					Spec: dynatracev1beta1.DynaKubeSpec{
+						APIURL: testAPIURL,
 						OneAgent: dynatracev1beta1.OneAgentSpec{
 							ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
 						},
-					},
-					Status: dynatracev1beta1.DynaKubeStatus{
-						ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-							TenantUUID: tenantUUID,
-						},
-						LatestAgentVersionUnixPaas: agentVersion,
 					},
 				},
 				&v1.Secret{
@@ -599,10 +543,8 @@ func TestHandleMetadata(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dkName,
 		},
-		Status: dynatracev1beta1.DynaKubeStatus{
-			ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-				TenantUUID: testTenantUUID,
-			},
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			APIURL: testAPIURL,
 		},
 	}
 	provisioner := &OneAgentProvisioner{


### PR DESCRIPTION
# Description
In case we can't access the Dynatrace tenant the operator can't update the connection info on the dynakube which makes it impossible for the csi provisioner to create the metadata entry in the db.

To counteract that, we can determine the tenantUUID from the apiUrl.

## How can this be tested?
Disable connection to the dynatrace tenant (use a network policy)
deploy a dynakube with csi-driver usage
deploy sample apps.

the sample apps should start up with a dummy volume after exceeding the max mount attempts


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

