### PR TITLE
increases timeout of validating webhook configuration to 10s

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
@@ -40,6 +40,6 @@ webhooks:
         resources:
           - dynakubes
     name: webhook.dynatrace.com
-    timeoutSeconds: 2
+    timeoutSeconds: 10
     sideEffects: None
 {{ end }}


### PR DESCRIPTION
# Description

- sets timeout of validating webhook to 10s after diskussion to allow for completion of initialization procedure on K8s systems.

## How can this be tested?
- deploy an operator and check if the validating webhooks `timeoutSeconds` is set to `10s`


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

