### PR TITLE
GH-1562: Fix dynatrace-operator.image for google-marketplace

### DIFF
--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -28,7 +28,7 @@ Check if default image is used
 	{{- printf "%s" .Values.image -}}
 {{- else -}}
 	{{- if eq .Values.platform "google-marketplace" -}}
-    	{{- printf "%s:%s" "gcr.io/dynatrace-marketplace-prod/dynatrace-operator" "{{ .Chart.AppVersion }}" }}
+    	{{- printf "%s:%s" "gcr.io/dynatrace-marketplace-prod/dynatrace-operator" .Chart.AppVersion }}
 	{{- else -}}
 		{{- printf "%s:v%s" "docker.io/dynatrace/dynatrace-operator" .Chart.AppVersion }}
 	{{- end -}}


### PR DESCRIPTION
# Description

This change solves a bug in the definition of the `dynatrace-operator.image` for the `google-marketplace` platform in the Helm Chart.

This close #1562 

## How can this be tested?
Set the platform to `google-marketplace` in the values file and render the Helm Chart. A valid image should be generated.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

