### PR TITLE
Fix unconfigurable onegent classic privileged container

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -264,7 +264,7 @@ func (dk *DynaKube) FeatureAgentInitialConnectRetry() int {
 	return val
 }
 
-func (dk *DynaKube) FeatureAgentRunPrivileged() bool {
+func (dk *DynaKube) FeatureOneAgentPrivileged() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureRunOneAgentContainerPrivileged) == "true"
 }
 

--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -114,8 +114,8 @@ func (dk *DynaKube) NeedsOneAgentProxy() bool {
 	return !dk.FeatureOneAgentIgnoreProxy() && dk.hasProxy()
 }
 
-func (dk *DynaKube) IsOneAgentPrivileged() bool {
-	return dk.FeatureAgentRunPrivileged() || dk.ClassicFullStackMode()
+func (dk *DynaKube) NeedsOneAgentPrivileged() bool {
+	return dk.FeatureOneAgentPrivileged()
 }
 
 // ShouldAutoUpdateOneAgent returns true if the Operator should update OneAgent instances automatically.

--- a/src/api/v1beta1/properties_test.go
+++ b/src/api/v1beta1/properties_test.go
@@ -301,7 +301,7 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 	t.Run("is false by default", func(t *testing.T) {
 		dynakube := DynaKube{}
 
-		assert.False(t, dynakube.IsOneAgentPrivileged())
+		assert.False(t, dynakube.FeatureOneAgentPrivileged())
 	})
 	t.Run("is true when annotation is set to true", func(t *testing.T) {
 		dynakube := DynaKube{
@@ -312,7 +312,7 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 			},
 		}
 
-		assert.True(t, dynakube.IsOneAgentPrivileged())
+		assert.True(t, dynakube.FeatureOneAgentPrivileged())
 	})
 	t.Run("is false when annotation is set to false", func(t *testing.T) {
 		dynakube := DynaKube{
@@ -323,28 +323,7 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 			},
 		}
 
-		assert.False(t, dynakube.IsOneAgentPrivileged())
-	})
-	t.Run("is true in classicFullStack mode", func(t *testing.T) {
-		dynakube := DynaKube{
-			Spec: DynaKubeSpec{
-				OneAgent: OneAgentSpec{ClassicFullStack: &HostInjectSpec{}},
-			},
-		}
-
-		assert.True(t, dynakube.IsOneAgentPrivileged())
-
-		dynakube.Annotations = map[string]string{
-			AnnotationFeatureRunOneAgentContainerPrivileged: "false",
-		}
-
-		assert.True(t, dynakube.IsOneAgentPrivileged())
-
-		dynakube.Annotations = map[string]string{
-			AnnotationFeatureRunOneAgentContainerPrivileged: "true",
-		}
-
-		assert.True(t, dynakube.IsOneAgentPrivileged())
+		assert.False(t, dynakube.FeatureOneAgentPrivileged())
 	})
 }
 

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -226,7 +226,7 @@ func (dsInfo *builderInfo) podSpec() corev1.PodSpec {
 }
 
 func (dsInfo *builderInfo) serviceAccountName() string {
-	if dsInfo.instance != nil && dsInfo.instance.IsOneAgentPrivileged() {
+	if dsInfo.instance != nil && dsInfo.instance.NeedsOneAgentPrivileged() {
 		return privilegedServiceAccountName
 	}
 
@@ -315,7 +315,7 @@ func (dsInfo *builderInfo) securityContext() *corev1.SecurityContext {
 		securityContext.RunAsGroup = address.Of(int64(1000))
 	}
 
-	if dsInfo.instance != nil && dsInfo.instance.IsOneAgentPrivileged() {
+	if dsInfo.instance != nil && dsInfo.instance.NeedsOneAgentPrivileged() {
 		securityContext.Privileged = address.Of(true)
 	} else {
 		securityContext.Capabilities = defaultSecurityContextCapabilities()


### PR DESCRIPTION
# Description
`classicFullStack` does not require privileged container in call cases. By default it should use capabilities, only when the feature flag is set the container is privileged.


## How can this be tested?
Deploy oneagent with the following configurations:
- without privileged oneagent feature flag: oneagent security context should use capabiilties
- with privileged oneagent feature flag: oneagent security context should be privileged


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

