### PR TITLE
Make usage of response.Body.Close() more convinient

### DIFF
--- a/src/dtclient/activegate_auth_token.go
+++ b/src/dtclient/activegate_auth_token.go
@@ -39,12 +39,7 @@ func (dtc *dynatraceClient) GetActiveGateAuthToken(dynakubeName string) (*Active
 		return nil, err
 	}
 
-	defer func() {
-		err := response.Body.Close()
-		if err != nil {
-			log.Error(err, err.Error())
-		}
-	}()
+	defer CloseBodyAfterRequest(response)
 
 	authTokenInfo, err := dtc.handleAuthTokenResponse(response)
 	if err != nil {

--- a/src/dtclient/client.go
+++ b/src/dtclient/client.go
@@ -201,3 +201,9 @@ func DisableHostsRequests(disabledHostsRequests bool) Option {
 		c.disableHostsRequests = disabledHostsRequests
 	}
 }
+
+func CloseBodyAfterRequest(response *http.Response){
+	if response != nil && response.Body != nil{
+		response.Body.Close()
+	}
+}

--- a/src/dtclient/client.go
+++ b/src/dtclient/client.go
@@ -202,8 +202,8 @@ func DisableHostsRequests(disabledHostsRequests bool) Option {
 	}
 }
 
-func CloseBodyAfterRequest(response *http.Response){
-	if response != nil && response.Body != nil{
+func CloseBodyAfterRequest(response *http.Response) {
+	if response != nil && response.Body != nil {
 		response.Body.Close()
 	}
 }

--- a/src/dtclient/connection_info.go
+++ b/src/dtclient/connection_info.go
@@ -38,12 +38,7 @@ func (dtc *dynatraceClient) GetActiveGateConnectionInfo() (*ActiveGateConnection
 		return nil, errors.WithStack(err)
 	}
 
-	defer func() {
-		err := response.Body.Close()
-		if err != nil {
-			log.Error(err, err.Error())
-		}
-	}()
+	defer CloseBodyAfterRequest(response)
 
 	data, err := dtc.getServerResponseData(response)
 	if err != nil {
@@ -90,10 +85,7 @@ func (dtc *dynatraceClient) GetOneAgentConnectionInfo() (OneAgentConnectionInfo,
 	if err != nil {
 		return OneAgentConnectionInfo{}, err
 	}
-	defer func() {
-		// Swallow error, nothing has to be done at this point
-		_ = resp.Body.Close()
-	}()
+	defer CloseBodyAfterRequest(resp)
 
 	responseData, err := dtc.getServerResponseData(resp)
 	if err != nil {

--- a/src/dtclient/dynatrace_client.go
+++ b/src/dtclient/dynatrace_client.go
@@ -110,7 +110,7 @@ func (dtc *dynatraceClient) makeRequestAndUnmarshal(url string, token tokenType,
 	if err != nil {
 		return err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer CloseBodyAfterRequest(resp)
 
 	responseData, err := dtc.getServerResponseData(resp)
 	if err != nil {
@@ -125,7 +125,7 @@ func (dtc *dynatraceClient) makeRequestForBinary(url string, token tokenType, wr
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer CloseBodyAfterRequest(resp)
 
 	if resp.StatusCode != http.StatusOK {
 		var errorResponse serverErrorResponse
@@ -175,10 +175,7 @@ func (dtc *dynatraceClient) buildHostCache() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	defer func() {
-		// Swallow error
-		_ = resp.Body.Close()
-	}()
+	defer CloseBodyAfterRequest(resp)
 
 	responseData, err := dtc.getServerResponseData(resp)
 	if err != nil {

--- a/src/dtclient/dynatrace_client_test.go
+++ b/src/dtclient/dynatrace_client_test.go
@@ -32,7 +32,7 @@ func TestMakeRequest(t *testing.T) {
 		resp, err := dc.makeRequest(url, dynatraceApiToken)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
-		defer resp.Body.Close()
+		defer CloseBodyAfterRequest(resp)
 	}
 	{
 		resp, err := dc.makeRequest("%s/v1/deployment/installer/agent/connectioninfo", dynatraceApiToken) //nolint:bodyclose

--- a/src/dtclient/kubernetes_settings.go
+++ b/src/dtclient/kubernetes_settings.go
@@ -108,7 +108,7 @@ func (dtc *dynatraceClient) CreateOrUpdateKubernetesSetting(clusterLabel, kubeSy
 	if err != nil {
 		return "", fmt.Errorf("error making post request to dynatrace api: %w", err)
 	}
-	defer res.Body.Close()
+	defer CloseBodyAfterRequest(res)
 
 	resData, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -157,12 +157,7 @@ func (dtc *dynatraceClient) GetMonitoredEntitiesForKubeSystemUUID(kubeSystemUUID
 		return nil, err
 	}
 
-	defer func() {
-		err := res.Body.Close()
-		if err != nil {
-			log.Error(err, err.Error())
-		}
-	}()
+	defer CloseBodyAfterRequest(res)
 
 	var resDataJson monitoredEntitiesResponse
 	err = dtc.unmarshalToJson(res, &resDataJson)
@@ -200,12 +195,7 @@ func (dtc *dynatraceClient) GetSettingsForMonitoredEntities(monitoredEntities []
 		return GetSettingsResponse{}, err
 	}
 
-	defer func() {
-		err := res.Body.Close()
-		if err != nil {
-			log.Error(err, err.Error())
-		}
-	}()
+	defer CloseBodyAfterRequest(res)
 
 	var resDataJson GetSettingsResponse
 	err = dtc.unmarshalToJson(res, &resDataJson)

--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -142,10 +142,7 @@ func (dtc *dynatraceClient) GetProcessModuleConfig(prevRevision uint) (*ProcessM
 	if err != nil {
 		return nil, fmt.Errorf("error while requesting process module config: %w", err)
 	}
-	defer func() {
-		// Swallow error, nothing has to be done at this point
-		_ = resp.Body.Close()
-	}()
+	defer CloseBodyAfterRequest(resp)
 
 	responseData, err := dtc.getServerResponseData(resp)
 	if err != nil {

--- a/src/dtclient/send_event.go
+++ b/src/dtclient/send_event.go
@@ -54,12 +54,7 @@ func (dtc *dynatraceClient) SendEvent(eventData *EventData) error {
 		return fmt.Errorf("error making post request to dynatrace api: %w", err)
 	}
 
-	defer func() {
-		err := response.Body.Close()
-		if err != nil {
-			log.Error(err, err.Error())
-		}
-	}()
+	defer CloseBodyAfterRequest(response)
 
 	_, err = dtc.getServerResponseData(response)
 	return errors.WithStack(err)

--- a/src/dtclient/token.go
+++ b/src/dtclient/token.go
@@ -44,10 +44,7 @@ func (dtc *dynatraceClient) GetTokenScopes(token string) (TokenScopes, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error making post request to dynatrace api: %w", err)
 	}
-	defer func() {
-		// Swallow error, nothing has to be done at this point
-		_ = resp.Body.Close()
-	}()
+	defer CloseBodyAfterRequest(resp)
 
 	data, err := dtc.getServerResponseData(resp)
 	if err != nil {

--- a/test/kubeobjects/manifests/installation.go
+++ b/test/kubeobjects/manifests/installation.go
@@ -19,7 +19,7 @@ import (
 )
 
 func httpGetResponseReader(url string) (io.Reader, error) {
-	response, err := http.Get(url) //nolint:gosec //nolint:bodyclose // G107: Potential HTTP request made with variable url - fine, same applies to naked `http.Get(url)`
+	response, err := http.Get(url) //nolint:gosec,bodyclose // G107: Potential HTTP request made with variable url - fine, same applies to naked `http.Get(url)`
 	if err != nil {
 		return nil, err
 	}

--- a/test/kubeobjects/manifests/installation.go
+++ b/test/kubeobjects/manifests/installation.go
@@ -3,6 +3,7 @@ package manifests
 import (
 	"bytes"
 	"context"
+	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"io"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func httpGetResponseReader(url string) (io.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer dtclient.CloseBodyAfterRequest(response)
 
 	if response.StatusCode != http.StatusOK {
 		return nil, errors.New("Response status code was not 200(StatusOK): " + strconv.Itoa(response.StatusCode))

--- a/test/kubeobjects/manifests/installation.go
+++ b/test/kubeobjects/manifests/installation.go
@@ -19,7 +19,7 @@ import (
 )
 
 func httpGetResponseReader(url string) (io.Reader, error) {
-	response, err := http.Get(url) //nolint:gosec // G107: Potential HTTP request made with variable url - fine, same applies to naked `http.Get(url)`
+	response, err := http.Get(url) //nolint:gosec //nolint:bodyclose // G107: Potential HTTP request made with variable url - fine, same applies to naked `http.Get(url)`
 	if err != nil {
 		return nil, err
 	}

--- a/test/kubeobjects/manifests/installation.go
+++ b/test/kubeobjects/manifests/installation.go
@@ -3,13 +3,13 @@ package manifests
 import (
 	"bytes"
 	"context"
-	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"io"
 	"net/http"
 	"os"
 	"strconv"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,15 +55,6 @@ func installFromSingleUrl(t *testing.T, ctx context.Context, environmentConfig *
 	require.NoError(t, decoder.DecodeEach(ctx, manifestReader, decoder.IgnoreErrorHandler(decoder.CreateHandler(resources), k8serrors.IsAlreadyExists)))
 }
 
-func InstallFromFiles(paths []string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		for _, path := range paths {
-			installFromSingleFile(t, ctx, environmentConfig, path)
-		}
-		return ctx
-	}
-}
-
 func InstallFromFile(path string) features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
 		kubernetesManifest, err := os.Open(path)
@@ -75,13 +66,4 @@ func InstallFromFile(path string) features.Func {
 
 		return ctx
 	}
-}
-
-func installFromSingleFile(t *testing.T, ctx context.Context, environmentConfig *envconf.Config, path string) {
-	manifest, err := os.Open(path)
-	defer func() { require.NoError(t, manifest.Close()) }()
-	require.NoError(t, err)
-
-	resources := environmentConfig.Client().Resources()
-	require.NoError(t, decoder.DecodeEach(ctx, manifest, decoder.IgnoreErrorHandler(decoder.CreateHandler(resources), k8serrors.IsAlreadyExists)))
 }


### PR DESCRIPTION
# Description

Currently each response body needs to be closed after its not needed anymore. However we have to make sure that response and body are not nil, before calling the close function on it.

## How can this be tested?
Everything should work as before


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

