### PR TITLE
GH-1561: Support custom `registry` and image `tag`

### DIFF
--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -24,7 +24,9 @@ Create chart name and version as used by the chart label.
 Check if default image is used
 */}}
 {{- define "dynatrace-operator.image" -}}
-{{- if .Values.image -}}
+{{- if .Values.repository -}}
+	{{- printf "%s:v%s" .Values.repository (default .Chart.AppVersion .Values.tag) -}}
+{{- else if .Values.image -}}
 	{{- printf "%s" .Values.image -}}
 {{- else -}}
 	{{- if eq .Values.platform "google-marketplace" -}}

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -16,6 +16,10 @@
 platform: "kubernetes"
 
 image: ""
+# The docker repository to use. If it is defined, it has priority over the `image` definition.
+repository: ""
+# The image tag to use. The default is the chart appVersion.
+tag: ""
 customPullSecret: ""
 installCRD: false
 


### PR DESCRIPTION
# Description

This change allows defining custom `registry` and `tag` to be used by the operator. If `tag` is not defined Chart AppVersion is used as default. This would help us to streamline the deployment of the operator across all our different environments.

This close #1561 

## How can this be tested?

Define your custom values of the following keys and play around with the helm template:

```yaml
# The docker repository to use. If it is defined, it has priority over the `image` definition.
repository: ""
# The image tag to use. The default is the chart appVersion.
tag: ""
```

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

