### PR TITLE
Adds support-archive collection

### DIFF
--- a/src/cmd/csi/provisioner/builder.go
+++ b/src/cmd/csi/provisioner/builder.go
@@ -8,6 +8,7 @@ import (
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
 	csiprovisioner "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/provisioner"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -102,6 +103,7 @@ func addFlags(cmd *cobra.Command) {
 func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(0000)
+		version.LogVersion()
 
 		kubeConfig, err := builder.configProvider.GetConfig()
 		if err != nil {

--- a/src/cmd/csi/server/builder.go
+++ b/src/cmd/csi/server/builder.go
@@ -8,6 +8,7 @@ import (
 	dtcsi "github.com/Dynatrace/dynatrace-operator/src/controllers/csi"
 	csidriver "github.com/Dynatrace/dynatrace-operator/src/controllers/csi/driver"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/csi/metadata"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -108,6 +109,7 @@ func addFlags(cmd *cobra.Command) {
 func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(0000)
+		version.LogVersion()
 
 		kubeConfig, err := builder.configProvider.GetConfig()
 		if err != nil {

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -22,10 +22,10 @@ import (
 	csiServer "github.com/Dynatrace/dynatrace-operator/src/cmd/csi/server"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/operator"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/standalone"
+	"github.com/Dynatrace/dynatrace-operator/src/cmd/support_archive"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/troubleshoot"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/webhook"
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
-	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,7 +45,6 @@ func newRootCommand() *cobra.Command {
 		Use:  "dynatrace-operator",
 		RunE: rootCommand,
 	}
-
 	return cmd
 }
 
@@ -80,12 +79,15 @@ func createTroubleshootCommandBuilder() troubleshoot.CommandBuilder {
 		SetConfigProvider(cmdConfig.NewKubeConfigProvider())
 }
 
+func createSupportArchiveCommandBuilder() support_archive.CommandBuilder {
+	return support_archive.NewCommandBuilder()
+}
+
 func rootCommand(_ *cobra.Command, _ []string) error {
 	return errors.New("operator binary must be called with one of the subcommands")
 }
 
 func main() {
-	version.LogVersion()
 	ctrl.SetLogger(log)
 	cmd := newRootCommand()
 
@@ -96,6 +98,7 @@ func main() {
 		createCsiProvisionerCommandBuilder().Build(),
 		standalone.NewStandaloneCommand(),
 		createTroubleshootCommandBuilder().Build(),
+		createSupportArchiveCommandBuilder().Build(),
 	)
 
 	err := cmd.Execute()

--- a/src/cmd/operator/builder.go
+++ b/src/cmd/operator/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/certificates"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubesystem"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
@@ -112,6 +113,8 @@ func (builder CommandBuilder) setClientFromConfig(kubeCfg *rest.Config) (Command
 
 func (builder CommandBuilder) buildRun() func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		version.LogVersion()
+
 		kubeCfg, err := builder.configProvider.GetConfig()
 		if err != nil {
 			return err

--- a/src/cmd/troubleshoot/builder.go
+++ b/src/cmd/troubleshoot/builder.go
@@ -8,6 +8,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/config"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -78,6 +79,8 @@ func clusterOptions(opts *cluster.Options) {
 
 func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		version.LogVersion()
+
 		kubeConfig, err := builder.configProvider.GetConfig()
 		if err != nil {
 			return err

--- a/src/cmd/webhook/builder.go
+++ b/src/cmd/webhook/builder.go
@@ -10,6 +10,7 @@ import (
 	cmdManager "github.com/Dynatrace/dynatrace-operator/src/cmd/manager"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubesystem"
+	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/Dynatrace/dynatrace-operator/src/webhook"
 	"github.com/Dynatrace/dynatrace-operator/src/webhook/mutation/namespace_mutator"
 	"github.com/Dynatrace/dynatrace-operator/src/webhook/mutation/pod_mutator"
@@ -90,6 +91,8 @@ func addFlags(cmd *cobra.Command) {
 
 func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		version.LogVersion()
+
 		kubeConfig, err := builder.configProvider.GetConfig()
 		if err != nil {
 			return err


### PR DESCRIPTION
# Description
Adds the basic functionality for collecting support-archives from the operator components. This first part consists of
* the resp. sub command
* functionality to create the support-archive tarball
* collecting of the operator version in a text file into the support-archive

The support archive can retrieved either by
* copying it from the pod, the necessary command is printed on screen
* using the `--stdout` commandline switch to stream the tarball directly to a local file via stdout

Collection of additional items (logs, K8S objects) will be added in future PRs in the upcoming weeks.

**Note**: logging of the operator version to stdout has been duplicated and moved away from the common main so it doesn't interfere with writing the tarball to stdout.

## How can this be tested?
execute the following command:
`kubectl -n dynatrace exec pod/$(kubectl -n dynatrace get pods | grep dynatrace-operator | cut -f1 -d' ') -- /usr/local/bin/dynatrace-operator support-archive`

## Checklist
- [X] Unit tests have been updated/added
- [X] PR is labeled accordingly
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

