### PR TITLE
update csi registrar to 2.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY --from=operator-build /usr/lib/libgpg-error.so.* /usr/lib/
 COPY --from=operator-build /usr/lib/libgpgme.so.* /usr/lib/
 
 # csi binaries
-COPY --from=k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.1 /csi-node-driver-registrar /usr/local/bin
+COPY --from=k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.2 /csi-node-driver-registrar /usr/local/bin
 COPY --from=k8s.gcr.io/sig-storage/livenessprobe:v2.8.0 /livenessprobe /usr/local/bin
 
 # csi depdenencies


### PR DESCRIPTION
# Description
Bump version of registrar to v2.6.2.

## How can this be tested?
CSI driver registers correctly.
```
[]# kctl logs -cregistrar  pod/dynatrace-oneagent-csi-driver-q5z6t 
I1205 16:08:39.347839       1 main.go:166] Version: v2.6.2
I1205 16:08:39.446130       1 main.go:167] Running node-driver-registrar in mode=registration
I1205 16:08:39.846732       1 node_register.go:53] Starting Registration Server at: /registration/csi.oneagent.dynatrace.com-reg.sock
I1205 16:08:39.946770       1 node_register.go:62] Registration Server started at: /registration/csi.oneagent.dynatrace.com-reg.sock
I1205 16:08:40.146075       1 node_register.go:92] Skipping HTTP server because endpoint is set to: ""
I1205 16:08:40.270407       1 main.go:102] Received GetInfo call: &InfoRequest{}
I1205 16:08:40.270575       1 main.go:109] "Kubelet registration probe created" path="/var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/registration"
I1205 16:08:40.346461       1 main.go:120] Received NotifyRegistrationStatus call: &RegistrationStatus{PluginRegistered:true,Error:,}
```

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

