### PR TITLE
Use version in application monitoring without CSI (#1232)

### DIFF
--- a/src/config/agent_injection.go
+++ b/src/config/agent_injection.go
@@ -16,10 +16,11 @@ const (
 	AgentInstallerMode InstallMode = "installer"
 	AgentCsiMode       InstallMode = "provisioned"
 
-	AgentInstallModeEnv     = "MODE"
-	AgentInstallerUrlEnv    = "INSTALLER_URL"
-	AgentInstallerFlavorEnv = "FLAVOR"
-	AgentInstallerTechEnv   = "TECHNOLOGIES"
+	AgentInstallModeEnv      = "MODE"
+	AgentInstallerUrlEnv     = "INSTALLER_URL"
+	AgentInstallerFlavorEnv  = "FLAVOR"
+	AgentInstallerTechEnv    = "TECHNOLOGIES"
+	AgentInstallerVersionEnv = "VERSION"
 
 	AgentInstallPathEnv            = "INSTALLPATH"
 	AgentContainerCountEnv         = "CONTAINERS_COUNT"

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -22,6 +22,7 @@ type environment struct {
 	InstallerUrl  string             `json:"installerUrl"`
 
 	InstallerFlavor string          `json:"installerFlavor"`
+	InstallVersion  string          `json:"installVersion"`
 	InstallerTech   []string        `json:"installerTech"`
 	InstallPath     string          `json:"installPath"`
 	Containers      []containerInfo `json:"containers"`
@@ -103,6 +104,7 @@ func (env *environment) getDataIngestFieldSetters() []func() error {
 func (env *environment) setOptionalFields() {
 	env.addInstallerUrl()
 	env.addInstallerFlavor()
+	env.addInstallVersion()
 }
 
 func (env *environment) setMutationTypeFields() {
@@ -269,6 +271,11 @@ func (env *environment) addWorkloadName() error {
 func (env *environment) addInstallerUrl() {
 	url, _ := checkEnvVar(config.AgentInstallerUrlEnv)
 	env.InstallerUrl = url
+}
+
+func (env *environment) addInstallVersion() {
+	version, _ := checkEnvVar(config.AgentInstallerVersionEnv)
+	env.InstallVersion = version
 }
 
 func (env *environment) addOneAgentInjected() {

--- a/src/standalone/env_test.go
+++ b/src/standalone/env_test.go
@@ -25,6 +25,7 @@ func TestNewEnv(t *testing.T) {
 		assert.NotEmpty(t, env.InstallerFlavor)
 		assert.NotEmpty(t, env.InstallerTech)
 		assert.NotEmpty(t, env.InstallPath)
+		assert.NotEmpty(t, env.InstallVersion)
 		assert.Len(t, env.Containers, 5)
 
 		assert.NotEmpty(t, env.K8NodeName)
@@ -53,6 +54,7 @@ func TestNewEnv(t *testing.T) {
 		assert.True(t, env.FailurePolicy)
 		assert.NotEmpty(t, env.InstallerFlavor) // set to what is defined in arch.Flavor
 		assert.Empty(t, env.InstallerTech)
+		assert.Empty(t, env.InstallVersion)
 		assert.Empty(t, env.InstallPath)
 		assert.Empty(t, env.Containers)
 
@@ -98,6 +100,7 @@ func TestNewEnv(t *testing.T) {
 		assert.True(t, env.FailurePolicy)
 		assert.NotEmpty(t, env.InstallerFlavor)
 		assert.NotEmpty(t, env.InstallerTech)
+		assert.NotEmpty(t, env.InstallVersion)
 		assert.NotEmpty(t, env.InstallPath)
 		assert.Len(t, env.Containers, 5)
 
@@ -129,6 +132,7 @@ func prepOneAgentTestEnv(t *testing.T) func() {
 	envs := []string{
 		config.AgentInstallerFlavorEnv,
 		config.AgentInstallerTechEnv,
+		config.AgentInstallerVersionEnv,
 		config.K8sNodeNameEnv,
 		config.K8sPodNameEnv,
 		config.K8sPodUIDEnv,

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -43,7 +43,10 @@ func NewRunner(fs afero.Fs) (*Runner, error) {
 		if err != nil {
 			return nil, err
 		}
-
+		targetVersion := url.VersionLatest
+		if env.InstallVersion != "" {
+			targetVersion = env.InstallVersion
+		}
 		oneAgentInstaller = url.NewUrlInstaller(
 			fs,
 			client,
@@ -53,7 +56,7 @@ func NewRunner(fs afero.Fs) (*Runner, error) {
 				Flavor:        env.InstallerFlavor,
 				Arch:          arch.Arch,
 				Technologies:  env.InstallerTech,
-				TargetVersion: url.VersionLatest,
+				TargetVersion: targetVersion,
 				Url:           env.InstallerUrl,
 				PathResolver:  metadata.PathResolver{RootDir: config.AgentBinDirMount},
 			},

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/annotations.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/annotations.go
@@ -3,17 +3,18 @@ package oneagent_mutation
 import (
 	"net/url"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/src/webhook"
 	corev1 "k8s.io/api/core/v1"
 )
 
 type installerInfo struct {
-	flavor        string
-	technologies  string
-	installPath   string
-	installerURL  string
-	failurePolicy string
+	flavor       string
+	technologies string
+	installPath  string
+	installerURL string
+	version      string
 }
 
 func setInjectedAnnotation(pod *corev1.Pod) {
@@ -23,12 +24,12 @@ func setInjectedAnnotation(pod *corev1.Pod) {
 	pod.Annotations[dtwebhook.AnnotationOneAgentInjected] = "true"
 }
 
-func getInstallerInfo(pod *corev1.Pod) installerInfo {
+func getInstallerInfo(pod *corev1.Pod, dynakube dynatracev1beta1.DynaKube) installerInfo {
 	return installerInfo{
-		flavor:        kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFlavor, ""),
-		technologies:  url.QueryEscape(kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationTechnologies, "all")),
-		installPath:   kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInstallPath, dtwebhook.DefaultInstallPath),
-		installerURL:  kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInstallerUrl, ""),
-		failurePolicy: kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFailurePolicy, "silent"),
+		flavor:       kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFlavor, ""),
+		technologies: url.QueryEscape(kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationTechnologies, "all")),
+		installPath:  kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInstallPath, dtwebhook.DefaultInstallPath),
+		installerURL: kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationInstallerUrl, ""),
+		version:      dynakube.Version(),
 	}
 }

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/annotations_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/annotations_test.go
@@ -1,19 +1,26 @@
 package oneagent_mutation
 
+import "reflect"
+
 const (
 	testFlavor        = "testFlavor"
 	testTechnologies  = "testTech"
 	testInstallPath   = "testInstallPath"
 	testInstallerURL  = "testInstallerUrl"
 	testFailurePolicy = "testFailurePolicy"
+	testVersion       = "testVersion"
 )
 
 func getTestInstallerInfo() installerInfo {
 	return installerInfo{
-		flavor:        testFlavor,
-		technologies:  testTechnologies,
-		installPath:   testInstallPath,
-		installerURL:  testInstallerURL,
-		failurePolicy: testFailurePolicy,
+		flavor:       testFlavor,
+		technologies: testTechnologies,
+		installPath:  testInstallPath,
+		installerURL: testInstallerURL,
+		version:      testVersion,
 	}
+}
+
+func getInstallerInfoFieldCount() int {
+	return reflect.TypeOf(installerInfo{}).NumField()
 }

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/containers_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/containers_test.go
@@ -12,6 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var expectedBaseInitContainerEnvCount = getInstallerInfoFieldCount() + 2 // volumeMode + oneagent injected
+
 func TestConfigureInitContainer(t *testing.T) {
 	t.Run("add envs and volume mounts (no-csi)", func(t *testing.T) {
 		mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
@@ -20,7 +22,7 @@ func TestConfigureInitContainer(t *testing.T) {
 
 		mutator.configureInitContainer(request, installerInfo)
 
-		require.Len(t, request.InstallContainer.Env, 6)
+		require.Len(t, request.InstallContainer.Env, expectedBaseInitContainerEnvCount)
 		assert.Len(t, request.InstallContainer.VolumeMounts, 2)
 		envvar := kubeobjects.FindEnvVar(request.InstallContainer.Env, config.AgentInstallModeEnv)
 		require.NotNil(t, envvar)
@@ -34,7 +36,7 @@ func TestConfigureInitContainer(t *testing.T) {
 
 		mutator.configureInitContainer(request, installerInfo)
 
-		require.Len(t, request.InstallContainer.Env, 6)
+		require.Len(t, request.InstallContainer.Env, expectedBaseInitContainerEnvCount)
 		assert.Len(t, request.InstallContainer.VolumeMounts, 2)
 		envvar := kubeobjects.FindEnvVar(request.InstallContainer.Env, config.AgentInstallModeEnv)
 		require.NotNil(t, envvar)

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/env.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/env.go
@@ -50,6 +50,7 @@ func addInstallerInitEnvs(initContainer *corev1.Container, installer installerIn
 		corev1.EnvVar{Name: config.AgentInstallerTechEnv, Value: installer.technologies},
 		corev1.EnvVar{Name: config.AgentInstallPathEnv, Value: installer.installPath},
 		corev1.EnvVar{Name: config.AgentInstallerUrlEnv, Value: installer.installerURL},
+		corev1.EnvVar{Name: config.AgentInstallerVersionEnv, Value: installer.version},
 		corev1.EnvVar{Name: config.AgentInstallModeEnv, Value: volumeMode},
 		corev1.EnvVar{Name: config.AgentInjectedEnv, Value: "true"},
 	)

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/env_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/env_test.go
@@ -53,13 +53,14 @@ func TestAddInstallerInitEnvs(t *testing.T) {
 		testVolumeMode := "testMode"
 		installerInfo := getTestInstallerInfo()
 		addInstallerInitEnvs(container, installerInfo, testVolumeMode)
-		require.Len(t, container.Env, 6)
+		require.Len(t, container.Env, expectedBaseInitContainerEnvCount)
 		assert.Equal(t, installerInfo.flavor, container.Env[0].Value)
 		assert.Equal(t, installerInfo.technologies, container.Env[1].Value)
 		assert.Equal(t, installerInfo.installPath, container.Env[2].Value)
 		assert.Equal(t, installerInfo.installerURL, container.Env[3].Value)
-		assert.Equal(t, testVolumeMode, container.Env[4].Value)
-		assert.Equal(t, "true", container.Env[5].Value)
+		assert.Equal(t, installerInfo.version, container.Env[4].Value)
+		assert.Equal(t, testVolumeMode, container.Env[5].Value)
+		assert.Equal(t, "true", container.Env[6].Value)
 	})
 }
 

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
@@ -44,7 +44,7 @@ func (mutator *OneAgentPodMutator) Mutate(request *dtwebhook.MutationRequest) er
 		return errors.WithStack(err)
 	}
 
-	installerInfo := getInstallerInfo(request.Pod)
+	installerInfo := getInstallerInfo(request.Pod, request.DynaKube)
 	mutator.addVolumes(request.Pod, request.DynaKube)
 	mutator.configureInitContainer(request, installerInfo)
 	mutator.mutateUserContainers(request)

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
@@ -124,7 +124,7 @@ func TestMutate(t *testing.T) {
 		assert.Len(t, request.Pod.Annotations, initialAnnotationsLen+1)
 		assert.Equal(t, initialInitContainers, request.Pod.Spec.InitContainers)
 
-		assert.Len(t, request.InstallContainer.Env, 6+(initialContainersLen*2))
+		assert.Len(t, request.InstallContainer.Env, expectedBaseInitContainerEnvCount+(initialContainersLen*2))
 		assert.Len(t, request.InstallContainer.VolumeMounts, 3)
 	})
 	t.Run("everything turned on, should mutate the pod and init container in the request", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestMutate(t *testing.T) {
 		assert.Len(t, request.Pod.Annotations, initialAnnotationsLen+1)
 		assert.Equal(t, initialInitContainers, request.Pod.Spec.InitContainers)
 
-		assert.Len(t, request.InstallContainer.Env, 6+(initialContainersLen*2))
+		assert.Len(t, request.InstallContainer.Env, expectedBaseInitContainerEnvCount+(initialContainersLen*2))
 		assert.Len(t, request.InstallContainer.VolumeMounts, 3)
 	})
 }


### PR DESCRIPTION
# Description

cherry pick of https://github.com/Dynatrace/dynatrace-operator/pull/1232

## How can this be tested?
same as https://github.com/Dynatrace/dynatrace-operator/pull/1232


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

