### PR TITLE
Change order of e2e tests by adding prefix to classsicFullStack test

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -15,7 +15,8 @@ test/e2e/cloudnative: manifests/crd/helm
 	go test -v -tags e2e -timeout 30m -count=1 ./test/scenarios/cloudnative/basic
 
 ## Runs CloudNative e2e test only
-test/e2e/classic: manifests/crd/helm
+## TODO: rename after proper implementation of cleanup step
+test/e2e/zz_classic: manifests/crd/helm
 	go test -v -tags e2e -timeout 20m -count=1 ./test/scenarios/classic
 
 ## Runs CloudNative istio e2e test only

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -14,7 +14,7 @@ test/e2e/activegate/proxy: manifests/crd/helm
 test/e2e/cloudnative: manifests/crd/helm
 	go test -v -tags e2e -timeout 30m -count=1 ./test/scenarios/cloudnative/basic
 
-## Runs CloudNative e2e test only
+## Runs ClassicFullStack e2e test only
 ## TODO: rename after proper implementation of cleanup step
 test/e2e/zz_classic: manifests/crd/helm
 	go test -v -tags e2e -timeout 20m -count=1 ./test/scenarios/classic
@@ -35,6 +35,6 @@ test/e2e/cloudnative/network: manifests/crd/helm
 test/e2e/applicationmonitoring: manifests/crd/helm
 	go test -v -tags e2e -count=1 ./test/scenarios/applicationmonitoring
 
-## Runs Application Monitoring e2e test only
+## Runs SupportArchive e2e test only
 test/e2e/supportarchive: manifests/crd/helm
 	go test -v -tags e2e -count=1 ./test/scenarios/support_archive


### PR DESCRIPTION
# Description

Currently our e2e tests fail on Openshift, because the classicFullStack tests has some leftovers, which need to be cleaned up properly in a seperate ticket. However for now, to make the tests work we should run the classicFullstack test as last one in order to limit side issues.

## How can this be tested?
Run the e2e tests on an openshift cluster and check if they are working


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

