### PR TITLE
E2E test for support archive log collection.

### DIFF
--- a/src/cmd/support_archive/config.go
+++ b/src/cmd/support_archive/config.go
@@ -1,0 +1,7 @@
+package support_archive
+
+const OperatorVersionFileName = "operator-version.txt"
+const LogsDirectoryName = "logs"
+
+const operatorVersionCollectorName = "operatorVersionCollector"
+const logCollectorName = "logCollector"

--- a/src/cmd/support_archive/logs.go
+++ b/src/cmd/support_archive/logs.go
@@ -12,9 +12,6 @@ import (
 	clientgocorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-const logCollectorName = "logCollector"
-const logsDirectoryName = "logs"
-
 type logCollector struct {
 	collectorCommon
 
@@ -118,7 +115,7 @@ func (collector logCollector) collectContainerLogs(pod *corev1.Pod, container co
 
 func buildLogFileName(pod *corev1.Pod, container corev1.Container, logOptions corev1.PodLogOptions) string {
 	if logOptions.Previous {
-		return fmt.Sprintf("%s/%s/%s_previous.log", logsDirectoryName, pod.Name, container.Name)
+		return fmt.Sprintf("%s/%s/%s_previous.log", LogsDirectoryName, pod.Name, container.Name)
 	}
-	return fmt.Sprintf("%s/%s/%s.log", logsDirectoryName, pod.Name, container.Name)
+	return fmt.Sprintf("%s/%s/%s.log", LogsDirectoryName, pod.Name, container.Name)
 }

--- a/src/cmd/support_archive/operator_version.go
+++ b/src/cmd/support_archive/operator_version.go
@@ -9,9 +9,6 @@ import (
 	"github.com/go-logr/logr"
 )
 
-const operatorVersionCollectorName = "operatorVersionCollector"
-const operatorVersionFileName = "operator-version.txt"
-
 type operatorVersionCollector struct {
 	collectorCommon
 }
@@ -26,7 +23,7 @@ func newOperatorVersionCollector(log logr.Logger, supportArchive tarball) collec
 }
 
 func (vc operatorVersionCollector) Do() error {
-	logInfof(vc.log, "Storing operator version into %s", operatorVersionFileName)
+	logInfof(vc.log, "Storing operator version into %s", OperatorVersionFileName)
 
 	versionString := fmt.Sprintf("version: %s\ngitCommit: %s\nbuildDate: %s\ngoVersion %s\nplatform %s/%s\n",
 		version.Version,
@@ -34,7 +31,7 @@ func (vc operatorVersionCollector) Do() error {
 		version.BuildDate,
 		runtime.Version(),
 		runtime.GOOS, runtime.GOARCH)
-	vc.supportArchive.addFile(operatorVersionFileName, strings.NewReader(versionString))
+	vc.supportArchive.addFile(OperatorVersionFileName, strings.NewReader(versionString))
 
 	return nil
 }


### PR DESCRIPTION
# Description
E2E tests for log collection in support archive (see #1386)

## How can this be tested?
Run E2E tests in total or selectively with
`make manifests/branch test/e2e/supportarchive`

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

