### PR TITLE
Adds feature flag to set seccomp profile for initContainer

### DIFF
--- a/src/api/v1beta1/feature_flags.go
+++ b/src/api/v1beta1/feature_flags.go
@@ -90,6 +90,7 @@ const (
 	AnnotationFeatureAutomaticInjection    = AnnotationFeaturePrefix + "automatic-injection"
 	AnnotationFeatureLabelVersionDetection = AnnotationFeaturePrefix + "label-version-detection"
 	AnnotationInjectionFailurePolicy       = AnnotationFeaturePrefix + "injection-failure-policy"
+	AnnotationFeatureInitContainerSeccomp  = AnnotationFeaturePrefix + "init-container-seccomp-profile"
 
 	// CSI
 	AnnotationFeatureMaxFailedCsiMountAttempts = AnnotationFeaturePrefix + "max-csi-mount-attempts"
@@ -352,4 +353,8 @@ func (dk *DynaKube) FeatureSyntheticReplicas() int32 {
 	}
 
 	return int32(parsed)
+}
+
+func (dk *DynaKube) FeatureInitContainerSeccomp() bool {
+	return dk.getFeatureFlagRaw(AnnotationFeatureInitContainerSeccomp) == truePhrase
 }

--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -26,12 +26,12 @@ func createInstallInitContainerBase(webhookImage, clusterID string, pod *corev1.
 			{Name: config.K8sNamespaceEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("metadata.namespace")},
 			{Name: config.K8sNodeNameEnv, ValueFrom: kubeobjects.NewEnvVarSourceForField("spec.nodeName")},
 		},
-		SecurityContext: securityContextForInitContainer(pod),
+		SecurityContext: securityContextForInitContainer(pod, dynakube),
 		Resources:       *dynakube.InitResources(),
 	}
 }
 
-func securityContextForInitContainer(pod *corev1.Pod) *corev1.SecurityContext {
+func securityContextForInitContainer(pod *corev1.Pod, dk dynatracev1beta1.DynaKube) *corev1.SecurityContext {
 	initSecurityCtx := corev1.SecurityContext{
 		ReadOnlyRootFilesystem:   address.Of(true),
 		AllowPrivilegeEscalation: address.Of(false),
@@ -42,6 +42,8 @@ func securityContextForInitContainer(pod *corev1.Pod) *corev1.SecurityContext {
 			},
 		},
 	}
+
+	addSeccompProfile(&initSecurityCtx, dk)
 
 	return combineSecurityContexts(initSecurityCtx, *pod)
 }
@@ -110,4 +112,10 @@ func getBasePodName(pod *corev1.Pod) string {
 
 func addInitContainerToPod(pod *corev1.Pod, initContainer *corev1.Container) {
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *initContainer)
+}
+
+func addSeccompProfile(ctx *corev1.SecurityContext, dk dynatracev1beta1.DynaKube) {
+	if dk.FeatureInitContainerSeccomp() {
+		ctx.SeccompProfile = &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
+	}
 }

--- a/src/webhook/mutation/pod_mutator/init_container_test.go
+++ b/src/webhook/mutation/pod_mutator/init_container_test.go
@@ -44,6 +44,8 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 
 		require.NotNil(t, initContainer.SecurityContext.RunAsGroup)
 		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, defaultGroup)
+
+		assert.Nil(t, initContainer.SecurityContext.SeccompProfile)
 	})
 	t.Run("should overwrite partially", func(t *testing.T) {
 		dynakube := getTestDynakube()
@@ -192,5 +194,17 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 
 		assert.False(t, kubeobjects.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "fail")
 		assert.True(t, kubeobjects.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "silent")
+	})
+	t.Run("should set seccomp profile if feature flag is enabled", func(t *testing.T) {
+		dynakube := getTestDynakube()
+		dynakube.Annotations = map[string]string{v1beta1.AnnotationFeatureInitContainerSeccomp: "true"}
+		pod := getTestPod()
+		pod.Annotations = map[string]string{}
+		webhookImage := "test-image"
+		clusterID := "id"
+
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+
+		assert.True(t, initContainer.SecurityContext.SeccompProfile.Type == corev1.SeccompProfileTypeRuntimeDefault)
 	})
 }


### PR DESCRIPTION
# Description
Currently our initContainer does not have a seccomp profile set by default, which is caused by the fact that OCP < 4.11 does not allow seccomp profiles with its default restricted SCC. However we should add the option to configure it on DynaKube level in order to support [PodSecurityStandards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) properly

## How can this be tested?

- Deploy the operator
- Create a Dynakube with the feature flag: `feature.dynatrace.com/init-container-seccomp-profile: "true"`
- Deploy sample apps
- Check if the initContainers security context has properly set the seccomp profile runtime default


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

