### PR TITLE
Adds a switch to control cleanup behavior after E2E test

### DIFF
--- a/test/kubeobjects/environment/environment.go
+++ b/test/kubeobjects/environment/environment.go
@@ -3,27 +3,114 @@
 package environment
 
 import (
+	"context"
 	"os"
+	"testing"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/e2e-framework/klient/conf"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
 const (
-	useKind = "TEST_ENV_USE_KIND"
+	useKindEnvVar = "TEST_ENV_USE_KIND"
+	cleanupEnvVar = "TEST_ENV_CLEANUP"
 )
 
-func Get() env.Environment {
-	if os.Getenv(useKind) == "true" {
+type CleanupMode string
+
+const (
+	cleanupAlways      CleanupMode = "always"
+	cleanupOnSuccess               = "onSuccess"
+	cleanupNever                   = "never"
+	cleanupModeDefault             = cleanupAlways
+)
+
+type Environment struct {
+	env.Environment
+	skipCleanup CleanupMode
+	t           *testing.T
+}
+
+type CleanupFunction func(ctx context.Context, envconf *envconf.Config, t *testing.T) (context.Context, error)
+
+func Get() *Environment {
+	if os.Getenv(useKindEnvVar) == "true" {
 		environment := env.New()
 		environment.Setup(envfuncs.CreateKindCluster(envconf.RandomName("operator-test", 10)))
-		return environment
+
+		return &Environment{
+			Environment: environment,
+			skipCleanup: getSkipCleanupMode(),
+		}
 	}
 
 	kubeConfigPath := conf.ResolveKubeConfigFile()
 	envConfig := envconf.NewWithKubeConfig(kubeConfigPath)
-	return env.NewWithConfig(envConfig)
+
+	return &Environment{
+		Environment: env.NewWithConfig(envConfig),
+		skipCleanup: getSkipCleanupMode(),
+	}
+}
+
+func (environment *Environment) Test(t *testing.T, features ...features.Feature) {
+	environment.t = t
+	environment.Environment.Test(t, features...)
+}
+
+func (environment *Environment) AfterEachTest(cleanupFunctions ...func(context.Context, *envconf.Config, *testing.T) (context.Context, error)) *Environment {
+	for _, cleanupFunction := range cleanupFunctions {
+		environment.Environment.AfterEachTest(environment.wrapCleanupFunction(cleanupFunction))
+	}
+	return environment
+}
+
+func (environment *Environment) wrapCleanupFunction(cleanupFunction CleanupFunction) func(ctx context.Context, envconf *envconf.Config, t *testing.T) (context.Context, error) {
+	wrapper := cleanupFunctionWrapper{
+		environment:     environment,
+		wrappedFunction: cleanupFunction,
+	}
+	return wrapper.cleanup
+}
+
+func (environment *Environment) shallCleanup() bool {
+	switch environment.skipCleanup {
+	case cleanupAlways:
+		return true
+	case cleanupNever:
+		return false
+	case cleanupOnSuccess:
+		return !environment.t.Failed()
+	default:
+		return true
+	}
+}
+
+func getSkipCleanupMode() CleanupMode {
+	switch os.Getenv(cleanupEnvVar) {
+	case string(cleanupAlways):
+		return cleanupAlways
+	case string(cleanupNever):
+		return cleanupNever
+	case string(cleanupOnSuccess):
+		return cleanupOnSuccess
+	default:
+		return cleanupModeDefault
+	}
+}
+
+type cleanupFunctionWrapper struct {
+	environment     *Environment
+	wrappedFunction func(context.Context, *envconf.Config, *testing.T) (context.Context, error)
+}
+
+func (wrapper cleanupFunctionWrapper) cleanup(ctx context.Context, envconf *envconf.Config, t *testing.T) (context.Context, error) {
+	if wrapper.environment.shallCleanup() {
+		return wrapper.wrappedFunction(ctx, envconf, t)
+	}
+	return ctx, nil
 }

--- a/test/kubeobjects/environment/environment_test.go
+++ b/test/kubeobjects/environment/environment_test.go
@@ -1,0 +1,62 @@
+//go:build e2e
+
+package environment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+func TestEnvironmentCleanup(t *testing.T) {
+	tests := []struct {
+		title           string
+		envVarValue     string
+		testFailed      bool
+		cleanupExpected bool
+	}{
+		{"always cleanup after success", "always", false, true},
+		{"always cleanup after fail", "always", true, true},
+		{"never cleanup after success", "never", false, false},
+		{"never cleanup after fail", "never", true, false},
+		{"cleanup on success", "onSuccess", false, true},
+		{"do not cleanup on fail", "onSuccess", true, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			t.Setenv(cleanupEnvVar, test.envVarValue)
+
+			env := Get()
+			env.t = StubbedT{
+				failed: test.testFailed,
+				t:      t,
+			}
+
+			cleanupFunctionCalled := false
+			cleanupWrapper := env.wrapCleanupFunction(func(context.Context, *envconf.Config, *testing.T) (context.Context, error) {
+				cleanupFunctionCalled = true
+				return nil, nil
+			})
+			_, err := cleanupWrapper(nil, nil, nil)
+
+			assert.Nil(t, err)
+			assert.Equal(t, test.cleanupExpected, cleanupFunctionCalled)
+		})
+	}
+}
+
+type StubbedT struct {
+	failed bool
+	t      *testing.T
+}
+
+func (m StubbedT) Failed() bool {
+	return m.failed
+}
+
+func (m StubbedT) Errorf(format string, args ...interface{}) {
+	m.t.Errorf(format, args...)
+}

--- a/test/scenarios/README.md
+++ b/test/scenarios/README.md
@@ -1,4 +1,5 @@
 ### Table of contents
+- Running E2E tests
 - Active Gate
   - [basic](#activegate---basic)
   - [proxy](#activegate---proxy)
@@ -12,6 +13,27 @@
   - [network](#cloudnative---network)
   - [proxy](#cloudnative---proxy)
 - [Support Archive](#supportarchive)
+
+# Running E2E Tests
+
+## How to run E2E tests
+
+Create a kube config for accessing GKE clusters without having to use gcloud (<1.24):
+https://archive-docs.d2iq.com/dkp/kommander/2.0/clusters/attach-cluster/generate-kubeconfig/index.html
+
+Run E2E tests by calling the following make command:
+```bash
+export KUBECONFIG=<path_to>/kommander-cluster-admin-config
+make build manifests/branch test/e2e
+```
+
+## Cluster cleanup switch
+Usually the test cluster is cleaned up after each test to provide a clean slate for the next. The cleanup behaviour can be
+fine-tuned via the environment variable `TEST_ENV_CLEANUP`.
+
+* `always` - cleanup after each test
+* `never` - never clean up
+* `onSuccess` - only clea nup if test was successful
 
 # ActiveGate - basic
 ## Prerequisites

--- a/test/scenarios/activegate/basic/activegate_test.go
+++ b/test/scenarios/activegate/basic/activegate_test.go
@@ -10,10 +10,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/proxy"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios/activegate"
-	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
-var testEnvironment env.Environment
+var testEnvironment *environment.Environment
 
 func TestMain(m *testing.M) {
 	testEnvironment = environment.Get()

--- a/test/scenarios/activegate/proxy/activegate_test.go
+++ b/test/scenarios/activegate/proxy/activegate_test.go
@@ -10,10 +10,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/proxy"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios/activegate"
-	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
-var testEnvironment env.Environment
+var testEnvironment *environment.Environment
 
 func TestMain(m *testing.M) {
 	testEnvironment = environment.Get()

--- a/test/scenarios/applicationmonitoring/applicationmonitoring_test.go
+++ b/test/scenarios/applicationmonitoring/applicationmonitoring_test.go
@@ -9,10 +9,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
-	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
-var testEnvironment env.Environment
+var testEnvironment *environment.Environment
 
 func TestMain(m *testing.M) {
 	testEnvironment = environment.Get()

--- a/test/scenarios/classic/classic_test.go
+++ b/test/scenarios/classic/classic_test.go
@@ -13,10 +13,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/secrets"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
-var testEnvironment env.Environment
+var testEnvironment *environment.Environment
 
 func TestMain(m *testing.M) {
 	testEnvironment = environment.Get()

--- a/test/scenarios/cloudnative/basic/cloudnative_test.go
+++ b/test/scenarios/cloudnative/basic/cloudnative_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios/cloudnative"
-	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
-var testEnvironment env.Environment
+var testEnvironment *environment.Environment
 
 func TestMain(m *testing.M) {
 	testEnvironment = environment.Get()

--- a/test/scenarios/cloudnative/istio/cloudnative_test.go
+++ b/test/scenarios/cloudnative/istio/cloudnative_test.go
@@ -12,10 +12,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios/cloudnative"
-	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
-var testEnvironment env.Environment
+var testEnvironment *environment.Environment
 
 func TestMain(m *testing.M) {
 	testEnvironment = environment.Get()

--- a/test/scenarios/cloudnative/network/cloudnative_test.go
+++ b/test/scenarios/cloudnative/network/cloudnative_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios/cloudnative"
-	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
-var testEnvironment env.Environment
+var testEnvironment *environment.Environment
 
 func TestMain(m *testing.M) {
 	testEnvironment = environment.Get()

--- a/test/scenarios/cloudnative/proxy/cloudnative_test.go
+++ b/test/scenarios/cloudnative/proxy/cloudnative_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/proxy"
 	"github.com/Dynatrace/dynatrace-operator/test/sampleapps"
-	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
-var testEnvironment env.Environment
+var testEnvironment *environment.Environment
 
 func TestMain(m *testing.M) {
 	testEnvironment = environment.Get()

--- a/test/scenarios/support_archive/support_archive_test.go
+++ b/test/scenarios/support_archive/support_archive_test.go
@@ -30,12 +30,11 @@ import (
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/klient/conf"
-	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-var testEnvironment env.Environment
+var testEnvironment *environment.Environment
 
 const testAppNameNotInjected = "application1"
 const testAppNameInjected = "application2"


### PR DESCRIPTION
# Description
It often is hard to analyze failing E2E tests when the environment they failed in is already cleaned up. This PR adds a switch that allows fine tuning cleanup behavior via an environment variable:

`TEST_ENV_CLEANUP`
* `always` - cleanup after each test
* `never` - never clean up
* `onSuccess` - only cleanup if test was successful

## How can this be tested?
* Prepare an environment to run E2E tests in
* set said environment variable to a value of you choice and run E2E tests
* observe if cleanup has happened the way you expected by checking resources on the test cluster

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

