### PR TITLE
Remove deprecated `scan.connect.redhat.com` registry

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -52,7 +52,7 @@ jobs:
         registry: [gcr, dockerhub, rhcc]
         include:
         - registry: rhcc
-          url: scan.connect.redhat.com
+          url: quay.io
           repository: RHCC_REPOSITORY
           username: RHCC_USERNAME
           password: RHCC_PASSWORD

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -77,7 +77,6 @@ jobs:
           password: ${{ secrets[matrix.password] }}
       - name: Push ${{matrix.platform}} to ${{matrix.registry}}
         uses: ./.github/actions/upload-image
-        if: matrix.platform == 'amd64' || matrix.registry != 'rhcc'
         with:
           platform: ${{ matrix.platform }}
           labels: ${{ needs.prepare.outputs.labels }}
@@ -85,7 +84,7 @@ jobs:
           registry: ${{ matrix.url }}
           repository: ${{ secrets[matrix.repository] }}
       - name: Run preflight
-        if: matrix.registry == 'rhcc' && matrix.platform == 'amd64'
+        if: matrix.registry == 'rhcc'
         uses: ./.github/actions/preflight
         with:
          version: ${{ needs.prepare.outputs.version }}
@@ -109,8 +108,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        registry: [gcr, dockerhub]
+        registry: [rhcc, gcr, dockerhub]
         include:
+          - registry: rhcc
+            url: quay.io
+            repository: RHCC_REPOSITORY
+            username: RHCC_USERNAME
+            password: RHCC_PASSWORD
           - registry: gcr
             url: gcr.io
             repository: GCR_REPOSITORY

--- a/hack/build/ci/upload-docker-image.sh
+++ b/hack/build/ci/upload-docker-image.sh
@@ -15,10 +15,7 @@ readonly version=${4}
 readonly imageTarPath="/tmp/operator-${platform}.tar"
 
 targetImageTag="${registry}/${repository}:${version}"
-if [ "${registry}" != "scan.connect.redhat.com" ]
-then
-  targetImageTag=${targetImageTag}-${platform}
-fi
+targetImageTag=${targetImageTag}-${platform}
 
 docker load -i "${imageTarPath}"
 


### PR DESCRIPTION
# Description

`scan.connect.redhat.com` registry was deprecated and replaced with `quay.io`.

## How can this be tested?
Release with updated Secrets.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

