### PR TITLE
Fix dynakube sample image and version fields by setting empty string

### DIFF
--- a/assets/samples/classicFullStack.yaml
+++ b/assets/samples/classicFullStack.yaml
@@ -60,12 +60,12 @@ spec:
       # The version is expected to be provided in the semver format
       # Example: {major.minor.release}, e.g., "1.200.0"
       #
-      # version:
+      # version: ""
 
       # Optional: Sets the URI for the image containing the OneAgent installer used by the DaemonSet
       # Defaults to the latest OneAgent image on the tenant's registry
       #
-      image:
+      image: ""
 
       # Optional: Sets a node selector to control on which nodes the OneAgent will be deployed.
       # For more information on node selectors, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/

--- a/assets/samples/cloudNativeFullStack.yaml
+++ b/assets/samples/cloudNativeFullStack.yaml
@@ -138,14 +138,14 @@ spec:
       # Optional: Sets the URI for the image containing the OneAgent installer used by the DaemonSet
       # Defaults to the latest OneAgent image on the tenant's registry
       #
-      # image:
+      # image: ""
 
       # Optional: If specified, indicates the OneAgent version to use
       # Defaults to the configured version on your Dynatrace environment
       # The version is expected to be provided in the semver format
       # Example: {major.minor.release}, e.g., "1.200.0"
       #
-      # version:
+      # version: ""
 
       # Optional: Defines resources requests and limits for the initContainer
       # See more: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers

--- a/assets/samples/hostMonitoring.yaml
+++ b/assets/samples/hostMonitoring.yaml
@@ -60,12 +60,12 @@ spec:
       # The version is expected to be provided in the semver format
       # Example: {major.minor.release}, e.g., "1.200.0"
       #
-      # version:
+      # version: ""
 
       # Optional: Sets the URI for the image containing the OneAgent installer used by the DaemonSet
       # Defaults to the latest OneAgent image on the tenant's registry
       #
-      image:
+      image: ""
 
       # Optional: Sets a node selector to control on which nodes the OneAgent will be deployed.
       # For more information on node selectors, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/


### PR DESCRIPTION
# Description

Previously the image field in the samples was invalid as it was empty but not an empty string. As it is of type string it has to be set to an empty string in order to not be invalid when applying the dynakube. 

NOTE: I also did the same with the version fields as they are also of type string.

## Checklist
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

