### PR TITLE
Fixes csi-server "archive-is-available" logic

### DIFF
--- a/src/controllers/csi/driver/volumes/app/publisher.go
+++ b/src/controllers/csi/driver/volumes/app/publisher.go
@@ -69,10 +69,10 @@ func (publisher *AppVolumePublisher) PublishVolume(ctx context.Context, volumeCf
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
-	if bindCfg.Version == "" {
+	if !bindCfg.IsArchiveAvailable() {
 		return nil, status.Error(
 			codes.Unavailable,
-			fmt.Sprintf("version is not yet set, csi-provisioner hasn't finished setup yet for tenant: %s", bindCfg.TenantUUID),
+			fmt.Sprintf("version or digest is not yet set, csi-provisioner hasn't finished setup yet for tenant: %s", bindCfg.TenantUUID),
 		)
 	}
 
@@ -80,7 +80,7 @@ func (publisher *AppVolumePublisher) PublishVolume(ctx context.Context, volumeCf
 		return nil, err
 	}
 
-	agentsVersionsMetric.WithLabelValues(bindCfg.Version).Inc()
+	agentsVersionsMetric.WithLabelValues(bindCfg.MetricVersionLabel()).Inc()
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 

--- a/src/controllers/csi/driver/volumes/app/publisher_test.go
+++ b/src/controllers/csi/driver/volumes/app/publisher_test.go
@@ -166,9 +166,6 @@ func TestUnpublishVolume(t *testing.T) {
 
 		response, err := publisher.UnpublishVolume(context.TODO(), createTestVolumeInfo())
 
-		assert.Equal(t, 1, testutil.CollectAndCount(agentsVersionsMetric))
-		assert.Equal(t, float64(0), testutil.ToFloat64(agentsVersionsMetric.WithLabelValues(testAgentVersion)))
-
 		require.NoError(t, err)
 		require.Nil(t, response)
 		require.NotEmpty(t, mounter.MountPoints)
@@ -313,7 +310,7 @@ func mockUrlDynakubeMetadata(t *testing.T, publisher *AppVolumePublisher) {
 }
 
 func mockImageDynakubeMetadata(t *testing.T, publisher *AppVolumePublisher) {
-	err := publisher.db.InsertDynakube(context.TODO(), metadata.NewDynakube(testDynakubeName, testTenantUUID, testAgentVersion, testImageDigest, dynatracev1beta1.DefaultMaxFailedCsiMountAttempts))
+	err := publisher.db.InsertDynakube(context.TODO(), metadata.NewDynakube(testDynakubeName, testTenantUUID, "", testImageDigest, dynatracev1beta1.DefaultMaxFailedCsiMountAttempts))
 	require.NoError(t, err)
 }
 
@@ -344,7 +341,8 @@ func assertNoReferencesForUnpublishedVolume(t *testing.T, publisher *AppVolumePu
 }
 
 func resetMetrics() {
-	agentsVersionsMetric.WithLabelValues(testAgentVersion).Set(0)
+	agentsVersionsMetric.DeleteLabelValues(testAgentVersion)
+	agentsVersionsMetric.DeleteLabelValues(testImageDigest)
 }
 
 func createTestVolumeConfig() *csivolumes.VolumeConfig {

--- a/src/controllers/csi/driver/volumes/bind_config.go
+++ b/src/controllers/csi/driver/volumes/bind_config.go
@@ -31,3 +31,15 @@ func NewBindConfig(ctx context.Context, access metadata.Access, volumeCfg *Volum
 		MaxMountAttempts: dynakube.MaxFailedMountAttempts,
 	}, nil
 }
+
+func (cfg BindConfig) IsArchiveAvailable() bool {
+	return cfg.Version != "" || cfg.ImageDigest != ""
+}
+
+func (cfg BindConfig) MetricVersionLabel() string {
+	versionLabel := cfg.Version
+	if versionLabel == "" {
+		versionLabel = cfg.ImageDigest
+	}
+	return versionLabel
+}

--- a/src/controllers/csi/driver/volumes/bind_config_test.go
+++ b/src/controllers/csi/driver/volumes/bind_config_test.go
@@ -89,4 +89,3 @@ func TestMetricVersionLabel(t *testing.T) {
 		assert.Equal(t, bindCfg.ImageDigest, bindCfg.MetricVersionLabel())
 	})
 }
-

--- a/src/controllers/csi/driver/volumes/bind_config_test.go
+++ b/src/controllers/csi/driver/volumes/bind_config_test.go
@@ -45,3 +45,48 @@ func TestNewBindConfig(t *testing.T) {
 		assert.Equal(t, expected, *bindCfg)
 	})
 }
+
+func TestIsArchiveAvailable(t *testing.T) {
+	t.Run(`no version, no digest`, func(t *testing.T) {
+		bindCfg := BindConfig{}
+
+		assert.False(t, bindCfg.IsArchiveAvailable())
+	})
+	t.Run(`version set, no digest`, func(t *testing.T) {
+		bindCfg := BindConfig{
+			Version: "1.2.3",
+		}
+
+		assert.True(t, bindCfg.IsArchiveAvailable())
+	})
+	t.Run(`no version, digest set`, func(t *testing.T) {
+		bindCfg := BindConfig{
+			ImageDigest: "sha256:123",
+		}
+
+		assert.True(t, bindCfg.IsArchiveAvailable())
+	})
+}
+
+func TestMetricVersionLabel(t *testing.T) {
+	t.Run(`no version, no digest`, func(t *testing.T) {
+		bindCfg := BindConfig{}
+
+		assert.Empty(t, bindCfg.MetricVersionLabel())
+	})
+	t.Run(`version set, no digest`, func(t *testing.T) {
+		bindCfg := BindConfig{
+			Version: "1.2.3",
+		}
+
+		assert.Equal(t, bindCfg.Version, bindCfg.MetricVersionLabel())
+	})
+	t.Run(`no version, digest set`, func(t *testing.T) {
+		bindCfg := BindConfig{
+			ImageDigest: "sha256:123",
+		}
+
+		assert.Equal(t, bindCfg.ImageDigest, bindCfg.MetricVersionLabel())
+	})
+}
+

--- a/test/scenarios/cloudnative/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules.go
@@ -139,7 +139,7 @@ func imageHasBeenDownloaded(namespace string, secret tenant.Secret) features.Fun
 					Container: provisionerContainerName,
 				}).Stream(ctx)
 				require.NoError(t, err)
-				return logs.Contains(t, logStream, "Installed agent version: "+codeModulesVersion+" to tenant: "+secret.TenantUid), err
+				return logs.Contains(t, logStream, "Installed agent version: "+codeModulesImage), err
 			}, wait.WithTimeout(time.Minute*5))
 			require.NoError(t, err)
 

--- a/test/scenarios/cloudnative/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules.go
@@ -99,7 +99,7 @@ func CodeModules(t *testing.T, istioEnabled bool) features.Feature {
 	if istioEnabled {
 		istio.AssessIstio(builder, cloudNativeDynakube, sampleApp)
 	}
-	builder.Assess("codemodules have been downloaded", imageHasBeenDownloaded(cloudNativeDynakube.Namespace, secretConfigs[0]))
+	builder.Assess("codemodules have been downloaded", imageHasBeenDownloaded(cloudNativeDynakube.Namespace))
 	builder.Assess("checking storage used", measureDiskUsage(appDynakube.Namespace, storageMap))
 	assess.InstallDynakube(builder, &secretConfigs[1], appDynakube)
 	builder.Assess("storage size has not increased", diskUsageDoesNotIncrease(appDynakube.Namespace, storageMap))
@@ -127,7 +127,7 @@ func codeModulesAppInjectSpec() *dynatracev1beta1.AppInjectionSpec {
 	}
 }
 
-func imageHasBeenDownloaded(namespace string, secret tenant.Secret) features.Func {
+func imageHasBeenDownloaded(namespace string) features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
 		resource := environmentConfig.Client().Resources()
 		clientset, err := kubernetes.NewForConfig(resource.GetConfig())


### PR DESCRIPTION
# Description

Some logic was changed during the status rework, where the provisioner would not set the version field in the database in case codeModulesImage was used, which caused the server to be unable to know that it can mount stuff, when imageDigest is present.

Related to the same change the e2e log check is not correct as we no longer log the tag of the downloaded image, but the whole repo:tag@digest (if the image was provided via a tag)

## How can this be tested?
run `make test/e2e/cloudnative`

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

