### PR TITLE
Makes the securityContext copying safer

### DIFF
--- a/src/webhook/mutation/pod_mutator/config.go
+++ b/src/webhook/mutation/pod_mutator/config.go
@@ -10,9 +10,9 @@ const (
 	IncompatibleCRDEvent = "IncompatibleCRDPresent"
 	missingDynakubeEvent = "MissingDynakube"
 
-	defaultUser int64 = 1001
+	defaultUser  int64 = 1001
 	defaultGroup int64 = 1001
-	rootUser int64 = 0
+	rootUser     int64 = 0
 )
 
 var (

--- a/src/webhook/mutation/pod_mutator/config.go
+++ b/src/webhook/mutation/pod_mutator/config.go
@@ -10,9 +10,9 @@ const (
 	IncompatibleCRDEvent = "IncompatibleCRDPresent"
 	missingDynakubeEvent = "MissingDynakube"
 
-	defaultUser  int64 = 1001
-	defaultGroup int64 = 1001
-	rootUser     int64 = 0
+	defaultUser   int64 = 1001
+	defaultGroup  int64 = 1001
+	rootUserGroup int64 = 0
 )
 
 var (

--- a/src/webhook/mutation/pod_mutator/config.go
+++ b/src/webhook/mutation/pod_mutator/config.go
@@ -9,6 +9,10 @@ const (
 	updatePodEvent       = "UpdatePod"
 	IncompatibleCRDEvent = "IncompatibleCRDPresent"
 	missingDynakubeEvent = "MissingDynakube"
+
+	defaultUser int64 = 1001
+	defaultGroup int64 = 1001
+	rootUser int64 = 0
 )
 
 var (

--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -71,11 +71,10 @@ func copySecurityContextUserAndGroup(securityContext *corev1.SecurityContext, po
 		securityContext.RunAsGroup = containerSecurityContext.RunAsGroup
 	}
 
-	if notRoot(securityContext) {
+	if isNonRoot(securityContext) {
 		securityContext.RunAsNonRoot = address.Of(true)
 	}
 }
-
 
 func hasPodUserSet(ctx *corev1.PodSecurityContext) bool {
 	return ctx != nil && ctx.RunAsUser != nil
@@ -93,12 +92,11 @@ func hasContainerGroupSet(ctx *corev1.SecurityContext) bool {
 	return ctx != nil && ctx.RunAsGroup != nil
 }
 
-func notRoot(ctx *corev1.SecurityContext) bool {
+func isNonRoot(ctx *corev1.SecurityContext) bool {
 	return ctx != nil &&
-	 (ctx.RunAsUser != nil && *ctx.RunAsUser != rootUser) &&
-	 (ctx.RunAsGroup != nil && *ctx.RunAsGroup != rootUser)
+		(ctx.RunAsUser != nil && *ctx.RunAsUser != rootUser) &&
+		(ctx.RunAsGroup != nil && *ctx.RunAsGroup != rootUser)
 }
-
 
 func getBasePodName(pod *corev1.Pod) string {
 	basePodName := pod.GenerateName

--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -49,7 +49,7 @@ func securityContextForInitContainer(pod *corev1.Pod) *corev1.SecurityContext {
 }
 
 // combineSecurityContexts returns a SecurityContext that combines the provided SecurityContext
-// with the relevant parts of the provided Pod's SecurityContext and the Pod's 1. container's SecurityContext
+// with the user/group of the provided Pod's SecurityContext and the 1. container's SecurityContext
 func combineSecurityContexts(baseSecurityCtx corev1.SecurityContext, pod corev1.Pod) *corev1.SecurityContext {
 	containerSecurityCtx := pod.Spec.Containers[0].SecurityContext
 	podSecurityCtx := pod.Spec.SecurityContext

--- a/src/webhook/mutation/pod_mutator/init_container_test.go
+++ b/src/webhook/mutation/pod_mutator/init_container_test.go
@@ -9,48 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestCreateInstallInitContainerBaseWithDefaultUserAndGroup(t *testing.T) {
-	t.Run("should create the init container with default user and group", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		pod := getTestPod()
-		pod.Spec.Containers[0].SecurityContext = nil
-		webhookImage := "test-image"
-		clusterID := "id"
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
-		require.NotNil(t, initContainer)
-		assert.Equal(t, initContainer.Image, webhookImage)
-		assert.Equal(t, initContainer.Resources, testResourceRequirements)
-		assert.False(t, *initContainer.SecurityContext.AllowPrivilegeEscalation)
-		assert.False(t, *initContainer.SecurityContext.Privileged)
-		assert.True(t, *initContainer.SecurityContext.ReadOnlyRootFilesystem)
-		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
-		assert.Equal(t, initContainer.SecurityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
-		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, int64(1001))
-		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, int64(1001))
-	})
-}
-
-func TestCreateInstallInitContainerBaseWithSetUserAndGroup(t *testing.T) {
-	t.Run("should create the init container with set user and group", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		pod := getTestPod()
-		webhookImage := "test-image"
-		clusterID := "id"
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
-		require.NotNil(t, initContainer)
-		assert.Equal(t, initContainer.Image, webhookImage)
-		assert.Equal(t, initContainer.Resources, testResourceRequirements)
-		assert.False(t, *initContainer.SecurityContext.AllowPrivilegeEscalation)
-		assert.False(t, *initContainer.SecurityContext.Privileged)
-		assert.True(t, *initContainer.SecurityContext.ReadOnlyRootFilesystem)
-		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
-		assert.Equal(t, initContainer.SecurityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
-		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, int64(420))
-		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, int64(420))
-	})
-}
-
-func TestCreateInstallInitContainerBaseWithContainerSecurityContextSetWithoutUserAndGroup(t *testing.T) {
+func TestCreateInstallInitContainerBase(t *testing.T) {
 	t.Run("should create the init container with set container sec ctx but without user and group", func(t *testing.T) {
 		dynakube := getTestDynakube()
 		pod := getTestPod()
@@ -58,40 +17,113 @@ func TestCreateInstallInitContainerBaseWithContainerSecurityContextSetWithoutUse
 		pod.Spec.Containers[0].SecurityContext.RunAsGroup = nil
 		webhookImage := "test-image"
 		clusterID := "id"
+
 		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+
 		require.NotNil(t, initContainer)
 		assert.Equal(t, initContainer.Image, webhookImage)
 		assert.Equal(t, initContainer.Resources, testResourceRequirements)
-		assert.False(t, *initContainer.SecurityContext.AllowPrivilegeEscalation)
-		assert.False(t, *initContainer.SecurityContext.Privileged)
-		assert.True(t, *initContainer.SecurityContext.ReadOnlyRootFilesystem)
-		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
-		assert.Equal(t, initContainer.SecurityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
-		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, int64(1001))
-		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, int64(1001))
-	})
-}
 
-func TestCreateInstallInitContainerBaseWithPodSecurityContextSetWithUserAndGroup(t *testing.T) {
-	t.Run("should create the init container with set pod sec ctx with user and group", func(t *testing.T) {
+		require.NotNil(t, initContainer.SecurityContext.AllowPrivilegeEscalation)
+		assert.False(t, *initContainer.SecurityContext.AllowPrivilegeEscalation)
+
+		require.NotNil(t, initContainer.SecurityContext.Privileged)
+		assert.False(t, *initContainer.SecurityContext.Privileged)
+
+		require.NotNil(t, initContainer.SecurityContext.ReadOnlyRootFilesystem)
+		assert.True(t, *initContainer.SecurityContext.ReadOnlyRootFilesystem)
+
+		require.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
+		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
+
+		require.NotNil(t, initContainer.SecurityContext.RunAsUser)
+		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, defaultUser)
+
+		require.NotNil(t, initContainer.SecurityContext.RunAsGroup)
+		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, defaultGroup)
+	})
+	t.Run("should overwrite partially", func(t *testing.T) {
 		dynakube := getTestDynakube()
 		pod := getTestPod()
-		pod.Spec.Containers[0].SecurityContext = nil
-		pod.Spec.SecurityContext = new(corev1.PodSecurityContext)
-		pod.Spec.SecurityContext.RunAsUser = address.Of(int64(1234))
-		pod.Spec.SecurityContext.RunAsGroup = address.Of(int64(1234))
+		testUser := address.Of(int64(420))
+		pod.Spec.Containers[0].SecurityContext.RunAsUser = nil
+		pod.Spec.Containers[0].SecurityContext.RunAsGroup = testUser
 		webhookImage := "test-image"
 		clusterID := "id"
+
 		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
-		require.NotNil(t, initContainer)
-		assert.Equal(t, initContainer.Image, webhookImage)
-		assert.Equal(t, initContainer.Resources, testResourceRequirements)
-		assert.False(t, *initContainer.SecurityContext.AllowPrivilegeEscalation)
-		assert.False(t, *initContainer.SecurityContext.Privileged)
-		assert.True(t, *initContainer.SecurityContext.ReadOnlyRootFilesystem)
+
+		require.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
 		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
-		assert.Equal(t, initContainer.SecurityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
-		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, int64(1234))
-		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, int64(1234))
+
+		require.NotNil(t, *initContainer.SecurityContext.RunAsUser)
+		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, defaultUser)
+
+		require.NotNil(t, *initContainer.SecurityContext.RunAsGroup)
+		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, *testUser)
+	})
+	t.Run("container SecurityContext overrules defaults", func(t *testing.T) {
+		dynakube := getTestDynakube()
+		pod := getTestPod()
+		overruledUser := address.Of(int64(420))
+		testUser := address.Of(int64(420))
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{}
+		pod.Spec.SecurityContext.RunAsUser = overruledUser
+		pod.Spec.SecurityContext.RunAsGroup = overruledUser
+		pod.Spec.Containers[0].SecurityContext.RunAsUser = testUser
+		pod.Spec.Containers[0].SecurityContext.RunAsGroup = testUser
+		webhookImage := "test-image"
+		clusterID := "id"
+
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+
+		require.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
+		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
+
+		require.NotNil(t, *initContainer.SecurityContext.RunAsUser)
+		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, *testUser)
+
+		require.NotNil(t, *initContainer.SecurityContext.RunAsGroup)
+		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, *testUser)
+	})
+	t.Run("PodSecurityContext overrules defaults", func(t *testing.T) {
+		dynakube := getTestDynakube()
+		testUser := address.Of(int64(420))
+		pod := getTestPod()
+		pod.Spec.Containers[0].SecurityContext = nil
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{}
+		pod.Spec.SecurityContext.RunAsUser = testUser
+		pod.Spec.SecurityContext.RunAsGroup = testUser
+		webhookImage := "test-image"
+		clusterID := "id"
+
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+
+		require.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
+		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
+
+		require.NotNil(t, initContainer.SecurityContext.RunAsUser)
+		assert.Equal(t, *testUser, *initContainer.SecurityContext.RunAsUser)
+
+		require.NotNil(t, initContainer.SecurityContext.RunAsGroup)
+		assert.Equal(t, *testUser, *initContainer.SecurityContext.RunAsGroup)
+	})
+	t.Run("should not set RunAsNonRoot if root user is used", func(t *testing.T) {
+		dynakube := getTestDynakube()
+		pod := getTestPod()
+		pod.Spec.Containers[0].SecurityContext.RunAsUser = address.Of(rootUser)
+		pod.Spec.Containers[0].SecurityContext.RunAsGroup = address.Of(rootUser)
+		webhookImage := "test-image"
+		clusterID := "id"
+
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+
+		assert.Nil(t, initContainer.SecurityContext.RunAsNonRoot)
+
+		require.NotNil(t, *initContainer.SecurityContext.RunAsUser)
+		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, rootUser)
+
+		require.NotNil(t, *initContainer.SecurityContext.RunAsGroup)
+		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, rootUser)
 	})
 }

--- a/src/webhook/mutation/pod_mutator/init_container_test.go
+++ b/src/webhook/mutation/pod_mutator/init_container_test.go
@@ -111,8 +111,8 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 	t.Run("should not set RunAsNonRoot if root user is used", func(t *testing.T) {
 		dynakube := getTestDynakube()
 		pod := getTestPod()
-		pod.Spec.Containers[0].SecurityContext.RunAsUser = address.Of(rootUser)
-		pod.Spec.Containers[0].SecurityContext.RunAsGroup = address.Of(rootUser)
+		pod.Spec.Containers[0].SecurityContext.RunAsUser = address.Of(rootUserGroup)
+		pod.Spec.Containers[0].SecurityContext.RunAsGroup = address.Of(rootUserGroup)
 		webhookImage := "test-image"
 		clusterID := "id"
 
@@ -121,9 +121,9 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		assert.Nil(t, initContainer.SecurityContext.RunAsNonRoot)
 
 		require.NotNil(t, *initContainer.SecurityContext.RunAsUser)
-		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, rootUser)
+		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, rootUserGroup)
 
 		require.NotNil(t, *initContainer.SecurityContext.RunAsGroup)
-		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, rootUser)
+		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, rootUserGroup)
 	})
 }

--- a/src/webhook/mutation/pod_mutator/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/pod_mutator_test.go
@@ -91,16 +91,19 @@ func TestHandlePodMutation(t *testing.T) {
 		assert.NotNil(t, mutationRequest.InstallContainer)
 		assert.Len(t, mutationRequest.Pod.Spec.InitContainers, 2)
 
-		require.NotNil(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.Privileged)
-		assert.False(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.Privileged)
+		initSecurityContext := mutationRequest.Pod.Spec.InitContainers[1].SecurityContext
+		require.NotNil(t, initSecurityContext)
 
-		require.NotNil(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.AllowPrivilegeEscalation)
-		assert.False(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.AllowPrivilegeEscalation)
+		require.NotNil(t, initSecurityContext.Privileged)
+		assert.False(t, *initSecurityContext.Privileged)
 
-		require.NotNil(t, mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.ReadOnlyRootFilesystem)
-		assert.True(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.ReadOnlyRootFilesystem)
+		require.NotNil(t, initSecurityContext.AllowPrivilegeEscalation)
+		assert.False(t, *initSecurityContext.AllowPrivilegeEscalation)
 
-		assert.Nil(t, mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.RunAsNonRoot)
+		require.NotNil(t, initSecurityContext.ReadOnlyRootFilesystem)
+		assert.True(t, *initSecurityContext.ReadOnlyRootFilesystem)
+
+		assert.Nil(t, initSecurityContext.RunAsNonRoot)
 
 		assert.Equal(t, mutationRequest.Pod.Spec.InitContainers[1].Resources, testResourceRequirements)
 		assert.Equal(t, "true", mutationRequest.Pod.Annotations[dtwebhook.AnnotationDynatraceInjected])

--- a/src/webhook/mutation/pod_mutator/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/pod_mutator_test.go
@@ -90,11 +90,18 @@ func TestHandlePodMutation(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, mutationRequest.InstallContainer)
 		assert.Len(t, mutationRequest.Pod.Spec.InitContainers, 2)
+
+		require.NotNil(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.Privileged)
 		assert.False(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.Privileged)
+
+		require.NotNil(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.AllowPrivilegeEscalation)
 		assert.False(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.AllowPrivilegeEscalation)
+
+		require.NotNil(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.ReadOnlyRootFilesystem)
 		assert.True(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.ReadOnlyRootFilesystem)
-		assert.True(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.RunAsNonRoot)
-		assert.Equal(t, mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
+
+		assert.Nil(t, mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.RunAsNonRoot)
+
 		assert.Equal(t, mutationRequest.Pod.Spec.InitContainers[1].Resources, testResourceRequirements)
 		assert.Equal(t, "true", mutationRequest.Pod.Annotations[dtwebhook.AnnotationDynatraceInjected])
 		mutator1.(*dtwebhook.PodMutatorMock).AssertCalled(t, "Enabled", mutationRequest.BaseRequest)

--- a/src/webhook/mutation/pod_mutator/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/pod_mutator_test.go
@@ -97,7 +97,7 @@ func TestHandlePodMutation(t *testing.T) {
 		require.NotNil(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.AllowPrivilegeEscalation)
 		assert.False(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.AllowPrivilegeEscalation)
 
-		require.NotNil(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.ReadOnlyRootFilesystem)
+		require.NotNil(t, mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.ReadOnlyRootFilesystem)
 		assert.True(t, *mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.ReadOnlyRootFilesystem)
 
 		assert.Nil(t, mutationRequest.Pod.Spec.InitContainers[1].SecurityContext.RunAsNonRoot)


### PR DESCRIPTION
# Description

We didn't took enough precautions when determining the `SecurityContext` of the injected init-container.

Removing `SeccompProfile` as it causes problems on openshift with the SCCs
 `RunAsNonRoot ` is only set if the finalised `SecurityContext` is not using the root user/group 

## How can this be tested?
Deploy applicationMonitoring with sample apps that have a variety of `SecurityContext` set.
Priority of user/group to be used: (in order of least to max priority)
- default
- `PodSecurityContext`
- "1. container's" `SecurityContext`


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

