### PR TITLE
Update image tags in Dockerfile to use tag and digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN CGO_ENABLED=1 CGO_CFLAGS="-O2 -Wno-return-local-addr" \
     go build -tags "${GO_BUILD_TAGS}" -trimpath -ldflags="${GO_LINKER_ARGS}" \
     -o ./build/_output/bin/dynatrace-operator ./src/cmd/
 
-FROM registry.access.redhat.com/ubi9-micro:9.1.0@sha256:9fc815c51e62b33e4ff3225242ca2236ca4d6fcc3474e3b7e3004fea8924f8fd AS base
-FROM registry.access.redhat.com/ubi9:9.1.0@sha256:49124e4acd09c98927882760476d617a85f155cb45759aea56b2ab020563c4b8 AS dependency
+FROM registry.access.redhat.com/ubi9-micro:9.1.0 AS base
+FROM registry.access.redhat.com/ubi9:9.1.0 AS dependency
 RUN mkdir -p /tmp/rootfs-dependency
 COPY --from=base / /tmp/rootfs-dependency
 RUN dnf install --installroot /tmp/rootfs-dependency \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # setup build image
-FROM golang:1.20.3 AS go-base
+FROM golang:1.20.3@sha256:403f48633fb5ebd49f9a2b6ad6719f912df23dae44974a0c9445be331e72ff5e AS go-base
 RUN \
     --mount=type=cache,target=/var/cache/apt \
     apt-get update && apt-get install -y libbtrfs-dev libdevmapper-dev
@@ -19,8 +19,8 @@ RUN CGO_ENABLED=1 CGO_CFLAGS="-O2 -Wno-return-local-addr" \
     go build -tags "${GO_BUILD_TAGS}" -trimpath -ldflags="${GO_LINKER_ARGS}" \
     -o ./build/_output/bin/dynatrace-operator ./src/cmd/
 
-FROM registry.access.redhat.com/ubi9-micro:9.1.0 AS base
-FROM registry.access.redhat.com/ubi9:9.1.0 AS dependency
+FROM registry.access.redhat.com/ubi9-micro:9.1.0@sha256:9fc815c51e62b33e4ff3225242ca2236ca4d6fcc3474e3b7e3004fea8924f8fd AS base
+FROM registry.access.redhat.com/ubi9:9.1.0@sha256:49124e4acd09c98927882760476d617a85f155cb45759aea56b2ab020563c4b8 AS dependency
 RUN mkdir -p /tmp/rootfs-dependency
 COPY --from=base / /tmp/rootfs-dependency
 RUN dnf install --installroot /tmp/rootfs-dependency \
@@ -42,8 +42,8 @@ COPY --from=dependency /tmp/rootfs-dependency /
 COPY --from=operator-build /app/build/_output/bin /usr/local/bin
 
 # csi binaries
-COPY --from=registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0 /csi-node-driver-registrar /usr/local/bin
-COPY --from=registry.k8s.io/sig-storage/livenessprobe:v2.9.0 /livenessprobe /usr/local/bin
+COPY --from=registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0@sha256:4a4cae5118c4404e35d66059346b7fa0835d7e6319ff45ed73f4bba335cf5183 /csi-node-driver-registrar /usr/local/bin
+COPY --from=registry.k8s.io/sig-storage/livenessprobe:v2.9.0@sha256:2b10b24dafdc3ba94a03fc94d9df9941ca9d6a9207b927f5dfd21d59fbe05ba0 /livenessprobe /usr/local/bin
 
 COPY ./third_party_licenses /usr/share/dynatrace-operator/third_party_licenses
 COPY LICENSE /licenses/


### PR DESCRIPTION
# Description
 Currently we do not know if a dependency in the docker file has a newer image with the same tag or not, with this change, dependabot will care about notifying us and also open a PR is there is a new image for the same tag

## How can this be tested?
`make build` should run successfully


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

