### PR TITLE
Only require the activeGate token scope if activeGates are used

### DIFF
--- a/src/controllers/dynakube/dtclient_reconciler.go
+++ b/src/controllers/dynakube/dtclient_reconciler.go
@@ -142,7 +142,7 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance *dyn
 			dtclient.TokenScopeSettingsWrite)
 	}
 
-	if instance.FeatureActiveGateAuthToken() {
+	if instance.UseActiveGateAuthToken() {
 		tokens[dtclient.DynatraceApiToken].Scopes = append(tokens[dtclient.DynatraceApiToken].Scopes,
 			dtclient.TokenScopeActiveGateTokenCreate)
 	}


### PR DESCRIPTION
The token checking logic only checked if the feature-flag is present or not, and in 0.9 it became default, so it always required it, even though you may not even want to deploy activeGates 

## How can this be tested?
Use a token without the `activeGateTokenManagement.create` scope
Deploy a dynakube without ActiveGates => should work
Deploy a dynakube with ActiveGates => should complain about the tokens


## Checklist
- ~[x] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

