### PR TITLE
Add support for checking all dynakubes in troubleshoot subcommand

### DIFF
--- a/src/cmd/troubleshoot/builder.go
+++ b/src/cmd/troubleshoot/builder.go
@@ -15,9 +15,11 @@ import (
 )
 
 const (
-	use               = "troubleshoot"
-	dynakubeFlagName  = "dynakube"
-	namespaceFlagName = "namespace"
+	use                    = "troubleshoot"
+	dynakubeFlagName       = "dynakube"
+	dynakubeFlagShorthand  = "d"
+	namespaceFlagName      = "namespace"
+	namespaceFlagShorthand = "n"
 )
 
 var (
@@ -54,8 +56,8 @@ func (builder CommandBuilder) Build() *cobra.Command {
 }
 
 func addFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&dynakubeFlagValue, dynakubeFlagName, "", "Specify a different Dynakube name.")
-	cmd.PersistentFlags().StringVar(&namespaceFlagValue, namespaceFlagName, defaultNamespace(), "Specify a different Namespace.")
+	cmd.PersistentFlags().StringVarP(&dynakubeFlagValue, dynakubeFlagName, dynakubeFlagShorthand, "", "Specify a different Dynakube name.")
+	cmd.PersistentFlags().StringVarP(&namespaceFlagValue, namespaceFlagName, namespaceFlagShorthand, defaultNamespace(), "Specify a different Namespace.")
 }
 
 func defaultNamespace() string {

--- a/src/cmd/troubleshoot/builder.go
+++ b/src/cmd/troubleshoot/builder.go
@@ -106,6 +106,7 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 				return nil
 			}
 		}
+		resetLog()
 
 		perDynakubeTests := []troubleshootFunc{
 			checkDynakube,
@@ -127,7 +128,7 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 				dynakube:      dynakube,
 				dynakubeName:  dynakube.Name,
 			}
-
+			logNewDynakubef(troubleshootCtx.dynakubeName)
 			for _, test := range perDynakubeTests {
 				err = test(&troubleshootCtx)
 				if err != nil {
@@ -135,6 +136,8 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 					return nil
 				}
 			}
+			resetLog()
+			logOkf("'%s' - all checks passed", troubleshootCtx.dynakubeName)
 		}
 		return nil
 	}
@@ -144,7 +147,7 @@ func getDynakubes(troubleshootCtx *troubleshootContext) ([]dynatracev1beta1.Dyna
 	var err error
 	var dynakubes []dynatracev1beta1.DynaKube
 	if dynakubeFlagValue == "" {
-		logInfof("No Dynakube specified. Checking all Dynakubes in namespace '%s'", namespaceFlagValue)
+		logInfof("no Dynakube specified - checking all Dynakubes in namespace '%s'", namespaceFlagValue)
 		dynakubes, err = getAllDynakubesInNamespace(troubleshootCtx)
 		if err != nil {
 			return nil, err

--- a/src/cmd/troubleshoot/builder.go
+++ b/src/cmd/troubleshoot/builder.go
@@ -151,7 +151,7 @@ func getDynakubes(troubleshootCtx troubleshootContext) ([]dynatracev1beta1.DynaK
 	var err error
 	var dynakubes []dynatracev1beta1.DynaKube
 	if troubleshootCtx.dynakubeName == "" {
-		logInfof("no Dynakube specified - checking all Dynakubes in namespace '%s'", namespaceFlagValue)
+		logNewDynakubef("no Dynakube specified - checking all Dynakubes in namespace '%s'", namespaceFlagValue)
 		dynakubes, err = getAllDynakubesInNamespace(troubleshootCtx)
 		if err != nil {
 			return nil, err

--- a/src/cmd/troubleshoot/builder_test.go
+++ b/src/cmd/troubleshoot/builder_test.go
@@ -3,7 +3,10 @@ package troubleshoot
 import (
 	"testing"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestTroubleshootCommandBuilder(t *testing.T) {
@@ -14,5 +17,31 @@ func TestTroubleshootCommandBuilder(t *testing.T) {
 		assert.NotNil(t, csiCommand)
 		assert.Equal(t, use, csiCommand.Use)
 		assert.NotNil(t, csiCommand.RunE)
+	})
+
+	t.Run("getAllDynakubesInNamespace", func(t *testing.T) {
+		dynakube := dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testDynakube,
+				Namespace: "dynatrace",
+			},
+		}
+		clt := fake.NewClient(&dynakube)
+
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+
+		dynakubes, err := getAllDynakubesInNamespace(troubleshootCtx)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(dynakubes))
+		assert.Equal(t, dynakube.Name, dynakubes[0].Name)
+	})
+
+	t.Run("getDynakube - only check one dynakube if set", func(t *testing.T) {
+		troubleshootCtx := troubleshootContext{dynakubeName: testDynakube}
+
+		dynakubes, err := getDynakubes(troubleshootCtx)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(dynakubes))
+		assert.Equal(t, testDynakube, dynakubes[0].Name)
 	})
 }

--- a/src/cmd/troubleshoot/builder_test.go
+++ b/src/cmd/troubleshoot/builder_test.go
@@ -20,15 +20,10 @@ func TestTroubleshootCommandBuilder(t *testing.T) {
 	})
 
 	t.Run("getAllDynakubesInNamespace", func(t *testing.T) {
-		dynakube := dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testDynakube,
-				Namespace: "dynatrace",
-			},
-		}
+		dynakube := buildTestDynakube()
 		clt := fake.NewClient(&dynakube)
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 
 		dynakubes, err := getAllDynakubesInNamespace(troubleshootCtx)
 		assert.NoError(t, err)
@@ -37,11 +32,21 @@ func TestTroubleshootCommandBuilder(t *testing.T) {
 	})
 
 	t.Run("getDynakube - only check one dynakube if set", func(t *testing.T) {
-		troubleshootCtx := troubleshootContext{dynakubeName: testDynakube}
+		dynakube := buildTestDynakube()
+		troubleshootCtx := troubleshootContext{dynakube: dynakube}
 
 		dynakubes, err := getDynakubes(troubleshootCtx)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(dynakubes))
 		assert.Equal(t, testDynakube, dynakubes[0].Name)
 	})
+}
+
+func buildTestDynakube() dynatracev1beta1.DynaKube {
+	return dynatracev1beta1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testDynakube,
+			Namespace: testNamespace,
+		},
+	}
 }

--- a/src/cmd/troubleshoot/builder_test.go
+++ b/src/cmd/troubleshoot/builder_test.go
@@ -33,9 +33,12 @@ func TestTroubleshootCommandBuilder(t *testing.T) {
 
 	t.Run("getDynakube - only check one dynakube if set", func(t *testing.T) {
 		dynakube := buildTestDynakube()
-		troubleshootCtx := troubleshootContext{dynakube: dynakube}
+		troubleshootCtx := troubleshootContext{
+			dynakube:      dynakube,
+			namespaceName: testNamespace,
+		}
 
-		dynakubes, err := getDynakubes(troubleshootCtx)
+		dynakubes, err := getDynakubes(troubleshootCtx, dynakube.Name)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(dynakubes))
 		assert.Equal(t, testDynakube, dynakubes[0].Name)

--- a/src/cmd/troubleshoot/config.go
+++ b/src/cmd/troubleshoot/config.go
@@ -1,5 +1,13 @@
 package troubleshoot
 
-var (
-	log = newTroubleshootLogger("[          ]")
-)
+import "github.com/go-logr/logr"
+
+var log logr.Logger
+
+func init() {
+	resetLog()
+}
+
+func resetLog() {
+	log = newTroubleshootLogger("[          ]", false)
+}

--- a/src/cmd/troubleshoot/config.go
+++ b/src/cmd/troubleshoot/config.go
@@ -9,5 +9,5 @@ func init() {
 }
 
 func resetLog() {
-	log = newTroubleshootLogger("[          ]", false)
+	log = newTroubleshootLogger("", false)
 }

--- a/src/cmd/troubleshoot/config.go
+++ b/src/cmd/troubleshoot/config.go
@@ -4,10 +4,6 @@ import "github.com/go-logr/logr"
 
 var log logr.Logger
 
-func init() {
-	resetLog()
-}
-
 func resetLog() {
 	log = newTroubleshootLogger("", false)
 }

--- a/src/cmd/troubleshoot/config.go
+++ b/src/cmd/troubleshoot/config.go
@@ -5,5 +5,5 @@ import "github.com/go-logr/logr"
 var log logr.Logger
 
 func resetLog() {
-	log = newTroubleshootLogger("", false)
+	log = newTroubleshootLogger("")
 }

--- a/src/cmd/troubleshoot/connection.go
+++ b/src/cmd/troubleshoot/connection.go
@@ -7,7 +7,7 @@ import (
 )
 
 func checkDTClusterConnection(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("dtcluster", true)
+	log = newSubTestLogger("dtcluster")
 
 	logNewTestf("checking if tenant is accessible ...")
 

--- a/src/cmd/troubleshoot/connection.go
+++ b/src/cmd/troubleshoot/connection.go
@@ -7,7 +7,7 @@ import (
 )
 
 func checkDTClusterConnection(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[dtcluster ] ", true)
+	log = newTroubleshootLogger("dtcluster", true)
 
 	logNewTestf("checking if tenant is accessible ...")
 

--- a/src/cmd/troubleshoot/connection.go
+++ b/src/cmd/troubleshoot/connection.go
@@ -7,7 +7,7 @@ import (
 )
 
 func checkDTClusterConnection(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[dtcluster ] ")
+	log = newTroubleshootLogger("[dtcluster ] ", true)
 
 	logNewTestf("checking if tenant is accessible ...")
 

--- a/src/cmd/troubleshoot/context.go
+++ b/src/cmd/troubleshoot/context.go
@@ -15,7 +15,6 @@ type troubleshootContext struct {
 	apiReader          client.Reader
 	httpClient         *http.Client
 	namespaceName      string // the default namespace ("dynatrace") or value provided in the command line
-	dynakubeName       string // all dynakubes in namespaceName or value provided in the command line
 	dynakube           v1beta1.DynaKube
 	dynatraceApiSecret corev1.Secret
 	pullSecret         corev1.Secret

--- a/src/cmd/troubleshoot/context.go
+++ b/src/cmd/troubleshoot/context.go
@@ -14,8 +14,8 @@ type troubleshootContext struct {
 	context            context.Context
 	apiReader          client.Reader
 	httpClient         *http.Client
-	namespaceName      string // the default namespace ("dynatrace") or provided in the command line
-	dynakubeName       string // the default name of dynakube ("dynakube") or provided in the command line
+	namespaceName      string // the default namespace ("dynatrace") or value provided in the command line
+	dynakubeName       string // all dynakubes in namespaceName or value provided in the command line
 	dynakube           v1beta1.DynaKube
 	dynatraceApiSecret corev1.Secret
 	pullSecret         corev1.Secret

--- a/src/cmd/troubleshoot/dynakube.go
+++ b/src/cmd/troubleshoot/dynakube.go
@@ -20,7 +20,7 @@ const (
 )
 
 func checkDynakube(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("dynakube", true)
+	log = newSubTestLogger("dynakube")
 
 	logNewTestf("checking if '%s:%s' Dynakube is configured correctly", troubleshootCtx.namespaceName, troubleshootCtx.dynakubeName)
 

--- a/src/cmd/troubleshoot/dynakube.go
+++ b/src/cmd/troubleshoot/dynakube.go
@@ -20,7 +20,7 @@ const (
 )
 
 func checkDynakube(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[dynakube  ] ")
+	log = newTroubleshootLogger("[dynakube  ] ", true)
 
 	logNewTestf("checking if '%s:%s' Dynakube is configured correctly", troubleshootCtx.namespaceName, troubleshootCtx.dynakubeName)
 

--- a/src/cmd/troubleshoot/dynakube.go
+++ b/src/cmd/troubleshoot/dynakube.go
@@ -20,7 +20,7 @@ const (
 )
 
 func checkDynakube(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[dynakube  ] ", true)
+	log = newTroubleshootLogger("dynakube", true)
 
 	logNewTestf("checking if '%s:%s' Dynakube is configured correctly", troubleshootCtx.namespaceName, troubleshootCtx.dynakubeName)
 

--- a/src/cmd/troubleshoot/dynakube_test.go
+++ b/src/cmd/troubleshoot/dynakube_test.go
@@ -39,12 +39,12 @@ func (errorClt *errorClient) List(_ context.Context, _ client.ObjectList, _ ...c
 func TestDynakubeCRD(t *testing.T) {
 	t.Run("crd does not exist", func(t *testing.T) {
 		clt := fake.NewClientBuilder().Build()
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 
 		assert.ErrorContains(t, checkDynakubeCrdExists(&troubleshootCtx), "CRD for Dynakube missing")
 	})
 	t.Run("unrelated error", func(t *testing.T) {
-		troubleshootCtx := troubleshootContext{apiReader: &errorClient{}, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: &errorClient{}, namespaceName: testNamespace}
 
 		assert.ErrorContains(t, checkDynakubeCrdExists(&troubleshootCtx), "could not list Dynakube")
 	})
@@ -60,7 +60,7 @@ func TestDynakube(t *testing.T) {
 			).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 		assert.NoErrorf(t, getSelectedDynakubeIfItExists(&troubleshootCtx), "no dynakube found")
 	})
 	t.Run("dynakube does not exist", func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestDynakube(t *testing.T) {
 			).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testOtherDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 		assert.Errorf(t, getSelectedDynakubeIfItExists(&troubleshootCtx), "dynakube found")
 	})
 	t.Run("invalid namespace selected", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestDynakube(t *testing.T) {
 			).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testOtherNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testOtherNamespace}
 		assert.Errorf(t, getSelectedDynakubeIfItExists(&troubleshootCtx), "dynakube found")
 	})
 }
@@ -112,7 +112,7 @@ func TestDynatraceSecret(t *testing.T) {
 			).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 		assert.NoErrorf(t, getSelectedDynakubeIfItExists(&troubleshootCtx), "Dynatrace secret not found")
 	})
 	t.Run("Dynatrace secret does not exist", func(t *testing.T) {
@@ -125,7 +125,7 @@ func TestDynatraceSecret(t *testing.T) {
 			).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 		assert.Errorf(t, getDynatraceApiSecretIfItExists(&troubleshootCtx), "Dynatrace secret found")
 	})
 
@@ -187,7 +187,7 @@ func TestProxySecret(t *testing.T) {
 			).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 		assert.NoErrorf(t, setProxySecretIfItExists(&troubleshootCtx), "proxy secret not found")
 	})
 	t.Run("proxy secret does not exist", func(t *testing.T) {
@@ -201,7 +201,7 @@ func TestProxySecret(t *testing.T) {
 			Build()
 
 		troubleshootCtx := troubleshootContext{
-			apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube, dynakube: *dynakube,
+			apiReader: clt, namespaceName: testNamespace, dynakube: *dynakube,
 		}
 		assert.Errorf(t, setProxySecretIfItExists(&troubleshootCtx), "proxy secret found")
 	})

--- a/src/cmd/troubleshoot/dynakube_test.go
+++ b/src/cmd/troubleshoot/dynakube_test.go
@@ -51,6 +51,8 @@ func TestDynakubeCRD(t *testing.T) {
 }
 
 func TestDynakube(t *testing.T) {
+	resetLog()
+
 	t.Run("dynakube exists", func(t *testing.T) {
 		clt := fake.NewClientBuilder().
 			WithScheme(scheme.Scheme).
@@ -60,7 +62,11 @@ func TestDynakube(t *testing.T) {
 			).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
+		troubleshootCtx := troubleshootContext{
+			apiReader:     clt,
+			namespaceName: testNamespace,
+			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).build(),
+		}
 		assert.NoErrorf(t, getSelectedDynakubeIfItExists(&troubleshootCtx), "no dynakube found")
 	})
 	t.Run("dynakube does not exist", func(t *testing.T) {
@@ -72,7 +78,11 @@ func TestDynakube(t *testing.T) {
 			).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
+		troubleshootCtx := troubleshootContext{
+			apiReader:     clt,
+			namespaceName: testNamespace,
+			dynakube:      *testNewDynakubeBuilder(testNamespace, "doesnotexist").build(),
+		}
 		assert.Errorf(t, getSelectedDynakubeIfItExists(&troubleshootCtx), "dynakube found")
 	})
 	t.Run("invalid namespace selected", func(t *testing.T) {
@@ -112,7 +122,11 @@ func TestDynatraceSecret(t *testing.T) {
 			).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
+		troubleshootCtx := troubleshootContext{
+			apiReader:     clt,
+			namespaceName: testNamespace,
+			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).build(),
+		}
 		assert.NoErrorf(t, getSelectedDynakubeIfItExists(&troubleshootCtx), "Dynatrace secret not found")
 	})
 	t.Run("Dynatrace secret does not exist", func(t *testing.T) {

--- a/src/cmd/troubleshoot/endpoint_test.go
+++ b/src/cmd/troubleshoot/endpoint_test.go
@@ -10,7 +10,6 @@ func TestImagePullableActiveGateEndpoint(t *testing.T) {
 	t.Run("ActiveGate image", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).build(),
 		}
 		endpoint := getActiveGateImageEndpoint(&troubleshootCtx)
@@ -19,7 +18,6 @@ func TestImagePullableActiveGateEndpoint(t *testing.T) {
 	t.Run("ActiveGate custom image with version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube: *testNewDynakubeBuilder(testNamespace, testDynakube).
 				withApiUrl(testApiUrl).
 				withActiveGateImage(testValidCustomImageNameWithVersion).
@@ -32,7 +30,6 @@ func TestImagePullableActiveGateEndpoint(t *testing.T) {
 	t.Run("ActiveGate custom image without version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube: *testNewDynakubeBuilder(testNamespace, testDynakube).
 				withApiUrl(testApiUrl).
 				withActiveGateImage(testValidCustomImageNameWithoutVersion).
@@ -48,7 +45,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("OneAgent image", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -58,7 +54,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Classic Full Stack OneAgent custom image with version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withClassicFullStackCustomImage(testValidOneAgentCustomImageNameWithVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -67,7 +62,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Classic Full Stack OneAgent custom image without version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withClassicFullStackCustomImage(testValidOneAgentCustomImageNameWithoutVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -76,7 +70,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Classic Full Stack OneAgent regular image with version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withClassicFullStackImageVersion(testVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -85,7 +78,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Classic Full Stack OneAgent custom image and Version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withClassicFullStackCustomImage(testValidOneAgentCustomImageNameWithoutVersion).withClassicFullStackImageVersion(testVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -95,7 +87,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Cloud Native OneAgent custom image with version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withCloudNativeFullStackCustomImage(testValidOneAgentCustomImageNameWithVersion).build(),
 		}
 
@@ -105,7 +96,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Cloud Native OneAgent custom image without version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withCloudNativeFullStackCustomImage(testValidOneAgentCustomImageNameWithoutVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -114,7 +104,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Cloud Native OneAgent regular image with version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withCloudNativeFullStackImageVersion(testVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -123,7 +112,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Classic Full Stack OneAgent custom image and Version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withCloudNativeFullStackCustomImage(testValidOneAgentCustomImageNameWithoutVersion).withCloudNativeFullStackImageVersion(testVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -133,7 +121,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Host Monitoring OneAgent custom image with version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withHostMonitoringCustomImage(testValidOneAgentImageNameWithVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -142,7 +129,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Host Monitoring OneAgent custom image without version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withHostMonitoringCustomImage(testValidOneAgentImageNameWithoutVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -151,7 +137,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("Host Monitoring OneAgent regular image with version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withHostMonitoringImageVersion(testVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -160,7 +145,6 @@ func TestImagePullableOneAgentEndpoint(t *testing.T) {
 	t.Run("HostMonitoring OneAgent custom image and Version", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withHostMonitoringCustomImage(testValidOneAgentCustomImageNameWithoutVersion).withHostMonitoringImageVersion(testVersion).build(),
 		}
 		endpoint := getOneAgentImageEndpoint(&troubleshootCtx)
@@ -172,7 +156,6 @@ func TestImagePullableOneAgentCodeModulesEndpoint(t *testing.T) {
 	t.Run("CloudNative codeModules image", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).withCloudNativeCodeModulesImage(testValidOneAgentCodeModulesImageName).build(),
 		}
 		endpoint := getOneAgentCodeModulesImageEndpoint(&troubleshootCtx)
@@ -181,7 +164,6 @@ func TestImagePullableOneAgentCodeModulesEndpoint(t *testing.T) {
 	t.Run("ApplicationMonitoring codeModules image", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube: *testNewDynakubeBuilder(testNamespace, testDynakube).
 				withApiUrl(testApiUrl).
 				withApplicationMonitoringCodeModulesImage(testValidOneAgentCodeModulesImageName).
@@ -194,7 +176,6 @@ func TestImagePullableOneAgentCodeModulesEndpoint(t *testing.T) {
 	t.Run("No codeModules image", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).build(),
 		}
 		endpoint := getOneAgentCodeModulesImageEndpoint(&troubleshootCtx)

--- a/src/cmd/troubleshoot/image.go
+++ b/src/cmd/troubleshoot/image.go
@@ -27,7 +27,7 @@ type Auths struct {
 }
 
 func checkImagePullable(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[imagepull ] ", true)
+	log = newTroubleshootLogger("imagepull", true)
 
 	if troubleshootCtx.dynakube.NeedsOneAgent() {
 		err := checkOneAgentImagePullable(troubleshootCtx)

--- a/src/cmd/troubleshoot/image.go
+++ b/src/cmd/troubleshoot/image.go
@@ -27,7 +27,7 @@ type Auths struct {
 }
 
 func checkImagePullable(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("imagepull", true)
+	log = newSubTestLogger("imagepull")
 
 	if troubleshootCtx.dynakube.NeedsOneAgent() {
 		err := checkOneAgentImagePullable(troubleshootCtx)

--- a/src/cmd/troubleshoot/image.go
+++ b/src/cmd/troubleshoot/image.go
@@ -27,7 +27,7 @@ type Auths struct {
 }
 
 func checkImagePullable(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[imagepull ] ")
+	log = newTroubleshootLogger("[imagepull ] ", true)
 
 	if troubleshootCtx.dynakube.NeedsOneAgent() {
 		err := checkOneAgentImagePullable(troubleshootCtx)

--- a/src/cmd/troubleshoot/image_test.go
+++ b/src/cmd/troubleshoot/image_test.go
@@ -65,7 +65,6 @@ func TestOneAgentImagePullable(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			httpClient:    dockerServer.Client(),
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(dockerServer.URL + "/api").build(),
 			pullSecret:    *testNewSecretBuilder(testNamespace, testDynakube+pullSecretSuffix).dataAppend(dtpullsecret.DockerConfigJson, string(authsBytes)).build(),
 		}
@@ -106,7 +105,6 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 	troubleshootCtx := troubleshootContext{
 		httpClient:    dockerServer.Client(),
 		namespaceName: testNamespace,
-		dynakubeName:  testDynakube,
 		pullSecret:    *testNewSecretBuilder(testNamespace, testDynakube+pullSecretSuffix).dataAppend(dtpullsecret.DockerConfigJson, string(authsBytes)).build(),
 	}
 
@@ -200,7 +198,6 @@ func TestActiveGateImagePullable(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			httpClient:    dockerServer.Client(),
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			dynakube:      *testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(dockerServer.URL + "/api").build(),
 			pullSecret:    *testNewSecretBuilder(testNamespace, testDynakube+pullSecretSuffix).dataAppend(dtpullsecret.DockerConfigJson, string(authsBytes)).build(),
 		}
@@ -274,7 +271,6 @@ func TestImagePullablePullSecret(t *testing.T) {
 	t.Run("valid pull secret", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			pullSecret:    *testNewSecretBuilder(testNamespace, testDynakube+pullSecretSuffix).dataAppend(dtpullsecret.DockerConfigJson, pullSecretFieldValue).build(),
 		}
 		secret, err := getPullSecret(&troubleshootCtx)
@@ -284,7 +280,6 @@ func TestImagePullablePullSecret(t *testing.T) {
 	t.Run("invalid pull secret", func(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			pullSecret:    *testNewSecretBuilder(testNamespace, testDynakube+pullSecretSuffix).dataAppend("invalidToken", pullSecretFieldValue).build(),
 		}
 		secret, err := getPullSecret(&troubleshootCtx)

--- a/src/cmd/troubleshoot/logger.go
+++ b/src/cmd/troubleshoot/logger.go
@@ -42,6 +42,8 @@ func newTroubleshootLogger(testName string, subTest bool) logr.Logger {
 	config.NameKey = "name"
 	config.EncodeTime = zapcore.ISO8601TimeEncoder
 
+	testName = fmt.Sprintf("[%-10s] ", testName)
+
 	return logr.New(
 		troubleshootLogger{
 			logger:  ctrlzap.New(ctrlzap.WriteTo(os.Stdout), ctrlzap.Encoder(zapcore.NewConsoleEncoder(config))).WithName(testName),

--- a/src/cmd/troubleshoot/namespace.go
+++ b/src/cmd/troubleshoot/namespace.go
@@ -6,7 +6,7 @@ import (
 )
 
 func checkNamespace(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[namespace ] ")
+	log = newTroubleshootLogger("[namespace ] ", false)
 
 	logNewTestf("checking if namespace '%s' exists ...", troubleshootCtx.namespaceName)
 

--- a/src/cmd/troubleshoot/namespace.go
+++ b/src/cmd/troubleshoot/namespace.go
@@ -6,7 +6,7 @@ import (
 )
 
 func checkNamespace(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[namespace ] ", false)
+	log = newTroubleshootLogger("namespace", false)
 
 	logNewTestf("checking if namespace '%s' exists ...", troubleshootCtx.namespaceName)
 

--- a/src/cmd/troubleshoot/namespace.go
+++ b/src/cmd/troubleshoot/namespace.go
@@ -6,7 +6,7 @@ import (
 )
 
 func checkNamespace(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("namespace", false)
+	log = newTroubleshootLogger("namespace")
 
 	logNewTestf("checking if namespace '%s' exists ...", troubleshootCtx.namespaceName)
 

--- a/src/cmd/troubleshoot/namespace.go
+++ b/src/cmd/troubleshoot/namespace.go
@@ -1,22 +1,58 @@
 package troubleshoot
 
 import (
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func checkNamespace(troubleshootCtx *troubleshootContext) error {
 	log = newTroubleshootLogger("namespace")
 
-	logNewTestf("checking if namespace '%s' exists ...", troubleshootCtx.namespaceName)
+	logNewTestf("checking namespace '%s'", troubleshootCtx.namespaceName)
 
-	var namespace corev1.Namespace
-	err := troubleshootCtx.apiReader.Get(troubleshootCtx.context, client.ObjectKey{Name: troubleshootCtx.namespaceName}, &namespace)
+	tests := []troubleshootFunc{
+		checkNamespaceExists,
+		checkDynakubeCrdExists,
+	}
 
-	if err != nil {
-		return errorWithMessagef(err, "missing namespace '%s'", troubleshootCtx.namespaceName)
+	for _, test := range tests {
+		err := test(troubleshootCtx)
+
+		if err != nil {
+			logErrorf(err.Error())
+			return errors.Wrapf(err, "check for namespace %s failed", troubleshootCtx.namespaceName)
+		}
 	}
 
 	logOkf("using namespace '%s'", troubleshootCtx.namespaceName)
+	return nil
+}
+
+func checkNamespaceExists(troubleshootCtx *troubleshootContext) error {
+	namespace := &corev1.Namespace{}
+	err := troubleshootCtx.apiReader.Get(troubleshootCtx.context, client.ObjectKey{Name: troubleshootCtx.namespaceName}, namespace)
+
+	if err != nil {
+		return errorWithMessagef(err, "namespace '%s' missing", troubleshootCtx.namespaceName)
+	}
+
+	logInfof("namespace '%s' exists", troubleshootCtx.namespaceName)
+	return nil
+}
+
+func checkDynakubeCrdExists(troubleshootCtx *troubleshootContext) error {
+	dynakubeList := &dynatracev1beta1.DynaKubeList{}
+	err := troubleshootCtx.apiReader.List(troubleshootCtx.context, dynakubeList, &client.ListOptions{Namespace: troubleshootCtx.namespaceName})
+
+	if runtime.IsNotRegisteredError(err) {
+		return errorWithMessagef(err, "CRD for Dynakube missing")
+	} else if err != nil {
+		return errorWithMessagef(err, "could not list Dynakube")
+	}
+
+	logInfof("CRD for Dynakube exists")
 	return nil
 }

--- a/src/cmd/troubleshoot/namespace_test.go
+++ b/src/cmd/troubleshoot/namespace_test.go
@@ -30,7 +30,7 @@ func TestTroubleshootNamespace(t *testing.T) {
 			}).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 		assert.NoErrorf(t, checkNamespace(&troubleshootCtx), "'%s' namespace not found", troubleshootCtx.namespaceName)
 	})
 	t.Run("namespace does not exist in cluster", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestTroubleshootNamespace(t *testing.T) {
 			}).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 		assert.Errorf(t, checkNamespace(&troubleshootCtx), "'%s' namespace found", troubleshootCtx.namespaceName)
 	})
 	t.Run("invalid namespace selected", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestTroubleshootNamespace(t *testing.T) {
 			}).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testOtherNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testOtherNamespace}
 		assert.Errorf(t, checkNamespace(&troubleshootCtx), "'%s' namespace found", troubleshootCtx.namespaceName)
 	})
 }

--- a/src/kubeobjects/dynakube.go
+++ b/src/kubeobjects/dynakube.go
@@ -30,6 +30,13 @@ func (query DynakubeQuery) Get(objectKey client.ObjectKey) (dynatracev1beta1.Dyn
 	return dynakube, errors.WithStack(err)
 }
 
+func (query DynakubeQuery) List() (dynatracev1beta1.DynaKubeList, error) {
+	var dynakubes dynatracev1beta1.DynaKubeList
+	err := query.kubeReader.List(query.context(), &dynakubes, client.InNamespace(query.namespace))
+
+	return dynakubes, errors.WithStack(err)
+}
+
 func (query DynakubeQuery) WithContext(ctx context.Context) DynakubeQuery {
 	query.ctx = ctx
 


### PR DESCRIPTION
# Description

The troubleshoot command only checks one dynakube of which it assumes the name if no name is specified.
The new default will be that all dynakubes will be checked. 

Additional, shorthands for the troubleshoot parameters were introduced.

## How can this be tested?

Run troubleshoot subcommand without specifying a dynakube. 

## Checklist
- [x] Unit tests have been updated/added
- [ ] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

