### PR TITLE
Add digest to image signing

### DIFF
--- a/.github/actions/sign-image/action.yaml
+++ b/.github/actions/sign-image/action.yaml
@@ -18,13 +18,13 @@ runs:
     - name: Sign image with a key
       shell: bash
       run: |
-        cosign sign -y --key env://COSIGN_PRIVATE_KEY ${TAGS}
+        cosign sign -y --key env://COSIGN_PRIVATE_KEY ${IMAGE}
       env:
-        TAGS: ${{ inputs.image }}
+        IMAGE: ${{ inputs.image }}
         COSIGN_PRIVATE_KEY: ${{ inputs.signing-key }}
         COSIGN_PASSWORD: ${{ inputs.signing-password }}
     - name: Sign the images with GitHub OIDC Token
       shell: bash
-      run: cosign sign -y ${TAGS}
+      run: cosign sign -y ${IMAGE}
       env:
-        TAGS: ${{ inputs.image }}
+        IMAGE: ${{ inputs.image }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -89,10 +89,16 @@ jobs:
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{ matrix.url }}
           repository: ${{ secrets[matrix.repository] }}
+      - name: Get image digest
+        id: digest
+        env:
+          IMAGE: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}-${{ matrix.platform }}
+        run: |
+          hack/build/ci/get-image-digest.sh
       - name: Sign image for ${{matrix.registry}}
         uses: ./.github/actions/sign-image
         with:
-          image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}-${{ matrix.platform }}
+          image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}-${{ matrix.platform }}@${{steps.digest.outputs.digest}}
           signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
 

--- a/hack/build/ci/get-image-digest.sh
+++ b/hack/build/ci/get-image-digest.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+digest=$(skopeo inspect docker://"${IMAGE}" --format "{{.Digest}}")
+echo "digest=${digest}">> "$GITHUB_OUTPUT"
+


### PR DESCRIPTION
# Description
Adds an extra step for `publish-image` to get the digest of the published image and use that as well with cosign.

## How can this be tested?
I used cosign v2.0.1

I tested it on my fork by adding the new steps to the basic CI workflow so the signing also happens on pull-requests 
https://github.com/0sewa0/dynatrace-operator/pull/97/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR169-R182

Example successful run:
https://github.com/0sewa0/dynatrace-operator/actions/runs/4744096685/jobs/8424677189

## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

