### PR TITLE
Removes https proxy in samples

### DIFF
--- a/assets/samples/applicationMonitoring.yaml
+++ b/assets/samples/applicationMonitoring.yaml
@@ -27,7 +27,7 @@ spec:
   # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
   #
   # proxy:
-  #   value: https://my-proxy-url.com
+  #   value: http://my-proxy-url.com
   #   valueFrom: name-of-my-proxy-secret
 
   # Optional: Adds custom RootCAs from a configmap

--- a/assets/samples/applicationMonitoring.yaml
+++ b/assets/samples/applicationMonitoring.yaml
@@ -27,7 +27,7 @@ spec:
   # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
   #
   # proxy:
-  #   value: http://my-proxy-url.com
+  #   value: my-proxy-url.com
   #   valueFrom: name-of-my-proxy-secret
 
   # Optional: Adds custom RootCAs from a configmap

--- a/assets/samples/classicFullStack.yaml
+++ b/assets/samples/classicFullStack.yaml
@@ -29,7 +29,7 @@ spec:
   # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
   #
   # proxy:
-  #   value: https://my-proxy-url.com
+  #   value: http://my-proxy-url.com
   #   valueFrom: name-of-my-proxy-secret
 
   # Optional: Adds custom RootCAs from a configmap

--- a/assets/samples/classicFullStack.yaml
+++ b/assets/samples/classicFullStack.yaml
@@ -29,7 +29,7 @@ spec:
   # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
   #
   # proxy:
-  #   value: http://my-proxy-url.com
+  #   value: my-proxy-url.com
   #   valueFrom: name-of-my-proxy-secret
 
   # Optional: Adds custom RootCAs from a configmap

--- a/assets/samples/cloudNativeFullStack.yaml
+++ b/assets/samples/cloudNativeFullStack.yaml
@@ -30,7 +30,7 @@ spec:
   # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
   #
   # proxy:
-  #   value: http://my-proxy-url.com
+  #   value: my-proxy-url.com
   #   valueFrom: name-of-my-proxy-secret
 
   # Optional: Adds custom RootCAs from a configmap

--- a/assets/samples/cloudNativeFullStack.yaml
+++ b/assets/samples/cloudNativeFullStack.yaml
@@ -30,7 +30,7 @@ spec:
   # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
   #
   # proxy:
-  #   value: https://my-proxy-url.com
+  #   value: http://my-proxy-url.com
   #   valueFrom: name-of-my-proxy-secret
 
   # Optional: Adds custom RootCAs from a configmap

--- a/assets/samples/hostMonitoring.yaml
+++ b/assets/samples/hostMonitoring.yaml
@@ -25,7 +25,7 @@ spec:
   # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
   #
   # proxy:
-  #   value: https://my-proxy-url.com
+  #   value: http://my-proxy-url.com
   #   valueFrom: name-of-my-proxy-secret
 
   # Optional: Adds custom RootCAs from a configmap

--- a/assets/samples/hostMonitoring.yaml
+++ b/assets/samples/hostMonitoring.yaml
@@ -25,7 +25,7 @@ spec:
   # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
   #
   # proxy:
-  #   value: http://my-proxy-url.com
+  #   value: my-proxy-url.com
   #   valueFrom: name-of-my-proxy-secret
 
   # Optional: Adds custom RootCAs from a configmap


### PR DESCRIPTION
# Description

Having the https in the proxy examples is probably a mistake and confusing, as 
HTTPS proxies are rare and not widely supported and don't really make sense for a kubernetes environment.

## How can this be tested?
Read 🙃 

## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

