### PR TITLE
Unify the default namespace for supportachive and troubleshoot command

### DIFF
--- a/src/cmd/support_archive/builder.go
+++ b/src/cmd/support_archive/builder.go
@@ -7,6 +7,7 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/config"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/go-logr/logr"
@@ -70,7 +71,7 @@ func (builder CommandBuilder) Build() *cobra.Command {
 }
 
 func addFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&namespaceFlagValue, namespaceFlagName, "dynatrace", "Specify a different Namespace.")
+	cmd.PersistentFlags().StringVar(&namespaceFlagValue, namespaceFlagName, kubeobjects.DefaultNamespace(), "Specify a different Namespace.")
 	cmd.PersistentFlags().BoolVar(&tarballToStdoutFlagValue, tarballToStdoutFlagName, false, "Write tarball to stdout.")
 }
 

--- a/src/cmd/troubleshoot/builder.go
+++ b/src/cmd/troubleshoot/builder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/config"
@@ -68,16 +67,7 @@ func (builder CommandBuilder) Build() *cobra.Command {
 
 func addFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&dynakubeFlagValue, dynakubeFlagName, dynakubeFlagShorthand, "", "Specify a different Dynakube name.")
-	cmd.PersistentFlags().StringVarP(&namespaceFlagValue, namespaceFlagName, namespaceFlagShorthand, defaultNamespace(), "Specify a different Namespace.")
-}
-
-func defaultNamespace() string {
-	namespace := os.Getenv("POD_NAMESPACE")
-
-	if namespace == "" {
-		return "dynatrace"
-	}
-	return namespace
+	cmd.PersistentFlags().StringVarP(&namespaceFlagValue, namespaceFlagName, namespaceFlagShorthand, kubeobjects.DefaultNamespace(), "Specify a different Namespace.")
 }
 
 func clusterOptions(opts *cluster.Options) {

--- a/src/kubeobjects/env.go
+++ b/src/kubeobjects/env.go
@@ -1,6 +1,8 @@
 package kubeobjects
 
 import (
+	"os"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -35,4 +37,13 @@ func AddOrUpdate(envVars []corev1.EnvVar, desiredEnvVar corev1.EnvVar) []corev1.
 
 func NewEnvVarSourceForField(fieldPath string) *corev1.EnvVarSource {
 	return &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: fieldPath}}
+}
+
+func DefaultNamespace() string {
+	namespace := os.Getenv("POD_NAMESPACE")
+
+	if namespace == "" {
+		return "dynatrace"
+	}
+	return namespace
 }


### PR DESCRIPTION
# Description

Uses the same logic to determine the default namespace when running the supportarchive and troubleshoot command

## How can this be tested?
Run the troubleshoot/support archive command 

## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

