### PR TITLE
Add OwnerReferences to the "dynatrace-webhook-certs" secret

### DIFF
--- a/src/controllers/certificates/certificate_secret.go
+++ b/src/controllers/certificates/certificate_secret.go
@@ -41,7 +41,7 @@ func (certSecret *certificateSecret) setSecretFromReader(ctx context.Context, ap
 
 	switch {
 	case k8serrors.IsNotFound(err):
-		certSecret.secret, err = kubeobjects.NewSecretBuilder(certSecret.scheme, certSecret.owner).Build(buildSecretName(), namespace, map[string][]byte{})
+		certSecret.secret, err = kubeobjects.CreateSecret(certSecret.scheme, certSecret.owner, kubeobjects.NewSecretNameModifier(buildSecretName()), kubeobjects.NewSecretNamespaceModifier(namespace), kubeobjects.NewSecretDataModifier(map[string][]byte{}))
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/src/controllers/certificates/certificate_secret.go
+++ b/src/controllers/certificates/certificate_secret.go
@@ -41,7 +41,10 @@ func (certSecret *certificateSecret) setSecretFromReader(ctx context.Context, ap
 
 	switch {
 	case k8serrors.IsNotFound(err):
-		certSecret.secret, err = kubeobjects.CreateSecret(certSecret.scheme, certSecret.owner, kubeobjects.NewSecretNameModifier(buildSecretName()), kubeobjects.NewSecretNamespaceModifier(namespace), kubeobjects.NewSecretDataModifier(map[string][]byte{}))
+		certSecret.secret, err = kubeobjects.CreateSecret(certSecret.scheme, certSecret.owner,
+			kubeobjects.NewSecretNameModifier(buildSecretName()),
+			kubeobjects.NewSecretNamespaceModifier(namespace),
+			kubeobjects.NewSecretDataModifier(map[string][]byte{}))
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/src/controllers/certificates/certificate_secret.go
+++ b/src/controllers/certificates/certificate_secret.go
@@ -11,9 +11,11 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/webhook"
 	"github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -22,10 +24,15 @@ type certificateSecret struct {
 	secret          *corev1.Secret
 	certificates    *Certs
 	existsInCluster bool
+	owner           *appsv1.Deployment
+	scheme          *runtime.Scheme
 }
 
-func newCertificateSecret() *certificateSecret {
-	return &certificateSecret{}
+func newCertificateSecret(scheme *runtime.Scheme, deployment *appsv1.Deployment) *certificateSecret {
+	return &certificateSecret{
+		owner:  deployment,
+		scheme: scheme,
+	}
 }
 
 func (certSecret *certificateSecret) setSecretFromReader(ctx context.Context, apiReader client.Reader, namespace string) error {
@@ -34,7 +41,10 @@ func (certSecret *certificateSecret) setSecretFromReader(ctx context.Context, ap
 
 	switch {
 	case k8serrors.IsNotFound(err):
-		certSecret.secret = kubeobjects.NewSecret(buildSecretName(), namespace, map[string][]byte{})
+		certSecret.secret, err = kubeobjects.NewSecretBuilder(certSecret.scheme, certSecret.owner).Build(buildSecretName(), namespace, map[string][]byte{})
+		if err != nil {
+			return errors.WithStack(err)
+		}
 		certSecret.existsInCluster = false
 	case err != nil:
 		return errors.WithStack(err)

--- a/src/controllers/certificates/webhook_cert_controller.go
+++ b/src/controllers/certificates/webhook_cert_controller.go
@@ -25,6 +25,8 @@ const (
 	crdName                      = "dynakubes.dynatrace.com"
 	secretPostfix                = "-certs"
 	errorCertificatesSecretEmpty = "certificates secret is empty"
+
+	operatorDeploymentName = "dynatrace-operator"
 )
 
 func Add(mgr manager.Manager, ns string) error {
@@ -73,13 +75,13 @@ func (controller *WebhookCertificateController) Reconcile(ctx context.Context, r
 		return reconcile.Result{}, errors.WithStack(err)
 	}
 
-	webhookDeployment := appsv1.Deployment{}
-	err = controller.apiReader.Get(controller.ctx, types.NamespacedName{Name: webhook.DeploymentName, Namespace: controller.namespace}, &webhookDeployment)
+	operatorDeployment := appsv1.Deployment{}
+	err = controller.apiReader.Get(controller.ctx, types.NamespacedName{Name: operatorDeploymentName, Namespace: controller.namespace}, &operatorDeployment)
 	if err != nil {
 		return reconcile.Result{}, errors.WithStack(err)
 	}
 
-	certSecret := newCertificateSecret(controller.scheme, &webhookDeployment)
+	certSecret := newCertificateSecret(controller.scheme, &operatorDeployment)
 
 	err = certSecret.setSecretFromReader(controller.ctx, controller.apiReader, controller.namespace)
 	if err != nil {

--- a/src/controllers/certificates/webhook_cert_controller_test.go
+++ b/src/controllers/certificates/webhook_cert_controller_test.go
@@ -139,7 +139,7 @@ func TestReconcile(t *testing.T) {
 			},
 			&appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      webhook.DeploymentName,
+					Name:      operatorDeploymentName,
 					Namespace: testNamespace,
 				},
 			})
@@ -167,7 +167,7 @@ func TestReconcile(t *testing.T) {
 			},
 			&appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      webhook.DeploymentName,
+					Name:      operatorDeploymentName,
 					Namespace: testNamespace,
 				},
 			})
@@ -181,7 +181,7 @@ func TestReconcile(t *testing.T) {
 	t.Run(`update crd successfully with up-to-date secret`, func(t *testing.T) {
 		fakeClient := fake.NewClient(crd, &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      webhook.DeploymentName,
+				Name:      operatorDeploymentName,
 				Namespace: testNamespace,
 			},
 		})
@@ -208,7 +208,7 @@ func TestReconcile(t *testing.T) {
 	t.Run(`do not skip certificates generation if no configuration exists`, func(t *testing.T) {
 		fakeClient := fake.NewClient(crd, &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      webhook.DeploymentName,
+				Name:      operatorDeploymentName,
 				Namespace: testNamespace,
 			},
 		})
@@ -344,7 +344,7 @@ func newFakeClientBuilder() *fakeClientBuilder {
 		},
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      webhook.DeploymentName,
+				Name:      operatorDeploymentName,
 				Namespace: testNamespace,
 			},
 		},

--- a/src/controllers/certificates/webhook_cert_controller_test.go
+++ b/src/controllers/certificates/webhook_cert_controller_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/src/webhook"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,16 +126,23 @@ func TestReconcile(t *testing.T) {
 	}
 
 	t.Run(`reconcile successfully without mutatingwebhookconfiguration`, func(t *testing.T) {
-		fakeClient := fake.NewClient(crd, &admissionregistrationv1.ValidatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: webhook.DeploymentName,
-			},
-			Webhooks: []admissionregistrationv1.ValidatingWebhook{
-				{
-					ClientConfig: admissionregistrationv1.WebhookClientConfig{},
+		fakeClient := fake.NewClient(crd,
+			&admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: webhook.DeploymentName,
+				},
+				Webhooks: []admissionregistrationv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregistrationv1.WebhookClientConfig{},
+					},
 				},
 			},
-		})
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      webhook.DeploymentName,
+					Namespace: testNamespace,
+				},
+			})
 		controller, request := prepareController(fakeClient)
 		result, err := controller.Reconcile(context.TODO(), request)
 
@@ -142,19 +151,26 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run(`reconcile successfully without validatingwebhookconfiguration`, func(t *testing.T) {
-		fakeClient := fake.NewClient(crd, &admissionregistrationv1.MutatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: webhook.DeploymentName,
-			},
-			Webhooks: []admissionregistrationv1.MutatingWebhook{
-				{
-					ClientConfig: admissionregistrationv1.WebhookClientConfig{},
+		fakeClient := fake.NewClient(crd,
+			&admissionregistrationv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: webhook.DeploymentName,
 				},
-				{
-					ClientConfig: admissionregistrationv1.WebhookClientConfig{},
+				Webhooks: []admissionregistrationv1.MutatingWebhook{
+					{
+						ClientConfig: admissionregistrationv1.WebhookClientConfig{},
+					},
+					{
+						ClientConfig: admissionregistrationv1.WebhookClientConfig{},
+					},
 				},
 			},
-		})
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      webhook.DeploymentName,
+					Namespace: testNamespace,
+				},
+			})
 		controller, request := prepareController(fakeClient)
 		result, err := controller.Reconcile(context.TODO(), request)
 
@@ -163,8 +179,13 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run(`update crd successfully with up-to-date secret`, func(t *testing.T) {
-		fakeClient := fake.NewClient(crd)
-		cs := newCertificateSecret()
+		fakeClient := fake.NewClient(crd, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      webhook.DeploymentName,
+				Namespace: testNamespace,
+			},
+		})
+		cs := newCertificateSecret(scheme.Scheme, &appsv1.Deployment{})
 		_ = cs.setSecretFromReader(context.TODO(), fakeClient, testNamespace)
 		_ = cs.validateCertificates(testNamespace)
 		_ = cs.createOrUpdateIfNecessary(context.TODO(), fakeClient)
@@ -185,7 +206,12 @@ func TestReconcile(t *testing.T) {
 	// Generation must not be skipped because webhook startup routine listens for the secret
 	// See cmd/operator/manager.go and cmd/operator/watcher.go
 	t.Run(`do not skip certificates generation if no configuration exists`, func(t *testing.T) {
-		fakeClient := fake.NewClient(crd)
+		fakeClient := fake.NewClient(crd, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      webhook.DeploymentName,
+				Namespace: testNamespace,
+			},
+		})
 		controller, request := prepareController(fakeClient)
 		result, err := controller.Reconcile(context.TODO(), request)
 
@@ -232,6 +258,7 @@ func prepareController(clt client.Client) (*WebhookCertificateController, reconc
 		client:    clt,
 		apiReader: clt,
 		namespace: testNamespace,
+		scheme:    scheme.Scheme,
 	}
 
 	request := reconcile.Request{
@@ -313,6 +340,12 @@ func newFakeClientBuilder() *fakeClientBuilder {
 				{
 					ClientConfig: admissionregistrationv1.WebhookClientConfig{},
 				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      webhook.DeploymentName,
+				Namespace: testNamespace,
 			},
 		},
 	}

--- a/src/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -94,7 +94,7 @@ func (r *Reconciler) getActiveGateAuthToken() (map[string][]byte, error) {
 
 func (r *Reconciler) createSecret(secretData map[string][]byte) error {
 	secretName := r.dynakube.ActiveGateAuthTokenSecret()
-	secret, err := kubeobjects.NewSecretBuilder(r.scheme, r.dynakube).Build(secretName, r.dynakube.Namespace, secretData)
+	secret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube, kubeobjects.NewSecretNameModifier(secretName), kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace), kubeobjects.NewSecretDataModifier(secretData))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/src/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -13,7 +13,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -95,12 +94,12 @@ func (r *Reconciler) getActiveGateAuthToken() (map[string][]byte, error) {
 
 func (r *Reconciler) createSecret(secretData map[string][]byte) error {
 	secretName := r.dynakube.ActiveGateAuthTokenSecret()
-	secret := kubeobjects.NewSecret(secretName, r.dynakube.Namespace, secretData)
-	if err := controllerutil.SetControllerReference(r.dynakube, secret, r.scheme); err != nil {
+	secret, err := kubeobjects.NewSecretBuilder(r.scheme, r.dynakube).Build(secretName, r.dynakube.Namespace, secretData)
+	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	err := r.client.Create(context.TODO(), secret)
+	err = r.client.Create(context.TODO(), secret)
 	if err != nil {
 		return errors.Errorf("failed to create secret '%s': %v", secretName, err)
 	}

--- a/src/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -94,7 +94,10 @@ func (r *Reconciler) getActiveGateAuthToken() (map[string][]byte, error) {
 
 func (r *Reconciler) createSecret(secretData map[string][]byte) error {
 	secretName := r.dynakube.ActiveGateAuthTokenSecret()
-	secret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube, kubeobjects.NewSecretNameModifier(secretName), kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace), kubeobjects.NewSecretDataModifier(secretData))
+	secret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube,
+		kubeobjects.NewSecretNameModifier(secretName),
+		kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace),
+		kubeobjects.NewSecretDataModifier(secretData))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/src/controllers/dynakube/activegate/internal/customproperties/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/customproperties/reconciler.go
@@ -100,9 +100,9 @@ func (r *Reconciler) updateCustomProperties(customProperties *corev1.Secret) err
 }
 
 func (r *Reconciler) createCustomProperties() error {
-	customPropertiesSecret, err := kubeobjects.NewSecretBuilder(r.scheme, r.instance).Build(r.buildCustomPropertiesName(r.instance.Name), r.instance.Namespace, map[string][]byte{
+	customPropertiesSecret, err := kubeobjects.CreateSecret(r.scheme, r.instance, kubeobjects.NewSecretNameModifier(r.buildCustomPropertiesName(r.instance.Name)), kubeobjects.NewSecretNamespaceModifier(r.instance.Namespace), kubeobjects.NewSecretDataModifier(map[string][]byte{
 		DataKey: []byte(r.customPropertiesSource.Value),
-	})
+	}))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/src/controllers/dynakube/activegate/internal/customproperties/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/customproperties/reconciler.go
@@ -100,9 +100,12 @@ func (r *Reconciler) updateCustomProperties(customProperties *corev1.Secret) err
 }
 
 func (r *Reconciler) createCustomProperties() error {
-	customPropertiesSecret, err := kubeobjects.CreateSecret(r.scheme, r.instance, kubeobjects.NewSecretNameModifier(r.buildCustomPropertiesName(r.instance.Name)), kubeobjects.NewSecretNamespaceModifier(r.instance.Namespace), kubeobjects.NewSecretDataModifier(map[string][]byte{
-		DataKey: []byte(r.customPropertiesSource.Value),
-	}))
+	customPropertiesSecret, err := kubeobjects.CreateSecret(r.scheme, r.instance,
+		kubeobjects.NewSecretNameModifier(r.buildCustomPropertiesName(r.instance.Name)),
+		kubeobjects.NewSecretNamespaceModifier(r.instance.Namespace),
+		kubeobjects.NewSecretDataModifier(map[string][]byte{
+			DataKey: []byte(r.customPropertiesSource.Value),
+		}))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/src/controllers/dynakube/activegate/internal/proxy/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/proxy/reconciler.go
@@ -59,10 +59,12 @@ func (r *Reconciler) generateForDynakube(ctx context.Context, dynakube *dynatrac
 	}
 
 	coreLabels := kubeobjects.NewCoreLabels(dynakube.Name, kubeobjects.ActiveGateComponentLabel)
-	secret, err := kubeobjects.NewSecretBuilder(r.scheme, r.dynakube).
-		WithType(corev1.SecretTypeOpaque).
-		WithLables(coreLabels.BuildMatchLabels()).
-		Build(capability.BuildProxySecretName(), r.dynakube.Namespace, data)
+	secret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube,
+		kubeobjects.NewSecretTypeModifier(corev1.SecretTypeOpaque),
+		kubeobjects.NewSecretLabelsModifier(coreLabels.BuildMatchLabels()),
+		kubeobjects.NewSecretNameModifier(capability.BuildProxySecretName()),
+		kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace),
+		kubeobjects.NewSecretDataModifier(data))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/src/controllers/dynakube/activegate/internal/proxy/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/proxy/reconciler.go
@@ -60,10 +60,10 @@ func (r *Reconciler) generateForDynakube(ctx context.Context, dynakube *dynatrac
 
 	coreLabels := kubeobjects.NewCoreLabels(dynakube.Name, kubeobjects.ActiveGateComponentLabel)
 	secret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube,
-		kubeobjects.NewSecretTypeModifier(corev1.SecretTypeOpaque),
-		kubeobjects.NewSecretLabelsModifier(coreLabels.BuildMatchLabels()),
 		kubeobjects.NewSecretNameModifier(capability.BuildProxySecretName()),
 		kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace),
+		kubeobjects.NewSecretLabelsModifier(coreLabels.BuildMatchLabels()),
+		kubeobjects.NewSecretTypeModifier(corev1.SecretTypeOpaque),
 		kubeobjects.NewSecretDataModifier(data))
 	if err != nil {
 		return errors.WithStack(err)

--- a/src/controllers/dynakube/activegate/internal/proxy/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/proxy/reconciler.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,6 +31,7 @@ var _ controllers.Reconciler = &Reconciler{}
 type Reconciler struct {
 	client    client.Client
 	apiReader client.Reader
+	scheme    *runtime.Scheme
 	dynakube  *dynatracev1beta1.DynaKube
 }
 
@@ -41,10 +43,11 @@ func (r *Reconciler) Reconcile() error {
 	return r.ensureDeleted(context.TODO(), r.dynakube)
 }
 
-func NewReconciler(client client.Client, apiReader client.Reader, dynakube *dynatracev1beta1.DynaKube) *Reconciler {
+func NewReconciler(client client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube) *Reconciler {
 	return &Reconciler{
 		client:    client,
 		apiReader: apiReader,
+		scheme:    scheme,
 		dynakube:  dynakube,
 	}
 }
@@ -56,16 +59,14 @@ func (r *Reconciler) generateForDynakube(ctx context.Context, dynakube *dynatrac
 	}
 
 	coreLabels := kubeobjects.NewCoreLabels(dynakube.Name, kubeobjects.ActiveGateComponentLabel)
-	secret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      capability.BuildProxySecretName(),
-			Namespace: r.dynakube.Namespace,
-			Labels:    coreLabels.BuildMatchLabels(),
-		},
-		Data: data,
-		Type: corev1.SecretTypeOpaque,
+	secret, err := kubeobjects.NewSecretBuilder(r.scheme, r.dynakube).
+		WithType(corev1.SecretTypeOpaque).
+		WithLables(coreLabels.BuildMatchLabels()).
+		Build(capability.BuildProxySecretName(), r.dynakube.Namespace, data)
+	if err != nil {
+		return errors.WithStack(err)
 	}
+
 	secretQuery := kubeobjects.NewSecretQuery(ctx, r.client, r.apiReader, log)
 
 	err = secretQuery.CreateOrUpdate(*secret)

--- a/src/controllers/dynakube/activegate/internal/proxy/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/proxy/reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +39,7 @@ func newTestReconcilerWithInstance(client client.Client) *Reconciler {
 		},
 	}
 
-	r := NewReconciler(client, client, instance)
+	r := NewReconciler(client, client, scheme.Scheme, instance)
 	return r
 }
 

--- a/src/controllers/dynakube/activegate/reconciler.go
+++ b/src/controllers/dynakube/activegate/reconciler.go
@@ -38,7 +38,7 @@ var _ controllers.Reconciler = (*Reconciler)(nil)
 
 func NewReconciler(ctx context.Context, clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client) controllers.Reconciler { //nolint:revive // argument-limit doesn't apply to constructors
 	authTokenReconciler := authtoken.NewReconciler(clt, apiReader, scheme, dynakube, dtc)
-	proxyReconciler := proxy.NewReconciler(clt, apiReader, dynakube)
+	proxyReconciler := proxy.NewReconciler(clt, apiReader, scheme, dynakube)
 	newCustomPropertiesReconcilerFunc := func(customPropertiesOwnerName string, customPropertiesSource *dynatracev1beta1.DynaKubeValueSource) controllers.Reconciler {
 		return customproperties.NewReconciler(clt, dynakube, customPropertiesOwnerName, scheme, customPropertiesSource)
 	}

--- a/src/controllers/dynakube/connectioninfo/reconciler.go
+++ b/src/controllers/dynakube/connectioninfo/reconciler.go
@@ -125,7 +125,10 @@ func (r *Reconciler) createTenantConnectionInfoConfigMap(secretName string, conn
 
 func (r *Reconciler) createTenantTokenSecret(secretName string, connectionInfo dtclient.ConnectionInfo) error {
 	secretData := extractSensitiveData(connectionInfo)
-	secret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube, kubeobjects.NewSecretNameModifier(secretName), kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace), kubeobjects.NewSecretDataModifier(secretData))
+	secret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube,
+		kubeobjects.NewSecretNameModifier(secretName),
+		kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace),
+		kubeobjects.NewSecretDataModifier(secretData))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/src/controllers/dynakube/connectioninfo/reconciler.go
+++ b/src/controllers/dynakube/connectioninfo/reconciler.go
@@ -106,7 +106,10 @@ func (r *Reconciler) maintainConnectionInfoObjects(secretName string, configMapN
 
 func (r *Reconciler) createTenantConnectionInfoConfigMap(secretName string, connectionInfo dtclient.ConnectionInfo) error {
 	configMapData := extractPublicData(connectionInfo)
-	configMap, err := kubeobjects.NewConfigMapBuilder(r.scheme, r.dynakube).Build(secretName, r.dynakube.Namespace, configMapData)
+	configMap, err := kubeobjects.CreateConfigMap(r.scheme, r.dynakube,
+		kubeobjects.NewConfigMapNameModifier(secretName),
+		kubeobjects.NewConfigMapNamespaceModifier(r.dynakube.Namespace),
+		kubeobjects.NewConfigMapDataModifier(configMapData))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -122,7 +125,7 @@ func (r *Reconciler) createTenantConnectionInfoConfigMap(secretName string, conn
 
 func (r *Reconciler) createTenantTokenSecret(secretName string, connectionInfo dtclient.ConnectionInfo) error {
 	secretData := extractSensitiveData(connectionInfo)
-	secret, err := kubeobjects.NewSecretBuilder(r.scheme, r.dynakube).Build(secretName, r.dynakube.Namespace, secretData)
+	secret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube, kubeobjects.NewSecretNameModifier(secretName), kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace), kubeobjects.NewSecretDataModifier(secretData))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/src/controllers/dynakube/deploymentmetadata/reconciler.go
+++ b/src/controllers/dynakube/deploymentmetadata/reconciler.go
@@ -56,7 +56,10 @@ func (r *Reconciler) addActiveGateDeploymentMetadata(configMapData map[string]st
 
 func (r *Reconciler) maintainMetadataConfigMap(configMapData map[string]string) error {
 	configMapQuery := kubeobjects.NewConfigMapQuery(r.context, r.client, r.apiReader, log)
-	configMap, err := kubeobjects.NewConfigMapBuilder(r.scheme, &r.dynakube).Build(GetDeploymentMetadataConfigMapName(r.dynakube.Name), r.dynakube.Namespace, configMapData)
+	configMap, err := kubeobjects.CreateConfigMap(r.scheme, &r.dynakube,
+		kubeobjects.NewConfigMapNameModifier(GetDeploymentMetadataConfigMapName(r.dynakube.Name)),
+		kubeobjects.NewConfigMapNamespaceModifier(r.dynakube.Namespace),
+		kubeobjects.NewConfigMapDataModifier(configMapData))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/src/controllers/dynakube/deploymentmetadata/reconciler.go
+++ b/src/controllers/dynakube/deploymentmetadata/reconciler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 type Reconciler struct {
@@ -57,8 +56,8 @@ func (r *Reconciler) addActiveGateDeploymentMetadata(configMapData map[string]st
 
 func (r *Reconciler) maintainMetadataConfigMap(configMapData map[string]string) error {
 	configMapQuery := kubeobjects.NewConfigMapQuery(r.context, r.client, r.apiReader, log)
-	configMap := kubeobjects.NewConfigMap(GetDeploymentMetadataConfigMapName(r.dynakube.Name), r.dynakube.Namespace, configMapData)
-	if err := controllerutil.SetControllerReference(&r.dynakube, configMap, r.scheme); err != nil {
+	configMap, err := kubeobjects.NewConfigMapBuilder(r.scheme, &r.dynakube).Build(GetDeploymentMetadataConfigMapName(r.dynakube.Name), r.dynakube.Namespace, configMapData)
+	if err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/src/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/src/controllers/dynakube/dtpullsecret/reconciler.go
@@ -82,7 +82,11 @@ func (r *Reconciler) updatePullSecretIfOutdated(pullSecret *corev1.Secret, desir
 }
 
 func (r *Reconciler) createPullSecret(pullSecretData map[string][]byte) (*corev1.Secret, error) {
-	pullSecret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube, kubeobjects.NewSecretTypeModifier(corev1.SecretTypeDockerConfigJson), kubeobjects.NewSecretNameModifier(extendWithPullSecretSuffix(r.dynakube.Name)), kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace), kubeobjects.NewSecretDataModifier(pullSecretData))
+	pullSecret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube,
+		kubeobjects.NewSecretNameModifier(extendWithPullSecretSuffix(r.dynakube.Name)),
+		kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace),
+		kubeobjects.NewSecretTypeModifier(corev1.SecretTypeDockerConfigJson),
+		kubeobjects.NewSecretDataModifier(pullSecretData))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/src/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/src/controllers/dynakube/dtpullsecret/reconciler.go
@@ -82,7 +82,7 @@ func (r *Reconciler) updatePullSecretIfOutdated(pullSecret *corev1.Secret, desir
 }
 
 func (r *Reconciler) createPullSecret(pullSecretData map[string][]byte) (*corev1.Secret, error) {
-	pullSecret, err := kubeobjects.NewSecretBuilder(r.scheme, r.dynakube).WithType(corev1.SecretTypeDockerConfigJson).Build(extendWithPullSecretSuffix(r.dynakube.Name), r.dynakube.Namespace, pullSecretData)
+	pullSecret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube, kubeobjects.NewSecretTypeModifier(corev1.SecretTypeDockerConfigJson), kubeobjects.NewSecretNameModifier(extendWithPullSecretSuffix(r.dynakube.Name)), kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace), kubeobjects.NewSecretDataModifier(pullSecretData))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/src/controllers/dynakube/token/reader_test.go
+++ b/src/controllers/dynakube/token/reader_test.go
@@ -49,12 +49,12 @@ func testReadTokens(t *testing.T) {
 				Namespace: "dynatrace",
 			},
 		}
-		secret, err := kubeobjects.NewSecretBuilder(scheme.Scheme, &dynakube).Build("dynakube", "dynatrace", map[string][]byte{
+		secret, err := kubeobjects.CreateSecret(scheme.Scheme, &dynakube, kubeobjects.NewSecretNameModifier("dynakube"), kubeobjects.NewSecretNamespaceModifier("dynatrace"), kubeobjects.NewSecretDataModifier(map[string][]byte{
 			dtclient.DynatraceApiToken:        []byte(testApiToken),
 			dtclient.DynatracePaasToken:       []byte(testPaasToken),
 			dtclient.DynatraceDataIngestToken: []byte(testDataIngestToken),
 			testIrrelevantTokenKey:            []byte(testIrrelevantToken),
-		})
+		}))
 		assert.NoError(t, err)
 		clt := fake.NewClient(secret, &dynakube)
 

--- a/src/controllers/dynakube/token/reader_test.go
+++ b/src/controllers/dynakube/token/reader_test.go
@@ -7,6 +7,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/stretchr/testify/assert"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -42,18 +43,21 @@ func testReadTokens(t *testing.T) {
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run("tokens are found if secret exists", func(t *testing.T) {
-		clt := fake.NewClient(kubeobjects.NewSecret("dynakube", "dynatrace", map[string][]byte{
-			dtclient.DynatraceApiToken:        []byte(testApiToken),
-			dtclient.DynatracePaasToken:       []byte(testPaasToken),
-			dtclient.DynatraceDataIngestToken: []byte(testDataIngestToken),
-			testIrrelevantTokenKey:            []byte(testIrrelevantToken),
-		}))
 		dynakube := dynatracev1beta1.DynaKube{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "dynakube",
 				Namespace: "dynatrace",
 			},
 		}
+		secret, err := kubeobjects.NewSecretBuilder(scheme.Scheme, &dynakube).Build("dynakube", "dynatrace", map[string][]byte{
+			dtclient.DynatraceApiToken:        []byte(testApiToken),
+			dtclient.DynatracePaasToken:       []byte(testPaasToken),
+			dtclient.DynatraceDataIngestToken: []byte(testDataIngestToken),
+			testIrrelevantTokenKey:            []byte(testIrrelevantToken),
+		})
+		assert.NoError(t, err)
+		clt := fake.NewClient(secret, &dynakube)
+
 		reader := NewReader(clt, &dynakube)
 
 		tokens, err := reader.readTokens(context.Background())

--- a/src/kubeobjects/configmap_test.go
+++ b/src/kubeobjects/configmap_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
+	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -275,4 +277,14 @@ func createTestConfigMap(labels map[string]string, data map[string]string) *core
 		Data: data,
 	}
 	return configMap
+}
+
+func TestConfigMapBuilder(t *testing.T) {
+	t.Run("create config map", func(t *testing.T) {
+		secret, err := NewConfigMapBuilder(scheme.Scheme, &appsv1.Deployment{}).Build(testConfigMapName, testNamespace, map[string]string{})
+		require.NoError(t, err)
+		assert.Len(t, secret.OwnerReferences, 1)
+
+		assert.Equal(t, secret.Name, testConfigMapName)
+	})
 }


### PR DESCRIPTION
# Description

`OwnerReferences` field of the `dynatrace-webhook-certs` secret  is set to `dynatrace-webhook` Deployment to allow k8s  automatically remove the secret when the operator is uninstalled.

Additionally `OwnerReferences` of the `dynatrace-activegate-internal-proxy` secret is set to `<Dynakube>`.

## How can this be tested?
Deploy operator on a cluster.
Install `<dynakube>` with ActiveGate enabled and proxy.
Check `OwnerReferences` of `dynatrace-activegate-internal-proxy` and `dynatrace-webhook-certs` secrets.
Delete the `<dynakube>` and uninstall the operator.
Both secrets should be automatically removed.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

