### PR TITLE
Safer check for dummy volume

### DIFF
--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -97,7 +97,7 @@ func (publisher *AppVolumePublisher) UnpublishVolume(ctx context.Context, volume
 	}
 	log.Info("loaded volume info", "id", volume.VolumeID, "pod name", volume.PodName, "version", volume.Version, "dynakube", volume.TenantUUID)
 
-	if volume.MountAttempts > 0 {
+	if volume.Version == "" {
 		log.Info("requester has a dummy volume, no node-level unmount is needed")
 		return &csi.NodeUnpublishVolumeResponse{}, publisher.db.DeleteVolume(ctx, volume.VolumeID)
 	}


### PR DESCRIPTION
In a stress test we noticed that during unmount a portion of the sample apps got stuck, the amount differed after each try, but it was never 0.

The logs are pointing to that "dummy" volumes are getting unmounted even-though none were mounted.
Context: A dummy volume is mounted in case there was too many failed attempts by the csi-driver to mount.

Looking at the database after unmount showed that the volumes table was empty, so every unmount happened.
Looking at the database before we unmounted showed the possible culprit.

The `MountAttempt` column was not always 0, which should be the case for none-dummy volumes.
The `Version` field was always set, which means every mount happened correctly, no dummy was actually mounted.

TLDR: The `Version` field is a more reliable way to determine if a volume is Dummy or not.

## How can this be tested?
My scenario was: 100 Pods distributed on 2 BIG nodes.
CloudNative monitoring all 100 Pods.
Delete the deployment for the 100 pods
 (also tried it with 200 pods)

## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

