### PR TITLE
Fixes hostMonitoring mode with csi volume

### DIFF
--- a/src/controllers/csi/gc/reconciler.go
+++ b/src/controllers/csi/gc/reconciler.go
@@ -66,6 +66,11 @@ func (gc *CSIGarbageCollector) Reconcile(ctx context.Context, request reconcile.
 		return defaultReconcileResult, nil
 	}
 
+	if !dynakube.NeedAppInjection() {
+		log.Info("app injection not enabled, skip garbage collection", "dynakube", dynakube.Name)
+		return defaultReconcileResult, nil
+	}
+
 	dynakubeList, err := getAllDynakubes(ctx, gc.apiReader, dynakube.Namespace)
 	if err != nil {
 		return defaultReconcileResult, err


### PR DESCRIPTION
# Description
 If only hostMonitoring was enabled, then the csi provisioner didn't do anything, which caused the csi server to be unable to complete the request for oneagent volumes

## How can this be tested?
Dynakube with hostMonitoring works as expected now.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

