### PR TITLE
Remove `previous log not found` warning in support archive logs

### DIFF
--- a/src/cmd/support_archive/logs.go
+++ b/src/cmd/support_archive/logs.go
@@ -3,12 +3,12 @@ package support_archive
 import (
 	"context"
 	"fmt"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgocorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )

--- a/src/cmd/support_archive/logs.go
+++ b/src/cmd/support_archive/logs.go
@@ -96,7 +96,7 @@ func (collector logCollector) collectContainerLogs(pod *corev1.Pod, container co
 	podLogs, err := req.Stream(collector.context)
 
 	if logOptions.Previous && err != nil {
-		if k8serrors.IsBadRequest(err){ // Prevent logging of "previous terminated container not found" error
+		if k8serrors.IsBadRequest(err) { // Prevent logging of "previous terminated container not found" error
 			return
 		}
 


### PR DESCRIPTION
# Description

Currently, collection of the support archive often produces warnings like this:

`previous terminated container "server" in pod "dynatrace-oneagent-csi-driver-78m44" not found`

These warnings are perfectly normal as often "previous" logs do not exist when the containers in pods didn't crash and restart. Nevertheless, this can be alarming to the unknowing user and we should therefore remove this warning.

## How can this be tested?
1. Deploy the operator
2. Run support archive `kubectl exec -n dynatrace deployment/dynatrace-operator -- /usr/local/bin/dynatrace-operator support-archive`
3. Check if the logs have a note about previous container logs not found (they should not have one)


## Checklist
- [] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)



