### PR TITLE
Revert digest usage for tenant-registry images (#1741)

### DIFF
--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -91,7 +91,11 @@ func (statefulSetBuilder Builder) addLabels(sts *appsv1.StatefulSet) {
 }
 
 func (statefulSetBuilder Builder) buildAppLabels() *kubeobjects.AppLabels {
-	return kubeobjects.NewAppLabels(kubeobjects.ActiveGateComponentLabel, statefulSetBuilder.dynakube.Name, statefulSetBuilder.capability.ShortName(), "")
+	version := statefulSetBuilder.dynakube.Status.Synthetic.Version
+	if version == "" {
+		version = statefulSetBuilder.dynakube.Status.ActiveGate.Version
+	}
+	return kubeobjects.NewAppLabels(kubeobjects.ActiveGateComponentLabel, statefulSetBuilder.dynakube.Name, statefulSetBuilder.capability.ShortName(), version)
 }
 
 func (statefulSetBuilder Builder) addUserAnnotations(sts *appsv1.StatefulSet) {

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -67,7 +67,7 @@ func NewDynaKubeController(kubeClient client.Client, apiReader client.Reader, sc
 		config:                 config,
 		operatorNamespace:      os.Getenv(kubeobjects.EnvPodNamespace),
 		clusterID:              clusterID,
-		digestProvider:         version.GetImageDigest,
+		versionProvider:        version.GetImageVersion,
 	}
 }
 
@@ -91,7 +91,7 @@ type Controller struct {
 	config                 *rest.Config
 	operatorNamespace      string
 	clusterID              string
-	digestProvider         version.ImageDigestFunc
+	versionProvider        version.ImageVersionFunc
 }
 
 // Reconcile reads that state of the cluster for a DynaKube object and makes changes based on the state read
@@ -234,7 +234,7 @@ func (controller *Controller) reconcileDynaKube(ctx context.Context, dynakube *d
 		controller.apiReader,
 		dynatraceClient,
 		controller.fs,
-		controller.digestProvider,
+		controller.versionProvider,
 		timeprovider.New(),
 	)
 	err = versionReconciler.Reconcile(ctx)

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dynatraceclient"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/token"
+	dkVersion "github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/version"
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
@@ -18,7 +19,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/src/version"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/src/webhook"
-	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -661,8 +661,8 @@ func createDTMockClient(paasTokenScopes, apiTokenScopes dtclient.TokenScopes) *d
 	return mockClient
 }
 
-func fakeDigestProvider(context.Context, string, *dockerconfig.DockerConfig) (digest.Digest, error) {
-	return "", nil
+func fakeDigestProvider(context.Context, string, *dockerconfig.DockerConfig) (dkVersion.ImageVersion, error) {
+	return dkVersion.ImageVersion{}, nil
 }
 
 func createFakeClientAndReconciler(mockClient dtclient.Client, instance *dynatracev1beta1.DynaKube, paasToken, apiToken string) *Controller {
@@ -697,7 +697,7 @@ func createFakeClientAndReconciler(mockClient dtclient.Client, instance *dynatra
 		scheme:                 scheme.Scheme,
 		dynatraceClientBuilder: mockDtcBuilder,
 		fs:                     afero.Afero{Fs: afero.NewMemMapFs()},
-		digestProvider:         fakeDigestProvider,
+		versionProvider:        fakeDigestProvider,
 	}
 
 	return controller

--- a/src/controllers/dynakube/version/activegate.go
+++ b/src/controllers/dynakube/version/activegate.go
@@ -9,20 +9,20 @@ import (
 )
 
 type activeGateUpdater struct {
-	dynakube   *dynatracev1beta1.DynaKube
-	dtClient   dtclient.Client
-	digestFunc ImageDigestFunc
+	dynakube    *dynatracev1beta1.DynaKube
+	dtClient    dtclient.Client
+	versionFunc ImageVersionFunc
 }
 
 func newActiveGateUpdater(
 	dynakube *dynatracev1beta1.DynaKube,
 	dtClient dtclient.Client,
-	digestFunc ImageDigestFunc,
+	versionFunc ImageVersionFunc,
 ) *activeGateUpdater {
 	return &activeGateUpdater{
-		dynakube:   dynakube,
-		dtClient:   dtClient,
-		digestFunc: digestFunc,
+		dynakube:    dynakube,
+		dtClient:    dtClient,
+		versionFunc: versionFunc,
 	}
 }
 
@@ -62,7 +62,7 @@ func (updater *activeGateUpdater) CheckForDowngrade(latestVersion string) (bool,
 	return false, nil
 }
 
-func (updater *activeGateUpdater) UseDefaults(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
+func (updater *activeGateUpdater) UseTenantRegistry(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
 	defaultImage := updater.dynakube.DefaultActiveGateImage()
-	return updateVersionStatus(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg)
 }

--- a/src/controllers/dynakube/version/activegate_test.go
+++ b/src/controllers/dynakube/version/activegate_test.go
@@ -68,13 +68,18 @@ func TestActiveGateUseDefault(t *testing.T) {
 			},
 		}
 		expectedImage := dynakube.DefaultActiveGateImage()
+		expectedVersion := "1.2.3"
 		mockClient := &dtclient.MockDynatraceClient{}
-		registry := newFakeRegistryForImages(expectedImage)
+		registry := newFakeRegistry(map[string]ImageVersion{
+			expectedImage: {
+				Version: expectedVersion,
+			},
+		})
 		updater := newActiveGateUpdater(dynakube, mockClient, registry.ImageVersionExt)
 
-		err := updater.UseDefaults(context.TODO(), &dockerconfig.DockerConfig{})
+		err := updater.UseTenantRegistry(context.TODO(), &dockerconfig.DockerConfig{})
 		require.NoError(t, err)
-		assertVersionStatusEquals(t, registry, getTaggedReference(t, expectedImage), dynakube.Status.ActiveGate.VersionStatus)
-		assert.Empty(t, dynakube.Status.ActiveGate.Version)
+		assert.Equal(t, expectedImage, dynakube.Status.ActiveGate.ImageID)
+		assert.Equal(t, expectedVersion, dynakube.Status.ActiveGate.Version)
 	})
 }

--- a/src/controllers/dynakube/version/codemodules.go
+++ b/src/controllers/dynakube/version/codemodules.go
@@ -56,7 +56,7 @@ func (updater *codeModulesUpdater) CheckForDowngrade(latestVersion string) (bool
 	return false, nil
 }
 
-func (updater *codeModulesUpdater) UseDefaults(_ context.Context, _ *dockerconfig.DockerConfig) error {
+func (updater *codeModulesUpdater) UseTenantRegistry(_ context.Context, _ *dockerconfig.DockerConfig) error {
 	customVersion := updater.CustomVersion()
 	if customVersion != "" {
 		updater.dynakube.Status.CodeModules = dynatracev1beta1.CodeModulesStatus{

--- a/src/controllers/dynakube/version/codemodules_test.go
+++ b/src/controllers/dynakube/version/codemodules_test.go
@@ -64,7 +64,7 @@ func TestCodeModulesUseDefault(t *testing.T) {
 		mockClient := &dtclient.MockDynatraceClient{}
 		updater := newCodeModulesUpdater(dynakube, mockClient)
 
-		err := updater.UseDefaults(ctx, nil)
+		err := updater.UseTenantRegistry(ctx, nil)
 		require.NoError(t, err)
 		assertDefaultCodeModulesStatus(t, testVersion, dynakube.Status.CodeModules)
 	})
@@ -83,7 +83,7 @@ func TestCodeModulesUseDefault(t *testing.T) {
 		mockLatestAgentVersion(mockClient, testVersion)
 		updater := newCodeModulesUpdater(dynakube, mockClient)
 
-		err := updater.UseDefaults(ctx, nil)
+		err := updater.UseTenantRegistry(ctx, nil)
 		require.NoError(t, err)
 		assertDefaultCodeModulesStatus(t, testVersion, dynakube.Status.CodeModules)
 	})

--- a/src/controllers/dynakube/version/image_hash.go
+++ b/src/controllers/dynakube/version/image_hash.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
@@ -12,39 +13,64 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ImageDigestFunc can fetch image information from img
-type ImageDigestFunc func(ctx context.Context, imageName string, dockerConfig *dockerconfig.DockerConfig) (digest.Digest, error)
+const (
+	// VersionLabel is the name of the label used on ActiveGate-provided images.
+	VersionLabel = "com.dynatrace.build-version"
+)
 
-var _ ImageDigestFunc = GetImageDigest
+type ImageVersion struct {
+	Version string
+	Digest  digest.Digest
+}
 
-// GetImageDigest fetches image information for imageName
-func GetImageDigest(ctx context.Context, imageName string, dockerConfig *dockerconfig.DockerConfig) (digest.Digest, error) {
+// ImageVersionFunc can fetch image information from img
+type ImageVersionFunc func(ctx context.Context, imageName string, dockerConfig *dockerconfig.DockerConfig) (ImageVersion, error)
+
+var _ ImageVersionFunc = GetImageVersion
+
+// GetImageVersion fetches image information for imageName
+func GetImageVersion(ctx context.Context, imageName string, dockerConfig *dockerconfig.DockerConfig) (ImageVersion, error) {
 	transportImageName := fmt.Sprintf("docker://%s", imageName)
 
 	imageReference, err := alltransports.ParseImageName(transportImageName)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return ImageVersion{}, errors.WithStack(err)
 	}
 
 	systemContext := dockerconfig.MakeSystemContext(imageReference.DockerReference(), dockerConfig)
 
-	imageSource, err := imageReference.NewImageSource(ctx, systemContext)
+	imageSource, err := imageReference.NewImageSource(context.TODO(), systemContext)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return ImageVersion{}, errors.WithStack(err)
 	}
 	defer closeImageSource(imageSource)
 
-	imageManifest, _, err := imageSource.GetManifest(ctx, nil)
+	imageManifest, _, err := imageSource.GetManifest(context.TODO(), nil)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return ImageVersion{}, errors.WithStack(err)
 	}
 
 	digest, err := manifest.Digest(imageManifest)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return ImageVersion{}, errors.WithStack(err)
 	}
 
-	return digest, nil
+	sourceImage, err := image.FromUnparsedImage(context.TODO(), systemContext, image.UnparsedInstance(imageSource, nil))
+	if err != nil {
+		return ImageVersion{}, errors.WithStack(err)
+	}
+
+	inspectedImage, err := sourceImage.Inspect(context.TODO())
+	if err != nil {
+		return ImageVersion{}, errors.WithStack(err)
+	} else if inspectedImage == nil {
+		return ImageVersion{}, errors.Errorf("could not inspect image: '%s'", transportImageName)
+	}
+
+	return ImageVersion{
+		Digest:  digest,
+		Version: inspectedImage.Labels[VersionLabel], // empty if unset
+	}, nil
 }
 
 func closeImageSource(source types.ImageSource) {

--- a/src/controllers/dynakube/version/image_hash_test.go
+++ b/src/controllers/dynakube/version/image_hash_test.go
@@ -8,50 +8,33 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/dockerconfig"
 	"github.com/containers/image/v5/docker/reference"
-	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 )
 
 type fakeRegistry struct {
-	imageHashes map[string]string
+	imageVersions map[string]ImageVersion
 }
 
 func newEmptyFakeRegistry() *fakeRegistry {
-	return newFakeRegistry(make(map[string]string))
+	return newFakeRegistry(make(map[string]ImageVersion))
 }
 
-func newFakeRegistryForImages(images ...string) *fakeRegistry {
-	registryMap := make(map[string]string, len(images))
-	for i, imageInfo := range images {
-		registryMap[imageInfo] = fmt.Sprintf("hash-%d", i)
-	}
-	return newFakeRegistry(registryMap)
-}
-
-func newFakeRegistry(src map[string]string) *fakeRegistry {
+func newFakeRegistry(src map[string]ImageVersion) *fakeRegistry {
 	reg := fakeRegistry{
-		imageHashes: make(map[string]string),
-	}
-	for key, val := range src {
-		reg.setHash(key, val)
+		imageVersions: src,
 	}
 	return &reg
 }
 
-func (registry *fakeRegistry) setHash(imagePath, hash string) *fakeRegistry {
-	registry.imageHashes[imagePath] = hash
-	return registry
-}
-
-func (registry *fakeRegistry) ImageVersion(imagePath string) (digest.Digest, error) {
-	if version, exists := registry.imageHashes[imagePath]; !exists {
-		return "", fmt.Errorf(`cannot provide version for image: "%s"`, imagePath)
+func (registry *fakeRegistry) ImageVersion(imagePath string) (ImageVersion, error) {
+	if version, exists := registry.imageVersions[imagePath]; !exists {
+		return ImageVersion{}, fmt.Errorf(`cannot provide version for image: "%s"`, imagePath)
 	} else {
-		return digest.NewDigestFromBytes(digest.SHA256, []byte(imagePath+":"+version)), nil
+		return version, nil
 	}
 }
 
-func (registry *fakeRegistry) ImageVersionExt(_ context.Context, imagePath string, _ *dockerconfig.DockerConfig) (digest.Digest, error) {
+func (registry *fakeRegistry) ImageVersionExt(_ context.Context, imagePath string, _ *dockerconfig.DockerConfig) (ImageVersion, error) {
 	return registry.ImageVersion(imagePath)
 }
 
@@ -64,5 +47,5 @@ func assertVersionStatusEquals(t *testing.T, registry *fakeRegistry, imageRef re
 	expectedDigest, err := registry.ImageVersion(imageRef.String())
 
 	assert.NoError(t, err, "Image version is unexpectedly unknown for '%s'", imageRef.String())
-	assert.Contains(t, versionStatus.ImageID, expectedDigest.String())
+	assert.Contains(t, versionStatus.ImageID, expectedDigest.Digest)
 }

--- a/src/controllers/dynakube/version/oneagent.go
+++ b/src/controllers/dynakube/version/oneagent.go
@@ -9,20 +9,20 @@ import (
 )
 
 type oneAgentUpdater struct {
-	dynakube   *dynatracev1beta1.DynaKube
-	dtClient   dtclient.Client
-	digestFunc ImageDigestFunc
+	dynakube    *dynatracev1beta1.DynaKube
+	dtClient    dtclient.Client
+	versionFunc ImageVersionFunc
 }
 
 func newOneAgentUpdater(
 	dynakube *dynatracev1beta1.DynaKube,
 	dtClient dtclient.Client,
-	digestFunc ImageDigestFunc,
+	versionFunc ImageVersionFunc,
 ) *oneAgentUpdater {
 	return &oneAgentUpdater{
-		dynakube:   dynakube,
-		dtClient:   dtClient,
-		digestFunc: digestFunc,
+		dynakube:    dynakube,
+		dtClient:    dtClient,
+		versionFunc: versionFunc,
 	}
 }
 
@@ -58,7 +58,7 @@ func (updater oneAgentUpdater) LatestImageInfo() (*dtclient.LatestImageInfo, err
 	return updater.dtClient.GetLatestOneAgentImage()
 }
 
-func (updater *oneAgentUpdater) UseDefaults(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
+func (updater *oneAgentUpdater) UseTenantRegistry(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
 	var err error
 	latestVersion := updater.CustomVersion()
 	if latestVersion == "" {
@@ -74,14 +74,7 @@ func (updater *oneAgentUpdater) UseDefaults(ctx context.Context, dockerCfg *dock
 	}
 
 	defaultImage := updater.dynakube.DefaultOneAgentImage()
-	err = updateVersionStatus(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
-	if err != nil {
-		return err
-	}
-
-	updater.Target().Version = latestVersion
-
-	return nil
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg)
 }
 
 func (updater *oneAgentUpdater) CheckForDowngrade(latestVersion string) (bool, error) {

--- a/src/controllers/dynakube/version/reconciler.go
+++ b/src/controllers/dynakube/version/reconciler.go
@@ -19,19 +19,19 @@ const (
 type Reconciler struct {
 	dynakube     *dynatracev1beta1.DynaKube
 	dtClient     dtclient.Client
-	digestFunc   ImageDigestFunc
+	versionFunc  ImageVersionFunc
 	timeProvider *timeprovider.Provider
 
 	fs        afero.Afero
 	apiReader client.Reader
 }
 
-func NewReconciler(dynakube *dynatracev1beta1.DynaKube, apiReader client.Reader, dtClient dtclient.Client, fs afero.Afero, digestProvider ImageDigestFunc, timeProvider *timeprovider.Provider) *Reconciler { //nolint:revive
+func NewReconciler(dynakube *dynatracev1beta1.DynaKube, apiReader client.Reader, dtClient dtclient.Client, fs afero.Afero, digestProvider ImageVersionFunc, timeProvider *timeprovider.Provider) *Reconciler { //nolint:revive
 	return &Reconciler{
 		dynakube:     dynakube,
 		apiReader:    apiReader,
 		fs:           fs,
-		digestFunc:   digestProvider,
+		versionFunc:  digestProvider,
 		timeProvider: timeProvider,
 		dtClient:     dtClient,
 	}
@@ -40,10 +40,10 @@ func NewReconciler(dynakube *dynatracev1beta1.DynaKube, apiReader client.Reader,
 // Reconcile updates the version status used by the dynakube
 func (reconciler *Reconciler) Reconcile(ctx context.Context) error {
 	updaters := []versionStatusUpdater{
-		newActiveGateUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.digestFunc),
-		newOneAgentUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.digestFunc),
+		newActiveGateUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.versionFunc),
+		newOneAgentUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.versionFunc),
 		newCodeModulesUpdater(reconciler.dynakube, reconciler.dtClient),
-		newSyntheticUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.digestFunc),
+		newSyntheticUpdater(reconciler.dynakube, reconciler.dtClient, reconciler.versionFunc),
 	}
 
 	neededUpdaters := reconciler.needsReconcile(updaters)

--- a/src/controllers/dynakube/version/reconciler_test.go
+++ b/src/controllers/dynakube/version/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/src/timeprovider"
+	"github.com/opencontainers/go-digest"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -28,6 +29,9 @@ const (
 func TestReconcile(t *testing.T) {
 	ctx := context.Background()
 	latestAgentVersion := "1.2.3.4-5"
+	testOneAgentHash := digest.FromString("sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f")
+	testActiveGateHash := digest.FromString("sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d72f")
+	testCodeModulesHash := digest.FromString("sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d82f")
 
 	dynakubeTemplate := dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace},
@@ -51,7 +55,7 @@ func TestReconcile(t *testing.T) {
 			dynakube:     dynakubeTemplate.DeepCopy(),
 			apiReader:    fake.NewClient(),
 			fs:           afero.Afero{Fs: afero.NewMemMapFs()},
-			digestFunc:   faultyRegistry.ImageVersionExt,
+			versionFunc:  faultyRegistry.ImageVersionExt,
 			timeProvider: timeprovider.New(),
 		}
 		err := versionReconciler.Reconcile(ctx)
@@ -67,7 +71,16 @@ func TestReconcile(t *testing.T) {
 		setupPullSecret(t, fakeClient, *dynakube)
 
 		dkStatus := &dynakube.Status
-		registry := newFakeRegistryForImages(testActiveGateImage.String(), testOneAgentImage.String())
+		registry := newFakeRegistry(map[string]ImageVersion{
+			dynakube.DefaultActiveGateImage(): {
+				Version: testActiveGateImage.Tag,
+				Digest:  testActiveGateHash,
+			},
+			dynakube.DefaultOneAgentImage(): {
+				Version: testOneAgentImage.Tag,
+				Digest:  testOneAgentHash,
+			},
+		})
 		mockClient := &dtclient.MockDynatraceClient{}
 		mockLatestAgentVersion(mockClient, latestAgentVersion)
 
@@ -75,15 +88,14 @@ func TestReconcile(t *testing.T) {
 			dynakube:     dynakube,
 			apiReader:    fakeClient,
 			fs:           afero.Afero{Fs: afero.NewMemMapFs()},
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 			timeProvider: timeProvider,
 			dtClient:     mockClient,
 		}
 		err := versionReconciler.Reconcile(ctx)
 		require.NoError(t, err)
-		assertVersionStatusEquals(t, registry, getTaggedReference(t, testActiveGateImage.String()), dkStatus.ActiveGate.VersionStatus)
-		assertVersionStatusEquals(t, registry, getTaggedReference(t, testOneAgentImage.String()), dkStatus.OneAgent.VersionStatus)
-		assert.Equal(t, latestAgentVersion, dkStatus.OneAgent.VersionStatus.Version)
+		assertStatusBasedOnTenantRegistry(t, dynakube.DefaultActiveGateImage(), testActiveGateImage.Tag, dkStatus.ActiveGate.VersionStatus)
+		assertStatusBasedOnTenantRegistry(t, dynakube.DefaultOneAgentImage(), testOneAgentImage.Tag, dkStatus.OneAgent.VersionStatus)
 		assert.Equal(t, latestAgentVersion, dkStatus.CodeModules.VersionStatus.Version)
 
 		// no change if probe not old enough
@@ -109,7 +121,21 @@ func TestReconcile(t *testing.T) {
 		setupPullSecret(t, fakeClient, *dynakube)
 
 		dkStatus := &dynakube.Status
-		registry := newFakeRegistryForImages(testActiveGateImage.String(), testOneAgentImage.String(), testCodeModulesImage.String())
+
+		registry := newFakeRegistry(map[string]ImageVersion{
+			testActiveGateImage.String(): {
+				Version: testActiveGateImage.Tag,
+				Digest:  testActiveGateHash,
+			},
+			testOneAgentImage.String(): {
+				Version: testOneAgentImage.Tag,
+				Digest:  testOneAgentHash,
+			},
+			testCodeModulesImage.String(): {
+				Version: testCodeModulesImage.Tag,
+				Digest:  testCodeModulesHash,
+			},
+		})
 		mockClient := &dtclient.MockDynatraceClient{}
 		mockActiveGateImageInfo(mockClient, testActiveGateImage)
 		mockCodeModulesImageInfo(mockClient, testCodeModulesImage)
@@ -119,7 +145,7 @@ func TestReconcile(t *testing.T) {
 			dynakube:     dynakube,
 			apiReader:    fakeClient,
 			fs:           afero.Afero{Fs: afero.NewMemMapFs()},
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 			timeProvider: timeprovider.New(),
 			dtClient:     mockClient,
 		}
@@ -209,21 +235,21 @@ func TestNeedsUpdate(t *testing.T) {
 func getTestOneAgentImageInfo() dtclient.LatestImageInfo {
 	return dtclient.LatestImageInfo{
 		Source: testDockerRegistry + "/linux/oneagent",
-		Tag:    "latest",
+		Tag:    "1.2.3.4-5",
 	}
 }
 
 func getTestActiveGateImageInfo() dtclient.LatestImageInfo {
 	return dtclient.LatestImageInfo{
 		Source: testDockerRegistry + "/linux/activegate",
-		Tag:    "latest",
+		Tag:    "1.2.3.4-5",
 	}
 }
 
 func getTestCodeModulesImage() dtclient.LatestImageInfo {
 	return dtclient.LatestImageInfo{
 		Source: testDockerRegistry + "/linux/codemodules",
-		Tag:    "latest",
+		Tag:    "1.2.3.4-5",
 	}
 }
 

--- a/src/controllers/dynakube/version/synthetic.go
+++ b/src/controllers/dynakube/version/synthetic.go
@@ -10,20 +10,20 @@ import (
 )
 
 type syntheticUpdater struct {
-	dynakube   *dynatracev1beta1.DynaKube
-	dtClient   dtclient.Client
-	digestFunc ImageDigestFunc
+	dynakube    *dynatracev1beta1.DynaKube
+	dtClient    dtclient.Client
+	versionFunc ImageVersionFunc
 }
 
 func newSyntheticUpdater(
 	dynakube *dynatracev1beta1.DynaKube,
 	dtClient dtclient.Client,
-	digestFunc ImageDigestFunc,
+	versionFunc ImageVersionFunc,
 ) *syntheticUpdater {
 	return &syntheticUpdater{
-		dynakube:   dynakube,
-		dtClient:   dtClient,
-		digestFunc: digestFunc,
+		dynakube:    dynakube,
+		dtClient:    dtClient,
+		versionFunc: versionFunc,
 	}
 }
 
@@ -63,7 +63,7 @@ func (updater syntheticUpdater) CheckForDowngrade(latestVersion string) (bool, e
 	return false, nil
 }
 
-func (updater *syntheticUpdater) UseDefaults(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
+func (updater *syntheticUpdater) UseTenantRegistry(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
 	defaultImage := updater.dynakube.DefaultSyntheticImage()
-	return updateVersionStatus(ctx, updater.Target(), defaultImage, updater.digestFunc, dockerCfg)
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg)
 }

--- a/src/controllers/dynakube/version/synthetic_test.go
+++ b/src/controllers/dynakube/version/synthetic_test.go
@@ -11,7 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestSyntheticUseDefaults(t *testing.T) {
+func TestSyntheticUseTenantRegistry(t *testing.T) {
+	testVersion := "1.2.3"
+	testHash := getTestDigest()
 	t.Run("default image specified", func(t *testing.T) {
 		dynakube := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -32,12 +34,16 @@ func TestSyntheticUseDefaults(t *testing.T) {
 		}
 		expectedImage := dynakube.DefaultSyntheticImage()
 		mockClient := &dtclient.MockDynatraceClient{}
-		registry := newFakeRegistryForImages(expectedImage)
+		registry := newFakeRegistry(map[string]ImageVersion{
+			expectedImage: {
+				Version: testVersion,
+				Digest:  testHash,
+			},
+		})
 		updater := newSyntheticUpdater(dynakube, mockClient, registry.ImageVersionExt)
 
-		err := updater.UseDefaults(context.TODO(), &dockerconfig.DockerConfig{})
+		err := updater.UseTenantRegistry(context.TODO(), &dockerconfig.DockerConfig{})
 		require.NoError(t, err, "default image set")
-		assertVersionStatusEquals(t, registry, getTaggedReference(t, expectedImage), dynakube.Status.Synthetic.VersionStatus)
-		require.Empty(t, dynakube.Status.Synthetic.Version, "zero version reported")
+		assertStatusBasedOnTenantRegistry(t, expectedImage, testVersion, dynakube.Status.Synthetic.VersionStatus)
 	})
 }

--- a/src/controllers/dynakube/version/updater.go
+++ b/src/controllers/dynakube/version/updater.go
@@ -24,7 +24,7 @@ type versionStatusUpdater interface {
 	CheckForDowngrade(latestVersion string) (bool, error)
 	LatestImageInfo() (*dtclient.LatestImageInfo, error)
 
-	UseDefaults(context.Context, *dockerconfig.DockerConfig) error
+	UseTenantRegistry(context.Context, *dockerconfig.DockerConfig) error
 }
 
 func (reconciler *Reconciler) run(ctx context.Context, updater versionStatusUpdater, dockerCfg *dockerconfig.DockerConfig) error {
@@ -40,7 +40,7 @@ func (reconciler *Reconciler) run(ctx context.Context, updater versionStatusUpda
 	customImage := updater.CustomImage()
 	if customImage != "" {
 		log.Info("updating version status according to custom image", "updater", updater.Name())
-		err = updateVersionStatus(ctx, updater.Target(), customImage, reconciler.digestFunc, dockerCfg)
+		err = setImageIDWithDigest(ctx, updater.Target(), customImage, reconciler.versionFunc, dockerCfg)
 		return err
 	}
 
@@ -68,7 +68,7 @@ func (reconciler *Reconciler) run(ctx context.Context, updater versionStatusUpda
 			return err
 		}
 
-		err = updateVersionStatus(ctx, updater.Target(), publicImage.String(), reconciler.digestFunc, dockerCfg)
+		err = setImageIDWithDigest(ctx, updater.Target(), publicImage.String(), reconciler.versionFunc, dockerCfg)
 		if err != nil {
 			log.Info("could not update version status according to the public registry", "updater", updater.Name())
 			return err
@@ -77,7 +77,7 @@ func (reconciler *Reconciler) run(ctx context.Context, updater versionStatusUpda
 	}
 
 	log.Info("updating version status according to the tenant registry", "updater", updater.Name())
-	err = updater.UseDefaults(ctx, dockerCfg)
+	err = updater.UseTenantRegistry(ctx, dockerCfg)
 	return err
 }
 
@@ -94,11 +94,11 @@ func determineSource(updater versionStatusUpdater) dynatracev1beta1.VersionSourc
 	return dynatracev1beta1.TenantRegistryVersionSource
 }
 
-func updateVersionStatus(
+func setImageIDWithDigest(
 	ctx context.Context,
 	target *dynatracev1beta1.VersionStatus,
 	imageUri string,
-	digestFunc ImageDigestFunc,
+	imageVersionFunc ImageVersionFunc,
 	dockerCfg *dockerconfig.DockerConfig,
 ) error {
 	ref, err := reference.Parse(imageUri)
@@ -113,12 +113,12 @@ func updateVersionStatus(
 	if canonRef, ok := ref.(reference.Canonical); ok {
 		target.ImageID = canonRef.String()
 	} else if taggedRef, ok := ref.(reference.NamedTagged); ok {
-		digest, err := digestFunc(ctx, imageUri, dockerCfg)
+		imageVersion, err := imageVersionFunc(ctx, imageUri, dockerCfg)
 		if err != nil {
 			target.ImageID = taggedRef.String()
 			log.Error(err, "failed to get image digest, falling back to tag")
 		} else {
-			canonRef, err := reference.WithDigest(taggedRef, digest)
+			canonRef, err := reference.WithDigest(taggedRef, imageVersion.Digest)
 			if err != nil {
 				target.ImageID = taggedRef.String()
 				log.Error(err, "failed to create canonical image reference, falling back to tag")
@@ -136,6 +136,39 @@ func updateVersionStatus(
 	// Version will be set elsewhere, as it differs between modes
 	// unset is necessary so we have a consistent status
 	target.Version = ""
+	return nil
+}
+
+func updateVersionStatusForTenantRegistry(
+	ctx context.Context,
+	target *dynatracev1beta1.VersionStatus,
+	imageUri string,
+	imageVersionFunc ImageVersionFunc,
+	dockerCfg *dockerconfig.DockerConfig,
+) error {
+	ref, err := reference.Parse(imageUri)
+	if err != nil {
+		return errors.WithMessage(err, "failed to parse image uri")
+	}
+
+	log.Info("updating image version info for tenant registry image",
+		"image", imageUri,
+		"oldImageID", target.ImageID,
+		"oldVersion", target.Version)
+
+	if taggedRef, ok := ref.(reference.NamedTagged); ok {
+		imageVersion, err := imageVersionFunc(ctx, imageUri, dockerCfg)
+		if err != nil {
+			log.Error(err, "failed to determine image version, ignoring version")
+		}
+		target.ImageID = taggedRef.String()
+		target.Version = imageVersion.Version
+	}
+
+	log.Info("updated image version info for tenant registry image",
+		"newImageID", target.ImageID,
+		"newVersion", target.Version)
+
 	return nil
 }
 

--- a/src/controllers/dynakube/version/updater_test.go
+++ b/src/controllers/dynakube/version/updater_test.go
@@ -51,7 +51,7 @@ func (m *mockUpdater) LatestImageInfo() (*dtclient.LatestImageInfo, error) {
 	args := m.Called()
 	return args.Get(0).(*dtclient.LatestImageInfo), args.Error(1)
 }
-func (m *mockUpdater) UseDefaults(_ context.Context, _ *dockerconfig.DockerConfig) error {
+func (m *mockUpdater) UseTenantRegistry(_ context.Context, _ *dockerconfig.DockerConfig) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -71,12 +71,16 @@ func TestRun(t *testing.T) {
 	timeProvider := timeprovider.New()
 
 	t.Run("set source and probe at the end, if no error", func(t *testing.T) {
-		registry := newFakeRegistryForImages(testImage.String())
+		registry := newFakeRegistry(map[string]ImageVersion{
+			testImage.String(): {
+				Version: testImage.Tag,
+			},
+		})
 		target := &dynatracev1beta1.VersionStatus{}
 		versionReconciler := Reconciler{
 			dynakube:     &dynatracev1beta1.DynaKube{},
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newCustomImageUpdater(target, testImage.String())
 		err := versionReconciler.run(ctx, updater, testDockerCfg)
@@ -91,7 +95,7 @@ func TestRun(t *testing.T) {
 		versionReconciler := Reconciler{
 			dynakube:     &dynatracev1beta1.DynaKube{},
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newCustomImageUpdater(target, "incorrect-uri")
 		err := versionReconciler.run(ctx, updater, testDockerCfg)
@@ -105,42 +109,46 @@ func TestRun(t *testing.T) {
 		versionReconciler := Reconciler{
 			dynakube:     &dynatracev1beta1.DynaKube{},
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newDefaultUpdater(target, false)
 
 		// 1. call => status empty => should run
 		err := versionReconciler.run(ctx, updater, testDockerCfg)
 		require.NoError(t, err)
-		updater.AssertNumberOfCalls(t, "UseDefaults", 1)
+		updater.AssertNumberOfCalls(t, "UseTenantRegistry", 1)
 		assert.Equal(t, timeProvider.Now(), target.LastProbeTimestamp)
 		assert.Equal(t, dynatracev1beta1.TenantRegistryVersionSource, target.Source)
 
 		// 2. call => status NOT empty => should NOT run
 		err = versionReconciler.run(ctx, updater, testDockerCfg)
 		require.NoError(t, err)
-		updater.AssertNumberOfCalls(t, "UseDefaults", 1)
+		updater.AssertNumberOfCalls(t, "UseTenantRegistry", 1)
 
 		// 3. call => source is different => should run
 		target.Source = dynatracev1beta1.CustomImageVersionSource
 		err = versionReconciler.run(ctx, updater, testDockerCfg)
 		require.NoError(t, err)
-		updater.AssertNumberOfCalls(t, "UseDefaults", 2)
+		updater.AssertNumberOfCalls(t, "UseTenantRegistry", 2)
 
 		// 4. call => source is NOT different => should NOT run
 		err = versionReconciler.run(ctx, updater, testDockerCfg)
 		require.NoError(t, err)
-		updater.AssertNumberOfCalls(t, "UseDefaults", 2)
+		updater.AssertNumberOfCalls(t, "UseTenantRegistry", 2)
 	})
 	t.Run("public registry", func(t *testing.T) {
-		registry := newFakeRegistryForImages(testImage.String())
+		registry := newFakeRegistry(map[string]ImageVersion{
+			testImage.String(): {
+				Version: testImage.Tag,
+			},
+		})
 		target := &dynatracev1beta1.VersionStatus{
 			Source: dynatracev1beta1.TenantRegistryVersionSource,
 		}
 		versionReconciler := Reconciler{
 			dynakube:     enablePublicRegistry(&dynatracev1beta1.DynaKube{}),
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newPublicRegistryUpdater(target, &testImage, false)
 		updater.On("IsClassicFullStackEnabled").Return(false)
@@ -156,14 +164,18 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("public registry, no downgrade allowed", func(t *testing.T) {
-		registry := newFakeRegistryForImages(testImage.String())
+		registry := newFakeRegistry(map[string]ImageVersion{
+			testImage.String(): {
+				Version: testImage.Tag,
+			},
+		})
 		target := &dynatracev1beta1.VersionStatus{
 			Source: dynatracev1beta1.TenantRegistryVersionSource,
 		}
 		versionReconciler := Reconciler{
 			dynakube:     enablePublicRegistry(&dynatracev1beta1.DynaKube{}),
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newPublicRegistryUpdater(target, &testImage, false)
 		updater.On("IsClassicFullStackEnabled").Return(false)
@@ -178,19 +190,23 @@ func TestRun(t *testing.T) {
 		assert.Empty(t, target.ImageID)
 	})
 	t.Run("classicfullstack enabled, public registry is ignored", func(t *testing.T) {
-		registry := newFakeRegistryForImages(testImage.String())
+		registry := newFakeRegistry(map[string]ImageVersion{
+			testImage.String(): {
+				Version: testImage.Tag,
+			},
+		})
 		target := &dynatracev1beta1.VersionStatus{
 			Source: dynatracev1beta1.TenantRegistryVersionSource,
 		}
 		versionReconciler := Reconciler{
 			dynakube:     enablePublicRegistry(newClassicFullStackDynakube()),
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newClassicFullStackUpdater(target, false)
 		updater.On("CustomImage").Return("")
 		updater.On("CustomVersion").Return("")
-		updater.On("UseDefaults").Return(nil)
+		updater.On("UseTenantRegistry").Return(nil)
 
 		err := versionReconciler.run(ctx, updater, testDockerCfg)
 		require.NoError(t, err)
@@ -200,19 +216,23 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, target.Version, target.Version)
 	})
 	t.Run("classicfullstack enabled, public registry is ignored, custom image is set", func(t *testing.T) {
-		registry := newFakeRegistryForImages(testImage.String())
+		registry := newFakeRegistry(map[string]ImageVersion{
+			testImage.String(): {
+				Version: testImage.Tag,
+			},
+		})
 		target := &dynatracev1beta1.VersionStatus{
 			Source: dynatracev1beta1.TenantRegistryVersionSource,
 		}
 		versionReconciler := Reconciler{
 			dynakube:     enablePublicRegistry(newClassicFullStackDynakube()),
 			timeProvider: timeProvider,
-			digestFunc:   registry.ImageVersionExt,
+			versionFunc:  registry.ImageVersionExt,
 		}
 		updater := newClassicFullStackUpdater(target, false)
 		updater.On("CustomImage").Return(testImage.String())
 		updater.On("CustomVersion").Return(testImage.Tag)
-		updater.On("UseDefaults").Return(nil)
+		updater.On("UseTenantRegistry").Return(nil)
 
 		err := versionReconciler.run(ctx, updater, testDockerCfg)
 		require.NoError(t, err)
@@ -280,15 +300,19 @@ func TestUpdateVersionStatus(t *testing.T) {
 	t.Run("failing to get digest should not cause error, should fall back to using the tag", func(t *testing.T) {
 		registry := newEmptyFakeRegistry()
 		target := dynatracev1beta1.VersionStatus{}
-		err := updateVersionStatus(ctx, &target, testImage.String(), registry.ImageVersionExt, testDockerCfg)
+		err := setImageIDWithDigest(ctx, &target, testImage.String(), registry.ImageVersionExt, testDockerCfg)
 		assert.NoError(t, err)
 		assert.Equal(t, testImage.String(), target.ImageID)
 	})
 
 	t.Run("set status", func(t *testing.T) {
-		registry := newFakeRegistryForImages(testImage.String())
+		registry := newFakeRegistry(map[string]ImageVersion{
+			testImage.String(): {
+				Version: testImage.Tag,
+			},
+		})
 		target := dynatracev1beta1.VersionStatus{}
-		err := updateVersionStatus(ctx, &target, testImage.String(), registry.ImageVersionExt, testDockerCfg)
+		err := setImageIDWithDigest(ctx, &target, testImage.String(), registry.ImageVersionExt, testDockerCfg)
 		require.NoError(t, err)
 		assertVersionStatusEquals(t, registry, getTaggedReference(t, testImage.String()), target)
 	})
@@ -298,11 +322,11 @@ func TestUpdateVersionStatus(t *testing.T) {
 		expectedDigest := "sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f"
 		expectedID := expectedRepo + "@" + expectedDigest
 		target := dynatracev1beta1.VersionStatus{}
-		boomFunc := func(_ context.Context, imagePath string, _ *dockerconfig.DockerConfig) (digest.Digest, error) {
+		boomFunc := func(_ context.Context, imagePath string, _ *dockerconfig.DockerConfig) (ImageVersion, error) {
 			t.Error("digest function was called unexpectedly")
-			return "", nil
+			return ImageVersion{}, nil
 		}
-		err := updateVersionStatus(ctx, &target, expectedID, boomFunc, testDockerCfg)
+		err := setImageIDWithDigest(ctx, &target, expectedID, boomFunc, testDockerCfg)
 		require.NoError(t, err)
 		assert.Equal(t, expectedID, target.ImageID)
 	})
@@ -311,11 +335,11 @@ func TestUpdateVersionStatus(t *testing.T) {
 		expectedDigest := "sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f"
 		expectedID := expectedRepo + ":tag@" + expectedDigest
 		target := dynatracev1beta1.VersionStatus{}
-		boomFunc := func(_ context.Context, imagePath string, _ *dockerconfig.DockerConfig) (digest.Digest, error) {
+		boomFunc := func(_ context.Context, imagePath string, _ *dockerconfig.DockerConfig) (ImageVersion, error) {
 			t.Error("digest function was called unexpectedly")
-			return "", nil
+			return ImageVersion{}, nil
 		}
-		err := updateVersionStatus(ctx, &target, expectedID, boomFunc, testDockerCfg)
+		err := setImageIDWithDigest(ctx, &target, expectedID, boomFunc, testDockerCfg)
 		require.NoError(t, err)
 		assert.Equal(t, expectedID, target.ImageID)
 	})
@@ -366,7 +390,7 @@ func newDefaultUpdater(target *dynatracev1beta1.VersionStatus, autoUpdate bool) 
 	updater.On("CustomImage").Return("")
 	updater.On("IsPublicRegistryEnabled").Return(false)
 	updater.On("CustomVersion").Return("")
-	updater.On("UseDefaults").Return(nil)
+	updater.On("UseTenantRegistry").Return(nil)
 	return updater
 }
 
@@ -409,4 +433,13 @@ func getTaggedReference(t *testing.T, image string) reference.NamedTagged {
 	taggedRef, ok := ref.(reference.NamedTagged)
 	require.True(t, ok)
 	return taggedRef
+}
+
+func assertStatusBasedOnTenantRegistry(t *testing.T, expectedImage, expectedVersion string, versionStatus dynatracev1beta1.VersionStatus) { //nolint:revive // argument-limit
+	assert.Equal(t, expectedImage, versionStatus.ImageID)
+	assert.Equal(t, expectedVersion, versionStatus.Version)
+}
+
+func getTestDigest() digest.Digest {
+	return digest.FromString("sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f")
 }


### PR DESCRIPTION
# Description

cherry pick of #1741

## How can this be tested?
same as #1741


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

