### PR TITLE
POC: Replaces the httpClient with retryHttpClient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/containers/image/v5 v5.24.2
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/go-logr/logr v1.2.3
+	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/klauspost/compress v1.15.15
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/opencontainers/go-digest v1.0.0
@@ -81,6 +82,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -555,10 +555,15 @@ github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FK
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/src/dtclient/activegate_auth_token.go
+++ b/src/dtclient/activegate_auth_token.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 )
 
@@ -50,7 +51,7 @@ func (dtc *dynatraceClient) GetActiveGateAuthToken(dynakubeName string) (*Active
 	return authTokenInfo, nil
 }
 
-func (dtc *dynatraceClient) createAuthTokenRequest(dynakubeName string) (*http.Request, error) {
+func (dtc *dynatraceClient) createAuthTokenRequest(dynakubeName string) (*retryablehttp.Request, error) {
 	body := &ActiveGateAuthTokenParams{
 		Name:           dynakubeName,
 		SeedToken:      false,

--- a/src/dtclient/agent_version_test.go
+++ b/src/dtclient/agent_version_test.go
@@ -56,12 +56,8 @@ func TestGetEntityIDForIP(t *testing.T) {
 	dynatraceServer, _ := createTestDynatraceServer(t, &ipHandler{}, "")
 	defer dynatraceServer.Close()
 
-	dtc := dynatraceClient{
-		apiToken:   apiToken,
-		paasToken:  paasToken,
-		httpClient: dynatraceServer.Client(),
-		url:        dynatraceServer.URL,
-	}
+	dtc := createTestDynatraceClient(*dynatraceServer)
+
 	require.NoError(t, dtc.setHostCacheFromResponse([]byte(
 		fmt.Sprintf(`[
 	{
@@ -146,12 +142,7 @@ func TestGetLatestAgent(t *testing.T) {
 	dynatraceServer, _ := createTestDynatraceServer(t, &ipHandler{fs}, "")
 	defer dynatraceServer.Close()
 
-	dtc := dynatraceClient{
-		apiToken:   apiToken,
-		paasToken:  paasToken,
-		httpClient: dynatraceServer.Client(),
-		url:        dynatraceServer.URL,
-	}
+	dtc := createTestDynatraceClient(*dynatraceServer)
 
 	t.Run(`file download successful`, func(t *testing.T) {
 		file, err := afero.TempFile(fs, "client", "installer")

--- a/src/dtclient/communication_hosts_test.go
+++ b/src/dtclient/communication_hosts_test.go
@@ -39,35 +39,29 @@ func TestReadCommunicationHosts(t *testing.T) {
 		return dc.readResponseForOneAgentConnectionInfo(response)
 	}
 
-	{
-		m, err := readFromString(goodCommunicationEndpointsResponse)
-		if assert.NoError(t, err) {
-			expected := []CommunicationHost{
-				{Protocol: "https", Host: "example.live.dynatrace.com", Port: 443},
-				{Protocol: "https", Host: "managedhost.com", Port: 9999},
-				{Protocol: "https", Host: "10.0.0.1", Port: 8000},
-				{Protocol: "http", Host: "insecurehost", Port: 80},
-			}
-			assert.Equal(t, expected, m.CommunicationHosts)
+	m, err := readFromString(goodCommunicationEndpointsResponse)
+	if assert.NoError(t, err) {
+		expected := []CommunicationHost{
+			{Protocol: "https", Host: "example.live.dynatrace.com", Port: 443},
+			{Protocol: "https", Host: "managedhost.com", Port: 9999},
+			{Protocol: "https", Host: "10.0.0.1", Port: 8000},
+			{Protocol: "http", Host: "insecurehost", Port: 80},
 		}
+		assert.Equal(t, expected, m.CommunicationHosts)
 	}
-	{
-		m, err := readFromString(mixedCommunicationEndpointsResponse)
-		if assert.NoError(t, err) {
-			expected := []CommunicationHost{
-				{Protocol: "https", Host: "example.live.dynatrace.com", Port: 443},
-			}
-			assert.Equal(t, expected, m.CommunicationHosts)
+	m, err = readFromString(mixedCommunicationEndpointsResponse)
+	if assert.NoError(t, err) {
+		expected := []CommunicationHost{
+			{Protocol: "https", Host: "example.live.dynatrace.com", Port: 443},
 		}
+		assert.Equal(t, expected, m.CommunicationHosts)
 	}
-	{
-		_, err := readFromString("")
-		assert.Error(t, err, "empty response")
-	}
-	{
-		_, err := readFromString(`{"communicationEndpoints": ["shouldnotbeparsed"]}`)
-		assert.Error(t, err, "no hosts available")
-	}
+
+	_, err = readFromString("")
+	assert.Error(t, err, "empty response")
+
+	_, err = readFromString(`{"communicationEndpoints": ["shouldnotbeparsed"]}`)
+	assert.Error(t, err, "no hosts available")
 }
 
 func TestParseEndpoints(t *testing.T) {

--- a/src/dtclient/image.go
+++ b/src/dtclient/image.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 )
 
@@ -89,7 +90,7 @@ func (dtc *dynatraceClient) handleLatestImageResponse(response *http.Response) (
 	return latestImageInfo, err
 }
 
-func (dtc *dynatraceClient) createLatestImageRequest(url string) (*http.Request, error) {
+func (dtc *dynatraceClient) createLatestImageRequest(url string) (*retryablehttp.Request, error) {
 	body := &LatestImageInfo{}
 
 	bodyData, err := json.Marshal(body)

--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 )
 
@@ -152,8 +153,8 @@ func (dtc *dynatraceClient) GetProcessModuleConfig(prevRevision uint) (*ProcessM
 	return dtc.readResponseForProcessModuleConfig(responseData)
 }
 
-func (dtc *dynatraceClient) createProcessModuleConfigRequest(prevRevision uint) (*http.Request, error) {
-	req, err := http.NewRequest(http.MethodGet, dtc.getProcessModuleConfigUrl(), nil)
+func (dtc *dynatraceClient) createProcessModuleConfigRequest(prevRevision uint) (*retryablehttp.Request, error) {
+	req, err := retryablehttp.NewRequest(http.MethodGet, dtc.getProcessModuleConfigUrl(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing http request: %w", err)
 	}

--- a/src/dtclient/send_event.go
+++ b/src/dtclient/send_event.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 )
 
@@ -41,9 +42,9 @@ func (dtc *dynatraceClient) SendEvent(eventData *EventData) error {
 		return errors.WithStack(err)
 	}
 
-	req, err := http.NewRequest("POST", dtc.getEventsUrl(), bytes.NewBuffer(jsonStr))
+	req, err := retryablehttp.NewRequest(http.MethodPost, dtc.getEventsUrl(), bytes.NewBuffer(jsonStr))
 	if err != nil {
-		return fmt.Errorf("error initializing http request: %w", err)
+		return errors.Wrap(err, "error initializing http request")
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Api-Token %s", dtc.apiToken))

--- a/src/dtclient/token.go
+++ b/src/dtclient/token.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 )
 
@@ -33,7 +34,7 @@ func (dtc *dynatraceClient) GetTokenScopes(token string) (TokenScopes, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	req, err := http.NewRequest("POST", dtc.getTokensLookupUrl(), bytes.NewBuffer(jsonStr))
+	req, err := retryablehttp.NewRequest(http.MethodPost, dtc.getTokensLookupUrl(), bytes.NewBuffer(jsonStr))
 	if err != nil {
 		return nil, fmt.Errorf("error initializing http request: %w", err)
 	}


### PR DESCRIPTION
# Description
A very rough POC on how we could replace the `httpClient` in the dtclient, to a `retryableHttpClient` that will retry the requests given how we configure it.
We can configure basically everything:
```
retryClient := retryablehttp.NewClient()

retryClient.Backoff = retryablehttp.LinearJitterBackoff 		// Logic for the backoff, could be custom
retryClient.CheckRetry = retryablehttp.DefaultRetryPolicy 	// Logic for the retry, could be custom
retryClient.ErrorHandler = ... 													// Logic for special error handling, nil by default
retryClient.RetryMax = 4 														// defaults to 4
retryClient.RetryWaitMax = 30 												// defaults to 30 sec
retryClient.RetryWaitMin = 1 													// defaults to 1 sec 
```

The problem is that the dtclient's codebase is a bit old so integrating this nicely might require a bit of a refactor. (especially in the unit testing)

Sidenote:
```
httpClient: retryClient.StandardClient()
```
We can convert the special client into a normal `httpClient`, but the problem is that how the convert works is that it creates a special `Transport` for the `httpClient`. And this special `Transport` does not have the configurations that we already use. (example `TLSClientConfig`)

## How can this be tested?
In normal conditions nothing should be noticeable (didn't mess with the logger, so there might be spam 😬 )
Dunno how can you actually create conditions where this retry logic applicable/noticeable. 😓 (other then some elaborate mock in the unittests)

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

