### PR TITLE
Update `ruxitagentproc.conf` file only for cloud native and application monitoring

### DIFF
--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -89,7 +89,7 @@ func (provisioner *OneAgentProvisioner) Reconcile(ctx context.Context, request r
 		}
 		return reconcile.Result{}, err
 	}
-	if !dk.NeedsCSIDriver() {
+	if !dk.NeedsCSIDriver() || !dk.NeedAppInjection() {
 		log.Info("CSI driver not needed")
 		return reconcile.Result{RequeueAfter: longRequeueDuration}, provisioner.db.DeleteDynakube(ctx, request.Name)
 	}

--- a/src/controllers/csi/provisioner/controller_test.go
+++ b/src/controllers/csi/provisioner/controller_test.go
@@ -179,7 +179,38 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		dynakubeMetadatas, err := db.GetAllDynakubes(ctx)
 		require.NoError(t, err)
 		require.Len(t, dynakubeMetadatas, 0)
+	})
+	t.Run(`host monitoring used`, func(t *testing.T) {
+		gc := &CSIGarbageCollectorMock{}
+		gc.On("Reconcile").Return(reconcile.Result{}, nil)
+		db := metadata.FakeMemoryDB()
+		db.InsertDynakube(ctx, &metadata.Dynakube{Name: dynakubeName})
+		provisioner := &OneAgentProvisioner{
+			apiReader: fake.NewClient(
+				&dynatracev1beta1.DynaKube{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: dynakubeName,
+					},
+					Spec: dynatracev1beta1.DynaKubeSpec{
+						OneAgent: dynatracev1beta1.OneAgentSpec{
+							HostMonitoring: &dynatracev1beta1.HostInjectSpec{},
+						},
+					},
+				},
+			),
+			db: db,
+			gc: gc,
+		}
+		result, err := provisioner.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: dynakubeName}})
 
+		gc.AssertNumberOfCalls(t, "Reconcile", 0)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, reconcile.Result{RequeueAfter: longRequeueDuration}, result)
+
+		dynakubeMetadatas, err := db.GetAllDynakubes(ctx)
+		require.NoError(t, err)
+		require.Len(t, dynakubeMetadatas, 0)
 	})
 	t.Run(`no tokens`, func(t *testing.T) {
 		gc := &CSIGarbageCollectorMock{}


### PR DESCRIPTION
# Description
host group in `ruxitagentproc.conf` file should not be updated for host monitoring dynakubes. 

## How can this be tested?
Create 2 Dynakubes:
* `cloudNativeFullStack` with host group
* `hostMonitoring` with different host group

`ruxitagentproc.conf` managed by the CSI driver should not get the host group defined in the `hostMonitoring` Dynakube.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

