### PR TITLE
Add rhcc registry to matrix

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         platform: [amd64, arm64]
-        registry: [gcr, dockerhub]
+        registry: [gcr, dockerhub, rhcc]
         include:
         - registry: rhcc
           url: scan.connect.redhat.com
@@ -77,7 +77,7 @@ jobs:
           password: ${{ secrets[matrix.password] }}
       - name: Push ${{matrix.platform}} to ${{matrix.registry}}
         uses: ./.github/actions/upload-image
-        if: matrix.registry != 'rhcc' || ( matrix.registry == 'rhcc' && matrix.platform == 'amd64' )
+        if: matrix.platform == 'amd64' || matrix.registry != 'rhcc'
         with:
           platform: ${{ matrix.platform }}
           labels: ${{ needs.prepare.outputs.labels }}


### PR DESCRIPTION
# Description
`rhcc` is missing from `registry` array, leading to incorrect values being used for push to RHCC registry.

see #1196 

## How can this be tested?
push a new tag 😄 


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

