### PR TITLE
Allow the use of a existing priorityclass

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -246,7 +246,7 @@ spec:
       securityContext: {}
       serviceAccountName: dynatrace-oneagent-csi-driver
       terminationGracePeriodSeconds: 30
-      priorityClassName: dynatrace-high-priority
+      priorityClassName: {{ include "dynatrace-operator.CSIPriorityClassName" . }}
       volumes:
       # This volume is where the registrar registers the plugin with kubelet
       - name: registration-dir

--- a/config/helm/chart/default/templates/Common/csi/priority-class.yaml
+++ b/config/helm/chart/default/templates/Common/csi/priority-class.yaml
@@ -1,5 +1,5 @@
 {{- include "dynatrace-operator.platformRequired" . }}
-{{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
+{{ if (eq (include "dynatrace-operator.needPriorityClass" .) "true") }}
 
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/_csidriver.tpl
+++ b/config/helm/chart/default/templates/_csidriver.tpl
@@ -22,6 +22,22 @@ Check if we need the csi driver.
 {{- end -}}
 
 {{/*
+CSI PriorityClassName
+*/}}
+{{- define "dynatrace-operator.CSIPriorityClassName" -}}
+	{{- default "dynatrace-high-priority" .Values.csidriver.existingPriorityClassName -}}
+{{- end -}}
+
+{{/*
+Check if we need the csi default priority class
+*/}}
+{{- define "dynatrace-operator.needPriorityClass" -}}
+	{{- if and (eq (include "dynatrace-operator.needCSI" .) "true") (not .Values.csidriver.existingPriorityClassName) -}}
+		{{- printf "true" -}}
+	{{- end -}}
+{{- end -}}
+
+{{/*
 CSI plugin-dir path
 */}}
 {{- define "dynatrace-operator.CSIPluginDir" -}}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -489,4 +489,12 @@ tests:
       - equal:
           path: spec.template.spec.containers[2].volumeMounts[2].mountPath
           value: "my/kubelet/plugins/csi.oneagent.dynatrace.com/"
-
+  - it: should use existing priority class if given
+    set:
+      platform: kubernetes
+      csidriver.existingPriorityClassName: "my-custom-priority-class"
+      csidriver.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: "my-custom-priority-class"

--- a/config/helm/chart/default/tests/Common/csi/priority-class_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/priority-class_test.yaml
@@ -33,3 +33,11 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: should not exists if csi enabled and custom priority class name is given
+    set:
+      platform: kubernetes
+      csidriver.existingPriorityClassName: "my-custom-priority-class"
+      csidriver.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -51,6 +51,7 @@ csidriver:
   enabled: false
   nodeSelector: {}
   kubeletPath: "/var/lib/kubelet"
+  existingPriorityClassName: "" # if defined, use this priorityclass instead of creating a new one
   priorityClassValue: "1000000"
   maxUnmountedVolumeAge: "" # defined in days, must be a plain number, default is "14"
   tolerations:


### PR DESCRIPTION
# Description

Allow to precise existing priorityclass instead of creating a dedicated one.
We use higher priority than the maximum user created one, which makes this DS have less priority than our "cluster" priority class. This makes the DS not able to provision on some nodes.

## How can this be tested?

- Set `.Values.csidriver.existingPriorityClassName` to an existing priority class name.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

