### PR TITLE
Add check for poddisruptionbudget

### DIFF
--- a/config/helm/chart/default/Chart.yaml
+++ b/config/helm/chart/default/Chart.yaml
@@ -20,7 +20,7 @@ home: https://www.dynatrace.com/
 type: application
 version: 0.0.0-snapshot
 appVersion: 0.0.0-snapshot
-kubeVersion: '>=1.21.0-0'
+kubeVersion: '>=1.19.0-0'
 maintainers:
 - name: 0sewa0
   email: marcell.sevcsik@dynatrace.com

--- a/config/helm/chart/default/templates/Common/webhook/poddisruptionbudget-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/poddisruptionbudget-webhook.yaml
@@ -1,6 +1,7 @@
 {{- include "dynatrace-operator.platformRequired" . }}
 {{ if and (.Values.webhook).highAvailability (eq (include "dynatrace-operator.partial" .) "false") }}
-apiVersion: policy/v1
+# v1 version supported since k8s 1.21
+apiVersion: {{ .Capabilities.APIVersions.Has "policy/v1" | ternary "policy/v1" "policy/v1beta1" }}
 kind: PodDisruptionBudget
 metadata:
   name: dynatrace-webhook


### PR DESCRIPTION
# Description

API versions of Kubernetes resources may change without underlying functionality changing. We want to apply the correct version of the resource depending on the resource that is available.

Currently the only version that changed since 1.19 is `PodDisruptionBudgets` - Version `v1` was added in k8s 1.21.

This PR adds a helm check to this version and sets the min kubernetes version to 1.19.

## How can this be tested?

- helm install can be done 
	- on 1.19
	- on 1.26 without problems
- `make install` always deploys version v1


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

