### PR TITLE
Makes additional kubemon permission default

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -4212,7 +4212,7 @@ spec:
           args:
             - operator
           # Replace this with the built image name
-          image: quay.io/dynatrace/dynatrace-operator:snapshot
+          image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -4371,7 +4371,7 @@ spec:
             - webhook-server
             # OLM mounts the certificates here, so we reuse it for simplicity
             - --certs-dir=/tmp/k8s-webhook-server/serving-certs/
-          image: quay.io/dynatrace/dynatrace-operator:snapshot
+          image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -4802,7 +4802,7 @@ spec:
         # - Needs access to the filesystem of pods on the node, and mount stuff to it,needs to read/write to it, needs root permissions to do so
         # - Needs access to a dedicated folder on the node to persist data, needs to read/write to it.
       - name: server
-        image: quay.io/dynatrace/dynatrace-operator:snapshot
+        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
         imagePullPolicy: Always
         args:
         - csi-server
@@ -4866,7 +4866,7 @@ spec:
         - name: tmp-dir
           mountPath: /tmp
       - name: provisioner
-        image: quay.io/dynatrace/dynatrace-operator:snapshot
+        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
         imagePullPolicy: Always
         args:
           - csi-provisioner
@@ -4923,7 +4923,7 @@ spec:
         # Used for registering the driver with kubelet
         # - Needs access to the registration socket, needs to read/write to it, needs root permissions to do so.
       - name: registrar
-        image: quay.io/dynatrace/dynatrace-operator:snapshot
+        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
         imagePullPolicy: Always
         env:
         - name: DRIVER_REG_SOCK_PATH
@@ -4970,7 +4970,7 @@ spec:
         # Used to make a gRPC request (Probe()) to the driver to check if its running
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
       - name: liveness-probe
-        image: quay.io/dynatrace/dynatrace-operator:snapshot
+        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
         imagePullPolicy: Always
         args:
         - --csi-address=/csi/csi.sock

--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -163,7 +163,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -3515,6 +3514,7 @@ rules:
       - resourcequotas
       - pods/proxy
       - nodes/proxy
+      - nodes/metrics
       - services
     verbs:
       - list
@@ -4212,7 +4212,7 @@ spec:
           args:
             - operator
           # Replace this with the built image name
-          image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+          image: quay.io/dynatrace/dynatrace-operator:snapshot
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -4371,7 +4371,7 @@ spec:
             - webhook-server
             # OLM mounts the certificates here, so we reuse it for simplicity
             - --certs-dir=/tmp/k8s-webhook-server/serving-certs/
-          image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+          image: quay.io/dynatrace/dynatrace-operator:snapshot
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -4802,7 +4802,7 @@ spec:
         # - Needs access to the filesystem of pods on the node, and mount stuff to it,needs to read/write to it, needs root permissions to do so
         # - Needs access to a dedicated folder on the node to persist data, needs to read/write to it.
       - name: server
-        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+        image: quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
         - csi-server
@@ -4866,7 +4866,7 @@ spec:
         - name: tmp-dir
           mountPath: /tmp
       - name: provisioner
-        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+        image: quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
           - csi-provisioner
@@ -4923,7 +4923,7 @@ spec:
         # Used for registering the driver with kubelet
         # - Needs access to the registration socket, needs to read/write to it, needs root permissions to do so.
       - name: registrar
-        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+        image: quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         env:
         - name: DRIVER_REG_SOCK_PATH
@@ -4970,7 +4970,7 @@ spec:
         # Used to make a gRPC request (Probe()) to the driver to check if its running
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
       - name: liveness-probe
-        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+        image: quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
         - --csi-address=/csi/csi.sock

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -177,7 +177,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -3529,6 +3528,7 @@ rules:
       - resourcequotas
       - pods/proxy
       - nodes/proxy
+      - nodes/metrics
       - services
     verbs:
       - list
@@ -4354,7 +4354,7 @@ spec:
           args:
             - operator
           # Replace this with the built image name
-          image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+          image: quay.io/dynatrace/dynatrace-operator:snapshot
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -4513,7 +4513,7 @@ spec:
             - webhook-server
             # OLM mounts the certificates here, so we reuse it for simplicity
             - --certs-dir=/tmp/k8s-webhook-server/serving-certs/
-          image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+          image: quay.io/dynatrace/dynatrace-operator:snapshot
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -5226,7 +5226,7 @@ spec:
         # - Needs access to the filesystem of pods on the node, and mount stuff to it,needs to read/write to it, needs root permissions to do so
         # - Needs access to a dedicated folder on the node to persist data, needs to read/write to it.
       - name: server
-        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+        image: quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
         - csi-server
@@ -5290,7 +5290,7 @@ spec:
         - name: tmp-dir
           mountPath: /tmp
       - name: provisioner
-        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+        image: quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
           - csi-provisioner
@@ -5347,7 +5347,7 @@ spec:
         # Used for registering the driver with kubelet
         # - Needs access to the registration socket, needs to read/write to it, needs root permissions to do so.
       - name: registrar
-        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+        image: quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         env:
         - name: DRIVER_REG_SOCK_PATH
@@ -5394,7 +5394,7 @@ spec:
         # Used to make a gRPC request (Probe()) to the driver to check if its running
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
       - name: liveness-probe
-        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
+        image: quay.io/dynatrace/dynatrace-operator:snapshot
         imagePullPolicy: Always
         args:
         - --csi-address=/csi/csi.sock

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -4354,7 +4354,7 @@ spec:
           args:
             - operator
           # Replace this with the built image name
-          image: quay.io/dynatrace/dynatrace-operator:snapshot
+          image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -4513,7 +4513,7 @@ spec:
             - webhook-server
             # OLM mounts the certificates here, so we reuse it for simplicity
             - --certs-dir=/tmp/k8s-webhook-server/serving-certs/
-          image: quay.io/dynatrace/dynatrace-operator:snapshot
+          image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
           imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
@@ -5226,7 +5226,7 @@ spec:
         # - Needs access to the filesystem of pods on the node, and mount stuff to it,needs to read/write to it, needs root permissions to do so
         # - Needs access to a dedicated folder on the node to persist data, needs to read/write to it.
       - name: server
-        image: quay.io/dynatrace/dynatrace-operator:snapshot
+        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
         imagePullPolicy: Always
         args:
         - csi-server
@@ -5290,7 +5290,7 @@ spec:
         - name: tmp-dir
           mountPath: /tmp
       - name: provisioner
-        image: quay.io/dynatrace/dynatrace-operator:snapshot
+        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
         imagePullPolicy: Always
         args:
           - csi-provisioner
@@ -5347,7 +5347,7 @@ spec:
         # Used for registering the driver with kubelet
         # - Needs access to the registration socket, needs to read/write to it, needs root permissions to do so.
       - name: registrar
-        image: quay.io/dynatrace/dynatrace-operator:snapshot
+        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
         imagePullPolicy: Always
         env:
         - name: DRIVER_REG_SOCK_PATH
@@ -5394,7 +5394,7 @@ spec:
         # Used to make a gRPC request (Probe()) to the driver to check if its running
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
       - name: liveness-probe
-        image: quay.io/dynatrace/dynatrace-operator:snapshot
+        image: quay.io/dynatrace/dynatrace-operator:snapshot-release-0-9
         imagePullPolicy: Always
         args:
         - --csi-address=/csi/csi.sock

--- a/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
   conversion:

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
@@ -31,10 +31,8 @@ rules:
       - resourcequotas
       - pods/proxy
       - nodes/proxy
-      - services
-      {{- if default false (.Values.additionalPermissions).pvcMonitoring}}
       - nodes/metrics
-      {{- end }}
+      - services
     verbs:
       - list
       - watch

--- a/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
@@ -29,6 +29,7 @@ tests:
               - resourcequotas
               - pods/proxy
               - nodes/proxy
+              - nodes/metrics
               - services
             verbs:
               - list
@@ -91,39 +92,4 @@ tests:
               - /readyz
               - /livez
             verbs:
-              - get
-
-  - it: should add additional permissions when flag is enabled
-    set:
-      platform: kubernetes
-      additionalPermissions.pvcMonitoring: true
-    asserts:
-      - isKind:
-          of: ClusterRole
-      - equal:
-          path: metadata.name
-          value: dynatrace-kubernetes-monitoring
-      - isNotEmpty:
-          path: metadata.labels
-      - isNotEmpty:
-          path: rules
-      - contains:
-          path: rules
-          content:
-            apiGroups:
-              - ""
-            resources:
-              - nodes
-              - pods
-              - namespaces
-              - replicationcontrollers
-              - events
-              - resourcequotas
-              - pods/proxy
-              - nodes/proxy
-              - services
-              - nodes/metrics
-            verbs:
-              - list
-              - watch
               - get

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -70,6 +70,3 @@ csidriver:
 
 securityContextConstraints:
   enabled: true # Only applicable for Openshift
-
-additionalPermissions:
-  pvcMonitoring: false


### PR DESCRIPTION
# Description
Removes the `additionalPermissions.pvcMonitoring ` so the additional permissions are turned on by default

## How can this be tested?
Deploy/look-at the manifests


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

