### PR TITLE
Add SecurityContextConstraint for ActiveGate with read-only root filesystem

### DIFF
--- a/config/helm/chart/default/templates/Openshift/activegate/securitycontextconstraints.yaml
+++ b/config/helm/chart/default/templates/Openshift/activegate/securitycontextconstraints.yaml
@@ -21,11 +21,7 @@ allowPrivilegedContainer: false
 fsGroup:
   type: RunAsAny
 priority: 1
-{{- if (.Values.activeGate).readOnlyFs }}
-readOnlyRootFilesystem: true
-{{ else }}
 readOnlyRootFilesystem: false
-{{ end }}
 requiredDropCapabilities:
   - ALL
 runAsUser:


### PR DESCRIPTION
# Description

Security Context Constraint helm template for the Activegate needs an update because  `activeGate.readOnlyFs` value can't be configured in the helm values.

The obsolete value has been removed from Activegate SCC and the current state is
```
readOnlyRootFilesystem: false
```
It's correct setting for AG pod with writable file system and read only filesystem.


## How can this be tested?
Deploy the following dynakube on an OpenShift cluster
```
metadata:
  #annotations:
  #  feature.dynatrace.com/activegate-readonly-fs: "true"
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://<APIURL>/api
  activeGate:
    capabilities:
    - routing
    #- kubernetes-monitoring
```
enable/disable commented out annotations and capabilities and check what SCC is used by AG pod:
```
 oc get pod dynatrace-activegate-0 -o "custom-columns=POD NAME:.metadata.name,SCC:.metadata.annotations.openshift\.io/scc,SERVICEACCOUNT:.spec.serviceAccountName"
```
Results:
```
POD NAME                SCC                    SERVICEACCOUNT
dynakube-activegate-0   dynatrace-activegate   dynatrace-activegate

POD NAME                SCC                         SERVICEACCOUNT
dynakube-activegate-0   dynatrace-activegate   dynatrace-activegate

POD NAME                SCC                    SERVICEACCOUNT
dynakube-activegate-0   dynatrace-activegate   dynatrace-kubernetes-monitoring

POD NAME                SCC                         SERVICEACCOUNT
dynakube-activegate-0   dynatrace-activegate   dynatrace-kubernetes-monitoring
```


## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

