### PR TITLE
Lower default csi gc interval to 7 days

### DIFF
--- a/src/controllers/csi/gc/unmounted.go
+++ b/src/controllers/csi/gc/unmounted.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultMaxUnmountedCsiVolumeAge = 14 * 24 * time.Hour
+	defaultMaxUnmountedCsiVolumeAge = 7 * 24 * time.Hour
 	maxUnmountedCsiVolumeAgeEnv     = "MAX_UNMOUNTED_VOLUME_AGE"
 )
 


### PR DESCRIPTION
# Description

Currently the default time to garbage collect old agent log files is 14 days, however this was introduced due to the fact that the agent itself is doing that on other platforms. This might not fit on containerised environments.

## How can this be tested?
Create a Dynakube with CSI Driver usage
Create sample apps and let injection happen
Delete the sample apps
The Logs from the agent should be collected after 7 Days


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

