### PR TITLE
Fixes growing number of communicationHosts in Status

### DIFF
--- a/src/controllers/dynakube/connectioninfo/reconciler.go
+++ b/src/controllers/dynakube/connectioninfo/reconciler.go
@@ -85,9 +85,7 @@ func (r *Reconciler) updateDynakubeOneAgentStatus(connectionInfo dtclient.OneAge
 }
 
 func copyCommunicationHosts(dest *dynatracev1beta1.OneAgentConnectionInfoStatus, src []dtclient.CommunicationHost) {
-	if dest.CommunicationHosts == nil {
-		dest.CommunicationHosts = make([]dynatracev1beta1.CommunicationHostStatus, 0, len(src))
-	}
+	dest.CommunicationHosts = make([]dynatracev1beta1.CommunicationHostStatus, 0, len(src))
 	for _, host := range src {
 		dest.CommunicationHosts = append(dest.CommunicationHosts, dynatracev1beta1.CommunicationHostStatus{
 			Protocol: host.Protocol,


### PR DESCRIPTION
# Description

The `communicationHosts` should not be appended to the already present `communicationHosts` in the `Status`.
We have to override them, otherwise the list will be infinitely growing.

## How can this be tested?
check the `communicationHost` are present in the status,
check that it does not grow(with duplicates) after reconciling that status again,


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

