### PR TITLE
Makes tenantUUID usage consistent in provisioner

### DIFF
--- a/src/controllers/csi/provisioner/agent.go
+++ b/src/controllers/csi/provisioner/agent.go
@@ -36,7 +36,10 @@ func newAgentUrlUpdater(
 	recorder record.EventRecorder,
 	dk *dynatracev1beta1.DynaKube) (*agentUpdater, error) {
 
-	tenantUUID := dk.ConnectionInfo().TenantUUID
+	tenantUUID, err := dk.TenantUUID()
+	if err != nil {
+		return nil, err
+	}
 	targetVersion := dk.CodeModulesVersion()
 
 	agentInstaller := url.NewUrlInstaller(fs, dtc, getUrlProperties(targetVersion, previousVersion, path))
@@ -64,7 +67,10 @@ func newAgentImageUpdater(
 	recorder record.EventRecorder,
 	dk *dynatracev1beta1.DynaKube) (*agentUpdater, error) {
 
-	tenantUUID := dk.ConnectionInfo().TenantUUID
+	tenantUUID, err := dk.TenantUUID()
+	if err != nil {
+		return nil, err
+	}
 	certPath := path.ImageCertPath(tenantUUID)
 
 	agentInstaller, err := setupImageInstaller(ctx, fs, apiReader, path, db, certPath, dk)

--- a/src/controllers/csi/provisioner/agent_test.go
+++ b/src/controllers/csi/provisioner/agent_test.go
@@ -46,11 +46,6 @@ func TestUpdateAgent(t *testing.T) {
 					},
 				},
 			},
-			Status: dynatracev1beta1.DynaKubeStatus{
-				ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-					TenantUUID: tenantUUID,
-				},
-			},
 		}
 		updater := createTestAgentUrlUpdater(t, &dk)
 		processModuleCache := createTestProcessModuleConfigCache("1")
@@ -93,9 +88,6 @@ func TestUpdateAgent(t *testing.T) {
 			},
 			Status: dynatracev1beta1.DynaKubeStatus{
 				LatestAgentVersionUnixPaas: testVersion,
-				ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-					TenantUUID: tenantUUID,
-				},
 			},
 		}
 		updater := createTestAgentUrlUpdater(t, &dk)
@@ -180,11 +172,6 @@ func TestUpdateAgent(t *testing.T) {
 					},
 				},
 			},
-			Status: dynatracev1beta1.DynaKubeStatus{
-				ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-					TenantUUID: tenantUUID,
-				},
-			},
 		}
 		mockedPullSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -222,6 +209,7 @@ func TestUpdateAgent(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL:           "https://" + testTenantUUID + ".dynatrace.com",
 				CustomPullSecret: pullSecretName,
 				TrustedCAs:       trustedCAName,
 				OneAgent: dynatracev1beta1.OneAgentSpec{
@@ -230,11 +218,6 @@ func TestUpdateAgent(t *testing.T) {
 							CodeModulesImage: image + ":" + tag,
 						},
 					},
-				},
-			},
-			Status: dynatracev1beta1.DynaKubeStatus{
-				ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-					TenantUUID: tenantUUID,
 				},
 			},
 		}
@@ -287,9 +270,6 @@ func testUpdateOneagent(t *testing.T, alreadyInstalled bool) {
 		},
 		Status: dynatracev1beta1.DynaKubeStatus{
 			LatestAgentVersionUnixPaas: testVersion,
-			ConnectionInfo: dynatracev1beta1.ConnectionInfoStatus{
-				TenantUUID: tenantUUID,
-			},
 		},
 	}
 	updater := createTestAgentUrlUpdater(t, &dk)


### PR DESCRIPTION
# Description
Some parts of the provisioner used the `dynakube.TenantUUID()` function to determine the `tenantUUID` while others used the `dynkube.Status.ConnectionInfo.TenantUUID` property, which causes inconsistent results in case the apiUrl is an alias.

`dynkube.Status.ConnectionInfo.TenantUUID` is more accurate as we ask the dynatrace tenant to get it, however using this would break the timeout feature of the CSI-driver. (We wouldn't be able to do anything in case we couldn't access the tenant)
So using `dynakube.TenantUUID()` is more reliable when it comes to resilience.

## How can this be tested?
Deploy dynakube with a apiURL that has an alias, and it should work as expected. (same without alias)

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

