### PR TITLE
Fixed log.Info function call arguments

### DIFF
--- a/src/ingestendpoint/secret.go
+++ b/src/ingestendpoint/secret.go
@@ -106,7 +106,7 @@ func (g *EndpointSecretGenerator) GenerateForDynakube(ctx context.Context, dk *d
 		return err
 	}
 
-	log.Info("done updating data-ingest endpoint secrets", "update/creation count")
+	log.Info("done updating data-ingest endpoint secrets")
 	return nil
 }
 


### PR DESCRIPTION
# Description

log.Info function call has been fixed. Number of  `creations`/`updates` is printed earlier.
```
{"level":"info","ts":"2023-01-13T09:10:52.087Z","logger":"ingestendpoint","msg":"reconciling data-ingest endpoint secret for","dynakube":"dynakube"}
...
{"level":"info","ts":"2023-01-13T09:10:52.093Z","logger":"ingestendpoint","msg":"reconciled secret for multiple namespaces","name":"dynatrace-data-ingest-endpoint","creationCount":0,"updateCount":0}
{"level":"info","ts":"2023-01-13T09:10:52.093Z","logger":"ingestendpoint","msg":"done updating data-ingest endpoint secrets"}
```

## How can this be tested?
No stacktrace messages related to the log.Info call in the operator log
```
{"level":"dpanic","ts":"2023-01-13T09:10:52.093Z","logger":"ingestendpoint","msg":"odd number of arguments passed as key-value pairs for logging","ignored key":"update/creation count","stacktrace":"github.com/Dynatrace/dynatrace-operator/src/logger.logSink.Info\n\t/app/src/logger/logger.go:32\ngithub.com/go-logr/logr.Logger.Info\n\t/go/pkg/mod/github.com/go-logr/logr@v1.2.3/logr.go:261\ngithub.com/Dynatrace/dynatrace-operator/src/ingestendpoint.(*EndpointSecretGenerator).GenerateForDynakube\n\t/app/src/ingestendpoint/secret.go:109...
```

## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

