### PR TITLE
Adds make target for classic e2e test case

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -7,7 +7,11 @@ test/e2e/activegate:
 
 ## Runs CloudNative e2e test only
 test/e2e/cloudnative:
-	go test -v -tags e2e -count=1 -failfast ./test/cloudnative
+	go test -v -tags e2e -timeout 10m -count=1 -failfast ./test/cloudnative
+
+## Runs CloudNative e2e test only
+test/e2e/classic:
+	go test -v -tags e2e -timeout 10m -count=1 -failfast ./test/classic
 
 ## Runs CloudNative istio e2e test only
 test/e2e/cloudnative/istio:


### PR DESCRIPTION
# Description

adds a `make` target for classic e2e tests

## How can this be tested?
`make test/e2e/classic`


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

