### PR TITLE
Update CRD `caBundle` if certificate secret is up to date

### DIFF
--- a/src/controllers/certificates/certificate_secret_test.go
+++ b/src/controllers/certificates/certificate_secret_test.go
@@ -82,8 +82,8 @@ func TestAreConfigsValid(t *testing.T) {
 	t.Run(`true if no configs were given`, func(t *testing.T) {
 		certSecret := newCertificateSecret()
 
-		assert.True(t, certSecret.areConfigsValid(nil))
-		assert.True(t, certSecret.areConfigsValid(make([]*admissionregistrationv1.WebhookClientConfig, 0)))
+		assert.True(t, certSecret.areWebhookConfigsValid(nil))
+		assert.True(t, certSecret.areWebhookConfigsValid(make([]*admissionregistrationv1.WebhookClientConfig, 0)))
 	})
 	t.Run(`true if all CABundle matches certificate data, false otherwise`, func(t *testing.T) {
 		certSecret := newCertificateSecret()
@@ -101,13 +101,13 @@ func TestAreConfigsValid(t *testing.T) {
 			CABundle: testValue1,
 		})
 
-		assert.True(t, certSecret.areConfigsValid(webhookConfigs))
+		assert.True(t, certSecret.areWebhookConfigsValid(webhookConfigs))
 
 		webhookConfigs = append(webhookConfigs, &admissionregistrationv1.WebhookClientConfig{
 			CABundle: testValue2,
 		})
 
-		assert.False(t, certSecret.areConfigsValid(webhookConfigs))
+		assert.False(t, certSecret.areWebhookConfigsValid(webhookConfigs))
 	})
 }
 
@@ -187,48 +187,4 @@ func TestCreateOrUpdateIfNecessary(t *testing.T) {
 		assert.NotNil(t, newSecret)
 		assert.EqualValues(t, certSecret.certificates.Data, newSecret.Data)
 	})
-}
-
-func TestUpdateClientConfigurations(t *testing.T) {
-	mutatingWebhookConfig := admissionregistrationv1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testName,
-			Namespace: testNamespace,
-		},
-		Webhooks: []admissionregistrationv1.MutatingWebhook{
-			{
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{},
-			},
-			{
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{},
-			},
-			{
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{},
-			},
-		},
-	}
-	secret := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      buildSecretName(),
-			Namespace: testNamespace,
-		},
-		Data: map[string][]byte{RootCert: testValue1},
-	}
-	fakeClient := fake.NewClient(&mutatingWebhookConfig, &secret)
-	clientConfigs := getClientConfigsFromMutatingWebhook(&mutatingWebhookConfig)
-	certSecret := newCertificateSecret()
-	certSecret.secret = &secret
-
-	err := certSecret.updateClientConfigurations(context.TODO(), fakeClient, clientConfigs, &mutatingWebhookConfig)
-
-	assert.NoError(t, err)
-
-	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: testName, Namespace: testNamespace}, &mutatingWebhookConfig)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(mutatingWebhookConfig.Webhooks))
-
-	for _, mutatingWebhook := range mutatingWebhookConfig.Webhooks {
-		assert.EqualValues(t, mutatingWebhook.ClientConfig.CABundle, secret.Data[RootCert])
-	}
 }

--- a/src/controllers/certificates/webhook_cert_controller.go
+++ b/src/controllers/certificates/webhook_cert_controller.go
@@ -2,6 +2,7 @@ package certificates
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/src/eventfilter"
@@ -9,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -62,18 +62,23 @@ func (controller *WebhookCertificateController) Reconcile(ctx context.Context, r
 	controller.namespace = request.Namespace
 	controller.ctx = ctx
 
-	mutatingWebhookConfiguration, err := controller.getMutatingWebhookConfiguration(ctx)
+	mutatingWebhookConfiguration, err := controller.getMutatingWebhookConfiguration()
 	if err != nil {
 		// Generation must not be skipped because webhook startup routine listens for the secret
 		// See cmd/operator/manager.go and cmd/operator/watcher.go
 		log.Info("could not find mutating webhook configuration, this is normal when deployed using OLM")
 	}
 
-	validatingWebhookConfiguration, err := controller.getValidatingWebhookConfiguration(ctx)
+	validatingWebhookConfiguration, err := controller.getValidatingWebhookConfiguration()
 	if err != nil {
 		// Generation must not be skipped because webhook startup routine listens for the secret
 		// See cmd/operator/manager.go and cmd/operator/watcher.go
 		log.Info("could not find validating webhook configuration, this is normal when deployed using OLM")
+	}
+
+	crd, err := controller.getCRDConfiguration()
+	if err != nil {
+		log.Info("could not find CRD")
 	}
 
 	certSecret := newCertificateSecret()
@@ -91,12 +96,14 @@ func (controller *WebhookCertificateController) Reconcile(ctx context.Context, r
 	mutatingWebhookConfigs := getClientConfigsFromMutatingWebhook(mutatingWebhookConfiguration)
 	validatingWebhookConfigs := getClientConfigsFromValidatingWebhook(validatingWebhookConfiguration)
 
-	areMutatingWebhookConfigsValid := certSecret.areConfigsValid(mutatingWebhookConfigs)
-	areValidatingWebhookConfigsValid := certSecret.areConfigsValid(validatingWebhookConfigs)
+	areMutatingWebhookConfigsValid := certSecret.areWebhookConfigsValid(mutatingWebhookConfigs)
+	areValidatingWebhookConfigsValid := certSecret.areWebhookConfigsValid(validatingWebhookConfigs)
+	isCRDConversionConfigValid := certSecret.isCRDConversionValid(crd.Spec.Conversion)
 
 	if certSecret.isRecent() &&
 		areMutatingWebhookConfigsValid &&
-		areValidatingWebhookConfigsValid {
+		areValidatingWebhookConfigsValid &&
+		isCRDConversionConfigValid {
 		log.Info("secret for certificates up to date, skipping update")
 		controller.cancelMgr()
 		return reconcile.Result{RequeueAfter: SuccessDuration}, nil
@@ -106,17 +113,22 @@ func (controller *WebhookCertificateController) Reconcile(ctx context.Context, r
 		return reconcile.Result{}, errors.WithStack(err)
 	}
 
-	if err = controller.updateCRDConfiguration(certSecret.secret); err != nil {
-		return reconcile.Result{}, errors.WithStack(err)
-	}
-
-	err = certSecret.updateClientConfigurations(controller.ctx, controller.client, mutatingWebhookConfigs, mutatingWebhookConfiguration)
+	bundle, err := certSecret.loadCombinedBundle()
 	if err != nil {
 		return reconcile.Result{}, errors.WithStack(err)
 	}
 
-	err = certSecret.updateClientConfigurations(controller.ctx, controller.client, validatingWebhookConfigs, validatingWebhookConfiguration)
+	err = controller.updateClientConfigurations(bundle, mutatingWebhookConfigs, mutatingWebhookConfiguration)
 	if err != nil {
+		return reconcile.Result{}, errors.WithStack(err)
+	}
+
+	err = controller.updateClientConfigurations(bundle, validatingWebhookConfigs, validatingWebhookConfiguration)
+	if err != nil {
+		return reconcile.Result{}, errors.WithStack(err)
+	}
+
+	if err = controller.updateCRDConfiguration(bundle); err != nil {
 		return reconcile.Result{}, errors.WithStack(err)
 	}
 
@@ -131,10 +143,10 @@ func (controller *WebhookCertificateController) cancelMgr() {
 	}
 }
 
-func (controller *WebhookCertificateController) getMutatingWebhookConfiguration(ctx context.Context) (
+func (controller *WebhookCertificateController) getMutatingWebhookConfiguration() (
 	*admissionregistrationv1.MutatingWebhookConfiguration, error) {
 	var mutatingWebhook admissionregistrationv1.MutatingWebhookConfiguration
-	err := controller.apiReader.Get(ctx, client.ObjectKey{
+	err := controller.apiReader.Get(controller.ctx, client.ObjectKey{
 		Name: webhook.DeploymentName,
 	}, &mutatingWebhook)
 	if err != nil {
@@ -147,10 +159,10 @@ func (controller *WebhookCertificateController) getMutatingWebhookConfiguration(
 	return &mutatingWebhook, nil
 }
 
-func (controller *WebhookCertificateController) getValidatingWebhookConfiguration(ctx context.Context) (
+func (controller *WebhookCertificateController) getValidatingWebhookConfiguration() (
 	*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 	var mutatingWebhook admissionregistrationv1.ValidatingWebhookConfiguration
-	err := controller.apiReader.Get(ctx, client.ObjectKey{
+	err := controller.apiReader.Get(controller.ctx, client.ObjectKey{
 		Name: webhook.DeploymentName,
 	}, &mutatingWebhook)
 	if err != nil {
@@ -163,8 +175,33 @@ func (controller *WebhookCertificateController) getValidatingWebhookConfiguratio
 	return &mutatingWebhook, nil
 }
 
-func (controller *WebhookCertificateController) updateCRDConfiguration(secret *corev1.Secret) error {
+func (controller *WebhookCertificateController) getCRDConfiguration() (
+	*apiv1.CustomResourceDefinition, error) {
+	var crd apiv1.CustomResourceDefinition
+	if err := controller.apiReader.Get(controller.ctx, types.NamespacedName{Name: crdName}, &crd); err != nil {
+		return nil, err
+	}
 
+	return &crd, nil
+}
+
+func (controller *WebhookCertificateController) updateClientConfigurations(bundle []byte,
+	webhookClientConfigs []*admissionregistrationv1.WebhookClientConfig, webhookConfig client.Object) error {
+	if webhookConfig == nil || reflect.ValueOf(webhookConfig).IsNil() {
+		return nil
+	}
+
+	for i := range webhookClientConfigs {
+		webhookClientConfigs[i].CABundle = bundle
+	}
+
+	if err := controller.client.Update(controller.ctx, webhookConfig); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (controller *WebhookCertificateController) updateCRDConfiguration(bundle []byte) error {
 	var crd apiv1.CustomResourceDefinition
 	if err := controller.apiReader.Get(controller.ctx, types.NamespacedName{Name: crdName}, &crd); err != nil {
 		return err
@@ -175,17 +212,8 @@ func (controller *WebhookCertificateController) updateCRDConfiguration(secret *c
 		return nil
 	}
 
-	data, hasData := secret.Data[RootCert]
-	if !hasData {
-		return errors.New(errorCertificatesSecretEmpty)
-	}
-
-	if oldData, hasOldData := secret.Data[RootCertOld]; hasOldData {
-		data = append(data, oldData...)
-	}
-
 	// update crd
-	crd.Spec.Conversion.Webhook.ClientConfig.CABundle = data
+	crd.Spec.Conversion.Webhook.ClientConfig.CABundle = bundle
 	if err := controller.client.Update(controller.ctx, &crd); err != nil {
 		return err
 	}

--- a/src/controllers/certificates/webhook_cert_controller_test.go
+++ b/src/controllers/certificates/webhook_cert_controller_test.go
@@ -169,6 +169,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 		actualCrd := &apiv1.CustomResourceDefinition{}
 		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: crdName}, actualCrd)
+		require.NoError(t, err)
 		assert.Equal(t, expectedBundle, actualCrd.Spec.Conversion.Webhook.ClientConfig.CABundle)
 	})
 


### PR DESCRIPTION
# Description
When the webhook certificate exists on the cluster the `caBundle` field of the CRD conversion webhook was never updated.

## How can this be tested?
1. Install Operator (Webhook should be running without error logs)
2. Delete `.spec.conversion.webhook.clientConfig.caBundle`
3. Restart Operator pod

CRD should be updated to include correct `caBundle`!


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

