### PR TITLE
Fixes check for ignored namespaces

### DIFF
--- a/src/mapper/mapper.go
+++ b/src/mapper/mapper.go
@@ -78,7 +78,7 @@ func updateNamespace(namespace *corev1.Namespace, deployedDynakubes *dynatracev1
 	for i := range deployedDynakubes.Items {
 		dynakube := &deployedDynakubes.Items[i]
 		if isIgnoredNamespace(dynakube, namespace.Name) {
-			return false, nil
+			continue
 		}
 		matches, err := match(dynakube, namespace)
 


### PR DESCRIPTION
# Description

In case you had 2 Dynakubes, 1 used the `ignored-namespaces` feature-flag, and 1 didn't, then depending on the order in which the dynakubes were applied the result was different. (sometimes the `ignored-namespaces` feature-flag was considered, while sometimes it was not)

## How can this be tested?
Have 2 Dynakubes, 1 use the `ignored-namespaces` feature-flag, 1 doesn't
No matter in what order the dynakubes are applied, the `ignored-namespaces` should always be considered.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

