### PR TITLE
Added annotations for generated ActiveGate Pods

### DIFF
--- a/src/api/v1beta1/activegate_types.go
+++ b/src/api/v1beta1/activegate_types.go
@@ -80,6 +80,10 @@ type ActiveGateSpec struct {
 	// name. If not specified the setting will be removed from the StatefulSet.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Priority Class name",order=23,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:PriorityClass"}
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// Optional: Adds additional annotations to the ActiveGate pods
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Annotations",order=27,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // CapabilityProperties is a struct which can be embedded by ActiveGate capabilities

--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -51,6 +51,7 @@ func (statefulSetBuilder StatefulSetBuilder) getBase() appsv1.StatefulSet {
 	var sts appsv1.StatefulSet
 	sts.ObjectMeta = statefulSetBuilder.getBaseObjectMeta()
 	sts.Spec = statefulSetBuilder.getBaseSpec()
+	sts.Spec.Template.ObjectMeta.Annotations = kubeobjects.MergeMap(sts.Spec.Template.ObjectMeta.Annotations, statefulSetBuilder.dynakube.Spec.ActiveGate.Annotations)
 	statefulSetBuilder.addLabels(&sts)
 	statefulSetBuilder.addTemplateSpec(&sts)
 

--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
@@ -337,3 +337,33 @@ func TestBuildCommonEnvs(t *testing.T) {
 		assert.Equal(t, dynakube.Spec.NetworkZone, zoneEnv.Value)
 	})
 }
+func TestAnnotations(t *testing.T) {
+	t.Run("default annotations", func(t *testing.T) {
+		dynakube := getTestDynakube()
+		multiCapability := capability.NewMultiCapability(&dynakube)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		sts, _ := builder.CreateStatefulSet(nil)
+		expectedTemplateAnnotations := map[string]string{
+			consts.AnnotationActiveGateConfigurationHash: testConfigHash,
+		}
+
+		require.NotEmpty(t, sts.Spec.Template.Labels)
+		assert.Equal(t, expectedTemplateAnnotations, sts.Spec.Template.Annotations)
+	})
+	t.Run("add annotations", func(t *testing.T) {
+		dynakube := getTestDynakube()
+		dynakube.Spec.ActiveGate.Annotations = map[string]string{
+			"test": "test",
+		}
+		multiCapability := capability.NewMultiCapability(&dynakube)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		sts, _ := builder.CreateStatefulSet(nil)
+		expectedTemplateAnnotations := map[string]string{
+			consts.AnnotationActiveGateConfigurationHash: testConfigHash,
+			"test": "test",
+		}
+
+		require.NotEmpty(t, sts.Spec.Template.Labels)
+		assert.Equal(t, expectedTemplateAnnotations, sts.Spec.Template.Annotations)
+	})
+}


### PR DESCRIPTION
# Description

With this change a Annotations field will be introduced in the ActiveGate section of the Dynakube.
With it, it is possible to add configurable annotations to the ActiveGate Pods.

## How can this be tested?
Apply a Dynakube object where there are annotations in the ActiveGate sections set. Check, whether the annotations are present in the ActiveGate Pods spec.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

