### PR TITLE
new examples for arm architecture, multi-architecture and multi-dynakube environments

### DIFF
--- a/assets/samples/classicFullStack-ARM.yaml
+++ b/assets/samples/classicFullStack-ARM.yaml
@@ -1,0 +1,147 @@
+apiVersion: dynatrace.com/v1beta1
+kind: DynaKube
+metadata:
+  name: dynakube
+  namespace: dynatrace
+spec:
+  # Dynatrace apiUrl including the `/api` path at the end.
+  # For SaaS, set `ENVIRONMENTID` to your environment ID.
+  # For Managed, change the apiUrl address.
+  # For instructions on how to determine the environment ID and how to configure the apiUrl address, see https://www.dynatrace.com/support/help/reference/dynatrace-concepts/environment-id/.
+  apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
+
+  # Optional: Name of the secret holding the credentials required to connect to the Dynatrace tenant
+  # If unset, the name of this custom resource is used
+  #
+  # tokens: ""
+
+  # Optional: Defines a custom pull secret in case you use a private registry when pulling images from the dynatrace environment
+  # The secret has to be of type 'kubernetes.io/dockerconfigjson' (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  #
+  # customPullSecret: "custom-pull-secret"
+
+  # Optional: Disable certificate validation checks for installer download and API communication
+  #
+  # skipCertCheck: false
+
+  # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
+  #
+  # proxy:
+  #   value: my-proxy-url.com
+  #   valueFrom: name-of-my-proxy-secret
+
+  # Optional: Adds custom RootCAs from a configmap
+  # The key to the data must be "certs"
+  # This property only affects certificates used to communicate with the Dynatrace API.
+  # The property is not applied to the ActiveGate
+  #
+  # trustedCAs: name-of-my-ca-configmap
+
+  # Optional: Sets Network Zone for OneAgent and ActiveGate pods
+  # Make sure networkZones are enabled on your cluster before (see https://www.dynatrace.com/support/help/setup-and-configuration/network-zones/network-zones-basic-info/)
+  #
+  # networkZone: name-of-my-network-zone
+
+  # Optional: If enabled, and if Istio is installed on the Kubernetes environment, the
+  # Operator will create the corresponding VirtualService and ServiceEntry objects to allow access
+  # to the Dynatrace cluster from agents or activeGates. Disabled by default.
+  #
+  # enableIstio: false
+
+  # Configuration for OneAgent instances
+  #
+  oneAgent:
+    # Enables classic fullstack monitoring and changes its settings
+    # Cannot be used in conjunction with cloud-native fullstack monitoring, application-only monitoring or host monitoring
+    #
+    classicFullStack:
+      # Optional: If specified, indicates the OneAgent version to use
+      # Defaults to "latest"
+      # The version is expected to be provided in the semver format
+      # Example: {major.minor.release}, e.g., "1.200.0"
+      #
+      # version:
+
+      # Optional: Sets the URI for the image containing the OneAgent installer used by the DaemonSet
+      # pulls the requireed multi-arch image for OneAgent from docker hub
+      # https://hub.docker.com/r/dynatrace/dynatrace-oneagent
+      image: "dynatrace/oneagent" 
+
+      # Optional: Sets a node selector to control on which nodes the OneAgent will be deployed.
+      # For more information on node selectors, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+      #
+      # nodeSelector: {}
+
+      # Optional: Sets the priority class assigned to the OneAgent Pods. No class is set by default.
+      # For more information on priority classes, see https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+      #
+      # priorityClassName: priority-class
+
+      # Optional: Specifies tolerations to include with the OneAgent DaemonSet.
+      # For more information on tolerations, see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+      #
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
+          effect: NoSchedule
+
+      # Optional: Adds resource settings for OneAgent container
+      # Consumption of the OneAgent heavily depends on the workload to monitor
+      # The values should be adjusted according to the workload
+      #
+      # oneAgentResources:
+      #   requests:
+      #     cpu: 100m
+      #     memory: 512Mi
+      #   limits:
+      #     cpu: 300m
+      #     memory: 1.5Gi
+
+      # Optional: Enables or disables automatic updates of OneAgent pods
+      # By default, if a new version is available, the OneAgent pods are restarted to apply the update
+      # If set to "false", this behavior is disabled
+      # Defaults to "true"
+      #
+      # autoUpdate: true
+
+      # Optional: Sets the DNS Policy for OneAgent pods
+      # Defaults to "ClusterFirstWithHostNet"
+      # For more information on DNS policies, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+      #
+      # dnsPolicy: "ClusterFirstWithHostNet"
+
+      # Optional: Adds custom annotations to OneAgent pods
+      #
+      # annotations:
+      #   custom: annotation
+
+      # Optional: Adds custom labels to OneAgent pods
+      # Can be used to structure workloads
+      #
+      # labels:
+      #   custom: label
+
+      # Optional: Adds custom environment variables to OneAgent pods
+      # This installer script is needed to start the multi arch image with ARM support
+      env:
+        - name: ONEAGENT_INSTALLER_SCRIPT_URL
+          value: "https://ENVIRONMENTID.live.dynatrace.com/api/v1/deployment/installer/agent/unix/default/latest?arch=arm&flavor=default&Api-Token=PAASTOKEN"
+
+      # Optional: Adds custom arguments to the OneAgent installer
+      # For a list of available options, see https://www.dynatrace.com/support/help/shortlink/linux-custom-installation
+      # For a list of the limitations for OneAgents in Docker, see https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
+      #
+      # args: []
+
+  # Configuration for ActiveGate instances.
+  # NOTE: ARM architecture is not currently supported by the Dynatrace Active Gate
+  # Please use an external Active Gate:
+  # https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-activegate/installation/linux/linux-install-an-environment-activegate
+

--- a/assets/samples/classicFullStack-MultiArch.yaml
+++ b/assets/samples/classicFullStack-MultiArch.yaml
@@ -1,0 +1,387 @@
+apiVersion: dynatrace.com/v1beta1
+kind: DynaKube
+metadata:
+  name: oneagent-linux
+  namespace: dynatrace
+spec:
+  # Dynatrace apiUrl including the `/api` path at the end.
+  # For SaaS, set `ENVIRONMENTID` to your environment ID.
+  # For Managed, change the apiUrl address.
+  # For instructions on how to determine the environment ID and how to configure the apiUrl address, see https://www.dynatrace.com/support/help/reference/dynatrace-concepts/environment-id/.
+  apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
+
+  # Optional: Name of the secret holding the credentials required to connect to the Dynatrace tenant
+  # If unset, the name of this custom resource is used
+  # For multiple Dynakube setup, each Dynakube can point to the same secret,
+  # but must be set in each Dynakube resouce  
+  tokens: "TOKEN-SECRET-NAME"
+
+  # Optional: Defines a custom pull secret in case you use a private registry when pulling images from the dynatrace environment
+  # The secret has to be of type 'kubernetes.io/dockerconfigjson' (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  #
+  # customPullSecret: "custom-pull-secret"
+
+  # Optional: Disable certificate validation checks for installer download and API communication
+  #
+  # skipCertCheck: false
+
+  # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
+  #
+  # proxy:
+  #   value: my-proxy-url.com
+  #   valueFrom: name-of-my-proxy-secret
+
+  # Optional: Adds custom RootCAs from a configmap
+  # The key to the data must be "certs"
+  # This property only affects certificates used to communicate with the Dynatrace API.
+  # The property is not applied to the ActiveGate
+  #
+  # trustedCAs: name-of-my-ca-configmap
+
+  # Optional: Sets Network Zone for OneAgent and ActiveGate pods
+  # Make sure networkZones are enabled on your cluster before (see https://www.dynatrace.com/support/help/setup-and-configuration/network-zones/network-zones-basic-info/)
+  #
+  # networkZone: name-of-my-network-zone
+
+  # Optional: If enabled, and if Istio is installed on the Kubernetes environment, the
+  # Operator will create the corresponding VirtualService and ServiceEntry objects to allow access
+  # to the Dynatrace cluster from agents or activeGates. Disabled by default.
+  #
+  # enableIstio: false
+
+  # Configuration for OneAgent instances
+  #
+  oneAgent:
+    # Enables classic fullstack monitoring and changes its settings
+    # Cannot be used in conjunction with cloud-native fullstack monitoring, application-only monitoring or host monitoring
+    #
+    classicFullStack:
+      # Optional: If specified, indicates the OneAgent version to use
+      # Defaults to "latest"
+      # The version is expected to be provided in the semver format
+      # Example: {major.minor.release}, e.g., "1.200.0"
+      #
+      # version:
+
+      # Optional: Sets the URI for the image containing the OneAgent installer used by the DaemonSet
+      # Defaults to the latest OneAgent image on the tenant's registry
+      #
+      image:
+
+      # Optional: Sets a node selector to control on which nodes the OneAgent will be deployed.
+      # For more information on node selectors, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+      # This node selector will deploy only to nodes with the
+      # "kubernetes.io/arch=amd64" label
+      nodeSelector:
+        kubernetes.io/arch: amd64
+
+      # Optional: Sets the priority class assigned to the OneAgent Pods. No class is set by default.
+      # For more information on priority classes, see https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+      #
+      # priorityClassName: priority-class
+
+      # Optional: Specifies tolerations to include with the OneAgent DaemonSet.
+      # For more information on tolerations, see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+      #
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+
+      # Optional: Adds resource settings for OneAgent container
+      # Consumption of the OneAgent heavily depends on the workload to monitor
+      # The values should be adjusted according to the workload
+      #
+      # oneAgentResources:
+      #   requests:
+      #     cpu: 100m
+      #     memory: 512Mi
+      #   limits:
+      #     cpu: 300m
+      #     memory: 1.5Gi
+
+      # Optional: Enables or disables automatic updates of OneAgent pods
+      # By default, if a new version is available, the OneAgent pods are restarted to apply the update
+      # If set to "false", this behavior is disabled
+      # Defaults to "true"
+      #
+      # autoUpdate: true
+
+      # Optional: Sets the DNS Policy for OneAgent pods
+      # Defaults to "ClusterFirstWithHostNet"
+      # For more information on DNS policies, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+      #
+      # dnsPolicy: "ClusterFirstWithHostNet"
+
+      # Optional: Adds custom annotations to OneAgent pods
+      #
+      # annotations:
+      #   custom: annotation
+
+      # Optional: Adds custom labels to OneAgent pods
+      # Can be used to structure workloads
+      #
+      # labels:
+      #   custom: label
+
+      # Optional: Adds custom environment variables to OneAgent pods
+      #
+      # env: []
+
+      # Optional: Adds custom arguments to the OneAgent installer
+      # For a list of available options, see https://www.dynatrace.com/support/help/shortlink/linux-custom-installation
+      # For a list of the limitations for OneAgents in Docker, see https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
+      #
+      # args: []
+
+  # Configuration for ActiveGate instances.
+  #
+  activeGate:
+    # Specifies which capabilities will be enabled on ActiveGate instances
+    # The following capabilities can be set:
+    # - routing
+    # - kubernetes-monitoring
+    # - metrics-ingest
+    # - dynatrace-api
+    #
+    capabilities:
+      - routing
+      - kubernetes-monitoring
+      - dynatrace-api
+
+    # Optional: Sets the image used to deploy ActiveGate instances
+    # Defaults to the latest ActiveGate image on the tenant's registry
+    # Example: "ENVIRONMENTID.live.dynatrace.com/linux/activegate:latest"
+    #
+    image: ""
+
+    # Optional: Sets how many ActiveGate pods are spawned by the StatefulSet
+    # Defaults to "1"
+    #
+    # replicas: 1
+
+    # Optional: Specifies tolerations to include with the ActiveGate StatefulSet.
+    # For more information on tolerations, see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    #
+    # tolerations:
+    # - effect: NoSchedule
+    #   key: node-role.kubernetes.io/master
+    #   operator: Exists
+
+    # Optional: Sets a node selector to control on which nodes the ActiveGate will be deployed.
+    # For more information on node selectors, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+    #
+    # nodeSelector: {}
+
+    # Optional: Specifies resource settings for ActiveGate instances
+    # Consumption of the ActiveGate heavily depends on the workload to monitor
+    # The values should be adjusted according to the workload
+    #
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1.5Gi
+
+    # Optional: Adds custom labels to ActiveGate pods
+    # Can be used to structure workloads
+    #
+    # labels:
+    #   custom: label
+
+    # Optional: Adds custom environment variables to ActiveGate pods
+    #
+    # env: []
+
+    # Optional: Sets the activation group for ActiveGate instances
+    #
+    # group: ""
+
+    # Optional: Defines a custom properties file, the file contents can be provided either as a value in this yaml or as a reference to a secret.
+    # If a reference to a secret is used, then the file contents must be stored under the 'customProperties' key within the secret.
+    #
+    # customProperties:
+    #   value: |
+    #     [connectivity]
+    #     networkZone=
+    #   valueFrom: myCustomPropertiesConfigMap
+
+    # Optional: Specifies the name of a secret containing a TLS certificate, a TLS key and the TLS key's password to be used by ActiveGate instances
+    # If unset, a self-signed certificate is used
+    # The secret is expected to have the following key-value pairs
+    # server.p12: TLS certificate and TLS key pair in pkcs12 format
+    # password: passphrase to decrypt the TLS certificate and TLS key pair
+    #
+    # tlsSecretName: "my-tls-secret"
+
+    # Optional: Sets the DNS Policy for ActiveGate pods
+    # Defaults to "Default"
+    # For more information on DNS policies, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+    #
+    # dnsPolicy: "Default"
+
+    # Optional: Specifies the priority class to assign to the ActiveGate Pods
+    # No class is set by default
+    # For more information on priority classes, see https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    #
+    # priorityClassName: priority-class
+
+    # Optional: Adds custom annotations to ActiveGate pods
+    #
+    # annotations:
+    #   custom: annotation
+
+    # Optional: Adds TopologySpreadConstraints to ActiveGate pods
+    # For more information on TopologySpreadConstraints, see https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    #
+    # topologySpreadConstraints: []
+---
+apiVersion: dynatrace.com/v1beta1
+kind: DynaKube
+metadata:
+  name: oneagent-ARM
+  namespace: dynatrace
+spec:
+  # Dynatrace apiUrl including the `/api` path at the end.
+  # For SaaS, set `ENVIRONMENTID` to your environment ID.
+  # For Managed, change the apiUrl address.
+  # For instructions on how to determine the environment ID and how to configure the apiUrl address, see https://www.dynatrace.com/support/help/reference/dynatrace-concepts/environment-id/.
+  apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
+
+  # Optional: Name of the secret holding the credentials required to connect to the Dynatrace tenant
+  # If unset, the name of this custom resource is used
+  # For multiple Dynakube setup, each Dynakube can point to the same secret,
+  # but must be set in each Dynakube resouce  
+  tokens: "TOKEN-SECRET-NAME"
+
+  # Optional: Defines a custom pull secret in case you use a private registry when pulling images from the dynatrace environment
+  # The secret has to be of type 'kubernetes.io/dockerconfigjson' (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  #
+  # customPullSecret: "custom-pull-secret"
+
+  # Optional: Disable certificate validation checks for installer download and API communication
+  #
+  # skipCertCheck: false
+
+  # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
+  #
+  # proxy:
+  #   value: my-proxy-url.com
+  #   valueFrom: name-of-my-proxy-secret
+
+  # Optional: Adds custom RootCAs from a configmap
+  # The key to the data must be "certs"
+  # This property only affects certificates used to communicate with the Dynatrace API.
+  # The property is not applied to the ActiveGate
+  #
+  # trustedCAs: name-of-my-ca-configmap
+
+  # Optional: Sets Network Zone for OneAgent and ActiveGate pods
+  # Make sure networkZones are enabled on your cluster before (see https://www.dynatrace.com/support/help/setup-and-configuration/network-zones/network-zones-basic-info/)
+  #
+  # networkZone: name-of-my-network-zone
+
+  # Optional: If enabled, and if Istio is installed on the Kubernetes environment, the
+  # Operator will create the corresponding VirtualService and ServiceEntry objects to allow access
+  # to the Dynatrace cluster from agents or activeGates. Disabled by default.
+  #
+  # enableIstio: false
+
+  # Configuration for OneAgent instances
+  #
+  oneAgent:
+    # Enables classic fullstack monitoring and changes its settings
+    # Cannot be used in conjunction with cloud-native fullstack monitoring, application-only monitoring or host monitoring
+    #
+    classicFullStack:
+      # Optional: If specified, indicates the OneAgent version to use
+      # Defaults to "latest"
+      # The version is expected to be provided in the semver format
+      # Example: {major.minor.release}, e.g., "1.200.0"
+      #
+      # version:
+
+      # Optional: Sets the URI for the image containing the OneAgent installer used by the DaemonSet
+      # pulls the requireed multi-arch image for OneAgent from docker hub
+      # https://hub.docker.com/r/dynatrace/dynatrace-oneagent
+      image: "dynatrace/oneagent" 
+
+      # Optional: Sets a node selector to control on which nodes the OneAgent will be deployed.
+      # For more information on node selectors, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+      # This node selector will deploy only to nodes with the
+      # "kubernetes.io/arch=arm64" label
+      nodeSelector:
+          kubernetes.io/arch: arm64
+
+      # Optional: Sets the priority class assigned to the OneAgent Pods. No class is set by default.
+      # For more information on priority classes, see https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+      #
+      # priorityClassName: priority-class
+
+      # Optional: Specifies tolerations to include with the OneAgent DaemonSet.
+      # For more information on tolerations, see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+      #
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
+          effect: NoSchedule
+
+      # Optional: Adds resource settings for OneAgent container
+      # Consumption of the OneAgent heavily depends on the workload to monitor
+      # The values should be adjusted according to the workload
+      #
+      # oneAgentResources:
+      #   requests:
+      #     cpu: 100m
+      #     memory: 512Mi
+      #   limits:
+      #     cpu: 300m
+      #     memory: 1.5Gi
+
+      # Optional: Enables or disables automatic updates of OneAgent pods
+      # By default, if a new version is available, the OneAgent pods are restarted to apply the update
+      # If set to "false", this behavior is disabled
+      # Defaults to "true"
+      #
+      # autoUpdate: true
+
+      # Optional: Sets the DNS Policy for OneAgent pods
+      # Defaults to "ClusterFirstWithHostNet"
+      # For more information on DNS policies, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+      #
+      # dnsPolicy: "ClusterFirstWithHostNet"
+
+      # Optional: Adds custom annotations to OneAgent pods
+      #
+      # annotations:
+      #   custom: annotation
+
+      # Optional: Adds custom labels to OneAgent pods
+      # Can be used to structure workloads
+      #
+      # labels:
+      #   custom: label
+
+      # Optional: Adds custom environment variables to OneAgent pods
+      # This installer script is needed to start the multi arch image with ARM support
+      env:
+        - name: ONEAGENT_INSTALLER_SCRIPT_URL
+          value: "https://ENVIRONMENTID.live.dynatrace.com/api/v1/deployment/installer/agent/unix/default/latest?arch=arm&flavor=default&Api-Token=PAASTOKEN"
+
+      # Optional: Adds custom arguments to the OneAgent installer
+      # For a list of available options, see https://www.dynatrace.com/support/help/shortlink/linux-custom-installation
+      # For a list of the limitations for OneAgents in Docker, see https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
+      #
+      # args: []

--- a/assets/samples/hybrid-fullStack-hostMonitoring.yaml
+++ b/assets/samples/hybrid-fullStack-hostMonitoring.yaml
@@ -1,0 +1,395 @@
+apiVersion: dynatrace.com/v1beta1
+kind: DynaKube
+metadata:
+  name: full-stack
+  namespace: dynatrace
+spec:
+  # Dynatrace apiUrl including the `/api` path at the end.
+  # For SaaS, set `ENVIRONMENTID` to your environment ID.
+  # For Managed, change the apiUrl address.
+  # For instructions on how to determine the environment ID and how to configure the apiUrl address, see https://www.dynatrace.com/support/help/reference/dynatrace-concepts/environment-id/.
+  apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
+
+  # Optional: Name of the secret holding the credentials required to connect to the Dynatrace tenant
+  # If unset, the name of this custom resource is used
+  # For multiple Dynakube setup, each Dynakube can point to the same secret,
+  # but must be set in each Dynakube resouce  
+  tokens: "TOKEN-SECRET-NAME"
+
+  # Optional: Defines a custom pull secret in case you use a private registry when pulling images from the dynatrace environment
+  # The secret has to be of type 'kubernetes.io/dockerconfigjson' (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  #
+  # customPullSecret: "custom-pull-secret"
+
+  # Optional: Disable certificate validation checks for installer download and API communication
+  #
+  # skipCertCheck: false
+
+  # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
+  #
+  # proxy:
+  #   value: my-proxy-url.com
+  #   valueFrom: name-of-my-proxy-secret
+
+  # Optional: Adds custom RootCAs from a configmap
+  # The key to the data must be "certs"
+  # This property only affects certificates used to communicate with the Dynatrace API.
+  # The property is not applied to the ActiveGate
+  #
+  # trustedCAs: name-of-my-ca-configmap
+
+  # Optional: Sets Network Zone for OneAgent and ActiveGate pods
+  # Make sure networkZones are enabled on your cluster before (see https://www.dynatrace.com/support/help/setup-and-configuration/network-zones/network-zones-basic-info/)
+  #
+  # networkZone: name-of-my-network-zone
+
+  # Optional: If enabled, and if Istio is installed on the Kubernetes environment, the
+  # Operator will create the corresponding VirtualService and ServiceEntry objects to allow access
+  # to the Dynatrace cluster from agents or activeGates. Disabled by default.
+  #
+  # enableIstio: false
+
+  # Configuration for OneAgent instances
+  #
+  oneAgent:
+    # Enables classic fullstack monitoring and changes its settings
+    # Cannot be used in conjunction with cloud-native fullstack monitoring, application-only monitoring or host monitoring
+    #
+    classicFullStack:
+      # Optional: If specified, indicates the OneAgent version to use
+      # Defaults to "latest"
+      # The version is expected to be provided in the semver format
+      # Example: {major.minor.release}, e.g., "1.200.0"
+      #
+      # version:
+
+      # Optional: Sets the URI for the image containing the OneAgent installer used by the DaemonSet
+      # Defaults to the latest OneAgent image on the tenant's registry
+      #
+      image:
+
+      # Optional: Sets a node selector to control on which nodes the OneAgent will be deployed.
+      # For more information on node selectors, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+      # This will ensure that Dynatrace pods will deploy only to nodes with the
+      # "full=stack" label 
+      # NOTE: this label is a placeholder and should be modified to meet your needs
+      nodeSelector:
+        full: stack
+
+      # Optional: Sets the priority class assigned to the OneAgent Pods. No class is set by default.
+      # For more information on priority classes, see https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+      #
+      # priorityClassName: priority-class
+
+      # Optional: Specifies tolerations to include with the OneAgent DaemonSet.
+      # For more information on tolerations, see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+      #
+      # We've removed the master/ control plane node taints for the full stack daemonset
+      # We'll use host monitoring mode to monitor the master nodes in the second daemonset
+      # 
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node-role.kubernetes.io/master
+      #     operator: Exists
+      #   - effect: NoSchedule
+      #     key: node-role.kubernetes.io/control-plane
+      #     operator: Exists
+
+      # Optional: Adds resource settings for OneAgent container
+      # Consumption of the OneAgent heavily depends on the workload to monitor
+      # The values should be adjusted according to the workload
+      #
+      # oneAgentResources:
+      #   requests:
+      #     cpu: 100m
+      #     memory: 512Mi
+      #   limits:
+      #     cpu: 300m
+      #     memory: 1.5Gi
+
+      # Optional: Enables or disables automatic updates of OneAgent pods
+      # By default, if a new version is available, the OneAgent pods are restarted to apply the update
+      # If set to "false", this behavior is disabled
+      # Defaults to "true"
+      #
+      # autoUpdate: true
+
+      # Optional: Sets the DNS Policy for OneAgent pods
+      # Defaults to "ClusterFirstWithHostNet"
+      # For more information on DNS policies, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+      #
+      # dnsPolicy: "ClusterFirstWithHostNet"
+
+      # Optional: Adds custom annotations to OneAgent pods
+      #
+      # annotations:
+      #   custom: annotation
+
+      # Optional: Adds custom labels to OneAgent pods
+      # Can be used to structure workloads
+      #
+      # labels:
+      #   custom: label
+
+      # Optional: Adds custom environment variables to OneAgent pods
+      #
+      # env: []
+
+      # Optional: Adds custom arguments to the OneAgent installer
+      # For a list of available options, see https://www.dynatrace.com/support/help/shortlink/linux-custom-installation
+      # For a list of the limitations for OneAgents in Docker, see https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
+      # 
+      # To further seperate the different deployment modes you can assign host groups to each node pool/ node group
+      # best practices in Dynatrace is to use host groups:
+      # https://www.dynatrace.com/support/help/how-to-use-dynatrace/infrastructure-monitoring/hosts/configuration/organize-your-environment-using-host-groups
+      args:
+        - --set-host-group=full-stack
+  # Configuration for ActiveGate instances.
+  #
+  activeGate:
+    # Specifies which capabilities will be enabled on ActiveGate instances
+    # The following capabilities can be set:
+    # - routing
+    # - kubernetes-monitoring
+    # - metrics-ingest
+    # - dynatrace-api
+    #
+    capabilities:
+      - routing
+      - kubernetes-monitoring
+      - dynatrace-api
+
+    # Optional: Sets the image used to deploy ActiveGate instances
+    # Defaults to the latest ActiveGate image on the tenant's registry
+    # Example: "ENVIRONMENTID.live.dynatrace.com/linux/activegate:latest"
+    #
+    image: ""
+
+    # Optional: Sets how many ActiveGate pods are spawned by the StatefulSet
+    # Defaults to "1"
+    #
+    # replicas: 1
+
+    # Optional: Specifies tolerations to include with the ActiveGate StatefulSet.
+    # For more information on tolerations, see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    #
+    # tolerations:
+    # - effect: NoSchedule
+    #   key: node-role.kubernetes.io/master
+    #   operator: Exists
+
+    # Optional: Sets a node selector to control on which nodes the ActiveGate will be deployed.
+    # For more information on node selectors, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+    #
+    # nodeSelector: {}
+
+    # Optional: Specifies resource settings for ActiveGate instances
+    # Consumption of the ActiveGate heavily depends on the workload to monitor
+    # The values should be adjusted according to the workload
+    #
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1.5Gi
+
+    # Optional: Adds custom labels to ActiveGate pods
+    # Can be used to structure workloads
+    #
+    # labels:
+    #   custom: label
+
+    # Optional: Adds custom environment variables to ActiveGate pods
+    #
+    # env: []
+
+    # Optional: Sets the activation group for ActiveGate instances
+    #
+    # group: ""
+
+    # Optional: Defines a custom properties file, the file contents can be provided either as a value in this yaml or as a reference to a secret.
+    # If a reference to a secret is used, then the file contents must be stored under the 'customProperties' key within the secret.
+    #
+    # customProperties:
+    #   value: |
+    #     [connectivity]
+    #     networkZone=
+    #   valueFrom: myCustomPropertiesConfigMap
+
+    # Optional: Specifies the name of a secret containing a TLS certificate, a TLS key and the TLS key's password to be used by ActiveGate instances
+    # If unset, a self-signed certificate is used
+    # The secret is expected to have the following key-value pairs
+    # server.p12: TLS certificate and TLS key pair in pkcs12 format
+    # password: passphrase to decrypt the TLS certificate and TLS key pair
+    #
+    # tlsSecretName: "my-tls-secret"
+
+    # Optional: Sets the DNS Policy for ActiveGate pods
+    # Defaults to "Default"
+    # For more information on DNS policies, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+    #
+    # dnsPolicy: "Default"
+
+    # Optional: Specifies the priority class to assign to the ActiveGate Pods
+    # No class is set by default
+    # For more information on priority classes, see https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    #
+    # priorityClassName: priority-class
+
+    # Optional: Adds custom annotations to ActiveGate pods
+    #
+    # annotations:
+    #   custom: annotation
+
+    # Optional: Adds TopologySpreadConstraints to ActiveGate pods
+    # For more information on TopologySpreadConstraints, see https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    #
+    # topologySpreadConstraints: []
+---
+apiVersion: dynatrace.com/v1beta1
+kind: DynaKube
+metadata:
+  name: infra-only
+  namespace: dynatrace
+spec:
+  # Dynatrace apiUrl including the `/api` path at the end.
+  # For SaaS, set `ENVIRONMENTID` to your environment ID.
+  # For Managed, change the apiUrl address.
+  # For instructions on how to determine the environment ID and how to configure the apiUrl address, see https://www.dynatrace.com/support/help/reference/dynatrace-concepts/environment-id/.
+  apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
+
+  # Optional: Name of the secret holding the credentials required to connect to the Dynatrace tenant
+  # If unset, the name of this custom resource is used
+  # For multiple Dynakube setup, each Dynakube can point to the same secret,
+  # but must be set in each Dynakube resouce  
+  tokens: "TOKEN-SECRET-NAME"
+
+  # Optional: Defines a custom pull secret in case you use a private registry when pulling images from the dynatrace environment
+  # The secret has to be of type 'kubernetes.io/dockerconfigjson' (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  #
+  # customPullSecret: "custom-pull-secret"
+
+  # Optional: Disable certificate validation checks for installer download and API communication
+  #
+  # skipCertCheck: false
+
+  # Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
+  #
+  # proxy:
+  #   value: my-proxy-url.com
+  #   valueFrom: name-of-my-proxy-secret
+
+  # Optional: Adds custom RootCAs from a configmap
+  # The key to the data must be "certs"
+  # This property only affects certificates used to communicate with the Dynatrace API.
+  # The property is not applied to the ActiveGate
+  #
+  # trustedCAs: name-of-my-ca-configmap
+
+  # Optional: Sets Network Zone for OneAgent and ActiveGate pods
+  # Make sure networkZones are enabled on your cluster before (see https://www.dynatrace.com/support/help/setup-and-configuration/network-zones/network-zones-basic-info/)
+  #
+  # networkZone: name-of-my-network-zone
+
+  # Optional: If enabled, and if Istio is installed on the Kubernetes environment, the
+  # Operator will create the corresponding VirtualService and ServiceEntry objects to allow access
+  # to the Dynatrace cluster from agents or activeGates. Disabled by default.
+  #
+  # enableIstio: false
+
+  # Configuration for OneAgent instances
+  #
+  oneAgent:
+    # Enables classic fullstack monitoring and changes its settings
+    # Cannot be used in conjunction with cloud-native fullstack monitoring, application-only monitoring or host monitoring
+    #
+    hostMonitoring:
+      # Optional: If specified, indicates the OneAgent version to use
+      # Defaults to "latest"
+      # The version is expected to be provided in the semver format
+      # Example: {major.minor.release}, e.g., "1.200.0"
+      #
+      # version:
+
+      # Optional: Sets the URI for the image containing the OneAgent installer used by the DaemonSet
+      # pulls the requireed multi-arch image for OneAgent from docker hub
+      # https://hub.docker.com/r/dynatrace/dynatrace-oneagent
+      image: 
+
+      # Optional: Sets a node selector to control on which nodes the OneAgent will be deployed.
+      # For more information on node selectors, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+      # This will ensure that Dynatrace pods will deploy only to nodes with the
+      # "infra=only" label 
+      # NOTE: this label is a placeholder and should be modified to meet your needs
+      nodeSelector:
+          infra: only
+      # Optional: Sets the priority class assigned to the OneAgent Pods. No class is set by default.
+      # For more information on priority classes, see https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+      #
+      # priorityClassName: priority-class
+
+      # Optional: Specifies tolerations to include with the OneAgent DaemonSet.
+      # For more information on tolerations, see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+      # 
+      # Adding these tolerations to the host monitoring mode will allow for deployment to your control plane nodes
+      # Deploying in host only mode to master/control plane nodes is in Dynatrace best practices
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+      # Optional: Adds resource settings for OneAgent container
+      # Consumption of the OneAgent heavily depends on the workload to monitor
+      # The values should be adjusted according to the workload
+      #
+      # oneAgentResources:
+      #   requests:
+      #     cpu: 100m
+      #     memory: 512Mi
+      #   limits:
+      #     cpu: 300m
+      #     memory: 1.5Gi
+
+      # Optional: Enables or disables automatic updates of OneAgent pods
+      # By default, if a new version is available, the OneAgent pods are restarted to apply the update
+      # If set to "false", this behavior is disabled
+      # Defaults to "true"
+      #
+      # autoUpdate: true
+
+      # Optional: Sets the DNS Policy for OneAgent pods
+      # Defaults to "ClusterFirstWithHostNet"
+      # For more information on DNS policies, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+      #
+      # dnsPolicy: "ClusterFirstWithHostNet"
+
+      # Optional: Adds custom annotations to OneAgent pods
+      #
+      # annotations:
+      #   custom: annotation
+
+      # Optional: Adds custom labels to OneAgent pods
+      # Can be used to structure workloads
+      #
+      # labels:
+      #   custom: label
+
+      # Optional: Adds custom environment variables to OneAgent pods
+      # This installer script is needed to start the multi arch image with ARM support
+      env:
+        - name: ONEAGENT_INSTALLER_SCRIPT_URL
+          value: "https://ENVIRONMENTID.live.dynatrace.com/api/v1/deployment/installer/agent/unix/default/latest?arch=arm&flavor=default&Api-Token=PAASTOKEN"
+
+      # Optional: Adds custom arguments to the OneAgent installer
+      # For a list of available options, see https://www.dynatrace.com/support/help/shortlink/linux-custom-installation
+      # For a list of the limitations for OneAgents in Docker, see https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
+      #
+      # To further seperate the different deployment modes you can assign host groups to each node pool/ node group
+      # best practices in Dynatrace is to use host groups:
+      # https://www.dynatrace.com/support/help/how-to-use-dynatrace/infrastructure-monitoring/hosts/configuration/organize-your-environment-using-host-groups
+      args:
+        - --set-host-group=infra-only


### PR DESCRIPTION
# new examples for arm architecture, multi-architecture and multi-dynakube environments

1. hybrid-fullStack-hostMonitoring.yaml
    - Full stack & host monitoring environment - ideally used for on-prem environments with multiple node pools
2. classicFullStack-ARM.yaml
     - example reference for full stack in ARM architecture based environments. Active gate has been removed.
3.  classicFullStack-MultiArch.yaml
    - example reference for hybrid clusters running multiple architectures. 


- This provides documentation for arm based cluster deployments, which does not currently exist
- Many many Dynatrace users are moving workloads over to ARM based architecture for cloud cost savings

## How can this be tested?

-  Deploying the ARM dynakube samples can be tested by deploying to k8s cluster with an arm node pool
- Toleration for standard Kubernetes architecture labels have been added to account for ARM node taints
- node selectors have been added for standard Kubernetes architecture node annotations for ARM & AMD

- Deploying the hybrid dynakube samples requires separate node pools; one with labels for infra-only desired node deployments, and one with full stack desired node deployments. The labels in use are placeholder examples (full=stack & infra=only), as this yaml stands, these labels would need to be added to their respective node pools.