### PR TITLE
Collect `.yaml` instead of `.json` manifests in support archive

### DIFF
--- a/src/cmd/support_archive/config.go
+++ b/src/cmd/support_archive/config.go
@@ -4,7 +4,7 @@ const OperatorVersionFileName = "operator-version.txt"
 const LogsDirectoryName = "logs"
 const ManifestsDirectoryName = "manifests"
 const InjectedNamespacesManifestsDirectoryName = "injected_namespaces"
-const ManifestsFileExtension = ".json"
+const ManifestsFileExtension = ".yaml"
 
 const operatorVersionCollectorName = "operatorVersionCollector"
 const logCollectorName = "logCollector"

--- a/src/cmd/support_archive/resources.go
+++ b/src/cmd/support_archive/resources.go
@@ -3,8 +3,8 @@ package support_archive
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
+	"sigs.k8s.io/yaml"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -65,22 +65,15 @@ func (collector k8sResourceCollector) readObjectsList(groupVersionKind schema.Gr
 }
 
 func (collector k8sResourceCollector) storeObject(resource unstructured.Unstructured) {
-	document, err := resource.MarshalJSON()
+	yamlManifest, err := yaml.Marshal(resource)
 	if err != nil {
 		logErrorf(collector.log, err, "Failed to marshal %s %s/%s", resource.GetKind(), collector.namespace, resource.GetName())
 		return
 	}
 
-	var prettyJson bytes.Buffer
-	err = json.Indent(&prettyJson, document, "", "  ")
-	if err != nil {
-		logErrorf(collector.log, err, "Failed to pretty print %s %s/%s", resource.GetKind(), collector.namespace, resource.GetName())
-		return
-	}
-
 	fileName := collector.createFileName(resource.GetKind(), resource)
 
-	err = collector.supportArchive.addFile(fileName, &prettyJson)
+	err = collector.supportArchive.addFile(fileName, bytes.NewBuffer(yamlManifest))
 	if err != nil {
 		logErrorf(collector.log, err, "Failed to add %s to support archive", fileName)
 		return

--- a/src/cmd/support_archive/resources.go
+++ b/src/cmd/support_archive/resources.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"sigs.k8s.io/yaml"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 )
 
 const k8sResourceCollectorName = "k8sResourceCollector"

--- a/src/cmd/support_archive/resources_test.go
+++ b/src/cmd/support_archive/resources_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 const testOperatorNamespace = "dynatrace"
+const manifestExtension = ".yaml"
 
 func TestManifestCollector_Success(t *testing.T) {
 	logBuffer := bytes.Buffer{}
@@ -95,13 +96,13 @@ func TestManifestCollector_Success(t *testing.T) {
 	require.NoError(t, newK8sObjectCollector(ctx, log, supportArchive, testOperatorNamespace, clt).Do())
 
 	expectedFiles := []string{
-		fmt.Sprintf("%s/Namespace-some-app-namespace.json", InjectedNamespacesManifestsDirectoryName),
-		fmt.Sprintf("%s/Namespace-dynatrace.json", testOperatorNamespace),
+		fmt.Sprintf("%s/Namespace-some-app-namespace%s", InjectedNamespacesManifestsDirectoryName, manifestExtension),
+		fmt.Sprintf("%s/Namespace-dynatrace%s", testOperatorNamespace, manifestExtension),
 
-		fmt.Sprintf("%s/Deployment/deployment1.json", testOperatorNamespace),
-		fmt.Sprintf("%s/StatefulSet/statefulset1.json", testOperatorNamespace),
-		fmt.Sprintf("%s/DaemonSet/daemonset1.json", testOperatorNamespace),
-		fmt.Sprintf("%s/DynaKube/dynakube1.json", testOperatorNamespace),
+		fmt.Sprintf("%s/Deployment/deployment1%s", testOperatorNamespace, manifestExtension),
+		fmt.Sprintf("%s/StatefulSet/statefulset1%s", testOperatorNamespace, manifestExtension),
+		fmt.Sprintf("%s/DaemonSet/daemonset1%s", testOperatorNamespace, manifestExtension),
+		fmt.Sprintf("%s/DynaKube/dynakube1%s", testOperatorNamespace, manifestExtension),
 	}
 
 	tarReader := tar.NewReader(&tarBuffer)
@@ -180,15 +181,15 @@ func TestManifestCollector_PartialCollectionOnMissingResources(t *testing.T) {
 
 	hdr, err := tarReader.Next()
 	require.NoError(t, err)
-	assert.Equal(t, expectedFilename("injected_namespaces/Namespace-some-app-namespace.json"), hdr.Name)
+	assert.Equal(t, expectedFilename(fmt.Sprintf("injected_namespaces/Namespace-some-app-namespace%s", manifestExtension)), hdr.Name)
 
 	hdr, err = tarReader.Next()
 	require.NoError(t, err)
-	assert.Equal(t, expectedFilename(fmt.Sprintf("%s/StatefulSet/statefulset1.json", testOperatorNamespace)), hdr.Name)
+	assert.Equal(t, expectedFilename(fmt.Sprintf("%s/StatefulSet/statefulset1%s", testOperatorNamespace, manifestExtension)), hdr.Name)
 
 	hdr, err = tarReader.Next()
 	require.NoError(t, err)
-	assert.Equal(t, expectedFilename(fmt.Sprintf("%s/DynaKube/dynakube1.json", testOperatorNamespace)), hdr.Name)
+	assert.Equal(t, expectedFilename(fmt.Sprintf("%s/DynaKube/dynakube1%s", testOperatorNamespace, manifestExtension)), hdr.Name)
 
 	_, err = tarReader.Next()
 	require.ErrorIs(t, err, io.EOF)


### PR DESCRIPTION
# Description

Currently the support archive collects kubernetes objects as json, but we should collect them as yaml manifests, as its easier to read and a more native approach

## How can this be tested?
1. Deploy the operator
2. Run support archive `kubectl exec -n dynatrace deployment/dynatrace-operator -- /usr/local/bin/dynatrace-operator support-archive`
3. Check if the generated archive has the correct manifests stored as .yaml and check if the content is right


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

