### PR TITLE
Ignores public registry feature flag when classicFullStack is enabled

### DIFF
--- a/src/controllers/dynakube/version/activegate.go
+++ b/src/controllers/dynakube/version/activegate.go
@@ -54,6 +54,10 @@ func (updater activeGateUpdater) IsPublicRegistryEnabled() bool {
 	return updater.dynakube.FeaturePublicRegistry()
 }
 
+func (updater activeGateUpdater) IsClassicFullStackEnabled() bool {
+	return updater.dynakube.ClassicFullStackMode()
+}
+
 func (updater activeGateUpdater) LatestImageInfo() (*dtclient.LatestImageInfo, error) {
 	return updater.dtClient.GetLatestActiveGateImage()
 }

--- a/src/controllers/dynakube/version/codemodules.go
+++ b/src/controllers/dynakube/version/codemodules.go
@@ -48,6 +48,10 @@ func (updater codeModulesUpdater) IsPublicRegistryEnabled() bool {
 	return updater.dynakube.FeaturePublicRegistry()
 }
 
+func (updater codeModulesUpdater) IsClassicFullStackEnabled() bool {
+	return updater.dynakube.ClassicFullStackMode()
+}
+
 func (updater codeModulesUpdater) LatestImageInfo() (*dtclient.LatestImageInfo, error) {
 	return updater.dtClient.GetLatestCodeModulesImage()
 }

--- a/src/controllers/dynakube/version/oneagent.go
+++ b/src/controllers/dynakube/version/oneagent.go
@@ -55,6 +55,10 @@ func (updater oneAgentUpdater) IsPublicRegistryEnabled() bool {
 	return updater.dynakube.FeaturePublicRegistry()
 }
 
+func (updater oneAgentUpdater) IsClassicFullStackEnabled() bool {
+	return updater.dynakube.ClassicFullStackMode()
+}
+
 func (updater oneAgentUpdater) LatestImageInfo() (*dtclient.LatestImageInfo, error) {
 	return updater.dtClient.GetLatestOneAgentImage()
 }

--- a/src/controllers/dynakube/version/updater.go
+++ b/src/controllers/dynakube/version/updater.go
@@ -17,6 +17,7 @@ type versionStatusUpdater interface {
 
 	CustomImage() string
 	CustomVersion() string
+	IsClassicFullStackEnabled() bool
 	IsAutoUpdateEnabled() bool
 	IsPublicRegistryEnabled() bool
 	LatestImageInfo() (*dtclient.LatestImageInfo, error)
@@ -51,7 +52,7 @@ func (reconciler *Reconciler) run(ctx context.Context, updater versionStatusUpda
 		}
 	}
 
-	if updater.IsPublicRegistryEnabled() {
+	if updater.IsPublicRegistryEnabled() && !updater.IsClassicFullStackEnabled() {
 		var publicImage *dtclient.LatestImageInfo
 		publicImage, err = updater.LatestImageInfo()
 		if err != nil {
@@ -75,7 +76,7 @@ func determineSource(updater versionStatusUpdater) dynatracev1beta1.VersionSourc
 	if updater.CustomImage() != "" {
 		return dynatracev1beta1.CustomImageVersionSource
 	}
-	if updater.IsPublicRegistryEnabled() {
+	if updater.IsPublicRegistryEnabled() && !updater.IsClassicFullStackEnabled() {
 		return dynatracev1beta1.PublicRegistryVersionSource
 	}
 	if updater.CustomVersion() != "" {


### PR DESCRIPTION
# Description
With this the newly introduced public registry feature flag is ignored when using classicFullStack. If a custom image is set, this takes priority, if not then tenant registry is used. 

## How can this be tested?
Apply a dynakube which has classicFullStack and public registry feature flag enabled, check the dynakube status.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

