### PR TITLE
Refactor creating loggers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Important characteristics:
     - Example: in webhook/mutation `var nsLog = log.WithName("namespace")` (the name of this logger is `mutation-webhook.namespace`)
 - Use the logger defined in the `dynatrace-operator/src/logger` and always give it a name.
   - The name of the logger (given via `.WithName("...")`) should use `-` to divide longer names.
-  - Example: `var log = logger.NewDTLogger().WithName("mutation-webhook")`
+  - Example: `var log = logger.Factory.GetLogger("mutation-webhook")`
 
 #### Don'ts
 - Don't use `fmt.Sprintf` for creating log messages, the values you wish to replace via `Sprintf` should be provided to the logger as key-value pairs.

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: dynakubes.dynatrace.com
 spec:
@@ -122,6 +122,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -140,6 +141,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -164,6 +166,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -184,6 +187,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -365,6 +369,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -383,6 +388,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -407,6 +413,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -427,6 +434,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -621,6 +629,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -639,6 +648,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -663,6 +673,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -683,6 +694,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -995,6 +1007,12 @@ spec:
               activeGate:
                 description: General configuration about ActiveGate instances
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: 'Optional: Adds additional annotations to the ActiveGate
+                      pods'
+                    type: object
                   capabilities:
                     description: Activegate capabilities enabled (routing, kubernetes-monitoring,
                       metrics-ingest, dynatrace-api)
@@ -1058,6 +1076,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -1076,6 +1095,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -1100,6 +1120,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -1120,6 +1141,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -1284,6 +1306,7 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         matchLabelKeys:
                           description: MatchLabelKeys is a set of pod label keys to
                             select the pods over which spreading will be calculated.
@@ -1476,6 +1499,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -1494,6 +1518,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -1518,6 +1543,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -1538,6 +1564,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -1690,6 +1717,7 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         matchLabelKeys:
                           description: MatchLabelKeys is a set of pod label keys to
                             select the pods over which spreading will be calculated.
@@ -1857,6 +1885,7 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               networkZone:
                 description: 'Optional: Sets Network Zone for OneAgent and ActiveGate
                   pods'
@@ -1984,6 +2013,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
                                     metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -2002,6 +2032,7 @@ spec:
                                   required:
                                   - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
                                     only resources limits and requests (limits.cpu,
@@ -2027,6 +2058,7 @@ spec:
                                   required:
                                   - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
                                     namespace
@@ -2048,6 +2080,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                           required:
                           - name
@@ -2227,6 +2260,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
                                     metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -2245,6 +2279,7 @@ spec:
                                   required:
                                   - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
                                     only resources limits and requests (limits.cpu,
@@ -2270,6 +2305,7 @@ spec:
                                   required:
                                   - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
                                     namespace
@@ -2291,6 +2327,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                           required:
                           - name
@@ -2494,6 +2531,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
                                     metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -2512,6 +2550,7 @@ spec:
                                   required:
                                   - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
                                     only resources limits and requests (limits.cpu,
@@ -2537,6 +2576,7 @@ spec:
                                   required:
                                   - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
                                     namespace
@@ -2558,6 +2598,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                           required:
                           - name
@@ -2732,6 +2773,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -2750,6 +2792,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -2774,6 +2817,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -2794,6 +2838,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -2946,6 +2991,7 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         matchLabelKeys:
                           description: MatchLabelKeys is a set of pod label keys to
                             select the pods over which spreading will be calculated.

--- a/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/generated/dynatrace-operator-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -131,6 +131,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -149,6 +150,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -173,6 +175,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -193,6 +196,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -374,6 +378,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -392,6 +397,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -416,6 +422,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -436,6 +443,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -630,6 +638,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -648,6 +657,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -672,6 +682,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -692,6 +703,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -1004,6 +1016,12 @@ spec:
               activeGate:
                 description: General configuration about ActiveGate instances
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: 'Optional: Adds additional annotations to the ActiveGate
+                      pods'
+                    type: object
                   capabilities:
                     description: Activegate capabilities enabled (routing, kubernetes-monitoring,
                       metrics-ingest, dynatrace-api)
@@ -1067,6 +1085,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -1085,6 +1104,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -1109,6 +1129,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -1129,6 +1150,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -1293,6 +1315,7 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         matchLabelKeys:
                           description: MatchLabelKeys is a set of pod label keys to
                             select the pods over which spreading will be calculated.
@@ -1485,6 +1508,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -1503,6 +1527,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -1527,6 +1552,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -1547,6 +1573,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -1699,6 +1726,7 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         matchLabelKeys:
                           description: MatchLabelKeys is a set of pod label keys to
                             select the pods over which spreading will be calculated.
@@ -1866,6 +1894,7 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               networkZone:
                 description: 'Optional: Sets Network Zone for OneAgent and ActiveGate
                   pods'
@@ -1993,6 +2022,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
                                     metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -2011,6 +2041,7 @@ spec:
                                   required:
                                   - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
                                     only resources limits and requests (limits.cpu,
@@ -2036,6 +2067,7 @@ spec:
                                   required:
                                   - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
                                     namespace
@@ -2057,6 +2089,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                           required:
                           - name
@@ -2236,6 +2269,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
                                     metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -2254,6 +2288,7 @@ spec:
                                   required:
                                   - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
                                     only resources limits and requests (limits.cpu,
@@ -2279,6 +2314,7 @@ spec:
                                   required:
                                   - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
                                     namespace
@@ -2300,6 +2336,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                           required:
                           - name
@@ -2503,6 +2540,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
                                     metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -2521,6 +2559,7 @@ spec:
                                   required:
                                   - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
                                     only resources limits and requests (limits.cpu,
@@ -2546,6 +2585,7 @@ spec:
                                   required:
                                   - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
                                     namespace
@@ -2567,6 +2607,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                           required:
                           - name
@@ -2741,6 +2782,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -2759,6 +2801,7 @@ spec:
                               required:
                               - fieldPath
                               type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
@@ -2783,6 +2826,7 @@ spec:
                               required:
                               - resource
                               type: object
+                              x-kubernetes-map-type: atomic
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
                                 namespace
@@ -2803,6 +2847,7 @@ spec:
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                       required:
                       - name
@@ -2955,6 +3000,7 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         matchLabelKeys:
                           description: MatchLabelKeys is a set of pod label keys to
                             select the pods over which spreading will be calculated.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/Dynatrace/dynatrace-operator
 go 1.19
 
 require (
-	cloud.google.com/go/profiler v0.3.0
 	github.com/container-storage-interface/spec v1.6.0
 	github.com/containers/image/v5 v5.23.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
@@ -33,7 +32,6 @@ require (
 )
 
 require (
-	cloud.google.com/go v0.103.0 // indirect
 	cloud.google.com/go/compute v1.7.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.28 // indirect
@@ -77,10 +75,7 @@ require (
 	github.com/google/go-containerregistry v0.11.0 // indirect
 	github.com/google/go-intervals v0.0.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/pprof v0.0.0-20220412212628-83db2b799d1f // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
-	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -137,7 +132,6 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
-	google.golang.org/api v0.96.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220720214146-176da50484ac // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Dynatrace/dynatrace-operator
 go 1.19
 
 require (
+	cloud.google.com/go/profiler v0.3.0
 	github.com/container-storage-interface/spec v1.6.0
 	github.com/containers/image/v5 v5.23.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
@@ -32,6 +33,7 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.103.0 // indirect
 	cloud.google.com/go/compute v1.7.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.28 // indirect
@@ -75,7 +77,10 @@ require (
 	github.com/google/go-containerregistry v0.11.0 // indirect
 	github.com/google/go-intervals v0.0.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20220412212628-83db2b799d1f // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -132,6 +137,7 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/api v0.96.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220720214146-176da50484ac // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,9 +31,6 @@ cloud.google.com/go v0.97.0/go.mod h1:GF7l59pYBVlXQIBLx3a761cZ41F9bBH3JUlihCt2Ud
 cloud.google.com/go v0.99.0/go.mod h1:w0Xx2nLzqWJPuozYQX+hFfCSI8WioryfRDzkoI/Y2ZA=
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
 cloud.google.com/go v0.102.0/go.mod h1:oWcCzKlqJ5zgHQt9YsaeTY9KzIvjyy0ArmiBUgpQ+nc=
-cloud.google.com/go v0.102.1/go.mod h1:XZ77E9qnTEnrgEOvr4xzfdX5TRo7fB4T2F4O6+34hIU=
-cloud.google.com/go v0.103.0 h1:YXtxp9ymmZjlGzxV7VrYQ8aaQuAgcqxSy6YhDX4I458=
-cloud.google.com/go v0.103.0/go.mod h1:vwLx1nqLrzLX/fpwSMOXmFIqBOyHsvHbnAdbGSJ+mKk=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -49,10 +46,7 @@ cloud.google.com/go/compute v1.7.0 h1:v/k9Eueb8aAJ0vZuxKMrgm6kPhCLZU9HxFU+AFDs9U
 cloud.google.com/go/compute v1.7.0/go.mod h1:435lt8av5oL9P3fv1OEzSbSUe+ybHXGMPQHHZWZxy9U=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
-cloud.google.com/go/iam v0.3.0 h1:exkAomrVUuzx9kWFI1wm3KI0uoDeUFPB4kKGzx6x+Gc=
 cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp4bnY=
-cloud.google.com/go/profiler v0.3.0 h1:R6y/xAeifaUXxd2x6w+jIwKxoKl8Cv5HJvcvASTPWJo=
-cloud.google.com/go/profiler v0.3.0/go.mod h1:9wYk9eY4iZHsev8TQb61kh3wiOiSyz/xOYixWPzweCU=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -64,8 +58,6 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq6kuBTW58Y=
-cloud.google.com/go/storage v1.23.0 h1:wWRIaDURQA8xxHguFCshYepGlrWIrbBnAmc7wfg07qY=
-cloud.google.com/go/storage v1.23.0/go.mod h1:vOEEDNFnciUMhBeT6hsJIn3ieU5cFRmzeLgDvXzfIXc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774 h1:SCbEWT58NSt7d2mcFdvxC9uyrdcTfvBbPLThhkDmXzg=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -462,7 +454,6 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
-github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -531,8 +522,6 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20220412212628-83db2b799d1f h1:VrKTY4lquiy1oJzVZgXrauku9Jx9P+POv/gTLakG4Wk=
-github.com/google/pprof v0.0.0-20220412212628-83db2b799d1f/go.mod h1:Pt31oes+eGImORns3McJn8zHefuQl2rG8l6xQjGYB4U=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -541,18 +530,14 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
-github.com/googleapis/enterprise-certificate-proxy v0.1.0 h1:zO8WHNx/MYiAKJ3d5spxZXZE6KHmIQGQcAzwUzV7qQw=
-github.com/googleapis/enterprise-certificate-proxy v0.1.0/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/OthfcblKl4IGNaM=
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
-github.com/googleapis/gax-go/v2 v2.4.0 h1:dS9eYAjhrE2RjmzYw2XAPvcXfmcQLtFEQWn0CR82awk=
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
-github.com/googleapis/go-type-adapters v1.0.0 h1:9XdMn+d/G57qq1s8dNc5IesGCXHf6V2HZ2JwRxfA2tA=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -587,7 +572,6 @@ github.com/honeycombio/libhoney-go v1.15.2 h1:5NGcjOxZZma13dmzNcl3OtGbF1hECA0XHJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -1091,8 +1075,6 @@ golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20220617184016-355a448f1bc9/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220909164309-bea034e7d591 h1:D0B/7al0LLrVC8aWF4+oxpv/m8bc7ViFfVS8/gXGdqI=
 golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1115,7 +1097,6 @@ golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
-golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
 golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 h1:2o1E+E8TpNLklK9nHiPiK1uzIYrIHt+cQx3ynCwq9V8=
 golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1223,7 +1204,6 @@ golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1239,10 +1219,7 @@ golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1339,7 +1316,6 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
-golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f h1:uF6paiQQebLeSXkrTqHqz0MXhXXS1KgF41eUdBNvxK0=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
 gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=
@@ -1383,10 +1359,6 @@ google.golang.org/api v0.75.0/go.mod h1:pU9QmyHLnzlpar1Mjt4IbapUCy8J+6HD6GeELN69
 google.golang.org/api v0.78.0/go.mod h1:1Sg78yoMLOhlQTeF+ARBoytAcH1NNyyl390YMy6rKmw=
 google.golang.org/api v0.80.0/go.mod h1:xY3nI94gbvBrE0J6NHXhxOmW97HG7Khjkku6AFB3Hyg=
 google.golang.org/api v0.84.0/go.mod h1:NTsGnUFJMYROtiquksZHBWtHfeMC7iYthki7Eq3pa8o=
-google.golang.org/api v0.85.0/go.mod h1:AqZf8Ep9uZ2pyTvgL+x0D3Zt0eoT9b5E8fmzfu6FO2g=
-google.golang.org/api v0.86.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
-google.golang.org/api v0.96.0 h1:F60cuQPJq7K7FzsxMYHAUJSiXh2oKctHxBMbDygxhfM=
-google.golang.org/api v0.96.0/go.mod h1:w7wJQLTM+wvQpNf5JyEcBoxK0RH7EDrh/L4qfsuJ13s=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1481,9 +1453,6 @@ google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP
 google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
-google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
-google.golang.org/genproto v0.0.0-20220624142145-8cd45d7dbd1f/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
-google.golang.org/genproto v0.0.0-20220628213854-d9e0b6570c03/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220720214146-176da50484ac h1:EOa+Yrhx1C0O+4pHeXeWrCwdI0tWI6IfUU56Vebs9wQ=
 google.golang.org/genproto v0.0.0-20220720214146-176da50484ac/go.mod h1:GkXuJDJ6aQ7lnJcRF+SJVgFdQhypqgl3LB1C9vabdRE=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,9 @@ cloud.google.com/go v0.97.0/go.mod h1:GF7l59pYBVlXQIBLx3a761cZ41F9bBH3JUlihCt2Ud
 cloud.google.com/go v0.99.0/go.mod h1:w0Xx2nLzqWJPuozYQX+hFfCSI8WioryfRDzkoI/Y2ZA=
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
 cloud.google.com/go v0.102.0/go.mod h1:oWcCzKlqJ5zgHQt9YsaeTY9KzIvjyy0ArmiBUgpQ+nc=
+cloud.google.com/go v0.102.1/go.mod h1:XZ77E9qnTEnrgEOvr4xzfdX5TRo7fB4T2F4O6+34hIU=
+cloud.google.com/go v0.103.0 h1:YXtxp9ymmZjlGzxV7VrYQ8aaQuAgcqxSy6YhDX4I458=
+cloud.google.com/go v0.103.0/go.mod h1:vwLx1nqLrzLX/fpwSMOXmFIqBOyHsvHbnAdbGSJ+mKk=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -46,7 +49,10 @@ cloud.google.com/go/compute v1.7.0 h1:v/k9Eueb8aAJ0vZuxKMrgm6kPhCLZU9HxFU+AFDs9U
 cloud.google.com/go/compute v1.7.0/go.mod h1:435lt8av5oL9P3fv1OEzSbSUe+ybHXGMPQHHZWZxy9U=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
+cloud.google.com/go/iam v0.3.0 h1:exkAomrVUuzx9kWFI1wm3KI0uoDeUFPB4kKGzx6x+Gc=
 cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp4bnY=
+cloud.google.com/go/profiler v0.3.0 h1:R6y/xAeifaUXxd2x6w+jIwKxoKl8Cv5HJvcvASTPWJo=
+cloud.google.com/go/profiler v0.3.0/go.mod h1:9wYk9eY4iZHsev8TQb61kh3wiOiSyz/xOYixWPzweCU=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -58,6 +64,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq6kuBTW58Y=
+cloud.google.com/go/storage v1.23.0 h1:wWRIaDURQA8xxHguFCshYepGlrWIrbBnAmc7wfg07qY=
+cloud.google.com/go/storage v1.23.0/go.mod h1:vOEEDNFnciUMhBeT6hsJIn3ieU5cFRmzeLgDvXzfIXc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774 h1:SCbEWT58NSt7d2mcFdvxC9uyrdcTfvBbPLThhkDmXzg=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -454,6 +462,7 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -522,6 +531,8 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20220412212628-83db2b799d1f h1:VrKTY4lquiy1oJzVZgXrauku9Jx9P+POv/gTLakG4Wk=
+github.com/google/pprof v0.0.0-20220412212628-83db2b799d1f/go.mod h1:Pt31oes+eGImORns3McJn8zHefuQl2rG8l6xQjGYB4U=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -530,14 +541,18 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
+github.com/googleapis/enterprise-certificate-proxy v0.1.0 h1:zO8WHNx/MYiAKJ3d5spxZXZE6KHmIQGQcAzwUzV7qQw=
+github.com/googleapis/enterprise-certificate-proxy v0.1.0/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/OthfcblKl4IGNaM=
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
+github.com/googleapis/gax-go/v2 v2.4.0 h1:dS9eYAjhrE2RjmzYw2XAPvcXfmcQLtFEQWn0CR82awk=
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
+github.com/googleapis/go-type-adapters v1.0.0 h1:9XdMn+d/G57qq1s8dNc5IesGCXHf6V2HZ2JwRxfA2tA=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -572,6 +587,7 @@ github.com/honeycombio/libhoney-go v1.15.2 h1:5NGcjOxZZma13dmzNcl3OtGbF1hECA0XHJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -1075,6 +1091,8 @@ golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220617184016-355a448f1bc9/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220909164309-bea034e7d591 h1:D0B/7al0LLrVC8aWF4+oxpv/m8bc7ViFfVS8/gXGdqI=
 golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1097,6 +1115,7 @@ golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
+golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
 golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 h1:2o1E+E8TpNLklK9nHiPiK1uzIYrIHt+cQx3ynCwq9V8=
 golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1204,6 +1223,7 @@ golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1219,7 +1239,10 @@ golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1316,6 +1339,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f h1:uF6paiQQebLeSXkrTqHqz0MXhXXS1KgF41eUdBNvxK0=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
 gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=
@@ -1359,6 +1383,10 @@ google.golang.org/api v0.75.0/go.mod h1:pU9QmyHLnzlpar1Mjt4IbapUCy8J+6HD6GeELN69
 google.golang.org/api v0.78.0/go.mod h1:1Sg78yoMLOhlQTeF+ARBoytAcH1NNyyl390YMy6rKmw=
 google.golang.org/api v0.80.0/go.mod h1:xY3nI94gbvBrE0J6NHXhxOmW97HG7Khjkku6AFB3Hyg=
 google.golang.org/api v0.84.0/go.mod h1:NTsGnUFJMYROtiquksZHBWtHfeMC7iYthki7Eq3pa8o=
+google.golang.org/api v0.85.0/go.mod h1:AqZf8Ep9uZ2pyTvgL+x0D3Zt0eoT9b5E8fmzfu6FO2g=
+google.golang.org/api v0.86.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
+google.golang.org/api v0.96.0 h1:F60cuQPJq7K7FzsxMYHAUJSiXh2oKctHxBMbDygxhfM=
+google.golang.org/api v0.96.0/go.mod h1:w7wJQLTM+wvQpNf5JyEcBoxK0RH7EDrh/L4qfsuJ13s=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1453,6 +1481,9 @@ google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP
 google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20220624142145-8cd45d7dbd1f/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20220628213854-d9e0b6570c03/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220720214146-176da50484ac h1:EOa+Yrhx1C0O+4pHeXeWrCwdI0tWI6IfUU56Vebs9wQ=
 google.golang.org/genproto v0.0.0-20220720214146-176da50484ac/go.mod h1:GkXuJDJ6aQ7lnJcRF+SJVgFdQhypqgl3LB1C9vabdRE=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -95,7 +95,7 @@ const (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("dynakube-api")
+	log = logger.Factory.GetLogger("dynakube-api")
 )
 
 func (dk *DynaKube) getDisableFlagWithDeprecatedAnnotation(annotation string, deprecatedAnnotation string) bool {

--- a/src/builder/builder.go
+++ b/src/builder/builder.go
@@ -35,7 +35,15 @@ func (b *GenericBuilder[T]) AddModifier(modifiers ...Modifier[T]) Builder[T] {
 	return b
 }
 
-func NewBuilder[T any](data T) GenericBuilder[T] {
+func NewBuilderWithInitialData[T any](data T) GenericBuilder[T] {
+	return GenericBuilder[T]{
+		data:      &data,
+		modifiers: []Modifier[T]{},
+	}
+}
+
+func NewBuilder[T any]() GenericBuilder[T] {
+	var data T
 	return GenericBuilder[T]{
 		data:      &data,
 		modifiers: []Modifier[T]{},

--- a/src/builder/builder.go
+++ b/src/builder/builder.go
@@ -35,15 +35,7 @@ func (b *GenericBuilder[T]) AddModifier(modifiers ...Modifier[T]) Builder[T] {
 	return b
 }
 
-func NewBuilderWithInitialData[T any](data T) GenericBuilder[T] {
-	return GenericBuilder[T]{
-		data:      &data,
-		modifiers: []Modifier[T]{},
-	}
-}
-
-func NewBuilder[T any]() GenericBuilder[T] {
-	var data T
+func NewBuilder[T any](data T) GenericBuilder[T] {
 	return GenericBuilder[T]{
 		data:      &data,
 		modifiers: []Modifier[T]{},

--- a/src/cmd/certificates/config.go
+++ b/src/cmd/certificates/config.go
@@ -3,5 +3,5 @@ package certificates
 import "github.com/Dynatrace/dynatrace-operator/src/logger"
 
 var (
-	log = logger.NewDTLogger().WithName("certificate-watcher")
+	log = logger.Factory.GetLogger("certificate-watcher")
 )

--- a/src/cmd/csi/provisioner/command_test.go
+++ b/src/cmd/csi/provisioner/command_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/config"
 	cmdManager "github.com/Dynatrace/dynatrace-operator/src/cmd/manager"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
-	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -41,7 +40,4 @@ func TestCsiCommand(t *testing.T) {
 	exists, err := afero.Exists(memFs, dtcsi.DataPath)
 	assert.True(t, exists)
 	assert.NoError(t, err)
-
-	// logging new line so go test can parse output correctly
-	logger.Factory.GetLogger("")
 }

--- a/src/cmd/csi/provisioner/command_test.go
+++ b/src/cmd/csi/provisioner/command_test.go
@@ -43,5 +43,5 @@ func TestCsiCommand(t *testing.T) {
 	assert.NoError(t, err)
 
 	// logging new line so go test can parse output correctly
-	logger.NewDTLogger().Info("")
+	logger.Factory.GetLogger("")
 }

--- a/src/cmd/csi/provisioner/config.go
+++ b/src/cmd/csi/provisioner/config.go
@@ -1,9 +1,0 @@
-package provisioner
-
-import (
-	"github.com/Dynatrace/dynatrace-operator/src/logger"
-)
-
-var (
-	_ = logger.Factory.GetLogger("csi-launcher")
-)

--- a/src/cmd/csi/provisioner/config.go
+++ b/src/cmd/csi/provisioner/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	_ = logger.NewDTLogger().WithName("csi-launcher")
+	_ = logger.Factory.GetLogger("csi-launcher")
 )

--- a/src/cmd/csi/server/command_test.go
+++ b/src/cmd/csi/server/command_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/config"
 	cmdManager "github.com/Dynatrace/dynatrace-operator/src/cmd/manager"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
-	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -41,7 +40,4 @@ func TestCsiCommand(t *testing.T) {
 	exists, err := afero.Exists(memFs, dtcsi.DataPath)
 	assert.True(t, exists)
 	assert.NoError(t, err)
-
-	// logging new line so go test can parse output correctly
-	logger.Factory.GetLogger("")
 }

--- a/src/cmd/csi/server/command_test.go
+++ b/src/cmd/csi/server/command_test.go
@@ -43,5 +43,5 @@ func TestCsiCommand(t *testing.T) {
 	assert.NoError(t, err)
 
 	// logging new line so go test can parse output correctly
-	logger.NewDTLogger().Info("")
+	logger.Factory.GetLogger("")
 }

--- a/src/cmd/csi/server/config.go
+++ b/src/cmd/csi/server/config.go
@@ -1,9 +1,0 @@
-package server
-
-import (
-	"github.com/Dynatrace/dynatrace-operator/src/logger"
-)
-
-var (
-	_ = logger.Factory.GetLogger("csi-launcher")
-)

--- a/src/cmd/csi/server/config.go
+++ b/src/cmd/csi/server/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	_ = logger.NewDTLogger().WithName("csi-launcher")
+	_ = logger.Factory.GetLogger("csi-launcher")
 )

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"os"
 
+	"cloud.google.com/go/profiler"
 	cmdConfig "github.com/Dynatrace/dynatrace-operator/src/cmd/config"
 	csiProvisioner "github.com/Dynatrace/dynatrace-operator/src/cmd/csi/provisioner"
 	csiServer "github.com/Dynatrace/dynatrace-operator/src/cmd/csi/server"
@@ -36,8 +37,11 @@ var (
 )
 
 const (
-	envPodNamespace = "POD_NAMESPACE"
-	envPodName      = "POD_NAME"
+	envPodNamespace        = "POD_NAMESPACE"
+	envPodName             = "POD_NAME"
+	gcpCloudProfileEnabled = "GCP_CLOUD_PROFILER_ENABLED"
+	gcpProvileService      = "GCP_PROFILE_SERVICE"
+	gcpProfileDebugLogging = "GCP_PROFILE_DEBUG_LOGGING"
 )
 
 func newRootCommand() *cobra.Command {
@@ -85,6 +89,12 @@ func rootCommand(_ *cobra.Command, _ []string) error {
 }
 
 func main() {
+	err := enableGcpProfilingIfNeeded()
+	if err != nil {
+		log.Info(err.Error())
+		os.Exit(1)
+	}
+
 	version.LogVersion()
 	ctrl.SetLogger(log)
 	cmd := newRootCommand()
@@ -98,9 +108,21 @@ func main() {
 		createTroubleshootCommandBuilder().Build(),
 	)
 
-	err := cmd.Execute()
+	err = cmd.Execute()
 	if err != nil {
 		log.Info(err.Error())
 		os.Exit(1)
 	}
+}
+
+func enableGcpProfilingIfNeeded() error {
+	if os.Getenv(gcpCloudProfileEnabled) != "true" {
+		return nil
+	}
+
+	profilerCfg := profiler.Config{
+		Service:      os.Getenv(gcpProvileService),
+		DebugLogging: os.Getenv(gcpProfileDebugLogging) == "true",
+	}
+	return profiler.Start(profilerCfg)
 }

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("main")
+	log = logger.Factory.GetLogger("main")
 )
 
 const (

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	"cloud.google.com/go/profiler"
 	cmdConfig "github.com/Dynatrace/dynatrace-operator/src/cmd/config"
 	csiProvisioner "github.com/Dynatrace/dynatrace-operator/src/cmd/csi/provisioner"
 	csiServer "github.com/Dynatrace/dynatrace-operator/src/cmd/csi/server"
@@ -37,11 +36,8 @@ var (
 )
 
 const (
-	envPodNamespace        = "POD_NAMESPACE"
-	envPodName             = "POD_NAME"
-	gcpCloudProfileEnabled = "GCP_CLOUD_PROFILER_ENABLED"
-	gcpProvileService      = "GCP_PROFILE_SERVICE"
-	gcpProfileDebugLogging = "GCP_PROFILE_DEBUG_LOGGING"
+	envPodNamespace = "POD_NAMESPACE"
+	envPodName      = "POD_NAME"
 )
 
 func newRootCommand() *cobra.Command {
@@ -89,12 +85,6 @@ func rootCommand(_ *cobra.Command, _ []string) error {
 }
 
 func main() {
-	err := enableGcpProfilingIfNeeded()
-	if err != nil {
-		log.Info(err.Error())
-		os.Exit(1)
-	}
-
 	version.LogVersion()
 	ctrl.SetLogger(log)
 	cmd := newRootCommand()
@@ -108,21 +98,9 @@ func main() {
 		createTroubleshootCommandBuilder().Build(),
 	)
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		log.Info(err.Error())
 		os.Exit(1)
 	}
-}
-
-func enableGcpProfilingIfNeeded() error {
-	if os.Getenv(gcpCloudProfileEnabled) != "true" {
-		return nil
-	}
-
-	profilerCfg := profiler.Config{
-		Service:      os.Getenv(gcpProvileService),
-		DebugLogging: os.Getenv(gcpProfileDebugLogging) == "true",
-	}
-	return profiler.Start(profilerCfg)
 }

--- a/src/cmd/manager/test.go
+++ b/src/cmd/manager/test.go
@@ -33,7 +33,7 @@ func (mgr *TestManager) GetScheme() *runtime.Scheme {
 }
 
 func (mgr *TestManager) GetLogger() logr.Logger {
-	return logger.Factory.GetLogger("")
+	return logger.Factory.GetLogger("test-manager")
 }
 
 func (mgr *TestManager) SetFields(interface{}) error {

--- a/src/cmd/manager/test.go
+++ b/src/cmd/manager/test.go
@@ -33,7 +33,7 @@ func (mgr *TestManager) GetScheme() *runtime.Scheme {
 }
 
 func (mgr *TestManager) GetLogger() logr.Logger {
-	return logger.NewDTLogger()
+	logger.Factory.GetLogger("")
 }
 
 func (mgr *TestManager) SetFields(interface{}) error {

--- a/src/cmd/manager/test.go
+++ b/src/cmd/manager/test.go
@@ -33,7 +33,7 @@ func (mgr *TestManager) GetScheme() *runtime.Scheme {
 }
 
 func (mgr *TestManager) GetLogger() logr.Logger {
-	logger.Factory.GetLogger("")
+	return logger.Factory.GetLogger("")
 }
 
 func (mgr *TestManager) SetFields(interface{}) error {

--- a/src/controllers/certificates/config.go
+++ b/src/controllers/certificates/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("webhook-certificates")
+	log = logger.Factory.GetLogger("webhook-certificates")
 )

--- a/src/controllers/csi/driver/config.go
+++ b/src/controllers/csi/driver/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	log               = logger.NewDTLogger().WithName("csi-driver")
+	log               = logger.Factory.GetLogger("csi-driver")
 	memoryUsageMetric = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "dynatrace",
 		Subsystem: "csi_driver",

--- a/src/controllers/csi/driver/server.go
+++ b/src/controllers/csi/driver/server.go
@@ -71,7 +71,7 @@ func (svr *CSIDriverServer) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (svr *CSIDriverServer) Start(ctx context.Context) error {
-	defer metadata.LogAccessOverview(ctx, log, svr.db)
+	defer metadata.LogAccessOverview(ctx, svr.db)
 	proto, addr, err := parseEndpoint(svr.opts.Endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to parse endpoint '%s': %w", svr.opts.Endpoint, err)

--- a/src/controllers/csi/driver/volumes/app/config.go
+++ b/src/controllers/csi/driver/volumes/app/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	log                  = logger.Factory.GetLogger("csi-app")
+	log                  = logger.Factory.GetLogger("csi-appvolume")
 	agentsVersionsMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "dynatrace",
 		Subsystem: "csi_driver",

--- a/src/controllers/csi/driver/volumes/app/config.go
+++ b/src/controllers/csi/driver/volumes/app/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	log                  = logger.NewDTLogger().WithName("csi-driver.app")
+	log                  = logger.Factory.GetLogger("csi-driver.app")
 	agentsVersionsMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "dynatrace",
 		Subsystem: "csi_driver",

--- a/src/controllers/csi/driver/volumes/app/config.go
+++ b/src/controllers/csi/driver/volumes/app/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	log                  = logger.Factory.GetLogger("csi-driver.app")
+	log                  = logger.Factory.GetLogger("csi-app")
 	agentsVersionsMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "dynatrace",
 		Subsystem: "csi_driver",

--- a/src/controllers/csi/driver/volumes/host/config.go
+++ b/src/controllers/csi/driver/volumes/host/config.go
@@ -6,4 +6,4 @@ import (
 
 const Mode = "host"
 
-var log = logger.Factory.GetLogger("csi-host")
+var log = logger.Factory.GetLogger("csi-hostvolume")

--- a/src/controllers/csi/driver/volumes/host/config.go
+++ b/src/controllers/csi/driver/volumes/host/config.go
@@ -6,4 +6,4 @@ import (
 
 const Mode = "host"
 
-var log = logger.Factory.GetLogger("csi-driver.host")
+var log = logger.Factory.GetLogger("csi-host")

--- a/src/controllers/csi/driver/volumes/host/config.go
+++ b/src/controllers/csi/driver/volumes/host/config.go
@@ -6,4 +6,4 @@ import (
 
 const Mode = "host"
 
-var log = logger.NewDTLogger().WithName("csi-driver.host")
+var log = logger.Factory.GetLogger("csi-driver.host")

--- a/src/controllers/csi/gc/config.go
+++ b/src/controllers/csi/gc/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("csi-gc")
+	log = logger.Factory.GetLogger("csi-gc")
 
 	reclaimedMemoryMetric = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "dynatrace",

--- a/src/controllers/csi/metadata/config.go
+++ b/src/controllers/csi/metadata/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("csi-metadata")
+	log = logger.Factory.GetLogger("csi-metadata")
 )

--- a/src/controllers/csi/metadata/correctness.go
+++ b/src/controllers/csi/metadata/correctness.go
@@ -12,7 +12,7 @@ import (
 // CorrectMetadata checks if the entries in the storage are actually valid
 // Removes not valid entries
 func CorrectMetadata(ctx context.Context, cl client.Client, access Access) error {
-	defer LogAccessOverview(ctx, log, access)
+	defer LogAccessOverview(ctx, access)
 	if err := correctVolumes(ctx, cl, access); err != nil {
 		return err
 	}

--- a/src/controllers/csi/metadata/metadata.go
+++ b/src/controllers/csi/metadata/metadata.go
@@ -3,8 +3,6 @@ package metadata
 import (
 	"context"
 	"time"
-
-	"github.com/go-logr/logr"
 )
 
 // Dynakube stores the necessary info from the Dynakube that is needed to be used during volume mount/unmount.
@@ -126,7 +124,7 @@ func NewAccessOverview(ctx context.Context, access Access) (*AccessOverview, err
 	}, nil
 }
 
-func LogAccessOverview(ctx context.Context, log logr.Logger, access Access) {
+func LogAccessOverview(ctx context.Context, access Access) {
 	overview, err := NewAccessOverview(ctx, access)
 	if err != nil {
 		log.Error(err, "Failed to get an overview of the stored csi metadata")

--- a/src/controllers/csi/provisioner/config.go
+++ b/src/controllers/csi/provisioner/config.go
@@ -10,5 +10,5 @@ const (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("csi-provisioner")
+	log = logger.Factory.GetLogger("csi-provisioner")
 )

--- a/src/controllers/dynakube/activegate/internal/authtoken/config.go
+++ b/src/controllers/dynakube/activegate/internal/authtoken/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("dynakube-activegate-authtoken")
+	log = logger.Factory.GetLogger("dynakube-activegate-authtoken")
 )

--- a/src/controllers/dynakube/activegate/internal/capability/config.go
+++ b/src/controllers/dynakube/activegate/internal/capability/config.go
@@ -4,4 +4,4 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
 )
 
-var log = logger.NewDTLogger().WithName("dynakube-activegate-capability")
+var log = logger.Factory.GetLogger("dynakube-activegate-capability")

--- a/src/controllers/dynakube/activegate/internal/customproperties/config.go
+++ b/src/controllers/dynakube/activegate/internal/customproperties/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("activegate-customproperties")
+	log = logger.Factory.GetLogger("activegate-customproperties")
 )

--- a/src/controllers/dynakube/activegate/internal/proxy/config.go
+++ b/src/controllers/dynakube/activegate/internal/proxy/config.go
@@ -4,4 +4,4 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
 )
 
-var log = logger.NewDTLogger().WithName("dynakube-activegate-proxy")
+var log = logger.Factory.GetLogger("dynakube-activegate-proxy")

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/builder.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/builder.go
@@ -10,5 +10,5 @@ type Modifier = builder.Modifier[Data]
 type Builder = builder.GenericBuilder[Data]
 
 func NewBuilder(data Data) Builder {
-	return builder.NewBuilder(data)
+	return builder.NewBuilderWithInitialData(data)
 }

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/builder.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/builder.go
@@ -10,5 +10,5 @@ type Modifier = builder.Modifier[Data]
 type Builder = builder.GenericBuilder[Data]
 
 func NewBuilder(data Data) Builder {
-	return builder.NewBuilderWithInitialData(data)
+	return builder.NewBuilder(data)
 }

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
@@ -25,7 +25,7 @@ type initContainerModifier interface {
 }
 
 var (
-	log = logger.NewDTLogger().WithName("activegate-statefulset-builder")
+	log = logger.Factory.GetLogger("activegate-statefulset-builder")
 )
 
 func GenerateAllModifiers(dynakube dynatracev1beta1.DynaKube, capability capability.Capability) []builder.Modifier {

--- a/src/controllers/dynakube/activegate/internal/statefulset/config.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/config.go
@@ -36,5 +36,5 @@ const (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("activegate-statefulset-reconciler")
+	log = logger.Factory.GetLogger("activegate-statefulset-reconciler")
 )

--- a/src/controllers/dynakube/activegate/internal/statefulset/config.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/config.go
@@ -36,5 +36,5 @@ const (
 )
 
 var (
-	log = logger.Factory.GetLogger("activegate-statefulset-reconciler")
+	log = logger.Factory.GetLogger("activegate-statefulset")
 )

--- a/src/controllers/dynakube/activegate/internal/statefulset/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/reconciler.go
@@ -218,13 +218,13 @@ func (r *Reconciler) getAuthTokenValue() (string, error) {
 
 func (r *Reconciler) getDataFromCustomProperty(customProperties *dynatracev1beta1.DynaKubeValueSource) (string, error) {
 	if customProperties.ValueFrom != "" {
-		return kubeobjects.GetDataFromSecretName(r.apiReader, types.NamespacedName{Namespace: r.dynakube.Namespace, Name: customProperties.ValueFrom}, customproperties.DataKey)
+		return kubeobjects.GetDataFromSecretName(r.apiReader, types.NamespacedName{Namespace: r.dynakube.Namespace, Name: customProperties.ValueFrom}, customproperties.DataKey, log)
 	}
 	return customProperties.Value, nil
 }
 
 func (r *Reconciler) getDataFromAuthTokenSecret() (string, error) {
-	return kubeobjects.GetDataFromSecretName(r.apiReader, types.NamespacedName{Namespace: r.dynakube.Namespace, Name: r.dynakube.ActiveGateAuthTokenSecret()}, authtoken.ActiveGateAuthTokenName)
+	return kubeobjects.GetDataFromSecretName(r.apiReader, types.NamespacedName{Namespace: r.dynakube.Namespace, Name: r.dynakube.ActiveGateAuthTokenSecret()}, authtoken.ActiveGateAuthTokenName, log)
 }
 
 func needsCustomPropertyHash(customProperties *dynatracev1beta1.DynaKubeValueSource) bool {

--- a/src/controllers/dynakube/apimonitoring/config.go
+++ b/src/controllers/dynakube/apimonitoring/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("automatic-api-monitoring")
+	log = logger.Factory.GetLogger("automatic-api-monitoring")
 )

--- a/src/controllers/dynakube/config.go
+++ b/src/controllers/dynakube/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("dynakube-controller")
+	log = logger.Factory.GetLogger("dynakube-controller")
 )

--- a/src/controllers/dynakube/config.go
+++ b/src/controllers/dynakube/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.Factory.GetLogger("dynakube-controller")
+	log = logger.Factory.GetLogger("dynakube")
 )

--- a/src/controllers/dynakube/connectioninfo/config.go
+++ b/src/controllers/dynakube/connectioninfo/config.go
@@ -16,5 +16,5 @@ const (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("dynakube.connectioninfo")
+	log = logger.Factory.GetLogger("dynakube.connectioninfo")
 )

--- a/src/controllers/dynakube/connectioninfo/config.go
+++ b/src/controllers/dynakube/connectioninfo/config.go
@@ -16,5 +16,5 @@ const (
 )
 
 var (
-	log = logger.Factory.GetLogger("dynakube.connectioninfo")
+	log = logger.Factory.GetLogger("dynakube-connectioninfo")
 )

--- a/src/controllers/dynakube/dtpullsecret/config.go
+++ b/src/controllers/dynakube/dtpullsecret/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("dynakube-pullsecret")
+	log = logger.Factory.GetLogger("dynakube-pullsecret")
 )

--- a/src/controllers/dynakube/istio/config.go
+++ b/src/controllers/dynakube/istio/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("dynakube-istio")
+	log = logger.Factory.GetLogger("dynakube-istio")
 )

--- a/src/controllers/dynakube/istio/reconciler.go
+++ b/src/controllers/dynakube/istio/reconciler.go
@@ -161,11 +161,11 @@ func (reconciler *IstioReconciler) reconcileIstioCreateConfigurations(instance *
 			role:       role,
 		}
 
-		createdServiceEntry, err := handleIstioConfigurationForServiceEntry(istioConfig, log)
+		createdServiceEntry, err := handleIstioConfigurationForServiceEntry(istioConfig)
 		if err != nil {
 			return false, err
 		}
-		createdVirtualService, err := handleIstioConfigurationForVirtualService(istioConfig, log)
+		createdVirtualService, err := handleIstioConfigurationForVirtualService(istioConfig)
 		if err != nil {
 			return false, err
 		}

--- a/src/controllers/dynakube/istio/serviceentry.go
+++ b/src/controllers/dynakube/istio/serviceentry.go
@@ -9,7 +9,6 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
-	"github.com/go-logr/logr"
 	istio "istio.io/api/networking/v1alpha3"
 	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istioclientset "istio.io/client-go/pkg/clientset/versioned"
@@ -70,8 +69,7 @@ func buildServiceEntryIP(name, namespace, host string, port uint32) *istiov1alph
 	}
 }
 
-func handleIstioConfigurationForServiceEntry(istioConfig *istioConfiguration, log logr.Logger) (bool, error) {
-
+func handleIstioConfigurationForServiceEntry(istioConfig *istioConfiguration) (bool, error) {
 	probe, err := kubeobjects.KubernetesObjectProbe(ServiceEntryGVK, istioConfig.instance.GetNamespace(), istioConfig.name, istioConfig.reconciler.config)
 	if probe == kubeobjects.ProbeObjectFound {
 		return false, nil

--- a/src/controllers/dynakube/istio/virtualservice.go
+++ b/src/controllers/dynakube/istio/virtualservice.go
@@ -6,7 +6,6 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
-	"github.com/go-logr/logr"
 	istio "istio.io/api/networking/v1alpha3"
 	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istioclientset "istio.io/client-go/pkg/clientset/versioned"
@@ -77,8 +76,7 @@ func buildVirtualServiceTLSRoute(host string, port uint32) []*istio.TLSRoute {
 	}}
 }
 
-func handleIstioConfigurationForVirtualService(istioConfig *istioConfiguration, log logr.Logger) (bool, error) {
-
+func handleIstioConfigurationForVirtualService(istioConfig *istioConfiguration) (bool, error) {
 	probe, err := kubeobjects.KubernetesObjectProbe(VirtualServiceGVK, istioConfig.instance.GetNamespace(), istioConfig.name, istioConfig.reconciler.config)
 	if probe == kubeobjects.ProbeObjectFound {
 		return false, nil

--- a/src/controllers/dynakube/oneagent/config.go
+++ b/src/controllers/dynakube/oneagent/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("dynakube-oneagent")
+	log = logger.Factory.GetLogger("dynakube-oneagent")
 )

--- a/src/controllers/dynakube/status/config.go
+++ b/src/controllers/dynakube/status/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("dynakube-status")
+	log = logger.Factory.GetLogger("dynakube-status")
 )

--- a/src/controllers/dynakube/version/config.go
+++ b/src/controllers/dynakube/version/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("dynakube-updates")
+	log = logger.Factory.GetLogger("dynakube-updates")
 )

--- a/src/controllers/dynakube/version/config.go
+++ b/src/controllers/dynakube/version/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.Factory.GetLogger("dynakube-updates")
+	log = logger.Factory.GetLogger("dynakube-version")
 )

--- a/src/controllers/nodes/config.go
+++ b/src/controllers/nodes/config.go
@@ -13,6 +13,6 @@ const (
 )
 
 var (
-	log                 = logger.NewDTLogger().WithName("nodes-controller")
+	log                 = logger.Factory.GetLogger("nodes-controller")
 	unschedulableTaints = []string{"ToBeDeletedByClusterAutoscaler"}
 )

--- a/src/controllers/nodes/config.go
+++ b/src/controllers/nodes/config.go
@@ -13,6 +13,6 @@ const (
 )
 
 var (
-	log                 = logger.Factory.GetLogger("nodes-controller")
+	log                 = logger.Factory.GetLogger("nodes")
 	unschedulableTaints = []string{"ToBeDeletedByClusterAutoscaler"}
 )

--- a/src/dockerconfig/config.go
+++ b/src/dockerconfig/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("docker-config")
+	log = logger.Factory.GetLogger("docker-config")
 )

--- a/src/dtclient/config.go
+++ b/src/dtclient/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("dtclient")
+	log = logger.Factory.GetLogger("dtclient")
 )

--- a/src/ingestendpoint/config.go
+++ b/src/ingestendpoint/config.go
@@ -3,5 +3,5 @@ package ingestendpoint
 import "github.com/Dynatrace/dynatrace-operator/src/logger"
 
 var (
-	log = logger.NewDTLogger().WithName("ingestendpoint")
+	log = logger.Factory.GetLogger("ingestendpoint")
 )

--- a/src/initgeneration/config.go
+++ b/src/initgeneration/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("initgeneration")
+	log = logger.Factory.GetLogger("initgeneration")
 )

--- a/src/installer/image/config.go
+++ b/src/installer/image/config.go
@@ -20,5 +20,5 @@ const (
 
 var (
 	CacheDir = filepath.Join(dtcsi.DataPath, "cache")
-	log      = logger.NewDTLogger().WithName("oneagent-image-installer")
+	log      = logger.Factory.GetLogger("oneagent-image-installer")
 )

--- a/src/installer/image/config.go
+++ b/src/installer/image/config.go
@@ -20,5 +20,5 @@ const (
 
 var (
 	CacheDir = filepath.Join(dtcsi.DataPath, "cache")
-	log      = logger.Factory.GetLogger("oneagent-image-installer")
+	log      = logger.Factory.GetLogger("oneagent-image")
 )

--- a/src/installer/symlink/config.go
+++ b/src/installer/symlink/config.go
@@ -11,5 +11,5 @@ const (
 )
 
 var (
-	log = logger.Factory.GetLogger("oneagent-installer-symlink")
+	log = logger.Factory.GetLogger("oneagent-symlink")
 )

--- a/src/installer/symlink/config.go
+++ b/src/installer/symlink/config.go
@@ -11,5 +11,5 @@ const (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("oneagent-installer-symlink")
+	log = logger.Factory.GetLogger("oneagent-installer-symlink")
 )

--- a/src/installer/url/config.go
+++ b/src/installer/url/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("oneagent-url-installer")
+	log = logger.Factory.GetLogger("oneagent-url-installer")
 )
 
 const (

--- a/src/installer/url/config.go
+++ b/src/installer/url/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	log = logger.Factory.GetLogger("oneagent-url-installer")
+	log = logger.Factory.GetLogger("oneagent-url")
 )
 
 const (

--- a/src/installer/zip/config.go
+++ b/src/installer/zip/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("oneagent-installer-zip")
+	log = logger.Factory.GetLogger("oneagent-installer-zip")
 )
 
 // Checks if a file is under /agent/conf

--- a/src/installer/zip/config.go
+++ b/src/installer/zip/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	log = logger.Factory.GetLogger("oneagent-installer-zip")
+	log = logger.Factory.GetLogger("oneagent-zip")
 )
 
 // Checks if a file is under /agent/conf

--- a/src/kubeobjects/secret.go
+++ b/src/kubeobjects/secret.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
-	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -128,8 +127,8 @@ func ExtractToken(secret *corev1.Secret, key string) (string, error) {
 	return strings.TrimSpace(string(value)), nil
 }
 
-func GetDataFromSecretName(apiReader client.Reader, namespacedName types.NamespacedName, dataKey string) (string, error) {
-	query := NewSecretQuery(context.TODO(), nil, apiReader, logger.Factory.GetLogger(""))
+func GetDataFromSecretName(apiReader client.Reader, namespacedName types.NamespacedName, dataKey string, log logr.Logger) (string, error) {
+	query := NewSecretQuery(context.TODO(), nil, apiReader, log)
 	secret, err := query.Get(namespacedName)
 	if err != nil {
 		return "", errors.WithStack(err)

--- a/src/kubeobjects/secret.go
+++ b/src/kubeobjects/secret.go
@@ -129,7 +129,7 @@ func ExtractToken(secret *corev1.Secret, key string) (string, error) {
 }
 
 func GetDataFromSecretName(apiReader client.Reader, namespacedName types.NamespacedName, dataKey string) (string, error) {
-	query := NewSecretQuery(context.TODO(), nil, apiReader, logger.NewDTLogger())
+	query := NewSecretQuery(context.TODO(), nil, apiReader, logger.Factory.GetLogger(""))
 	secret, err := query.Get(namespacedName)
 	if err != nil {
 		return "", errors.WithStack(err)

--- a/src/kubeobjects/secret_test.go
+++ b/src/kubeobjects/secret_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var log = logger.Factory.GetLogger("")
+var log = logger.Factory.GetLogger("test-secret")
 
 func TestSecretQuery(t *testing.T) {
 	t.Run(`Get secret`, testGetSecret)

--- a/src/kubeobjects/secret_test.go
+++ b/src/kubeobjects/secret_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var log = logger.NewDTLogger()
+var log = logger.Factory.GetLogger("")
 
 func TestSecretQuery(t *testing.T) {
 	t.Run(`Get secret`, testGetSecret)

--- a/src/kubeobjects/secret_test.go
+++ b/src/kubeobjects/secret_test.go
@@ -334,13 +334,13 @@ func TestGetDataFromSecretName(t *testing.T) {
 			},
 		})
 
-		value, err := GetDataFromSecretName(client, types.NamespacedName{Name: testSecretName, Namespace: testNamespace}, testKey1)
+		value, err := GetDataFromSecretName(client, types.NamespacedName{Name: testSecretName, Namespace: testNamespace}, testKey1, log)
 
 		assert.NoError(t, err)
 		assert.Equal(t, value, testValue1)
 	})
 	t.Run(`ExtractToken handles missing key`, func(t *testing.T) {
-		value, err := GetDataFromSecretName(fake.NewClient(), types.NamespacedName{Name: testSecretName, Namespace: testNamespace}, testKey1)
+		value, err := GetDataFromSecretName(fake.NewClient(), types.NamespacedName{Name: testSecretName, Namespace: testNamespace}, testKey1, log)
 		assert.Error(t, err)
 		assert.Empty(t, value)
 	})

--- a/src/logger/factory.go
+++ b/src/logger/factory.go
@@ -1,0 +1,17 @@
+package logger
+
+import "github.com/go-logr/logr"
+
+var Factory factory
+
+func init() {
+	Factory = factory{logger: NewDTLogger()}
+}
+
+type factory struct {
+	logger logr.Logger
+}
+
+func (f factory) GetLogger(name string) logr.Logger {
+	return f.logger.WithName(name)
+}

--- a/src/logger/factory.go
+++ b/src/logger/factory.go
@@ -5,7 +5,7 @@ import "github.com/go-logr/logr"
 var Factory factory
 
 func init() {
-	Factory = factory{logger: NewDTLogger()}
+	Factory = factory{logger: newLogger()}
 }
 
 type factory struct {

--- a/src/logger/factory.go
+++ b/src/logger/factory.go
@@ -2,11 +2,7 @@ package logger
 
 import "github.com/go-logr/logr"
 
-var Factory factory
-
-func init() {
-	Factory = factory{logger: newLogger()}
-}
+var Factory factory = factory{logger: newLogger()}
 
 type factory struct {
 	logger logr.Logger

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -9,46 +9,46 @@ import (
 	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-type DTLogger struct {
+type logSink struct {
 	infoLogger  logr.Logger
 	errorLogger logr.Logger
 }
 
-func NewDTLogger() logr.Logger {
+func newLogger() logr.Logger {
 	config := zap.NewProductionEncoderConfig()
 	config.EncodeTime = zapcore.ISO8601TimeEncoder
 
 	return logr.New(
-		DTLogger{
+		logSink{
 			infoLogger:  ctrlzap.New(ctrlzap.WriteTo(os.Stdout), ctrlzap.Encoder(zapcore.NewJSONEncoder(config))),
 			errorLogger: ctrlzap.New(ctrlzap.WriteTo(&errorPrettify{}), ctrlzap.Encoder(zapcore.NewJSONEncoder(config))),
 		},
 	)
 }
 
-func (dtl DTLogger) Init(info logr.RuntimeInfo) {}
+func (dtl logSink) Init(logr.RuntimeInfo) {}
 
-func (dtl DTLogger) Info(level int, msg string, keysAndValues ...interface{}) {
+func (dtl logSink) Info(_ int, msg string, keysAndValues ...interface{}) {
 	dtl.infoLogger.Info(msg, keysAndValues...)
 }
 
-func (dtl DTLogger) Enabled(level int) bool {
+func (dtl logSink) Enabled(int) bool {
 	return dtl.infoLogger.Enabled()
 }
 
-func (dtl DTLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+func (dtl logSink) Error(err error, msg string, keysAndValues ...interface{}) {
 	dtl.errorLogger.Error(err, msg, keysAndValues...)
 }
 
-func (dtl DTLogger) WithValues(keysAndValues ...interface{}) logr.LogSink {
-	return DTLogger{
+func (dtl logSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	return logSink{
 		infoLogger:  dtl.infoLogger.WithValues(keysAndValues...),
 		errorLogger: dtl.errorLogger.WithValues(keysAndValues...),
 	}
 }
 
-func (dtl DTLogger) WithName(name string) logr.LogSink {
-	return DTLogger{
+func (dtl logSink) WithName(name string) logr.LogSink {
+	return logSink{
 		infoLogger:  dtl.infoLogger.WithName(name),
 		errorLogger: dtl.errorLogger.WithName(name),
 	}

--- a/src/mapper/config.go
+++ b/src/mapper/config.go
@@ -11,5 +11,5 @@ const (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("namespace-mapper")
+	log = logger.Factory.GetLogger("namespace-mapper")
 )

--- a/src/processmoduleconfig/config.go
+++ b/src/processmoduleconfig/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("processmoduleconfig")
+	log = logger.Factory.GetLogger("processmoduleconfig")
 )

--- a/src/standalone/config.go
+++ b/src/standalone/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("standalone-init")
+	log = logger.Factory.GetLogger("standalone-init")
 )

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -21,7 +21,7 @@ var (
 	// BuildDate is the date when the binary was build. Assigned externally.
 	BuildDate = ""
 
-	log = logger.NewDTLogger().WithName("dynatrace-operator-version")
+	log = logger.Factory.GetLogger("dynatrace-operator-version")
 )
 
 // LogVersion logs metadata about the Operator.

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -21,7 +21,7 @@ var (
 	// BuildDate is the date when the binary was build. Assigned externally.
 	BuildDate = ""
 
-	log = logger.Factory.GetLogger("dynatrace-operator-version")
+	log = logger.Factory.GetLogger("version")
 )
 
 // LogVersion logs metadata about the Operator.

--- a/src/webhook/mutation/namespace_mutator/config.go
+++ b/src/webhook/mutation/namespace_mutator/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("mutation-webhook.namespace")
+	log = logger.Factory.GetLogger("mutation-webhook.namespace")
 )

--- a/src/webhook/mutation/namespace_mutator/config.go
+++ b/src/webhook/mutation/namespace_mutator/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.Factory.GetLogger("mutation-webhook.namespace")
+	log = logger.Factory.GetLogger("mutation-webhook-namespace")
 )

--- a/src/webhook/mutation/namespace_mutator/config.go
+++ b/src/webhook/mutation/namespace_mutator/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logger.Factory.GetLogger("mutation-webhook-namespace")
+	log = logger.Factory.GetLogger("mutation-namespace")
 )

--- a/src/webhook/mutation/pod_mutator/config.go
+++ b/src/webhook/mutation/pod_mutator/config.go
@@ -16,5 +16,5 @@ const (
 )
 
 var (
-	log = logger.Factory.GetLogger("mutation-webhook.pod")
+	log = logger.Factory.GetLogger("mutation-webhook-pod")
 )

--- a/src/webhook/mutation/pod_mutator/config.go
+++ b/src/webhook/mutation/pod_mutator/config.go
@@ -16,5 +16,5 @@ const (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("mutation-webhook.pod")
+	log = logger.Factory.GetLogger("mutation-webhook.pod")
 )

--- a/src/webhook/mutation/pod_mutator/config.go
+++ b/src/webhook/mutation/pod_mutator/config.go
@@ -16,5 +16,5 @@ const (
 )
 
 var (
-	log = logger.Factory.GetLogger("mutation-webhook-pod")
+	log = logger.Factory.GetLogger("mutation")
 )

--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/config.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/config.go
@@ -11,5 +11,5 @@ const (
 )
 
 var (
-	log = logger.Factory.GetLogger("mutation-webhook-pod-dataingest")
+	log = logger.Factory.GetLogger("mutation-dataingest")
 )

--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/config.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/config.go
@@ -11,5 +11,5 @@ const (
 )
 
 var (
-	log = logger.Factory.GetLogger("mutation-webhook.pod.dataingest")
+	log = logger.Factory.GetLogger("mutation-webhook-pod-dataingest")
 )

--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/config.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/config.go
@@ -11,5 +11,5 @@ const (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("mutation-webhook.pod.dataingest")
+	log = logger.Factory.GetLogger("mutation-webhook.pod.dataingest")
 )

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/config.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	log = logger.Factory.GetLogger("mutation-webhook-pod-oneagent")
+	log = logger.Factory.GetLogger("mutation-oneagent")
 )
 
 const (

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/config.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	log = logger.NewDTLogger().WithName("mutation-webhook.pod.oneagent")
+	log = logger.Factory.GetLogger("mutation-webhook.pod.oneagent")
 )
 
 const (

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/config.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	log = logger.Factory.GetLogger("mutation-webhook.pod.oneagent")
+	log = logger.Factory.GetLogger("mutation-webhook-pod-oneagent")
 )
 
 const (

--- a/src/webhook/validation/config.go
+++ b/src/webhook/validation/config.go
@@ -8,7 +8,7 @@ import (
 
 const oneagentEnableVolumeStorageEnvVarName = "ONEAGENT_ENABLE_VOLUME_STORAGE"
 
-var log = logger.Factory.GetLogger("validation-webhook")
+var log = logger.Factory.GetLogger("validation")
 
 type validator func(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string
 

--- a/src/webhook/validation/config.go
+++ b/src/webhook/validation/config.go
@@ -8,7 +8,7 @@ import (
 
 const oneagentEnableVolumeStorageEnvVarName = "ONEAGENT_ENABLE_VOLUME_STORAGE"
 
-var log = logger.NewDTLogger().WithName("validation-webhook")
+var log = logger.Factory.GetLogger("validation-webhook")
 
 type validator func(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string
 


### PR DESCRIPTION
# Description
Currently separate logger instance is created for when `NewDTLogger` is called. Number of loggers allocate memory which causes increased memory consumption.

This PR changes how loggers are created:
- create singleton logger (with memory allocated only for this instance) 
- use `logger.Factory.GetLogger("name")` to get sublogger of singleton logger

_Removed in d9c09b9f4f33a22540ac97cabd97c52ce4ac27d2_
~~To measure it, GCP Cloud Provider is added. It can be enabled by adding env vars:~~
```
env:
- name: GCP_CLOUD_PROFILER_ENABLED    # default "false"
  value: "true"
- name: GCP_PROFILE_SERVICE
  value: mgk-dto
- name: GCP_PROFILE_DEBUG             # default "false"
  value: "true"
```
heap profile:
![Screenshot from 2022-10-10 11-27-10](https://user-images.githubusercontent.com/35979436/194837130-6f92002b-0d1f-4ef9-b9a8-ea36ad68492d.png)
note `troubleshoot` logger is separate logger instance on purpose.

## How can this be tested?
Check if logs are still there.
Check heap profile.

## Checklist
~- [ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

