### PR TITLE
image push on prereleases

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+ # include prerelease tags too
 
 permissions:
   contents: read
@@ -104,6 +105,7 @@ jobs:
 
   push-rhcc:
     name: Push amd64 image to RHCC
+    if: ${{ !contains(github.ref, '-rc') }}
     environment: Release
     needs: [prepare, build]
     runs-on: ubuntu-latest


### PR DESCRIPTION
running image publishing a prerelease generation but omit pushing to RedHat Container Center

# Description

- added the image push workflow to prereleases
- omitted pushing to RedHat Container Center for prereleases 

## How can this be tested?
- create a fork
- setup gcr and quay.io access (push to quay instead of dockerhub)
- setup signing
- create a prerelease

## Checklist
- [ ] ~~Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

