### PR TITLE
Remove comment of wrong default value for MAX_UNMOUNTED_VOLUME_AGE

### DIFF
--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -53,7 +53,7 @@ csidriver:
   kubeletPath: "/var/lib/kubelet"
   existingPriorityClassName: "" # if defined, use this priorityclass instead of creating a new one
   priorityClassValue: "1000000"
-  maxUnmountedVolumeAge: "" # defined in days, must be a plain number, default is "14"
+  maxUnmountedVolumeAge: "" # defined in days, must be a plain number
   tolerations:
     - effect: NoSchedule
       key: node-role.kubernetes.io/master


### PR DESCRIPTION
# Description

The comment in our values file is wrong as the default is 7 days, which is correctly stated in our documentation. We should remove the comment in order to avoid maintaining two locations.

## How can this be tested?
Just a docu update

## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

