### PR TITLE
Make mounting of pods more safe

### DIFF
--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -69,10 +69,6 @@ func (publisher *AppVolumePublisher) PublishVolume(ctx context.Context, volumeCf
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
-	if err = publisher.ensureMountSteps(ctx, bindCfg, volumeCfg); err != nil{
-		return nil, err
-	}
-
 	if bindCfg.Version == "" {
 		return nil, status.Error(
 			codes.Unavailable,
@@ -80,6 +76,9 @@ func (publisher *AppVolumePublisher) PublishVolume(ctx context.Context, volumeCf
 		)
 	}
 
+	if err = publisher.ensureMountSteps(ctx, bindCfg, volumeCfg); err != nil{
+		return nil, err
+	}
 
 	agentsVersionsMetric.WithLabelValues(bindCfg.Version).Inc()
 	return &csi.NodePublishVolumeResponse{}, nil

--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -104,7 +104,7 @@ func (publisher *AppVolumePublisher) UnpublishVolume(ctx context.Context, volume
 	}
 	log.Info("loaded volume info", "id", volume.VolumeID, "pod name", volume.PodName, "version", volume.Version, "dynakube", volume.TenantUUID)
 
-	if volume.Version == ""{
+	if volume.Version == "" {
 		log.Info("requester has a dummy volume, no node-level unmount is needed")
 		return &csi.NodeUnpublishVolumeResponse{}, publisher.db.DeleteVolume(ctx, volume.VolumeID)
 	}

--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -76,7 +76,7 @@ func (publisher *AppVolumePublisher) PublishVolume(ctx context.Context, volumeCf
 		)
 	}
 
-	if err = publisher.ensureMountSteps(ctx, bindCfg, volumeCfg); err != nil{
+	if err = publisher.ensureMountSteps(ctx, bindCfg, volumeCfg); err != nil {
 		return nil, err
 	}
 

--- a/src/controllers/csi/driver/volumes/app/publisher_test.go
+++ b/src/controllers/csi/driver/volumes/app/publisher_test.go
@@ -33,7 +33,7 @@ const (
 func TestPublishVolume(t *testing.T) {
 	t.Run(`using url`, func(t *testing.T) {
 		mounter := mount.NewFakeMounter([]mount.MountPoint{})
-		publisher := newPublisherForTesting(t, mounter)
+		publisher := newPublisherForTesting(mounter)
 		mockUrlDynakubeMetadata(t, &publisher)
 
 		response, err := publisher.PublishVolume(context.TODO(), createTestVolumeConfig())
@@ -61,7 +61,7 @@ func TestPublishVolume(t *testing.T) {
 
 	t.Run(`using code modules image`, func(t *testing.T) {
 		mounter := mount.NewFakeMounter([]mount.MountPoint{})
-		publisher := newPublisherForTesting(t, mounter)
+		publisher := newPublisherForTesting(mounter)
 		mockImageDynakubeMetadata(t, &publisher)
 
 		response, err := publisher.PublishVolume(context.TODO(), createTestVolumeConfig())
@@ -89,7 +89,7 @@ func TestPublishVolume(t *testing.T) {
 
 	t.Run(`too many mount attempts`, func(t *testing.T) {
 		mounter := mount.NewFakeMounter([]mount.MountPoint{})
-		publisher := newPublisherForTesting(t, mounter)
+		publisher := newPublisherForTesting(mounter)
 		mockFailedPublishedVolume(t, &publisher)
 
 		response, err := publisher.PublishVolume(context.TODO(), createTestVolumeConfig())
@@ -102,7 +102,7 @@ func TestPublishVolume(t *testing.T) {
 
 func TestHasTooManyMountAttempts(t *testing.T) {
 	t.Run(`initial try`, func(t *testing.T) {
-		publisher := newPublisherForTesting(t, nil)
+		publisher := newPublisherForTesting(nil)
 		bindCfg := &csivolumes.BindConfig{
 			TenantUUID:       testTenantUUID,
 			MaxMountAttempts: dynatracev1beta1.DefaultMaxFailedCsiMountAttempts,
@@ -120,7 +120,7 @@ func TestHasTooManyMountAttempts(t *testing.T) {
 
 	})
 	t.Run(`too many mount attempts`, func(t *testing.T) {
-		publisher := newPublisherForTesting(t, nil)
+		publisher := newPublisherForTesting(nil)
 		mockFailedPublishedVolume(t, &publisher)
 		bindCfg := &csivolumes.BindConfig{
 			MaxMountAttempts: dynatracev1beta1.DefaultMaxFailedCsiMountAttempts,
@@ -140,7 +140,7 @@ func TestUnpublishVolume(t *testing.T) {
 			{Path: testTargetPath},
 			{Path: fmt.Sprintf("/%s/run/%s/mapped", testTenantUUID, testVolumeId)},
 		})
-		publisher := newPublisherForTesting(t, mounter)
+		publisher := newPublisherForTesting(mounter)
 		mockPublishedVolume(t, &publisher)
 
 		assert.Equal(t, 1, testutil.CollectAndCount(agentsVersionsMetric))
@@ -163,7 +163,7 @@ func TestUnpublishVolume(t *testing.T) {
 			{Path: testTargetPath},
 			{Path: fmt.Sprintf("/%s/run/%s/mapped", testTenantUUID, testVolumeId)},
 		})
-		publisher := newPublisherForTesting(t, mounter)
+		publisher := newPublisherForTesting(mounter)
 
 		response, err := publisher.UnpublishVolume(context.TODO(), createTestVolumeInfo())
 
@@ -179,7 +179,7 @@ func TestUnpublishVolume(t *testing.T) {
 	t.Run(`remove dummy volume created after too many failed attempts`, func(t *testing.T) {
 		resetMetrics()
 		mounter := mount.NewFakeMounter([]mount.MountPoint{})
-		publisher := newPublisherForTesting(t, mounter)
+		publisher := newPublisherForTesting(mounter)
 		mockFailedPublishedVolume(t, &publisher)
 
 		response, err := publisher.UnpublishVolume(context.TODO(), createTestVolumeInfo())
@@ -193,7 +193,7 @@ func TestUnpublishVolume(t *testing.T) {
 func TestNodePublishAndUnpublishVolume(t *testing.T) {
 	resetMetrics()
 	mounter := mount.NewFakeMounter([]mount.MountPoint{})
-	publisher := newPublisherForTesting(t, mounter)
+	publisher := newPublisherForTesting(mounter)
 	mockUrlDynakubeMetadata(t, &publisher)
 
 	publishResponse, err := publisher.PublishVolume(context.TODO(), createTestVolumeConfig())
@@ -219,7 +219,7 @@ func TestNodePublishAndUnpublishVolume(t *testing.T) {
 
 func TestStoreAndLoadPodInfo(t *testing.T) {
 	mounter := mount.NewFakeMounter([]mount.MountPoint{})
-	publisher := newPublisherForTesting(t, mounter)
+	publisher := newPublisherForTesting(mounter)
 
 	bindCfg := &csivolumes.BindConfig{
 		Version:    testAgentVersion,
@@ -241,14 +241,30 @@ func TestStoreAndLoadPodInfo(t *testing.T) {
 
 func TestLoadPodInfo_Empty(t *testing.T) {
 	mounter := mount.NewFakeMounter([]mount.MountPoint{})
-	publisher := newPublisherForTesting(t, mounter)
+	publisher := newPublisherForTesting(mounter)
 
 	volume, err := publisher.loadVolume(context.TODO(), testVolumeId)
 	require.NoError(t, err)
 	require.Nil(t, volume)
 }
 
-func newPublisherForTesting(t *testing.T, mounter *mount.FakeMounter) AppVolumePublisher {
+func TestMountIfDBHasError(t *testing.T) {
+	mounter := mount.NewFakeMounter([]mount.MountPoint{})
+	publisher := newPublisherForTesting(mounter)
+	publisher.db = &metadata.FakeFailDB{}
+
+	bindCfg := &csivolumes.BindConfig{
+		TenantUUID:       testTenantUUID,
+		MaxMountAttempts: dynatracev1beta1.DefaultMaxFailedCsiMountAttempts,
+	}
+
+	err := publisher.ensureMountSteps(context.TODO(), bindCfg, createTestVolumeConfig())
+	require.Error(t, err)
+	require.Empty(t, mounter.MountPoints)
+}
+
+
+func newPublisherForTesting(mounter *mount.FakeMounter) AppVolumePublisher {
 	objects := []client.Object{
 		&dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{

--- a/src/controllers/csi/driver/volumes/app/publisher_test.go
+++ b/src/controllers/csi/driver/volumes/app/publisher_test.go
@@ -263,7 +263,6 @@ func TestMountIfDBHasError(t *testing.T) {
 	require.Empty(t, mounter.MountPoints)
 }
 
-
 func newPublisherForTesting(mounter *mount.FakeMounter) AppVolumePublisher {
 	objects := []client.Object{
 		&dynatracev1beta1.DynaKube{


### PR DESCRIPTION
# Description
If there are a lot of pods that request a volume at the same time (only managed to reproduce it with > 50 pods), then some pods are failing to write the correct info into the database, because its locked by other write attempts. Due to this, the pod will be mounted and can start without a problem. 

During unmount the CSI Driver thinks the pod has a dummy volume, which is actually wrong, as the database is wrong. This leads to the fact that the CSI Driver does not unmount the volume and the pod is stuck in terminating.

## How can this be tested?
1. Create a DynaKube setup with cloudNative or applicationMonitoring with CSI Driver
2. Schedule sample apps (> 50) on a single node
3. Check that the CSI Driver has problems writing a mounted pod into the DB
4. After deleting the sample apps, they might get stuck


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

