### PR TITLE
Add a CLEANUP option for the e2e tests

### DIFF
--- a/hack/e2e/run_all.sh
+++ b/hack/e2e/run_all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-tests=$(make help | grep -oE "test\/e2e\/\S*")
+tests=$(make help | grep -oE "test\/e2e\/\S*" | grep -v "%\/debug")
 result=0
 for test in $tests
 do

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -1,40 +1,44 @@
+## Start a test and skip TEARDOWN steps if it fails
+test/e2e/%/debug:
+	@make SKIPCLEANUP="-args --fail-fast" $(@D)
+
 ## Runs e2e tests
 test/e2e:
 	./hack/e2e/run_all.sh
 
 ## Runs ActiveGate e2e test only
 test/e2e/activegate: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/activegate/basic
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/activegate/basic $(SKIPCLEANUP)
 
 ## Runs ActiveGate proxy e2e test only
 test/e2e/activegate/proxy: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/activegate/proxy
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/activegate/proxy $(SKIPCLEANUP)
 
 ## Runs CloudNative e2e test only
 test/e2e/cloudnative: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 30m -count=1 ./test/scenarios/cloudnative/basic
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 30m -count=1 ./test/scenarios/cloudnative/basic $(SKIPCLEANUP)
 
 ## Runs ClassicFullStack e2e test only
 ## TODO: rename after proper implementation of cleanup step
 test/e2e/zz_classic: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/classic
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/classic $(SKIPCLEANUP)
 
 ## Runs CloudNative istio e2e test only
 test/e2e/cloudnative/istio: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/cloudnative/istio
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/cloudnative/istio $(SKIPCLEANUP)
 
 ## Runs CloudNative proxy e2e test only
 test/e2e/cloudnative/proxy: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/cloudnative/proxy
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/cloudnative/proxy $(SKIPCLEANUP)
 
 ## Runs CloudNative network problem e2e test only
 test/e2e/cloudnative/network: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/cloudnative/network
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/cloudnative/network $(SKIPCLEANUP)
 
 ## Runs Application Monitoring e2e test only
 test/e2e/applicationmonitoring: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/applicationmonitoring
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/applicationmonitoring $(SKIPCLEANUP)
 
 ## Runs SupportArchive e2e test only
 test/e2e/supportarchive: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/support_archive
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/support_archive $(SKIPCLEANUP)

--- a/test/helpers/kubeobjects/environment/environment.go
+++ b/test/helpers/kubeobjects/environment/environment.go
@@ -24,6 +24,8 @@ func Get() env.Environment {
 	}
 
 	kubeConfigPath := conf.ResolveKubeConfigFile()
-	envConfig := envconf.NewWithKubeConfig(kubeConfigPath)
+
+	cfg, _ := envconf.NewFromFlags()
+	envConfig := cfg.WithKubeconfigFile(kubeConfigPath)
 	return env.NewWithConfig(envConfig)
 }


### PR DESCRIPTION
# Description

Added `test/e2e/%/debug` target to start a test and skip `teardown` steps if it fails. The `--fail-fast` flag is appended to the test command arguments if `debug` target is used.

The `%/debug` target is ignored by the `run_all.sh` script.

## How can this be tested?
Launch any e2e test in the debug mode and manually remove operator deployment
```
terminal 1: make test/e2e/cloudnative/debug
`=== RUN   TestActiveGate/activegate-capabilities/operator_started`
terminal 2: kubectl -n dynatrace delete deployment.apps/dynatrace-operator 
```
The test will fail but `service/dynatrace-webhook`, `deployment.apps/dynatrace-webhook` should exist.


## Checklist
~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

