### PR TITLE
Limit k8s.io/client-go to v0.x.y

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,6 +34,10 @@
     {
       "matchUpdateTypes": ["digest", "pin", "pinDigest"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["k8s.io/client-go"],
+      "allowedVersions": "< 1.0"
     }
   ]
 }


### PR DESCRIPTION
# Description
For k8s.io/client.go the use of v0.x.y is recommended for K8S >= 1.17.


## How can this be tested?
Check created PRs

## Checklist
- [n/a] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

