### PR TITLE
Simplify dtclient timeout logic

### DIFF
--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -28,7 +28,7 @@ CONTROLLER_GEN=$(shell hack/build/command.sh controller-gen)
 
 prerequisites/setup-pre-commit:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golang_ci_cmd_version)
-	go install github.com/daixiang0/gci@v$(gci_version)
+	go install github.com/daixiang0/gci@$(gci_version)
 	go install golang.org/x/tools/cmd/goimports@$(golang_tools_version)
 	cp ./.github/pre-commit ./.git/hooks/pre-commit
 	chmod +x ./.git/hooks/pre-commit

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -28,7 +28,7 @@ CONTROLLER_GEN=$(shell hack/build/command.sh controller-gen)
 
 prerequisites/setup-pre-commit:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golang_ci_cmd_version)
-	go install github.com/daixiang0/gci@$(gci_version)
+	go install github.com/daixiang0/gci@v$(gci_version)
 	go install golang.org/x/tools/cmd/goimports@$(golang_tools_version)
 	cp ./.github/pre-commit ./.git/hooks/pre-commit
 	chmod +x ./.git/hooks/pre-commit

--- a/src/dtclient/activegate_auth_token.go
+++ b/src/dtclient/activegate_auth_token.go
@@ -2,7 +2,6 @@ package dtclient
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -28,11 +27,10 @@ type ActiveGateAuthTokenParams struct {
 }
 
 func (dtc *dynatraceClient) GetActiveGateAuthToken(dynakubeName string) (*ActiveGateAuthTokenInfo, error) {
-	request, cancel, err := dtc.createAuthTokenRequest(dynakubeName)
+	request, err := dtc.createAuthTokenRequest(dynakubeName)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	defer cancel()
 
 	response, err := dtc.httpClient.Do(request)
 
@@ -52,7 +50,7 @@ func (dtc *dynatraceClient) GetActiveGateAuthToken(dynakubeName string) (*Active
 	return authTokenInfo, nil
 }
 
-func (dtc *dynatraceClient) createAuthTokenRequest(dynakubeName string) (*http.Request, context.CancelFunc, error) {
+func (dtc *dynatraceClient) createAuthTokenRequest(dynakubeName string) (*http.Request, error) {
 	body := &ActiveGateAuthTokenParams{
 		Name:           dynakubeName,
 		SeedToken:      false,
@@ -61,19 +59,19 @@ func (dtc *dynatraceClient) createAuthTokenRequest(dynakubeName string) (*http.R
 	}
 	bodyData, err := json.Marshal(body)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	request, cancel, err := createBaseRequest(
+	request, err := createBaseRequest(
 		dtc.getActiveGateAuthTokenUrl(),
 		http.MethodPost,
 		dtc.apiToken,
 		bytes.NewReader(bodyData),
 	)
 	if err != nil {
-		return nil, nil, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	return request, cancel, nil
+	return request, nil
 }
 
 func (dtc *dynatraceClient) handleAuthTokenResponse(response *http.Response) (*ActiveGateAuthTokenInfo, error) {

--- a/src/dtclient/client.go
+++ b/src/dtclient/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/http/httpproxy"
@@ -141,6 +142,7 @@ func NewClient(url, apiToken, paasToken string, opts ...Option) (Client, error) 
 		hostCache: make(map[string]hostInfo),
 		httpClient: &http.Client{
 			Transport: http.DefaultTransport.(*http.Transport).Clone(),
+			Timeout:   15 * time.Minute,
 		},
 	}
 

--- a/src/dtclient/image.go
+++ b/src/dtclient/image.go
@@ -2,7 +2,6 @@ package dtclient
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 
@@ -52,11 +51,10 @@ func (dtc *dynatraceClient) GetLatestActiveGateImage() (*LatestImageInfo, error)
 }
 
 func (dtc *dynatraceClient) processLatestImageRequest(url string) (*LatestImageInfo, error) {
-	request, cancel, err := dtc.createLatestImageRequest(url)
+	request, err := dtc.createLatestImageRequest(url)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	defer cancel()
 
 	response, err := dtc.httpClient.Do(request)
 	if err != nil {
@@ -95,15 +93,15 @@ func (dtc *dynatraceClient) handleLatestImageResponse(response *http.Response) (
 	return latestImageInfo, err
 }
 
-func (dtc *dynatraceClient) createLatestImageRequest(url string) (*http.Request, context.CancelFunc, error) {
+func (dtc *dynatraceClient) createLatestImageRequest(url string) (*http.Request, error) {
 	body := &LatestImageInfo{}
 
 	bodyData, err := json.Marshal(body)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	request, cancel, err := createBaseRequest(
+	request, err := createBaseRequest(
 		url,
 		http.MethodGet,
 		dtc.apiToken,
@@ -111,10 +109,10 @@ func (dtc *dynatraceClient) createLatestImageRequest(url string) (*http.Request,
 	)
 
 	if err != nil {
-		return nil, nil, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
 
-	return request, cancel, nil
+	return request, nil
 }
 
 func (dtc *dynatraceClient) readResponseForLatestImage(response []byte) (*LatestImageInfo, error) {

--- a/src/dtclient/kubernetes_settings.go
+++ b/src/dtclient/kubernetes_settings.go
@@ -99,11 +99,10 @@ func (dtc *dynatraceClient) CreateOrUpdateKubernetesSetting(clusterLabel, kubeSy
 		return "", err
 	}
 
-	req, cancel, err := createBaseRequest(dtc.getSettingsUrl(false), http.MethodPost, dtc.apiToken, bytes.NewReader(bodyData))
+	req, err := createBaseRequest(dtc.getSettingsUrl(false), http.MethodPost, dtc.apiToken, bytes.NewReader(bodyData))
 	if err != nil {
 		return "", err
 	}
-	defer cancel()
 
 	res, err := dtc.httpClient.Do(req)
 	if err != nil {
@@ -139,11 +138,10 @@ func (dtc *dynatraceClient) GetMonitoredEntitiesForKubeSystemUUID(kubeSystemUUID
 		return nil, errors.New("no kube-system namespace UUID given")
 	}
 
-	req, cancel, err := createBaseRequest(dtc.getEntitiesUrl(), http.MethodGet, dtc.apiToken, nil)
+	req, err := createBaseRequest(dtc.getEntitiesUrl(), http.MethodGet, dtc.apiToken, nil)
 	if err != nil {
 		return nil, err
 	}
-	defer cancel()
 
 	q := req.URL.Query()
 	q.Add("pageSize", "500")
@@ -180,11 +178,10 @@ func (dtc *dynatraceClient) GetSettingsForMonitoredEntities(monitoredEntities []
 		scopes = append(scopes, entity.EntityId)
 	}
 
-	req, cancel, err := createBaseRequest(dtc.getSettingsUrl(true), http.MethodGet, dtc.apiToken, nil)
+	req, err := createBaseRequest(dtc.getSettingsUrl(true), http.MethodGet, dtc.apiToken, nil)
 	if err != nil {
 		return GetSettingsResponse{}, err
 	}
-	defer cancel()
 
 	q := req.URL.Query()
 	q.Add("schemaIds", "builtin:cloud.kubernetes")


### PR DESCRIPTION
# Description

Undoes the previous commit about using the `NewRequestWithContext` with a quick work around timeout, as it cause unexplainable problems (1 specific request always got its context immediately canceled)

So now we just set a default timeout on the client itself

## How can this be tested?
Run e2e test, and they should all pass.


## Checklist
- [ x] Unit tests have been updated/added
- [ x] PR is labeled accordingly
- [ x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

