### PR TITLE
Adds feature flag to configure failure policy per dynakube

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -70,6 +70,7 @@ const (
 	AnnotationFeatureOneAgentInitialConnectRetry    = AnnotationFeaturePrefix + "oneagent-initial-connect-retry-ms"
 	AnnotationFeatureRunOneAgentContainerPrivileged = AnnotationFeaturePrefix + "oneagent-privileged"
 	AnnotationFeatureOneAgentSecCompProfile         = AnnotationFeaturePrefix + "oneagent-seccomp-profile"
+	AnnotationInjectionFailurePolicy                = AnnotationFeaturePrefix + "injection-failure-policy"
 
 	// injection (webhook)
 
@@ -89,8 +90,10 @@ const (
 	// CSI
 	AnnotationFeatureMaxFailedCsiMountAttempts = AnnotationFeaturePrefix + "max-csi-mount-attempts"
 
-	falsePhrase = "false"
-	truePhrase  = "true"
+	falsePhrase  = "false"
+	truePhrase   = "true"
+	silentPhrase = "silent"
+	failPhrase   = "fail"
 
 	// synthetic node type
 	AnnotationFeatureSyntheticNodeType = AnnotationFeaturePrefix + "synthetic-node-type"
@@ -314,4 +317,11 @@ func (dk *DynaKube) FeatureSyntheticNodeType() string {
 		return SyntheticNodeS
 	}
 	return node
+}
+
+func (dk *DynaKube) FeatureInjectionFailurePolicy() string {
+	if dk.getFeatureFlagRaw(AnnotationInjectionFailurePolicy) == failPhrase {
+		return failPhrase
+	}
+	return silentPhrase
 }

--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -18,7 +18,7 @@ func createInstallInitContainerBase(webhookImage, clusterID string, pod *corev1.
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Args:            []string{"init"},
 		Env: []corev1.EnvVar{
-			{Name: config.InjectionFailurePolicyEnv, Value: kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFailurePolicy, "silent")},
+			{Name: config.InjectionFailurePolicyEnv, Value: dynakube.FeatureInjectionFailurePolicy()},
 			{Name: config.K8sPodNameEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("metadata.name")},
 			{Name: config.K8sPodUIDEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("metadata.uid")},
 			{Name: config.K8sBasePodNameEnv, Value: getBasePodName(pod)},

--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -12,19 +12,13 @@ import (
 )
 
 func createInstallInitContainerBase(webhookImage, clusterID string, pod *corev1.Pod, dynakube dynatracev1beta1.DynaKube) *corev1.Container {
-	injectionFailurePolicy := kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFailurePolicy, "silent")
-
-	if dynakube.FeatureInjectionFailurePolicy() == "fail" {
-		injectionFailurePolicy = dynakube.FeatureInjectionFailurePolicy()
-	}
-
 	return &corev1.Container{
 		Name:            dtwebhook.InstallContainerName,
 		Image:           webhookImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Args:            []string{"init"},
 		Env: []corev1.EnvVar{
-			{Name: config.InjectionFailurePolicyEnv, Value: injectionFailurePolicy},
+			{Name: config.InjectionFailurePolicyEnv, Value: kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFailurePolicy, dynakube.FeatureInjectionFailurePolicy())},
 			{Name: config.K8sPodNameEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("metadata.name")},
 			{Name: config.K8sPodUIDEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("metadata.uid")},
 			{Name: config.K8sBasePodNameEnv, Value: getBasePodName(pod)},

--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -12,13 +12,19 @@ import (
 )
 
 func createInstallInitContainerBase(webhookImage, clusterID string, pod *corev1.Pod, dynakube dynatracev1beta1.DynaKube) *corev1.Container {
+	injectionFailurePolicy := kubeobjects.GetField(pod.Annotations, dtwebhook.AnnotationFailurePolicy, "silent")
+
+	if dynakube.FeatureInjectionFailurePolicy() == "fail" {
+		injectionFailurePolicy = dynakube.FeatureInjectionFailurePolicy()
+	}
+
 	return &corev1.Container{
 		Name:            dtwebhook.InstallContainerName,
 		Image:           webhookImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Args:            []string{"init"},
 		Env: []corev1.EnvVar{
-			{Name: config.InjectionFailurePolicyEnv, Value: dynakube.FeatureInjectionFailurePolicy()},
+			{Name: config.InjectionFailurePolicyEnv, Value: injectionFailurePolicy},
 			{Name: config.K8sPodNameEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("metadata.name")},
 			{Name: config.K8sPodUIDEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("metadata.uid")},
 			{Name: config.K8sBasePodNameEnv, Value: getBasePodName(pod)},

--- a/src/webhook/mutation/pod_mutator/init_container_test.go
+++ b/src/webhook/mutation/pod_mutator/init_container_test.go
@@ -1,6 +1,8 @@
 package pod_mutator
 
 import (
+	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
@@ -125,5 +127,41 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 
 		require.NotNil(t, *initContainer.SecurityContext.RunAsGroup)
 		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, rootUserGroup)
+	})
+	t.Run("should handle failure policy feature flag correctly", func(t *testing.T) {
+		dynakube := getTestDynakube()
+		dynakube.Annotations = map[string]string{v1beta1.AnnotationInjectionFailurePolicy: "fail"}
+		pod := getTestPod()
+		webhookImage := "test-image"
+		clusterID := "id"
+
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+
+		assert.True(t, kubeobjects.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "fail")
+		assert.False(t, kubeobjects.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "silent")
+	})
+	t.Run("should set default failure policy to silent", func(t *testing.T) {
+		dynakube := getTestDynakube()
+		dynakube.Annotations = map[string]string{v1beta1.AnnotationInjectionFailurePolicy: "test"}
+		pod := getTestPod()
+		webhookImage := "test-image"
+		clusterID := "id"
+
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+
+		assert.False(t, kubeobjects.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "fail")
+		assert.True(t, kubeobjects.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "silent")
+	})
+	t.Run("should take silent as failure policy if set explicitly", func(t *testing.T) {
+		dynakube := getTestDynakube()
+		dynakube.Annotations = map[string]string{v1beta1.AnnotationInjectionFailurePolicy: "silent"}
+		pod := getTestPod()
+		webhookImage := "test-image"
+		clusterID := "id"
+
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+
+		assert.False(t, kubeobjects.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "fail")
+		assert.True(t, kubeobjects.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "silent")
 	})
 }

--- a/src/webhook/mutation/pod_mutator/init_container_test.go
+++ b/src/webhook/mutation/pod_mutator/init_container_test.go
@@ -1,12 +1,12 @@
 package pod_mutator
 
 import (
-	dtwebhook "github.com/Dynatrace/dynatrace-operator/src/webhook"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
+	dtwebhook "github.com/Dynatrace/dynatrace-operator/src/webhook"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"

--- a/src/webhook/mutation/pod_mutator/init_container_test.go
+++ b/src/webhook/mutation/pod_mutator/init_container_test.go
@@ -1,10 +1,10 @@
 package pod_mutator
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
-	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
# Description

Currently the failure policy environment variable is set via pod annotations. With this the logic should be changed to an approach where the environment variable can be set via a feature flag in the dynakube.

## How can this be tested?
Deploy the operator and inject into sample apps and check their respective environment variables.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

