### PR TITLE
Replaces `::set-output` by using output env var

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -18,7 +18,7 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
     - name: Set up Golang
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
+      uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
       with:
         go-version-file: "${{ github.workspace }}/go.mod"
     - name: Prepare build parameters
@@ -27,7 +27,7 @@ runs:
       run: |
         hack/build/ci/prepare-build-variables.sh
     - name: Setup cache
-      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
+      uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
       with:
         path: |
           ~/go/pkg/mod
@@ -39,7 +39,7 @@ runs:
       run: |
         hack/build/ci/download-go-build-deps.sh
     - name: Build target
-      uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94 # v3.1.1
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
       with:
         builder: ${{ steps.buildx.outputs.name }}
         build-args: |

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -16,7 +16,7 @@ runs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # v2.0.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # v2.0.0
+      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
     - name: Set up Golang
       uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
       with:

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # v2.0.0
+      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
     - name: Set up Golang

--- a/.github/actions/upload-image/action.yaml
+++ b/.github/actions/upload-image/action.yaml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Download artifact
-      uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
+      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
       with:
         name: operator-${{ inputs.platform }}
         path: /tmp

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,63 @@ updates:
     include: "scope"
   labels:
     - "dependencies"
+
+- package-ecosystem: "github-actions"
+  directory: "/.github/actions/build-image"
+  schedule:
+    interval: "weekly"
+    day: "friday"
+    time: "03:00"
+  commit-message:
+    prefix: "Actions"
+    include: "scope"
+  labels:
+    - "dependencies"
+
+- package-ecosystem: "github-actions"
+  directory: "/.github/actions/create-manifests"
+  schedule:
+    interval: "weekly"
+    day: "friday"
+    time: "03:00"
+  commit-message:
+    prefix: "Actions"
+    include: "scope"
+  labels:
+    - "dependencies"
+
+- package-ecosystem: "github-actions"
+  directory: "/.github/actions/preflight"
+  schedule:
+    interval: "weekly"
+    day: "friday"
+    time: "03:00"
+  commit-message:
+    prefix: "Actions"
+    include: "scope"
+  labels:
+    - "dependencies"
+
+- package-ecosystem: "github-actions"
+  directory: "/.github/actions/sign-image"
+  schedule:
+    interval: "weekly"
+    day: "friday"
+    time: "03:00"
+  commit-message:
+    prefix: "Actions"
+    include: "scope"
+  labels:
+    - "dependencies"
+
+- package-ecosystem: "github-actions"
+  directory: "/.github/actions/upload-image"
+  schedule:
+    interval: "weekly"
+    day: "friday"
+    time: "03:00"
+  commit-message:
+    prefix: "Actions"
+    include: "scope"
+  labels:
+    - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,10 @@ updates:
   labels:
     - "dependencies"
 
+# Running through subdirectories is not yet possible with dependabot
+# An open issue can be found here: https://github.com/dependabot/dependabot-core/issues/5137
+# If this issue has been closed, the items below must be edited accordingly
+# Issue is still open as of 2022-11-10, check again after 2023-03-01
 - package-ecosystem: "github-actions"
   directory: "/.github/actions/build-image"
   schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,8 +111,8 @@ jobs:
           # Reason: global envs do not work in workflow calls
           # More info: https://github.com/actions/runner/issues/480#issuecomment-1021278915
 
-          echo ::set-output name=registry::${{ env.DOCKER_REGISTRY }}
-          echo ::set-output name=repository::${{ env.DOCKER_REPOSITORY }}
+          echo "registry=${{ env.DOCKER_REGISTRY }}" >> "$GITHUB_OUTPUT"
+          echo "repository=${{ env.DOCKER_REPOSITORY }}" >> "$GITHUB_OUTPUT"
     outputs:
       labels: ${{ steps.meta.outputs.labels }}
       version: ${{ steps.prep.outputs.docker_image_tag }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Set up Helm
         uses: azure/setup-helm@f382f75448129b3be48f8121b9857be18d815a82 # v3.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download dependencies
         id: helm-unittest-download
         run: |
@@ -42,6 +44,8 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Set up Helm
         uses: azure/setup-helm@f382f75448129b3be48f8121b9857be18d815a82 # v3.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Linting
         id: helm-linting
         run: |

--- a/hack/build/ci/prepare-build-variables.sh
+++ b/hack/build/ci/prepare-build-variables.sh
@@ -22,15 +22,15 @@ createDockerImageLabels() {
   echo "build-date=$(date --iso-8601)"
 }
 
-setBuildRelatedVariables() {
-  echo ::set-output name=go_linker_args::"${go_linker_args}"
-  echo ::set-output name=docker_image_labels::"${docker_image_labels}"
-  echo ::set-output name=docker_image_tag::"${docker_image_tag}"
+printBuildRelatedVariables() {
+  echo "go_linker_args=${go_linker_args}"
+  echo "docker_image_labels=${docker_image_labels}"
+  echo "docker_image_tag=${docker_image_tag}"
 }
 
 # prepare variables
 docker_image_tag=$(createDockerImageTag)
 docker_image_labels=$(createDockerImageLabels)
 go_linker_args=$(hack/build/create_go_linker_args.sh "${docker_image_tag}" "${GITHUB_SHA}")
-setBuildRelatedVariables
+printBuildRelatedVariables >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
# Description

GitHub Actions deprecated the use of `echo ::set-output`.
These changes are made according to their migration guide here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## How can this be tested?

* This PR is used to test the actions' workflow

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

