### PR TITLE
Improves crd generation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -148,6 +148,7 @@ issues:
     - linters:
         - revive
       path: src/dtclient # it's awaiting refactoring
-    - linters:
-        - "*"
-      path: src/api/v1alpha1 # legacy version, should not be changed
+
+run:
+  skip-dirs:
+    - src/api/v1alpha1 # legacy version, should not be changed

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -148,3 +148,6 @@ issues:
     - linters:
         - revive
       path: src/dtclient # it's awaiting refactoring
+    - linters:
+        - "*"
+      path: src/api/v1alpha1 # legacy version, should not be changed

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -601,8 +601,10 @@ spec:
                   or from a secret with the field ''proxy'''
                 properties:
                   value:
+                    description: nolint:unused
                     type: string
                   valueFrom:
+                    description: nolint:unused
                     type: string
                 type: object
               routing:

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -601,10 +601,8 @@ spec:
                   or from a secret with the field ''proxy'''
                 properties:
                   value:
-                    description: nolint:unused
                     type: string
                   valueFrom:
-                    description: nolint:unused
                     type: string
                 type: object
               routing:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -1,5 +1,5 @@
 {{- include "dynatrace-operator.platformRequired" . }}
-{{ if and .Values.installCRD (eq (include "dynatrace-operator.partial" .) "false") }}
+{{ if and .Values.installCRD (or (eq (include "dynatrace-operator.partial" .) "false") (eq (include "dynatrace-operator.partial" .) "crd")) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -612,8 +612,10 @@ spec:
                   or from a secret with the field ''proxy'''
                 properties:
                   value:
+                    description: nolint:unused
                     type: string
                   valueFrom:
+                    description: nolint:unused
                     type: string
                 type: object
               routing:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -612,10 +612,8 @@ spec:
                   or from a secret with the field ''proxy'''
                 properties:
                   value:
-                    description: nolint:unused
                     type: string
                   valueFrom:
-                    description: nolint:unused
                     type: string
                 type: object
               routing:

--- a/hack/helm/generate-crd.sh
+++ b/hack/helm/generate-crd.sh
@@ -19,7 +19,7 @@ mv "${SOURCE_CRD_DIR}/tmp_crd" "${SOURCE_CRD_FILE}"
 
 # Define the header for the helm yaml file
 HELM_HEADER="{{- include \"dynatrace-operator.platformRequired\" . }}
-{{ if and .Values.installCRD (eq (include \"dynatrace-operator.partial\" .) \"false\") }}"
+{{ if and .Values.installCRD (or (eq (include \"dynatrace-operator.partial\" .) \"false\") (eq (include \"dynatrace-operator.partial\" .) \"crd\")) }}"
 
 # Get the previously patched crd content
 CRD_CONTENT="$(cat "${SOURCE_CRD_FILE}")"
@@ -33,3 +33,5 @@ HELM_FOOTER="{{- end -}}"
 	echo "$CRD_CONTENT"
 	echo "$HELM_FOOTER"
 } >"${HELM_CRD_DIR}/${DYNATRACE_OPERATOR_CRD_YAML}"
+
+rm "${SOURCE_CRD_FILE}"

--- a/hack/make/manifests/config.mk
+++ b/hack/make/manifests/config.mk
@@ -6,6 +6,7 @@ HELM_TEMPLATES_DIR=$(HELM_CHART_DEFAULT_DIR)/templates/
 HELM_CRD_DIR=$(HELM_TEMPLATES_DIR)/Common/crd/
 
 MANIFESTS_DIR=config/deploy/
+RELEASE_CRD_YAML=config/deploy/dynatrace-operator-crd.yaml
 
 KUBERNETES_CORE_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes.yaml
 KUBERNETES_AUTOPILOT_YAML=$(MANIFESTS_DIR)kubernetes/gke-autopilot.yaml

--- a/hack/make/manifests/crd.mk
+++ b/hack/make/manifests/crd.mk
@@ -14,3 +14,10 @@ manifests/crd/uninstall: prerequisites/kustomize manifests/crd/generate
 manifests/crd/helm: prerequisites/kustomize helm/version manifests/crd/generate
 	./hack/helm/generate-crd.sh $(KUSTOMIZE) $(HELM_CRD_DIR) $(MANIFESTS_DIR)
 
+## Builds a CRD for the release
+manifests/crd/release: manifests/crd/helm
+	helm template dynatrace-operator config/helm/chart/default \
+			--namespace dynatrace \
+			--set installCRD=true \
+			--set partial="crd" > $(RELEASE_CRD_YAML)
+

--- a/src/api/v1alpha1/dynakube_types.go
+++ b/src/api/v1alpha1/dynakube_types.go
@@ -221,8 +221,8 @@ type DynaKubeValueSource struct {
 }
 
 type DynaKubeProxy struct {
-	Value string `json:"value,omitempty"` // nolint:unused
-	ValueFrom string `json:"valueFrom,omitempty"` // nolint:unused
+	Value     string `json:"value,omitempty"`
+	ValueFrom string `json:"valueFrom,omitempty"`
 }
 
 // DynaKubeStatus defines the observed state of DynaKube

--- a/src/api/v1alpha1/dynakube_types.go
+++ b/src/api/v1alpha1/dynakube_types.go
@@ -221,10 +221,8 @@ type DynaKubeValueSource struct {
 }
 
 type DynaKubeProxy struct {
-	// nolint:unused
-	Value string `json:"value,omitempty"`
-	// nolint:unused
-	ValueFrom string `json:"valueFrom,omitempty"`
+	Value string `json:"value,omitempty"` // nolint:unused
+	ValueFrom string `json:"valueFrom,omitempty"` // nolint:unused
 }
 
 // DynaKubeStatus defines the observed state of DynaKube


### PR DESCRIPTION
# Description
Adds `make` target to generate only the CRD for the `dynatrace` namespace.
Meant to be used for releases

## How can this be tested?
Try `make manifests/crd/release` and check if the `config/deploy/dynatrace-operator-crd.yaml` is correct.
Try `make manifests` and see if it works as expected. (it should produce the same as before)


## Checklist
- ~[x] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

