### PR TITLE
Fixes e2e test which checks for disk usages in codeModules injection test

### DIFF
--- a/test/scenarios/cloudnative/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules.go
@@ -178,7 +178,6 @@ func diskUsageDoesNotIncrease(namespace string, storageMap map[string]int) featu
 		resource := environmentConfig.Client().Resources()
 		err := csi.ForEachPod(ctx, resource, namespace, func(podItem corev1.Pod) {
 			diskUsage := getDiskUsage(ctx, t, environmentConfig.Client().Resources(), podItem, provisionerContainerName, dataPath)
-			// Dividing it by 1000 so the sizes do not need to be exactly the same down to the byte
 			assert.InDelta(t, storageMap[podItem.Name], diskUsage, 100)
 		})
 		require.NoError(t, err)

--- a/test/scenarios/cloudnative/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules.go
@@ -39,6 +39,7 @@ const (
 	codeModulesVersion     = "1.246.0.20220627-183412"
 	codeModulesImage       = "quay.io/dynatrace/codemodules:" + codeModulesVersion
 	codeModulesImageDigest = "7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f"
+	diskUsageDelta         = 100000
 
 	dataPath                 = "/data/"
 	provisionerContainerName = "provisioner"
@@ -178,7 +179,7 @@ func diskUsageDoesNotIncrease(namespace string, storageMap map[string]int) featu
 		resource := environmentConfig.Client().Resources()
 		err := csi.ForEachPod(ctx, resource, namespace, func(podItem corev1.Pod) {
 			diskUsage := getDiskUsage(ctx, t, environmentConfig.Client().Resources(), podItem, provisionerContainerName, dataPath)
-			assert.InDelta(t, storageMap[podItem.Name], diskUsage, 100)
+			assert.InDelta(t, storageMap[podItem.Name], diskUsage, diskUsageDelta)
 		})
 		require.NoError(t, err)
 

--- a/test/scenarios/cloudnative/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules.go
@@ -39,7 +39,7 @@ const (
 	codeModulesVersion     = "1.246.0.20220627-183412"
 	codeModulesImage       = "quay.io/dynatrace/codemodules:" + codeModulesVersion
 	codeModulesImageDigest = "7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f"
-	diskUsageDelta         = 100000
+	diskUsageKiBDelta      = 100000
 
 	dataPath                 = "/data/"
 	provisionerContainerName = "provisioner"
@@ -179,7 +179,7 @@ func diskUsageDoesNotIncrease(namespace string, storageMap map[string]int) featu
 		resource := environmentConfig.Client().Resources()
 		err := csi.ForEachPod(ctx, resource, namespace, func(podItem corev1.Pod) {
 			diskUsage := getDiskUsage(ctx, t, environmentConfig.Client().Resources(), podItem, provisionerContainerName, dataPath)
-			assert.InDelta(t, storageMap[podItem.Name], diskUsage, diskUsageDelta)
+			assert.InDelta(t, storageMap[podItem.Name], diskUsage, diskUsageKiBDelta)
 		})
 		require.NoError(t, err)
 

--- a/test/scenarios/cloudnative/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules.go
@@ -179,7 +179,7 @@ func diskUsageDoesNotIncrease(namespace string, storageMap map[string]int) featu
 		err := csi.ForEachPod(ctx, resource, namespace, func(podItem corev1.Pod) {
 			diskUsage := getDiskUsage(ctx, t, environmentConfig.Client().Resources(), podItem, provisionerContainerName, dataPath)
 			// Dividing it by 1000 so the sizes do not need to be exactly the same down to the byte
-			assert.Equal(t, storageMap[podItem.Name]/1000, diskUsage/1000)
+			assert.InDelta(t, storageMap[podItem.Name], diskUsage, 100)
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
# Description

Previously the test did check precisely whether the disk usage changed or not. This did fail every now and then, which resulted in the test to be flaky. Now there is no exact check for equality but rather a check whether the difference of the disk usage is below a threshold. After many tests locally I think 100 as a value for the difference proved sufficient.

## How can this be tested?
Run `make test/e2e/cloudnative`


## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

