### PR TITLE
Version/bump base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM registry.access.redhat.com/ubi9-minimal:9.1.0 as dependency-src
 
 RUN  microdnf install util-linux tar --nodocs -y && microdnf clean all
 
-FROM registry.access.redhat.com/ubi9-micro:9.0.0
+FROM registry.access.redhat.com/ubi9-micro:9.1.0
 
 # operator dependencies
 COPY --from=operator-build /etc/ssl/cert.pem /etc/ssl/cert.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN if [ -d ./mod ]; then mkdir -p ${GOPATH}/pkg && [ -d mod ] && mv ./mod ${GOP
 
 RUN CGO_ENABLED=1 CGO_CFLAGS="-O2 -Wno-return-local-addr" go build -ldflags="${GO_LINKER_ARGS}" -o ./build/_output/bin/dynatrace-operator ./src/cmd/
 
-FROM registry.access.redhat.com/ubi9-minimal:9.0.0 as dependency-src
+FROM registry.access.redhat.com/ubi9-minimal:9.1.0 as dependency-src
 
 RUN  microdnf install util-linux tar --nodocs -y && microdnf clean all
 


### PR DESCRIPTION
# Description

Bumps the version of the used `ubi-minimal` and `ubi-micro` images from 9.0.0 to 9.1.0.
Cherrypicked changes from the corresponding dependabot PRs.

## How can this be tested?

* Build the image from this branch making sure no build errors occur
* Deploy the operator
* Make sure the operator does not explode

## Checklist
- [ ] Unit tests have been updated/added
  - N.A.
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

