### PR TITLE
Removes registrar liveness-probe

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -182,17 +182,6 @@ spec:
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
         command:
         - csi-node-driver-registrar
-        livenessProbe:
-          exec:
-            command:
-              - csi-node-driver-registrar
-              - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-              - --mode=kubelet-registration-probe
-          failureThreshold: 3
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           {{- if .Values.csidriver.registrar.resources }}
           {{- toYaml .Values.csidriver.registrar.resources | nindent 10 }}


### PR DESCRIPTION
# Description

The liveness probe of the `registrar` container of the csi driver is unnecessary.
This liveness probe was only needed for windows nodes on an certain kubernetes versions.
- We do not support windows nodes so having it is not necessary

Furthermore there is an issue, that it can cause high CPU usage. 

## How can this be tested?
Deploy the csi driver, check if it works as expected

## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

