### PR TITLE
Combine changes of old branch with master

### DIFF
--- a/src/cmd/troubleshoot/builder.go
+++ b/src/cmd/troubleshoot/builder.go
@@ -2,23 +2,29 @@ package troubleshoot
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/config"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 )
 
 const (
-	use               = "troubleshoot"
-	dynakubeFlagName  = "dynakube"
-	namespaceFlagName = "namespace"
+	use                    = "troubleshoot"
+	dynakubeFlagName       = "dynakube"
+	dynakubeFlagShorthand  = "d"
+	namespaceFlagName      = "namespace"
+	namespaceFlagShorthand = "n"
 
 	namespaceCheckName           = "namespace"
+	crdCheckName                 = "crd"
 	dynakubeCheckName            = "dynakube"
 	dtClusterConnectionCheckName = "DynatraceClusterConnection"
 	imagePullableCheckName       = "imagePullable"
@@ -59,8 +65,8 @@ func (builder CommandBuilder) Build() *cobra.Command {
 }
 
 func addFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&dynakubeFlagValue, dynakubeFlagName, "dynakube", "Specify a different Dynakube name.")
-	cmd.PersistentFlags().StringVar(&namespaceFlagValue, namespaceFlagName, defaultNamespace(), "Specify a different Namespace.")
+	cmd.PersistentFlags().StringVarP(&dynakubeFlagValue, dynakubeFlagName, dynakubeFlagShorthand, "", "Specify a different Dynakube name.")
+	cmd.PersistentFlags().StringVarP(&namespaceFlagValue, namespaceFlagName, namespaceFlagShorthand, defaultNamespace(), "Specify a different Namespace.")
 }
 
 func defaultNamespace() string {
@@ -95,49 +101,122 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 
 		apiReader := k8scluster.GetAPIReader()
 
-		troubleshootCtx := &troubleshootContext{
+		troubleshootCtx := troubleshootContext{
 			context:       context.Background(),
 			apiReader:     apiReader,
 			httpClient:    &http.Client{},
 			namespaceName: namespaceFlagValue,
-			dynakubeName:  dynakubeFlagValue,
 		}
 
 		results := NewChecksResults()
+		_ = runChecks(results, &troubleshootCtx, getDynakubeUnrelatedChecks()) // ignore error to avoid polluting pretty logs
+		resetLogger()
 
-		_ = runChecks(results, troubleshootCtx, getChecks(results)) // ignore error to avoid polluting pretty logs
+		dynakubes, err := getDynakubes(troubleshootCtx, dynakubeFlagValue)
+		if err != nil {
+			return nil
+		}
+
+		runChecksForAllDynakubes(results, getDynakubeSpecificChecks(results, getDynakubeUnrelatedChecks()), dynakubes, apiReader)
+
 		return nil
 	}
 }
 
-func getChecks(results ChecksResults) []*Check {
+func runChecksForAllDynakubes(results ChecksResults, checks []*Check, dynakubes []dynatracev1beta1.DynaKube, apiReader client.Reader) {
+	for _, dynakube := range dynakubes {
+		results.check2Result = results.resetResults(getDynakubeUnrelatedChecks())
+		logNewDynakubef(dynakube.Name)
+
+		troubleshootCtx := troubleshootContext{
+			context:       context.Background(),
+			apiReader:     apiReader,
+			httpClient:    &http.Client{},
+			namespaceName: namespaceFlagValue,
+			dynakube:      dynakube,
+		}
+
+		_ = runChecks(results, &troubleshootCtx, getDynakubeSpecificChecks(results, checks)) // ignore error to avoid polluting pretty logs
+		resetLogger()
+		if !results.hasErrors() {
+			logOkf("'%s' - all checks passed", dynakube.Name)
+		}
+	}
+}
+
+func getDynakubeUnrelatedChecks() []*Check {
 	namespaceCheck := &Check{
 		Name: namespaceCheckName,
 		Do:   checkNamespace,
 	}
+	crdCheck := &Check{
+		Name: crdCheckName,
+		Do:   checkCRD,
+	}
+	return []*Check{namespaceCheck, crdCheck}
+}
+
+func getDynakubeSpecificChecks(results ChecksResults, globalPrerequisites []*Check) []*Check {
 	dynakubeCheck := &Check{
 		Name: dynakubeCheckName,
 		Do: func(troubleshootCtx *troubleshootContext) error {
 			return checkDynakube(results, troubleshootCtx)
 		},
-		Prerequisites: []*Check{namespaceCheck},
+		Prerequisites: globalPrerequisites,
 	}
 	dtClusterConnectionCheck := &Check{
 		Name: dtClusterConnectionCheckName,
 		Do: func(troubleshootCtx *troubleshootContext) error {
 			return checkDtClusterConnection(results, troubleshootCtx)
 		},
-		Prerequisites: []*Check{namespaceCheck, dynakubeCheck},
+		Prerequisites: append(globalPrerequisites, dynakubeCheck),
 	}
 	imagePullableCheck := &Check{
 		Name:          imagePullableCheckName,
 		Do:            verifyAllImagesAvailable,
-		Prerequisites: []*Check{namespaceCheck, dynakubeCheck},
+		Prerequisites: append(globalPrerequisites, dynakubeCheck),
 	}
 	proxySettingsCheck := &Check{
 		Name:          proxySettingsCheckName,
 		Do:            checkProxySettings,
-		Prerequisites: []*Check{namespaceCheck, dynakubeCheck},
+		Prerequisites: append(globalPrerequisites, dynakubeCheck),
 	}
-	return []*Check{namespaceCheck, dynakubeCheck, dtClusterConnectionCheck, imagePullableCheck, proxySettingsCheck}
+	return []*Check{dynakubeCheck, dtClusterConnectionCheck, imagePullableCheck, proxySettingsCheck}
+}
+
+func getDynakubes(troubleshootCtx troubleshootContext, dynakubeName string) ([]dynatracev1beta1.DynaKube, error) {
+	var err error
+	var dynakubes []dynatracev1beta1.DynaKube
+
+	if dynakubeName == "" {
+		logNewDynakubef("no Dynakube specified - checking all Dynakubes in namespace '%s'", troubleshootCtx.namespaceName)
+		dynakubes, err = getAllDynakubesInNamespace(troubleshootCtx)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		dynakube := dynatracev1beta1.DynaKube{}
+		dynakube.Name = dynakubeName
+		dynakubes = append(dynakubes, dynakube)
+	}
+
+	return dynakubes, nil
+}
+
+func getAllDynakubesInNamespace(troubleshootContext troubleshootContext) ([]dynatracev1beta1.DynaKube, error) {
+	query := kubeobjects.NewDynakubeQuery(troubleshootContext.apiReader, troubleshootContext.namespaceName).WithContext(troubleshootContext.context)
+	dynakubes, err := query.List()
+
+	if err != nil {
+		logErrorf("failed to list Dynakubes: %v", err)
+		return nil, err
+	}
+
+	if len(dynakubes.Items) == 0 {
+		err = fmt.Errorf("no Dynakubes found in namespace '%s'", troubleshootContext.namespaceName)
+		logErrorf(err.Error())
+		return nil, err
+	}
+
+	return dynakubes.Items, nil
 }

--- a/src/cmd/troubleshoot/builder.go
+++ b/src/cmd/troubleshoot/builder.go
@@ -125,7 +125,7 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 
 func runChecksForAllDynakubes(results ChecksResults, checks []*Check, dynakubes []dynatracev1beta1.DynaKube, apiReader client.Reader) {
 	for _, dynakube := range dynakubes {
-		results.check2Result = results.resetResults(getDynakubeUnrelatedChecks())
+		results.checkResultMap = results.resetResults(getDynakubeUnrelatedChecks())
 		logNewDynakubef(dynakube.Name)
 
 		troubleshootCtx := troubleshootContext{

--- a/src/cmd/troubleshoot/builder_test.go
+++ b/src/cmd/troubleshoot/builder_test.go
@@ -3,7 +3,10 @@ package troubleshoot
 import (
 	"testing"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestTroubleshootCommandBuilder(t *testing.T) {
@@ -15,4 +18,38 @@ func TestTroubleshootCommandBuilder(t *testing.T) {
 		assert.Equal(t, use, csiCommand.Use)
 		assert.NotNil(t, csiCommand.RunE)
 	})
+
+	t.Run("getAllDynakubesInNamespace", func(t *testing.T) {
+		dynakube := buildTestDynakube()
+		clt := fake.NewClient(&dynakube)
+
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
+
+		dynakubes, err := getAllDynakubesInNamespace(troubleshootCtx)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(dynakubes))
+		assert.Equal(t, dynakube.Name, dynakubes[0].Name)
+	})
+
+	t.Run("getDynakube - only check one dynakube if set", func(t *testing.T) {
+		dynakube := buildTestDynakube()
+		troubleshootCtx := troubleshootContext{
+			dynakube:      dynakube,
+			namespaceName: testNamespace,
+		}
+
+		dynakubes, err := getDynakubes(troubleshootCtx, dynakube.Name)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(dynakubes))
+		assert.Equal(t, testDynakube, dynakubes[0].Name)
+	})
+}
+
+func buildTestDynakube() dynatracev1beta1.DynaKube {
+	return dynatracev1beta1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testDynakube,
+			Namespace: testNamespace,
+		},
+	}
 }

--- a/src/cmd/troubleshoot/checks.go
+++ b/src/cmd/troubleshoot/checks.go
@@ -31,6 +31,16 @@ func NewChecksResults() ChecksResults {
 	return ChecksResults{check2Result: map[*Check]Result{}}
 }
 
+func (checkResults ChecksResults) resetResults(keepChecks []*Check) map[*Check]Result {
+	keptResults := map[*Check]Result{}
+
+	for _, check := range keepChecks {
+		keptResults[check] = checkResults.check2Result[check]
+	}
+
+	return keptResults
+}
+
 func (checkResults ChecksResults) set(check *Check, result Result) {
 	checkResults.check2Result[check] = result
 }
@@ -40,6 +50,15 @@ func (checkResults ChecksResults) failedPrerequisites(check *Check) []*Check {
 		return checkResults.check2Result[check] == FAILED
 	}
 	return functional.Filter(check.Prerequisites, isFailed)
+}
+
+func (checkResults ChecksResults) hasErrors() bool {
+	for _, result := range checkResults.check2Result {
+		if result == FAILED {
+			return true
+		}
+	}
+	return false
 }
 
 func runChecks(results ChecksResults, troubleshootCtx *troubleshootContext, checks []*Check) error {

--- a/src/cmd/troubleshoot/checks.go
+++ b/src/cmd/troubleshoot/checks.go
@@ -24,36 +24,36 @@ type Check struct {
 }
 
 type ChecksResults struct {
-	check2Result map[*Check]Result
+	checkResultMap map[*Check]Result
 }
 
 func NewChecksResults() ChecksResults {
-	return ChecksResults{check2Result: map[*Check]Result{}}
+	return ChecksResults{checkResultMap: map[*Check]Result{}}
 }
 
 func (checkResults ChecksResults) resetResults(keepChecks []*Check) map[*Check]Result {
 	keptResults := map[*Check]Result{}
 
 	for _, check := range keepChecks {
-		keptResults[check] = checkResults.check2Result[check]
+		keptResults[check] = checkResults.checkResultMap[check]
 	}
 
 	return keptResults
 }
 
 func (checkResults ChecksResults) set(check *Check, result Result) {
-	checkResults.check2Result[check] = result
+	checkResults.checkResultMap[check] = result
 }
 
 func (checkResults ChecksResults) failedPrerequisites(check *Check) []*Check {
 	isFailed := func(check *Check) bool {
-		return checkResults.check2Result[check] == FAILED
+		return checkResults.checkResultMap[check] == FAILED
 	}
 	return functional.Filter(check.Prerequisites, isFailed)
 }
 
 func (checkResults ChecksResults) hasErrors() bool {
-	for _, result := range checkResults.check2Result {
+	for _, result := range checkResults.checkResultMap {
 		if result == FAILED {
 			return true
 		}

--- a/src/cmd/troubleshoot/checks_test.go
+++ b/src/cmd/troubleshoot/checks_test.go
@@ -77,6 +77,7 @@ func Test_runChecks(t *testing.T) {
 			failingCheckDependendOnFailingCheck, // should be skipped and error should not be reported
 		}
 		results := NewChecksResults()
+		resetLogger()
 		err := runChecks(results, tsContext, checks)
 		require.Error(t, err)
 

--- a/src/cmd/troubleshoot/config.go
+++ b/src/cmd/troubleshoot/config.go
@@ -1,5 +1,9 @@
 package troubleshoot
 
-var (
-	log = newTroubleshootLogger("[          ]")
-)
+import "github.com/go-logr/logr"
+
+var log logr.Logger
+
+func resetLogger() {
+	log = newTroubleshootLogger("")
+}

--- a/src/cmd/troubleshoot/connection.go
+++ b/src/cmd/troubleshoot/connection.go
@@ -10,7 +10,7 @@ import (
 )
 
 func checkDtClusterConnection(results ChecksResults, troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[dtcluster ] ")
+	log = newSubTestLogger("dtcluster")
 
 	logNewCheckf("checking if tenant is accessible ...")
 

--- a/src/cmd/troubleshoot/context.go
+++ b/src/cmd/troubleshoot/context.go
@@ -16,7 +16,6 @@ type troubleshootContext struct {
 	apiReader          client.Reader
 	httpClient         *http.Client
 	namespaceName      string // the default namespace ("dynatrace") or provided in the command line
-	dynakubeName       string // the default name of dynakube ("dynakube") or provided in the command line
 	dynakube           v1beta1.DynaKube
 	dynatraceApiSecret corev1.Secret
 	pullSecret         corev1.Secret

--- a/src/cmd/troubleshoot/crd.go
+++ b/src/cmd/troubleshoot/crd.go
@@ -1,0 +1,33 @@
+package troubleshoot
+
+import (
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func checkCRD(troubleshootCtx *troubleshootContext) error {
+	log = newTroubleshootLogger("crd")
+
+	logNewCheckf("checking if CRD for Dynakube exists ...")
+
+	dynakubeList := &dynatracev1beta1.DynaKubeList{}
+	err := troubleshootCtx.apiReader.List(troubleshootCtx.context, dynakubeList, &client.ListOptions{Namespace: troubleshootCtx.namespaceName})
+
+	if err != nil {
+		return determineDynakubeError(err)
+	}
+
+	logOkf("CRD for Dynakube exists")
+	return nil
+}
+
+func determineDynakubeError(err error) error {
+	if runtime.IsNotRegisteredError(err) {
+		err = errors.Wrap(err, "CRD for Dynakube missing")
+	} else {
+		err = errors.Wrap(err, "could not list Dynakube")
+	}
+	return err
+}

--- a/src/cmd/troubleshoot/image.go
+++ b/src/cmd/troubleshoot/image.go
@@ -26,7 +26,7 @@ type Auths struct {
 }
 
 func verifyAllImagesAvailable(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[imagepull ] ")
+	log = newSubTestLogger("imagepull")
 
 	if troubleshootCtx.dynakube.NeedsOneAgent() {
 		verifyImageIsAvailable(troubleshootCtx, componentOneAgent, false)

--- a/src/cmd/troubleshoot/image_test.go
+++ b/src/cmd/troubleshoot/image_test.go
@@ -89,7 +89,6 @@ func TestOneAgentImagePullable(t *testing.T) {
 	troubleshootCtx := troubleshootContext{
 		context:       context.TODO(),
 		namespaceName: testNamespace,
-		dynakubeName:  testDynakube,
 		pullSecret:    *secret,
 		httpClient:    dockerServer.Client(),
 	}
@@ -181,7 +180,6 @@ func TestOneAgentCustomImagePullable(t *testing.T) {
 	troubleshootCtx := troubleshootContext{
 		httpClient:    dockerServer.Client(),
 		namespaceName: testNamespace,
-		dynakubeName:  testDynakube,
 		context:       context.TODO(),
 		pullSecret:    *secret,
 	}
@@ -307,7 +305,6 @@ func TestOneAgentImageNotPullable(t *testing.T) {
 	troubleshootCtx := troubleshootContext{
 		context:       context.TODO(),
 		namespaceName: testNamespace,
-		dynakubeName:  testDynakube,
 		pullSecret:    *secret,
 		httpClient:    dockerServer.Client(),
 	}
@@ -421,7 +418,6 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 		context:       context.TODO(),
 		httpClient:    dockerServer.Client(),
 		namespaceName: testNamespace,
-		dynakubeName:  testDynakube,
 		pullSecret:    *secret,
 	}
 
@@ -561,7 +557,6 @@ func TestActiveGateImagePullable(t *testing.T) {
 		context:       context.TODO(),
 		httpClient:    dockerServer.Client(),
 		namespaceName: testNamespace,
-		dynakubeName:  testDynakube,
 		pullSecret:    *secret,
 	}
 
@@ -630,7 +625,6 @@ func TestActiveGateImageNotPullable(t *testing.T) {
 		context:       context.TODO(),
 		httpClient:    dockerServer.Client(),
 		namespaceName: testNamespace,
-		dynakubeName:  testDynakube,
 		pullSecret:    *secret,
 	}
 
@@ -695,7 +689,6 @@ func TestImagePullablePullSecret(t *testing.T) {
 	t.Run("valid pull secret", func(t *testing.T) {
 		troubleshootcontext := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			pullSecret:    *testNewSecretBuilder(testNamespace, testDynakube+pullSecretSuffix).dataAppend(dtpullsecret.DockerConfigJson, pullSecretFieldValue).build(),
 		}
 		secret, err := getPullSecretToken(&troubleshootcontext)
@@ -706,7 +699,6 @@ func TestImagePullablePullSecret(t *testing.T) {
 	t.Run("invalid pull secret", func(t *testing.T) {
 		troubleshootcontext := troubleshootContext{
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 			pullSecret:    *testNewSecretBuilder(testNamespace, testDynakube+pullSecretSuffix).dataAppend("invalidToken", pullSecretFieldValue).build(),
 		}
 		secret, err := getPullSecretToken(&troubleshootcontext)

--- a/src/cmd/troubleshoot/logger.go
+++ b/src/cmd/troubleshoot/logger.go
@@ -23,36 +23,57 @@ const (
 	colorYellow = "\033[33m"
 	colorReset  = "\033[0m"
 
-	levelNewCheck = 1
-	levelSuccess  = 2
-	levelWarning  = 3
-	levelError    = 4
+	levelNewCheck    = 1
+	levelSuccess     = 2
+	levelWarning     = 3
+	levelError       = 4
+	levelNewDynakube = 5
 )
 
 type troubleshootLogger struct {
 	logger logr.Logger
 }
 
-func newTroubleshootLogger(testName string) logr.Logger {
-	return newTroubleshootLoggerToWriter(testName, os.Stdout)
+type subTestLogger struct {
+	troubleshootLogger
 }
 
-func newTroubleshootLoggerToWriter(testName string, out io.Writer) logr.Logger {
+func newRawTroubleshootLogger(testName string, out io.Writer) troubleshootLogger {
 	config := zap.NewProductionEncoderConfig()
 	config.TimeKey = ""
 	config.LevelKey = ""
 	config.NameKey = "name"
 	config.EncodeTime = zapcore.ISO8601TimeEncoder
 
-	return logr.New(
-		troubleshootLogger{
-			logger: ctrlzap.New(ctrlzap.WriteTo(out), ctrlzap.Encoder(zapcore.NewConsoleEncoder(config))).WithName(testName),
-		},
-	)
+	testName = fmt.Sprintf("[%-10s] ", testName)
+
+	return troubleshootLogger{
+		logger: ctrlzap.New(ctrlzap.WriteTo(out), ctrlzap.Encoder(zapcore.NewConsoleEncoder(config))).WithName(testName),
+	}
+}
+
+func newTroubleshootLoggerToWriter(testName string, out io.Writer) logr.Logger {
+	return logr.New(newRawTroubleshootLogger(testName, out))
+}
+
+func newSubTestLoggerToWriter(testName string, out io.Writer) logr.Logger {
+	return logr.New(subTestLogger{newRawTroubleshootLogger(testName, out)})
+}
+
+func newTroubleshootLogger(testName string) logr.Logger {
+	return newTroubleshootLoggerToWriter(testName, os.Stdout)
+}
+
+func newSubTestLogger(testName string) logr.Logger {
+	return newSubTestLoggerToWriter(testName, os.Stdout)
 }
 
 func logNewCheckf(format string, v ...interface{}) {
 	log.V(levelNewCheck).Info(fmt.Sprintf(format, v...))
+}
+
+func logNewDynakubef(format string, v ...interface{}) {
+	log.V(levelNewDynakube).Info(fmt.Sprintf(format, v...))
 }
 
 func logInfof(format string, v ...interface{}) {
@@ -73,20 +94,33 @@ func logErrorf(format string, v ...interface{}) {
 
 func (dtl troubleshootLogger) Init(_ logr.RuntimeInfo) {}
 
+func (dtl subTestLogger) Info(level int, message string, keysAndValues ...interface{}) {
+	message = addPrefixes(level, message)
+	message = " |" + message
+	dtl.logger.Info(message, keysAndValues...)
+}
+
 func (dtl troubleshootLogger) Info(level int, message string, keysAndValues ...interface{}) {
+	message = addPrefixes(level, message)
+	dtl.logger.Info(message, keysAndValues...)
+}
+
+func addPrefixes(level int, message string) string {
 	switch level {
 	case levelNewCheck:
-		dtl.logger.Info(prefixNewTest+message, keysAndValues...)
+		return prefixNewTest + message
 	case levelSuccess:
-		dtl.logger.Info(withSuccessPrefix(message), keysAndValues...)
+		return withSuccessPrefix(message)
 	case levelWarning:
-		dtl.logger.Info(withWarningPrefix(message), keysAndValues...)
+		return withWarningPrefix(message)
 	case levelError:
 		// Info is used for errors to suppress printing a stacktrace
 		// Printing a stacktrace would confuse people in thinking the troubleshooter crashed
-		dtl.logger.Info(withErrorPrefix(message), keysAndValues...)
+		return withErrorPrefix(message)
+	case levelNewDynakube:
+		return message
 	default:
-		dtl.logger.Info(prefixInfo+message, keysAndValues...)
+		return prefixInfo + message
 	}
 }
 

--- a/src/cmd/troubleshoot/namespace.go
+++ b/src/cmd/troubleshoot/namespace.go
@@ -7,7 +7,7 @@ import (
 )
 
 func checkNamespace(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("[namespace ] ")
+	log = newTroubleshootLogger("namespace")
 
 	logNewCheckf("checking if namespace '%s' exists ...", troubleshootCtx.namespaceName)
 

--- a/src/cmd/troubleshoot/namespace_test.go
+++ b/src/cmd/troubleshoot/namespace_test.go
@@ -30,7 +30,7 @@ func TestTroubleshootNamespace(t *testing.T) {
 			}).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 		assert.NoErrorf(t, checkNamespace(&troubleshootCtx), "'%s' namespace not found", troubleshootCtx.namespaceName)
 	})
 	t.Run("namespace does not exist in cluster", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestTroubleshootNamespace(t *testing.T) {
 			}).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 		assert.Errorf(t, checkNamespace(&troubleshootCtx), "'%s' namespace found", troubleshootCtx.namespaceName)
 	})
 	t.Run("invalid namespace selected", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestTroubleshootNamespace(t *testing.T) {
 			}).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testOtherNamespace, dynakubeName: testDynakube}
+		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testOtherNamespace}
 		assert.Errorf(t, checkNamespace(&troubleshootCtx), "'%s' namespace found", troubleshootCtx.namespaceName)
 	})
 }

--- a/src/cmd/troubleshoot/proxy.go
+++ b/src/cmd/troubleshoot/proxy.go
@@ -10,7 +10,7 @@ import (
 )
 
 func checkProxySettings(troubleshootCtx *troubleshootContext) error {
-	return checkProxySettingsWithLog(troubleshootCtx, newTroubleshootLogger("[proxy     ] "))
+	return checkProxySettingsWithLog(troubleshootCtx, newSubTestLogger("proxy"))
 }
 
 func checkProxySettingsWithLog(troubleshootCtx *troubleshootContext, logger logr.Logger) error {

--- a/src/cmd/troubleshoot/proxy_test.go
+++ b/src/cmd/troubleshoot/proxy_test.go
@@ -22,7 +22,6 @@ func TestCheckProxySettings(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			context:       context.TODO(),
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 		}
 
 		logOutput := runProxyTestWithTestLogger(t.Name(), func(logger logr.Logger) {
@@ -42,7 +41,6 @@ func TestCheckProxySettings(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			context:       context.TODO(),
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 		}
 
 		logOutput := runProxyTestWithTestLogger(t.Name(), func(logger logr.Logger) {
@@ -62,7 +60,6 @@ func TestCheckProxySettings(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			context:       context.TODO(),
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 		}
 
 		logOutput := runProxyTestWithTestLogger(t.Name(), func(logger logr.Logger) {
@@ -83,7 +80,6 @@ func TestCheckProxySettings(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			context:       context.TODO(),
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 		}
 
 		troubleshootCtx.dynakube = *testNewDynakubeBuilder(testNamespace, testDynakube).
@@ -121,7 +117,6 @@ func TestCheckProxySettings(t *testing.T) {
 			context:       context.TODO(),
 			apiReader:     clt,
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 		}
 
 		troubleshootCtx.dynakube = *testNewDynakubeBuilder(testNamespace, testDynakube).
@@ -145,7 +140,6 @@ func TestCheckProxySettings(t *testing.T) {
 		troubleshootCtx := troubleshootContext{
 			context:       context.TODO(),
 			namespaceName: testNamespace,
-			dynakubeName:  testDynakube,
 		}
 
 		troubleshootCtx.dynakube = *testNewDynakubeBuilder(testNamespace, testDynakube).

--- a/src/kubeobjects/dynakube.go
+++ b/src/kubeobjects/dynakube.go
@@ -30,6 +30,13 @@ func (query DynakubeQuery) Get(objectKey client.ObjectKey) (dynatracev1beta1.Dyn
 	return dynakube, errors.WithStack(err)
 }
 
+func (query DynakubeQuery) List() (dynatracev1beta1.DynaKubeList, error) {
+	var dynakubes dynatracev1beta1.DynaKubeList
+	err := query.kubeReader.List(query.context(), &dynakubes, client.InNamespace(query.namespace))
+
+	return dynakubes, errors.WithStack(err)
+}
+
 func (query DynakubeQuery) WithContext(ctx context.Context) DynakubeQuery {
 	query.ctx = ctx
 


### PR DESCRIPTION
# Description

The troubleshoot command only checks one dynakube of which it assumes the name if no name is specified.
The new default will be that all dynakubes will be checked. 

Additional, shorthands for the troubleshoot parameters were introduced.

## How can this be tested?

Run troubleshoot subcommand without specifying a dynakube. 

## Checklist
- [x] Unit tests have been updated/added
- [ ] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)


