### PR TITLE
Add support-archive E2E test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tramp
 .org-id-locations
 *_archive
 !/src/cmd/support_archive
+!/test/support_archive
 # flymake-mode
 *_flymake.*
 # eshell files

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -1,5 +1,5 @@
 ## Runs e2e tests
-test/e2e: manifests/branch test/e2e/cloudnative test/e2e/applicationmonitoring test/e2e/activegate
+test/e2e: manifests/branch test/e2e/cloudnative test/e2e/applicationmonitoring test/e2e/activegate test/e2e/supportarchive
 
 ## Runs ActiveGate e2e test only
 test/e2e/activegate:
@@ -24,3 +24,7 @@ test/e2e/cloudnative/proxy:
 ## Runs Application Monitoring e2e test only
 test/e2e/applicationmonitoring:
 	go test -v -tags e2e -count=1 -failfast ./test/appmon
+
+## Runs Application Monitoring e2e test only
+test/e2e/supportarchive:
+	go test -v -tags e2e -count=1 -failfast ./test/support_archive

--- a/test/activegate/activegate_test.go
+++ b/test/activegate/activegate_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/csi"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/environment"
@@ -233,7 +234,7 @@ func checkService(ctx context.Context, t *testing.T, environmentConfig *envconf.
 }
 
 func assertMountPointMissing(t *testing.T, environmentConfig *envconf.Config, podItem corev1.Pod, containerName string, mountPoints []string) { //nolint:revive // argument-limit
-	executionQuery := pod.NewExecutionQuery(podItem, containerName, "cat /proc/mounts")
+	executionQuery := pod.NewExecutionQuery(podItem, containerName, bash.ReadFile("/proc/mounts")...)
 	executionResult, err := executionQuery.Execute(environmentConfig.Client().RESTConfig())
 	require.NoError(t, err)
 

--- a/test/activegate/activegate_test.go
+++ b/test/activegate/activegate_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/csi"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/environment"
@@ -22,6 +21,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/proxy"
 	"github.com/Dynatrace/dynatrace-operator/test/secrets"
+	"github.com/Dynatrace/dynatrace-operator/test/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/webhook"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -234,7 +234,7 @@ func checkService(ctx context.Context, t *testing.T, environmentConfig *envconf.
 }
 
 func assertMountPointMissing(t *testing.T, environmentConfig *envconf.Config, podItem corev1.Pod, containerName string, mountPoints []string) { //nolint:revive // argument-limit
-	executionQuery := pod.NewExecutionQuery(podItem, containerName, bash.ReadFile("/proc/mounts")...)
+	executionQuery := pod.NewExecutionQuery(podItem, containerName, shell.ReadFile("/proc/mounts")...)
 	executionResult, err := executionQuery.Execute(environmentConfig.Client().RESTConfig())
 	require.NoError(t, err)
 

--- a/test/appmon/dataingest.go
+++ b/test/appmon/dataingest.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/config"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
+	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
@@ -116,7 +117,7 @@ func assessDeploymentHasDataIngestFile(t *testing.T, restConfig *rest.Config) de
 }
 
 func getDataIngestMetadataFromPod(t *testing.T, restConfig *rest.Config, dataIngestPod corev1.Pod) metadata {
-	query := pod.NewExecutionQuery(dataIngestPod, dataIngestPod.Spec.Containers[0].Name, "cat", metadataFile)
+	query := pod.NewExecutionQuery(dataIngestPod, dataIngestPod.Spec.Containers[0].Name, bash.ReadFile(metadataFile)...)
 	result, err := query.Execute(restConfig)
 
 	require.NoError(t, err)

--- a/test/appmon/dataingest.go
+++ b/test/appmon/dataingest.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/config"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
-	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
@@ -19,6 +18,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/secrets"
+	"github.com/Dynatrace/dynatrace-operator/test/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/webhook"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -117,7 +117,7 @@ func assessDeploymentHasDataIngestFile(t *testing.T, restConfig *rest.Config) de
 }
 
 func getDataIngestMetadataFromPod(t *testing.T, restConfig *rest.Config, dataIngestPod corev1.Pod) metadata {
-	query := pod.NewExecutionQuery(dataIngestPod, dataIngestPod.Spec.Containers[0].Name, bash.ReadFile(metadataFile)...)
+	query := pod.NewExecutionQuery(dataIngestPod, dataIngestPod.Spec.Containers[0].Name, shell.ReadFile(metadataFile)...)
 	result, err := query.Execute(restConfig)
 
 	require.NoError(t, err)

--- a/test/appmon/dataingest.go
+++ b/test/appmon/dataingest.go
@@ -116,12 +116,12 @@ func assessDeploymentHasDataIngestFile(t *testing.T, restConfig *rest.Config) de
 }
 
 func getDataIngestMetadataFromPod(t *testing.T, restConfig *rest.Config, dataIngestPod corev1.Pod) metadata {
-	query := pod.NewExecutionQuery(dataIngestPod, dataIngestPod.Spec.Containers[0].Name, "cat "+metadataFile)
+	query := pod.NewExecutionQuery(dataIngestPod, dataIngestPod.Spec.Containers[0].Name, "cat", metadataFile)
 	result, err := query.Execute(restConfig)
 
 	require.NoError(t, err)
 
-	assert.Empty(t, result.StdErr)
+	assert.Zero(t, result.StdErr.Len())
 	assert.NotEmpty(t, result.StdOut)
 
 	var dataIngestMetadata metadata

--- a/test/appmon/labelversiondetection.go
+++ b/test/appmon/labelversiondetection.go
@@ -222,7 +222,6 @@ func assertValue(t *testing.T, restConfig *rest.Config, podItem corev1.Pod, vari
 	require.NoError(t, err)
 
 	stdOut := strings.TrimSpace(executionResult.StdOut.String())
-	stdErr := executionResult.StdErr.String()
-	assert.Empty(t, stdErr)
+	assert.Zero(t, executionResult.StdErr.Len())
 	assert.Equal(t, expectedValue, stdOut, "%s:%s pod - %s variable has invalid value", podItem.Namespace, podItem.Name, variableName)
 }

--- a/test/appmon/labelversiondetection.go
+++ b/test/appmon/labelversiondetection.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
-	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
@@ -18,6 +17,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/secrets"
+	"github.com/Dynatrace/dynatrace-operator/test/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/webhook"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -219,7 +219,7 @@ func assertValues(t *testing.T, restConfig *rest.Config, podItem corev1.Pod, exp
 }
 
 func assertValue(t *testing.T, restConfig *rest.Config, podItem corev1.Pod, variableName string, expectedValue string) { //nolint:revive // argument-limit
-	executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, bash.Shell(bash.Echo(fmt.Sprintf("$%s", variableName)))...)
+	executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, shell.Shell(shell.Echo(fmt.Sprintf("$%s", variableName)))...)
 	executionResult, err := executionQuery.Execute(restConfig)
 	require.NoError(t, err)
 

--- a/test/appmon/labelversiondetection.go
+++ b/test/appmon/labelversiondetection.go
@@ -4,11 +4,13 @@ package appmon
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
+	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
@@ -217,7 +219,7 @@ func assertValues(t *testing.T, restConfig *rest.Config, podItem corev1.Pod, exp
 }
 
 func assertValue(t *testing.T, restConfig *rest.Config, podItem corev1.Pod, variableName string, expectedValue string) { //nolint:revive // argument-limit
-	executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, "echo $"+variableName)
+	executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, bash.Shell(bash.Echo(fmt.Sprintf("$%s", variableName)))...)
 	executionResult, err := executionQuery.Execute(restConfig)
 	require.NoError(t, err)
 

--- a/test/bash/bash.go
+++ b/test/bash/bash.go
@@ -1,7 +1,6 @@
 package bash
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -11,7 +10,7 @@ func DiskUsageWithTotal(directory string) Command {
 	return Command{"du", "-c", directory}
 }
 
-func FilterLastLineOnly() []string {
+func FilterLastLineOnly() Command {
 	return Command{"tail", "-n", "1"}
 }
 
@@ -35,11 +34,7 @@ func Shell(command Command) Command {
 }
 
 func (c Command) String() string {
-	cmdString := ""
-	for _, str := range c {
-		cmdString = fmt.Sprintf("%s %s", cmdString, str)
-	}
-	return strings.Trim(cmdString, " ")
+	return strings.Join(c, " ")
 }
 
 func Echo(msg string) Command {

--- a/test/bash/bash.go
+++ b/test/bash/bash.go
@@ -41,3 +41,7 @@ func (c Command) String() string {
 	}
 	return strings.Trim(cmdString, " ")
 }
+
+func Echo(msg string) Command {
+	return Command{"echo", msg}
+}

--- a/test/bash/bash.go
+++ b/test/bash/bash.go
@@ -5,36 +5,36 @@ import (
 	"strings"
 )
 
-type BashCmd []string
+type Command []string
 
-func DiskUsageWithTotal(directory string) BashCmd {
-	return BashCmd{"du", "-c", directory}
+func DiskUsageWithTotal(directory string) Command {
+	return Command{"du", "-c", directory}
 }
 
 func FilterLastLineOnly() []string {
-	return BashCmd{"tail", "-n", "1"}
+	return Command{"tail", "-n", "1"}
 }
 
-func Pipe(source []string, sink []string) BashCmd {
+func Pipe(source []string, sink []string) Command {
 	piped := source
 	piped = append(piped, "|")
 	piped = append(piped, sink...)
 	return piped
 }
 
-func ReadFile(path string) BashCmd {
-	return BashCmd{"cat", path}
+func ReadFile(path string) Command {
+	return Command{"cat", path}
 }
 
-func ListDirectory(path string) BashCmd {
-	return BashCmd{"ls", path}
+func ListDirectory(path string) Command {
+	return Command{"ls", path}
 }
 
-func Shell(command BashCmd) BashCmd {
-	return BashCmd{"sh", "-c", command.String()}
+func Shell(command Command) Command {
+	return Command{"sh", "-c", command.String()}
 }
 
-func (c BashCmd) String() string {
+func (c Command) String() string {
 	cmdString := ""
 	for _, str := range c {
 		cmdString = fmt.Sprintf("%s %s", cmdString, str)

--- a/test/bash/bash.go
+++ b/test/bash/bash.go
@@ -1,23 +1,43 @@
 package bash
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
-func DiskUsageWithTotal(directory string) string {
-	return fmt.Sprintf("du -c %s", directory)
+type BashCmd []string
+
+func DiskUsageWithTotal(directory string) BashCmd {
+	return BashCmd{"du", "-c", directory}
 }
 
-func FilterLastLineOnly() string {
-	return "tail -n 1"
+func FilterLastLineOnly() []string {
+	return BashCmd{"tail", "-n", "1"}
 }
 
-func Pipe(source string, sink string) string {
-	return fmt.Sprintf("%s | %s", source, sink)
+func Pipe(source []string, sink []string) BashCmd {
+	piped := source
+	piped = append(piped, "|")
+	piped = append(piped, sink...)
+	return piped
 }
 
-func ReadFile(path string) string {
-	return fmt.Sprintf("cat %s", path)
+func ReadFile(path string) BashCmd {
+	return BashCmd{"cat", path}
 }
 
-func ListDirectory(path string) string {
-	return fmt.Sprintf("ls %s", path)
+func ListDirectory(path string) BashCmd {
+	return BashCmd{"ls", path}
+}
+
+func Shell(command BashCmd) BashCmd {
+	return BashCmd{"sh", "-c", command.String()}
+}
+
+func (c BashCmd) String() string {
+	cmdString := ""
+	for _, str := range c {
+		cmdString = fmt.Sprintf("%s %s", cmdString, str)
+	}
+	return strings.Trim(cmdString, " ")
 }

--- a/test/bash/bash_test.go
+++ b/test/bash/bash_test.go
@@ -6,9 +6,7 @@ import (
 )
 
 func TestStringifier(t *testing.T) {
-	cmd := Pipe(DiskUsageWithTotal("/foobar"), FilterLastLineOnly())
-
 	assert.Equal(t, "du -c /foobar", DiskUsageWithTotal("/foobar").String())
 	assert.Equal(t, "tail -n 1", FilterLastLineOnly().String())
-	assert.Equal(t, "du -c /foobar | tail -n 1", cmd.String())
+	assert.Equal(t, "du -c /foobar | tail -n 1", Pipe(DiskUsageWithTotal("/foobar"), FilterLastLineOnly()).String())
 }

--- a/test/bash/bash_test.go
+++ b/test/bash/bash_test.go
@@ -1,0 +1,14 @@
+package bash
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStringifier(t *testing.T) {
+	cmd := Pipe(DiskUsageWithTotal("/foobar"), FilterLastLineOnly())
+
+	assert.Equal(t, "du -c /foobar", DiskUsageWithTotal("/foobar").String())
+	assert.Equal(t, "tail -n 1", FilterLastLineOnly().String())
+	assert.Equal(t, "du -c /foobar | tail -n 1", cmd.String())
+}

--- a/test/classic/install_test.go
+++ b/test/classic/install_test.go
@@ -7,13 +7,13 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/setup"
+	"github.com/Dynatrace/dynatrace-operator/test/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/webhook"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,7 +62,7 @@ func isAgentInjected(ctx context.Context, t *testing.T, environmentConfig *envco
 	for _, podItem := range pods.Items {
 		require.NotNil(t, podItem)
 
-		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, bash.ListDirectory("/var/lib/dynatrace")...)
+		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, shell.ListDirectory("/var/lib/dynatrace")...)
 		executionResult, err := executionQuery.Execute(environmentConfig.Client().RESTConfig())
 
 		require.NoError(t, err)

--- a/test/classic/install_test.go
+++ b/test/classic/install_test.go
@@ -61,7 +61,7 @@ func isAgentInjected(ctx context.Context, t *testing.T, environmentConfig *envco
 	for _, podItem := range pods.Items {
 		require.NotNil(t, podItem)
 
-		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, "ls /var/lib/dynatrace")
+		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, "ls", "/var/lib/dynatrace")
 		executionResult, err := executionQuery.Execute(environmentConfig.Client().RESTConfig())
 
 		require.NoError(t, err)

--- a/test/classic/install_test.go
+++ b/test/classic/install_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/oneagent"
@@ -61,7 +62,7 @@ func isAgentInjected(ctx context.Context, t *testing.T, environmentConfig *envco
 	for _, podItem := range pods.Items {
 		require.NotNil(t, podItem)
 
-		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, "ls", "/var/lib/dynatrace")
+		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, bash.ListDirectory("/var/lib/dynatrace")...)
 		executionResult, err := executionQuery.Execute(environmentConfig.Client().RESTConfig())
 
 		require.NoError(t, err)

--- a/test/cloudnative/cloudnative_test.go
+++ b/test/cloudnative/cloudnative_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 	testEnvironment.BeforeEachTest(oneagent.WaitForDaemonSetPodsDeletion())
 	testEnvironment.BeforeEachTest(namespace.Recreate(namespace.NewBuilder(dynakube.Namespace).Build()))
 
-	testEnvironment.AfterEachTest(namespace.Delete(sampleapps.Namespace))
+	testEnvironment.AfterEachTest(namespace.DeleteIfExists(sampleapps.Namespace))
 	testEnvironment.AfterEachTest(dynakube.DeleteIfExists(dynakube.NewBuilder().WithDefaultObjectMeta().Build()))
 	testEnvironment.AfterEachTest(oneagent.WaitForDaemonSetPodsDeletion())
 	testEnvironment.AfterEachTest(namespace.Delete(dynakube.Namespace))

--- a/test/cloudnative/codemodules.go
+++ b/test/cloudnative/codemodules.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/secrets"
 	"github.com/Dynatrace/dynatrace-operator/test/setup"
+	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -136,8 +137,11 @@ func imageHasBeenDownloaded(ctx context.Context, t *testing.T, environmentConfig
 
 		var codeModulesManifest manifest
 		err = json.Unmarshal(result.StdOut.Bytes(), &codeModulesManifest)
-
+		if err != nil {
+			errors.WithMessagef(err, "json:\n%s", result.StdOut)
+		}
 		require.NoError(t, err)
+
 		assert.Equal(t, codeModulesVersion, codeModulesManifest.Version)
 	})
 

--- a/test/cloudnative/codemodules.go
+++ b/test/cloudnative/codemodules.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/src/webhook"
 	"github.com/Dynatrace/dynatrace-operator/src/webhook/mutation/pod_mutator/oneagent_mutation"
-	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/csi"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/istiosetup"
@@ -24,6 +23,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/secrets"
 	"github.com/Dynatrace/dynatrace-operator/test/setup"
+	"github.com/Dynatrace/dynatrace-operator/test/shell"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -123,14 +123,14 @@ func imageHasBeenDownloaded(ctx context.Context, t *testing.T, environmentConfig
 	err := csi.ForEachPod(ctx, resource, func(podItem corev1.Pod) {
 		var result *pod.ExecutionResult
 		result, err := pod.
-			NewExecutionQuery(podItem, "provisioner", bash.ListDirectory(dataPath)...).
+			NewExecutionQuery(podItem, "provisioner", shell.ListDirectory(dataPath)...).
 			Execute(restConfig)
 
 		require.NoError(t, err)
 		assert.Contains(t, result.StdOut.String(), "codemodules")
 
 		result, err = pod.
-			NewExecutionQuery(podItem, "provisioner", bash.Shell(bash.ReadFile(getManifestPath()))...).
+			NewExecutionQuery(podItem, "provisioner", shell.Shell(shell.ReadFile(getManifestPath()))...).
 			Execute(restConfig)
 
 		require.NoError(t, err)
@@ -158,9 +158,9 @@ func diskUsageDoesNotIncrease(secretConfig secrets.Secret) features.Func {
 		err := csi.ForEachPod(ctx, resource, func(podItem corev1.Pod) {
 			var result *pod.ExecutionResult
 			result, err := pod.
-				NewExecutionQuery(podItem, "provisioner", bash.Shell(bash.Pipe(
-					bash.DiskUsageWithTotal(dataPath),
-					bash.FilterLastLineOnly()))...).
+				NewExecutionQuery(podItem, "provisioner", shell.Shell(shell.Pipe(
+					shell.DiskUsageWithTotal(dataPath),
+					shell.FilterLastLineOnly()))...).
 				Execute(restConfig)
 
 			require.NoError(t, err)
@@ -187,9 +187,9 @@ func diskUsageDoesNotIncrease(secretConfig secrets.Secret) features.Func {
 		err = csi.ForEachPod(ctx, resource, func(podItem corev1.Pod) {
 			var result *pod.ExecutionResult
 			result, err = pod.
-				NewExecutionQuery(podItem, "provisioner", bash.Shell(bash.Pipe(
-					bash.DiskUsageWithTotal(dataPath),
-					bash.FilterLastLineOnly()))...).
+				NewExecutionQuery(podItem, "provisioner", shell.Shell(shell.Pipe(
+					shell.DiskUsageWithTotal(dataPath),
+					shell.FilterLastLineOnly()))...).
 				Execute(restConfig)
 
 			require.NoError(t, err)
@@ -219,16 +219,16 @@ func volumesAreMountedCorrectly() features.Func {
 			assert.True(t, isVolumeMounted(t, volumeMounts, oneagent_mutation.OneAgentBinVolumeName))
 
 			executionResult, err := pod.
-				NewExecutionQuery(podItem, sampleapps.Name, bash.ListDirectory(webhook.DefaultInstallPath)...).
+				NewExecutionQuery(podItem, sampleapps.Name, shell.ListDirectory(webhook.DefaultInstallPath)...).
 				Execute(environmentConfig.Client().RESTConfig())
 
 			require.NoError(t, err)
 			assert.NotEmpty(t, executionResult.StdOut.String())
 
 			executionResult, err = pod.
-				NewExecutionQuery(podItem, sampleapps.Name, bash.Shell(bash.Pipe(
-					bash.DiskUsageWithTotal(webhook.DefaultInstallPath),
-					bash.FilterLastLineOnly()))...).
+				NewExecutionQuery(podItem, sampleapps.Name, shell.Shell(shell.Pipe(
+					shell.DiskUsageWithTotal(webhook.DefaultInstallPath),
+					shell.FilterLastLineOnly()))...).
 				Execute(environmentConfig.Client().RESTConfig())
 
 			require.NoError(t, err)

--- a/test/cloudnative/codemodules.go
+++ b/test/cloudnative/codemodules.go
@@ -138,7 +138,7 @@ func imageHasBeenDownloaded(ctx context.Context, t *testing.T, environmentConfig
 		var codeModulesManifest manifest
 		err = json.Unmarshal(result.StdOut.Bytes(), &codeModulesManifest)
 		if err != nil {
-			errors.WithMessagef(err, "json:\n%s", result.StdOut)
+			err = errors.WithMessagef(err, "json:\n%s", result.StdOut)
 		}
 		require.NoError(t, err)
 

--- a/test/cloudnative/install.go
+++ b/test/cloudnative/install.go
@@ -117,7 +117,7 @@ func checkInitContainers(ctx context.Context, t *testing.T, environmentConfig *e
 		require.NoError(t, err)
 		logs.AssertContains(t, logStream, "standalone agent init completed")
 
-		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, "cat /opt/dynatrace/oneagent-paas/log/nginx/ruxitagent_nginx_myapp-__bootstrap_1.0.log")
+		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, "cat", "/opt/dynatrace/oneagent-paas/log/nginx/ruxitagent_nginx_myapp-__bootstrap_1.0.log")
 		executionResult, err := executionQuery.Execute(environmentConfig.Client().RESTConfig())
 
 		require.NoError(t, err)

--- a/test/cloudnative/install.go
+++ b/test/cloudnative/install.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/istiosetup"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
@@ -117,7 +118,7 @@ func checkInitContainers(ctx context.Context, t *testing.T, environmentConfig *e
 		require.NoError(t, err)
 		logs.AssertContains(t, logStream, "standalone agent init completed")
 
-		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, "cat", "/opt/dynatrace/oneagent-paas/log/nginx/ruxitagent_nginx_myapp-__bootstrap_1.0.log")
+		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, bash.ReadFile("/opt/dynatrace/oneagent-paas/log/nginx/ruxitagent_nginx_myapp-__bootstrap_1.0.log")...)
 		executionResult, err := executionQuery.Execute(environmentConfig.Client().RESTConfig())
 
 		require.NoError(t, err)

--- a/test/cloudnative/install.go
+++ b/test/cloudnative/install.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/istiosetup"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
@@ -17,6 +16,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/secrets"
 	"github.com/Dynatrace/dynatrace-operator/test/setup"
+	"github.com/Dynatrace/dynatrace-operator/test/shell"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -118,7 +118,7 @@ func checkInitContainers(ctx context.Context, t *testing.T, environmentConfig *e
 		require.NoError(t, err)
 		logs.AssertContains(t, logStream, "standalone agent init completed")
 
-		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, bash.ReadFile("/opt/dynatrace/oneagent-paas/log/nginx/ruxitagent_nginx_myapp-__bootstrap_1.0.log")...)
+		executionQuery := pod.NewExecutionQuery(podItem, sampleapps.Name, shell.ReadFile("/opt/dynatrace/oneagent-paas/log/nginx/ruxitagent_nginx_myapp-__bootstrap_1.0.log")...)
 		executionResult, err := executionQuery.Execute(environmentConfig.Client().RESTConfig())
 
 		require.NoError(t, err)

--- a/test/cloudnative/network_problems.go
+++ b/test/cloudnative/network_problems.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
@@ -76,11 +75,11 @@ func checkForDummyVolume(ctx context.Context, t *testing.T, environmentConfig *e
 		var result *pod.ExecutionResult
 		result, err := pod.
 			NewExecutionQuery(podItem, sampleapps.Name,
-				bash.ListDirectory(agentMountPath)).
+				bash.ListDirectory(agentMountPath)...).
 			Execute(restConfig)
 
 		require.NoError(t, err)
-		assert.Contains(t, result.StdOut.String(), ldPreloadError)
+		assert.Contains(t, result.StdErr.String(), ldPreloadError)
 	}
 	return ctx
 }

--- a/test/cloudnative/network_problems.go
+++ b/test/cloudnative/network_problems.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Dynatrace/dynatrace-operator/test/bash"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/pod"
@@ -15,6 +14,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/secrets"
 	"github.com/Dynatrace/dynatrace-operator/test/setup"
+	"github.com/Dynatrace/dynatrace-operator/test/shell"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,7 +75,7 @@ func checkForDummyVolume(ctx context.Context, t *testing.T, environmentConfig *e
 		var result *pod.ExecutionResult
 		result, err := pod.
 			NewExecutionQuery(podItem, sampleapps.Name,
-				bash.ListDirectory(agentMountPath)...).
+				shell.ListDirectory(agentMountPath)...).
 			Execute(restConfig)
 
 		require.NoError(t, err)

--- a/test/kubeobjects/environment/environment.go
+++ b/test/kubeobjects/environment/environment.go
@@ -1,8 +1,11 @@
+//go:build e2e
+
 package environment
 
 import (
 	"os"
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/e2e-framework/klient/conf"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -21,6 +24,6 @@ func Get() env.Environment {
 	}
 
 	kubeConfigPath := conf.ResolveKubeConfigFile()
-	kubeConfig := envconf.NewWithKubeConfig(kubeConfigPath)
-	return env.NewWithConfig(kubeConfig)
+	envConfig := envconf.NewWithKubeConfig(kubeConfigPath)
+	return env.NewWithConfig(envConfig)
 }

--- a/test/kubeobjects/pod/execute.go
+++ b/test/kubeobjects/pod/execute.go
@@ -2,9 +2,9 @@ package pod
 
 import (
 	"bytes"
-	"github.com/Dynatrace/dynatrace-operator/test/shell"
 	"net/http"
 
+	"github.com/Dynatrace/dynatrace-operator/test/shell"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"

--- a/test/kubeobjects/pod/execute.go
+++ b/test/kubeobjects/pod/execute.go
@@ -2,6 +2,7 @@ package pod
 
 import (
 	"bytes"
+	"github.com/Dynatrace/dynatrace-operator/test/shell"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -24,7 +25,7 @@ type ExecutionResult struct {
 
 type ExecutionQuery struct {
 	pod       v1.Pod
-	command   []string
+	command   shell.Command
 	container string
 	tty       bool
 }

--- a/test/operator/pods.go
+++ b/test/operator/pods.go
@@ -1,0 +1,15 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+)
+
+func Get(t *testing.T, ctx context.Context, resource *resources.Resources) (pods corev1.PodList) {
+	require.NoError(t, resource.WithNamespace("dynatrace").List(ctx, &pods))
+	return pods
+}

--- a/test/setup/setup.go
+++ b/test/setup/setup.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package setup
 
 import (

--- a/test/shell/shell.go
+++ b/test/shell/shell.go
@@ -1,4 +1,4 @@
-package bash
+package shell
 
 import (
 	"strings"

--- a/test/shell/shell_test.go
+++ b/test/shell/shell_test.go
@@ -1,4 +1,4 @@
-package bash
+package shell
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/test/shell/shell_test.go
+++ b/test/shell/shell_test.go
@@ -1,8 +1,9 @@
 package shell
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringifier(t *testing.T) {

--- a/test/support_archive/install.go
+++ b/test/support_archive/install.go
@@ -1,0 +1,17 @@
+//go:build e2e
+
+package support_archive
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/test/secrets"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func getSecretConfig(t *testing.T) secrets.Secret {
+	secretConfig, err := secrets.DefaultSingleTenant(afero.NewOsFs())
+	require.NoError(t, err)
+	return secretConfig
+}

--- a/test/support_archive/support_archive_test.go
+++ b/test/support_archive/support_archive_test.go
@@ -6,9 +6,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
-	"fmt"
 	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -32,15 +30,6 @@ import (
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
-	workingDir, err := os.Getwd()
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	//	require.NoError(m, err)
-
-	fmt.Println(workingDir)
-
 	testEnvironment = environment.Get()
 	testEnvironment.BeforeEachTest(dynakube.DeleteIfExists(dynakube.NewBuilder().WithDefaultObjectMeta().Build()))
 	testEnvironment.BeforeEachTest(oneagent.WaitForDaemonSetPodsDeletion())

--- a/test/support_archive/support_archive_test.go
+++ b/test/support_archive/support_archive_test.go
@@ -1,0 +1,119 @@
+//go:build e2e
+
+package support_archive
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/environment"
+	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/namespace"
+	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/pod"
+	"github.com/Dynatrace/dynatrace-operator/test/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/test/operator"
+	"github.com/Dynatrace/dynatrace-operator/test/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/klient/conf"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+var testEnvironment env.Environment
+
+func TestMain(m *testing.M) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	//	require.NoError(m, err)
+
+	fmt.Println(workingDir)
+
+	testEnvironment = environment.Get()
+	testEnvironment.BeforeEachTest(dynakube.DeleteIfExists(dynakube.NewBuilder().WithDefaultObjectMeta().Build()))
+	testEnvironment.BeforeEachTest(oneagent.WaitForDaemonSetPodsDeletion())
+	testEnvironment.BeforeEachTest(namespace.Recreate(namespace.NewBuilder(dynakube.Namespace).Build()))
+
+	testEnvironment.AfterEachTest(dynakube.DeleteIfExists(dynakube.NewBuilder().WithDefaultObjectMeta().Build()))
+	testEnvironment.AfterEachTest(oneagent.WaitForDaemonSetPodsDeletion())
+	testEnvironment.AfterEachTest(namespace.Delete(dynakube.Namespace))
+
+	testEnvironment.Run(m)
+}
+
+func TestSupportArchive(t *testing.T) {
+	testEnvironment.Test(t, SupportArchiveExecution(t))
+}
+
+func SupportArchiveExecution(t *testing.T) features.Feature {
+	secretConfig := getSecretConfig(t)
+
+	supportArchiveExecution := features.New("support archive execution")
+	setup.InstallDynatraceFromSource(supportArchiveExecution, &secretConfig)
+	setup.AssessOperatorDeployment(supportArchiveExecution)
+	supportArchiveExecution.Assess("support archive subcommand can be executed correctly", checkSupportArchiveExecution())
+	return supportArchiveExecution.Feature()
+}
+
+func checkSupportArchiveExecution() features.Func {
+	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+		result := executeSupportArchive(context.TODO(), t, environmentConfig, "--stdout")
+		require.NotNil(t, result)
+
+		zipReader, err := gzip.NewReader(result.StdOut)
+		require.NoError(t, err)
+
+		tarReader := tar.NewReader(zipReader)
+		hdr, err := tarReader.Next()
+		require.NoError(t, err)
+		assert.Equal(t, "operator-version.txt", hdr.Name)
+
+		resultString := make([]byte, hdr.Size)
+		resultLen, err := tarReader.Read(resultString)
+		require.Equal(t, io.EOF, err)
+		assert.Equal(t, hdr.Size, int64(resultLen))
+
+		return ctx
+	}
+}
+
+func executeSupportArchive(ctx context.Context, t *testing.T, environmentConfig *envconf.Config, cmdLineArguments string) *pod.ExecutionResult {
+	resources := environmentConfig.Client().Resources()
+	pods := operator.Get(t, ctx, resources)
+	for _, podItem := range pods.Items {
+		require.NotNil(t, podItem)
+
+		if strings.Contains(podItem.Name, "dynatrace-operator") {
+			executionQuery := pod.NewExecutionQuery(podItem,
+				"dynatrace-operator",
+				"/usr/local/bin/dynatrace-operator",
+				"support-archive",
+				cmdLineArguments)
+			executionResult, err := executionQuery.Execute(environmentConfig.Client().RESTConfig())
+			require.NoError(t, err)
+
+			return executionResult
+		}
+	}
+	t.Fatalf("didn't find operator pod, support-archive command hasn't been executed")
+	return nil
+}
+
+// Note: mainly for dev purposes, test requires a running cluster with deployed operator to be successful
+func TestExecSupportArchive(t *testing.T) {
+	t.Skip("dev helper test")
+	kubeConfigPath := conf.ResolveKubeConfigFile()
+	envConfig := envconf.NewWithKubeConfig(kubeConfigPath)
+
+	checkSupportArchiveExecution()(context.TODO(), t, envConfig)
+}


### PR DESCRIPTION
# Description

Add E2E tests for the support-archive subcommand recently added in #1343.

## How can this be tested?
`make test/e2e/supportarchive`

## Checklist
- [n/a] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

