### PR TITLE
Fixes statsd ports not being exposed correctly if only statsd is enabled

### DIFF
--- a/src/api/v1beta1/properties.go
+++ b/src/api/v1beta1/properties.go
@@ -147,6 +147,10 @@ func (dk *DynaKube) NeedsActiveGateServicePorts() bool {
 		dk.IsMetricsIngestActiveGateEnabled()
 }
 
+func (dk *DynaKube) NeedsActiveGateService() bool {
+	return dk.NeedsActiveGateServicePorts() || dk.IsStatsdActiveGateEnabled()
+}
+
 func (dk *DynaKube) IsStatsdActiveGateEnabled() bool {
 	return dk.IsActiveGateMode(StatsdIngestCapability.DisplayName)
 }

--- a/src/controllers/dynakube/activegate/internal/capability/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/capability/reconciler.go
@@ -44,7 +44,7 @@ func (r *Reconciler) Reconcile() error {
 		return errors.WithStack(err)
 	}
 
-	if r.dynakube.NeedsActiveGateServicePorts() {
+	if r.dynakube.NeedsActiveGateServicePorts() || r.dynakube.IsStatsdActiveGateEnabled() {
 		err = r.createOrUpdateService()
 		if err != nil {
 			return errors.WithStack(err)

--- a/src/controllers/dynakube/activegate/internal/capability/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/capability/reconciler.go
@@ -44,7 +44,7 @@ func (r *Reconciler) Reconcile() error {
 		return errors.WithStack(err)
 	}
 
-	if r.dynakube.NeedsActiveGateServicePorts() || r.dynakube.IsStatsdActiveGateEnabled() {
+	if r.dynakube.NeedsActiveGateService() {
 		err = r.createOrUpdateService()
 		if err != nil {
 			return errors.WithStack(err)

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd.go
@@ -61,7 +61,7 @@ func (statsd StatsdModifier) Modify(sts *appsv1.StatefulSet) {
 
 }
 
-func (statsd *StatsdModifier) getActiveGateVolumeMounts(presentMounts []corev1.VolumeMount) []corev1.VolumeMount {
+func (statsd StatsdModifier) getActiveGateVolumeMounts(presentMounts []corev1.VolumeMount) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{{Name: dataSourceStatsdLogs, MountPath: extensionsLogsDir + "/statsd", ReadOnly: true}}
 	neededMount := corev1.VolumeMount{
 		ReadOnly:  false,
@@ -167,13 +167,8 @@ func (statsd StatsdModifier) buildCommand() []string {
 
 func (statsd StatsdModifier) buildPorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
-		{Name: consts.StatsdIngestTargetPort, ContainerPort: consts.StatsdIngestPort},
+		{Name: consts.StatsdIngestTargetPort, ContainerPort: consts.StatsdIngestPort, Protocol: corev1.ProtocolUDP},
 		{Name: statsdProbesPortName, ContainerPort: statsdProbesPort},
-		{
-			Name:          consts.StatsdIngestTargetPort,
-			ContainerPort: consts.StatsdIngestPort,
-			Protocol:      corev1.ProtocolUDP,
-		},
 	}
 }
 

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd.go
@@ -128,15 +128,7 @@ func (statsd StatsdModifier) buildContainer() corev1.Container {
 		SecurityContext: statsd.buildSecurityContext(),
 		Resources:       statsd.buildResourceRequirements(),
 	}
-	if statsd.dynakube.NeedsActiveGateServicePorts() {
-		container.Ports = []corev1.ContainerPort{
-			{
-				Name:          consts.StatsdIngestTargetPort,
-				ContainerPort: consts.StatsdIngestPort,
-				Protocol:      corev1.ProtocolUDP,
-			},
-		}
-	}
+
 	return container
 }
 
@@ -177,6 +169,11 @@ func (statsd StatsdModifier) buildPorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
 		{Name: consts.StatsdIngestTargetPort, ContainerPort: consts.StatsdIngestPort},
 		{Name: statsdProbesPortName, ContainerPort: statsdProbesPort},
+		{
+			Name:          consts.StatsdIngestTargetPort,
+			ContainerPort: consts.StatsdIngestPort,
+			Protocol:      corev1.ProtocolUDP,
+		},
 	}
 }
 

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd_test.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd_test.go
@@ -1,6 +1,7 @@
 package modifiers
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
@@ -16,37 +17,19 @@ func TestStatsd_BuildContainerAndVolumes(t *testing.T) {
 	assertion := assert.New(t)
 	requirement := require.New(t)
 
-	t.Run("happy path", func(t *testing.T) {
+	t.Run("modifier creates correct container", func(t *testing.T) {
 		dynakube := getBaseDynakube()
 		statsd := NewStatsdModifier(dynakube, capability.NewMultiCapability(&dynakube))
 		container := statsd.buildContainer()
 
-		assertion.NotEmpty(container.ReadinessProbe, "Expected readiness probe is defined")
-		assertion.Equal("/readyz", container.ReadinessProbe.HTTPGet.Path, "Expected there is a readiness probe at /readyz")
-		assertion.NotEmpty(container.LivenessProbe, "Expected liveness probe is defined")
-		assertion.Equal("/livez", container.LivenessProbe.HTTPGet.Path, "Expected there is a liveness probe at /livez")
-		assertion.Empty(container.StartupProbe, "Expected there is no startup probe")
+		assertIsContainerCorrect(assertion, container)
 
-		for _, port := range []int32{
-			consts.StatsdIngestPort, statsdProbesPort,
-		} {
-			assertion.Truef(kubeobjects.PortIsIn(container.Ports, port), "Expected that StatsD container defines port %d", port)
-		}
+		dynakube.Spec.ActiveGate.Capabilities = append(dynakube.Spec.ActiveGate.Capabilities,
+			dynatracev1beta1.RoutingCapability.DisplayName)
+		statsd = NewStatsdModifier(dynakube, capability.NewMultiCapability(&dynakube))
+		container = statsd.buildContainer()
 
-		for _, mountPath := range []string{
-			dataSourceStartupArgsMountPoint,
-			dataSourceAuthTokenMountPoint,
-			dataSourceMetadataMountPoint,
-			statsdLogsDir,
-		} {
-			assertion.Truef(kubeobjects.MountPathIsIn(container.VolumeMounts, mountPath), "Expected that StatsD container defines mount point %s", mountPath)
-		}
-
-		for _, envVar := range []string{
-			envStatsdStartupArgsPath, envDataSourceProbeServerPort, envStatsdMetadata, envDataSourceLogFile,
-		} {
-			assertion.Truef(kubeobjects.EnvVarIsIn(container.Env, envVar), "Expected that StatsD container defined environment variable %s", envVar)
-		}
+		assertIsContainerCorrect(assertion, container)
 	})
 
 	t.Run("hardened container security context", func(t *testing.T) {
@@ -78,4 +61,44 @@ func TestStatsd_BuildContainerAndVolumes(t *testing.T) {
 		assert.True(t, container.Resources.Requests.Cpu().IsZero())
 		assert.Equal(t, resource.NewScaledQuantity(500, resource.Mega).String(), container.Resources.Requests.Memory().String())
 	})
+}
+
+func assertIsContainerCorrect(assertion *assert.Assertions, container corev1.Container) {
+	assertion.NotEmpty(container.ReadinessProbe, "Expected readiness probe is defined")
+	assertion.Equal("/readyz", container.ReadinessProbe.HTTPGet.Path, "Expected there is a readiness probe at /readyz")
+	assertion.NotEmpty(container.LivenessProbe, "Expected liveness probe is defined")
+	assertion.Equal("/livez", container.LivenessProbe.HTTPGet.Path, "Expected there is a liveness probe at /livez")
+	assertion.Empty(container.StartupProbe, "Expected there is no startup probe")
+
+	expectedPorts := []int32{
+		consts.StatsdIngestPort,
+		statsdProbesPort,
+	}
+	expectedMountPaths := []string{
+		dataSourceStartupArgsMountPoint,
+		dataSourceAuthTokenMountPoint,
+		dataSourceMetadataMountPoint,
+		statsdLogsDir,
+	}
+	expectedEnvVars := []string{
+		envStatsdStartupArgsPath,
+		envDataSourceProbeServerPort,
+		envStatsdMetadata,
+		envDataSourceLogFile,
+	}
+
+	for _, expectedPort := range expectedPorts {
+		assertion.Truef(kubeobjects.PortIsIn(container.Ports, expectedPort),
+			"Expected that StatsD container defines port %d", expectedPort)
+	}
+
+	for _, expectedMountPath := range expectedMountPaths {
+		assertion.Truef(kubeobjects.MountPathIsIn(container.VolumeMounts, expectedMountPath),
+			"Expected that StatsD container defines mount point %s", expectedMountPath)
+	}
+
+	for _, expectedEnvVar := range expectedEnvVars {
+		assertion.Truef(kubeobjects.EnvVarIsIn(container.Env, expectedEnvVar),
+			"Expected that StatsD container defined environment variable %s", expectedEnvVar)
+	}
 }

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd_test.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/statsd_test.go
@@ -1,7 +1,6 @@
 package modifiers
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
@@ -10,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 

--- a/src/controllers/dynakube/activegate/reconciler.go
+++ b/src/controllers/dynakube/activegate/reconciler.go
@@ -106,7 +106,7 @@ func (r *Reconciler) deleteCapability(agCapability capability.Capability) error 
 }
 
 func (r *Reconciler) deleteService(agCapability capability.Capability) error {
-	if r.dynakube.NeedsActiveGateServicePorts() {
+	if r.dynakube.NeedsActiveGateServicePorts() || r.dynakube.IsStatsdActiveGateEnabled() {
 		return nil
 	}
 

--- a/src/controllers/dynakube/activegate/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/reconciler_test.go
@@ -103,5 +103,4 @@ func TestReconciler_Reconcile(t *testing.T) {
 		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
 		assert.True(t, errors.IsNotFound(err))
 	})
-
 }

--- a/src/controllers/dynakube/activegate/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/reconciler_test.go
@@ -74,7 +74,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				ActiveGate: dynatracev1beta1.ActiveGateSpec{
-					Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.RoutingCapability.DisplayName},
+					Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.StatsdIngestCapability.DisplayName},
 				},
 			},
 		}
@@ -83,7 +83,16 @@ func TestReconciler_Reconcile(t *testing.T) {
 		err := r.Reconcile()
 		require.NoError(t, err)
 
+		// assert that service is created if statsd is enabled
 		var service corev1.Service
+		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
+		require.NoError(t, err)
+
+		// assert that service is created if other capabilities are enabled
+		instance.Spec.ActiveGate.Capabilities = []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.RoutingCapability.DisplayName}
+
+		err = r.Reconcile()
+		require.NoError(t, err)
 		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
 		require.NoError(t, err)
 
@@ -94,4 +103,5 @@ func TestReconciler_Reconcile(t *testing.T) {
 		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
 		assert.True(t, errors.IsNotFound(err))
 	})
+
 }

--- a/src/controllers/dynakube/activegate/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -74,7 +76,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				ActiveGate: dynatracev1beta1.ActiveGateSpec{
-					Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.StatsdIngestCapability.DisplayName},
+					Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.RoutingCapability.DisplayName},
 				},
 			},
 		}
@@ -83,16 +85,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		err := r.Reconcile()
 		require.NoError(t, err)
 
-		// assert that service is created if statsd is enabled
 		var service corev1.Service
-		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
-		require.NoError(t, err)
-
-		// assert that service is created if other capabilities are enabled
-		instance.Spec.ActiveGate.Capabilities = []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.RoutingCapability.DisplayName}
-
-		err = r.Reconcile()
-		require.NoError(t, err)
 		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
 		require.NoError(t, err)
 
@@ -100,7 +93,99 @@ func TestReconciler_Reconcile(t *testing.T) {
 		instance.Spec.ActiveGate = dynatracev1beta1.ActiveGateSpec{}
 		err = r.Reconcile()
 		require.NoError(t, err)
+
 		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
 		assert.True(t, errors.IsNotFound(err))
 	})
+}
+
+func TestServiceCreation(t *testing.T) {
+	dynatraceClient := &dtclient.MockDynatraceClient{}
+	dynatraceClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+	dynakube := &dynatracev1beta1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testName,
+		},
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			ActiveGate: dynatracev1beta1.ActiveGateSpec{},
+		},
+	}
+	t.Run("service exposes correct ports for single capabilities", func(t *testing.T) {
+		fakeClient := fake.NewClient(testKubeSystemNamespace)
+		reconciler := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dynatraceClient)
+
+		expectedCapabilityPorts := map[dynatracev1beta1.CapabilityDisplayName][]string{
+			dynatracev1beta1.RoutingCapability.DisplayName: {
+				consts.HttpsServicePortName,
+				consts.HttpServicePortName,
+			},
+			dynatracev1beta1.MetricsIngestCapability.DisplayName: {
+				consts.HttpsServicePortName,
+				consts.HttpServicePortName,
+			},
+			dynatracev1beta1.DynatraceApiCapability.DisplayName: {
+				consts.HttpsServicePortName,
+				consts.HttpServicePortName,
+			},
+			dynatracev1beta1.StatsdIngestCapability.DisplayName: {
+				consts.StatsdIngestPortName,
+			},
+			dynatracev1beta1.KubeMonCapability.DisplayName: {},
+		}
+
+		for capability, expectedPorts := range expectedCapabilityPorts {
+			dynakube.Spec.ActiveGate.Capabilities = []dynatracev1beta1.CapabilityDisplayName{
+				capability,
+			}
+
+			err := reconciler.Reconcile()
+			require.NoError(t, err)
+
+			activegateService := getTestActiveGateService(t, fakeClient)
+			assertContainsAllPorts(t, expectedPorts, activegateService.Spec.Ports)
+		}
+	})
+
+	t.Run("service exposes correct ports for multiple capabilities", func(t *testing.T) {
+		fakeClient := fake.NewClient(testKubeSystemNamespace)
+		reconciler := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dynatraceClient)
+
+		dynakube.Spec.ActiveGate.Capabilities = []dynatracev1beta1.CapabilityDisplayName{
+			dynatracev1beta1.RoutingCapability.DisplayName,
+			dynatracev1beta1.StatsdIngestCapability.DisplayName,
+		}
+		expectedPorts := []string{
+			consts.HttpsServicePortName,
+			consts.HttpServicePortName,
+			consts.StatsdIngestPortName,
+		}
+
+		err := reconciler.Reconcile()
+		require.NoError(t, err)
+
+		activegateService := getTestActiveGateService(t, fakeClient)
+		assertContainsAllPorts(t, expectedPorts, activegateService.Spec.Ports)
+	})
+}
+
+func assertContainsAllPorts(t *testing.T, expectedPorts []string, servicePorts []corev1.ServicePort) {
+	actualPorts := make([]string, 0, len(servicePorts))
+
+	for _, servicePort := range servicePorts {
+		actualPorts = append(actualPorts, servicePort.Name)
+	}
+
+	for _, expectedPort := range expectedPorts {
+		assert.Contains(t, actualPorts, expectedPort)
+	}
+}
+
+func getTestActiveGateService(t *testing.T, fakeClient client.Client) corev1.Service {
+	var activegateService corev1.Service
+	err := fakeClient.Get(context.TODO(), client.ObjectKey{Name: testServiceName, Namespace: testNamespace}, &activegateService)
+
+	require.NoError(t, err)
+
+	return activegateService
 }


### PR DESCRIPTION
# Description

The ActiveGate service used to expose ports of an ActiveGate deployment was only created if one of the following capabilities was enabled.
* routing
* kubernetes-monitoring
* dynatrace-api

This lead to no service being created if only the statsd capability was enabled and ports not being correctly exposed on the container.

## How can this be tested?

* Create a cluster and deploy the operator
* Deploy a dynakube using one of the following ActiveGate capabilities
  * routing
  * kubernetes-monitoring
  * dynatrace-api
* The created ActiveGate service should expose the ports 80 and 443
* Deploy a dynakube using the statsd capability
* The created ActiveGate service should expose the port 18125
* Deploy a dynakube with one of the previous capabiltiies in addition with the statsd capability
* The created ActiveGate service should expose all previously mentioned ports

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

