### PR TITLE
Moves go build tags to a common location

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -36,6 +36,7 @@ runs:
         builder: ${{ steps.buildx.outputs.name }}
         build-args: |
           GO_LINKER_ARGS=${{ steps.prep.outputs.go_linker_args }}
+          GO_BUILD_TAGS=${{ steps.prep.outputs.go_build_tags }}
         context: .
         file: ./Dockerfile
         platforms: linux/${{ inputs.platform }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ RUN go mod download && go mod verify
 # build operator binary
 FROM go-mod AS operator-build
 ARG GO_LINKER_ARGS
+ARG GO_BUILD_TAGS
 COPY src ./src
 RUN CGO_ENABLED=1 CGO_CFLAGS="-O2 -Wno-return-local-addr" \
-    go build -tags "containers_image_openpgp,osusergo,netgo,sqlite_omit_load_extension,containers_image_storage_stub,containers_image_docker_daemon_stub" -trimpath -ldflags="${GO_LINKER_ARGS}" \
+    go build -tags "${GO_BUILD_TAGS}" -trimpath -ldflags="${GO_LINKER_ARGS}" \
     -o ./build/_output/bin/dynatrace-operator ./src/cmd/
 
 # download additional image dependencies

--- a/hack/build/build_image.sh
+++ b/hack/build/build_image.sh
@@ -13,6 +13,7 @@ tag=${2}
 
 commit=$(git rev-parse HEAD)
 go_linker_args=$(hack/build/create_go_linker_args.sh "${tag}" "${commit}")
+go_build_tags=$(hack/build/create_go_build_tags.sh false)
 
 out_image="${image}:${tag}"
 
@@ -20,5 +21,6 @@ out_image="${image}:${tag}"
 mkdir -p third_party_licenses
 docker build . -f ./Dockerfile -t "${out_image}" \
   --build-arg "GO_LINKER_ARGS=${go_linker_args}" \
+  --build-arg "GO_BUILD_TAGS=${go_build_tags}" \
   --label "quay.expires-after=14d"
 rm -rf third_party_licenses

--- a/hack/build/ci/prepare-build-variables.sh
+++ b/hack/build/ci/prepare-build-variables.sh
@@ -24,6 +24,7 @@ createDockerImageLabels() {
 
 printBuildRelatedVariables() {
   echo "go_linker_args=${go_linker_args}"
+  echo "go_build_tags=${go_build_tags}"
   echo "docker_image_labels=${docker_image_labels}"
   echo "docker_image_tag=${docker_image_tag}"
 }
@@ -32,5 +33,6 @@ printBuildRelatedVariables() {
 docker_image_tag=$(createDockerImageTag)
 docker_image_labels=$(createDockerImageLabels)
 go_linker_args=$(hack/build/create_go_linker_args.sh "${docker_image_tag}" "${GITHUB_SHA}")
+go_build_tags=$(hack/build/create_go_build_tags.sh false)
 printBuildRelatedVariables >> "$GITHUB_OUTPUT"
 

--- a/hack/build/create_go_build_tags.sh
+++ b/hack/build/create_go_build_tags.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <needs-e2e-tag>"
+    exit 1
+fi
+
+needs_e2e_tag=$1
+
+go_build_tags=(
+    "containers_image_openpgp"
+    "osusergo"
+    "netgo"
+    "sqlite_omit_load_extension"
+    "containers_image_storage_stub"
+    "containers_image_docker_daemon_stub"
+)
+
+if "${needs_e2e_tag}"; then
+    go_build_tags+=("e2e")
+fi
+
+printf "%s," "${go_build_tags[@]}"

--- a/hack/build/create_go_build_tags.sh
+++ b/hack/build/create_go_build_tags.sh
@@ -8,15 +8,26 @@ fi
 needs_e2e_tag=$1
 
 go_build_tags=(
+    # Needed for the image library(https://github.com/containers/image), to use the open go implementation of gpgme. creating new signatures is not possible but we never do that
     "containers_image_openpgp"
+
+     # If CGO is enabled, certain standard libraries will also use CGO, these explicitly disallow that
     "osusergo"
     "netgo"
+
+    # Disables the ability to add load extensions for sqlite3, needed to statically build when using the sqlite library. We never use extensions so its good to disable it.
     "sqlite_omit_load_extension"
+
+    # Removes the containers-storage/docker-daemon parts of the image library(https://github.com/containers/image) as we are not using it.
+    # More info about the disabled parts:
+    # - https://github.com/containers/image/blob/main/docs/containers-transports.5.md#containers-storagestorage-specifierimage-iddocker-referenceimage-id
+    # - https://github.com/containers/image/blob/main/docs/containers-transports.5.md#docker-daemondocker-referencealgodigest
     "containers_image_storage_stub"
     "containers_image_docker_daemon_stub"
 )
 
 if "${needs_e2e_tag}"; then
+    # Used for enabling e2e testing code
     go_build_tags+=("e2e")
 fi
 

--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -23,12 +23,12 @@ go/vet:
 
 ## Runs golangci-lint
 go/golangci:
-	golangci-lint run --build-tags "containers_image_openpgp,osusergo,netgo,sqlite_omit_load_extension,containers_image_storage_stub,containers_image_docker_daemon_stub,e2e" --timeout 300s
+	golangci-lint run --build-tags "$(shell ./hack/build/create_go_build_tags.sh true)" --timeout 300s
 
 ## Runs all the linting tools
 go/lint: go/format go/vet go/golangci
 
 ## Runs all go unit tests and writes the coverprofile to cover.out
 go/test:
-	go test ./... -coverprofile cover.out -tags "containers_image_openpgp,osusergo,netgo,sqlite_omit_load_extension,containers_image_storage_stub,containers_image_docker_daemon_stub"
+	go test ./... -coverprofile cover.out -tags "$(shell ./hack/build/create_go_build_tags.sh false)"
 

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -4,37 +4,37 @@ test/e2e:
 
 ## Runs ActiveGate e2e test only
 test/e2e/activegate: manifests/crd/helm
-	go test -v -tags e2e -timeout 20m -count=1 ./test/scenarios/activegate/basic
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/activegate/basic
 
 ## Runs ActiveGate proxy e2e test only
 test/e2e/activegate/proxy: manifests/crd/helm
-	go test -v -tags e2e -timeout 20m -count=1 ./test/scenarios/activegate/proxy
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/activegate/proxy
 
 ## Runs CloudNative e2e test only
 test/e2e/cloudnative: manifests/crd/helm
-	go test -v -tags e2e -timeout 30m -count=1 ./test/scenarios/cloudnative/basic
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 30m -count=1 ./test/scenarios/cloudnative/basic
 
 ## Runs ClassicFullStack e2e test only
 ## TODO: rename after proper implementation of cleanup step
 test/e2e/zz_classic: manifests/crd/helm
-	go test -v -tags e2e -timeout 20m -count=1 ./test/scenarios/classic
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/classic
 
 ## Runs CloudNative istio e2e test only
 test/e2e/cloudnative/istio: manifests/crd/helm
-	go test -v -tags e2e -timeout 20m -count=1 ./test/scenarios/cloudnative/istio
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/cloudnative/istio
 
 ## Runs CloudNative proxy e2e test only
 test/e2e/cloudnative/proxy: manifests/crd/helm
-	go test -v -tags e2e -count=1 ./test/scenarios/cloudnative/proxy
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/cloudnative/proxy
 
 ## Runs CloudNative network problem e2e test only
 test/e2e/cloudnative/network: manifests/crd/helm
-	go test -v -tags e2e -timeout 20m -count=1 ./test/scenarios/cloudnative/network
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/cloudnative/network
 
 ## Runs Application Monitoring e2e test only
 test/e2e/applicationmonitoring: manifests/crd/helm
-	go test -v -tags e2e -count=1 ./test/scenarios/applicationmonitoring
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/applicationmonitoring
 
 ## Runs SupportArchive e2e test only
 test/e2e/supportarchive: manifests/crd/helm
-	go test -v -tags e2e -count=1 ./test/scenarios/support_archive
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/support_archive


### PR DESCRIPTION
# Description

 We had inconsistent use of our go build tags, so this moves it into a shell script that is used all over the codebase to get the correct build tags.

## How can this be tested?
you can run `./hack/build/create_go_build_tags.sh true` to check the tags (the `true` arg is for if we need the e2e tag or not)

## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

