### PR TITLE
Use chart version in `application.yaml`

### DIFF
--- a/config/helm/chart/default/templates/application.yaml
+++ b/config/helm/chart/default/templates/application.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   descriptor:
     type: "Dynatrace Operator"
-    version: "0.10.1"
+    version: {{ .Chart.AppVersion }}
     maintainers:
       - name: Dynatrace LLC
         url: https://www.dynatrace.com/


### PR DESCRIPTION
# Description

Use the version set in the Chart.yaml.
This makes it easier during release, so we don't have to do magic to update the version here

## How can this be tested?
Set the AppVersion in the Chart.yaml to something
Set the platform in the values.yaml to google-marketplace
Run helm template (or generate the manifests)
Check if the application.yaml version has been updated

## Checklist
- ~[ ] Unit tests have been updated/added~
- [X] PR is labeled accordingly
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

