### PR TITLE
Fixes e2e networking related tests for openshift

### DIFF
--- a/test/helpers/istio/install.go
+++ b/test/helpers/istio/install.go
@@ -5,14 +5,18 @@ package istio
 import (
 	"context"
 	"os"
+	"path"
 	"strings"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/istio"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/manifests"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
+	"github.com/Dynatrace/dynatrace-operator/test/project"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,22 +25,40 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
 const (
-	istioNamespace         = "istio-system"
-	istioInitContainerName = "istio-init"
-	enforceIstioEnv        = "ENFORCE_ISTIO"
+	istioNamespace                  = "istio-system"
+	istioInitContainerName          = "istio-init"
+	openshiftIstioInitContainerName = "istio-validation"
+	enforceIstioEnv                 = "ENFORCE_ISTIO"
 )
 
 var InjectionLabel = map[string]string{
 	"istio-injection": "enabled",
 }
 
+var networkAttachmentPath = path.Join(project.TestDataDir(), "network/ocp-istio-cni.yaml")
+
 func enforceIstio() bool {
 	return os.Getenv(enforceIstioEnv) == "true"
+}
+
+func AddIstioNetworkAttachment(namespace corev1.Namespace) func(ctx context.Context, environmentConfig *envconf.Config, t *testing.T) (context.Context, error) {
+	return func(ctx context.Context, environmentConfig *envconf.Config, t *testing.T) (context.Context, error) {
+		if kubeobjects.ResolvePlatformFromEnv() != kubeobjects.Openshift {
+			return ctx, nil
+		}
+		for key, value := range InjectionLabel {
+			if namespace.Labels[key] == value {
+				ctx = manifests.InstallFromFile(networkAttachmentPath, decoder.MutateNamespace(namespace.Name))(ctx, t, environmentConfig)
+			}
+		}
+		return ctx, nil
+	}
 }
 
 func AssertIstioNamespace() func(ctx context.Context, environmentConfig *envconf.Config, t *testing.T) (context.Context, error) {
@@ -91,6 +113,10 @@ func checkOperatorIstioInitContainers(testDynakube dynatracev1beta1.DynaKube) fe
 }
 
 func assertIstioInitContainer(t *testing.T, pods corev1.PodList, testDynakube dynatracev1beta1.DynaKube) {
+	istioInitName := istioInitContainerName
+	if kubeobjects.ResolvePlatformFromEnv() == kubeobjects.Openshift {
+		istioInitName = openshiftIstioInitContainerName
+	}
 	for _, podItem := range pods.Items {
 		if podItem.DeletionTimestamp != nil {
 			continue
@@ -108,12 +134,12 @@ func assertIstioInitContainer(t *testing.T, pods corev1.PodList, testDynakube dy
 		istioInitFound := false
 
 		for _, initContainer := range podItem.Spec.InitContainers {
-			if initContainer.Name == istioInitContainerName {
+			if initContainer.Name == istioInitName {
 				istioInitFound = true
 				break
 			}
 		}
-		assert.True(t, istioInitFound, "'%s' pod - '%s' init container not found", podItem.Name, istioInitContainerName)
+		assert.True(t, istioInitFound, "'%s' pod - '%s' init container not found", podItem.Name, istioInitName)
 	}
 }
 

--- a/test/helpers/kubeobjects/namespace/namespace.go
+++ b/test/helpers/kubeobjects/namespace/namespace.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/istio"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -82,6 +83,8 @@ func Create(namespace corev1.Namespace) features.Func {
 			}
 			require.NoError(t, err)
 		}
+
+		ctx, _ = istio.AddIstioNetworkAttachment(namespace)(ctx, environmentConfig, t)
 		return ctx
 	}
 }

--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/manifests"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
@@ -27,14 +28,18 @@ var (
 	sampleNamespaceNetworkPolicy = path.Join(project.TestDataDir(), "network/sample-ns-denial.yaml")
 
 	proxyDeploymentPath = path.Join(project.TestDataDir(), "network/proxy.yaml")
+	proxySCCPath = path.Join(project.TestDataDir(), "network/proxy-scc.yaml")
 
 	ProxySpec = &dynatracev1beta1.DynaKubeProxy{
-		Value: "http://squid.proxy:3128",
+		Value: "http://squid.proxy.svc.cluster.local:3128",
 	}
 )
 
 func SetupProxyWithTeardown(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {
 	if testDynakube.Spec.Proxy != nil {
+		if kubeobjects.ResolvePlatformFromEnv() == kubeobjects.Openshift {
+			builder.Assess("install proxy scc", manifests.InstallFromFile(proxySCCPath))
+		}
 		builder.Assess("create proxy namespace", namespace.Create(namespace.NewBuilder(proxyNamespaceName).Build()))
 		builder.Assess("install proxy", manifests.InstallFromFile(proxyDeploymentPath))
 		builder.Assess("proxy started", deployment.WaitFor(proxyDeploymentName, proxyNamespaceName))

--- a/test/helpers/sampleapps/deployment.go
+++ b/test/helpers/sampleapps/deployment.go
@@ -10,6 +10,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,7 +25,7 @@ type SampleDeployment struct {
 	sampleApp
 }
 
-func NewSampleDeployment(t *testing.T, testDynakube dynatracev1beta1.DynaKube) SampleApp {
+func NewSampleDeployment(t *testing.T, testDynakube dynatracev1beta1.DynaKube) sampleapps.SampleApp {
 	return &SampleDeployment{
 		sampleApp: *newSampleApp(t, testDynakube),
 	}

--- a/test/helpers/sampleapps/interface/sampleapp.go
+++ b/test/helpers/sampleapps/interface/sampleapp.go
@@ -1,0 +1,37 @@
+//go:build e2e
+
+package sampleapps
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+type SampleApp interface {
+	Name() string
+	ContainerName() string
+	Namespace() *corev1.Namespace
+
+	WithName(name string)
+	WithNamespace(namespace corev1.Namespace)
+	WithAnnotations(annotations map[string]string)
+	WithLabels(labels map[string]string)
+	WithEnvs(envs []corev1.EnvVar)
+	Build() client.Object
+
+	Install() features.Func
+	Uninstall() features.Func
+	Restart(ctx context.Context, t *testing.T, config *envconf.Config) context.Context
+	RestartHalf(ctx context.Context, t *testing.T, config *envconf.Config) context.Context
+	UninstallNamespace() features.Func
+
+	Get(ctx context.Context, t *testing.T, resource *resources.Resources) client.Object
+	GetPods(ctx context.Context, t *testing.T, resource *resources.Resources) corev1.PodList
+}
+

--- a/test/helpers/sampleapps/pod.go
+++ b/test/helpers/sampleapps/pod.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +21,7 @@ type SamplePod struct {
 	sampleApp
 }
 
-func NewSamplePod(t *testing.T, testDynakube dynatracev1beta1.DynaKube) SampleApp {
+func NewSamplePod(t *testing.T, testDynakube dynatracev1beta1.DynaKube) sampleapps.SampleApp {
 	return &SamplePod{
 		sampleApp: *newSampleApp(t, testDynakube),
 	}

--- a/test/helpers/sampleapps/sampleapp.go
+++ b/test/helpers/sampleapps/sampleapp.go
@@ -33,28 +33,6 @@ var (
 	sccPath             = path.Join(project.TestDataDir(), "sample-app/restricted-csi.yaml")
 )
 
-type SampleApp interface {
-	Name() string
-	ContainerName() string
-	Namespace() *corev1.Namespace
-
-	WithName(name string)
-	WithNamespace(namespace corev1.Namespace)
-	WithAnnotations(annotations map[string]string)
-	WithLabels(labels map[string]string)
-	WithEnvs(envs []corev1.EnvVar)
-	Build() client.Object
-
-	Install() features.Func
-	Uninstall() features.Func
-	Restart(ctx context.Context, t *testing.T, config *envconf.Config) context.Context
-	RestartHalf(ctx context.Context, t *testing.T, config *envconf.Config) context.Context
-	UninstallNamespace() features.Func
-
-	Get(ctx context.Context, t *testing.T, resource *resources.Resources) client.Object
-	GetPods(ctx context.Context, t *testing.T, resource *resources.Resources) corev1.PodList
-}
-
 type restartFunc func(t *testing.T, ctx context.Context, pods corev1.PodList, resource *resources.Resources)
 
 type sampleApp struct {

--- a/test/scenarios/applicationmonitoring/dataingest.go
+++ b/test/scenarios/applicationmonitoring/dataingest.go
@@ -15,7 +15,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	sample "github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/assess"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/teardown"
@@ -48,12 +49,12 @@ func dataIngest(t *testing.T) features.Feature {
 			UseCSIDriver: address.Of(false),
 		}).Build()
 
-	sampleDeployment := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleDeployment := sample.NewSampleDeployment(t, testDynakube)
 	sampleDeployment.WithAnnotations(map[string]string{
 		webhook.AnnotationOneAgentInject:   "false",
 		webhook.AnnotationDataIngestInject: "true",
 	})
-	samplePod := sampleapps.NewSamplePod(t, testDynakube)
+	samplePod := sample.NewSamplePod(t, testDynakube)
 	samplePod.WithAnnotations(map[string]string{
 		webhook.AnnotationOneAgentInject:   "false",
 		webhook.AnnotationDataIngestInject: "true",

--- a/test/scenarios/applicationmonitoring/labelversiondetection.go
+++ b/test/scenarios/applicationmonitoring/labelversiondetection.go
@@ -13,7 +13,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	sample "github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/assess"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/teardown"
@@ -240,7 +241,7 @@ func buildDisabledBuildLabelNamespace(testDynakube dynatracev1beta1.DynaKube) co
 }
 
 func buildDisabledBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta1.DynaKube) sampleapps.SampleApp {
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleApp := sample.NewSampleDeployment(t, testDynakube)
 	sampleApp.WithNamespace(buildDisabledBuildLabelNamespace(testDynakube))
 	return sampleApp
 }
@@ -250,7 +251,7 @@ func buildDefaultBuildLabelNamespace(testDynakube dynatracev1beta1.DynaKube) cor
 }
 
 func buildDefaultBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta1.DynaKube) sampleapps.SampleApp {
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleApp := sample.NewSampleDeployment(t, testDynakube)
 	sampleApp.WithNamespace(buildDefaultBuildLabelNamespace(testDynakube))
 	sampleApp.WithLabels(map[string]string{
 		"app.kubernetes.io/version": "app-kubernetes-io-version",
@@ -274,7 +275,7 @@ func buildCustomBuildLabelNamespace(testDynakube dynatracev1beta1.DynaKube) core
 }
 
 func buildCustomBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta1.DynaKube) sampleapps.SampleApp {
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleApp := sample.NewSampleDeployment(t, testDynakube)
 	sampleApp.WithNamespace(buildCustomBuildLabelNamespace(testDynakube))
 	sampleApp.WithLabels(map[string]string{
 		"app.kubernetes.io/version": "app-kubernetes-io-version",
@@ -298,7 +299,7 @@ func buildPreservedBuildLabelNamespace(testDynakube dynatracev1beta1.DynaKube) c
 }
 
 func buildPreservedBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta1.DynaKube) sampleapps.SampleApp {
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleApp := sample.NewSampleDeployment(t, testDynakube)
 	sampleApp.WithNamespace(buildPreservedBuildLabelNamespace(testDynakube))
 	sampleApp.WithLabels(map[string]string{
 		"app.kubernetes.io/version": "app-kubernetes-io-version",
@@ -358,7 +359,7 @@ func buildInvalidBuildLabelNamespace(testDynakube dynatracev1beta1.DynaKube) cor
 }
 
 func buildInvalidBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta1.DynaKube) sampleapps.SampleApp {
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleApp := sample.NewSampleDeployment(t, testDynakube)
 	sampleApp.WithNamespace(buildInvalidBuildLabelNamespace(testDynakube))
 	sampleApp.WithLabels(map[string]string{
 		"app.kubernetes.io/version": "app-kubernetes-io-version",

--- a/test/scenarios/classic/install.go
+++ b/test/scenarios/classic/install.go
@@ -9,7 +9,8 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
+	sample "github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/assess"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
@@ -28,7 +29,7 @@ func install(t *testing.T) features.Feature {
 		ClassicFullstack(&dynatracev1beta1.HostInjectSpec{}).
 		Build()
 
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleApp := sample.NewSampleDeployment(t, testDynakube)
 
 	// Register sample apps install and teardown
 	builder.Assess("install sample app", sampleApp.Install())

--- a/test/scenarios/cloudnative/basic/cloudnative_test.go
+++ b/test/scenarios/cloudnative/basic/cloudnative_test.go
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 
 func TestCloudNative(t *testing.T) {
 	testEnvironment.Test(t, cloudnative.Install(t, false))
-	testEnvironment.Test(t, cloudnative.Upgrade(t, false))
+	testEnvironment.Test(t, cloudnative.Upgrade(t))
 	testEnvironment.Test(t, cloudnative.CodeModules(t, false))
-	testEnvironment.Test(t, cloudnative.SpecificAgentVersion(t, false))
+	testEnvironment.Test(t, cloudnative.SpecificAgentVersion(t))
 }

--- a/test/scenarios/cloudnative/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules.go
@@ -21,7 +21,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/logs"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
+	sample "github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/assess"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/teardown"
@@ -82,7 +83,7 @@ func CodeModules(t *testing.T, istioEnabled bool) features.Feature {
 		namespaceBuilder = namespaceBuilder.WithLabels(istio.InjectionLabel)
 	}
 	sampleNamespace := namespaceBuilder.WithLabels(cloudNativeDynakube.NamespaceSelector().MatchLabels).Build()
-	sampleApp := sampleapps.NewSampleDeployment(t, cloudNativeDynakube)
+	sampleApp := sample.NewSampleDeployment(t, cloudNativeDynakube)
 	sampleApp.WithNamespace(sampleNamespace)
 
 	// Register operator install

--- a/test/scenarios/cloudnative/install.go
+++ b/test/scenarios/cloudnative/install.go
@@ -13,7 +13,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/logs"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
+	sample "github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/assess"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/teardown"
@@ -53,7 +54,7 @@ func Install(t *testing.T, istioEnabled bool) features.Feature {
 		namespaceBuilder = namespaceBuilder.WithLabels(istio.InjectionLabel)
 	}
 	sampleNamespace := namespaceBuilder.Build()
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleApp := sample.NewSampleDeployment(t, testDynakube)
 	sampleApp.WithNamespace(sampleNamespace)
 
 	// Register sample app install

--- a/test/scenarios/cloudnative/istio/cloudnative_test.go
+++ b/test/scenarios/cloudnative/istio/cloudnative_test.go
@@ -23,7 +23,5 @@ func TestMain(m *testing.M) {
 
 func TestCloudNative(t *testing.T) {
 	testEnvironment.Test(t, cloudnative.Install(t, true))
-	testEnvironment.Test(t, cloudnative.Upgrade(t, true))
 	testEnvironment.Test(t, cloudnative.CodeModules(t, true))
-	testEnvironment.Test(t, cloudnative.SpecificAgentVersion(t, true))
 }

--- a/test/scenarios/cloudnative/network_problems.go
+++ b/test/scenarios/cloudnative/network_problems.go
@@ -11,7 +11,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	sample"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/assess"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/teardown"
@@ -45,7 +46,7 @@ func NetworkProblems(t *testing.T) features.Feature {
 
 	namespaceBuilder := namespace.NewBuilder("network-problem-sample")
 	sampleNamespace := namespaceBuilder.Build()
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleApp := sample.NewSampleDeployment(t, testDynakube)
 	sampleApp.WithNamespace(sampleNamespace)
 
 	// Register operator install

--- a/test/scenarios/cloudnative/proxy/proxy.go
+++ b/test/scenarios/cloudnative/proxy/proxy.go
@@ -12,7 +12,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/proxy"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
+	sample "github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/assess"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/teardown"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
@@ -41,7 +42,7 @@ func withProxy(t *testing.T, proxySpec *dynatracev1beta1.DynaKubeProxy) features
 		Build()
 
 	sampleNamespace := namespace.NewBuilder("proxy-sample").WithLabels(testDynakube.NamespaceSelector().MatchLabels).Build()
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleApp := sample.NewSampleDeployment(t, testDynakube)
 	sampleApp.WithLabels(testDynakube.NamespaceSelector().MatchLabels)
 	sampleApp.WithNamespace(sampleNamespace)
 

--- a/test/scenarios/cloudnative/specific_agent_version.go
+++ b/test/scenarios/cloudnative/specific_agent_version.go
@@ -15,7 +15,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/webhook"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	sample "github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/interface"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/assess"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/teardown"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
@@ -29,7 +30,7 @@ import (
 
 const agentVersion = "VERSION"
 
-func SpecificAgentVersion(t *testing.T, istioEnabled bool) features.Feature {
+func SpecificAgentVersion(t *testing.T) features.Feature {
 	builder := features.New("cloudnative with specific agent version")
 	secretConfig := tenant.GetSingleTenantSecret(t)
 
@@ -42,12 +43,9 @@ func SpecificAgentVersion(t *testing.T, istioEnabled bool) features.Feature {
 		WithDynakubeNamespaceSelector().
 		ApiUrl(secretConfig.ApiUrl).
 		CloudNativeWithAgentVersion(defaultCloudNativeSpec(), oldVersion)
-	if istioEnabled {
-		dynakubeBuilder = dynakubeBuilder.WithIstio()
-	}
 	testDynakube := dynakubeBuilder.Build()
 	sampleNamespace := namespace.NewBuilder("specific-agent-sample").WithLabels(testDynakube.NamespaceSelector().MatchLabels).Build()
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
+	sampleApp := sample.NewSampleDeployment(t, testDynakube)
 	sampleApp.WithNamespace(sampleNamespace)
 
 	// Register sample app install

--- a/test/scenarios/cloudnative/upgrade.go
+++ b/test/scenarios/cloudnative/upgrade.go
@@ -14,16 +14,13 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-func Upgrade(t *testing.T, istioEnabled bool) features.Feature {
+func Upgrade(t *testing.T) features.Feature {
 	builder := features.New("upgrade_installation")
 	secretConfig := tenant.GetSingleTenantSecret(t)
 	dynakubeBuilder := dynakube.NewBuilder().
 		WithDefaultObjectMeta().
 		ApiUrl(secretConfig.ApiUrl).
 		CloudNative(defaultCloudNativeSpec())
-	if istioEnabled {
-		dynakubeBuilder = dynakubeBuilder.WithIstio()
-	}
 	testDynakube := dynakubeBuilder.Build()
 
 	sampleNamespace := namespace.NewBuilder("upgrade-sample").Build()
@@ -40,7 +37,6 @@ func Upgrade(t *testing.T, istioEnabled bool) features.Feature {
 	assess.UpgradeOperatorFromSource(builder, testDynakube)
 	assessSampleAppsRestartHalf(builder, sampleApp)
 	assessSampleInitContainers(builder, sampleApp)
-
 	builder.Teardown(sampleApp.UninstallNamespace())
 	teardown.UninstallDynatrace(builder, testDynakube)
 

--- a/test/testdata/network/dynatrace-denial.yaml
+++ b/test/testdata/network/dynatrace-denial.yaml
@@ -7,4 +7,14 @@ spec:
   podSelector: {}
   policyTypes:
   - Egress
-  - Ingress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/8
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector: {}

--- a/test/testdata/network/ocp-istio-cni.yaml
+++ b/test/testdata/network/ocp-istio-cni.yaml
@@ -1,0 +1,4 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni

--- a/test/testdata/network/proxy-scc.yaml
+++ b/test/testdata/network/proxy-scc.yaml
@@ -1,0 +1,30 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: proxy
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+ - "*"
+allowedUnsafeSysctls:
+ - "*"
+priority: 1
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+users:
+  - system:serviceaccount:proxy:proxy
+volumes:
+- "*"

--- a/test/testdata/network/proxy.yaml
+++ b/test/testdata/network/proxy.yaml
@@ -4,6 +4,14 @@ metadata:
   name: proxy
   annotations:
     dynatrace.com/inject: "false"
+  labels:
+    app: squid
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: proxy
+  namespace: proxy
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -60,12 +68,19 @@ spec:
       labels:
         app: squid
     spec:
+      serviceAccountName: proxy
       containers:
       - image: ubuntu/squid
         name: squid
         volumeMounts:
           - mountPath: /etc/squid/
             name: config-volume
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+             - CAP_NET_RAW
+
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
# Description
 Currently some e2e tests fail (catastrophically, so they kill other tests aswell) specifically on openshift for several reasons:
 - the proxy that is used/deployed does not have a SCC, so it get restricted too much + `CAP_NET_RAW` capability is not granted by default on openshift
 - the `NetworkPolicy` used to deny egress to the internet from the dynatrace namespace is way to strict (it works on kubernetes, because by default nothing enforces the policy, not even istio)
 - For istio to work on openshift a certain resource must be created in each namespace using istio. (`NetworkAttachmentDefinition`) 
    - In order to do this in a nice way (when we create a namespace that has the istio injection + we are on openshift) I had to do a small reorg of the `sampleapps` package to avoid a circular dependency.
 - The istio initcontainer is named differently on openshift. 🤷  

## How can this be tested?
run `make PLATFORM="openshift" test/e2e`


## Checklist
- ~[x] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

