### PR TITLE
Fixes an issue where the ActiveGate's statefulset is deleted and recreated if labeled manually

### DIFF
--- a/src/controllers/dynakube/activegate/internal/statefulset/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/reconciler.go
@@ -72,7 +72,7 @@ func (r *Reconciler) manageStatefulSet() error {
 		return errors.WithStack(err)
 	}
 
-	deleted, err := r.deleteStatefulSetIfOldLabelsAreUsed(desiredSts)
+	deleted, err := r.deleteStatefulSetIfSelectorChanged(desiredSts)
 	if deleted || err != nil {
 		return errors.WithStack(err)
 	}
@@ -154,21 +154,29 @@ func (r *Reconciler) recreateStatefulSet(currentSts, desiredSts *appsv1.Stateful
 	return true, r.client.Create(context.TODO(), desiredSts)
 }
 
-func (r *Reconciler) deleteStatefulSetIfOldLabelsAreUsed(desiredSts *appsv1.StatefulSet) (bool, error) {
+// the selector, e.g. MatchLabels, of a stateful set is immutable.
+// if it changed, for example due to a new operator version, deleteStatefulSetIfSelectorChanged deletes the stateful set
+// so it can be updated correctly afterwards.
+func (r *Reconciler) deleteStatefulSetIfSelectorChanged(desiredSts *appsv1.StatefulSet) (bool, error) {
 	currentSts, err := r.getStatefulSet(desiredSts)
 	if err != nil {
 		return false, err
 	}
 
-	if !reflect.DeepEqual(currentSts.Labels, desiredSts.Labels) {
-		log.Info("deleting existing stateful set")
+	if hasSelectorChanged(desiredSts, currentSts) {
+		log.Info("deleting existing stateful set because selector changed")
 		if err = r.client.Delete(context.TODO(), desiredSts); err != nil {
 			return false, err
 		}
+
 		return true, nil
 	}
 
 	return false, nil
+}
+
+func hasSelectorChanged(desiredSts *appsv1.StatefulSet, currentSts *appsv1.StatefulSet) bool {
+	return !reflect.DeepEqual(currentSts.Spec.Selector, desiredSts.Spec.Selector)
 }
 
 func (r *Reconciler) calculateActiveGateConfigurationHash() (string, error) {

--- a/src/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
@@ -184,36 +184,65 @@ func TestReconcile_UpdateStatefulSetIfOutdated(t *testing.T) {
 }
 
 func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
-	r := createDefaultReconciler(t)
-	desiredSts, err := r.buildDesiredStatefulSet()
-	require.NoError(t, err)
-	require.NotNil(t, desiredSts)
+	t.Run("statefulset is deleted when old labels are used", func(t *testing.T) {
+		r := createDefaultReconciler(t)
+		desiredSts, err := r.buildDesiredStatefulSet()
+		require.NoError(t, err)
+		require.NotNil(t, desiredSts)
 
-	deleted, err := r.deleteStatefulSetIfOldLabelsAreUsed(desiredSts)
-	assert.Error(t, err)
-	assert.False(t, deleted)
-	assert.True(t, k8serrors.IsNotFound(errors.Cause(err)))
+		deleted, err := r.deleteStatefulSetIfSelectorChanged(desiredSts)
+		assert.Error(t, err)
+		assert.False(t, deleted)
+		assert.True(t, k8serrors.IsNotFound(errors.Cause(err)))
 
-	created, err := r.createStatefulSetIfNotExists(desiredSts)
-	require.True(t, created)
-	require.NoError(t, err)
+		created, err := r.createStatefulSetIfNotExists(desiredSts)
+		require.True(t, created)
+		require.NoError(t, err)
 
-	deleted, err = r.deleteStatefulSetIfOldLabelsAreUsed(desiredSts)
-	assert.NoError(t, err)
-	assert.False(t, deleted)
+		deleted, err = r.deleteStatefulSetIfSelectorChanged(desiredSts)
+		assert.NoError(t, err)
+		assert.False(t, deleted)
 
-	r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: testValue}
-	desiredSts, err = r.buildDesiredStatefulSet()
-	require.NoError(t, err)
-	correctLabels := desiredSts.Labels
-	desiredSts.Labels = map[string]string{"activegate": "dynakube"}
-	err = r.client.Update(context.TODO(), desiredSts)
-	assert.NoError(t, err)
+		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: testValue}
+		desiredSts, err = r.buildDesiredStatefulSet()
+		require.NoError(t, err)
 
-	desiredSts.Labels = correctLabels
-	deleted, err = r.deleteStatefulSetIfOldLabelsAreUsed(desiredSts)
-	assert.NoError(t, err)
-	assert.True(t, deleted)
+		correctLabels := desiredSts.Spec.Selector.MatchLabels
+		desiredSts.Spec.Selector.MatchLabels = map[string]string{"activegate": "dynakube"}
+		err = r.client.Update(context.TODO(), desiredSts)
+		assert.NoError(t, err)
+
+		desiredSts.Spec.Selector.MatchLabels = correctLabels
+		deleted, err = r.deleteStatefulSetIfSelectorChanged(desiredSts)
+		assert.NoError(t, err)
+		assert.True(t, deleted)
+	})
+	t.Run("statefulset is not deleted when custom labels are used", func(t *testing.T) {
+		r := createDefaultReconciler(t)
+		appliedStatefulset, err := r.buildDesiredStatefulSet()
+
+		require.NoError(t, err)
+		require.NotNil(t, appliedStatefulset)
+
+		created, err := r.createStatefulSetIfNotExists(appliedStatefulset)
+
+		require.True(t, created)
+		require.NoError(t, err)
+
+		appliedStatefulset.Labels[testName] = testValue
+		err = r.client.Update(context.TODO(), appliedStatefulset)
+
+		require.NoError(t, err)
+
+		desiredStatefulset, err := r.buildDesiredStatefulSet()
+
+		require.NoError(t, err)
+
+		deleted, err := r.deleteStatefulSetIfSelectorChanged(desiredStatefulset)
+
+		assert.NoError(t, err)
+		assert.False(t, deleted)
+	})
 }
 
 func TestReconcile_GetCustomPropertyHash(t *testing.T) {
@@ -271,4 +300,59 @@ func TestReconcile_GetActiveGateAuthTokenHash(t *testing.T) {
 	hash, err = r.calculateActiveGateConfigurationHash()
 	assert.NoError(t, err)
 	assert.Empty(t, hash)
+}
+
+func TestManageStatefulSet(t *testing.T) {
+	t.Run("do not delete statefulset if custom labels were added", func(t *testing.T) {
+		r := createDefaultReconciler(t)
+		desiredStatefulSet, err := r.buildDesiredStatefulSet()
+
+		require.NoError(t, err)
+
+		err = r.manageStatefulSet()
+		assert.NoError(t, err)
+
+		actualStatefulSet, err := r.getStatefulSet(desiredStatefulSet)
+		assert.NoError(t, err)
+		assert.NotNil(t, actualStatefulSet)
+
+		actualStatefulSet.Labels[testName] = testValue
+		err = r.client.Update(context.TODO(), actualStatefulSet)
+
+		require.NoError(t, err)
+
+		err = r.manageStatefulSet()
+		assert.NoError(t, err)
+
+		actualStatefulSet, err = r.getStatefulSet(desiredStatefulSet)
+		assert.NoError(t, err)
+		assert.NotNil(t, actualStatefulSet)
+		assert.Contains(t, actualStatefulSet.Labels, testName)
+	})
+	t.Run("delete statefulset if selector differs", func(t *testing.T) {
+		r := createDefaultReconciler(t)
+		desiredStatefulSet, err := r.buildDesiredStatefulSet()
+
+		require.NoError(t, err)
+
+		err = r.manageStatefulSet()
+		assert.NoError(t, err)
+
+		actualStatefulSet, err := r.getStatefulSet(desiredStatefulSet)
+		assert.NoError(t, err)
+		assert.NotNil(t, actualStatefulSet)
+
+		actualStatefulSet.Spec.Selector.MatchLabels["activegate"] = testValue
+		err = r.client.Update(context.TODO(), actualStatefulSet)
+
+		require.NoError(t, err)
+
+		err = r.manageStatefulSet()
+		assert.NoError(t, err)
+
+		actualStatefulSet, err = r.getStatefulSet(desiredStatefulSet)
+		assert.Error(t, err)
+		assert.Nil(t, actualStatefulSet)
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
 }


### PR DESCRIPTION
# Description

Cherrypick of https://github.com/Dynatrace/dynatrace-operator/pull/1331

## How can this be tested?

Same as https://github.com/Dynatrace/dynatrace-operator/pull/1331

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

