### PR TITLE
Adapt activegate e2e test for operator deployment with readonly active gate

### DIFF
--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/readonly.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/readonly.go
@@ -43,7 +43,7 @@ func (mod ReadOnlyModifier) Modify(sts *appsv1.StatefulSet) error {
 }
 
 func (mod ReadOnlyModifier) getVolumes() []corev1.Volume {
-	volumes := []corev1.Volume{
+	return []corev1.Volume{
 		{
 			Name: consts.GatewayLibTempVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -67,24 +67,18 @@ func (mod ReadOnlyModifier) getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
-		}}
-
-	_, err := kubeobjects.GetVolumeByName(mod.presentVolumes, consts.GatewayConfigVolumeName)
-	if err != nil {
-		volumes = append(volumes,
-			corev1.Volume{
-				Name: consts.GatewayConfigVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
+		},
+		{
+			Name: consts.GatewayConfigVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
-		)
+		},
 	}
-	return volumes
 }
 
 func (mod ReadOnlyModifier) getVolumeMounts() []corev1.VolumeMount {
-	volumeMounts := []corev1.VolumeMount{
+	return []corev1.VolumeMount{
 		{
 			ReadOnly:  false,
 			Name:      consts.GatewayLibTempVolumeName,
@@ -104,15 +98,11 @@ func (mod ReadOnlyModifier) getVolumeMounts() []corev1.VolumeMount {
 			ReadOnly:  false,
 			Name:      consts.GatewayTmpVolumeName,
 			MountPath: consts.GatewayTmpMountPoint,
-		}}
-
-	neededMount := corev1.VolumeMount{
-		ReadOnly:  false,
-		Name:      consts.GatewayConfigVolumeName,
-		MountPath: consts.GatewayConfigMountPoint,
+		},
+		{
+			ReadOnly:  false,
+			Name:      consts.GatewayConfigVolumeName,
+			MountPath: consts.GatewayConfigMountPoint,
+		},
 	}
-	if !kubeobjects.IsVolumeMountPresent(mod.presentMounts, neededMount) {
-		volumeMounts = append(volumeMounts, neededMount)
-	}
-	return volumeMounts
 }

--- a/test/helpers/steps/assess/dynakube.go
+++ b/test/helpers/steps/assess/dynakube.go
@@ -29,10 +29,14 @@ func CreateDynakube(builder *features.FeatureBuilder, secretConfig *tenant.Secre
 	builder.Assess("dynakube created", dynakube.Create(testDynakube))
 }
 
+func UpdateDynakube(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {
+	builder.Assess("dynakube updated", dynakube.Update(testDynakube))
+}
+
 func verifyDynakubeStartup(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {
 	if testDynakube.NeedsOneAgent() {
 		builder.Assess("oneagent started", oneagent.WaitForDaemonset(testDynakube))
 		builder.Assess("osAgent can connect", oneagent.OSAgentCanConnect(testDynakube))
 	}
-	builder.Assess("dynakube phase changes to 'Running'", dynakube.WaitForDynakubePhase(testDynakube))
+	builder.Assess("dynakube phase changes to 'Running'", dynakube.WaitForDynakubePhase(testDynakube, dynatracev1beta1.Running))
 }


### PR DESCRIPTION
# Description

ReadOnly modifier - removed statsd related conditions.

ActiveGate e2e test (no proxy) performs additional steps to verify readonly ActiveGate:
- dynakube is updated with `activegate-readonly-fs` annotation
- next step waits until dynakube is reconciled and ActiveGate pod is running
- verification if InitContainer and Container RootFilesystems are ReadOnly
- verification if appropriate Volumes are added
- verification if appropriate VolumeMounts are added

## How can this be tested?
Use the following command to start the test
```
make test/e2e/activegate
```

## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

