### PR TITLE
Adds missing properties for data enrichment

### DIFF
--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -79,26 +79,31 @@ func (env *environment) setRequiredFields() error {
 	return nil
 }
 
-func (env *environment) getOneAgentFieldSetters() []func() error {
+func (env *environment) getCommonFieldSetters() []func() error {
 	return []func() error{
+		env.addK8PodName,
+		env.addK8PodUID,
+		env.addK8Namespace,
+	}
+}
+
+func (env *environment) getOneAgentFieldSetters() []func() error {
+	return append(env.getCommonFieldSetters(),
 		env.addMode,
 		env.addInstallerTech,
 		env.addInstallPath,
 		env.addContainers,
 		env.addK8NodeName,
-		env.addK8PodName,
-		env.addK8PodUID,
 		env.addK8BasePodName,
-		env.addK8Namespace,
-	}
+	)
 }
 
 func (env *environment) getDataIngestFieldSetters() []func() error {
-	return []func() error{
+	return append(env.getCommonFieldSetters(),
 		env.addWorkloadKind,
 		env.addWorkloadName,
 		env.addK8ClusterID,
-	}
+	)
 }
 
 func (env *environment) setOptionalFields() {

--- a/src/standalone/env_test.go
+++ b/src/standalone/env_test.go
@@ -59,10 +59,10 @@ func TestNewEnv(t *testing.T) {
 		assert.Empty(t, env.Containers)
 
 		assert.Empty(t, env.K8NodeName)
-		assert.Empty(t, env.K8PodName)
-		assert.Empty(t, env.K8PodUID)
 		assert.Empty(t, env.K8BasePodName)
-		assert.Empty(t, env.K8Namespace)
+		assert.NotEmpty(t, env.K8PodName)
+		assert.NotEmpty(t, env.K8PodUID)
+		assert.NotEmpty(t, env.K8Namespace)
 
 		assert.NotEmpty(t, env.K8ClusterID)
 		assert.NotEmpty(t, env.WorkloadKind)
@@ -175,6 +175,9 @@ func prepDataIngestTestEnv(t *testing.T, isUnknownWorkload bool) func() {
 		config.EnrichmentWorkloadKindEnv,
 		config.EnrichmentWorkloadNameEnv,
 		config.K8sClusterIDEnv,
+		config.K8sPodNameEnv,
+		config.K8sPodUIDEnv,
+		config.K8sNamespaceEnv,
 	}
 	for _, envvar := range envs {
 		if isUnknownWorkload &&
@@ -203,7 +206,7 @@ func prepDataIngestTestEnv(t *testing.T, isUnknownWorkload bool) func() {
 func resetTestEnv(envs []string) func() {
 	return func() {
 		for _, envvar := range envs {
-			os.Unsetenv(envvar)
+			_ = os.Unsetenv(envvar)
 		}
 	}
 }


### PR DESCRIPTION
# Description

Environment variables set for pod-name, -uid, and namespace name are not correctly evaluated in the standalone init.
These changes add evaluation for common environment variables to the data ingest environment and the oneagent environment.

## How can this be tested?

* Deploy the operator and a application monitoring or cloudnative dynakube
* Deploy a sample deployment with the `oneagent.dynatrace.com/inject: "false"` annotation set
* Exec into the pod and check that all fields are set in `/var/lib/dynatrace/enrichment/dt_metadata.properties`


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

