### PR TITLE
Removed duplication of activegate-statsd container definition in AG statefulset

### DIFF
--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
@@ -40,7 +40,6 @@ func GenerateAllModifiers(dynakube dynatracev1beta1.DynaKube, capability capabil
 		NewProxyModifier(dynakube),
 		NewRawImageModifier(dynakube),
 		NewReadOnlyModifier(dynakube),
-		NewStatsdModifier(dynakube, capability),
 		newSyntheticModifier(dynakube),
 	}
 }


### PR DESCRIPTION
# Description

Activegate-statsd container definition was added twice to AG statefulset spec if statsd-ingest capability was enabled. The PR removes duplication of activegate-statsd container definition.

## How can this be tested?
Deploy dynakube with ActiveGate having statsd capability enabled.


## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

