### PR TITLE
Skip pushing image and manifest when creating a PR from a fork

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,6 +148,7 @@ jobs:
     strategy:
       matrix:
         platform: [amd64, arm64]
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -173,6 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COMBINED: ${{ github.ref_protected }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
# Description

With this the CI is altered in a way, such that if a PR is created from a fork it does not fail anymore. Previously it failed because of missing access tokens. These steps are now skipped.

# How can this be tested?
Create a fork with the change to the CI. Then create a fork from the fork and create a PR and take a look at the steps that are triggered by the CI.

For example already done here: https://github.com/aorcholski/dynatrace-operator/pull/2

## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

