### PR TITLE
Add feature flag to configure custom seccomp profile for oneagent

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -68,6 +68,7 @@ const (
 	AnnotationFeatureOneAgentIgnoreProxy            = AnnotationFeaturePrefix + "oneagent-ignore-proxy"
 	AnnotationFeatureOneAgentInitialConnectRetry    = AnnotationFeaturePrefix + "oneagent-initial-connect-retry-ms"
 	AnnotationFeatureRunOneAgentContainerPrivileged = AnnotationFeaturePrefix + "oneagent-privileged"
+	AnnotationFeatureOneAgentSecCompProfile         = AnnotationFeaturePrefix + "oneagent-seccomp-profile"
 
 	// injection (webhook)
 
@@ -267,6 +268,10 @@ func (dk *DynaKube) FeatureAgentInitialConnectRetry() int {
 
 func (dk *DynaKube) FeatureOneAgentPrivileged() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureRunOneAgentContainerPrivileged) == truePhrase
+}
+
+func (dk *DynaKube) FeatureOneAgentSecCompProfile() string {
+	return dk.getFeatureFlagRaw(AnnotationFeatureOneAgentSecCompProfile)
 }
 
 func (dk *DynaKube) getFeatureFlagRaw(annotation string) string {

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -322,8 +322,15 @@ func (dsInfo *builderInfo) securityContext() *corev1.SecurityContext {
 		securityContext.Privileged = address.Of(true)
 	} else {
 		securityContext.Capabilities = defaultSecurityContextCapabilities()
-	}
 
+		if dsInfo.dynakube != nil && dsInfo.dynakube.FeatureOneAgentSecCompProfile() != "" {
+			secCompName := dsInfo.dynakube.FeatureOneAgentSecCompProfile()
+			securityContext.SeccompProfile = &corev1.SeccompProfile{
+				Type:             corev1.SeccompProfileTypeLocalhost,
+				LocalhostProfile: &secCompName,
+			}
+		}
+	}
 	return &securityContext
 }
 

--- a/src/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -283,6 +283,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		assert.Equal(t, address.Of(int64(1000)), securityContext.RunAsGroup)
 		assert.Equal(t, address.Of(true), securityContext.RunAsNonRoot)
 		assert.NotEmpty(t, securityContext.Capabilities)
+		assert.Nil(t, securityContext.SeccompProfile)
 	})
 
 	t.Run(`No User and group id set when read only mode is disabled`, func(t *testing.T) {
@@ -313,6 +314,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		assert.Nil(t, securityContext.RunAsNonRoot)
 		assert.Nil(t, securityContext.Privileged)
 		assert.NotEmpty(t, securityContext.Capabilities)
+		assert.Nil(t, securityContext.SeccompProfile)
 	})
 
 	t.Run(`privileged security context when feature flag is enabled`, func(t *testing.T) {
@@ -343,6 +345,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		assert.Equal(t, address.Of(true), securityContext.RunAsNonRoot)
 		assert.Equal(t, address.Of(true), securityContext.Privileged)
 		assert.Empty(t, securityContext.Capabilities)
+		assert.Nil(t, securityContext.SeccompProfile)
 	})
 
 	t.Run(`privileged security context when feature flag is enabled for classic fullstack`, func(t *testing.T) {
@@ -373,6 +376,73 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		assert.Nil(t, securityContext.RunAsNonRoot)
 		assert.Equal(t, address.Of(true), securityContext.Privileged)
 		assert.Empty(t, securityContext.Capabilities)
+		assert.Nil(t, securityContext.SeccompProfile)
+	})
+
+	t.Run(`localhost seccomp profile when feature flag is enabled`, func(t *testing.T) {
+		customSecCompProfile := "seccomp.json"
+		instance := dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					dynatracev1beta1.AnnotationFeatureOneAgentSecCompProfile: customSecCompProfile,
+				},
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testURL,
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					ClassicFullStack: &dynatracev1beta1.HostInjectSpec{},
+				},
+			},
+		}
+		dsInfo := NewClassicFullStack(&instance, testClusterID)
+		ds, err := dsInfo.BuildDaemonSet()
+		require.NoError(t, err)
+
+		assert.GreaterOrEqual(t, 1, len(ds.Spec.Template.Spec.Containers))
+
+		securityContext := ds.Spec.Template.Spec.Containers[0].SecurityContext
+
+		assert.NotNil(t, securityContext)
+		assert.Nil(t, securityContext.RunAsUser)
+		assert.Nil(t, securityContext.RunAsGroup)
+		assert.Nil(t, securityContext.RunAsNonRoot)
+		assert.Nil(t, securityContext.Privileged)
+		assert.NotEmpty(t, securityContext.Capabilities)
+		assert.Equal(t, corev1.SeccompProfileTypeLocalhost, securityContext.SeccompProfile.Type)
+		assert.Equal(t, customSecCompProfile, *securityContext.SeccompProfile.LocalhostProfile)
+	})
+
+	t.Run(`localhost seccomp profile disabled if privileged security context enabled`, func(t *testing.T) {
+		customSecCompProfile := "seccomp.json"
+		instance := dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					dynatracev1beta1.AnnotationFeatureOneAgentSecCompProfile:         customSecCompProfile,
+					dynatracev1beta1.AnnotationFeatureRunOneAgentContainerPrivileged: "true",
+				},
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testURL,
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					ClassicFullStack: &dynatracev1beta1.HostInjectSpec{},
+				},
+			},
+		}
+		dsInfo := NewClassicFullStack(&instance, testClusterID)
+		ds, err := dsInfo.BuildDaemonSet()
+		require.NoError(t, err)
+
+		assert.GreaterOrEqual(t, 1, len(ds.Spec.Template.Spec.Containers))
+
+		securityContext := ds.Spec.Template.Spec.Containers[0].SecurityContext
+
+		assert.NotNil(t, securityContext)
+		assert.Nil(t, securityContext.RunAsUser)
+		assert.Nil(t, securityContext.RunAsGroup)
+		assert.Nil(t, securityContext.RunAsNonRoot)
+		assert.Equal(t, address.Of(true), securityContext.Privileged)
+		assert.Empty(t, securityContext.Capabilities)
+		assert.Nil(t, securityContext.SeccompProfile)
 	})
 }
 


### PR DESCRIPTION
# Description

Currently it's not possible to set a different seccompProfile for the OneAgent. Setting seccomp profile via annotation is deprecated starting with kubernetes 1.27 and other changes are overwritten by the operator. To make it possible `feature.dynatrace.com/oneagent-seccomp-profile: <name>` feature flag is added. 

The seccomp profile has to be stored on nodes in the `/var/lib/kubelet/seccomp/` directory. Specify the relative path. For instance:
```
     feature.dynatrace.com/oneagent-seccomp-profile: "custom-seccomp-profile.json" 
```
means the `/var/lib/kubelet/seccomp/custom-seccomp-profile.json` file has to exist. No check/verification by the operator is done.

## How can this be tested?
- deploy cluster
- copy `custom-seccomp-profile.json` to the `/var/lib/kubelet/seccomp/` directory on your nodes 
```
{
	"architectures": [
		"SCMP_ARCH_X86_64"
	]
}
```
- apply dynakube
```
metadata:
  annotations:
     feature.dynatrace.com/oneagent-seccomp-profile: "custom-seccomp-profile.json"
  name: dynakube
  namespace: dynatrace
spec:
  oneAgent:
    cloudNativeFullStack: {}
```
- check out `dynakube-oneagent-XXXXX` pod
```
  containers:
  - args:
    ...
    name: dynatrace-oneagent
    securityContext:
        ...
        seccompProfile:
            localhostProfile: custom-seccomp-profile.json
            type: Localhost
```

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

