### PR TITLE
Adds basic openshift support for the e2e tests

### DIFF
--- a/test/activegate/activegate_test.go
+++ b/test/activegate/activegate_test.go
@@ -137,7 +137,7 @@ func install(t *testing.T, proxySpec *v1beta1.DynaKubeProxy) features.Feature {
 
 func installAndDeploy(builder *features.FeatureBuilder, secretConfig secrets.Secret) {
 	builder.Setup(secrets.ApplyDefault(secretConfig))
-	builder.Setup(operator.InstallAllForKubernetes())
+	builder.Setup(operator.InstallAll())
 }
 
 func assessDeployment(builder *features.FeatureBuilder) {

--- a/test/appmon/dataingest.go
+++ b/test/appmon/dataingest.go
@@ -51,7 +51,7 @@ func dataIngest(t *testing.T) features.Feature {
 
 	require.NoError(t, err)
 
-	dataIngestFeature.Setup(operator.InstallForKubernetes())
+	dataIngestFeature.Setup(operator.Install())
 	dataIngestFeature.Setup(operator.WaitForDeployment())
 	dataIngestFeature.Setup(webhook.WaitForDeployment())
 	dataIngestFeature.Setup(secrets.ApplyDefault(tenantSecret))

--- a/test/appmon/labelversiondetection.go
+++ b/test/appmon/labelversiondetection.go
@@ -100,7 +100,7 @@ func installOperator(t *testing.T) features.Feature {
 	defaultInstallation := features.New("default installation")
 
 	defaultInstallation.Setup(secrets.ApplyDefault(secretConfig))
-	defaultInstallation.Setup(operator.InstallForKubernetes())
+	defaultInstallation.Setup(operator.Install())
 	defaultInstallation.Assess("operator started", operator.WaitForDeployment())
 	defaultInstallation.Assess("webhook started", webhook.WaitForDeployment())
 

--- a/test/cloudnative/network_problems.go
+++ b/test/cloudnative/network_problems.go
@@ -43,7 +43,7 @@ func NetworkProblems(t *testing.T) features.Feature {
 	createNetworkProblems.Setup(manifests.InstallFromFile(csiNetworkPolicy))
 	createNetworkProblems.Setup(manifests.InstallFromFile(sampleNSPath))
 	createNetworkProblems.Setup(secrets.ApplyDefault(secretConfigs[0]))
-	createNetworkProblems.Setup(operator.InstallAllForKubernetes())
+	createNetworkProblems.Setup(operator.InstallAll())
 
 	setup.AssessDeployment(createNetworkProblems)
 

--- a/test/operator/installation.go
+++ b/test/operator/installation.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	platformEnv = "PLATFORM"
+	platformEnv       = "PLATFORM"
 	openshiftPlatform = "openshift"
 )
 

--- a/test/operator/installation.go
+++ b/test/operator/installation.go
@@ -1,10 +1,35 @@
 package operator
 
 import (
+	"os"
+
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
+
+const (
+	platformEnv = "PLATFORM"
+	openshiftPlatform = "openshift"
+)
+
+func InstallAll() features.Func {
+	platform := os.Getenv(platformEnv)
+	if platform == openshiftPlatform {
+		return InstallAllForOpenshift()
+	} else {
+		return InstallAllForKubernetes()
+	}
+}
+
+func Install() features.Func {
+	platform := os.Getenv(platformEnv)
+	if platform == openshiftPlatform {
+		return InstallForOpenshift()
+	} else {
+		return InstallForKubernetes()
+	}
+}
 
 func InstallAllForKubernetes() features.Func {
 	return manifests.InstallFromFile("../../config/deploy/kubernetes/kubernetes-all.yaml")
@@ -12,6 +37,14 @@ func InstallAllForKubernetes() features.Func {
 
 func InstallForKubernetes() features.Func {
 	return manifests.InstallFromFile("../../config/deploy/kubernetes/kubernetes.yaml")
+}
+
+func InstallAllForOpenshift() features.Func {
+	return manifests.InstallFromFile("../../config/deploy/openshift/openshift-all.yaml")
+}
+
+func InstallForOpenshift() features.Func {
+	return manifests.InstallFromFile("../../config/deploy/openshift/openshift.yaml")
 }
 
 func WaitForDeployment() features.Func {

--- a/test/setup/setup.go
+++ b/test/setup/setup.go
@@ -13,7 +13,7 @@ import (
 
 func InstallAndDeploy(builder *features.FeatureBuilder, secretConfig secrets.Secret, deploymentPath string) {
 	builder.Setup(secrets.ApplyDefault(secretConfig))
-	builder.Setup(operator.InstallAllForKubernetes())
+	builder.Setup(operator.InstallAll())
 	builder.Setup(manifests.InstallFromFile(deploymentPath))
 }
 


### PR DESCRIPTION
# Description

A quick temporary solution to run the e2e tests against Openshift clusters, by setting the `PLATFORM` envvar to `openshift`

## How can this be tested?
Run the e2e tests against a Openshift cluster, by setting the `PLATFORM` envvar


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

