### PR TITLE
Revert digest usage for tenant-registry images

### DIFF
--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -91,7 +91,11 @@ func (statefulSetBuilder Builder) addLabels(sts *appsv1.StatefulSet) {
 }
 
 func (statefulSetBuilder Builder) buildAppLabels() *kubeobjects.AppLabels {
-	return kubeobjects.NewAppLabels(kubeobjects.ActiveGateComponentLabel, statefulSetBuilder.dynakube.Name, statefulSetBuilder.capability.ShortName(), "")
+	version := statefulSetBuilder.dynakube.Status.Synthetic.Version
+	if version == "" {
+		version = statefulSetBuilder.dynakube.Status.ActiveGate.Version
+	}
+	return kubeobjects.NewAppLabels(kubeobjects.ActiveGateComponentLabel, statefulSetBuilder.dynakube.Name, statefulSetBuilder.capability.ShortName(), version)
 }
 
 func (statefulSetBuilder Builder) addUserAnnotations(sts *appsv1.StatefulSet) {

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -67,7 +67,7 @@ func NewDynaKubeController(kubeClient client.Client, apiReader client.Reader, sc
 		config:                 config,
 		operatorNamespace:      os.Getenv(kubeobjects.EnvPodNamespace),
 		clusterID:              clusterID,
-		digestProvider:         version.GetImageDigest,
+		digestProvider:         version.GetImageVersion,
 	}
 }
 
@@ -91,7 +91,7 @@ type Controller struct {
 	config                 *rest.Config
 	operatorNamespace      string
 	clusterID              string
-	digestProvider         version.ImageDigestFunc
+	digestProvider         version.ImageVersionFunc
 }
 
 // Reconcile reads that state of the cluster for a DynaKube object and makes changes based on the state read

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -67,7 +67,7 @@ func NewDynaKubeController(kubeClient client.Client, apiReader client.Reader, sc
 		config:                 config,
 		operatorNamespace:      os.Getenv(kubeobjects.EnvPodNamespace),
 		clusterID:              clusterID,
-		digestProvider:         version.GetImageVersion,
+		versionProvider:        version.GetImageVersion,
 	}
 }
 
@@ -91,7 +91,7 @@ type Controller struct {
 	config                 *rest.Config
 	operatorNamespace      string
 	clusterID              string
-	digestProvider         version.ImageVersionFunc
+	versionProvider        version.ImageVersionFunc
 }
 
 // Reconcile reads that state of the cluster for a DynaKube object and makes changes based on the state read
@@ -238,7 +238,7 @@ func (controller *Controller) reconcileDynaKube(ctx context.Context, dynakube *d
 		controller.apiReader,
 		dynatraceClient,
 		controller.fs,
-		controller.digestProvider,
+		controller.versionProvider,
 		timeprovider.New(),
 	)
 	err = versionReconciler.Reconcile(ctx)

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dynatraceclient"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/token"
+	dkVersion "github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/version"
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
@@ -18,7 +19,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/src/version"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/src/webhook"
-	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -661,8 +661,8 @@ func createDTMockClient(paasTokenScopes, apiTokenScopes dtclient.TokenScopes) *d
 	return mockClient
 }
 
-func fakeDigestProvider(context.Context, string, *dockerconfig.DockerConfig) (digest.Digest, error) {
-	return "", nil
+func fakeDigestProvider(context.Context, string, *dockerconfig.DockerConfig) (dkVersion.ImageVersion, error) {
+	return dkVersion.ImageVersion{}, nil
 }
 
 func createFakeClientAndReconciler(mockClient dtclient.Client, instance *dynatracev1beta1.DynaKube, paasToken, apiToken string) *Controller {

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -697,7 +697,7 @@ func createFakeClientAndReconciler(mockClient dtclient.Client, instance *dynatra
 		scheme:                 scheme.Scheme,
 		dynatraceClientBuilder: mockDtcBuilder,
 		fs:                     afero.Afero{Fs: afero.NewMemMapFs()},
-		digestProvider:         fakeDigestProvider,
+		versionProvider:        fakeDigestProvider,
 	}
 
 	return controller

--- a/src/controllers/dynakube/version/activegate.go
+++ b/src/controllers/dynakube/version/activegate.go
@@ -11,13 +11,13 @@ import (
 type activeGateUpdater struct {
 	dynakube   *dynatracev1beta1.DynaKube
 	dtClient   dtclient.Client
-	digestFunc ImageDigestFunc
+	digestFunc ImageVersionFunc
 }
 
 func newActiveGateUpdater(
 	dynakube *dynatracev1beta1.DynaKube,
 	dtClient dtclient.Client,
-	digestFunc ImageDigestFunc,
+	digestFunc ImageVersionFunc,
 ) *activeGateUpdater {
 	return &activeGateUpdater{
 		dynakube:   dynakube,
@@ -62,8 +62,7 @@ func (updater *activeGateUpdater) CheckForDowngrade(latestVersion string) (bool,
 	return false, nil
 }
 
-func (updater *activeGateUpdater) UseDefaults(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
-	updater.Target().ImageID = updater.dynakube.DefaultActiveGateImage()
-	updater.Target().Version = ""
-	return nil
+func (updater *activeGateUpdater) UseTenantRegistry(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
+	defaultImage := updater.dynakube.DefaultActiveGateImage()
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
 }

--- a/src/controllers/dynakube/version/activegate.go
+++ b/src/controllers/dynakube/version/activegate.go
@@ -63,6 +63,7 @@ func (updater *activeGateUpdater) CheckForDowngrade(latestVersion string) (bool,
 }
 
 func (updater *activeGateUpdater) UseDefaults(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
-	defaultImage := updater.dynakube.DefaultActiveGateImage()
-	return updateVersionStatus(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
+	updater.Target().ImageID = updater.dynakube.DefaultActiveGateImage()
+	updater.Target().Version = ""
+	return nil
 }

--- a/src/controllers/dynakube/version/activegate.go
+++ b/src/controllers/dynakube/version/activegate.go
@@ -9,20 +9,20 @@ import (
 )
 
 type activeGateUpdater struct {
-	dynakube   *dynatracev1beta1.DynaKube
-	dtClient   dtclient.Client
-	digestFunc ImageVersionFunc
+	dynakube    *dynatracev1beta1.DynaKube
+	dtClient    dtclient.Client
+	versionFunc ImageVersionFunc
 }
 
 func newActiveGateUpdater(
 	dynakube *dynatracev1beta1.DynaKube,
 	dtClient dtclient.Client,
-	digestFunc ImageVersionFunc,
+	versionFunc ImageVersionFunc,
 ) *activeGateUpdater {
 	return &activeGateUpdater{
-		dynakube:   dynakube,
-		dtClient:   dtClient,
-		digestFunc: digestFunc,
+		dynakube:    dynakube,
+		dtClient:    dtClient,
+		versionFunc: versionFunc,
 	}
 }
 
@@ -64,5 +64,5 @@ func (updater *activeGateUpdater) CheckForDowngrade(latestVersion string) (bool,
 
 func (updater *activeGateUpdater) UseTenantRegistry(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
 	defaultImage := updater.dynakube.DefaultActiveGateImage()
-	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg)
 }

--- a/src/controllers/dynakube/version/activegate_test.go
+++ b/src/controllers/dynakube/version/activegate_test.go
@@ -68,12 +68,18 @@ func TestActiveGateUseDefault(t *testing.T) {
 			},
 		}
 		expectedImage := dynakube.DefaultActiveGateImage()
+		expectedVersion := "1.2.3"
 		mockClient := &dtclient.MockDynatraceClient{}
-		updater := newActiveGateUpdater(dynakube, mockClient, nil)
+		registry := newFakeRegistry(map[string]ImageVersion{
+			expectedImage: {
+				Version: expectedVersion,
+			},
+		})
+		updater := newActiveGateUpdater(dynakube, mockClient, registry.ImageVersionExt)
 
-		err := updater.UseDefaults(context.TODO(), &dockerconfig.DockerConfig{})
+		err := updater.UseTenantRegistry(context.TODO(), &dockerconfig.DockerConfig{})
 		require.NoError(t, err)
 		assert.Equal(t, expectedImage, dynakube.Status.ActiveGate.ImageID)
-		assert.Empty(t, dynakube.Status.ActiveGate.Version)
+		assert.Equal(t, expectedVersion, dynakube.Status.ActiveGate.Version)
 	})
 }

--- a/src/controllers/dynakube/version/activegate_test.go
+++ b/src/controllers/dynakube/version/activegate_test.go
@@ -69,12 +69,11 @@ func TestActiveGateUseDefault(t *testing.T) {
 		}
 		expectedImage := dynakube.DefaultActiveGateImage()
 		mockClient := &dtclient.MockDynatraceClient{}
-		registry := newFakeRegistryForImages(expectedImage)
-		updater := newActiveGateUpdater(dynakube, mockClient, registry.ImageVersionExt)
+		updater := newActiveGateUpdater(dynakube, mockClient, nil)
 
 		err := updater.UseDefaults(context.TODO(), &dockerconfig.DockerConfig{})
 		require.NoError(t, err)
-		assertVersionStatusEquals(t, registry, getTaggedReference(t, expectedImage), dynakube.Status.ActiveGate.VersionStatus)
+		assert.Equal(t, expectedImage, dynakube.Status.ActiveGate.ImageID)
 		assert.Empty(t, dynakube.Status.ActiveGate.Version)
 	})
 }

--- a/src/controllers/dynakube/version/codemodules.go
+++ b/src/controllers/dynakube/version/codemodules.go
@@ -56,7 +56,7 @@ func (updater *codeModulesUpdater) CheckForDowngrade(latestVersion string) (bool
 	return false, nil
 }
 
-func (updater *codeModulesUpdater) UseDefaults(_ context.Context, _ *dockerconfig.DockerConfig) error {
+func (updater *codeModulesUpdater) UseTenantRegistry(_ context.Context, _ *dockerconfig.DockerConfig) error {
 	customVersion := updater.CustomVersion()
 	if customVersion != "" {
 		updater.dynakube.Status.CodeModules = dynatracev1beta1.CodeModulesStatus{

--- a/src/controllers/dynakube/version/codemodules_test.go
+++ b/src/controllers/dynakube/version/codemodules_test.go
@@ -64,7 +64,7 @@ func TestCodeModulesUseDefault(t *testing.T) {
 		mockClient := &dtclient.MockDynatraceClient{}
 		updater := newCodeModulesUpdater(dynakube, mockClient)
 
-		err := updater.UseDefaults(ctx, nil)
+		err := updater.UseTenantRegistry(ctx, nil)
 		require.NoError(t, err)
 		assertDefaultCodeModulesStatus(t, testVersion, dynakube.Status.CodeModules)
 	})
@@ -83,7 +83,7 @@ func TestCodeModulesUseDefault(t *testing.T) {
 		mockLatestAgentVersion(mockClient, testVersion)
 		updater := newCodeModulesUpdater(dynakube, mockClient)
 
-		err := updater.UseDefaults(ctx, nil)
+		err := updater.UseTenantRegistry(ctx, nil)
 		require.NoError(t, err)
 		assertDefaultCodeModulesStatus(t, testVersion, dynakube.Status.CodeModules)
 	})

--- a/src/controllers/dynakube/version/image_hash.go
+++ b/src/controllers/dynakube/version/image_hash.go
@@ -5,46 +5,71 @@ import (
 	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
-	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
-// ImageDigestFunc can fetch image information from img
-type ImageDigestFunc func(ctx context.Context, imageName string, dockerConfig *dockerconfig.DockerConfig) (digest.Digest, error)
+const (
+	// VersionLabel is the name of the label used on ActiveGate-provided images.
+	VersionLabel = "com.dynatrace.build-version"
+)
 
-var _ ImageDigestFunc = GetImageDigest
+type ImageVersion struct {
+	Version string
+	Hash    string
+}
 
-// GetImageDigest fetches image information for imageName
-func GetImageDigest(ctx context.Context, imageName string, dockerConfig *dockerconfig.DockerConfig) (digest.Digest, error) {
+// ImageVersionFunc can fetch image information from img
+type ImageVersionFunc func(ctx context.Context, imageName string, dockerConfig *dockerconfig.DockerConfig) (ImageVersion, error)
+
+var _ ImageVersionFunc = GetImageVersion
+
+// GetImageVersion fetches image information for imageName
+func GetImageVersion(ctx context.Context, imageName string, dockerConfig *dockerconfig.DockerConfig) (ImageVersion, error) {
 	transportImageName := fmt.Sprintf("docker://%s", imageName)
 
 	imageReference, err := alltransports.ParseImageName(transportImageName)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return ImageVersion{}, errors.WithStack(err)
 	}
 
 	systemContext := dockerconfig.MakeSystemContext(imageReference.DockerReference(), dockerConfig)
 
-	imageSource, err := imageReference.NewImageSource(ctx, systemContext)
+	imageSource, err := imageReference.NewImageSource(context.TODO(), systemContext)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return ImageVersion{}, errors.WithStack(err)
 	}
 	defer closeImageSource(imageSource)
 
-	imageManifest, _, err := imageSource.GetManifest(ctx, nil)
+	imageManifest, _, err := imageSource.GetManifest(context.TODO(), nil)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return ImageVersion{}, errors.WithStack(err)
 	}
 
 	digest, err := manifest.Digest(imageManifest)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return ImageVersion{}, errors.WithStack(err)
 	}
 
-	return digest, nil
+	sourceImage, err := image.FromUnparsedImage(context.TODO(), systemContext, image.UnparsedInstance(imageSource, nil))
+	if err != nil {
+		return ImageVersion{}, errors.WithStack(err)
+	}
+
+	inspectedImage, err := sourceImage.Inspect(context.TODO())
+	if err != nil {
+		return ImageVersion{}, errors.WithStack(err)
+	} else if inspectedImage == nil {
+		return ImageVersion{}, errors.Errorf("could not inspect image: '%s'", transportImageName)
+	}
+
+	return ImageVersion{
+		Hash:    digest.Encoded(),
+		Version: inspectedImage.Labels[VersionLabel], // empty if unset
+	}, nil
 }
 
 func closeImageSource(source types.ImageSource) {

--- a/src/controllers/dynakube/version/image_hash.go
+++ b/src/controllers/dynakube/version/image_hash.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -19,7 +20,7 @@ const (
 
 type ImageVersion struct {
 	Version string
-	Hash    string
+	Digest  digest.Digest
 }
 
 // ImageVersionFunc can fetch image information from img
@@ -67,7 +68,7 @@ func GetImageVersion(ctx context.Context, imageName string, dockerConfig *docker
 	}
 
 	return ImageVersion{
-		Hash:    digest.Encoded(),
+		Digest:  digest,
 		Version: inspectedImage.Labels[VersionLabel], // empty if unset
 	}, nil
 }

--- a/src/controllers/dynakube/version/image_hash_test.go
+++ b/src/controllers/dynakube/version/image_hash_test.go
@@ -47,5 +47,5 @@ func assertVersionStatusEquals(t *testing.T, registry *fakeRegistry, imageRef re
 	expectedDigest, err := registry.ImageVersion(imageRef.String())
 
 	assert.NoError(t, err, "Image version is unexpectedly unknown for '%s'", imageRef.String())
-	assert.Contains(t, versionStatus.ImageID, expectedDigest.Hash)
+	assert.Contains(t, versionStatus.ImageID, expectedDigest.Digest)
 }

--- a/src/controllers/dynakube/version/image_hash_test.go
+++ b/src/controllers/dynakube/version/image_hash_test.go
@@ -8,50 +8,33 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
 	"github.com/containers/image/v5/docker/reference"
-	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 )
 
 type fakeRegistry struct {
-	imageHashes map[string]string
+	imageVersions map[string]ImageVersion
 }
 
 func newEmptyFakeRegistry() *fakeRegistry {
-	return newFakeRegistry(make(map[string]string))
+	return newFakeRegistry(make(map[string]ImageVersion))
 }
 
-func newFakeRegistryForImages(images ...string) *fakeRegistry {
-	registryMap := make(map[string]string, len(images))
-	for i, imageInfo := range images {
-		registryMap[imageInfo] = fmt.Sprintf("hash-%d", i)
-	}
-	return newFakeRegistry(registryMap)
-}
-
-func newFakeRegistry(src map[string]string) *fakeRegistry {
+func newFakeRegistry(src map[string]ImageVersion) *fakeRegistry {
 	reg := fakeRegistry{
-		imageHashes: make(map[string]string),
-	}
-	for key, val := range src {
-		reg.setHash(key, val)
+		imageVersions: src,
 	}
 	return &reg
 }
 
-func (registry *fakeRegistry) setHash(imagePath, hash string) *fakeRegistry {
-	registry.imageHashes[imagePath] = hash
-	return registry
-}
-
-func (registry *fakeRegistry) ImageVersion(imagePath string) (digest.Digest, error) {
-	if version, exists := registry.imageHashes[imagePath]; !exists {
-		return "", fmt.Errorf(`cannot provide version for image: "%s"`, imagePath)
+func (registry *fakeRegistry) ImageVersion(imagePath string) (ImageVersion, error) {
+	if version, exists := registry.imageVersions[imagePath]; !exists {
+		return ImageVersion{}, fmt.Errorf(`cannot provide version for image: "%s"`, imagePath)
 	} else {
-		return digest.NewDigestFromBytes(digest.SHA256, []byte(imagePath+":"+version)), nil
+		return version, nil
 	}
 }
 
-func (registry *fakeRegistry) ImageVersionExt(_ context.Context, imagePath string, _ *dockerconfig.DockerConfig) (digest.Digest, error) {
+func (registry *fakeRegistry) ImageVersionExt(_ context.Context, imagePath string, _ *dockerconfig.DockerConfig) (ImageVersion, error) {
 	return registry.ImageVersion(imagePath)
 }
 
@@ -64,5 +47,5 @@ func assertVersionStatusEquals(t *testing.T, registry *fakeRegistry, imageRef re
 	expectedDigest, err := registry.ImageVersion(imageRef.String())
 
 	assert.NoError(t, err, "Image version is unexpectedly unknown for '%s'", imageRef.String())
-	assert.Contains(t, versionStatus.ImageID, expectedDigest.String())
+	assert.Contains(t, versionStatus.ImageID, expectedDigest.Hash)
 }

--- a/src/controllers/dynakube/version/oneagent.go
+++ b/src/controllers/dynakube/version/oneagent.go
@@ -73,12 +73,7 @@ func (updater *oneAgentUpdater) UseDefaults(ctx context.Context, dockerCfg *dock
 		return err
 	}
 
-	defaultImage := updater.dynakube.DefaultOneAgentImage()
-	err = updateVersionStatus(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
-	if err != nil {
-		return err
-	}
-
+	updater.Target().ImageID = updater.dynakube.DefaultOneAgentImage()
 	updater.Target().Version = latestVersion
 
 	return nil

--- a/src/controllers/dynakube/version/oneagent.go
+++ b/src/controllers/dynakube/version/oneagent.go
@@ -9,20 +9,20 @@ import (
 )
 
 type oneAgentUpdater struct {
-	dynakube   *dynatracev1beta1.DynaKube
-	dtClient   dtclient.Client
-	digestFunc ImageVersionFunc
+	dynakube    *dynatracev1beta1.DynaKube
+	dtClient    dtclient.Client
+	versionFunc ImageVersionFunc
 }
 
 func newOneAgentUpdater(
 	dynakube *dynatracev1beta1.DynaKube,
 	dtClient dtclient.Client,
-	digestFunc ImageVersionFunc,
+	versionFunc ImageVersionFunc,
 ) *oneAgentUpdater {
 	return &oneAgentUpdater{
-		dynakube:   dynakube,
-		dtClient:   dtClient,
-		digestFunc: digestFunc,
+		dynakube:    dynakube,
+		dtClient:    dtClient,
+		versionFunc: versionFunc,
 	}
 }
 
@@ -74,7 +74,7 @@ func (updater *oneAgentUpdater) UseTenantRegistry(ctx context.Context, dockerCfg
 	}
 
 	defaultImage := updater.dynakube.DefaultOneAgentImage()
-	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg)
 }
 
 func (updater *oneAgentUpdater) CheckForDowngrade(latestVersion string) (bool, error) {

--- a/src/controllers/dynakube/version/oneagent_test.go
+++ b/src/controllers/dynakube/version/oneagent_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
-	"github.com/containers/image/v5/docker/reference"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,7 +67,7 @@ func TestOneAgentUseDefault(t *testing.T) {
 		err := updater.UseDefaults(context.TODO(), &dockerconfig.DockerConfig{})
 
 		require.NoError(t, err)
-		assertDefaultOneAgentStatus(t, registry, getTaggedReference(t, expectedImage), testVersion, dynakube.Status.OneAgent.VersionStatus)
+		assertStatusBasedOnTenantRegistry(t, expectedImage, testVersion, dynakube.Status.OneAgent.VersionStatus)
 	})
 	t.Run("Set according to default", func(t *testing.T) {
 		dynakube := &dynatracev1beta1.DynaKube{
@@ -89,7 +88,7 @@ func TestOneAgentUseDefault(t *testing.T) {
 		err := updater.UseDefaults(context.TODO(), &dockerconfig.DockerConfig{})
 
 		require.NoError(t, err)
-		assertDefaultOneAgentStatus(t, registry, getTaggedReference(t, expectedImage), testVersion, dynakube.Status.OneAgent.VersionStatus)
+		assertStatusBasedOnTenantRegistry(t, expectedImage, testVersion, dynakube.Status.OneAgent.VersionStatus)
 	})
 	t.Run("Don't allow downgrades", func(t *testing.T) {
 		dynakube := &dynatracev1beta1.DynaKube{
@@ -200,7 +199,7 @@ func TestCheckForDowngrade(t *testing.T) {
 	}
 }
 
-func assertDefaultOneAgentStatus(t *testing.T, registry *fakeRegistry, imageRef reference.NamedTagged, expectedVersion string, versionStatus dynatracev1beta1.VersionStatus) { //nolint:revive // argument-limit
-	assertVersionStatusEquals(t, registry, imageRef, versionStatus)
+func assertStatusBasedOnTenantRegistry(t *testing.T, expectedImage, expectedVersion string, versionStatus dynatracev1beta1.VersionStatus) { //nolint:revive // argument-limit
+	assert.Equal(t, expectedImage, versionStatus.ImageID)
 	assert.Equal(t, expectedVersion, versionStatus.Version)
 }

--- a/src/controllers/dynakube/version/oneagent_test.go
+++ b/src/controllers/dynakube/version/oneagent_test.go
@@ -47,7 +47,7 @@ func TestOneAgentUpdater(t *testing.T) {
 
 func TestOneAgentUseDefault(t *testing.T) {
 	testVersion := "1.2.3"
-	testHash := "sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f"
+	testDigest := getTestDigest()
 	t.Run("Set according to version field", func(t *testing.T) {
 		dynakube := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
@@ -63,7 +63,7 @@ func TestOneAgentUseDefault(t *testing.T) {
 		registry := newFakeRegistry(map[string]ImageVersion{
 			expectedImage: {
 				Version: testVersion,
-				Hash:    testHash,
+				Digest:  testDigest,
 			},
 		})
 
@@ -88,7 +88,7 @@ func TestOneAgentUseDefault(t *testing.T) {
 		registry := newFakeRegistry(map[string]ImageVersion{
 			expectedImage: {
 				Version: testVersion,
-				Hash:    testHash,
+				Digest:  testDigest,
 			},
 		})
 
@@ -124,7 +124,7 @@ func TestOneAgentUseDefault(t *testing.T) {
 		registry := newFakeRegistry(map[string]ImageVersion{
 			expectedImage: {
 				Version: testVersion,
-				Hash:    testHash,
+				Digest:  testDigest,
 			},
 		})
 

--- a/src/controllers/dynakube/version/reconciler.go
+++ b/src/controllers/dynakube/version/reconciler.go
@@ -19,14 +19,14 @@ const (
 type Reconciler struct {
 	dynakube     *dynatracev1beta1.DynaKube
 	dtClient     dtclient.Client
-	digestFunc   ImageDigestFunc
+	digestFunc   ImageVersionFunc
 	timeProvider *timeprovider.Provider
 
 	fs        afero.Afero
 	apiReader client.Reader
 }
 
-func NewReconciler(dynakube *dynatracev1beta1.DynaKube, apiReader client.Reader, dtClient dtclient.Client, fs afero.Afero, digestProvider ImageDigestFunc, timeProvider *timeprovider.Provider) *Reconciler { //nolint:revive
+func NewReconciler(dynakube *dynatracev1beta1.DynaKube, apiReader client.Reader, dtClient dtclient.Client, fs afero.Afero, digestProvider ImageVersionFunc, timeProvider *timeprovider.Provider) *Reconciler { //nolint:revive
 	return &Reconciler{
 		dynakube:     dynakube,
 		apiReader:    apiReader,

--- a/src/controllers/dynakube/version/reconciler.go
+++ b/src/controllers/dynakube/version/reconciler.go
@@ -19,7 +19,7 @@ const (
 type Reconciler struct {
 	dynakube     *dynatracev1beta1.DynaKube
 	dtClient     dtclient.Client
-	digestFunc   ImageVersionFunc
+	versionFunc  ImageVersionFunc
 	timeProvider *timeprovider.Provider
 
 	fs        afero.Afero
@@ -31,7 +31,7 @@ func NewReconciler(dynakube *dynatracev1beta1.DynaKube, apiReader client.Reader,
 		dynakube:     dynakube,
 		apiReader:    apiReader,
 		fs:           fs,
-		digestFunc:   digestProvider,
+		versionFunc:  digestProvider,
 		timeProvider: timeProvider,
 		dtClient:     dtClient,
 	}
@@ -40,10 +40,10 @@ func NewReconciler(dynakube *dynatracev1beta1.DynaKube, apiReader client.Reader,
 // Reconcile updates the version status used by the dynakube
 func (reconciler *Reconciler) Reconcile(ctx context.Context) error {
 	updaters := []versionStatusUpdater{
-		newActiveGateUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.digestFunc),
-		newOneAgentUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.digestFunc),
+		newActiveGateUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.versionFunc),
+		newOneAgentUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.versionFunc),
 		newCodeModulesUpdater(reconciler.dynakube, reconciler.dtClient),
-		newSyntheticUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.digestFunc),
+		newSyntheticUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.versionFunc),
 	}
 
 	neededUpdaters := reconciler.needsReconcile(updaters)

--- a/src/controllers/dynakube/version/reconciler_test.go
+++ b/src/controllers/dynakube/version/reconciler_test.go
@@ -28,6 +28,9 @@ const (
 func TestReconcile(t *testing.T) {
 	ctx := context.Background()
 	latestAgentVersion := "1.2.3.4-5"
+	testOneAgentHash := "sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f"
+	testActiveGateHash := "sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d72f"
+	testCodeModulesHash := "sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d82f"
 
 	dynakubeTemplate := dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace},
@@ -67,7 +70,16 @@ func TestReconcile(t *testing.T) {
 		setupPullSecret(t, fakeClient, *dynakube)
 
 		dkStatus := &dynakube.Status
-		registry := newFakeRegistryForImages(testActiveGateImage.String(), testOneAgentImage.String())
+		registry := newFakeRegistry(map[string]ImageVersion{
+			dynakube.DefaultActiveGateImage(): {
+				Version: testActiveGateImage.Tag,
+				Hash:    testActiveGateHash,
+			},
+			dynakube.DefaultOneAgentImage(): {
+				Version: testOneAgentImage.Tag,
+				Hash:    testOneAgentHash,
+			},
+		})
 		mockClient := &dtclient.MockDynatraceClient{}
 		mockLatestAgentVersion(mockClient, latestAgentVersion)
 
@@ -81,9 +93,8 @@ func TestReconcile(t *testing.T) {
 		}
 		err := versionReconciler.Reconcile(ctx)
 		require.NoError(t, err)
-		assertStatusBasedOnTenantRegistry(t, testActiveGateImage.String(), "", dkStatus.ActiveGate.VersionStatus)
-		assertStatusBasedOnTenantRegistry(t, testOneAgentImage.String(), "1.2.3.4-5", dkStatus.OneAgent.VersionStatus)
-		assert.Equal(t, latestAgentVersion, dkStatus.OneAgent.VersionStatus.Version)
+		assertStatusBasedOnTenantRegistry(t, dynakube.DefaultActiveGateImage(), testActiveGateImage.Tag, dkStatus.ActiveGate.VersionStatus)
+		assertStatusBasedOnTenantRegistry(t, dynakube.DefaultOneAgentImage(), testOneAgentImage.Tag, dkStatus.OneAgent.VersionStatus)
 		assert.Equal(t, latestAgentVersion, dkStatus.CodeModules.VersionStatus.Version)
 
 		// no change if probe not old enough
@@ -109,7 +120,21 @@ func TestReconcile(t *testing.T) {
 		setupPullSecret(t, fakeClient, *dynakube)
 
 		dkStatus := &dynakube.Status
-		registry := newFakeRegistryForImages(testActiveGateImage.String(), testOneAgentImage.String(), testCodeModulesImage.String())
+
+		registry := newFakeRegistry(map[string]ImageVersion{
+			testActiveGateImage.String(): {
+				Version: testActiveGateImage.Tag,
+				Hash:    testActiveGateHash,
+			},
+			testOneAgentImage.String(): {
+				Version: testOneAgentImage.Tag,
+				Hash:    testOneAgentHash,
+			},
+			testCodeModulesImage.String(): {
+				Version: testCodeModulesImage.Tag,
+				Hash:    testCodeModulesHash,
+			},
+		})
 		mockClient := &dtclient.MockDynatraceClient{}
 		mockActiveGateImageInfo(mockClient, testActiveGateImage)
 		mockCodeModulesImageInfo(mockClient, testCodeModulesImage)
@@ -209,21 +234,21 @@ func TestNeedsUpdate(t *testing.T) {
 func getTestOneAgentImageInfo() dtclient.LatestImageInfo {
 	return dtclient.LatestImageInfo{
 		Source: testDockerRegistry + "/linux/oneagent",
-		Tag:    "latest",
+		Tag:    "1.2.3.4-5",
 	}
 }
 
 func getTestActiveGateImageInfo() dtclient.LatestImageInfo {
 	return dtclient.LatestImageInfo{
 		Source: testDockerRegistry + "/linux/activegate",
-		Tag:    "latest",
+		Tag:    "1.2.3.4-5",
 	}
 }
 
 func getTestCodeModulesImage() dtclient.LatestImageInfo {
 	return dtclient.LatestImageInfo{
 		Source: testDockerRegistry + "/linux/codemodules",
-		Tag:    "latest",
+		Tag:    "1.2.3.4-5",
 	}
 }
 

--- a/src/controllers/dynakube/version/reconciler_test.go
+++ b/src/controllers/dynakube/version/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/src/timeprovider"
+	"github.com/opencontainers/go-digest"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -28,9 +29,9 @@ const (
 func TestReconcile(t *testing.T) {
 	ctx := context.Background()
 	latestAgentVersion := "1.2.3.4-5"
-	testOneAgentHash := "sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f"
-	testActiveGateHash := "sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d72f"
-	testCodeModulesHash := "sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d82f"
+	testOneAgentHash := digest.FromString("sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f")
+	testActiveGateHash := digest.FromString("sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d72f")
+	testCodeModulesHash := digest.FromString("sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d82f")
 
 	dynakubeTemplate := dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace},
@@ -73,11 +74,11 @@ func TestReconcile(t *testing.T) {
 		registry := newFakeRegistry(map[string]ImageVersion{
 			dynakube.DefaultActiveGateImage(): {
 				Version: testActiveGateImage.Tag,
-				Hash:    testActiveGateHash,
+				Digest:  testActiveGateHash,
 			},
 			dynakube.DefaultOneAgentImage(): {
 				Version: testOneAgentImage.Tag,
-				Hash:    testOneAgentHash,
+				Digest:  testOneAgentHash,
 			},
 		})
 		mockClient := &dtclient.MockDynatraceClient{}
@@ -124,15 +125,15 @@ func TestReconcile(t *testing.T) {
 		registry := newFakeRegistry(map[string]ImageVersion{
 			testActiveGateImage.String(): {
 				Version: testActiveGateImage.Tag,
-				Hash:    testActiveGateHash,
+				Digest:  testActiveGateHash,
 			},
 			testOneAgentImage.String(): {
 				Version: testOneAgentImage.Tag,
-				Hash:    testOneAgentHash,
+				Digest:  testOneAgentHash,
 			},
 			testCodeModulesImage.String(): {
 				Version: testCodeModulesImage.Tag,
-				Hash:    testCodeModulesHash,
+				Digest:  testCodeModulesHash,
 			},
 		})
 		mockClient := &dtclient.MockDynatraceClient{}

--- a/src/controllers/dynakube/version/reconciler_test.go
+++ b/src/controllers/dynakube/version/reconciler_test.go
@@ -81,8 +81,8 @@ func TestReconcile(t *testing.T) {
 		}
 		err := versionReconciler.Reconcile(ctx)
 		require.NoError(t, err)
-		assertVersionStatusEquals(t, registry, getTaggedReference(t, testActiveGateImage.String()), dkStatus.ActiveGate.VersionStatus)
-		assertVersionStatusEquals(t, registry, getTaggedReference(t, testOneAgentImage.String()), dkStatus.OneAgent.VersionStatus)
+		assertStatusBasedOnTenantRegistry(t, testActiveGateImage.String(), "", dkStatus.ActiveGate.VersionStatus)
+		assertStatusBasedOnTenantRegistry(t, testOneAgentImage.String(), "1.2.3.4-5", dkStatus.OneAgent.VersionStatus)
 		assert.Equal(t, latestAgentVersion, dkStatus.OneAgent.VersionStatus.Version)
 		assert.Equal(t, latestAgentVersion, dkStatus.CodeModules.VersionStatus.Version)
 

--- a/src/controllers/dynakube/version/reconciler_test.go
+++ b/src/controllers/dynakube/version/reconciler_test.go
@@ -54,7 +54,7 @@ func TestReconcile(t *testing.T) {
 			dynakube:     dynakubeTemplate.DeepCopy(),
 			apiReader:    fake.NewClient(),
 			fs:           afero.Afero{Fs: afero.NewMemMapFs()},
-			digestFunc:   faultyRegistry.ImageVersionExt,
+			versionFunc:  faultyRegistry.ImageVersionExt,
 			timeProvider: timeprovider.New(),
 		}
 		err := versionReconciler.Reconcile(ctx)
@@ -87,7 +87,7 @@ func TestReconcile(t *testing.T) {
 			dynakube:     dynakube,
 			apiReader:    fakeClient,
 			fs:           afero.Afero{Fs: afero.NewMemMapFs()},
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 			timeProvider: timeProvider,
 			dtClient:     mockClient,
 		}
@@ -144,7 +144,7 @@ func TestReconcile(t *testing.T) {
 			dynakube:     dynakube,
 			apiReader:    fakeClient,
 			fs:           afero.Afero{Fs: afero.NewMemMapFs()},
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 			timeProvider: timeprovider.New(),
 			dtClient:     mockClient,
 		}

--- a/src/controllers/dynakube/version/synthetic.go
+++ b/src/controllers/dynakube/version/synthetic.go
@@ -10,20 +10,20 @@ import (
 )
 
 type syntheticUpdater struct {
-	dynakube   *dynatracev1beta1.DynaKube
-	dtClient   dtclient.Client
-	digestFunc ImageVersionFunc
+	dynakube    *dynatracev1beta1.DynaKube
+	dtClient    dtclient.Client
+	versionFunc ImageVersionFunc
 }
 
 func newSyntheticUpdater(
 	dynakube *dynatracev1beta1.DynaKube,
 	dtClient dtclient.Client,
-	digestFunc ImageVersionFunc,
+	versionFunc ImageVersionFunc,
 ) *syntheticUpdater {
 	return &syntheticUpdater{
-		dynakube:   dynakube,
-		dtClient:   dtClient,
-		digestFunc: digestFunc,
+		dynakube:    dynakube,
+		dtClient:    dtClient,
+		versionFunc: versionFunc,
 	}
 }
 
@@ -65,5 +65,5 @@ func (updater syntheticUpdater) CheckForDowngrade(latestVersion string) (bool, e
 
 func (updater *syntheticUpdater) UseTenantRegistry(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
 	defaultImage := updater.dynakube.DefaultSyntheticImage()
-	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg)
 }

--- a/src/controllers/dynakube/version/synthetic.go
+++ b/src/controllers/dynakube/version/synthetic.go
@@ -64,6 +64,7 @@ func (updater syntheticUpdater) CheckForDowngrade(latestVersion string) (bool, e
 }
 
 func (updater *syntheticUpdater) UseDefaults(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
-	defaultImage := updater.dynakube.DefaultSyntheticImage()
-	return updateVersionStatus(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
+	updater.Target().ImageID = updater.dynakube.DefaultSyntheticImage()
+	updater.Target().Version = ""
+	return nil
 }

--- a/src/controllers/dynakube/version/synthetic.go
+++ b/src/controllers/dynakube/version/synthetic.go
@@ -12,13 +12,13 @@ import (
 type syntheticUpdater struct {
 	dynakube   *dynatracev1beta1.DynaKube
 	dtClient   dtclient.Client
-	digestFunc ImageDigestFunc
+	digestFunc ImageVersionFunc
 }
 
 func newSyntheticUpdater(
 	dynakube *dynatracev1beta1.DynaKube,
 	dtClient dtclient.Client,
-	digestFunc ImageDigestFunc,
+	digestFunc ImageVersionFunc,
 ) *syntheticUpdater {
 	return &syntheticUpdater{
 		dynakube:   dynakube,
@@ -63,8 +63,7 @@ func (updater syntheticUpdater) CheckForDowngrade(latestVersion string) (bool, e
 	return false, nil
 }
 
-func (updater *syntheticUpdater) UseDefaults(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
-	updater.Target().ImageID = updater.dynakube.DefaultSyntheticImage()
-	updater.Target().Version = ""
-	return nil
+func (updater *syntheticUpdater) UseTenantRegistry(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
+	defaultImage := updater.dynakube.DefaultSyntheticImage()
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
 }

--- a/src/controllers/dynakube/version/synthetic_test.go
+++ b/src/controllers/dynakube/version/synthetic_test.go
@@ -37,7 +37,7 @@ func TestSyntheticUseDefaults(t *testing.T) {
 
 		err := updater.UseDefaults(context.TODO(), &dockerconfig.DockerConfig{})
 		require.NoError(t, err, "default image set")
-		assertVersionStatusEquals(t, registry, getTaggedReference(t, expectedImage), dynakube.Status.Synthetic.VersionStatus)
+		assertStatusBasedOnTenantRegistry(t, expectedImage, "", dynakube.Status.Synthetic.VersionStatus)
 		require.Empty(t, dynakube.Status.Synthetic.Version, "zero version reported")
 	})
 }

--- a/src/controllers/dynakube/version/synthetic_test.go
+++ b/src/controllers/dynakube/version/synthetic_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestSyntheticUseTenantRegistry(t *testing.T) {
 	testVersion := "1.2.3"
-	testHash := "sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f"
+	testHash := getTestDigest()
 	t.Run("default image specified", func(t *testing.T) {
 		dynakube := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -37,7 +37,7 @@ func TestSyntheticUseTenantRegistry(t *testing.T) {
 		registry := newFakeRegistry(map[string]ImageVersion{
 			expectedImage: {
 				Version: testVersion,
-				Hash:    testHash,
+				Digest:  testHash,
 			},
 		})
 		updater := newSyntheticUpdater(dynakube, mockClient, registry.ImageVersionExt)

--- a/src/controllers/dynakube/version/updater.go
+++ b/src/controllers/dynakube/version/updater.go
@@ -160,7 +160,7 @@ func updateVersionStatusForTenantRegistry(
 	if taggedRef, ok := ref.(reference.NamedTagged); ok {
 		imageVersion, err := imageVersionFunc(ctx, imageUri, dockerCfg)
 		if err != nil {
-			log.Error(err, "failed to get image digest, falling back to tag")
+			log.Error(err, "failed to determine image version, ignoring version")
 		}
 		target.ImageID = taggedRef.String()
 		target.Version = imageVersion.Version

--- a/src/controllers/dynakube/version/updater.go
+++ b/src/controllers/dynakube/version/updater.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/version"
 	"github.com/containers/image/v5/docker/reference"
-	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -119,7 +118,7 @@ func setImageIDWithDigest(
 			target.ImageID = taggedRef.String()
 			log.Error(err, "failed to get image digest, falling back to tag")
 		} else {
-			canonRef, err := reference.WithDigest(taggedRef, digest.Digest(imageVersion.Hash))
+			canonRef, err := reference.WithDigest(taggedRef, imageVersion.Digest)
 			if err != nil {
 				target.ImageID = taggedRef.String()
 				log.Error(err, "failed to create canonical image reference, falling back to tag")

--- a/src/controllers/dynakube/version/updater.go
+++ b/src/controllers/dynakube/version/updater.go
@@ -41,7 +41,7 @@ func (reconciler *Reconciler) run(ctx context.Context, updater versionStatusUpda
 	customImage := updater.CustomImage()
 	if customImage != "" {
 		log.Info("updating version status according to custom image", "updater", updater.Name())
-		err = setImageIDWithDigest(ctx, updater.Target(), customImage, reconciler.digestFunc, dockerCfg)
+		err = setImageIDWithDigest(ctx, updater.Target(), customImage, reconciler.versionFunc, dockerCfg)
 		return err
 	}
 
@@ -69,7 +69,7 @@ func (reconciler *Reconciler) run(ctx context.Context, updater versionStatusUpda
 			return err
 		}
 
-		err = setImageIDWithDigest(ctx, updater.Target(), publicImage.String(), reconciler.digestFunc, dockerCfg)
+		err = setImageIDWithDigest(ctx, updater.Target(), publicImage.String(), reconciler.versionFunc, dockerCfg)
 		if err != nil {
 			log.Info("could not update version status according to the public registry", "updater", updater.Name())
 			return err

--- a/src/controllers/dynakube/version/updater_test.go
+++ b/src/controllers/dynakube/version/updater_test.go
@@ -79,7 +79,7 @@ func TestRun(t *testing.T) {
 		versionReconciler := Reconciler{
 			dynakube:     &dynatracev1beta1.DynaKube{},
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newCustomImageUpdater(target, testImage.String())
 		err := versionReconciler.run(ctx, updater, testDockerCfg)
@@ -94,7 +94,7 @@ func TestRun(t *testing.T) {
 		versionReconciler := Reconciler{
 			dynakube:     &dynatracev1beta1.DynaKube{},
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newCustomImageUpdater(target, "incorrect-uri")
 		err := versionReconciler.run(ctx, updater, testDockerCfg)
@@ -108,7 +108,7 @@ func TestRun(t *testing.T) {
 		versionReconciler := Reconciler{
 			dynakube:     &dynatracev1beta1.DynaKube{},
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newDefaultUpdater(target, false)
 
@@ -147,7 +147,7 @@ func TestRun(t *testing.T) {
 		versionReconciler := Reconciler{
 			dynakube:     enablePublicRegistry(&dynatracev1beta1.DynaKube{}),
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newPublicRegistryUpdater(target, &testImage, false)
 		updater.On("IsClassicFullStackEnabled").Return(false)
@@ -174,7 +174,7 @@ func TestRun(t *testing.T) {
 		versionReconciler := Reconciler{
 			dynakube:     enablePublicRegistry(&dynatracev1beta1.DynaKube{}),
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newPublicRegistryUpdater(target, &testImage, false)
 		updater.On("IsClassicFullStackEnabled").Return(false)
@@ -200,7 +200,7 @@ func TestRun(t *testing.T) {
 		versionReconciler := Reconciler{
 			dynakube:     enablePublicRegistry(newClassicFullStackDynakube()),
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newClassicFullStackUpdater(target, false)
 		updater.On("CustomImage").Return("")
@@ -226,7 +226,7 @@ func TestRun(t *testing.T) {
 		versionReconciler := Reconciler{
 			dynakube:     enablePublicRegistry(newClassicFullStackDynakube()),
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newClassicFullStackUpdater(target, false)
 		updater.On("CustomImage").Return(testImage.String())

--- a/src/controllers/dynakube/version/updater_test.go
+++ b/src/controllers/dynakube/version/updater_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/timeprovider"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -437,4 +438,8 @@ func getTaggedReference(t *testing.T, image string) reference.NamedTagged {
 func assertStatusBasedOnTenantRegistry(t *testing.T, expectedImage, expectedVersion string, versionStatus dynatracev1beta1.VersionStatus) { //nolint:revive // argument-limit
 	assert.Equal(t, expectedImage, versionStatus.ImageID)
 	assert.Equal(t, expectedVersion, versionStatus.Version)
+}
+
+func getTestDigest() digest.Digest {
+	return digest.FromString("sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f")
 }


### PR DESCRIPTION
As the tenant-registry is not made to be used with digest, this change goes back to the previous solution of using the build-label on the images of the tenant-registry in order to determine the version, so we can update the oneagent/activegate when necessary.

## How can this be tested?
deploy oneagents/activegates
check if the `image` field only uses the tag, and check that the version label on the statefulset and daemonset is set.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

