### PR TITLE
Adds support for official codemodules image

### DIFF
--- a/src/controllers/csi/metadata/path_resolver.go
+++ b/src/controllers/csi/metadata/path_resolver.go
@@ -46,8 +46,12 @@ func (pr PathResolver) AgentSharedBinaryDirBase() string {
 	return filepath.Join(pr.RootDir, dtcsi.SharedAgentBinDir)
 }
 
-func (pr PathResolver) AgentTempUnzipDir() string {
+func (pr PathResolver) AgentTempUnzipRootDir() string {
 	return filepath.Join(pr.RootDir, "tmp_zip")
+}
+
+func (pr PathResolver) AgentTempUnzipDir() string {
+	return filepath.Join(pr.AgentTempUnzipRootDir(), "opt", "dynatrace", "oneagent")
 }
 
 func (pr PathResolver) AgentSharedBinaryDirForImage(digest string) string {

--- a/src/installer/zip/gzip.go
+++ b/src/installer/zip/gzip.go
@@ -32,7 +32,7 @@ func (extractor OneAgentExtractor) ExtractGzip(sourceFilePath, targetDir string)
 	}
 	defer gzipReader.Close()
 
-	tmpUnzipDir := extractor.pathResolver.AgentTempUnzipDir()
+	tmpUnzipDir := extractor.pathResolver.AgentTempUnzipRootDir()
 	tarReader := tar.NewReader(gzipReader)
 	err = extractFilesFromGzip(fs, tmpUnzipDir, tarReader)
 	if err != nil {

--- a/src/installer/zip/zip.go
+++ b/src/installer/zip/zip.go
@@ -33,7 +33,7 @@ func (extractor OneAgentExtractor) ExtractZip(sourceFile afero.File, targetDir s
 		return errors.WithStack(err)
 	}
 
-	extractDest := extractor.pathResolver.AgentTempUnzipDir()
+	extractDest := extractor.pathResolver.AgentTempUnzipRootDir()
 	if extractor.pathResolver.RootDir == config.AgentBinDirMount {
 		extractDest = targetDir
 	}


### PR DESCRIPTION
# Description

Originally the image in `codeModulesImage` was expected to have all its relevant contents in the root of the image, so when we unzip it we can just move the contents and nothing is left behind.
But the codemodule-images built by the pipeline is a bit different, it has all the relevant content under `/opt/dynatrace/oneagent`.

So we have to support both variants.

## How can this be tested?
Test 'original' image, where everything is at root: 
Set `codeModulesImage` to  `quay.io/dynatrace/codemodules:1.246.0.20220627-183412`

Test 'official' image, where everything is at `/opt/dynatrace/oneagent`:
Set `codeModulesImage` to  `quay.io/dynatrace/codemodules:1.259.0.20230103`

## Checklist
- ~[ ] Unit tests have been updated/added~ (the relevant parts are testing the "move" logic, which doesn't work with `afero`)
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

