### PR TITLE
Run troubleshoot command and collect output into support archive.

### DIFF
--- a/src/cmd/support_archive/operator_version_test.go
+++ b/src/cmd/support_archive/operator_version_test.go
@@ -27,16 +27,15 @@ func TestVersionCollector(t *testing.T) {
 	assert.Equal(t, operatorVersionCollectorName, versionCollector.Name())
 
 	require.NoError(t, versionCollector.Do())
-	tarReader := tar.NewReader(&tarBuffer)
 
 	assert.Contains(t, logBuffer.String(), "Storing operator version")
 
+	tarReader := tar.NewReader(&tarBuffer)
 	hdr, err := tarReader.Next()
 	require.NoError(t, err)
 	assert.Equal(t, "operator-version.txt", hdr.Name)
 
 	versionFile := make([]byte, hdr.Size)
-
 	bytesRead, err := tarReader.Read(versionFile)
 	if !errors.Is(err, io.EOF) {
 		require.NoError(t, err)

--- a/src/cmd/support_archive/troubleshoot.go
+++ b/src/cmd/support_archive/troubleshoot.go
@@ -1,0 +1,52 @@
+package support_archive
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/src/cmd/troubleshoot"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const troubleshootCollectorName = "troubleshoot"
+const TroublshootOutputFileName = "troubleshoot.txt"
+
+type troubleshootCollector struct {
+	collectorCommon
+
+	context    context.Context
+	apiReader  client.Reader
+	kubeConfig rest.Config
+	namespace  string
+}
+
+func newTroubleshootCollector(context context.Context, log logr.Logger, supportArchive tarball, namespace string, apiReader client.Reader, kubeConfig rest.Config) collector { //nolint:revive // argument-limit doesn't apply to constructors
+	return troubleshootCollector{
+		collectorCommon: collectorCommon{
+			log:            log,
+			supportArchive: supportArchive,
+		},
+		context:    context,
+		apiReader:  apiReader,
+		kubeConfig: kubeConfig,
+		namespace:  namespace,
+	}
+}
+
+func (t troubleshootCollector) Name() string {
+	return troubleshootCollectorName
+}
+
+func (t troubleshootCollector) Do() error {
+	logInfof(t.log, "Running troubleshoot command and storing output into %s", TroublshootOutputFileName)
+
+	troubleshootCmdOutput := bytes.Buffer{}
+	log := troubleshoot.NewTroubleshootLoggerToWriter(&troubleshootCmdOutput)
+
+	troubleshoot.RunTroubleshootCmd(context.Background(), log, t.apiReader, t.namespace, t.kubeConfig)
+
+	t.supportArchive.addFile(TroublshootOutputFileName, &troubleshootCmdOutput)
+	return nil
+}

--- a/src/cmd/support_archive/troubleshoot_test.go
+++ b/src/cmd/support_archive/troubleshoot_test.go
@@ -1,0 +1,67 @@
+package support_archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+func TestTroubleshootCollector(t *testing.T) {
+	logBuffer := bytes.Buffer{}
+	log := newSupportArchiveLogger(&logBuffer)
+
+	clt := fake.NewClientWithIndex(
+		&appsv1.Deployment{
+			TypeMeta:   typeMeta("Deployment"),
+			ObjectMeta: objectMeta("deployment1"),
+		},
+		&corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "core/v1",
+				Kind:       "Namespace",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "random",
+			},
+		},
+		&dynatracev1beta1.DynaKube{
+			TypeMeta:   typeMeta("DynaKube"),
+			ObjectMeta: objectMeta("dynakube1"),
+		},
+	)
+
+	tarBuffer := bytes.Buffer{}
+	supportArchive := tarball{
+		tarWriter: tar.NewWriter(&tarBuffer),
+	}
+
+	ctx := context.TODO()
+	require.NoError(t, newTroubleshootCollector(ctx, log, supportArchive, testOperatorNamespace, clt, rest.Config{}).Do())
+
+	tarReader := tar.NewReader(&tarBuffer)
+
+	hdr, err := tarReader.Next()
+	require.NoError(t, err)
+	assert.Equal(t, TroublshootOutputFileName, hdr.Name)
+
+	troubleshootFile := make([]byte, hdr.Size)
+	bytesRead, err := tarReader.Read(troubleshootFile)
+	if !errors.Is(err, io.EOF) {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, hdr.Size, int64(bytesRead))
+	_, err = tarReader.Next()
+	require.ErrorIs(t, err, io.EOF)
+}


### PR DESCRIPTION
# Description

The troubleshoot command is now automatically executed when a support archive is created. The output is added to `troubleshoot.txt` in the root of the support archive.

## How can this be tested?
Build and deploy the operator, run the `support-archive` subcommand and check the result for the newly added `troubleshoot.txt` file. It should contain a typical troubleshoot output. As a cross check you could run the `troubleshoot` command and compare results.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

