### PR TITLE
Respects folder fileMode during gzip unzip

### DIFF
--- a/src/installer/zip/gzip.go
+++ b/src/installer/zip/gzip.go
@@ -59,7 +59,7 @@ func extractFilesFromGzip(fs afero.Fs, targetDir string, reader *tar.Reader) err
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := fs.MkdirAll(target, common.MkDirFileMode); err != nil {
+			if err := fs.MkdirAll(target, header.FileInfo().Mode()); err != nil {
 				return errors.WithStack(err)
 			}
 		case tar.TypeLink:
@@ -108,11 +108,11 @@ func extractSymlink(fs afero.Fs, targetDir, target string, header *tar.Header) e
 }
 
 func extractFile(fs afero.Fs, target string, header *tar.Header, tarReader *tar.Reader) error {
-	mode := header.Mode
+	mode := header.FileInfo().Mode()
 	if isAgentConfFile(header.Name) {
 		mode = common.ReadWriteAllFileMode
 	}
-	destinationFile, err := fs.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(mode))
+	destinationFile, err := fs.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, mode)
 	defer (func() { _ = destinationFile.Close() })()
 	if err != nil {
 		return errors.WithStack(err)


### PR DESCRIPTION
# Description

When using the `codeModulesImage` the operator needs to unzip a gzip to create the directory that will be mounted to customer pods.
During this unzip process we don't respect the fileMode of the folders.

## How can this be tested?
Use `codeModulesImage`
Easy way to see this the `./codemodules/<image-hash>/log` folder has incorrect permissions it should be
`drwxrwxrwx` but currently we have it as `drwxr-xr-x`


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

