### PR TITLE
Fix nilpointer in cloudnative-proxy e2e istio pre-check

### DIFF
--- a/test/scenarios/cloudnative/proxy/cloudnative_test.go
+++ b/test/scenarios/cloudnative/proxy/cloudnative_test.go
@@ -14,9 +14,9 @@ import (
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	testEnvironment = environment.Get()
 	testEnvironment.BeforeEachTest(istio.AssertIstioNamespace())
 	testEnvironment.BeforeEachTest(istio.AssertIstiodDeployment())
-	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }
 


### PR DESCRIPTION
# Description

you have to first `Get` the testEnvironment before you can do anything with it. (otherwise you will get a nil pointer error)

## How can this be tested?
run `make test/e2e/cloudnative/proxy`


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

