### PR TITLE
Prevent update of dynakube image status incase of error during registry call

### DIFF
--- a/src/api/v1beta1/dynakube_status.go
+++ b/src/api/v1beta1/dynakube_status.go
@@ -124,11 +124,3 @@ func (dk *DynaKubeStatus) SetPhase(phase DynaKubePhaseType) bool {
 	dk.Phase = phase
 	return upd
 }
-
-// SetPhaseOnError fills the phase with the Error value in case of any error
-func (dk *DynaKubeStatus) SetPhaseOnError(err error) bool {
-	if err != nil {
-		return dk.SetPhase(Error)
-	}
-	return false
-}

--- a/src/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -46,7 +46,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.S
 func (r *Reconciler) Reconcile() error {
 	err := r.reconcileAuthTokenSecret()
 	if err != nil {
-		return errors.Errorf("failed to create activeGateAuthToken secret: %v", err)
+		return errors.WithMessage(err, "failed to create activeGateAuthToken secret")
 	}
 	return nil
 }
@@ -77,7 +77,7 @@ func (r *Reconciler) reconcileAuthTokenSecret() error {
 func (r *Reconciler) ensureAuthTokenSecret() error {
 	agSecretData, err := r.getActiveGateAuthToken()
 	if err != nil {
-		return errors.Errorf("failed to create secret '%s': %v", r.dynakube.ActiveGateAuthTokenSecret(), err)
+		return errors.WithMessagef(err, "failed to create secret '%s'", r.dynakube.ActiveGateAuthTokenSecret())
 	}
 	return r.createSecret(agSecretData)
 }

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -124,9 +124,9 @@ func (controller *Controller) Reconcile(ctx context.Context, request reconcile.R
 
 		var serverErr dtclient.ServerError
 		isServerError := errors.As(err, &serverErr)
-		if isServerError && serverErr.Code == http.StatusTooManyRequests {
+		if isServerError && (serverErr.Code == http.StatusTooManyRequests || serverErr.Code == http.StatusServiceUnavailable) {
 			// should we set the phase to error ?
-			log.Info("request limit for Dynatrace API reached! Next reconcile in one minute")
+			log.Info("server is unavailable or request limit reached! trying again in one minute")
 			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		dynakube.Status.SetPhase(dynatracev1beta1.Error)

--- a/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/src/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/scheme"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/src/version"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -120,21 +119,6 @@ func TestReconcile_PhaseSetCorrectly(t *testing.T) {
 		Status:  metav1.ConditionTrue,
 		Reason:  dynatracev1beta1.ReasonTokenReady,
 		Message: "Ready",
-	})
-
-	t.Run("SetPhaseOnError called with different values, object and return value correctly modified", func(t *testing.T) {
-		dk := base.DeepCopy()
-
-		res := dk.Status.SetPhaseOnError(nil)
-		assert.False(t, res)
-		assert.Equal(t, dk.Status.Phase, dynatracev1beta1.DynaKubePhaseType(""))
-
-		res = dk.Status.SetPhaseOnError(errors.New("dummy error"))
-		assert.True(t, res)
-
-		if assert.NotNil(t, dk.Status.Phase) {
-			assert.Equal(t, dynatracev1beta1.Error, dk.Status.Phase)
-		}
 	})
 }
 

--- a/src/controllers/dynakube/version/activegate.go
+++ b/src/controllers/dynakube/version/activegate.go
@@ -64,5 +64,5 @@ func (updater *activeGateUpdater) CheckForDowngrade(latestVersion string) (bool,
 
 func (updater *activeGateUpdater) UseTenantRegistry(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
 	defaultImage := updater.dynakube.DefaultActiveGateImage()
-	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg)
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg, updater.dynakube)
 }

--- a/src/controllers/dynakube/version/oneagent.go
+++ b/src/controllers/dynakube/version/oneagent.go
@@ -74,7 +74,7 @@ func (updater *oneAgentUpdater) UseTenantRegistry(ctx context.Context, dockerCfg
 	}
 
 	defaultImage := updater.dynakube.DefaultOneAgentImage()
-	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg)
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg, updater.dynakube)
 }
 
 func (updater *oneAgentUpdater) CheckForDowngrade(latestVersion string) (bool, error) {

--- a/src/controllers/dynakube/version/synthetic.go
+++ b/src/controllers/dynakube/version/synthetic.go
@@ -65,5 +65,5 @@ func (updater syntheticUpdater) CheckForDowngrade(latestVersion string) (bool, e
 
 func (updater *syntheticUpdater) UseTenantRegistry(ctx context.Context, dockerCfg *dockerconfig.DockerConfig) error {
 	defaultImage := updater.dynakube.DefaultSyntheticImage()
-	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg)
+	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), defaultImage, updater.versionFunc, dockerCfg, updater.dynakube)
 }

--- a/src/controllers/dynakube/version/updater.go
+++ b/src/controllers/dynakube/version/updater.go
@@ -94,7 +94,7 @@ func determineSource(updater versionStatusUpdater) dynatracev1beta1.VersionSourc
 	return dynatracev1beta1.TenantRegistryVersionSource
 }
 
-func setImageIDWithDigest(
+func setImageIDWithDigest( //nolint:revive
 	ctx context.Context,
 	target *dynatracev1beta1.VersionStatus,
 	imageUri string,
@@ -144,7 +144,7 @@ func setImageIDWithDigest(
 	return nil
 }
 
-func updateVersionStatusForTenantRegistry(
+func updateVersionStatusForTenantRegistry( //nolint:revive
 	ctx context.Context,
 	target *dynatracev1beta1.VersionStatus,
 	imageUri string,


### PR DESCRIPTION
# Description

This PR should fix the problem that a new ressource (daemonset, statefulset) is rolled out, in case of an HTTP error from the registry, we try to get the manifest from. This call is expected to fail if the dynakube has a proxy fail, since the library is not aware of that. 

## How can this be tested?
Install the Operator
Create a Dynakube
Use a wrong image that does not exist as e.g oneAgent image
Check if a that no daemonset is rolled out


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

