### PR TITLE
Set --set-infra-only=true flag in hostMonitoring mode

### DIFF
--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -38,6 +38,8 @@ const (
 
 	inframonHostIdSource = "--set-host-id-source=k8s-node-name"
 	classicHostIdSource  = "--set-host-id-source=auto"
+
+	inframonInfraOnly = "--set-infra-only=true"
 )
 
 type HostMonitoring struct {
@@ -102,6 +104,7 @@ func (dsInfo *HostMonitoring) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 
 	if len(result.Spec.Template.Spec.Containers) > 0 {
 		appendHostIdArgument(result, inframonHostIdSource)
+		appendHostIdArgument(result, inframonInfraOnly)
 		dsInfo.appendInfraMonEnvVars(result)
 	}
 


### PR DESCRIPTION
For me it sounds that there is some misunderstanding what is really need needed to fix #1289. Especially based on comment https://github.com/Dynatrace/dynatrace-operator/pull/1304#issuecomment-1309906205 There is no anything which needs decission but this operator need set OneAgent parameters like it is documented. Same way like it is done when deploying OneAgent without this operator to standalone Docker nodes, etc. So I decided to create pull request about.

# Description
Set `--set-infra-only=true` flag in hostMonitoring mode to correctly consume host units like they are explained in "Infrastructure" column in this table https://www.dynatrace.com/support/help/monitoring-consumption/application-and-infrastructure-monitoring#host-units

Fixes: #1289


## How can this be tested?
After this change it is visible in Dynatrace portal that host "Monitoring mode" is **Infrastructure only** instead of **Full stack**
![image](https://user-images.githubusercontent.com/6213926/201069296-24afb83a-c34a-407f-aac4-684f547e70dc.png)



## Checklist
- [ ] Unit tests have been updated/added
- [ ] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

