### PR TITLE
Rename dynatrace-api related status fields in DynaKube to lowercase

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -3486,13 +3486,13 @@ spec:
                 type: object
               dynatraceApi:
                 properties:
-                  LastActiveGateConnectionInfoRequest:
+                  lastActiveGateConnectionInfoRequest:
                     format: date-time
                     type: string
-                  LastOneAgentConnectionInfoRequest:
+                  lastOneAgentConnectionInfoRequest:
                     format: date-time
                     type: string
-                  LastTokenScopeRequest:
+                  lastTokenScopeRequest:
                     format: date-time
                     type: string
                 type: object

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -3497,13 +3497,13 @@ spec:
                 type: object
               dynatraceApi:
                 properties:
-                  LastActiveGateConnectionInfoRequest:
+                  lastActiveGateConnectionInfoRequest:
                     format: date-time
                     type: string
-                  LastOneAgentConnectionInfoRequest:
+                  lastOneAgentConnectionInfoRequest:
                     format: date-time
                     type: string
-                  LastTokenScopeRequest:
+                  lastTokenScopeRequest:
                     format: date-time
                     type: string
                 type: object

--- a/src/api/v1beta1/dynakube_status.go
+++ b/src/api/v1beta1/dynakube_status.go
@@ -67,9 +67,9 @@ type DynaKubeStatus struct {
 const MaxRequestInterval = 15 * time.Minute
 
 type DynatraceApiStatus struct {
-	LastTokenScopeRequest               metav1.Time `json:"LastTokenScopeRequest,omitempty"`
-	LastOneAgentConnectionInfoRequest   metav1.Time `json:"LastOneAgentConnectionInfoRequest,omitempty"`
-	LastActiveGateConnectionInfoRequest metav1.Time `json:"LastActiveGateConnectionInfoRequest,omitempty"`
+	LastTokenScopeRequest               metav1.Time `json:"lastTokenScopeRequest,omitempty"`
+	LastOneAgentConnectionInfoRequest   metav1.Time `json:"lastOneAgentConnectionInfoRequest,omitempty"`
+	LastActiveGateConnectionInfoRequest metav1.Time `json:"lastActiveGateConnectionInfoRequest,omitempty"`
 }
 
 func (dynatraceApiStatus *DynatraceApiStatus) ResetCachedTimestamps() {


### PR DESCRIPTION
# Description

We should follow the rest of our statusfields and keep the lower case convention for status fields.

## How can this be tested?

1. Apply a DynaKube
2. Check if the status fields are named and set correctly


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

