### PR TITLE
Adapt usage of maxUnmountedVolumeAge in helm values

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -128,7 +128,7 @@ spec:
                 fieldPath: metadata.namespace
           {{- if .Values.csidriver.maxUnmountedVolumeAge }}
           - name: MAX_UNMOUNTED_VOLUME_AGE
-            value: {{ .Values.csidriver.maxUnmountedVolumeAge}}
+            value: "{{ .Values.csidriver.maxUnmountedVolumeAge}}"
           {{- end }}
         livenessProbe:
           failureThreshold: 3

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -37,13 +37,13 @@ tests:
     set:
       platform: kubernetes
       csidriver.enabled: true
-      csidriver.maxUnmountedVolumeAge: 1h
+      csidriver.maxUnmountedVolumeAge: "6"
     asserts:
     - equal:
         path: spec.template.spec.containers[1].env[1] #provisioner
         value:
           name: MAX_UNMOUNTED_VOLUME_AGE
-          value: 1h
+          value: "6"
 
   - it: should have nodeSelectors if set
     set:

--- a/src/controllers/csi/gc/unmounted.go
+++ b/src/controllers/csi/gc/unmounted.go
@@ -70,8 +70,11 @@ func determineMaxUnmountedVolumeAge(maxAgeEnvValue string) time.Duration {
 		log.Error(err, "failed to parse MaxUnmountedCsiVolumeAge from", "env", maxUnmountedCsiVolumeAgeEnv, "value", maxAgeEnvValue)
 		return defaultMaxUnmountedCsiVolumeAge
 	}
-	if maxAge < 0 {
+	if maxAge <= 0 {
+		log.Info("max unmounted csi volume age is set to 0, files will be deleted immediately")
 		return 0
 	}
+
+	log.Info("max unmounted csi volume age used", "age in days", maxAge)
 	return 24 * time.Duration(maxAge) * time.Hour
 }


### PR DESCRIPTION
# Description

Same as #1560

## How can this be tested?

Same as #1560


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

