### PR TITLE
Fixes the image tag creation logic to work with main

### DIFF
--- a/hack/build/ci/prepare-build-variables.sh
+++ b/hack/build/ci/prepare-build-variables.sh
@@ -6,7 +6,7 @@ createDockerImageTag() {
   else
     if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
       echo "${GITHUB_REF_NAME}"
-    elif [[ "${GITHUB_REF_NAME}" == "master" ]]; then
+    elif [[ "${GITHUB_REF_NAME}" == "main" ]]; then
       echo "snapshot"
     else
       echo "snapshot-$(echo "${GITHUB_REF_NAME}" | sed 's#[^a-zA-Z0-9_-]#-#g')"


### PR DESCRIPTION
# Description

the title explains it pretty well already :D

## How can this be tested?
run `make deploy/kubernetes` on the main branch, the image in the yamls should be `snapshot` and not `snapshot-`


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

