### PR TITLE
Installs operator in e2e tests via make

### DIFF
--- a/hack/make/deploy/kubernetes.mk
+++ b/hack/make/deploy/kubernetes.mk
@@ -9,6 +9,16 @@ deploy/kubernetes: manifests/crd/helm
 			--set manifests=true \
 			--set image="$(BRANCH_IMAGE)" | kubectl apply -f -
 
+## Deploy the operator in the Kubernetes cluster configured in ~/.kube/config
+deploy/kubernetes-no-csi: manifests/crd/helm
+	kubectl get namespace dynatrace || kubectl create namespace dynatrace
+	helm template dynatrace-operator config/helm/chart/default \
+			--namespace dynatrace \
+			--set installCRD=true \
+			--set platform="kubernetes" \
+			--set manifests=true \
+			--set image="$(BRANCH_IMAGE)" | kubectl apply -f -
+
 ## Deploy the operator in the Google Autopilot cluster configured in ~/.kube/config
 deploy/gke-autopilot: manifests/crd/helm
 	kubectl get namespace dynatrace || kubectl create namespace dynatrace

--- a/hack/make/deploy/openshift.mk
+++ b/hack/make/deploy/openshift.mk
@@ -8,3 +8,12 @@ deploy/openshift: manifests/crd/helm
 			--set csidriver.enabled=true \
 			--set manifests=true \
 			--set image="$(BRANCH_IMAGE)" | oc apply -f -
+
+deploy/openshift-no-csi: manifests/crd/helm
+	oc get project dynatrace || oc adm new-project --node-selector="" dynatrace
+	helm template dynatrace-operator config/helm/chart/default \
+			--namespace dynatrace \
+			--set installCRD=true \
+			--set platform="openshift" \
+			--set manifests=true \
+			--set image="$(BRANCH_IMAGE)" | oc apply -f -

--- a/test/operator/installation.go
+++ b/test/operator/installation.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"context"
 	"net/url"
-	"os"
 	"os/exec"
 	"path"
 	"strings"
@@ -33,7 +32,7 @@ func InstallFromSource(withCsi bool) features.Func {
 
 func InstallViaMake() features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		rootDir := getSourceRootDir()
+		rootDir := project.RootDir()
 
 		runBuildAndManifests(rootDir, t)
 
@@ -71,18 +70,6 @@ func runBuildAndManifests(rootDir string, t *testing.T) {
 		t.Fatal("failed to install the operator via the make command", err)
 		return
 	}
-}
-
-func getSourceRootDir() string {
-	currentDir, err := os.Getwd()
-
-	if err != nil {
-		return ""
-	}
-
-	rootDir := strings.Split(currentDir, "test")
-
-	return rootDir[0]
 }
 
 func manifestsPaths(withCsi bool) []string {

--- a/test/operator/installation.go
+++ b/test/operator/installation.go
@@ -30,7 +30,7 @@ func InstallFromSource(withCsi bool) features.Func {
 	return manifests.InstallFromFiles(paths)
 }
 
-func InstallViaMake() features.Func {
+func InstallViaMake(withCSI bool) features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
 		rootDir := project.RootDir()
 
@@ -46,6 +46,10 @@ func InstallViaMake() features.Func {
 		default:
 			t.Fatal("failed to install the operator via the make command as no correct platform was set")
 			return nil
+		}
+
+		if !withCSI {
+			makeTarget = strings.Join([]string{makeTarget, "no-csi"}, "-")
 		}
 
 		err := exec.Command("make", "-C", rootDir, makeTarget).Run()

--- a/test/operator/installation.go
+++ b/test/operator/installation.go
@@ -37,20 +37,7 @@ func InstallViaMake(withCSI bool) features.Func {
 		runBuildAndManifests(rootDir, t)
 
 		platform := kubeobjects.ResolvePlatformFromEnv()
-		makeTarget := "deploy"
-		switch platform {
-		case kubeobjects.Openshift:
-			makeTarget = strings.Join([]string{makeTarget, "openshift"}, "/")
-		case kubeobjects.Kubernetes:
-			makeTarget = strings.Join([]string{makeTarget, "kubernetes"}, "/")
-		default:
-			t.Fatal("failed to install the operator via the make command as no correct platform was set")
-			return nil
-		}
-
-		if !withCSI {
-			makeTarget = strings.Join([]string{makeTarget, "no-csi"}, "-")
-		}
+		makeTarget := getDeployMakeTarget(platform, withCSI, t)
 
 		err := exec.Command("make", "-C", rootDir, makeTarget).Run()
 		if err != nil {
@@ -60,6 +47,25 @@ func InstallViaMake(withCSI bool) features.Func {
 
 		return ctx
 	}
+}
+
+func getDeployMakeTarget(platform kubeobjects.Platform, withCSI bool, t *testing.T) string {
+	makeTarget := "deploy"
+	switch platform {
+	case kubeobjects.Openshift:
+		makeTarget = strings.Join([]string{makeTarget, "openshift"}, "/")
+	case kubeobjects.Kubernetes:
+		makeTarget = strings.Join([]string{makeTarget, "kubernetes"}, "/")
+	default:
+		t.Fatal("failed to install the operator via the make command as no correct platform was set")
+		return ""
+	}
+
+	if !withCSI {
+		makeTarget = strings.Join([]string{makeTarget, "no-csi"}, "-")
+	}
+
+	return makeTarget
 }
 
 func runBuildAndManifests(rootDir string, t *testing.T) {

--- a/test/operator/installation.go
+++ b/test/operator/installation.go
@@ -39,6 +39,11 @@ func InstallViaMake(withCSI bool) features.Func {
 		platform := kubeobjects.ResolvePlatformFromEnv()
 		makeTarget := getDeployMakeTarget(platform, withCSI, t)
 
+		if makeTarget == "" {
+			t.Fatal("failed to install the operator via the make command, as the make target was empty")
+			return nil
+		}
+
 		err := exec.Command("make", "-C", rootDir, makeTarget).Run()
 		if err != nil {
 			t.Fatal("failed to install the operator via the make command", err)

--- a/test/operator/installation.go
+++ b/test/operator/installation.go
@@ -39,11 +39,12 @@ func InstallViaMake() features.Func {
 
 		platform := kubeobjects.ResolvePlatformFromEnv()
 		makeTarget := "deploy"
-		if platform == kubeobjects.Openshift {
+		switch platform {
+		case kubeobjects.Openshift:
 			makeTarget = strings.Join([]string{makeTarget, "openshift"}, "/")
-		} else if platform == kubeobjects.Kubernetes {
+		case kubeobjects.Kubernetes:
 			makeTarget = strings.Join([]string{makeTarget, "kubernetes"}, "/")
-		} else {
+		default:
 			t.Fatal("failed to install the operator via the make command as no correct platform was set")
 			return nil
 		}

--- a/test/scenarios/activegate/installation.go
+++ b/test/scenarios/activegate/installation.go
@@ -87,7 +87,7 @@ func Install(t *testing.T, proxySpec *v1beta1.DynaKubeProxy) features.Feature {
 
 func installAndDeploy(builder *features.FeatureBuilder, secretConfig secrets.Secret) {
 	builder.Setup(secrets.ApplyDefault(secretConfig))
-	builder.Setup(operator.InstallViaMake())
+	builder.Setup(operator.InstallViaMake(false))
 }
 
 func assessDeployment(builder *features.FeatureBuilder) {

--- a/test/scenarios/activegate/installation.go
+++ b/test/scenarios/activegate/installation.go
@@ -87,7 +87,7 @@ func Install(t *testing.T, proxySpec *v1beta1.DynaKubeProxy) features.Feature {
 
 func installAndDeploy(builder *features.FeatureBuilder, secretConfig secrets.Secret) {
 	builder.Setup(secrets.ApplyDefault(secretConfig))
-	builder.Setup(operator.InstallFromSource(false))
+	builder.Setup(operator.InstallViaMake())
 }
 
 func assessDeployment(builder *features.FeatureBuilder) {

--- a/test/scenarios/applicationmonitoring/dataingest.go
+++ b/test/scenarios/applicationmonitoring/dataingest.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/config"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
-	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
@@ -48,13 +47,11 @@ func dataIngest(t *testing.T) features.Feature {
 	dataIngestDynakube := dynakube.NewBuilder().
 		WithDefaultObjectMeta().
 		ApiUrl(tenantSecret.ApiUrl).
-		ApplicationMonitoring(&v1beta1.ApplicationMonitoringSpec{
-			UseCSIDriver: address.Of(false),
-		}).Build()
+		ApplicationMonitoring(&v1beta1.ApplicationMonitoringSpec{}).Build()
 
 	require.NoError(t, err)
 
-	dataIngestFeature.Setup(operator.InstallFromSource(false))
+	dataIngestFeature.Setup(operator.InstallViaMake())
 	dataIngestFeature.Setup(operator.WaitForDeployment())
 	dataIngestFeature.Setup(webhook.WaitForDeployment())
 	dataIngestFeature.Setup(secrets.ApplyDefault(tenantSecret))

--- a/test/scenarios/applicationmonitoring/dataingest.go
+++ b/test/scenarios/applicationmonitoring/dataingest.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/config"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
@@ -47,11 +48,13 @@ func dataIngest(t *testing.T) features.Feature {
 	dataIngestDynakube := dynakube.NewBuilder().
 		WithDefaultObjectMeta().
 		ApiUrl(tenantSecret.ApiUrl).
-		ApplicationMonitoring(&v1beta1.ApplicationMonitoringSpec{}).Build()
+		ApplicationMonitoring(&v1beta1.ApplicationMonitoringSpec{
+			UseCSIDriver: address.Of(false),
+		}).Build()
 
 	require.NoError(t, err)
 
-	dataIngestFeature.Setup(operator.InstallViaMake())
+	dataIngestFeature.Setup(operator.InstallViaMake(false))
 	dataIngestFeature.Setup(operator.WaitForDeployment())
 	dataIngestFeature.Setup(webhook.WaitForDeployment())
 	dataIngestFeature.Setup(secrets.ApplyDefault(tenantSecret))

--- a/test/scenarios/applicationmonitoring/labelversiondetection.go
+++ b/test/scenarios/applicationmonitoring/labelversiondetection.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/operator"
+	"github.com/Dynatrace/dynatrace-operator/test/project"
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/secrets"
 	"github.com/Dynatrace/dynatrace-operator/test/shell"
@@ -131,7 +132,7 @@ func installDynakube(t *testing.T, name string, annotations map[string]string) f
 
 func installSampleApplications() features.Feature {
 	defaultInstallation := features.New("sample applications installation")
-	defaultInstallation.Assess("sample applications applied", manifests.InstallFromFile("../../testdata/application-monitoring/buildlabels-sample-apps.yaml"))
+	defaultInstallation.Assess("sample applications applied", manifests.InstallFromFile(project.RootDir()+"/test/testdata/application-monitoring/buildlabels-sample-apps.yaml"))
 	for _, namespaceName := range namespaceNames {
 		defaultInstallation.Assess(namespaceName+" is ready", deployment.WaitFor(sampleapps.Name, namespaceName))
 	}

--- a/test/scenarios/applicationmonitoring/labelversiondetection.go
+++ b/test/scenarios/applicationmonitoring/labelversiondetection.go
@@ -104,7 +104,7 @@ func installOperator(t *testing.T) features.Feature {
 	defaultInstallation := features.New("default installation")
 
 	defaultInstallation.Setup(secrets.ApplyDefault(secretConfig))
-	defaultInstallation.Setup(operator.InstallViaMake(true))
+	defaultInstallation.Setup(operator.InstallViaMake(false))
 	defaultInstallation.Assess("operator started", operator.WaitForDeployment())
 	defaultInstallation.Assess("webhook started", webhook.WaitForDeployment())
 

--- a/test/scenarios/applicationmonitoring/labelversiondetection.go
+++ b/test/scenarios/applicationmonitoring/labelversiondetection.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
@@ -103,7 +104,7 @@ func installOperator(t *testing.T) features.Feature {
 	defaultInstallation := features.New("default installation")
 
 	defaultInstallation.Setup(secrets.ApplyDefault(secretConfig))
-	defaultInstallation.Setup(operator.InstallViaMake())
+	defaultInstallation.Setup(operator.InstallViaMake(true))
 	defaultInstallation.Assess("operator started", operator.WaitForDeployment())
 	defaultInstallation.Assess("webhook started", webhook.WaitForDeployment())
 
@@ -125,7 +126,9 @@ func installDynakube(t *testing.T, name string, annotations map[string]string) f
 			},
 		}).
 		Tokens(dynakube.Name).
-		ApplicationMonitoring(&v1beta1.ApplicationMonitoringSpec{}).Build()))
+		ApplicationMonitoring(&v1beta1.ApplicationMonitoringSpec{
+			UseCSIDriver: address.Of(false),
+		}).Build()))
 	defaultInstallation.Assess("dynakube phase changes to 'Running'", dynakube.WaitForDynakubePhase(dynakube.NewBuilder().Name(name).Namespace(dynakube.Namespace).Build()))
 
 	return defaultInstallation.Feature()

--- a/test/scenarios/applicationmonitoring/labelversiondetection.go
+++ b/test/scenarios/applicationmonitoring/labelversiondetection.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/test/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/manifests"
@@ -102,7 +101,7 @@ func installOperator(t *testing.T) features.Feature {
 	defaultInstallation := features.New("default installation")
 
 	defaultInstallation.Setup(secrets.ApplyDefault(secretConfig))
-	defaultInstallation.Setup(operator.InstallFromSource(false))
+	defaultInstallation.Setup(operator.InstallViaMake())
 	defaultInstallation.Assess("operator started", operator.WaitForDeployment())
 	defaultInstallation.Assess("webhook started", webhook.WaitForDeployment())
 
@@ -124,9 +123,7 @@ func installDynakube(t *testing.T, name string, annotations map[string]string) f
 			},
 		}).
 		Tokens(dynakube.Name).
-		ApplicationMonitoring(&v1beta1.ApplicationMonitoringSpec{
-			UseCSIDriver: address.Of(false),
-		}).Build()))
+		ApplicationMonitoring(&v1beta1.ApplicationMonitoringSpec{}).Build()))
 	defaultInstallation.Assess("dynakube phase changes to 'Running'", dynakube.WaitForDynakubePhase(dynakube.NewBuilder().Name(name).Namespace(dynakube.Namespace).Build()))
 
 	return defaultInstallation.Feature()
@@ -134,7 +131,7 @@ func installDynakube(t *testing.T, name string, annotations map[string]string) f
 
 func installSampleApplications() features.Feature {
 	defaultInstallation := features.New("sample applications installation")
-	defaultInstallation.Assess("sample applications applied", manifests.InstallFromFile("../testdata/application-monitoring/buildlabels-sample-apps.yaml"))
+	defaultInstallation.Assess("sample applications applied", manifests.InstallFromFile("../../testdata/application-monitoring/buildlabels-sample-apps.yaml"))
 	for _, namespaceName := range namespaceNames {
 		defaultInstallation.Assess(namespaceName+" is ready", deployment.WaitFor(sampleapps.Name, namespaceName))
 	}

--- a/test/scenarios/applicationmonitoring/labelversiondetection.go
+++ b/test/scenarios/applicationmonitoring/labelversiondetection.go
@@ -5,6 +5,7 @@ package applicationmonitoring
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 	"testing"
 
@@ -132,7 +133,7 @@ func installDynakube(t *testing.T, name string, annotations map[string]string) f
 
 func installSampleApplications() features.Feature {
 	defaultInstallation := features.New("sample applications installation")
-	defaultInstallation.Assess("sample applications applied", manifests.InstallFromFile(project.RootDir()+"/test/testdata/application-monitoring/buildlabels-sample-apps.yaml"))
+	defaultInstallation.Assess("sample applications applied", manifests.InstallFromFile(path.Join(project.TestDataDir(), "application-monitoring/buildlabels-sample-apps.yaml")))
 	for _, namespaceName := range namespaceNames {
 		defaultInstallation.Assess(namespaceName+" is ready", deployment.WaitFor(sampleapps.Name, namespaceName))
 	}

--- a/test/scenarios/cloudnative/network_problems.go
+++ b/test/scenarios/cloudnative/network_problems.go
@@ -44,7 +44,7 @@ func NetworkProblems(t *testing.T) features.Feature {
 	createNetworkProblems.Setup(manifests.InstallFromFile(path.Join(project.TestDataDir(), csiNetworkPolicy)))
 	createNetworkProblems.Setup(manifests.InstallFromFile(path.Join(project.TestDataDir(), sampleNSPath)))
 	createNetworkProblems.Setup(secrets.ApplyDefault(secretConfigs[0]))
-	createNetworkProblems.Setup(operator.InstallFromSource(true))
+	createNetworkProblems.Setup(operator.InstallViaMake())
 
 	setup.AssessOperatorDeployment(createNetworkProblems)
 

--- a/test/scenarios/cloudnative/network_problems.go
+++ b/test/scenarios/cloudnative/network_problems.go
@@ -44,7 +44,7 @@ func NetworkProblems(t *testing.T) features.Feature {
 	createNetworkProblems.Setup(manifests.InstallFromFile(path.Join(project.TestDataDir(), csiNetworkPolicy)))
 	createNetworkProblems.Setup(manifests.InstallFromFile(path.Join(project.TestDataDir(), sampleNSPath)))
 	createNetworkProblems.Setup(secrets.ApplyDefault(secretConfigs[0]))
-	createNetworkProblems.Setup(operator.InstallViaMake())
+	createNetworkProblems.Setup(operator.InstallViaMake(true))
 
 	setup.AssessOperatorDeployment(createNetworkProblems)
 

--- a/test/setup/setup.go
+++ b/test/setup/setup.go
@@ -21,7 +21,7 @@ func InstallDynatraceFromSource(builder *features.FeatureBuilder, secretConfig *
 	if secretConfig != nil {
 		builder.Setup(secrets.ApplyDefault(*secretConfig))
 	}
-	builder.Setup(operator.InstallFromSource(true))
+	builder.Setup(operator.InstallViaMake())
 }
 
 func InstallDynatraceFromGithub(builder *features.FeatureBuilder, secretConfig *secrets.Secret, releaseTag string) {

--- a/test/setup/setup.go
+++ b/test/setup/setup.go
@@ -21,7 +21,7 @@ func InstallDynatraceFromSource(builder *features.FeatureBuilder, secretConfig *
 	if secretConfig != nil {
 		builder.Setup(secrets.ApplyDefault(*secretConfig))
 	}
-	builder.Setup(operator.InstallViaMake())
+	builder.Setup(operator.InstallViaMake(true))
 }
 
 func InstallDynatraceFromGithub(builder *features.FeatureBuilder, secretConfig *secrets.Secret, releaseTag string) {


### PR DESCRIPTION
# Description
This should change the installation process in the e2e tests regarding the operator. With this change the make command will be used to install the operator.

## How can this be tested?
Simply run the e2e tests.


## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

