### PR TITLE
Use csi less target for OLM bundle generation

### DIFF
--- a/config/deploy/kubernetes/kustomization.yaml
+++ b/config/deploy/kubernetes/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- kubernetes-all.yaml
+- kubernetes.yaml # only used in OLM bundle creation

--- a/config/deploy/openshift/kustomization.yaml
+++ b/config/deploy/openshift/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-all.yaml
+- openshift.yaml # only used in OLM bundle creation

--- a/config/manifests/bases/dynatrace-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dynatrace-operator.clusterserviceversion.yaml
@@ -441,6 +441,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'Optional: Adds additional annotations to the ActiveGate pods'
+        displayName: Annotations
+        path: activeGate.annotations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Optional: Adds additional annotations to the OneAgent pods'
         displayName: Annotations
         path: oneAgent.classicFullStack.annotations


### PR DESCRIPTION
# Description

We cant deploy the csi driver's daemonset using OLM so we should not put all the related stuff into the bundle, as they provide no value.

The `config/deploy/${platform}/kustomization.yaml` are only used during the bundle generation, so its ok to change it.

## How can this be tested?
Run `make bundle PLATFORM=kubernetes VERSION=1.2.3` and `make bundle PLATFORM=openshift VERSION=1.2.3` and check if the generated bundle has all the things we need. (and no csi driver components)


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

