### PR TITLE
Add safety check to prevent snapshot push from make command

### DIFF
--- a/hack/make/images.mk
+++ b/hack/make/images.mk
@@ -10,12 +10,17 @@ endif
 
 IMAGE_URI ?= "$(IMAGE):$(TAG)"
 
-## Pushes an ALREADY BUILT Operator image with a given IMAGE and TAG
-images/build:
-	./hack/build/build_image.sh "${IMAGE}" "${TAG}"
+ensure-tag-not-snapshot:
+ifeq ($(TAG), snapshot)
+	$(error "Image tag is snapshot, please set TAG to a valid tag")
+endif
 
 ## Builds an Operator image with a given IMAGE and TAG
-images/push:
+images/build: ensure-tag-not-snapshot
+	./hack/build/build_image.sh "${IMAGE}" "${TAG}"
+
+## Pushes an ALREADY BUILT Operator image with a given IMAGE and TAG
+images/push: ensure-tag-not-snapshot
 	./hack/build/push_image.sh "${IMAGE}" "${TAG}"
 
 images/build/push: images/build images/push


### PR DESCRIPTION
# Description

Currently its possible to run make build on the main branch, which pushes snapshot images to quay. 
This can cause interference with the e2e pipelines, as local builds do not support multi arch.

This PR adds a check to prevent accidental push of snapshot tags to the makefile.

## How can this be tested?

`make build` - should fail when on main branch (however, setting the tag manually works)

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

