### PR TITLE
Improves error for unexpected type for image ref in image installer

### DIFF
--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -30,7 +30,7 @@ func NewImageInstaller(fs afero.Fs, props *Properties) (*Installer, error) {
 	}
 	canonRef, ok := ref.(reference.Canonical)
 	if !ok {
-		return nil, errors.New("unexpected type of image reference provided to image installer")
+		return nil, errors.Errorf("unexpected type of image reference provided to image installer, expected reference with digest but received %s", props.ImageUri)
 	}
 	return &Installer{
 		fs:          fs,

--- a/src/installer/image/installer.go
+++ b/src/installer/image/installer.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -26,7 +27,7 @@ type Properties struct {
 func NewImageInstaller(fs afero.Fs, props *Properties) (*Installer, error) {
 	ref, err := reference.Parse(props.ImageUri)
 	if err != nil {
-		return nil, errors.WithMessage(err, "failed to parse image reference to create image installer")
+		return nil, errors.WithMessage(err, fmt.Sprintf("failed to parse image reference to create image installer, received imageUri: %s", props.ImageUri))
 	}
 	canonRef, ok := ref.(reference.Canonical)
 	if !ok {


### PR DESCRIPTION
Improves the error message when the provided image reference for the image installer does not have a digest.

This happens in case the image for the code-modules is in a registry that is not accessible by the operator, to set the status of the dynakube correctly (by getting and storing the digest), which will cause the operator to fall back to the "raw" text version of the provided image, which tends to be specified with a tag instead of a digest.

## How can this be tested?
Try to reproduce the above mentioned scenario (with a proxy, or something).
And now the error message should be more specific

## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

