### PR TITLE
Simplify usage of maxUnmountedVolumeAge in the values.yaml

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -128,7 +128,7 @@ spec:
                 fieldPath: metadata.namespace
           {{- if .Values.csidriver.maxUnmountedVolumeAge }}
           - name: MAX_UNMOUNTED_VOLUME_AGE
-            value: {{ .Values.csidriver.maxUnmountedVolumeAge}}
+            value: "{{ .Values.csidriver.maxUnmountedVolumeAge}}"
           {{- end }}
         livenessProbe:
           failureThreshold: 3

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -37,13 +37,13 @@ tests:
     set:
       platform: kubernetes
       csidriver.enabled: true
-      csidriver.maxUnmountedVolumeAge: 1h
+      csidriver.maxUnmountedVolumeAge: "6"
     asserts:
     - equal:
         path: spec.template.spec.containers[1].env[1] #provisioner
         value:
           name: MAX_UNMOUNTED_VOLUME_AGE
-          value: 1h
+          value: "6"
 
   - it: should have nodeSelectors if set
     set:

--- a/src/controllers/csi/gc/unmounted.go
+++ b/src/controllers/csi/gc/unmounted.go
@@ -72,7 +72,9 @@ func determineMaxUnmountedVolumeAge(maxAgeEnvValue string) time.Duration {
 		return defaultMaxUnmountedCsiVolumeAge
 	}
 	if maxAge < 0 {
-		return 0
+		maxAge = 0
 	}
+
+	log.Info("GarbageCollection is using", "MaxUnmountedCsiVolumeAge", maxAge)
 	return 24 * time.Duration(maxAge) * time.Hour
 }


### PR DESCRIPTION
# Description
Currently our helm chart fails if we set the maxUnmountedVolumeAge to a simple string in our helm chart with the following message:

`Error: INSTALLATION FAILED: release dynatrace-operator failed, and has been uninstalled due to atomic being set: DaemonSet in version "v1" cannot be handled as a DaemonSet: json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string `

This change makes it easier to use a simple string in the helm values file.

## How can this be tested?
Please include some guiding steps on how to test this change during a review.
Deploy the operator using helm
Set a value for maxUnmountedVolumeAge in the helm chart other than "" e.g "6"
Check if the env variable is present on the CSI Pods
Also check if the provisioner logs the current value of the env var at the top of the logs


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

