### PR TITLE
Renovate/check dev dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,8 +4,43 @@
     "config:base"
   ],
   "labels": ["dependencies"],
-  "enabledManagers": ["gomod", "dockerfile", "github-actions"],
   "digest": { "enabled": false },
+  "enabledManagers": [ "regex", "dockerfile", "gomod", "github-actions" ],
+  "regexManagers": [
+    {
+      "fileMatch": "(^|/|\\.)prerequisites.mk$",
+      "matchStrings": [
+        "go install github\\.com\/(?<depName>.*?)@(?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-releases",
+      "registryUrlTemplate": "https://github.com"
+    },
+    {
+      "fileMatch": "(^|/|\\.)prerequisites.mk$",
+      "matchStrings": [
+        "go install golang\\.org\/x\/(?<package>.*?)\/.*@(?<currentValue>.*?)\\n"
+      ],
+
+      "datasourceTemplate": "go",
+      "depNameTemplate": "golang.org/x/{{package}}"
+    },
+    {
+      "fileMatch": "(^|/|\\.)prerequisites.mk$",
+      "matchStrings": [
+        "\"sigs\\.k8s\\.io\/controller-tools\/cmd\/controller-gen@(?<currentValue>.*?)\"\\n"
+      ],
+      "datasourceTemplate": "go",
+      "depNameTemplate": "sigs.k8s.io/controller-tools"
+    },
+    {
+      "fileMatch": "(^|/|\\.)prerequisites.mk$",
+      "matchStrings": [
+        "\"sigs\\.k8s\\.io\/kustomize\/kustomize\/v4@(?<currentValue>.*?)\"\\n"
+      ],
+      "datasourceTemplate": "go",
+      "depNameTemplate": "sigs.k8s.io/kustomize/kustomize/v4"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],
@@ -30,6 +65,11 @@
       "commitMessagePrefix": "Actions:",
       "enabled": true,
       "allowedVersions": "/^v[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
+    },
+    {
+      "matchManagers": ["regex"],
+      "commitMessagePrefix": "Dev:",
+      "enabled": true
     },
     {
       "matchUpdateTypes": ["digest", "pin", "pinDigest"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,14 @@
       ],
       "datasourceTemplate": "go",
       "depNameTemplate": "sigs.k8s.io/kustomize/kustomize/v4"
+    },
+    {
+      "fileMatch": "(^|/|\\.)third-party-licenses.sh$",
+      "matchStrings": [
+        "go install github\\.com\/(?<depName>.*?)@(?<currentValue>.*?) &&"
+      ],
+      "datasourceTemplate": "github-releases",
+      "registryUrlTemplate": "https://github.com"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
# Description

Include dependencies in prerequisites.mk and third-party-licenses.sh into renovate checks.

## How can this be tested?
Effects can only be seen after merge to main, when it's picked up by renovate. But you can check https://github.com/StefanHauth/dynatrace-operator/issues/4 to see what the PRs will look like.

## Checklist
- [n/a] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

