### PR TITLE
Make csi limits and resources configurable with helm

### DIFF
--- a/config/deploy/kubernetes/kubernetes-all.yaml
+++ b/config/deploy/kubernetes/kubernetes-all.yaml
@@ -4832,10 +4832,10 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 150m
+            cpu: 50m
             memory: 100Mi
           requests:
-            cpu: 150m
+            cpu: 50m
             memory: 100Mi
         securityContext:
           runAsUser: 0
@@ -4941,12 +4941,12 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 20Mi
+          limits:
+            cpu: 20m
+            memory: 30Mi
+          requests:
+            cpu: 20m
+            memory: 30Mi
         securityContext:
           runAsUser: 0
           privileged: false
@@ -4975,11 +4975,11 @@ spec:
         - livenessprobe
         resources:
           limits:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 20m
+            memory: 30Mi
           requests:
-            cpu: 10m
-            memory: 20Mi
+            cpu: 20m
+            memory: 30Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         securityContext:

--- a/config/deploy/openshift/openshift-all.yaml
+++ b/config/deploy/openshift/openshift-all.yaml
@@ -5256,10 +5256,10 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 150m
+            cpu: 50m
             memory: 100Mi
           requests:
-            cpu: 150m
+            cpu: 50m
             memory: 100Mi
         securityContext:
           runAsUser: 0
@@ -5365,12 +5365,12 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 20Mi
+          limits:
+            cpu: 20m
+            memory: 30Mi
+          requests:
+            cpu: 20m
+            memory: 30Mi
         securityContext:
           runAsUser: 0
           privileged: false
@@ -5399,11 +5399,11 @@ spec:
         - livenessprobe
         resources:
           limits:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 20m
+            memory: 30Mi
           requests:
-            cpu: 10m
-            memory: 20Mi
+            cpu: 20m
+            memory: 30Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         securityContext:

--- a/config/helm/chart/default/questions.yml
+++ b/config/helm/chart/default/questions.yml
@@ -137,30 +137,114 @@ questions:
     type: boolean
     group: "CSI Driver Deployment Configuration"
 
-  - variable: csidriver.requests.cpu
-    label: "CPU resource requests settings for Dynatrace CSI Driver's pods"
-    description: "The minimum amount of CPU resources that the Dynatrace CSI Driver's pods should request. Affects scheduling. Default: 300m"
-    default: "300m"
+  - variable: csidriver.server.requests.cpu
+    label: "CPU resource requests settings for Dynatrace CSI Driver's server container"
+    description: "The minimum amount of CPU resources that the Dynatrace CSI Driver's server container should request. Affects scheduling. Default: 50m"
+    default: "50m"
     type: string
     group: "CSI Driver Deployment Configuration"
 
-  - variable: csidriver.requests.memory
-    label: "Memory resource requests settings for Dynatrace CSI Driver's pods"
-    description: "The minimum amount of memory that the Dynatrace CSI Driver's pods should request. Affects scheduling. Default: 100Mi"
+  - variable: csidriver.server.requests.memory
+    label: "Memory resource requests settings for Dynatrace CSI Driver's server container"
+    description: "The minimum amount of memory that the Dynatrace CSI Driver's server container should request. Affects scheduling. Default: 100Mi"
     default: "100Mi"
     type: string
     group: "CSI Driver Deployment Configuration"
 
-  - variable: csidriver.limits.cpu
-    label: "CPU resource limits settings for Dynatrace CSI Driver's pods"
-    description: "The maximum amount of CPU resources that the Dynatrace CSI Driver's pods can use. Default: 300m"
+  - variable: csidriver.server.limits.cpu
+    label: "CPU resource limits settings for Dynatrace CSI Driver's server container"
+    description: "The maximum amount of CPU resources that the Dynatrace CSI Driver's server container can use. Default: 50m"
+    default: "50m"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.server.limits.memory
+    label: "Memory resource limits settings for Dynatrace CSI Driver's server container"
+    description: "The maximum amount of memory that the Dynatrace CSI Driver's server container can use. Pod restarted if exceeded. Default: 100Mi"
+    default: "100Mi"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.provisioner.requests.cpu
+    label: "CPU resource requests settings for Dynatrace CSI Driver's provisioner container"
+    description: "The minimum amount of CPU resources that the Dynatrace CSI Driver's provisioner container should request. Affects scheduling. Default: 300m"
     default: "300m"
     type: string
     group: "CSI Driver Deployment Configuration"
 
-  - variable: csidriver.limits.memory
-    label: "Memory resource limits settings for Dynatrace CSI Driver's pods"
-    description: "The maximum amount of memory that the Dynatrace CSI Driver's pods can use. Pod restarted if exceeded. Default: 100Mi"
+  - variable: csidriver.provisioner.requests.memory
+    label: "Memory resource requests settings for Dynatrace CSI Driver's provisioner container"
+    description: "The minimum amount of memory that the Dynatrace CSI Driver's provisioner container should request. Affects scheduling. Default: 100Mi"
     default: "100Mi"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.provisioner.limits.cpu
+    label: "CPU resource limits settings for Dynatrace CSI Driver's provisioner container"
+    description: "The maximum amount of CPU resources that the Dynatrace CSI Driver's provisioner container can use. Default: 300m"
+    default: "300m"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.provisioner.limits.memory
+    label: "Memory resource limits settings for Dynatrace CSI Driver's provisioner container"
+    description: "The maximum amount of memory that the Dynatrace CSI Driver's provisioner container can use. Pod restarted if exceeded. Default: 100Mi"
+    default: "100Mi"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.registrar.requests.cpu
+    label: "CPU resource requests settings for Dynatrace CSI Driver's registrar container"
+    description: "The minimum amount of CPU resources that the Dynatrace CSI Driver's registrar container should request. Affects scheduling. Default: 20m"
+    default: "20m"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.registrar.requests.memory
+    label: "Memory resource requests settings for Dynatrace CSI Driver's registrar container"
+    description: "The minimum amount of memory that the Dynatrace CSI Driver's registrar container should request. Affects scheduling. Default: 30Mi"
+    default: "30Mi"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.registrar.limits.cpu
+    label: "CPU resource limits settings for Dynatrace CSI Driver's registrar container"
+    description: "The maximum amount of CPU resources that the Dynatrace CSI Driver's registrar container can use. Default: 20m"
+    default: "20m"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.registrar.limits.memory
+    label: "Memory resource limits settings for Dynatrace CSI Driver's registrar container"
+    description: "The maximum amount of memory that the Dynatrace CSI Driver's registrar container can use. Pod restarted if exceeded. Default: 30Mi"
+    default: "30Mi"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.livenessprobe.requests.cpu
+    label: "CPU resource requests settings for Dynatrace CSI Driver's livenessprobe container"
+    description: "The minimum amount of CPU resources that the Dynatrace CSI Driver's livenessprobe container should request. Affects scheduling. Default: 20m"
+    default: "20m"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.livenessprobe.requests.memory
+    label: "Memory resource requests settings for Dynatrace CSI Driver's livenessprobe container"
+    description: "The minimum amount of memory that the Dynatrace CSI Driver's livenessprobe container should request. Affects scheduling. Default: 30Mi"
+    default: "30Mi"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.livenessprobe.limits.cpu
+    label: "CPU resource limits settings for Dynatrace CSI Driver's livenessprobe container"
+    description: "The maximum amount of CPU resources that the Dynatrace CSI Driver's livenessprobe container can use. Default: 20m"
+    default: "20m"
+    type: string
+    group: "CSI Driver Deployment Configuration"
+
+  - variable: csidriver.livenessprobe.limits.memory
+    label: "Memory resource limits settings for Dynatrace CSI Driver's livenessprobe container"
+    description: "The maximum amount of memory that the Dynatrace CSI Driver's livenessprobe container can use. Pod restarted if exceeded. Default: 30Mi"
+    default: "30Mi"
     type: string
     group: "CSI Driver Deployment Configuration"

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -87,12 +87,9 @@ spec:
           name: livez
           protocol: TCP
         resources:
-          limits:
-            cpu: 150m
-            memory: 100Mi
-          requests:
-            cpu: 150m
-            memory: 100Mi
+          {{- if .Values.csidriver.server.resources }}
+          {{- toYaml .Values.csidriver.server.resources | nindent 10 }}
+          {{- end }}
         securityContext:
           runAsUser: 0
           privileged: true # Needed for mountPropagation
@@ -144,12 +141,9 @@ spec:
             name: livez
             protocol: TCP
         resources:
-          limits:
-            cpu: {{ default "300m" ((.Values.csidriver).limits).cpu }}
-            memory: {{ default "100Mi" ((.Values.csidriver).limits).memory }}
-          requests:
-            cpu: {{ default "300m" ((.Values.csidriver).requests).cpu }}
-            memory: {{ default "100Mi" ((.Values.csidriver).requests).memory }}
+          {{- if .Values.csidriver.provisioner.resources }}
+          {{- toYaml .Values.csidriver.provisioner.resources | nindent 10 }}
+          {{- end }}
         securityContext:
           runAsUser: 0
           privileged: true # Needed for mountPropagation
@@ -197,12 +191,9 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 20Mi
+          {{- if .Values.csidriver.registrar.resources }}
+          {{- toYaml .Values.csidriver.registrar.resources | nindent 10 }}
+          {{- end }}
         securityContext:
           runAsUser: 0
           privileged: false
@@ -230,12 +221,9 @@ spec:
         command:
         - livenessprobe
         resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
-          requests:
-            cpu: 10m
-            memory: 20Mi
+          {{- if .Values.csidriver.livenessprobe.resources }}
+          {{- toYaml .Values.csidriver.livenessprobe.resources | nindent 10 }}
+          {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         securityContext:

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -128,10 +128,10 @@ tests:
                     protocol: TCP
                 resources:
                   limits:
-                    cpu: 150m
+                    cpu: 50m
                     memory: 100Mi
                   requests:
-                    cpu: 150m
+                    cpu: 50m
                     memory: 100Mi
                 securityContext:
                   allowPrivilegeEscalation: true
@@ -233,11 +233,11 @@ tests:
                 name: registrar
                 resources:
                   limits:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 20m
+                    memory: 30Mi
                   requests:
-                    cpu: 10m
-                    memory: 20Mi
+                    cpu: 20m
+                    memory: 30Mi
                 securityContext:
                   privileged: false
                   readOnlyRootFilesystem: true
@@ -264,11 +264,11 @@ tests:
                 name: liveness-probe
                 resources:
                   limits:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 20m
+                    memory: 30Mi
                   requests:
-                    cpu: 10m
-                    memory: 20Mi
+                    cpu: 20m
+                    memory: 30Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   privileged: false
@@ -356,13 +356,13 @@ tests:
           path: spec.template.metadata.labels.testKey
           value: testValue
 
-  - it: should take resource limits from values file
+  - it: should take resource limits from values file for provisioner
     set:
       csidriver.enabled: true
-      csidriver.requests.cpu: 600m
-      csidriver.requests.memory: 200Mi
-      csidriver.limits.cpu: 900m
-      csidriver.limits.memory: 300Mi
+      csidriver.provisioner.resources.requests.cpu: 600m
+      csidriver.provisioner.resources.requests.memory: 200Mi
+      csidriver.provisioner.resources.limits.cpu: 900m
+      csidriver.provisioner.resources.limits.memory: 300Mi
     asserts:
       - equal:
           path: spec.template.spec.containers[1].name
@@ -378,6 +378,75 @@ tests:
           value: 900m
       - equal:
           path: spec.template.spec.containers[1].resources.limits.memory
+          value: 300Mi
+  - it: should take resource limits from values file for server
+    set:
+      csidriver.enabled: true
+      csidriver.server.resources.requests.cpu: 600m
+      csidriver.server.resources.requests.memory: 200Mi
+      csidriver.server.resources.limits.cpu: 900m
+      csidriver.server.resources.limits.memory: 300Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: server
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 600m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 200Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 900m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 300Mi
+  - it: should take resource limits from values file for registrar
+    set:
+      csidriver.enabled: true
+      csidriver.registrar.resources.requests.cpu: 600m
+      csidriver.registrar.resources.requests.memory: 200Mi
+      csidriver.registrar.resources.limits.cpu: 900m
+      csidriver.registrar.resources.limits.memory: 300Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: registrar
+      - equal:
+          path: spec.template.spec.containers[2].resources.requests.cpu
+          value: 600m
+      - equal:
+          path: spec.template.spec.containers[2].resources.requests.memory
+          value: 200Mi
+      - equal:
+          path: spec.template.spec.containers[2].resources.limits.cpu
+          value: 900m
+      - equal:
+          path: spec.template.spec.containers[2].resources.limits.memory
+          value: 300Mi
+  - it: should take resource limits from values file for livenessprobe
+    set:
+      csidriver.enabled: true
+      csidriver.livenessprobe.resources.requests.cpu: 600m
+      csidriver.livenessprobe.resources.requests.memory: 200Mi
+      csidriver.livenessprobe.resources.limits.cpu: 900m
+      csidriver.livenessprobe.resources.limits.memory: 300Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[3].name
+          value: liveness-probe
+      - equal:
+          path: spec.template.spec.containers[3].resources.requests.cpu
+          value: 600m
+      - equal:
+          path: spec.template.spec.containers[3].resources.requests.memory
+          value: 200Mi
+      - equal:
+          path: spec.template.spec.containers[3].resources.limits.cpu
+          value: 900m
+      - equal:
+          path: spec.template.spec.containers[3].resources.limits.memory
           value: 300Mi
   - it: should take kubelet path from values file
     set:

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -61,12 +61,38 @@ csidriver:
       operator: Exists
   labels: []
   annotations: []
-  requests:
-    cpu: 300m
-    memory: 100Mi
-  limits:
-    cpu: 300m
-    memory: 100Mi
+  server:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 100Mi
+      limits:
+        cpu: 50m
+        memory: 100Mi
+  provisioner:
+    resources:
+      requests:
+        cpu: 300m
+        memory: 100Mi
+      limits:
+        cpu: 300m
+        memory: 100Mi
+  registrar:
+    resources:
+      requests:
+        cpu: 20m
+        memory: 30Mi
+      limits:
+        cpu: 20m
+        memory: 30Mi
+  livenessprobe:
+    resources:
+      requests:
+        cpu: 20m
+        memory: 30Mi
+      limits:
+        cpu: 20m
+        memory: 30Mi
 
 securityContextConstraints:
   enabled: true # Only applicable for Openshift

--- a/config/helm/schema.yaml
+++ b/config/helm/schema.yaml
@@ -284,34 +284,118 @@ properties:
     title: Enables CSI driver
     description: The CloudNativeFullStack as well as AppOnly mode need the CSI driver to function properly.
     default: false
-  csidriver.requests.cpu:
+  csidriver.provisioner.resources.requests.cpu:
     type: string
-    title: CSI driver CPU request
+    title: CSI driver CPU request - provisioner
     description: |
       The amount of CPU allocation the CSI driver requests from the cluster.
       It is recommended for the CPU requests to be the same as the CPU limits.
     default: 300m
-  csidriver.requests.memory:
+  csidriver.provisioner.resources.requests.memory:
     type: string
-    title: CSI driver Memory request
+    title: CSI driver Memory request - provisioner
     description: |
       The amount of memory allocation the CSI driver requests from the cluster.
       It is recommended for the memory requests to be the same as the memory limits.
     default: 100Mi
-  csidriver.limits.cpu:
+  csidriver.provisioner.resources.limits.cpu:
     type: string
-    title: CSI driver CPU limit
+    title: CSI driver CPU limit - provisioner
     description: |
       The amount of CPU allocation to which the cluster may limit the CSI driver.
       It is recommended for the CPU limits to be the same as the CPU requests.
     default: 300m
-  csidriver.limits.memory:
+  csidriver.provisioner.resources.limits.memory:
     type: string
-    title: CSI driver Memory limit
+    title: CSI driver Memory limit - provisioner
     description: |
       The amount of memory allocation to which the cluster may limit the CSI driver.
       It is recommended for the memory limits to be the same as the memory requests.
     default: 100Mi
+  csidriver.server.resources.requests.cpu:
+    type: string
+    title: CSI driver CPU request - server
+    description: |
+      The amount of CPU allocation the CSI driver requests from the cluster.
+      It is recommended for the CPU requests to be the same as the CPU limits.
+    default: 50m
+  csidriver.server.resources.requests.memory:
+    type: string
+    title: CSI driver Memory request - server
+    description: |
+      The amount of memory allocation the CSI driver requests from the cluster.
+      It is recommended for the memory requests to be the same as the memory limits.
+    default: 100Mi
+  csidriver.server.resources.limits.cpu:
+    type: string
+    title: CSI driver CPU limit - server
+    description: |
+      The amount of CPU allocation to which the cluster may limit the CSI driver.
+      It is recommended for the CPU limits to be the same as the CPU requests.
+    default: 50m
+  csidriver.server.resources.limits.memory:
+    type: string
+    title: CSI driver Memory limit - server
+    description: |
+      The amount of memory allocation to which the cluster may limit the CSI driver.
+      It is recommended for the memory limits to be the same as the memory requests.
+    default: 100Mi
+  csidriver.registrar.resources.requests.cpu:
+    type: string
+    title: CSI driver CPU request - registrar
+    description: |
+      The amount of CPU allocation the CSI driver requests from the cluster.
+      It is recommended for the CPU requests to be the same as the CPU limits.
+    default: 20m
+  csidriver.registrar.resources.requests.memory:
+    type: string
+    title: CSI driver Memory request - registrar
+    description: |
+      The amount of memory allocation the CSI driver requests from the cluster.
+      It is recommended for the memory requests to be the same as the memory limits.
+    default: 30Mi
+  csidriver.registrar.resources.limits.cpu:
+    type: string
+    title: CSI driver CPU limit - registrar
+    description: |
+      The amount of CPU allocation to which the cluster may limit the CSI driver.
+      It is recommended for the CPU limits to be the same as the CPU requests.
+    default: 20m
+  csidriver.registrar.resources.limits.memory:
+    type: string
+    title: CSI driver Memory limit - registrar
+    description: |
+      The amount of memory allocation to which the cluster may limit the CSI driver.
+      It is recommended for the memory limits to be the same as the memory requests.
+    default: 30Mi
+  csidriver.livenessprobe.resources.requests.cpu:
+    type: string
+    title: CSI driver CPU request - livenessprobe
+    description: |
+      The amount of CPU allocation the CSI driver requests from the cluster.
+      It is recommended for the CPU requests to be the same as the CPU limits.
+    default: 20m
+  csidriver.livenessprobe.resources.requests.memory:
+    type: string
+    title: CSI driver Memory request - livenessprobe
+    description: |
+      The amount of memory allocation the CSI driver requests from the cluster.
+      It is recommended for the memory requests to be the same as the memory limits.
+    default: 30Mi
+  csidriver.livenessprobe.resources.limits.cpu:
+    type: string
+    title: CSI driver CPU limit - livenessprobe
+    description: |
+      The amount of CPU allocation to which the cluster may limit the CSI driver.
+      It is recommended for the CPU limits to be the same as the CPU requests.
+    default: 20m
+  csidriver.livenessprobe.resources.limits.memory:
+    type: string
+    title: CSI driver Memory limit - livenessprobe
+    description: |
+      The amount of memory allocation to which the cluster may limit the CSI driver.
+      It is recommended for the memory limits to be the same as the memory requests.
+    default: 30Mi
 
   activeGate.readOnlyFs:
     type: boolean
@@ -332,7 +416,7 @@ properties:
     type: string
     title: Platform
     description: |
-      Platform to deploy on. 
+      Platform to deploy on.
       Must be set to "google-marketplace" for GKE clusters.
     default: google-marketplace
     enum:


### PR DESCRIPTION
# Description

Currently only the provisioner container's resources and limits are configurable through helm, however also the other containers should be configurable, as some customers have a need to change them, because their clusters is bigger than average. 

## How can this be tested?
Edit the values.yaml file with your preferred -> run make manifests or make install -> check if the correct limits from the values file is inside the csi-pod. 


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

