### PR TITLE
Bump sigstore/cosign to v2.0.0 in /.github/actions/sign-image (sigstore/cosign-installer from v2.8.1 to v3.0.1)

### DIFF
--- a/.github/actions/sign-image/action.yaml
+++ b/.github/actions/sign-image/action.yaml
@@ -28,4 +28,3 @@ runs:
       run: cosign sign ${TAGS}
       env:
         TAGS: ${{ inputs.image }}
-        COSIGN_EXPERIMENTAL: "true"

--- a/.github/actions/sign-image/action.yaml
+++ b/.github/actions/sign-image/action.yaml
@@ -14,17 +14,17 @@ runs:
   using: "composite"
   steps:
     - name: Install Cosign
-      uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
+      uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65 # v3.0.1
     - name: Sign image with a key
       shell: bash
       run: |
-        cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+        cosign sign -y --key env://COSIGN_PRIVATE_KEY ${TAGS}
       env:
         TAGS: ${{ inputs.image }}
         COSIGN_PRIVATE_KEY: ${{ inputs.signing-key }}
         COSIGN_PASSWORD: ${{ inputs.signing-password }}
     - name: Sign the images with GitHub OIDC Token
       shell: bash
-      run: cosign sign ${TAGS}
+      run: cosign sign -y ${TAGS}
       env:
         TAGS: ${{ inputs.image }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -55,6 +55,8 @@ jobs:
     environment: Release
     needs: [prepare, build]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       matrix:
         platform: [amd64, arm64]
@@ -134,6 +136,8 @@ jobs:
     environment: Release
     needs: [prepare, push]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       matrix:
         registry: [gcr, dockerhub]


### PR DESCRIPTION
# Description

`COSIGN_EXPERIMENTAL` flag removed and additionally `cosign` version bumped to v2.0. Changes must be made in  one go because the flag changes behavior of the command and just removing the flag would break the pipeline. Additionally new arguments and permissions are needed: 
- new arguments: `-y`
- new permissions: `id-token: write`


## How can this be tested?
I tested the changes using my forked project.

## Checklist
~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

