### PR TITLE
Lower request amount for image manifest if codeModulesImage provides digest

### DIFF
--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -96,7 +96,7 @@ func (installer *ImageInstaller) installAgentFromImage() error {
 		log.Info("failed to get image digest", "image", imageRef)
 		return errors.WithStack(err)
 	}
-	log.Info("image digest", "image", imageRef, "digest", imageDigestEncoded)
+	log.Info("got image digest", "image", imageRef, "digest", imageDigestEncoded)
 
 	if installer.isAlreadyDownloaded(imageDigestEncoded) {
 		log.Info("image is already installed", "image", image, "digest", imageDigestEncoded)
@@ -138,6 +138,7 @@ func (installer ImageInstaller) isAlreadyDownloaded(imageDigestEncoded string) b
 
 func getImageDigestEncoded(systemContext *types.SystemContext, imageReference *types.ImageReference, imageRef reference.Named) (string, error) {
 	if c, ok := imageRef.(reference.Canonical); ok {
+		log.Info("using digest from imageRef, skipping request")
 		return c.Digest().Encoded(), nil
 	}
 

--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"context"
-	"github.com/containers/image/v5/docker/reference"
 	"os"
 	"path/filepath"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/installer/zip"
 	"github.com/Dynatrace/dynatrace-operator/src/processmoduleconfig"
 	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"

--- a/src/installer/image/installer_test.go
+++ b/src/installer/image/installer_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestIsAlreadyDownloaded(t *testing.T) {
 	imageDigest := "test"
-	imageWithDigest := "quay.io/somerepo/codemod@sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f"
 	pathResolver := metadata.PathResolver{}
 
 	t.Run(`returns early if path doesn't exist`, func(t *testing.T) {
@@ -32,11 +31,6 @@ func TestIsAlreadyDownloaded(t *testing.T) {
 		}
 		isDownloaded := installer.isAlreadyDownloaded(imageDigest)
 		assert.True(t, isDownloaded)
-	})
-	t.Run(`returns proper digest`, func(t *testing.T) {
-		digest := getImageDigestFromImageName(imageWithDigest)
-		assert.NotEmpty(t, digest)
-		assert.Equal(t, "7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f", digest.Encoded())
 	})
 }
 

--- a/src/installer/image/installer_test.go
+++ b/src/installer/image/installer_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestIsAlreadyDownloaded(t *testing.T) {
 	imageDigest := "test"
+	imageWithDigest := "quay.io/somerepo/codemod@sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f"
 	pathResolver := metadata.PathResolver{}
 
 	t.Run(`returns early if path doesn't exist`, func(t *testing.T) {
@@ -31,6 +32,11 @@ func TestIsAlreadyDownloaded(t *testing.T) {
 		}
 		isDownloaded := installer.isAlreadyDownloaded(imageDigest)
 		assert.True(t, isDownloaded)
+	})
+	t.Run(`returns proper digest`, func(t *testing.T) {
+		digest := getImageDigestFromImageName(imageWithDigest)
+		assert.NotEmpty(t, digest)
+		assert.Equal(t, "7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f", digest.Encoded())
 	})
 }
 

--- a/src/installer/image/source.go
+++ b/src/installer/image/source.go
@@ -8,33 +8,26 @@ import (
 	"github.com/pkg/errors"
 )
 
-func getSourceInfo(cacheDir string, pullInfo Properties) (*types.SystemContext, *types.ImageReference, error) {
+func getSourceInfo(cacheDir string, pullInfo Properties) (*types.SystemContext, *types.ImageReference, reference.Named, error) {
 	imageRef, err := parseImageReference(pullInfo.ImageUri)
 	if err != nil {
 		log.Info("failed to parse image reference", "image", pullInfo.ImageUri)
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, nil, errors.WithStack(err)
 	}
-	log.Info("parsed image reference", "imageRef", imageRef)
+	log.Info("parsed image reference", "image", pullInfo.ImageUri, "reference", imageRef)
 
 	sourceRef, err := getSourceReference(imageRef)
 	if err != nil {
 		log.Info("failed to get source reference", "image", pullInfo.ImageUri, "imageRef", imageRef)
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, nil, errors.WithStack(err)
 	}
-	log.Info("got source reference", "image", pullInfo.ImageUri)
 
 	sourceCtx := buildSourceContext(imageRef, cacheDir, pullInfo.DockerConfig)
-	return sourceCtx, sourceRef, nil
+	return sourceCtx, sourceRef, imageRef, nil
 }
 
 func parseImageReference(uri string) (reference.Named, error) {
-	ref, err := reference.ParseNormalizedNamed(uri)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	ref = reference.TagNameOnly(ref)
-
-	return ref, nil
+	return reference.ParseDockerRef(uri)
 }
 
 func getSourceReference(named reference.Named) (*types.ImageReference, error) {

--- a/src/installer/image/source_test.go
+++ b/src/installer/image/source_test.go
@@ -12,10 +12,10 @@ import (
 const (
 	testDir           = "test"
 	testImageRegistry = "quay.io"
-	testImageName = "busybox:1.36.0@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16"
-	testImageUri  = testImageRegistry + "/repo/" + testImageName
-	testPassword  = "pass"
-	testUsername  = "user"
+	testImageName     = "busybox:1.36.0@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16"
+	testImageUri      = testImageRegistry + "/repo/" + testImageName
+	testPassword      = "pass"
+	testUsername      = "user"
 )
 
 func TestGetSourceInfo(t *testing.T) {

--- a/src/installer/image/source_test.go
+++ b/src/installer/image/source_test.go
@@ -12,21 +12,24 @@ import (
 const (
 	testDir           = "test"
 	testImageRegistry = "quay.io"
-	testImageName     = "image:tag"
-	testImageUri      = testImageRegistry + "/repo/" + testImageName
-	testPassword      = "pass"
-	testUsername      = "user"
+	//testImageName     = "busybox:1.36.0"
+	//testImageName = "busybox@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16"
+	testImageName = "busybox:1.36.0@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16"
+	testImageUri  = testImageRegistry + "/repo/" + testImageName
+	testPassword  = "pass"
+	testUsername  = "user"
 )
 
 func TestGetSourceInfo(t *testing.T) {
 	t.Run(`not nil`, func(t *testing.T) {
-		sourceCtx, sourceRef, err := getSourceInfo(testDir, Properties{
+		sourceCtx, sourceRef, imageRef, err := getSourceInfo(testDir, Properties{
 			ImageUri:     testImageUri,
 			DockerConfig: createTestDockerConfig(),
 		})
 		require.NoError(t, err)
 		assert.NotNil(t, sourceCtx)
 		assert.NotNil(t, sourceRef)
+		assert.NotNil(t, imageRef)
 	})
 }
 
@@ -73,6 +76,5 @@ func getTestImageReference(t *testing.T) reference.Named {
 	imageRef, err := parseImageReference(testImageUri)
 	require.NoError(t, err)
 	require.NotNil(t, imageRef)
-	assert.Equal(t, testImageUri, imageRef.String())
 	return imageRef
 }

--- a/src/installer/image/source_test.go
+++ b/src/installer/image/source_test.go
@@ -12,8 +12,6 @@ import (
 const (
 	testDir           = "test"
 	testImageRegistry = "quay.io"
-	//testImageName     = "busybox:1.36.0"
-	//testImageName = "busybox@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16"
 	testImageName = "busybox:1.36.0@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16"
 	testImageUri  = testImageRegistry + "/repo/" + testImageName
 	testPassword  = "pass"


### PR DESCRIPTION
# Description

Currently we request the docker manifest for the codeModulesImage in each reconcile within the CSI Driver's provisioner, in order to get the image digest and check if it updated and if we need to redownload the image. However this can cause a lot of traffic for a image registry as this request is done once each 5 minutes per node per dynakube. 

## How can this be tested?
Deploy the operator and check following scenarios:

1. Deploy a dynakube with a codeModulesImage set without a digest e.g yourrepo/image:tag
Digest should be retrieved from registry by getting the manifest -> as before

2. Deploy a dynakube with a codeModulesImage set with a digest e.g yourrepo/image@sha256:digest
Digest should be taken from the image directly and no call should be made to the registry

3. Deploy a dynakube with a codeModulesImage set with a digest and a tag e.g yourrepo/image:tag@sha256:digest
Digest should be taken from the image directly and no call should be made to the registry


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

