### PR TITLE
Add space between target name and color code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ help:
 		helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
   gsub("\\\\", "", helpCommand); \
   gsub(":+$$", "", helpCommand); \
-		printf "  \x1b[32;01m%-35s\x1b[0m %s\n", helpCommand, helpMessage; \
+		printf "  \x1b[32;01m%-35s \x1b[0m %s\n", helpCommand, helpMessage; \
 	  } \
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST) | sort -u


### PR DESCRIPTION
# Description
If the e2e make target is longer than 35 char then the `make help` command will have an output for that make target where the color code is right next to the name of the target.
This is a problem for the `hack/e2e/run-all.sh` as it will try to run a make target that has an color code at the end, which wont exist, so make will complain that "target does not exist".

The best part is that this will not show up in the command line and does not affect every shell. (no problem on Mac and Fedora)

## How can this be tested?
To double check the issue, you could modify the `hack/e2e/run-all.sh` to instead of calling the make target, just put the name of the target into a file. (as it will not show up in the command line)
```
#!/usr/bin/env bash

tests=$(make help | grep -oE "test\/e2e\/\S*" | grep -v "%\/debug")
result=0
for test in $tests
do
    echo "$test" >> test.txt
done
exit $result
``` 

Prior to the change you should see entries like:
```
test/e2e/cloudnative/disabledautoinjection[0m
```

With the change it should be:
```
test/e2e/cloudnative/disabledautoinjection
```

## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

