### PR TITLE
Avoid panic when generating certificates for conversion webhook

### DIFF
--- a/src/controllers/certificates/certificate_secret.go
+++ b/src/controllers/certificates/certificate_secret.go
@@ -104,7 +104,8 @@ func (certSecret *certificateSecret) areWebhookConfigsValid(configs []*admission
 }
 
 func (certSecret *certificateSecret) isCRDConversionValid(conversion *apiextensionv1.CustomResourceConversion) bool {
-	return certSecret.isBundleValid(conversion.Webhook.ClientConfig.CABundle)
+	return conversion != nil && (conversion.Strategy == apiextensionv1.NoneConverter ||
+		conversion.Strategy == apiextensionv1.WebhookConverter && conversion.Webhook != nil && conversion.Webhook.ClientConfig != nil && certSecret.isBundleValid(conversion.Webhook.ClientConfig.CABundle))
 }
 
 func (certSecret *certificateSecret) isBundleValid(bundle []byte) bool {

--- a/src/controllers/certificates/certificate_secret_test.go
+++ b/src/controllers/certificates/certificate_secret_test.go
@@ -2,8 +2,9 @@ package certificates
 
 import (
 	"context"
-	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"testing"
+
+	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"

--- a/src/controllers/certificates/certificate_secret_test.go
+++ b/src/controllers/certificates/certificate_secret_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/stretchr/testify/assert"
@@ -13,6 +11,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
# Description
Currently if the CRD has no ClientConfig or the whole conversion section in the CRD was empty, the operator panicked, because of a nil pointer error. This should be solved with properly checking if the values, which are accessed inside `isBundleValid()` are set

## How can this be tested?
Deploy a CRD with an empty ClientConfig section
Start the operator and check if the cert-controller is still panicking


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

