### PR TITLE
Make support archive manifest names lowercase

### DIFF
--- a/src/cmd/support_archive/resources.go
+++ b/src/cmd/support_archive/resources.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -70,7 +71,6 @@ func (collector k8sResourceCollector) storeObject(resource unstructured.Unstruct
 		logErrorf(collector.log, err, "Failed to marshal %s %s/%s", resource.GetKind(), collector.namespace, resource.GetName())
 		return
 	}
-
 	fileName := collector.createFileName(resource.GetKind(), resource)
 
 	err = collector.supportArchive.addFile(fileName, bytes.NewBuffer(yamlManifest))
@@ -83,6 +83,7 @@ func (collector k8sResourceCollector) storeObject(resource unstructured.Unstruct
 }
 
 func (collector k8sResourceCollector) createFileName(kind string, resourceMeta unstructured.Unstructured) string {
+	kind = strings.ToLower(kind)
 	switch {
 	case resourceMeta.GetNamespace() != "":
 		return fmt.Sprintf("%s/%s/%s/%s%s", ManifestsDirectoryName, resourceMeta.GetNamespace(), kind, resourceMeta.GetName(), ManifestsFileExtension)

--- a/src/cmd/support_archive/resources_test.go
+++ b/src/cmd/support_archive/resources_test.go
@@ -96,13 +96,13 @@ func TestManifestCollector_Success(t *testing.T) {
 	require.NoError(t, newK8sObjectCollector(ctx, log, supportArchive, testOperatorNamespace, clt).Do())
 
 	expectedFiles := []string{
-		fmt.Sprintf("%s/Namespace-some-app-namespace%s", InjectedNamespacesManifestsDirectoryName, manifestExtension),
-		fmt.Sprintf("%s/Namespace-dynatrace%s", testOperatorNamespace, manifestExtension),
+		fmt.Sprintf("%s/namespace-some-app-namespace%s", InjectedNamespacesManifestsDirectoryName, manifestExtension),
+		fmt.Sprintf("%s/namespace-dynatrace%s", testOperatorNamespace, manifestExtension),
 
-		fmt.Sprintf("%s/Deployment/deployment1%s", testOperatorNamespace, manifestExtension),
-		fmt.Sprintf("%s/StatefulSet/statefulset1%s", testOperatorNamespace, manifestExtension),
-		fmt.Sprintf("%s/DaemonSet/daemonset1%s", testOperatorNamespace, manifestExtension),
-		fmt.Sprintf("%s/DynaKube/dynakube1%s", testOperatorNamespace, manifestExtension),
+		fmt.Sprintf("%s/deployment/deployment1%s", testOperatorNamespace, manifestExtension),
+		fmt.Sprintf("%s/statefulset/statefulset1%s", testOperatorNamespace, manifestExtension),
+		fmt.Sprintf("%s/daemonset/daemonset1%s", testOperatorNamespace, manifestExtension),
+		fmt.Sprintf("%s/dynakube/dynakube1%s", testOperatorNamespace, manifestExtension),
 	}
 
 	tarReader := tar.NewReader(&tarBuffer)
@@ -181,15 +181,15 @@ func TestManifestCollector_PartialCollectionOnMissingResources(t *testing.T) {
 
 	hdr, err := tarReader.Next()
 	require.NoError(t, err)
-	assert.Equal(t, expectedFilename(fmt.Sprintf("injected_namespaces/Namespace-some-app-namespace%s", manifestExtension)), hdr.Name)
+	assert.Equal(t, expectedFilename(fmt.Sprintf("injected_namespaces/namespace-some-app-namespace%s", manifestExtension)), hdr.Name)
 
 	hdr, err = tarReader.Next()
 	require.NoError(t, err)
-	assert.Equal(t, expectedFilename(fmt.Sprintf("%s/StatefulSet/statefulset1%s", testOperatorNamespace, manifestExtension)), hdr.Name)
+	assert.Equal(t, expectedFilename(fmt.Sprintf("%s/statefulset/statefulset1%s", testOperatorNamespace, manifestExtension)), hdr.Name)
 
 	hdr, err = tarReader.Next()
 	require.NoError(t, err)
-	assert.Equal(t, expectedFilename(fmt.Sprintf("%s/DynaKube/dynakube1%s", testOperatorNamespace, manifestExtension)), hdr.Name)
+	assert.Equal(t, expectedFilename(fmt.Sprintf("%s/dynakube/dynakube1%s", testOperatorNamespace, manifestExtension)), hdr.Name)
 
 	_, err = tarReader.Next()
 	require.ErrorIs(t, err, io.EOF)

--- a/test/scenarios/support_archive/install.go
+++ b/test/scenarios/support_archive/install.go
@@ -143,7 +143,7 @@ func getRequiredPodFiles(t *testing.T, ctx context.Context, resources *resources
 
 	for _, pod := range operatorPods {
 		requiredFiles = append(requiredFiles,
-			fmt.Sprintf("%s/%s/Pod/%s%s", support_archive.ManifestsDirectoryName, pod.Namespace, pod.Name, support_archive.ManifestsFileExtension))
+			fmt.Sprintf("%s/%s/pod/%s%s", support_archive.ManifestsDirectoryName, pod.Namespace, pod.Name, support_archive.ManifestsFileExtension))
 		for _, container := range pod.Spec.Containers {
 			requiredFiles = append(requiredFiles,
 				fmt.Sprintf("%s/%s/%s.log", support_archive.LogsDirectoryName, pod.Name, container.Name))
@@ -157,7 +157,7 @@ func getRequiredReplicaSetFiles(t *testing.T, ctx context.Context, resources *re
 	requiredFiles := make([]string, 0)
 	for _, replicaSet := range replicaSets.Items {
 		requiredFiles = append(requiredFiles,
-			fmt.Sprintf("%s/%s/ReplicaSet/%s%s", support_archive.ManifestsDirectoryName, replicaSet.Namespace, replicaSet.Name, support_archive.ManifestsFileExtension))
+			fmt.Sprintf("%s/%s/replicaset/%s%s", support_archive.ManifestsDirectoryName, replicaSet.Namespace, replicaSet.Name, support_archive.ManifestsFileExtension))
 	}
 	return requiredFiles
 }
@@ -167,7 +167,7 @@ func getRequiredServiceFiles(t *testing.T, ctx context.Context, resources *resou
 	requiredFiles := make([]string, 0)
 	for _, service := range services.Items {
 		requiredFiles = append(requiredFiles,
-			fmt.Sprintf("%s/%s/Service/%s%s", support_archive.ManifestsDirectoryName, service.Namespace, service.Name, support_archive.ManifestsFileExtension))
+			fmt.Sprintf("%s/%s/service/%s%s", support_archive.ManifestsDirectoryName, service.Namespace, service.Name, support_archive.ManifestsFileExtension))
 	}
 	return requiredFiles
 }
@@ -178,21 +178,21 @@ func getRequiredWorkloadFiles(namespace string) []string {
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
 			namespace,
-			"Deployment",
+			"deployment",
 			operator.DeploymentName,
 			support_archive.ManifestsFileExtension))
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
 			namespace,
-			"Deployment",
+			"deployment",
 			e2ewebhook.DeploymentName,
 			support_archive.ManifestsFileExtension))
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
 			namespace,
-			"DaemonSet",
+			"daemonset",
 			csi.DaemonSetName,
 			support_archive.ManifestsFileExtension))
 	return requiredFiles
@@ -201,13 +201,13 @@ func getRequiredWorkloadFiles(namespace string) []string {
 func getRequiredNamespaceFiles(namespace string) []string {
 	requiredFiles := make([]string, 0)
 	requiredFiles = append(requiredFiles,
-		fmt.Sprintf("%s/%s/Namespace-%s%s",
+		fmt.Sprintf("%s/%s/namespace-%s%s",
 			support_archive.ManifestsDirectoryName,
 			namespace,
 			namespace,
 			support_archive.ManifestsFileExtension))
 	requiredFiles = append(requiredFiles,
-		fmt.Sprintf("%s/%s/Namespace-%s%s",
+		fmt.Sprintf("%s/%s/namespace-%s%s",
 			support_archive.ManifestsDirectoryName,
 			support_archive.InjectedNamespacesManifestsDirectoryName,
 			testAppNameInjected,
@@ -221,7 +221,7 @@ func getRequiredDynaKubeFiles(testDynakube dynatracev1beta1.DynaKube) []string {
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
 			testDynakube.Namespace,
-			"DynaKube",
+			"dynakube",
 			testDynakube.Name,
 			support_archive.ManifestsFileExtension))
 


### PR DESCRIPTION
# Description
Currently some manifests are stored with the kind as prefix, which is uppercase. We should commonly store the with lowercase names.

## How can this be tested?
Deploy an operator pod and execute the support archive subcommand
the resulting manifests should be named properly in lowercase letters.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

