### PR TITLE
Remove platform suffix from RHCC release image

### DIFF
--- a/.github/actions/preflight/action.yaml
+++ b/.github/actions/preflight/action.yaml
@@ -28,7 +28,7 @@ runs:
     env:
       RHCC_APITOKEN: ${{ inputs.pyxis-api-token }}
       RHCC_PROJECT_ID: ${{ inputs.redhat-project-id }}
-      PREFLIGHT_VERSION: "1.4.0"
+      PREFLIGHT_VERSION: "1.4.3"
       IMAGE_URI: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.version }}
     run: |
       hack/build/ci/preflight.sh "${{ env.PREFLIGHT_VERSION }}" "${{ env.IMAGE_URI}}" "${{ inputs.report-name }}"

--- a/.github/actions/upload-image/action.yaml
+++ b/.github/actions/upload-image/action.yaml
@@ -16,6 +16,11 @@ inputs:
   repository:
     description: The repository in the registry where the image is uploaded
     required: true
+  skip-platform-suffix:
+    description: Set if platform suffix should be skipped for image
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -26,5 +31,7 @@ runs:
         path: /tmp
     - name: Upload image to Registry
       shell: bash
+      env:
+        IMAGE: "${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.version }}"
       run: |
-        hack/build/ci/upload-docker-image.sh "${{ inputs.platform }}" "${{ inputs.registry }}" "${{ inputs.repository }}" "${{ inputs.version }}"
+        hack/build/ci/upload-docker-image.sh "${{ inputs.platform }}" "${{ env.IMAGE }}" "${{ inputs.skip-platform-suffix }}"

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -58,13 +58,8 @@ jobs:
     strategy:
       matrix:
         platform: [amd64, arm64]
-        registry: [gcr, dockerhub, rhcc]
+        registry: [gcr, dockerhub]
         include:
-        - registry: rhcc
-          url: scan.connect.redhat.com
-          repository: RHCC_REPOSITORY
-          username: RHCC_USERNAME
-          password: RHCC_PASSWORD
         - registry: gcr
           url: gcr.io
           repository: GCR_REPOSITORY
@@ -86,33 +81,56 @@ jobs:
           password: ${{ secrets[matrix.password] }}
       - name: Push ${{matrix.platform}} to ${{matrix.registry}}
         uses: ./.github/actions/upload-image
-        if: matrix.platform == 'amd64' || matrix.registry != 'rhcc'
         with:
           platform: ${{ matrix.platform }}
           labels: ${{ needs.prepare.outputs.labels }}
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{ matrix.url }}
           repository: ${{ secrets[matrix.repository] }}
-      - name: Run preflight
-        if: matrix.registry == 'rhcc' && matrix.platform == 'amd64'
-        uses: ./.github/actions/preflight
-        with:
-         version: ${{ needs.prepare.outputs.version }}
-         registry: ${{ matrix.url }}
-         repository: ${{ secrets[matrix.repository] }}
-         report-name: "preflight.json"
-         redhat-project-id: ${{ secrets.REDHAT_PROJECT_ID }}
-         pyxis-api-token: ${{ secrets.PYXIS_API_TOKEN }}
       - name: Sign image for ${{matrix.registry}}
-        if: matrix.registry != 'rhcc'
         uses: ./.github/actions/sign-image
         with:
           image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}-${{ matrix.platform }}
           signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
 
+  push-rhcc:
+    name: Push amd64 image to RHCC
+    environment: Release
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    env:
+      SCAN_REGISTRY: "quay.io"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - name: Login to Registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          registry: ${{ env.SCAN_REGISTRY }}
+          username: ${{ secrets.RHCC_USERNAME }}
+          password: ${{ secrets.RHCC_PASSWORD }}
+      - name: Push amd64 image to scan registry
+        uses: ./.github/actions/upload-image
+        with:
+          platform: "amd64"
+          labels: ${{ needs.prepare.outputs.labels }}
+          version: ${{ needs.prepare.outputs.version }}
+          registry: ${{ env.SCAN_REGISTRY }}
+          repository: ${{ secrets.RHCC_REPOSITORY }}
+          skip-platform-suffix: true
+      - name: Run preflight
+        uses: ./.github/actions/preflight
+        with:
+          version: ${{ needs.prepare.outputs.version }}
+          registry: ${{ env.SCAN_REGISTRY }}
+          repository: ${{ secrets.RHCC_REPOSITORY }}
+          report-name: "preflight.json"
+          redhat-project-id: ${{ secrets.REDHAT_PROJECT_ID }}
+          pyxis-api-token: ${{ secrets.PYXIS_API_TOKEN }}
+
   manifest:
-    name: Create manifests
+    name: Create manifest
     environment: Release
     needs: [prepare, push]
     runs-on: ubuntu-latest

--- a/hack/build/ci/preflight.sh
+++ b/hack/build/ci/preflight.sh
@@ -3,7 +3,7 @@
 set -x
 
 readonly PREFLIGHT_VERSION="${1}"
-readonly IMAGE_TAG="${2}"
+readonly IMAGE_URI="${2}"
 readonly PREFLIGHT_REPORT_NAME="${3}"
 
 readonly PREFLIGHT_EXECUTABLE="preflight-linux-amd64"
@@ -15,7 +15,7 @@ download_preflight() {
 }
 
 check_image() {
-  ./"${PREFLIGHT_EXECUTABLE}" check container "${IMAGE_TAG}" \
+  ./"${PREFLIGHT_EXECUTABLE}" check container "${IMAGE_URI}" \
     --docker-config="${HOME}/.docker/config.json" \
     1> "${PREFLIGHT_REPORT_NAME}" 2> "${PREFLIGHT_LOG}"
   echo "${PREFLIGHT_EXECUTABLE} returned ${?}"
@@ -24,7 +24,7 @@ check_image() {
 }
 
 submit_report() {
-  ./"${PREFLIGHT_EXECUTABLE}" check container "${IMAGE_TAG}" \
+  ./"${PREFLIGHT_EXECUTABLE}" check container "${IMAGE_URI}" \
     --pyxis-api-token="${RHCC_APITOKEN}" --certification-project-id="${RHCC_PROJECT_ID}" \
     --docker-config="${HOME}/.docker/config.json" \
     --submit

--- a/hack/build/ci/upload-docker-image.sh
+++ b/hack/build/ci/upload-docker-image.sh
@@ -2,22 +2,15 @@
 
 set -x
 
-if [ -z "$4" ]
-then
-  echo "Usage: $0 <platform> <registry> <repository> <version>"
-  exit 1
-fi
+readonly platform="${1}"
+readonly targetImage="${2}"
+readonly skip_platform_suffix="${3}"
 
-readonly platform=${1}
-readonly registry=${2}
-readonly repository=${3}
-readonly version=${4}
 readonly imageTarPath="/tmp/operator-${platform}.tar"
 
-targetImageTag="${registry}/${repository}:${version}"
-if [ "${registry}" != "scan.connect.redhat.com" ]
+if [ -z "${skip_platform_suffix}" ]
 then
-  targetImageTag=${targetImageTag}-${platform}
+  targetImage=${targetImage}-${platform}
 fi
 
 docker load -i "${imageTarPath}"
@@ -26,8 +19,8 @@ docker load -i "${imageTarPath}"
 # Loaded image: alpine:latest
 #
 # we're interested in "alpine:latest", that's field=3
-srcImageTag=$(docker load -i "${imageTarPath}" | cut -d' ' -f3)
+srcImage=$(docker load -i "${imageTarPath}" | cut -d' ' -f3)
 
 docker load --input "${imageTarPath}"
-docker tag "${srcImageTag}" "${targetImageTag}"
-docker push "${targetImageTag}"
+docker tag "${srcImage}" "${targetImage}"
+docker push "${targetImage}"

--- a/hack/build/ci/upload-docker-image.sh
+++ b/hack/build/ci/upload-docker-image.sh
@@ -3,7 +3,7 @@
 set -x
 
 readonly platform="${1}"
-readonly targetImage="${2}"
+targetImage="${2}"
 readonly skip_platform_suffix="${3}"
 
 readonly imageTarPath="/tmp/operator-${platform}.tar"


### PR DESCRIPTION
# Description
Fix image push to RHCC with incorrect `-amd64` suffix:
- Move check whether suffix is needed to separate, optional parameter
	- Push `<version>` image instead of `<version>-<platform` image in case of RHCC
- Split RHCC image push from GCR/Dockerhub image push
	- Sign image for GCR/Dockerhub
	- Run preflight for RHCC
- Update preflight tool to `1.4.3`

## How can this be tested?
Normal behavior should not change for pushes/PRs, but release image push to RHCC should now use correct image:
- Check successful run in fork: https://github.com/chrismuellner/dynatrace-operator/actions/runs/3831691590


## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

