### PR TITLE
Adds additional check for custom fields during version status creation

### DIFF
--- a/src/controllers/dynakube/version/reconciler.go
+++ b/src/controllers/dynakube/version/reconciler.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"context"
+	"strings"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
@@ -104,9 +105,35 @@ func (reconciler *Reconciler) needsUpdate(updater versionStatusUpdater) bool {
 		return true
 	}
 
+	if hasCustomFieldChanged(updater) {
+		return true
+	}
+
 	if !reconciler.timeProvider.IsOutdated(updater.Target().LastProbeTimestamp, reconciler.dynakube.FeatureApiRequestThreshold()) {
 		log.Info("status timestamp still valid, skipping version status updater", "updater", updater.Name())
 		return false
 	}
 	return true
+}
+
+func hasCustomFieldChanged(updater versionStatusUpdater) bool {
+	if updater.Target().Source == dynatracev1beta1.CustomImageVersionSource {
+		oldImage := updater.Target().ImageID
+		newImage := updater.CustomImage()
+		// The old image is can be the same as the new image (if only digest was given, or a tag was given but couldn't get the digest)
+		// or the old image is the same as the new image but with the digest added to the end of it (if a tag was provide, and we could append the digest to the end)
+		// or the 2 images are different
+		if !strings.Contains(oldImage, newImage) {
+			log.Info("custom image value changed, update for version status is needed", "updater", updater.Name(), "oldImage", oldImage, "newImage", newImage)
+			return true
+		}
+	} else if updater.Target().Source == dynatracev1beta1.CustomVersionVersionSource {
+		oldVersion := updater.Target().Version
+		newVersion := updater.CustomVersion()
+		if oldVersion != newVersion {
+			log.Info("custom version value changed, update for version status is needed", "updater", updater.Name(), "oldVersion", oldVersion, "newVersion", newVersion)
+			return true
+		}
+	}
+	return false
 }

--- a/src/controllers/dynakube/version/reconciler_test.go
+++ b/src/controllers/dynakube/version/reconciler_test.go
@@ -193,14 +193,22 @@ func TestNeedsUpdate(t *testing.T) {
 				ClassicFullStack: &dynatracev1beta1.HostInjectSpec{},
 			},
 		},
+		Status: dynatracev1beta1.DynaKubeStatus{
+			OneAgent: dynatracev1beta1.OneAgentStatus{
+				VersionStatus: dynatracev1beta1.VersionStatus{
+					Source: dynatracev1beta1.TenantRegistryVersionSource,
+				},
+			},
+		},
 	}
 
 	t.Run("needs", func(t *testing.T) {
+		updatedDynakube := dynakube.DeepCopy()
 		reconciler := Reconciler{
-			dynakube:     &dynakube,
+			dynakube:     updatedDynakube,
 			timeProvider: timeProvider,
 		}
-		assert.True(t, reconciler.needsUpdate(newOneAgentUpdater(&dynakube, nil, nil)))
+		assert.True(t, reconciler.needsUpdate(newOneAgentUpdater(updatedDynakube, nil, nil)))
 	})
 	t.Run("does not need", func(t *testing.T) {
 		reconciler := Reconciler{
@@ -210,8 +218,11 @@ func TestNeedsUpdate(t *testing.T) {
 		assert.False(t, reconciler.needsUpdate(newOneAgentUpdater(&dynatracev1beta1.DynaKube{}, nil, nil)))
 	})
 	t.Run("does not need, because not old enough", func(t *testing.T) {
+		oldImage := "repo.com:tag@sha256:123"
+		newImage := "repo.com:tag"
 		updatedDynakube := dynakube.DeepCopy()
-		updatedDynakube.Status.OneAgent.Source = dynatracev1beta1.TenantRegistryVersionSource
+		setOneAgentCustomImageStatus(updatedDynakube, oldImage)
+		updatedDynakube.Spec.OneAgent.ClassicFullStack.Image = newImage
 		updatedDynakube.Status.OneAgent.LastProbeTimestamp = timeProvider.Now()
 		reconciler := Reconciler{
 			dynakube:     updatedDynakube,
@@ -222,14 +233,94 @@ func TestNeedsUpdate(t *testing.T) {
 
 	t.Run("needs, because source changed", func(t *testing.T) {
 		updatedDynakube := dynakube.DeepCopy()
-		updatedDynakube.Status.OneAgent.Source = dynatracev1beta1.CustomImageVersionSource
-		updatedDynakube.Status.OneAgent.LastProbeTimestamp = timeProvider.Now()
+		setOneAgentCustomImageStatus(updatedDynakube, "")
 		reconciler := Reconciler{
 			dynakube:     updatedDynakube,
 			timeProvider: timeProvider,
 		}
 		assert.True(t, reconciler.needsUpdate(newOneAgentUpdater(updatedDynakube, nil, nil)))
 	})
+
+	t.Run("needs, because custom image changed", func(t *testing.T) {
+		oldImage := "repo.com:tag@sha256:123"
+		newImage := "repo.com:newTag"
+		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube.Spec.OneAgent.ClassicFullStack.Image = newImage
+		setOneAgentCustomImageStatus(updatedDynakube, oldImage)
+		reconciler := Reconciler{
+			dynakube:     updatedDynakube,
+			timeProvider: timeProvider,
+		}
+		assert.True(t, reconciler.needsUpdate(newOneAgentUpdater(updatedDynakube, nil, nil)))
+	})
+
+	t.Run("needs, because custom version changed", func(t *testing.T) {
+		oldVersion := "1.2.3"
+		newVersion := "2.4.5"
+		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube.Spec.OneAgent.ClassicFullStack.Version = newVersion
+		setOneAgentCustomVersionStatus(updatedDynakube, oldVersion)
+		reconciler := Reconciler{
+			dynakube:     updatedDynakube,
+			timeProvider: timeProvider,
+		}
+		assert.True(t, reconciler.needsUpdate(newOneAgentUpdater(updatedDynakube, nil, nil)))
+	})
+}
+
+func TestHasCustomFieldChanged(t *testing.T) {
+	dynakube := dynatracev1beta1.DynaKube{
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			OneAgent: dynatracev1beta1.OneAgentSpec{
+				ClassicFullStack: &dynatracev1beta1.HostInjectSpec{},
+			},
+		},
+	}
+
+	t.Run("version changed", func(t *testing.T) {
+		oldVersion := "1.2.3"
+		newVersion := "2.4.5"
+		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube.Spec.OneAgent.ClassicFullStack.Version = newVersion
+		setOneAgentCustomVersionStatus(updatedDynakube, oldVersion)
+		assert.True(t, hasCustomFieldChanged(newOneAgentUpdater(updatedDynakube, nil, nil)))
+	})
+
+	t.Run("no change; version", func(t *testing.T) {
+		version := "1.2.3"
+		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube.Spec.OneAgent.ClassicFullStack.Version = version
+		setOneAgentCustomVersionStatus(updatedDynakube, version)
+		assert.False(t, hasCustomFieldChanged(newOneAgentUpdater(updatedDynakube, nil, nil)))
+	})
+
+	t.Run("image changed", func(t *testing.T) {
+		oldImage := "repo.com:tag@sha256:123"
+		newImage := "repo.com:Tag"
+		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube.Spec.OneAgent.ClassicFullStack.Image = newImage
+		setOneAgentCustomImageStatus(updatedDynakube, oldImage)
+		assert.True(t, hasCustomFieldChanged(newOneAgentUpdater(updatedDynakube, nil, nil)))
+	})
+
+	t.Run("no change; image", func(t *testing.T) {
+		oldImage := "repo.com:tag@sha256:123"
+		newImage := "repo.com:tag"
+		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube.Spec.OneAgent.ClassicFullStack.Version = newImage
+		setOneAgentCustomImageStatus(updatedDynakube, oldImage)
+		assert.False(t, hasCustomFieldChanged(newOneAgentUpdater(updatedDynakube, nil, nil)))
+	})
+}
+
+func setOneAgentCustomVersionStatus(dynakube *dynatracev1beta1.DynaKube, version string) {
+	dynakube.Status.OneAgent.Source = dynatracev1beta1.CustomVersionVersionSource
+	dynakube.Status.OneAgent.Version = version
+}
+
+func setOneAgentCustomImageStatus(dynakube *dynatracev1beta1.DynaKube, image string) {
+	dynakube.Status.OneAgent.Source = dynatracev1beta1.CustomImageVersionSource
+	dynakube.Status.OneAgent.ImageID = image
 }
 
 func getTestOneAgentImageInfo() dtclient.LatestImageInfo {


### PR DESCRIPTION

Currently the behaviour of the oneAgent daemonset changes is a bit weird, as if you change a custom image in the DynaKube, the operator has a timeout of changing the dynakube status between 1-15 mins depending on when the last request was made. 

This is now improved by not only checking if the digest changed of the manifest we pull, but also check if the image/version value in the spec itself changed.
So now if the image/version in the `dynakube` spec changes, then we overrule the timestamp and update the version status earlier.

## How can this be tested?
1. Choose a mode where you can set `version`(example: applicationMonitoring) or `image` (example: classicFullstack).
2. Set the chosen custom field to a value that works.
3. Wait for the dynakube's status to update, (and also the resources to be deployed if applicable)
    - also make sure that it does not constantly update the version status for each reconcile, do this by checking the logs
4. Change the chosen custom field to another value 
5. Make sure that the dynakube's status to updates "instantly" (within a minute) to reflect the new custom value.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

