### PR TITLE
Update registrar/livenessprobe to `v2.7.0`/`v2.9.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ COPY --from=operator-build /usr/lib/libgpg-error.so.* /usr/lib/
 COPY --from=operator-build /usr/lib/libgpgme.so.* /usr/lib/
 
 # csi binaries
-COPY --from=k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.2 /csi-node-driver-registrar /usr/local/bin
-COPY --from=k8s.gcr.io/sig-storage/livenessprobe:v2.8.0 /livenessprobe /usr/local/bin
+COPY --from=registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0 /csi-node-driver-registrar /usr/local/bin
+COPY --from=registry.k8s.io/sig-storage/livenessprobe:v2.9.0 /livenessprobe /usr/local/bin
 
 # csi depdenencies
 COPY --from=dependency-src /bin/mount /bin/umount /bin/tar /bin/


### PR DESCRIPTION
# Description
Update registrar and livenessprobe to latest versions.

Change registry to `registry.k8s.io` from `k8s.gcr.io`

## How can this be tested?
CSI driver functionality works.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

