### PR TITLE
Auto-detects platform for helm install

### DIFF
--- a/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{- if eq (default false .Values.olm) true}}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 

--- a/config/helm/chart/default/templates/Common/activegate/clusterrolebinding-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/clusterrolebinding-activegate.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{- if eq (default false .Values.olm) true}}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC

--- a/config/helm/chart/default/templates/Common/activegate/serviceaccount-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/serviceaccount-activegate.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if and .Values.installCRD (or (eq (include "dynatrace-operator.partial" .) "false") (eq (include "dynatrace-operator.partial" .) "crd")) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/config/helm/chart/default/templates/Common/csi/clusterrole-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/clusterrole-csi.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/csi/clusterrolebinding-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/clusterrolebinding-csi.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/csi/csidriver.yaml
+++ b/config/helm/chart/default/templates/Common/csi/csidriver.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
 # Copyright 2021 Dynatrace LLC
 
@@ -34,7 +33,7 @@ spec:
         dynatrace.com/inject: "false"
         kubectl.kubernetes.io/default-container: provisioner
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
-        {{- if and (eq (default false .Values.apparmor) true) (ne .Values.platform "openshift") }}
+        {{- if and (eq (default false .Values.apparmor) true) (ne (include "dynatrace-operator.platform" .) "openshift") }}
         container.apparmor.security.beta.kubernetes.io/driver: runtime/default
         container.apparmor.security.beta.kubernetes.io/registrar: runtime/default
         container.apparmor.security.beta.kubernetes.io/liveness-probe: runtime/default

--- a/config/helm/chart/default/templates/Common/csi/priority-class.yaml
+++ b/config/helm/chart/default/templates/Common/csi/priority-class.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if (eq (include "dynatrace-operator.needPriorityClass" .) "true") }}
 
 # Copyright 2021 Dynatrace LLC

--- a/config/helm/chart/default/templates/Common/csi/role-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/role-csi.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/csi/rolebinding-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/rolebinding-csi.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/csi/serviceaccount-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/serviceaccount-csi.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrolebinding-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrolebinding-kubernetes-monitoring.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-privileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-privileged.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-privileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-privileged.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrolebinding-oneagent-unprivileged.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent-privileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent-privileged.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 
@@ -21,9 +20,4 @@ metadata:
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
 automountServiceAccountToken: false
-{{- if eq .Values.platform "openshift"}}
-imagePullSecrets:
-- name: redhat-connect
-- name: redhat-connect-sso
-{{- end }}
 {{ end }}

--- a/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent-unprivileged.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 
@@ -21,9 +20,4 @@ metadata:
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
 automountServiceAccountToken: false
-{{- if eq .Values.platform "openshift"}}
-imagePullSecrets:
-- name: redhat-connect
-- name: redhat-connect-sso
-{{- end }}
 {{ end }}

--- a/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/operator/clusterrolebinding-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/clusterrolebinding-operator.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 
@@ -106,7 +105,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  {{- if ne .Values.platform "gke-autopilot"}}
+                  {{- if ne (include "dynatrace-operator.platform" .) "gke-autopilot" }}
                   - key: kubernetes.io/arch
                     operator: In
                     values:

--- a/config/helm/chart/default/templates/Common/operator/role-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/role-operator.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/operator/rolebinding-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/rolebinding-operator.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/operator/serviceaccount-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/serviceaccount-operator.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 
@@ -20,10 +19,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
-
-{{ if eq .Values.platform "openshift" }}
-imagePullSecrets:
-- name: redhat-connect
-- name: redhat-connect-sso
-{{ end }}
 {{ end }}

--- a/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/webhook/clusterrolebinding-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/clusterrolebinding-webhook.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 
@@ -74,7 +73,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                    {{- if ne .Values.platform "gke-autopilot"}}
+                    {{- if ne (include "dynatrace-operator.platform" .) "gke-autopilot"}}
                   - key: kubernetes.io/arch
                     operator: In
                     values:

--- a/config/helm/chart/default/templates/Common/webhook/mutatingwebhookconfiguration.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/mutatingwebhookconfiguration.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/webhook/poddisruptionbudget-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/poddisruptionbudget-webhook.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if and (.Values.webhook).highAvailability (eq (include "dynatrace-operator.partial" .) "false") }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/config/helm/chart/default/templates/Common/webhook/role-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/role-webhook.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/webhook/rolebinding-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/rolebinding-webhook.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/webhook/service.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/service.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/webhook/serviceaccount-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/serviceaccount-webhook.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 
@@ -20,10 +19,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
-{{- if eq .Values.platform "openshift" }}
-imagePullSecrets:
-- name: redhat-connect
-- name: redhat-connect-sso
-{{- end }}
 {{ end }}
 

--- a/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
@@ -1,4 +1,3 @@
-{{- include "dynatrace-operator.platformRequired" . }}
 {{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Openshift/activegate/securitycontextconstraints.yaml
+++ b/config/helm/chart/default/templates/Openshift/activegate/securitycontextconstraints.yaml
@@ -1,5 +1,4 @@
-{{- include "dynatrace-operator.platformRequired" . }}
-{{- if and (eq .Values.platform "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.partial" .) "false")}}
+{{- if and (eq (include "dynatrace-operator.platform" .) "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.partial" .) "false")}}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Openshift/csi/securitycontextconstraints-csidriver.yaml
+++ b/config/helm/chart/default/templates/Openshift/csi/securitycontextconstraints-csidriver.yaml
@@ -1,5 +1,4 @@
-{{- include "dynatrace-operator.platformRequired" . }}
-{{- if and (eq .Values.platform "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.needCSI" .) "true") }}
+{{- if and (eq (include "dynatrace-operator.platform" .) "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.needCSI" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Openshift/oneagent/securitycontextconstraints-privileged.yaml
+++ b/config/helm/chart/default/templates/Openshift/oneagent/securitycontextconstraints-privileged.yaml
@@ -1,5 +1,4 @@
-{{- include "dynatrace-operator.platformRequired" . }}
-{{- if and (eq .Values.platform "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.partial" .) "false")}}
+{{- if and (eq (include "dynatrace-operator.platform" .) "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.partial" .) "false")}}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Openshift/oneagent/securitycontextconstraints-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Openshift/oneagent/securitycontextconstraints-unprivileged.yaml
@@ -1,5 +1,4 @@
-{{- include "dynatrace-operator.platformRequired" . }}
-{{- if and (eq .Values.platform "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.partial" .) "false")}}
+{{- if and (eq (include "dynatrace-operator.platform" .) "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.partial" .) "false")}}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Openshift/operator/securitycontextconstraints.yaml
+++ b/config/helm/chart/default/templates/Openshift/operator/securitycontextconstraints.yaml
@@ -1,5 +1,4 @@
-{{- include "dynatrace-operator.platformRequired" . }}
-{{- if and (eq .Values.platform "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.partial" .) "false")}}
+{{- if and (eq (include "dynatrace-operator.platform" .) "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.partial" .) "false")}}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Openshift/webhook/securitycontextconstraints.yaml
+++ b/config/helm/chart/default/templates/Openshift/webhook/securitycontextconstraints.yaml
@@ -1,5 +1,4 @@
-{{- include "dynatrace-operator.platformRequired" . }}
-{{- if and (eq .Values.platform "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.partial" .) "false")}}
+{{- if and (eq (include "dynatrace-operator.platform" .) "openshift") ((.Values.securityContextConstraints).enabled) (eq (include "dynatrace-operator.partial" .) "false")}}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -27,7 +27,7 @@ Check if default image is used
 {{- if .Values.image -}}
 	{{- printf "%s" .Values.image -}}
 {{- else -}}
-	{{- if eq .Values.platform "google-marketplace" -}}
+	{{- if eq (include "dynatrace-operator.platform" .) "google-marketplace" -}}
     	{{- printf "%s:%s" "gcr.io/dynatrace-marketplace-prod/dynatrace-operator" .Chart.AppVersion }}
 	{{- else -}}
 		{{- printf "%s:v%s" "docker.io/dynatrace/dynatrace-operator" .Chart.AppVersion }}
@@ -44,30 +44,4 @@ Check if we are generating only a part of the yamls
 	{{- else -}}
 	    {{- printf "false" -}}
 	{{- end -}}
-{{- end -}}
-
-
-{{/*
-Check if platform is set
-*/}}
-{{- define "dynatrace-operator.platformSet" -}}
-{{- if or (eq .Values.platform "kubernetes") (eq .Values.platform "openshift") (eq .Values.platform "google-marketplace") (eq .Values.platform "gke-autopilot") -}}
-    {{ default "set" }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Exclude Kubernetes manifest not running on OLM
-*/}}
-{{- define "dynatrace-operator.openshiftOrOlm" -}}
-{{- if and (or (eq .Values.platform "openshift") (.Values.olm)) (eq (include "dynatrace-operator.partial" .) "false") -}}
-    {{ default "true" }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Check if the platform is set
-*/}}
-{{- define "dynatrace-operator.platformRequired" -}}
-{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift, google-marketplace, or gke-autopilot" (include "dynatrace-operator.platformSet" .))}}
 {{- end -}}

--- a/config/helm/chart/default/templates/_platform.tpl
+++ b/config/helm/chart/default/templates/_platform.tpl
@@ -1,0 +1,37 @@
+// Copyright 2020 Dynatrace LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{{/*
+Auto-detect the platform (if not set), according to the available APIVersions
+*/}}
+{{- define "dynatrace-operator.platform" -}}
+    {{- if .Values.platform}}
+        {{- printf .Values.platform -}}
+    {{- else if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+        {{- printf "openshift" -}}
+    {{- else if .Capabilities.APIVersions.Has "auto.gke.io/v1" }}
+        {{- printf "gke-autopilot" -}}
+    {{- else }}
+        {{- printf "kubernetes" -}}
+    {{- end -}}
+{{- end }}
+
+{{/*
+Exclude Kubernetes manifest not running on OLM
+*/}}
+{{- define "dynatrace-operator.openshiftOrOlm" -}}
+{{- if and (or (eq (include "dynatrace-operator.platform" .) "openshift") (.Values.olm)) (eq (include "dynatrace-operator.partial" .) "false") -}}
+    {{ default "true" }}
+{{- end -}}
+{{- end -}}

--- a/config/helm/chart/default/templates/application.yaml
+++ b/config/helm/chart/default/templates/application.yaml
@@ -1,5 +1,4 @@
-{{- include "dynatrace-operator.platformRequired" . }}
-{{- if eq .Values.platform "google-marketplace" }}
+{{- if eq (include "dynatrace-operator.platform" .) "google-marketplace" }}
 # Copyright 2020 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent-unprivileged_test.yaml
+++ b/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent-unprivileged_test.yaml
@@ -26,9 +26,5 @@ tests:
       - equal:
           path: metadata.name
           value: dynatrace-dynakube-oneagent-unprivileged
-      - equal:
-          path: imagePullSecrets
-          value:
-            - name: redhat-connect
-            - name: redhat-connect-sso
+
 

--- a/config/helm/chart/default/tests/Common/operator/serviceaccount-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/serviceaccount-operator_test.yaml
@@ -31,8 +31,4 @@ tests:
           value: NAMESPACE
       - isNotEmpty:
           path: metadata.labels
-      - equal:
-          path: imagePullSecrets
-          value:
-            - name: redhat-connect
-            - name: redhat-connect-sso
+

--- a/config/helm/chart/default/tests/Common/webhook/serviceaccount-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/serviceaccount-webhook_test.yaml
@@ -27,8 +27,4 @@ tests:
       - equal:
           path: metadata.namespace
           value: NAMESPACE
-      - equal:
-          path: imagePullSecrets
-          value:
-            - name: redhat-connect
-            - name: redhat-connect-sso
+

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # may be set to "kubernetes", "openshift", or "gke-autopilot"
-platform: "kubernetes"
+platform: ""
 
 image: ""
 customPullSecret: ""

--- a/hack/helm/generate-crd.sh
+++ b/hack/helm/generate-crd.sh
@@ -18,8 +18,7 @@ sed "s/namespace: dynatrace/namespace: {{.Release.Namespace}}/" "${SOURCE_CRD_FI
 mv "${SOURCE_CRD_DIR}/tmp_crd" "${SOURCE_CRD_FILE}"
 
 # Define the header for the helm yaml file
-HELM_HEADER="{{- include \"dynatrace-operator.platformRequired\" . }}
-{{ if and .Values.installCRD (or (eq (include \"dynatrace-operator.partial\" .) \"false\") (eq (include \"dynatrace-operator.partial\" .) \"crd\")) }}"
+HELM_HEADER="{{ if and .Values.installCRD (or (eq (include \"dynatrace-operator.partial\" .) \"false\") (eq (include \"dynatrace-operator.partial\" .) \"crd\")) }}"
 
 # Get the previously patched crd content
 CRD_CONTENT="$(cat "${SOURCE_CRD_FILE}")"


### PR DESCRIPTION
# Description

Using the available API versions on the target cluster we can determine the platform so the user don't have to set it manually.

The "mapping" is the following:
- `security.openshift.io/v1` ==> `openshift`
- `auto.gke.io/v1` ==> `gke-autopilot` 
- ~`app.k8s.io/v1beta1` ==> `google-marketplace`~ (not necessary, and actually can be dangerous)
- fallback ==> `kubernetes`

The `.Values.platform` is still available to override if something goes wrong.
Furthermore, this "auto-detect" feature does not work for `helm template`, which we use for development. 
(this is perfectly fine, and makes all the sense)

## How can this be tested?
Run `helm install dynatrace-operator config/helm/chart/default ...` on all the platforms to see if everything is applied correctly. (make sure to set an image that actually exists)


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

