### PR TITLE
Simplify logging and get rid of log singleton

### DIFF
--- a/src/cmd/troubleshoot/builder_test.go
+++ b/src/cmd/troubleshoot/builder_test.go
@@ -25,7 +25,7 @@ func TestTroubleshootCommandBuilder(t *testing.T) {
 
 		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
 
-		dynakubes, err := getAllDynakubesInNamespace(troubleshootCtx)
+		dynakubes, err := getAllDynakubesInNamespace(getNullLogger(t), troubleshootCtx)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(dynakubes))
 		assert.Equal(t, dynakube.Name, dynakubes[0].Name)
@@ -38,7 +38,7 @@ func TestTroubleshootCommandBuilder(t *testing.T) {
 			namespaceName: testNamespace,
 		}
 
-		dynakubes, err := getDynakubes(troubleshootCtx, dynakube.Name)
+		dynakubes, err := getDynakubes(getNullLogger(t), troubleshootCtx, dynakube.Name)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(dynakubes))
 		assert.Equal(t, testDynakube, dynakubes[0].Name)

--- a/src/cmd/troubleshoot/checks_test.go
+++ b/src/cmd/troubleshoot/checks_test.go
@@ -56,7 +56,7 @@ func Test_runChecks(t *testing.T) {
 	t.Run("no checks", func(t *testing.T) {
 		checks := []*Check{}
 		results := NewChecksResults()
-		err := runChecks(results, tsContext, checks)
+		err := runChecks(getNullLogger(t), results, tsContext, checks)
 		require.NoError(t, err)
 	})
 	t.Run("a few passing checks", func(t *testing.T) {
@@ -65,7 +65,7 @@ func Test_runChecks(t *testing.T) {
 			passingCheckDependendOnPassingCheck,
 		}
 		results := NewChecksResults()
-		err := runChecks(results, tsContext, checks)
+		err := runChecks(getNullLogger(t), results, tsContext, checks)
 		require.NoError(t, err)
 	})
 	t.Run("passing and failing checks", func(t *testing.T) {
@@ -77,8 +77,8 @@ func Test_runChecks(t *testing.T) {
 			failingCheckDependendOnFailingCheck, // should be skipped and error should not be reported
 		}
 		results := NewChecksResults()
-		resetLogger()
-		err := runChecks(results, tsContext, checks)
+
+		err := runChecks(getNullLogger(t), results, tsContext, checks)
 		require.Error(t, err)
 
 		aggregatedError := tserrors.AggregatedError{}
@@ -95,7 +95,7 @@ func Test_runChecks(t *testing.T) {
 			failingCheckDependendOnFailingCheck, // should be skipped and error should not be reported
 		}
 		results := NewChecksResults()
-		err := runChecks(results, tsContext, checks)
+		err := runChecks(getNullLogger(t), results, tsContext, checks)
 		require.Error(t, err)
 	})
 }

--- a/src/cmd/troubleshoot/config.go
+++ b/src/cmd/troubleshoot/config.go
@@ -1,9 +1,0 @@
-package troubleshoot
-
-import "github.com/go-logr/logr"
-
-var log logr.Logger
-
-func resetLogger() {
-	log = newTroubleshootLogger("")
-}

--- a/src/cmd/troubleshoot/context.go
+++ b/src/cmd/troubleshoot/context.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/token"
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
@@ -22,9 +23,10 @@ type troubleshootContext struct {
 	dynatraceApiSecretTokens token.Tokens
 	pullSecret               corev1.Secret
 	kubeConfig               rest.Config
+	baseLog                  logr.Logger
 }
 
-func (troubleshootCtx *troubleshootContext) SetTransportProxy(proxy string) error {
+func (troubleshootCtx *troubleshootContext) SetTransportProxy(log logr.Logger, proxy string) error {
 	if proxy != "" {
 		proxyUrl, err := url.Parse(proxy)
 		if err != nil {
@@ -36,7 +38,7 @@ func (troubleshootCtx *troubleshootContext) SetTransportProxy(proxy string) erro
 		}
 
 		troubleshootCtx.httpClient.Transport.(*http.Transport).Proxy = http.ProxyURL(proxyUrl)
-		logInfof("using '%s' proxy to connect to the registry", proxyUrl.Host)
+		logInfof(log, "using '%s' proxy to connect to the registry", proxyUrl.Host)
 	}
 
 	return nil

--- a/src/cmd/troubleshoot/crd.go
+++ b/src/cmd/troubleshoot/crd.go
@@ -8,9 +8,9 @@ import (
 )
 
 func checkCRD(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("crd")
+	log := troubleshootCtx.baseLog.WithName("crd")
 
-	logNewCheckf("checking if CRD for Dynakube exists ...")
+	logNewCheckf(log, "checking if CRD for Dynakube exists ...")
 
 	dynakubeList := &dynatracev1beta1.DynaKubeList{}
 	err := troubleshootCtx.apiReader.List(troubleshootCtx.context, dynakubeList, &client.ListOptions{Namespace: troubleshootCtx.namespaceName})
@@ -19,7 +19,7 @@ func checkCRD(troubleshootCtx *troubleshootContext) error {
 		return determineDynakubeError(err)
 	}
 
-	logOkf("CRD for Dynakube exists")
+	logOkf(log, "CRD for Dynakube exists")
 	return nil
 }
 

--- a/src/cmd/troubleshoot/image_test.go
+++ b/src/cmd/troubleshoot/image_test.go
@@ -1,7 +1,6 @@
 package troubleshoot
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dtpullsecret"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -65,17 +65,6 @@ func createSecret(auths Auths) (*corev1.Secret, error) {
 		build(), nil
 }
 
-func runWithTestLogger(testName string, function func()) string {
-	logBuffer := bytes.Buffer{}
-	logger := newTroubleshootLoggerToWriter(testName, &logBuffer)
-
-	oldLog := log
-	log = logger
-	function()
-	log = oldLog
-	return logBuffer.String()
-}
-
 func TestOneAgentImagePullable(t *testing.T) {
 	dockerServer, secret, _, err := setupDockerMocker(
 		[]string{
@@ -99,8 +88,8 @@ func TestOneAgentImagePullable(t *testing.T) {
 			withCloudNativeFullStack().
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		assert.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -111,8 +100,8 @@ func TestOneAgentImagePullable(t *testing.T) {
 			withCloudNativeFullStackImageVersion(testVersion).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -123,8 +112,8 @@ func TestOneAgentImagePullable(t *testing.T) {
 			withClassicFullStack().
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -135,8 +124,8 @@ func TestOneAgentImagePullable(t *testing.T) {
 			withClassicFullStackImageVersion(testVersion).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -147,8 +136,8 @@ func TestOneAgentImagePullable(t *testing.T) {
 			withHostMonitoring().
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -159,8 +148,8 @@ func TestOneAgentImagePullable(t *testing.T) {
 			withHostMonitoringImageVersion(testVersion).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -190,8 +179,8 @@ func TestOneAgentCustomImagePullable(t *testing.T) {
 			withCloudNativeFullStackCustomImage(server + "/" + testCustomOneAgentImage).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -202,8 +191,8 @@ func TestOneAgentCustomImagePullable(t *testing.T) {
 			withCloudNativeFullStackCustomImage(server + "/" + testCustomOneAgentImage + ":latest").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -214,8 +203,8 @@ func TestOneAgentCustomImagePullable(t *testing.T) {
 			withCloudNativeFullStackCustomImage(server + "/" + testCustomOneAgentImage + ":" + testVersion).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -226,8 +215,8 @@ func TestOneAgentCustomImagePullable(t *testing.T) {
 			withClassicFullStackCustomImage(server + "/" + testCustomOneAgentImage).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -238,8 +227,8 @@ func TestOneAgentCustomImagePullable(t *testing.T) {
 			withClassicFullStackCustomImage(server + "/" + testCustomOneAgentImage + ":latest").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -250,8 +239,8 @@ func TestOneAgentCustomImagePullable(t *testing.T) {
 			withClassicFullStackCustomImage(server + "/" + testCustomOneAgentImage + ":" + testVersion).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -262,8 +251,8 @@ func TestOneAgentCustomImagePullable(t *testing.T) {
 			withHostMonitoringCustomImage(server + "/" + testCustomOneAgentImage).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -274,8 +263,8 @@ func TestOneAgentCustomImagePullable(t *testing.T) {
 			withHostMonitoringCustomImage(server + "/" + testCustomOneAgentImage + ":latest").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -286,8 +275,8 @@ func TestOneAgentCustomImagePullable(t *testing.T) {
 			withHostMonitoringCustomImage(server + "/" + testCustomOneAgentImage + ":" + testVersion).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -315,8 +304,8 @@ func TestOneAgentImageNotPullable(t *testing.T) {
 			withCloudNativeFullStack().
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "reading manifest")
@@ -328,8 +317,8 @@ func TestOneAgentImageNotPullable(t *testing.T) {
 			withCloudNativeFullStackCustomImage(server + "/foobar").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "reading manifest")
@@ -341,8 +330,8 @@ func TestOneAgentImageNotPullable(t *testing.T) {
 			withClassicFullStack().
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "reading manifest")
@@ -354,8 +343,8 @@ func TestOneAgentImageNotPullable(t *testing.T) {
 			withClassicFullStackCustomImage(server + "/foobar").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "reading manifest")
@@ -367,8 +356,8 @@ func TestOneAgentImageNotPullable(t *testing.T) {
 			withHostMonitoring().
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "reading manifest")
@@ -380,8 +369,8 @@ func TestOneAgentImageNotPullable(t *testing.T) {
 			withHostMonitoringCustomImage(server + "/foobar").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "reading manifest")
@@ -393,8 +382,8 @@ func TestOneAgentImageNotPullable(t *testing.T) {
 			withHostMonitoringCustomImage("myunknownserver.com/foobar/image").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentOneAgent, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentOneAgent, false)
 		})
 		require.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "no such host")
@@ -425,8 +414,8 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 			withCloudNativeCodeModulesImage(server + "/" + testOneAgentCodeModulesImage + ":" + testVersion).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentCodeModules, true)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentCodeModules, true)
 		})
 		assert.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -437,8 +426,8 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 			withCloudNativeCodeModulesImage(server + "/" + testOneAgentCodeModulesImage + ":" + testVersion).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentCodeModules, true)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentCodeModules, true)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -449,8 +438,8 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 			withCloudNativeCodeModulesImage(server + "/" + testOneAgentCodeModulesImage + ":latest").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentCodeModules, true)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentCodeModules, true)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -461,8 +450,8 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 			withCloudNativeCodeModulesImage(server + "/" + testOneAgentCodeModulesImage).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentCodeModules, true)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentCodeModules, true)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -473,8 +462,8 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 			withApplicationMonitoringCodeModulesImage(server + "/" + testOneAgentCodeModulesImage + ":" + testVersion).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentCodeModules, true)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentCodeModules, true)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -485,8 +474,8 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 			withApplicationMonitoringCodeModulesImage(server + "/" + testOneAgentCodeModulesImage + ":latest").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentCodeModules, true)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentCodeModules, true)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -497,8 +486,8 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 			withApplicationMonitoringCodeModulesImage(server + "/" + testOneAgentCodeModulesImage).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentCodeModules, true)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentCodeModules, true)
 		})
 		require.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -509,8 +498,8 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 			withCloudNativeCodeModulesImage(server + "/non-existing-image").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentCodeModules, true)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentCodeModules, true)
 		})
 		assert.Contains(t, logOutput, "failed")
 		assert.NotContains(t, logOutput, "can be successfully pulled")
@@ -521,8 +510,8 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 			withCloudNativeCodeModulesImage("myunknownserver.com/myrepo/mymissingcodemodules").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentCodeModules, true)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentCodeModules, true)
 		})
 		assert.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "no such host")
@@ -534,8 +523,8 @@ func TestOneAgentCodeModulesImagePullable(t *testing.T) {
 			withCloudNativeCodeModulesImage("").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentCodeModules, true)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentCodeModules, true)
 		})
 		assert.NotContains(t, logOutput, "Unknown OneAgentCodeModules image")
 	})
@@ -565,8 +554,8 @@ func TestActiveGateImagePullable(t *testing.T) {
 			withApiUrl(dockerServer.URL + "/api").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentActiveGate, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentActiveGate, false)
 		})
 		assert.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -577,8 +566,8 @@ func TestActiveGateImagePullable(t *testing.T) {
 			withActiveGateCustomImage(server + "/" + testActiveGateCustomImage).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentActiveGate, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentActiveGate, false)
 		})
 		assert.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -589,8 +578,8 @@ func TestActiveGateImagePullable(t *testing.T) {
 			withActiveGateCustomImage(server + "/" + testActiveGateCustomImage + ":latest").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentActiveGate, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentActiveGate, false)
 		})
 		assert.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -601,8 +590,8 @@ func TestActiveGateImagePullable(t *testing.T) {
 			withActiveGateCustomImage(server + "/" + testActiveGateCustomImage + ":" + testVersion).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentActiveGate, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentActiveGate, false)
 		})
 		assert.NotContains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "can be successfully pulled")
@@ -629,8 +618,8 @@ func TestActiveGateImageNotPullable(t *testing.T) {
 			withApiUrl(dockerServer.URL + "/api").
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentActiveGate, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentActiveGate, false)
 		})
 		require.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "reading manifest")
@@ -643,8 +632,8 @@ func TestActiveGateImageNotPullable(t *testing.T) {
 			withActiveGateCapability(v1beta1.RoutingCapability.DisplayName).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentActiveGate, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentActiveGate, false)
 		})
 		require.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "reading manifest")
@@ -657,8 +646,8 @@ func TestActiveGateImageNotPullable(t *testing.T) {
 			withActiveGateCapability(v1beta1.RoutingCapability.DisplayName).
 			build()
 
-		logOutput := runWithTestLogger(t.Name(), func() {
-			verifyImageIsAvailable(&troubleshootCtx, componentActiveGate, false)
+		logOutput := runWithTestLogger(func(log logr.Logger) {
+			verifyImageIsAvailable(log, &troubleshootCtx, componentActiveGate, false)
 		})
 		require.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "no such host")

--- a/src/cmd/troubleshoot/logger_test.go
+++ b/src/cmd/troubleshoot/logger_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,4 +21,13 @@ func getNullLogger(t *testing.T) logr.Logger {
 	devNull, err := os.Open(os.DevNull)
 	require.NoError(t, err)
 	return NewTroubleshootLoggerToWriter(devNull)
+}
+
+func TestTroubleshootLogger(t *testing.T) {
+	const testLogOutput = "test log output"
+	logOutput := runWithTestLogger(func(log logr.Logger) {
+		logInfof(log, testLogOutput)
+	})
+
+	assert.Contains(t, logOutput, testLogOutput)
 }

--- a/src/cmd/troubleshoot/namespace.go
+++ b/src/cmd/troubleshoot/namespace.go
@@ -7,9 +7,9 @@ import (
 )
 
 func checkNamespace(troubleshootCtx *troubleshootContext) error {
-	log = newTroubleshootLogger("namespace")
+	log := troubleshootCtx.baseLog.WithName("namespace")
 
-	logNewCheckf("checking if namespace '%s' exists ...", troubleshootCtx.namespaceName)
+	logNewCheckf(log, "checking if namespace '%s' exists ...", troubleshootCtx.namespaceName)
 
 	var namespace corev1.Namespace
 	err := troubleshootCtx.apiReader.Get(troubleshootCtx.context, client.ObjectKey{Name: troubleshootCtx.namespaceName}, &namespace)
@@ -18,6 +18,6 @@ func checkNamespace(troubleshootCtx *troubleshootContext) error {
 		return errors.Wrapf(err, "missing namespace '%s'", troubleshootCtx.namespaceName)
 	}
 
-	logOkf("using namespace '%s'", troubleshootCtx.namespaceName)
+	logOkf(log, "using namespace '%s'", troubleshootCtx.namespaceName)
 	return nil
 }

--- a/src/cmd/troubleshoot/namespace_test.go
+++ b/src/cmd/troubleshoot/namespace_test.go
@@ -29,7 +29,11 @@ func TestTroubleshootNamespace(t *testing.T) {
 			}).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
+		troubleshootCtx := troubleshootContext{
+			apiReader:     clt,
+			namespaceName: testNamespace,
+			baseLog:       getNullLogger(t),
+		}
 		assert.NoErrorf(t, checkNamespace(&troubleshootCtx), "'%s' namespace not found", troubleshootCtx.namespaceName)
 	})
 	t.Run("namespace does not exist in cluster", func(t *testing.T) {
@@ -43,7 +47,11 @@ func TestTroubleshootNamespace(t *testing.T) {
 			}).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testNamespace}
+		troubleshootCtx := troubleshootContext{
+			apiReader:     clt,
+			namespaceName: testNamespace,
+			baseLog:       getNullLogger(t),
+		}
 		assert.Errorf(t, checkNamespace(&troubleshootCtx), "'%s' namespace found", troubleshootCtx.namespaceName)
 	})
 	t.Run("invalid namespace selected", func(t *testing.T) {
@@ -57,7 +65,11 @@ func TestTroubleshootNamespace(t *testing.T) {
 			}).
 			Build()
 
-		troubleshootCtx := troubleshootContext{apiReader: clt, namespaceName: testOtherNamespace}
+		troubleshootCtx := troubleshootContext{
+			apiReader:     clt,
+			namespaceName: testOtherNamespace,
+			baseLog:       getNullLogger(t),
+		}
 		assert.Errorf(t, checkNamespace(&troubleshootCtx), "'%s' namespace found", troubleshootCtx.namespaceName)
 	})
 }

--- a/src/cmd/troubleshoot/oneagentapm.go
+++ b/src/cmd/troubleshoot/oneagentapm.go
@@ -7,9 +7,9 @@ import (
 )
 
 func checkOneAgentAPM(ctx *troubleshootContext) error {
-	log = newTroubleshootLogger("oneAgentAPM")
+	log := ctx.baseLog.WithName("oneAgentAPM")
 
-	logNewCheckf("checking if OneAgentAPM object exists ...")
+	logNewCheckf(log, "checking if OneAgentAPM object exists ...")
 	exists, err := kubeobjects.CheckIfOneAgentAPMExists(&ctx.kubeConfig)
 
 	if err != nil {
@@ -20,6 +20,6 @@ func checkOneAgentAPM(ctx *troubleshootContext) error {
 		return errors.New("OneAgentAPM object still exists - either delete OneAgentAPM objects or fully install the oneAgent operator")
 	}
 
-	logOkf("OneAgentAPM does not exist")
+	logOkf(log, "OneAgentAPM does not exist")
 	return nil
 }

--- a/src/cmd/troubleshoot/proxy.go
+++ b/src/cmd/troubleshoot/proxy.go
@@ -7,56 +7,54 @@ import (
 )
 
 func checkProxySettings(troubleshootCtx *troubleshootContext) error {
-	return checkProxySettingsWithLog(troubleshootCtx, newSubTestLogger("proxy"))
+	return checkProxySettingsWithLog(troubleshootCtx, troubleshootCtx.baseLog.WithName("proxy"))
 }
 
-func checkProxySettingsWithLog(troubleshootCtx *troubleshootContext, logger logr.Logger) error {
-	log = logger
-
+func checkProxySettingsWithLog(troubleshootCtx *troubleshootContext, log logr.Logger) error {
 	var proxyURL string
-	logNewCheckf("Analyzing proxy settings ...")
+	logNewCheckf(log, "Analyzing proxy settings ...")
 
 	proxySettingsAvailable := false
 	if troubleshootCtx.dynakube.HasProxy() {
 		proxySettingsAvailable = true
-		logInfof("Reminder: Proxy settings in the Dynakube do not apply to pulling of pod images. Please set your proxy on accordingly on node level.")
-		logWarningf("Proxy settings in the Dynakube are ignored for codeModules images due to technical limitations.")
+		logInfof(log, "Reminder: Proxy settings in the Dynakube do not apply to pulling of pod images. Please set your proxy on accordingly on node level.")
+		logWarningf(log, "Proxy settings in the Dynakube are ignored for codeModules images due to technical limitations.")
 
 		var err error
 		proxyURL, err = getProxyURL(troubleshootCtx)
 		if err != nil {
-			logErrorf("Unexpected error when reading proxy settings from Dynakube: %v", err)
+			logErrorf(log, "Unexpected error when reading proxy settings from Dynakube: %v", err)
 			return nil
 		}
 	}
 
-	if checkEnvironmentProxySettings(proxyURL) {
+	if checkEnvironmentProxySettings(log, proxyURL) {
 		proxySettingsAvailable = true
 	}
 
 	if !proxySettingsAvailable {
-		logOkf("No proxy settings found.")
+		logOkf(log, "No proxy settings found.")
 	}
 	return nil
 }
 
-func checkEnvironmentProxySettings(proxyURL string) bool {
+func checkEnvironmentProxySettings(log logr.Logger, proxyURL string) bool {
 	envProxy := getEnvProxySettings()
 	if envProxy == nil {
 		return false
 	}
 
-	logInfof("Searching environment for proxy settings ...")
+	logInfof(log, "Searching environment for proxy settings ...")
 	if envProxy.HTTPProxy != "" {
-		logWarningf("HTTP_PROXY is set in environment. This setting will be used by the operator for codeModule image pulls.")
+		logWarningf(log, "HTTP_PROXY is set in environment. This setting will be used by the operator for codeModule image pulls.")
 		if proxySettingsDiffer(envProxy.HTTPProxy, proxyURL) {
-			logWarningf("Proxy settings in the Dynakube and HTTP_PROXY differ.")
+			logWarningf(log, "Proxy settings in the Dynakube and HTTP_PROXY differ.")
 		}
 	}
 	if envProxy.HTTPSProxy != "" {
-		logWarningf("HTTPS_PROXY is set in environment. This setting will be used by the operator for codeModule image pulls.")
+		logWarningf(log, "HTTPS_PROXY is set in environment. This setting will be used by the operator for codeModule image pulls.")
 		if proxySettingsDiffer(envProxy.HTTPSProxy, proxyURL) {
-			logWarningf("Proxy settings in the Dynakube and HTTPS_PROXY differ.")
+			logWarningf(log, "Proxy settings in the Dynakube and HTTPS_PROXY differ.")
 		}
 	}
 	return true
@@ -74,14 +72,14 @@ func getEnvProxySettings() *httpproxy.Config {
 	return nil
 }
 
-func applyProxySettings(troubleshootCtx *troubleshootContext) error {
+func applyProxySettings(log logr.Logger, troubleshootCtx *troubleshootContext) error {
 	proxyURL, err := getProxyURL(troubleshootCtx)
 	if err != nil {
 		return err
 	}
 
 	if proxyURL != "" {
-		err := troubleshootCtx.SetTransportProxy(proxyURL)
+		err := troubleshootCtx.SetTransportProxy(log, proxyURL)
 		if err != nil {
 			return errors.Wrapf(err, "error parsing proxy value")
 		}

--- a/src/cmd/troubleshoot/proxy_test.go
+++ b/src/cmd/troubleshoot/proxy_test.go
@@ -1,7 +1,6 @@
 package troubleshoot
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"testing"
@@ -24,7 +23,7 @@ func TestCheckProxySettings(t *testing.T) {
 			namespaceName: testNamespace,
 		}
 
-		logOutput := runProxyTestWithTestLogger(t.Name(), func(logger logr.Logger) {
+		logOutput := runWithTestLogger(func(logger logr.Logger) {
 			checkProxySettingsWithLog(&troubleshootCtx, logger)
 		})
 
@@ -43,7 +42,7 @@ func TestCheckProxySettings(t *testing.T) {
 			namespaceName: testNamespace,
 		}
 
-		logOutput := runProxyTestWithTestLogger(t.Name(), func(logger logr.Logger) {
+		logOutput := runWithTestLogger(func(logger logr.Logger) {
 			checkProxySettingsWithLog(&troubleshootCtx, logger)
 		})
 
@@ -62,7 +61,7 @@ func TestCheckProxySettings(t *testing.T) {
 			namespaceName: testNamespace,
 		}
 
-		logOutput := runProxyTestWithTestLogger(t.Name(), func(logger logr.Logger) {
+		logOutput := runWithTestLogger(func(logger logr.Logger) {
 			checkProxySettingsWithLog(&troubleshootCtx, logger)
 		})
 
@@ -85,7 +84,7 @@ func TestCheckProxySettings(t *testing.T) {
 			withProxy("http://foobar:1234").
 			build()
 
-		logOutput := runProxyTestWithTestLogger(t.Name(), func(logger logr.Logger) {
+		logOutput := runWithTestLogger(func(logger logr.Logger) {
 			checkProxySettingsWithLog(&troubleshootCtx, logger)
 		})
 
@@ -121,7 +120,7 @@ func TestCheckProxySettings(t *testing.T) {
 			withProxySecret(testSecretName).
 			build()
 
-		logOutput := runProxyTestWithTestLogger(t.Name(), func(logger logr.Logger) {
+		logOutput := runWithTestLogger(func(logger logr.Logger) {
 			checkProxySettingsWithLog(&troubleshootCtx, logger)
 		})
 
@@ -144,7 +143,7 @@ func TestCheckProxySettings(t *testing.T) {
 			withProxy("http://foobar:1234").
 			build()
 
-		logOutput := runProxyTestWithTestLogger(t.Name(), func(logger logr.Logger) {
+		logOutput := runWithTestLogger(func(logger logr.Logger) {
 			checkProxySettingsWithLog(&troubleshootCtx, logger)
 		})
 
@@ -154,11 +153,4 @@ func TestCheckProxySettings(t *testing.T) {
 		assert.Contains(t, logOutput, "Dynakube")
 		assert.NotContains(t, logOutput, "No proxy settings found.")
 	})
-}
-
-func runProxyTestWithTestLogger(testName string, function func(logger logr.Logger)) string {
-	logBuffer := bytes.Buffer{}
-	logger := newTroubleshootLoggerToWriter(testName, &logBuffer)
-	function(logger)
-	return logBuffer.String()
 }

--- a/src/cmd/troubleshoot/testutils.go
+++ b/src/cmd/troubleshoot/testutils.go
@@ -1,0 +1,23 @@
+package troubleshoot
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+func runWithTestLogger(function func(log logr.Logger)) string {
+	logBuffer := bytes.Buffer{}
+	logger := NewTroubleshootLoggerToWriter(&logBuffer)
+	function(logger)
+	return logBuffer.String()
+}
+
+func getNullLogger(t *testing.T) logr.Logger {
+	devNull, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+	return NewTroubleshootLoggerToWriter(devNull)
+}


### PR DESCRIPTION
# Description
This PR is a preparation for running the troubleshoot command within the support archive command.
First, it gets rid of the hidden log singleton in troubleshoot. This is needed so that the support archive command can provide an own logger to grab all output into a file. With this, logging had to be reworked a bit to keep separate subtest loggers with dedicated names.

Furthermore, formatting log lines seems to be implemented overly complicated, this has been simplified along the way.

## How can this be tested?
Build the operator, deploy it and run the troubleshoot command. Everything should work as before.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

