### PR TITLE
introduce dtclient basic request timeout

### DIFF
--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -28,7 +28,7 @@ CONTROLLER_GEN=$(shell hack/build/command.sh controller-gen)
 
 prerequisites/setup-pre-commit:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golang_ci_cmd_version)
-	go install github.com/daixiang0/gci@v$(gci_version)
+	go install github.com/daixiang0/gci@$(gci_version)
 	go install golang.org/x/tools/cmd/goimports@$(golang_tools_version)
 	cp ./.github/pre-commit ./.git/hooks/pre-commit
 	chmod +x ./.git/hooks/pre-commit

--- a/src/dtclient/dynatrace_client.go
+++ b/src/dtclient/dynatrace_client.go
@@ -50,10 +50,11 @@ var defaultConnectionTimeout = 15 * time.Minute
 // makeRequest does an HTTP request by formatting the URL from the given arguments and returns the response.
 // The response body must be closed by the caller when no longer used.
 func (dtc *dynatraceClient) makeRequest(url string, tokenType tokenType) (*http.Response, error) {
-	req, err := createRequestWithDefaultTimeout(url, http.MethodGet, nil)
+	req, cancel, err := createRequestWithDefaultTimeout(url, http.MethodGet, nil)
 	if err != nil {
 		return nil, err
 	}
+	defer cancel()
 
 	var authHeader string
 
@@ -79,10 +80,10 @@ func (dtc *dynatraceClient) makeRequest(url string, tokenType tokenType) (*http.
 	return dtc.httpClient.Do(req)
 }
 
-func createBaseRequest(url, method, apiToken string, body io.Reader) (*http.Request, error) {
-	req, err := createRequestWithDefaultTimeout(url, method, body)
+func createBaseRequest(url, method, apiToken string, body io.Reader) (*http.Request, context.CancelFunc, error) {
+	req, cancel, err := createRequestWithDefaultTimeout(url, method, body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Api-Token %s", apiToken))
@@ -91,18 +92,19 @@ func createBaseRequest(url, method, apiToken string, body io.Reader) (*http.Requ
 		req.Header.Add("Content-Type", "application/json")
 	}
 
-	return req, nil
+	return req, cancel, nil
 }
 
-func createRequestWithDefaultTimeout(url, method string, body io.Reader) (*http.Request, error) {
-	ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(defaultConnectionTimeout))
+func createRequestWithDefaultTimeout(url, method string, body io.Reader) (*http.Request, context.CancelFunc, error) {
+	ctx, cancel := context.WithTimeout(context.TODO(), defaultConnectionTimeout)
 
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
-		return nil, errors.WithMessage(err, "error initializing http request")
+		cancel()
+		return nil, nil, errors.WithMessage(err, "error initializing http request")
 	}
 
-	return req, nil
+	return req, cancel, nil
 }
 
 func (dtc *dynatraceClient) getServerResponseData(response *http.Response) ([]byte, error) {

--- a/src/dtclient/dynatrace_client_test.go
+++ b/src/dtclient/dynatrace_client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -253,4 +254,42 @@ func createTestDynatraceClientWithFunc(t *testing.T, handler http.HandlerFunc) (
 	require.NotNil(t, dynatraceClient)
 
 	return dynatraceServer, dynatraceClient
+}
+
+func TestRequestCreationWithDefaultTimeoutSetTo15Min(t *testing.T) {
+	shouldBeDoneByNow := time.Now().Add(15 * time.Minute).Add(time.Second)
+
+	request, err := createBaseRequest(
+		"",
+		http.MethodGet,
+		"",
+		strings.NewReader(""))
+	assert.NoError(t, err)
+	deadline, _ := request.Context().Deadline()
+	assert.Greater(t, shouldBeDoneByNow, deadline)
+}
+
+func TestMakeRequestWithDefaultDeadline(t *testing.T) {
+	dynatraceServer := httptest.NewServer(dynatraceServerHandler())
+	defer dynatraceServer.Close()
+
+	dc := &dynatraceClient{
+		url:       dynatraceServer.URL,
+		apiToken:  apiToken,
+		paasToken: paasToken,
+
+		hostCache:  make(map[string]hostInfo),
+		httpClient: http.DefaultClient,
+	}
+
+	require.NotNil(t, dc)
+
+	{
+		url := fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dc.url)
+		resp, err := dc.makeRequest(url, dynatraceApiToken)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		defer CloseBodyAfterRequest(resp)
+	}
 }

--- a/src/dtclient/dynatrace_client_test.go
+++ b/src/dtclient/dynatrace_client_test.go
@@ -272,6 +272,7 @@ func TestRequestCreationWithDefaultTimeoutSetTo15Min(t *testing.T) {
 }
 
 func TestMakeRequestWithDefaultDeadline(t *testing.T) {
+	defaultConnectionTimeout = 1
 	dynatraceServer := httptest.NewServer(dynatraceServerHandler())
 	defer dynatraceServer.Close()
 
@@ -290,8 +291,7 @@ func TestMakeRequestWithDefaultDeadline(t *testing.T) {
 		url := fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dc.url)
 		resp, err := dc.makeRequest(url, dynatraceApiToken)
 
-		assert.NoError(t, err)
-		assert.NotNil(t, resp)
-		defer CloseBodyAfterRequest(resp)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
 	}
 }

--- a/src/dtclient/dynatrace_client_test.go
+++ b/src/dtclient/dynatrace_client_test.go
@@ -273,6 +273,10 @@ func TestRequestCreationWithDefaultTimeoutSetTo15Min(t *testing.T) {
 
 func TestMakeRequestWithDefaultDeadline(t *testing.T) {
 	defaultConnectionTimeout = 1
+	defer func() {
+		defaultConnectionTimeout = 15 * time.Minute
+	}()
+
 	dynatraceServer := httptest.NewServer(dynatraceServerHandler())
 	defer dynatraceServer.Close()
 

--- a/src/dtclient/dynatrace_client_test.go
+++ b/src/dtclient/dynatrace_client_test.go
@@ -291,11 +291,9 @@ func TestMakeRequestWithDefaultDeadline(t *testing.T) {
 
 	require.NotNil(t, dc)
 
-	{
-		url := fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dc.url)
-		resp, err := dc.makeRequest(url, dynatraceApiToken)
+	url := fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dc.url)
+	resp, err := dc.makeRequest(url, dynatraceApiToken) //nolint:bodyclose
 
-		assert.Error(t, err)
-		assert.Nil(t, resp)
-	}
+	assert.Error(t, err)
+	assert.Nil(t, resp)
 }

--- a/src/dtclient/dynatrace_client_test.go
+++ b/src/dtclient/dynatrace_client_test.go
@@ -259,12 +259,14 @@ func createTestDynatraceClientWithFunc(t *testing.T, handler http.HandlerFunc) (
 func TestRequestCreationWithDefaultTimeoutSetTo15Min(t *testing.T) {
 	shouldBeDoneByNow := time.Now().Add(15 * time.Minute).Add(time.Second)
 
-	request, err := createBaseRequest(
+	request, cancel, err := createBaseRequest(
 		"",
 		http.MethodGet,
 		"",
 		strings.NewReader(""))
 	assert.NoError(t, err)
+	defer cancel()
+
 	deadline, _ := request.Context().Deadline()
 	assert.Greater(t, shouldBeDoneByNow, deadline)
 }

--- a/src/dtclient/image.go
+++ b/src/dtclient/image.go
@@ -2,6 +2,7 @@ package dtclient
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -51,10 +52,11 @@ func (dtc *dynatraceClient) GetLatestActiveGateImage() (*LatestImageInfo, error)
 }
 
 func (dtc *dynatraceClient) processLatestImageRequest(url string) (*LatestImageInfo, error) {
-	request, err := dtc.createLatestImageRequest(url)
+	request, cancel, err := dtc.createLatestImageRequest(url)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	defer cancel()
 
 	response, err := dtc.httpClient.Do(request)
 	if err != nil {
@@ -93,15 +95,15 @@ func (dtc *dynatraceClient) handleLatestImageResponse(response *http.Response) (
 	return latestImageInfo, err
 }
 
-func (dtc *dynatraceClient) createLatestImageRequest(url string) (*http.Request, error) {
+func (dtc *dynatraceClient) createLatestImageRequest(url string) (*http.Request, context.CancelFunc, error) {
 	body := &LatestImageInfo{}
 
 	bodyData, err := json.Marshal(body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	request, err := createBaseRequest(
+	request, cancel, err := createBaseRequest(
 		url,
 		http.MethodGet,
 		dtc.apiToken,
@@ -109,10 +111,10 @@ func (dtc *dynatraceClient) createLatestImageRequest(url string) (*http.Request,
 	)
 
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
-	return request, nil
+	return request, cancel, nil
 }
 
 func (dtc *dynatraceClient) readResponseForLatestImage(response []byte) (*LatestImageInfo, error) {

--- a/src/dtclient/kubernetes_settings.go
+++ b/src/dtclient/kubernetes_settings.go
@@ -99,10 +99,11 @@ func (dtc *dynatraceClient) CreateOrUpdateKubernetesSetting(clusterLabel, kubeSy
 		return "", err
 	}
 
-	req, err := createBaseRequest(dtc.getSettingsUrl(false), http.MethodPost, dtc.apiToken, bytes.NewReader(bodyData))
+	req, cancel, err := createBaseRequest(dtc.getSettingsUrl(false), http.MethodPost, dtc.apiToken, bytes.NewReader(bodyData))
 	if err != nil {
 		return "", err
 	}
+	defer cancel()
 
 	res, err := dtc.httpClient.Do(req)
 	if err != nil {
@@ -138,10 +139,11 @@ func (dtc *dynatraceClient) GetMonitoredEntitiesForKubeSystemUUID(kubeSystemUUID
 		return nil, errors.New("no kube-system namespace UUID given")
 	}
 
-	req, err := createBaseRequest(dtc.getEntitiesUrl(), http.MethodGet, dtc.apiToken, nil)
+	req, cancel, err := createBaseRequest(dtc.getEntitiesUrl(), http.MethodGet, dtc.apiToken, nil)
 	if err != nil {
 		return nil, err
 	}
+	defer cancel()
 
 	q := req.URL.Query()
 	q.Add("pageSize", "500")
@@ -178,10 +180,11 @@ func (dtc *dynatraceClient) GetSettingsForMonitoredEntities(monitoredEntities []
 		scopes = append(scopes, entity.EntityId)
 	}
 
-	req, err := createBaseRequest(dtc.getSettingsUrl(true), http.MethodGet, dtc.apiToken, nil)
+	req, cancel, err := createBaseRequest(dtc.getSettingsUrl(true), http.MethodGet, dtc.apiToken, nil)
 	if err != nil {
 		return GetSettingsResponse{}, err
 	}
+	defer cancel()
 
 	q := req.URL.Query()
 	q.Add("schemaIds", "builtin:cloud.kubernetes")


### PR DESCRIPTION
# Description

refactored the code to introduce a basic 15m timeout to requests of the dynatrace client.

## How can this be tested?
- run unit-tests
- debug code an verify timeout/deadline of context


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

