### PR TITLE
fixed renovate regex for dockerfile golang version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,7 @@
       "matchManagers": ["dockerfile"],
       "commitMessagePrefix": "Docker:",
       "enabled": true,
-      "allowedVersions": "/^v[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
+      "allowedVersions": "/^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
     },
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
# Description

- fixed the regex for the golang version in the dockerfile to enable renovate to update golang

## How can this be tested?
1. fork the repo
2. setup renovate
3. run renovate


## Checklist
- [ ] ~~Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

