### PR TITLE
Removes unnecessary http port for activegates

### DIFF
--- a/assets/calico/activegate-policy.yaml
+++ b/assets/calico/activegate-policy.yaml
@@ -18,15 +18,11 @@ spec:
     ports:
     # from activegate ports
     - protocol: TCP
-      port: 9999   
-    - protocol: TCP
-      port: 9998    
+      port: 9999
     - protocol: TCP
       port: 443
-    - protocol: TCP
-      port: 80
   egress:
-  # Allow DNS lookup 
+  # Allow DNS lookup
   - to:
     - namespaceSelector:
         matchLabels:

--- a/src/controllers/dynakube/activegate/consts/consts.go
+++ b/src/controllers/dynakube/activegate/consts/consts.go
@@ -12,10 +12,7 @@ const (
 	ProxySecretSuffix       = "internal-proxy"
 	HttpsServicePortName    = "https"
 	HttpsServicePort        = 443
-	HttpServicePortName     = "http"
-	HttpServicePort         = 80
 	HttpsContainerPort      = 9999
-	HttpContainerPort       = 9998
 
 	AuthTokenSecretVolumeName = "ag-authtoken-secret"
 	AuthTokenMountPoint       = connectioninfo.TokenBasePath + "/auth-token"

--- a/src/controllers/dynakube/activegate/internal/capability/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/capability/reconciler_test.go
@@ -228,7 +228,6 @@ func TestCreateOrUpdateService(t *testing.T) {
 		assert.NotNil(t, actualService)
 
 		assert.Equal(t, int32(443), actualService.Spec.Ports[0].Port)
-		assert.Equal(t, int32(80), actualService.Spec.Ports[1].Port)
 
 		require.NotEqual(t, actualService, service)
 		require.NotEqual(t, actualService.Spec.Ports, service.Spec.Ports)

--- a/src/controllers/dynakube/activegate/internal/capability/service.go
+++ b/src/controllers/dynakube/activegate/internal/capability/service.go
@@ -21,12 +21,6 @@ func CreateService(dynakube *dynatracev1beta1.DynaKube, feature string) *corev1.
 				Port:       consts.HttpsServicePort,
 				TargetPort: intstr.FromString(consts.HttpsServicePortName),
 			},
-			corev1.ServicePort{
-				Name:       consts.HttpServicePortName,
-				Protocol:   corev1.ProtocolTCP,
-				Port:       consts.HttpServicePort,
-				TargetPort: intstr.FromString(consts.HttpServicePortName),
-			},
 		)
 	}
 

--- a/src/controllers/dynakube/activegate/internal/capability/service_test.go
+++ b/src/controllers/dynakube/activegate/internal/capability/service_test.go
@@ -38,13 +38,6 @@ func TestCreateService(t *testing.T) {
 		Port:       consts.HttpsServicePort,
 		TargetPort: intstr.FromString(consts.HttpsServicePortName),
 	}
-	agHttpPort := corev1.ServicePort{
-		Name:       consts.HttpServicePortName,
-		Protocol:   corev1.ProtocolTCP,
-		Port:       consts.HttpServicePort,
-		TargetPort: intstr.FromString(consts.HttpServicePortName),
-	}
-
 	t.Run("check service name, labels and selector", func(t *testing.T) {
 		instance := testCreateInstance()
 		service := CreateService(instance, testComponentFeature)
@@ -78,6 +71,6 @@ func TestCreateService(t *testing.T) {
 		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports
 
-		assert.Contains(t, ports, agHttpsPort, agHttpPort)
+		assert.Contains(t, ports, agHttpsPort)
 	})
 }

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
@@ -47,10 +47,6 @@ func (mod ServicePortModifier) getPorts() []corev1.ContainerPort {
 			Name:          consts.HttpsServicePortName,
 			ContainerPort: consts.HttpsContainerPort,
 		},
-		{
-			Name:          consts.HttpServicePortName,
-			ContainerPort: consts.HttpContainerPort,
-		},
 	}
 }
 

--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -135,7 +135,7 @@ func (statefulSetBuilder Builder) buildBaseContainer() []corev1.Container {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/rest/health",
-					Port:   intstr.IntOrString{IntVal: 9999},
+					Port:   intstr.IntOrString{IntVal: consts.HttpsContainerPort},
 					Scheme: "HTTPS",
 				},
 			},

--- a/src/controllers/dynakube/activegate/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/reconciler_test.go
@@ -118,15 +118,12 @@ func TestServiceCreation(t *testing.T) {
 		expectedCapabilityPorts := map[dynatracev1beta1.CapabilityDisplayName][]string{
 			dynatracev1beta1.RoutingCapability.DisplayName: {
 				consts.HttpsServicePortName,
-				consts.HttpServicePortName,
 			},
 			dynatracev1beta1.MetricsIngestCapability.DisplayName: {
 				consts.HttpsServicePortName,
-				consts.HttpServicePortName,
 			},
 			dynatracev1beta1.DynatraceApiCapability.DisplayName: {
 				consts.HttpsServicePortName,
-				consts.HttpServicePortName,
 			},
 			dynatracev1beta1.KubeMonCapability.DisplayName: {},
 		}
@@ -161,7 +158,6 @@ func TestServiceCreation(t *testing.T) {
 		}
 		expectedPorts := []string{
 			consts.HttpsServicePortName,
-			consts.HttpServicePortName,
 		}
 
 		err := reconciler.Reconcile()


### PR DESCRIPTION
# Description

Removes http ports from the ActiveGate:
- `9998` on the ActiveGate container
- `80` on the ActiveGate service

These are not necessary, so we shouldn't keep them.

## How can this be tested?
Deployed ActiveGates work as expected

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

