### PR TITLE
Make image statically linked

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,24 +12,21 @@ RUN CGO_ENABLED=1 CGO_CFLAGS="-O2 -Wno-return-local-addr" \
     go build -tags "containers_image_openpgp,osusergo,netgo,sqlite_omit_load_extension,containers_image_storage_stub,containers_image_docker_daemon_stub" -trimpath -ldflags="${GO_LINKER_ARGS}" \
     -o ./build/_output/bin/dynatrace-operator ./src/cmd/
 
-FROM registry.access.redhat.com/ubi8-minimal:8.7-1049 as dependency-src
+FROM registry.access.redhat.com/ubi9-minimal:9.1.0 as dependency-src
 
 RUN microdnf install -y util-linux tar --nodocs
 
-FROM registry.access.redhat.com/ubi8-micro:8.7-4
+FROM registry.access.redhat.com/ubi9-micro:9.1.0
 
 # operator binary
 COPY --from=operator-build /app/build/_output/bin /usr/local/bin
 
 # # trusted certificates
-COPY --from=dependency-src etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/cert.pem
+COPY --from=dependency-src /etc/ssl/cert.pem /etc/ssl/cert.pem
 
 # csi dependencies
 COPY --from=dependency-src /bin/mount /bin/umount /bin/tar /bin/
 COPY --from=dependency-src /lib64/libmount.so.1 /lib64/libblkid.so.1 /lib64/libuuid.so.1 /lib64/
-
-# fix permission and add .so files to cache
-RUN chmod +x /usr/lib/* && ldconfig
 
 # csi binaries
 COPY --from=registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0 /csi-node-driver-registrar /usr/local/bin

--- a/hack/build/create_go_linker_args.sh
+++ b/hack/build/create_go_linker_args.sh
@@ -14,6 +14,6 @@ go_linker_args=(
   "-X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${version}'"
   "-X 'github.com/Dynatrace/dynatrace-operator/src/version.Commit=${commit}'"
   "-X 'github.com/Dynatrace/dynatrace-operator/src/version.BuildDate=${build_date}'"
-  "-s -w"
+  "-extldflags=-static -s -w"
 )
 echo "${go_linker_args[*]}"


### PR DESCRIPTION
# Description

By adding the `static` flag, and using build tags to limit the amount CGO things we build into our image I managed to make the image statically linked.

build tags used:
- `osusergo`, `netgo`: if CGO is enabled, certain standard libraries will also use CGO, these explicitly disallows that
- `sqlite_omit_load_extension`: Disables the ability to add load extensions for sqlite3, needed to statically build when using the sqlite library. We never use extensions so its good to disable it.
-  `containers_image_openpgp`: needed for the [image](https://github.com/containers/image) library, to use the open go implementation of gpgme. creating new signatures is not possible but we never do that
- `containers_image_storage_stub`: Removes the `containers-storage` parts of the [image](https://github.com/containers/image) library as we are not using it. [more info about the disabled part](https://github.com/containers/image/blob/4786bafd17ba981b5726864c8465f81aa2dac309/docs/containers-transports.5.md#containers-storagestorage-specifierimage-iddocker-referenceimage-id) 
- `containers_image_docker_daemon_stub `: Removes the `docker-daemon` parts of the [image](https://github.com/containers/image) library as we are not using it. [more info about the disabled part](https://github.com/containers/image/blob/4786bafd17ba981b5726864c8465f81aa2dac309/docs/containers-transports.5.md#docker-daemondocker-referencealgodigest)

## How can this be tested?
No change in behaviour.


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

