### PR TITLE
Add digest to ubi-9 base images in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN CGO_ENABLED=1 CGO_CFLAGS="-O2 -Wno-return-local-addr" \
     go build -tags "${GO_BUILD_TAGS}" -trimpath -ldflags="${GO_LINKER_ARGS}" \
     -o ./build/_output/bin/dynatrace-operator ./src/cmd/
 
-FROM registry.access.redhat.com/ubi9-micro:9.1.0 AS base
-FROM registry.access.redhat.com/ubi9:9.1.0 AS dependency
+FROM registry.access.redhat.com/ubi9-micro:9.1.0@sha256:9fc815c51e62b33e4ff3225242ca2236ca4d6fcc3474e3b7e3004fea8924f8fd AS base
+FROM registry.access.redhat.com/ubi9:9.1.0@sha256:49124e4acd09c98927882760476d617a85f155cb45759aea56b2ab020563c4b8 AS dependency
 RUN mkdir -p /tmp/rootfs-dependency
 COPY --from=base / /tmp/rootfs-dependency
 RUN dnf install --installroot /tmp/rootfs-dependency \


### PR DESCRIPTION
As we don't want to have any non-pinned images in our Dockerfile, the last missing piece were the base-images, as dependabot was not capable of updating them properly.


## How can this be tested?
Everything should work as before


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

