### PR TITLE
Makes SNAPSHOT_SUFFIX safer

### DIFF
--- a/hack/make/deploy/gcr.mk
+++ b/hack/make/deploy/gcr.mk
@@ -1,9 +1,9 @@
 ## Deploys the operator using a snapshot deployer image for a standard GKE cluster
 deploy/gke/deployer:
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/application/master/deploy/kube-app-manager-aio.yaml
-	./hack/gcr/deploy.sh ":snapshot-${SNAPSHOT_SUFFIX}"
+	./hack/gcr/deploy.sh ":snapshot${SNAPSHOT_SUFFIX}"
 
 ## Deploys the operator using a snapshot deployer image for an autopilot GKE cluster
 deploy/gke-autopilot/deployer:
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/application/master/deploy/kube-app-manager-aio.yaml
-	./hack/gcr/deploy.sh ":snapshot-${SNAPSHOT_SUFFIX}" "gke-autopilot"
+	./hack/gcr/deploy.sh ":snapshot${SNAPSHOT_SUFFIX}" "gke-autopilot"

--- a/hack/make/images.mk
+++ b/hack/make/images.mk
@@ -2,8 +2,8 @@ MASTER_IMAGE ?= quay.io/dynatrace/dynatrace-operator:snapshot
 
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
-SNAPSHOT_SUFFIX = $(shell git branch --show-current | sed "s/[^a-zA-Z0-9_-]/-/g")
-BRANCH_IMAGE ?= quay.io/dynatrace/dynatrace-operator:snapshot-${SNAPSHOT_SUFFIX}
+SNAPSHOT_SUFFIX = -$(shell git branch --show-current | sed "s/[^a-zA-Z0-9_-]/-/g")
+BRANCH_IMAGE ?= quay.io/dynatrace/dynatrace-operator:snapshot${SNAPSHOT_SUFFIX}
 OLM_IMAGE ?= registry.connect.redhat.com/dynatrace/dynatrace-operator:v${VERSION}
 
 # Image URL to use all building/pushing image targets
@@ -25,9 +25,9 @@ images/push:
 	./hack/build/push_image.sh
 
 ## Builds and pushes an Operator image with a snapshot tag
-images/push/tagged: export TAG=snapshot-${SNAPSHOT_SUFFIX}
+images/push/tagged: export TAG=snapshot${SNAPSHOT_SUFFIX}
 images/push/tagged: images/push
 
 ## Builds and pushes the deployer image for the Google marketplace to the development environment on GCR
 images/gcr/deployer:
-	./hack/gcr/deployer-image.sh ":snapshot-${SNAPSHOT_SUFFIX}"
+	./hack/gcr/deployer-image.sh ":snapshot${SNAPSHOT_SUFFIX}"

--- a/hack/make/manifests/manifests.mk
+++ b/hack/make/manifests/manifests.mk
@@ -5,5 +5,5 @@ manifests/prepare-directory:
 manifests: manifests/prepare-directory manifests/kubernetes manifests/openshift
 
 ## Generate manifests for the branch's image tag
-manifests/branch: export MASTER_IMAGE=quay.io/dynatrace/dynatrace-operator:snapshot-${SNAPSHOT_SUFFIX}
+manifests/branch: export MASTER_IMAGE=quay.io/dynatrace/dynatrace-operator:snapshot${SNAPSHOT_SUFFIX}
 manifests/branch: manifests


### PR DESCRIPTION
# Description

Makes the whole suffix part of the SNAPSHOT_SUFFIX

## How can this be tested?
Make commands still work


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

