### PR TITLE
Makes additional kubemon permission default (#1164)

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -3514,6 +3514,7 @@ rules:
       - resourcequotas
       - pods/proxy
       - nodes/proxy
+      - nodes/metrics
       - services
     verbs:
       - list

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -3528,6 +3528,7 @@ rules:
       - resourcequotas
       - pods/proxy
       - nodes/proxy
+      - nodes/metrics
       - services
     verbs:
       - list

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
@@ -31,10 +31,8 @@ rules:
       - resourcequotas
       - pods/proxy
       - nodes/proxy
-      - services
-      {{- if default false (.Values.additionalPermissions).pvcMonitoring}}
       - nodes/metrics
-      {{- end }}
+      - services
     verbs:
       - list
       - watch

--- a/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
@@ -29,6 +29,7 @@ tests:
               - resourcequotas
               - pods/proxy
               - nodes/proxy
+              - nodes/metrics
               - services
             verbs:
               - list
@@ -91,39 +92,4 @@ tests:
               - /readyz
               - /livez
             verbs:
-              - get
-
-  - it: should add additional permissions when flag is enabled
-    set:
-      platform: kubernetes
-      additionalPermissions.pvcMonitoring: true
-    asserts:
-      - isKind:
-          of: ClusterRole
-      - equal:
-          path: metadata.name
-          value: dynatrace-kubernetes-monitoring
-      - isNotEmpty:
-          path: metadata.labels
-      - isNotEmpty:
-          path: rules
-      - contains:
-          path: rules
-          content:
-            apiGroups:
-              - ""
-            resources:
-              - nodes
-              - pods
-              - namespaces
-              - replicationcontrollers
-              - events
-              - resourcequotas
-              - pods/proxy
-              - nodes/proxy
-              - services
-              - nodes/metrics
-            verbs:
-              - list
-              - watch
               - get

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -70,6 +70,3 @@ csidriver:
 
 securityContextConstraints:
   enabled: true # Only applicable for Openshift
-
-additionalPermissions:
-  pvcMonitoring: false


### PR DESCRIPTION
# Description

cherry pick of https://github.com/Dynatrace/dynatrace-operator/pull/1164

## How can this be tested?
same as https://github.com/Dynatrace/dynatrace-operator/pull/1164


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

