### PR TITLE
Make activegate SCC less fragile

### DIFF
--- a/config/helm/chart/default/templates/Openshift/activegate/securitycontextconstraints.yaml
+++ b/config/helm/chart/default/templates/Openshift/activegate/securitycontextconstraints.yaml
@@ -24,8 +24,7 @@ readOnlyRootFilesystem: false
 requiredDropCapabilities:
   - ALL
 runAsUser:
-  type: MustRunAs
-  uid: 1001
+  type: MustRunAsNonRoot
 seLinuxContext:
   type: RunAsAny
 seccompProfiles:


### PR DESCRIPTION
# Description

Setting `runAsUser` to `MustRunAs` is rather fragile as the moment something gets injected to a pod (with probably a different user) the SCC will no longer match, therefor the pod will not come up. 

## How can this be tested?
Run `make PLATFORM=openshift test/e2e/activegate/proxy` againts an openshift cluster, this will use istio to limit the dynatrace namespace, so the istio sidecar will be injected into every pod, which has the userid 1337.
If the tests passes then everything works as expected.


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

