### PR TITLE
Add runAsUser/runAsGroup fields to ActiveGate SecurityContext

### DIFF
--- a/config/helm/chart/default/templates/Openshift/activegate/securitycontextconstraints.yaml
+++ b/config/helm/chart/default/templates/Openshift/activegate/securitycontextconstraints.yaml
@@ -25,7 +25,8 @@ readOnlyRootFilesystem: false
 requiredDropCapabilities:
   - ALL
 runAsUser:
-  type: MustRunAsNonRoot
+  type: MustRunAs
+  uid: 1001
 seLinuxContext:
   type: RunAsAny
 seccompProfiles:

--- a/src/controllers/dynakube/activegate/consts/consts.go
+++ b/src/controllers/dynakube/activegate/consts/consts.go
@@ -3,6 +3,8 @@ package consts
 import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/connectioninfo"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -59,4 +61,26 @@ const (
 	GatewaySslMountPoint     = "/var/lib/dynatrace/gateway/ssl"
 	GatewayLogMountPoint     = "/var/log/dynatrace/gateway"
 	GatewayTmpMountPoint     = "/var/tmp/dynatrace/gateway"
+
+	DockerImageUser  int64 = 1001
+	DockerImageGroup int64 = 1001
+)
+
+var (
+	ContainerSecurityContext = corev1.SecurityContext{
+		Privileged:               address.Of(false),
+		AllowPrivilegeEscalation: address.Of(false),
+		RunAsNonRoot:             address.Of(true),
+		RunAsUser:                address.Of(DockerImageUser),
+		RunAsGroup:               address.Of(DockerImageGroup),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		ReadOnlyRootFilesystem: address.Of(false),
+	}
 )

--- a/src/controllers/dynakube/activegate/consts/consts.go
+++ b/src/controllers/dynakube/activegate/consts/consts.go
@@ -3,8 +3,6 @@ package consts
 import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/connectioninfo"
-	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -64,23 +62,4 @@ const (
 
 	DockerImageUser  int64 = 1001
 	DockerImageGroup int64 = 1001
-)
-
-var (
-	ContainerSecurityContext = corev1.SecurityContext{
-		Privileged:               address.Of(false),
-		AllowPrivilegeEscalation: address.Of(false),
-		RunAsNonRoot:             address.Of(true),
-		RunAsUser:                address.Of(DockerImageUser),
-		RunAsGroup:               address.Of(DockerImageGroup),
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{
-				"ALL",
-			},
-		},
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-		ReadOnlyRootFilesystem: address.Of(false),
-	}
 )

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -62,7 +63,7 @@ func (mod KubernetesMonitoringModifier) getInitContainers() []corev1.Container {
 	}
 	volumeMounts = append(volumeMounts, mod.getReadOnlyInitVolumeMounts()...)
 
-	return []corev1.Container{
+	containers := []corev1.Container{
 		{
 			Name:            initContainerTemplateName,
 			Image:           mod.dynakube.ActiveGateImage(),
@@ -72,11 +73,11 @@ func (mod KubernetesMonitoringModifier) getInitContainers() []corev1.Container {
 			Args:            []string{"-c", k8scrt2jksPath},
 			VolumeMounts:    volumeMounts,
 			Resources:       mod.capability.Properties().Resources,
-			SecurityContext: &corev1.SecurityContext{
-				ReadOnlyRootFilesystem: &readOnlyRootFs,
-			},
+			SecurityContext: consts.ContainerSecurityContext.DeepCopy(),
 		},
 	}
+	containers[0].SecurityContext.ReadOnlyRootFilesystem = address.Of(readOnlyRootFs)
+	return containers
 }
 
 func (mod KubernetesMonitoringModifier) getVolumes() []corev1.Volume {

--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -143,19 +143,7 @@ func (statefulSetBuilder Builder) buildBaseContainer() []corev1.Container {
 			PeriodSeconds:       15,
 			FailureThreshold:    3,
 		},
-		SecurityContext: &corev1.SecurityContext{
-			Privileged:               address.Of(false),
-			AllowPrivilegeEscalation: address.Of(false),
-			RunAsNonRoot:             address.Of(true),
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{
-					"ALL",
-				},
-			},
-			SeccompProfile: &corev1.SeccompProfile{
-				Type: corev1.SeccompProfileTypeRuntimeDefault,
-			},
-		},
+		SecurityContext: consts.ContainerSecurityContext.DeepCopy(),
 	}
 
 	return []corev1.Container{container}

--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -143,7 +143,7 @@ func (statefulSetBuilder Builder) buildBaseContainer() []corev1.Container {
 			PeriodSeconds:       15,
 			FailureThreshold:    3,
 		},
-		SecurityContext: consts.ContainerSecurityContext.DeepCopy(),
+		SecurityContext: modifiers.GetSecurityContext(false),
 	}
 
 	return []corev1.Container{container}

--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
@@ -2,11 +2,13 @@ package statefulset
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
@@ -416,5 +418,35 @@ func TestBuildCommonEnvs(t *testing.T) {
 			kubeobjects.VolumeClaimIsDefined(sts.Spec.VolumeClaimTemplates, modifiers.PersistentStorageMountName),
 			"declared volume claim: %s",
 			modifiers.PersistentStorageMountName)
+	})
+}
+
+func TestSecurityContexts(t *testing.T) {
+	checkSecurityContexts := func(t *testing.T, isReadOnlyFileSystem bool) {
+		dynakube := getTestDynakube()
+		if isReadOnlyFileSystem {
+			dynakube.Annotations = map[string]string{
+				dynatracev1beta1.AnnotationFeatureActiveGateReadOnlyFilesystem: "true",
+			}
+		}
+		dynakube.Spec.ActiveGate.Capabilities = append(dynakube.Spec.ActiveGate.Capabilities, dynatracev1beta1.KubeMonCapability.DisplayName)
+
+		multiCapability := capability.NewMultiCapability(&dynakube)
+
+		statefulsetBuilder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		sts, _ := statefulsetBuilder.CreateStatefulSet([]builder.Modifier{
+			modifiers.NewKubernetesMonitoringModifier(dynakube, multiCapability),
+			modifiers.NewReadOnlyModifier(dynakube),
+		})
+
+		require.NotEmpty(t, sts)
+		require.Truef(t, reflect.DeepEqual(sts.Spec.Template.Spec.InitContainers[0].SecurityContext, sts.Spec.Template.Spec.Containers[0].SecurityContext), "InitContainer and Container have different SecurityContexts")
+	}
+
+	t.Run("containers have the same security context if writable file system", func(t *testing.T) {
+		checkSecurityContexts(t, false)
+	})
+	t.Run("containers have the same security context if read-only filesystem", func(t *testing.T) {
+		checkSecurityContexts(t, true)
 	})
 }


### PR DESCRIPTION
# Description

ActiveGate containers i.e.  `activegate` regular container and `certificate-loader` init container should have the same securityContext. Additionally the securityContext should have `runAsUser` and `runAsGroup` fields set to the same value as it is specified by ActiveGate Dockerfile (`USER`).

## How can this be tested?
Deploy DynaKube with `kubernetes-monitoring` capability enabled on:
- a Kubernetes cluster
- an OpenShift cluster.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

