### PR TITLE
Fix failing RHCC image preflight scan upload

### DIFF
--- a/hack/build/ci/preflight.sh
+++ b/hack/build/ci/preflight.sh
@@ -20,7 +20,7 @@ check_image() {
     1> "${PREFLIGHT_REPORT_NAME}" 2> "${PREFLIGHT_LOG}"
   echo "${PREFLIGHT_EXECUTABLE} returned ${?}"
   cat "${PREFLIGHT_LOG}"
-  rm -rf artifacts preflight.log
+  rm -rf artifacts
   grep "Preflight result: PASSED" "${PREFLIGHT_LOG}" || exit 1
 }
 

--- a/hack/build/ci/preflight.sh
+++ b/hack/build/ci/preflight.sh
@@ -20,6 +20,7 @@ check_image() {
     1> "${PREFLIGHT_REPORT_NAME}" 2> "${PREFLIGHT_LOG}"
   echo "${PREFLIGHT_EXECUTABLE} returned ${?}"
   cat "${PREFLIGHT_LOG}"
+  rm -rf artifacts preflight.log
   grep "Preflight result: PASSED" "${PREFLIGHT_LOG}" || exit 1
 }
 
@@ -34,7 +35,7 @@ download_preflight
 check_image
 readonly passed=$?
 if [[ ${passed} -eq 0 ]]; then
-    submit_report
+  submit_report
 fi
 
 exit ${passed}


### PR DESCRIPTION
# Description

Preflight for the RHCC image fails on upload due to the checks running before the upload.
Fixed by removing the artifacts after generation. 

## How can this be tested?

Run the publish image action.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)

