### PR TITLE
ReadOnly support for CSI Driver to make it work for Bottlerocket OS.

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -94,6 +94,8 @@ spec:
           image: {{ include "dynatrace-operator.image" . }}
           imagePullPolicy: Always
           env:
+            - name: DT_MOUNT_READ_ONLY
+              value: "{{ .Values.csidriver.readOnlyFileSystem }}"
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -49,6 +49,7 @@ webhook:
 
 csidriver:
   enabled: false
+  readOnlyFileSystem: false # Set to true if you are deploying it in the bottlerocket OS
   nodeSelector: {}
   kubeletPath: "/var/lib/kubelet"
   existingPriorityClassName: "" # if defined, use this priorityclass instead of creating a new one

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/config.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/config.go
@@ -28,4 +28,6 @@ const (
 
 	preloadPath       = "/etc/ld.so.preload"
 	containerConfPath = "/var/lib/dynatrace/oneagent/agent/config/container.conf"
+
+	readOnlyFileSystem = "DT_MOUNT_READ_ONLY"
 )

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/volumes.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/volumes.go
@@ -2,7 +2,9 @@ package oneagent_mutation
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"strconv"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/config"
@@ -97,10 +99,19 @@ func addOneAgentVolumes(pod *corev1.Pod, dynakube dynatracev1beta1.DynaKube) {
 	)
 }
 
+func setReadOnly() *bool {
+	readOnly := false
+	if os.Getenv(readOnlyFileSystem) != "" {
+		readOnly, _ = strconv.ParseBool(os.Getenv(readOnlyFileSystem))
+	}
+	return &readOnly
+}
+
 func getInstallerVolumeSource(dynakube dynatracev1beta1.DynaKube) corev1.VolumeSource {
 	volumeSource := corev1.VolumeSource{}
 	if dynakube.NeedsCSIDriver() {
 		volumeSource.CSI = &corev1.CSIVolumeSource{
+			ReadOnly: setReadOnly(),
 			Driver: dtcsi.DriverName,
 			VolumeAttributes: map[string]string{
 				csivolumes.CSIVolumeAttributeModeField:     appvolumes.Mode,

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/volumes_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/volumes_test.go
@@ -1,6 +1,7 @@
 package oneagent_mutation
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/volumes_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/volumes_test.go
@@ -67,6 +67,26 @@ func TestAddOneAgentVolumes(t *testing.T) {
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.CSI)
 	})
 
+	t.Run("should add oneagent volumes, with csi read only considering bottlerocket OS", func(t *testing.T) {
+		pod := &corev1.Pod{}
+
+		err := os.Setenv(readOnlyFileSystem, "true")
+		assert.Nil(t, err)
+
+		dynakube := dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{},
+				},
+			},
+		}
+
+		addOneAgentVolumes(pod, dynakube)
+		require.Len(t, pod.Spec.Volumes, 2)
+		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.CSI)
+		assert.Equal(t, pod.Spec.Volumes[0].VolumeSource.CSI.ReadOnly, setReadOnly())
+	})
+
 	t.Run("should add oneagent volumes, without csi", func(t *testing.T) {
 		pod := &corev1.Pod{}
 		dynakube := dynatracev1beta1.DynaKube{


### PR DESCRIPTION
# Description

Adjustments to the mutating webhook that adds the CSI driver to the pod, giving the option to enable read only.

Using the current version, unable to enable the CSI driver due to the following error:
volumes/kubernetes.io~csi/oneagent-bin/mount/agent: permission denied
With this change it is possible to set readOnly: true for the CSI driver. The idea is not to make an interrupt switch, but to give the operator the ability to inflect read-only for the CSI driver in the Application pod.

We tested this change internally by creating a docker image with the changes and applied it to a large cluster and the pod startup time dropped dramatically.

## How can this be tested?
These changes are focused on giving effect to EKS using node groups with bottlerocket. So you need to test this change on a cluster with bottlerocket 1.11+

To enable this change, you need to build a new operator image using this branch and enable the following option in the helm chart values:
```
...
csidriver:
   enabled: true
   readOnlyFileSystem: true
...
```

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

