### PR TITLE
Build only `amd64` image on feature branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,7 +134,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Build image
-        if: matrix.platform != 'arm64' || github.ref_protected
+        if: matrix.platform == 'amd64' || github.ref_protected
         uses: ./.github/actions/build-image
         with:
           platform: ${{ matrix.platform }}
@@ -159,7 +159,7 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Upload Image
-        if: matrix.platform != 'arm64' || github.ref_protected
+        if: matrix.platform == 'amd64' || github.ref_protected
         uses: ./.github/actions/upload-image
         with:
           platform: ${{ matrix.platform }}


### PR DESCRIPTION
# Description

It's enough to build images with `amd64` to verify build/push works correctly. All remaining architectures will be built on merge to default branch.

## How can this be tested?
Check build on this PR.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

