### PR TITLE
Check network cut off works in e2e tests

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -29,7 +29,7 @@ test/e2e/cloudnative/istio: manifests/crd/helm
 
 ## Runs CloudNative proxy e2e test only
 test/e2e/cloudnative/proxy: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/cloudnative/proxy $(SKIPCLEANUP)
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/cloudnative/proxy $(SKIPCLEANUP)
 
 ## Runs CloudNative network problem e2e test only
 test/e2e/cloudnative/network: manifests/crd/helm

--- a/test/helpers/components/dynakube/dynakube.go
+++ b/test/helpers/components/dynakube/dynakube.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultName      = "dynakube"
-	defaultNamespace = "dynatrace"
+	DefaultNamespace = "dynatrace"
 )
 
 type Builder struct {
@@ -52,7 +52,7 @@ func (dynakubeBuilder Builder) Namespace(namespace string) Builder {
 func (dynakubeBuilder Builder) WithDefaultObjectMeta() Builder {
 	dynakubeBuilder.dynakube.ObjectMeta = metav1.ObjectMeta{
 		Name:        defaultName,
-		Namespace:   defaultNamespace,
+		Namespace:   DefaultNamespace,
 		Annotations: map[string]string{},
 	}
 

--- a/test/helpers/components/dynakube/dynakube.go
+++ b/test/helpers/components/dynakube/dynakube.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultName      = "dynakube"
-	DefaultNamespace = "dynatrace"
+	defaultNamespace = "dynatrace"
 )
 
 type Builder struct {
@@ -52,7 +52,7 @@ func (dynakubeBuilder Builder) Namespace(namespace string) Builder {
 func (dynakubeBuilder Builder) WithDefaultObjectMeta() Builder {
 	dynakubeBuilder.dynakube.ObjectMeta = metav1.ObjectMeta{
 		Name:        defaultName,
-		Namespace:   DefaultNamespace,
+		Namespace:   defaultNamespace,
 		Annotations: map[string]string{},
 	}
 

--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -9,7 +9,6 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/manifests"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
@@ -87,7 +86,7 @@ func ApproveConnectionsWithK8SAndProxy(builder *features.FeatureBuilder, proxySp
 func IsDynatraceNamespaceCutOff(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {
 	if testDynakube.HasProxy() {
 		isNetworkTrafficCutOff(builder, "ingress", curlPodNameDynatraceInboundTraffic, proxyNamespaceName, sampleapps.GetWebhookServiceUrl(testDynakube))
-		isNetworkTrafficCutOff(builder, "egress", curlPodNameDynatraceOutboundTraffic, dynakube.DefaultNamespace, internetUrl)
+		isNetworkTrafficCutOff(builder, "egress", curlPodNameDynatraceOutboundTraffic, testDynakube.Namespace, internetUrl)
 	}
 }
 

--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/manifests"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
@@ -21,11 +22,15 @@ import (
 const (
 	proxyNamespaceName  = "proxy"
 	proxyDeploymentName = "squid"
+
+	curlPodNameDynatraceInboundTraffic  = "dynatrace-inbound-traffic"
+	curlPodNameDynatraceOutboundTraffic = "dynatrace-outbound-traffic"
+
+	internetUrl = "dynatrace.com"
 )
 
 var (
-	dynatraceNetworkPolicy       = path.Join(project.TestDataDir(), "network/dynatrace-denial.yaml")
-	sampleNamespaceNetworkPolicy = path.Join(project.TestDataDir(), "network/sample-ns-denial.yaml")
+	dynatraceNetworkPolicy = path.Join(project.TestDataDir(), "network/dynatrace-denial.yaml")
 
 	proxyDeploymentPath = path.Join(project.TestDataDir(), "network/proxy.yaml")
 	proxySCCPath        = path.Join(project.TestDataDir(), "network/proxy-scc.yaml")
@@ -68,8 +73,25 @@ func CutOffDynatraceNamespace(builder *features.FeatureBuilder, proxySpec *dynat
 	}
 }
 
-func CutOffSampleNamespace(builder *features.FeatureBuilder, proxySpec *dynatracev1beta1.DynaKubeProxy) {
+func ApproveConnectionsWithK8SAndProxy(builder *features.FeatureBuilder, proxySpec *dynatracev1beta1.DynaKubeProxy) {
 	if proxySpec != nil {
-		builder.Assess("cut off sample namespace", manifests.InstallFromFile(sampleNamespaceNetworkPolicy))
+		if kubeobjects.ResolvePlatformFromEnv() == kubeobjects.Openshift {
+			builder.Assess("approve dynatrace-openshift network traffic", manifests.InstallFromFile(path.Join(project.TestDataDir(), "network/dynatrace-openshift-approval.yaml")))
+		} else {
+			builder.Assess("approve dynatrace-kube-system network traffic", manifests.InstallFromFile(path.Join(project.TestDataDir(), "network/dynatrace-kube-system-approval.yaml")))
+		}
+		builder.Assess("approve dynatrace-proxy network traffic", manifests.InstallFromFile(path.Join(project.TestDataDir(), "network/proxy-approval.yaml")))
 	}
+}
+
+func IsDynatraceNamespaceCutOff(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {
+	if testDynakube.HasProxy() {
+		isNetworkTrafficCutOff(builder, "ingress", curlPodNameDynatraceInboundTraffic, proxyNamespaceName, sampleapps.GetWebhookServiceUrl(testDynakube))
+		isNetworkTrafficCutOff(builder, "egress", curlPodNameDynatraceOutboundTraffic, dynakube.DefaultNamespace, internetUrl)
+	}
+}
+
+func isNetworkTrafficCutOff(builder *features.FeatureBuilder, directionName, podName, podNamespaceName, targetUrl string) {
+	builder.Assess(directionName+" - query namespace", sampleapps.InstallCutOffCurlPod(podName, podNamespaceName, targetUrl))
+	builder.Assess(directionName+" - namespace is cutoff", sampleapps.WaitForCutOffCurlPod(podName, podNamespaceName))
 }

--- a/test/scenarios/activegate/installation.go
+++ b/test/scenarios/activegate/installation.go
@@ -65,6 +65,8 @@ func Install(t *testing.T, proxySpec *dynatracev1beta1.DynaKubeProxy) features.F
 	// Register proxy install and uninstall
 	proxy.SetupProxyWithTeardown(builder, testDynakube)
 	proxy.CutOffDynatraceNamespace(builder, proxySpec)
+	proxy.IsDynatraceNamespaceCutOff(builder, testDynakube)
+	proxy.ApproveConnectionsWithK8SAndProxy(builder, proxySpec)
 
 	// Register actual test
 	assess.InstallDynakube(builder, &secretConfig, testDynakube)

--- a/test/scenarios/cloudnative/network_problems.go
+++ b/test/scenarios/cloudnative/network_problems.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
@@ -25,9 +24,8 @@ import (
 )
 
 const (
-	agentMountPath    = "/opt/dynatrace/oneagent-paas"
-	ldPreloadError    = "ERROR: ld.so: object '/opt/dynatrace/oneagent-paas/agent/lib64/liboneagentproc.so' from LD_PRELOAD cannot be preloaded"
-	podRestartTimeout = 5 * time.Minute
+	agentMountPath = "/opt/dynatrace/oneagent-paas"
+	ldPreloadError = "ERROR: ld.so: object '/opt/dynatrace/oneagent-paas/agent/lib64/liboneagentproc.so' from LD_PRELOAD cannot be preloaded"
 )
 
 var (
@@ -42,6 +40,9 @@ func NetworkProblems(t *testing.T) features.Feature {
 		WithDefaultObjectMeta().
 		ApiUrl(secretConfig.ApiUrl).
 		CloudNative(defaultCloudNativeSpec()).
+		WithAnnotations(map[string]string{
+			"feature.dynatrace.com/max-csi-mount-attempts": "2",
+		}).
 		Build()
 
 	namespaceBuilder := namespace.NewBuilder("network-problem-sample")

--- a/test/scenarios/cloudnative/proxy/proxy.go
+++ b/test/scenarios/cloudnative/proxy/proxy.go
@@ -56,7 +56,8 @@ func withProxy(t *testing.T, proxySpec *dynatracev1beta1.DynaKubeProxy) features
 	// Register proxy create and delete
 	proxy.SetupProxyWithTeardown(builder, testDynakube)
 	proxy.CutOffDynatraceNamespace(builder, proxySpec)
-	proxy.CutOffSampleNamespace(builder, proxySpec)
+	proxy.IsDynatraceNamespaceCutOff(builder, testDynakube)
+	proxy.ApproveConnectionsWithK8SAndProxy(builder, proxySpec)
 
 	// Register actual test
 	assess.InstallDynakube(builder, &secretConfig, testDynakube)

--- a/test/testdata/network/dynatrace-kube-system-approval.yaml
+++ b/test/testdata/network/dynatrace-kube-system-approval.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "dynatrace-kube-system-approval"
+  namespace: dynatrace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system

--- a/test/testdata/network/dynatrace-openshift-approval.yaml
+++ b/test/testdata/network/dynatrace-openshift-approval.yaml
@@ -1,0 +1,85 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "dynatrace-openshift-approval"
+  namespace: dynatrace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchExpressions:
+              - {
+                key: kubernetes.io/metadata.name,
+                operator: In,
+                values: [
+                  istio-system,
+                  kube-node-lease,
+                  kube-public,
+                  kube-system,
+                  openshift,
+                  openshift-apiserver,
+                  openshift-apiserver-operator,
+                  openshift-authentication,
+                  openshift-authentication-operator,
+                  openshift-cloud-controller-manager,
+                  openshift-cloud-controller-manager-operator,
+                  openshift-cloud-credential-operator,
+                  openshift-cloud-network-config-controller,
+                  openshift-cluster-csi-drivers,
+                  openshift-cluster-machine-approver,
+                  openshift-cluster-node-tuning-operator,
+                  openshift-cluster-samples-operator,
+                  openshift-cluster-storage-operator,
+                  openshift-cluster-version,
+                  openshift-config,
+                  openshift-config-managed,
+                  openshift-config-operator,
+                  openshift-console,
+                  openshift-console-operator,
+                  openshift-console-user-settings,
+                  openshift-controller-manager,
+                  openshift-controller-manager-operator,
+                  openshift-dns,
+                  openshift-dns-operator,
+                  openshift-etcd,
+                  openshift-etcd-operator,
+                  openshift-host-network,
+                  openshift-image-registry,
+                  openshift-infra,
+                  openshift-ingress,
+                  openshift-ingress-canary,
+                  openshift-ingress-operator,
+                  openshift-insights,
+                  openshift-kni-infra,
+                  openshift-kube-apiserver,
+                  openshift-kube-apiserver-operator,
+                  openshift-kube-controller-manager,
+                  openshift-kube-controller-manager-operator,
+                  openshift-kube-scheduler,
+                  openshift-kube-scheduler-operator,
+                  openshift-kube-storage-version-migrator,
+                  openshift-kube-storage-version-migrator-operator,
+                  openshift-machine-api,
+                  openshift-machine-config-operator,
+                  openshift-marketplace,
+                  openshift-monitoring,
+                  openshift-multus,
+                  openshift-network-diagnostics,
+                  openshift-network-operator,
+                  openshift-node,
+                  openshift-nutanix-infra,
+                  openshift-oauth-apiserver,
+                  openshift-openstack-infra,
+                  openshift-operator-lifecycle-manager,
+                  openshift-operators,
+                  openshift-ovirt-infra,
+                  openshift-route-controller-manager,
+                  openshift-sdn,
+                  openshift-service-ca,
+                  openshift-service-ca-operator,
+                  openshift-user-workload-monitoring,
+                  openshift-vsphere-infra
+                ] }

--- a/test/testdata/network/proxy-approval.yaml
+++ b/test/testdata/network/proxy-approval.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "proxy-approval"
+  namespace: dynatrace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: proxy
+          podSelector:
+            matchLabels:
+              app: squid


### PR DESCRIPTION
# Description

Added test steps to make sure the network is cut off. Bi-directional traffic between `dynatrace` and `kube-system`+`openshift-*`  namespaces is allowed (otherwise the operator doesn't work). Additionally bi-directional traffic between `dynatrace` namespace and the proxy POD is allowed .  

## How can this be tested?
Make sure NetworkPolicy is supported by your cluster. Use the following commands to start tests:
```
make test/e2e/activegate/proxy
make test/e2e/cloudnative/proxy
```

## Checklist
~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

