### PR TITLE
Removes unnecessary step in the e2e operator installation

### DIFF
--- a/test/operator/installation.go
+++ b/test/operator/installation.go
@@ -34,8 +34,6 @@ func InstallViaMake(withCSI bool) features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
 		rootDir := project.RootDir()
 
-		runBuildAndManifests(rootDir, t)
-
 		platform := kubeobjects.ResolvePlatformFromEnv()
 		makeTarget := getDeployMakeTarget(platform, withCSI, t)
 
@@ -73,19 +71,6 @@ func getDeployMakeTarget(platform kubeobjects.Platform, withCSI bool, t *testing
 	return makeTarget
 }
 
-func runBuildAndManifests(rootDir string, t *testing.T) {
-	err := exec.Command("make", "-C", rootDir, "build").Run()
-	if err != nil {
-		t.Fatal("failed to install the operator via the make command", err)
-		return
-	}
-
-	err = exec.Command("make", "-C", rootDir, "manifests/branch").Run()
-	if err != nil {
-		t.Fatal("failed to install the operator via the make command", err)
-		return
-	}
-}
 
 func manifestsPaths(withCsi bool) []string {
 	platform := kubeobjects.ResolvePlatformFromEnv()

--- a/test/operator/installation.go
+++ b/test/operator/installation.go
@@ -71,7 +71,6 @@ func getDeployMakeTarget(platform kubeobjects.Platform, withCSI bool, t *testing
 	return makeTarget
 }
 
-
 func manifestsPaths(withCsi bool) []string {
 	platform := kubeobjects.ResolvePlatformFromEnv()
 	paths := []string{}


### PR DESCRIPTION
# Description

`runBuildAndManifests` did the followings:
- build the image
  - this should not be done during the e2e test run, because it then wouldn't work well in a pipeline (also just no 😅 )
     - if you want to test local changes build the image separately 
- create the manifests
  - this is unnecessary as the `make deploy/...` will not use the manifests that were created 

## How can this be tested?
run any e2e test, now it should be faster :)


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/master/CONTRIBUTING.md)


