### PR TITLE
Fix the race condition of multiple dynakubes configured with and without a proxy

### DIFF
--- a/src/controllers/dynakube/activegate/capability/capability.go
+++ b/src/controllers/dynakube/activegate/capability/capability.go
@@ -199,8 +199,8 @@ func GenerateActiveGateCapabilities(dk *dynatracev1beta1.DynaKube) []Capability 
 	}
 }
 
-func BuildProxySecretName() string {
-	return "dynatrace" + "-" + consts.MultiActiveGateName + "-" + consts.ProxySecretSuffix
+func BuildProxySecretName(dynakubeName string) string {
+	return dynakubeName + "-" + consts.MultiActiveGateName + "-" + consts.ProxySecretSuffix
 }
 
 func BuildServiceName(dynakubeName string, module string) string {

--- a/src/controllers/dynakube/activegate/capability/capability_test.go
+++ b/src/controllers/dynakube/activegate/capability/capability_test.go
@@ -40,8 +40,8 @@ func buildDynakube(capabilities []dynatracev1beta1.CapabilityDisplayName) *dynat
 
 func TestBuildProxySecretName(t *testing.T) {
 	t.Run(`correct secret name`, func(t *testing.T) {
-		expectedProxySecretName := "dynatrace-activegate-internal-proxy"
-		actualProxySecretName := BuildProxySecretName()
+		expectedProxySecretName := "someDK-activegate-internal-proxy"
+		actualProxySecretName := BuildProxySecretName("someDK")
 		require.NotEmpty(t, actualProxySecretName)
 		assert.Equal(t, expectedProxySecretName, actualProxySecretName)
 	})

--- a/src/controllers/dynakube/activegate/internal/proxy/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/proxy/reconciler.go
@@ -58,7 +58,7 @@ func (r *Reconciler) generateForDynakube(ctx context.Context, dynakube *dynatrac
 
 	coreLabels := kubeobjects.NewCoreLabels(dynakube.Name, kubeobjects.ActiveGateComponentLabel)
 	secret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube,
-		kubeobjects.NewSecretNameModifier(capability.BuildProxySecretName()),
+		kubeobjects.NewSecretNameModifier(capability.BuildProxySecretName(dynakube.Name)),
 		kubeobjects.NewSecretNamespaceModifier(r.dynakube.Namespace),
 		kubeobjects.NewSecretLabelsModifier(coreLabels.BuildMatchLabels()),
 		kubeobjects.NewSecretTypeModifier(corev1.SecretTypeOpaque),
@@ -74,7 +74,7 @@ func (r *Reconciler) generateForDynakube(ctx context.Context, dynakube *dynatrac
 }
 
 func (r *Reconciler) ensureDeleted(ctx context.Context, dynakube *dynatracev1beta1.DynaKube) error {
-	secretName := capability.BuildProxySecretName()
+	secretName := capability.BuildProxySecretName(dynakube.Name)
 	secret := corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: dynakube.Namespace}}
 	if err := r.client.Delete(ctx, &secret); err != nil && !k8serrors.IsNotFound(err) {
 		return err

--- a/src/controllers/dynakube/activegate/internal/proxy/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/proxy/reconciler_test.go
@@ -50,7 +50,7 @@ func TestReconcileWithoutProxy(t *testing.T) {
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(), Namespace: testNamespace}, &proxySecret)
+		err = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		require.Error(t, err)
 		assert.Empty(t, proxySecret)
@@ -59,7 +59,7 @@ func TestReconcileWithoutProxy(t *testing.T) {
 	t.Run(`ensure proxy secret deleted`, func(t *testing.T) {
 		var testClient = fake.NewClientBuilder().WithObjects(&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      capability.BuildProxySecretName(),
+				Name:      capability.BuildProxySecretName(testDynakubeName),
 				Namespace: testNamespace,
 			},
 		}).Build()
@@ -69,7 +69,7 @@ func TestReconcileWithoutProxy(t *testing.T) {
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(), Namespace: testNamespace}, &proxySecret)
+		err = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		require.Error(t, err)
 		assert.Empty(t, proxySecret)
@@ -86,7 +86,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(), Namespace: testNamespace}, &proxySecret)
+		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		assert.Equal(t, []byte(proxyPassword), proxySecret.Data[proxyPasswordField])
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
@@ -100,7 +100,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(), Namespace: testNamespace}, &proxySecret)
+		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		assert.Equal(t, []byte(nil), proxySecret.Data[proxyPasswordField])
 		assert.Equal(t, []byte(nil), proxySecret.Data[proxyPortField])
@@ -120,7 +120,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(), Namespace: testNamespace}, &proxySecret)
+		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		assert.Equal(t, []byte(proxyPassword), proxySecret.Data[proxyPasswordField])
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
@@ -133,7 +133,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(), Namespace: testNamespace}, &proxySecret)
+		r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		assert.Equal(t, []byte(proxyPassword), proxySecret.Data[proxyPasswordField])
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
@@ -146,7 +146,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 
 		require.NoError(t, err)
 
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(), Namespace: testNamespace}, &proxySecret)
+		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		assert.Equal(t, []byte(proxyPassword), proxySecret.Data[proxyPasswordField])
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy.go
@@ -41,7 +41,7 @@ func (mod ProxyModifier) getVolumes() []corev1.Volume {
 			Name: consts.InternalProxySecretVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: capability.BuildProxySecretName(),
+					SecretName: capability.BuildProxySecretName(mod.dynakube.Name),
 				},
 			},
 		},

--- a/src/controllers/dynakube/dynakube_controller_test.go
+++ b/src/controllers/dynakube/dynakube_controller_test.go
@@ -277,7 +277,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		assert.NotNil(t, result)
 
 		var proxySecret corev1.Secret
-		name := capability.BuildProxySecretName()
+		name := capability.BuildProxySecretName(testName)
 		err = controller.client.Get(context.TODO(), client.ObjectKey{Name: name, Namespace: testNamespace}, &proxySecret)
 
 		assert.NoError(t, err)
@@ -311,7 +311,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		assert.NotNil(t, result)
 
 		var proxySecret corev1.Secret
-		name := capability.BuildProxySecretName()
+		name := capability.BuildProxySecretName(testName)
 		err = controller.client.Get(context.TODO(), client.ObjectKey{Name: name, Namespace: testNamespace}, &proxySecret)
 
 		assert.Error(t, err)


### PR DESCRIPTION
fixed the race condition of multiple dynakubes configured with and without proxy interfering with each others proxy secret by segmenting proxy secrets. this results in each dynakube handling it's own secrets only. 

# Description

Please include the following:
- each dynakube will only handle it's own secrets.
- fixes #1825

## How can this be tested?
- create two dynakubes where one has a proxy configured while the other has not.
- change the dynakube without proxy so it gets reconciled
- the secret of the dynakube with proxy should not be touched 


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

