### PR TITLE
Fix support archive E2E test.

### DIFF
--- a/test/scenarios/support_archive/install.go
+++ b/test/scenarios/support_archive/install.go
@@ -121,6 +121,7 @@ func collectRequiredFiles(t *testing.T, ctx context.Context, resources *resource
 	namespace := testDynakube.Namespace
 	requiredFiles := make([]string, 0)
 	requiredFiles = append(requiredFiles, support_archive.OperatorVersionFileName)
+	requiredFiles = append(requiredFiles, support_archive.TroublshootOutputFileName)
 	requiredFiles = append(requiredFiles, support_archive.SupportArchiveOutputFileName)
 	requiredFiles = append(requiredFiles, getRequiredPodFiles(t, ctx, resources, namespace)...)
 	requiredFiles = append(requiredFiles, getRequiredReplicaSetFiles(t, ctx, resources, namespace)...)


### PR DESCRIPTION
# Description
E2E test failed because it was surprised by the new `troubleshoot.txt` file.

## How can this be tested?
Run support archive E2E test.


## Checklist
- [n/a] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

