### PR TITLE
Fix disappearing init container incase of nil resources

### DIFF
--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -27,23 +27,23 @@ func createInstallInitContainerBase(webhookImage, clusterID string, pod *corev1.
 			{Name: config.K8sNodeNameEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("spec.nodeName")},
 		},
 		SecurityContext: securityContextForInitContainer(pod),
-		Resources:       *initContainerResources(dynakube),
+		Resources:       initContainerResources(dynakube),
 	}
 }
 
-func initContainerResources(dynakube dynatracev1beta1.DynaKube) *corev1.ResourceRequirements {
+func initContainerResources(dynakube dynatracev1beta1.DynaKube) corev1.ResourceRequirements {
 	customInitResources := dynakube.InitResources()
 	if customInitResources != nil {
-		return customInitResources
+		return *customInitResources
 	}
 	if !dynakube.NeedsCSIDriver() {
-		return nil
+		return corev1.ResourceRequirements{}
 	}
 	return defaultInitContainerResources()
 }
 
-func defaultInitContainerResources() *corev1.ResourceRequirements {
-	return &corev1.ResourceRequirements{
+func defaultInitContainerResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
 		Requests: kubeobjects.NewResources("30m", "30Mi"),
 		Limits:   kubeobjects.NewResources("100m", "60Mi"),
 	}

--- a/src/webhook/mutation/pod_mutator/init_container_test.go
+++ b/src/webhook/mutation/pod_mutator/init_container_test.go
@@ -202,7 +202,7 @@ func TestInitContainerResources(t *testing.T) {
 		initResources := initContainerResources(*dynakube)
 
 		require.NotNil(t, initResources)
-		assert.Equal(t, *defaultInitContainerResources(), *initResources)
+		assert.Equal(t, defaultInitContainerResources(), initResources)
 	})
 
 	t.Run("should return custom if set in dynakube", func(t *testing.T) {
@@ -211,7 +211,7 @@ func TestInitContainerResources(t *testing.T) {
 		initResources := initContainerResources(*dynakube)
 
 		require.NotNil(t, initResources)
-		assert.Equal(t, testResourceRequirements, *initResources)
+		assert.Equal(t, testResourceRequirements, initResources)
 	})
 
 	t.Run("should ignore if csi not used", func(t *testing.T) {
@@ -219,6 +219,6 @@ func TestInitContainerResources(t *testing.T) {
 
 		initResources := initContainerResources(*dynakube)
 
-		require.Nil(t, initResources)
+		require.Empty(t, initResources)
 	})
 }


### PR DESCRIPTION
# Description
When the initResources are nil then you basically do a `*nil` which causes the webhook to crash. (the webhook itself does not crash, but it will fail to do the injection)

## How can this be tested?
run `make test/e2e/applicationmonitoring`

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

