### PR TITLE
Avoid updates of indirect go dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,13 @@
       "matchManagers": ["gomod"],
       "commitMessagePrefix": "Go:",
       "enabled": true,
-      "allowedVersions": "/^v[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
+      "allowedVersions": "/^v[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$/",
+      "postUpdateOptions": [ "gomodTidy" ]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
     },
     {
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,7 @@
     {
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
-      "enabled": true
+      "enabled": false
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
# Description
Updates renovate pod config to avoid updates indirect dependencies

## How can this be tested?
Can't be tested directly, Observe incoming renovate PRs.

## Checklist
- [n/a] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

