### PR TITLE
Remove injected check for classicFullstack e2e test

### DIFF
--- a/test/scenarios/classic/install.go
+++ b/test/scenarios/classic/install.go
@@ -3,23 +3,12 @@
 package classic
 
 import (
-	"context"
-	"strings"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps"
-	sample "github.com/Dynatrace/dynatrace-operator/test/helpers/sampleapps/base"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/steps/assess"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
-	"sigs.k8s.io/e2e-framework/klient/wait"
-	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
@@ -32,44 +21,8 @@ func install(t *testing.T) features.Feature {
 		ClassicFullstack(&dynatracev1beta1.HostInjectSpec{}).
 		Build()
 
-	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
-
+	// check if oneAgent pods startup and report as ready
 	assess.InstallDynatraceWithTeardown(builder, &secretConfig, testDynakube)
 
-	// Register actual test
-	builder.Assess("install sample app", sampleApp.Install())
-	builder.Teardown(sampleApp.UninstallNamespace())
-	builder.Assess("sample apps are injected", isAgentInjected(sampleApp))
-
 	return builder.Feature()
-}
-
-func isAgentInjected(sampleApp sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
-		pods := sampleApp.GetPods(ctx, t, resources)
-		require.NoError(t, wait.For(classicInjected(ctx, resources, sampleApp, pods.Items)))
-		return ctx
-	}
-}
-
-func classicInjected(ctx context.Context, resources *resources.Resources, sampleApp sample.App, pods []corev1.Pod) func() (done bool, err error) {
-	return func() (done bool, err error) {
-		if pods == nil {
-			return false, nil
-		}
-		for _, podItem := range pods {
-			listCommand := shell.ListDirectory("/var/lib")
-			executionResult, err := pod.Exec(ctx, resources, podItem, sampleApp.ContainerName(), listCommand...)
-			if err != nil {
-				return false, err
-			}
-
-			stdOut := executionResult.StdOut.String()
-			if !strings.Contains(stdOut, "dynatrace") {
-				return false, nil
-			}
-		}
-		return true, nil
-	}
 }


### PR DESCRIPTION
# Description

Our e2e test for classicFullStack runs flaky, as the oneAgent needs more time to startup properly, than our sample apps come up. The problem is that the agent reports its ready state as ready, even though its not yet 100% ready to inject.

## How can this be tested?
run the classic e2e test (`make test/e2e/classic`)


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

