### PR TITLE
Overwrite the tenantUUID in the ruxitagentproc.conf

### DIFF
--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -189,7 +189,8 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 
 	latestProcessModuleConfig = latestProcessModuleConfig.
 		AddHostGroup(dk.HostGroup()).
-		AddConnectionInfo(dk.Status.OneAgent.ConnectionInfoStatus, tenantToken)
+		AddConnectionInfo(dk.Status.OneAgent.ConnectionInfoStatus, tenantToken).
+		AddTenantUUID(dynakubeMetadata.TenantUUID)
 
 	var agentUpdater *agentUpdater
 	if dk.CodeModulesImage() != "" {

--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -112,6 +112,11 @@ func (pmc *ProcessModuleConfig) AddHostGroup(hostGroup string) *ProcessModuleCon
 	return pmc.Add(property)
 }
 
+func (pmc *ProcessModuleConfig) AddTenantUUID(tenantUUID string) *ProcessModuleConfig {
+	property := ProcessModuleProperty{Section: generalSectionName, Key: "tenant", Value: tenantUUID}
+	return pmc.Add(property)
+}
+
 func (pmc ProcessModuleConfig) ToMap() ConfMap {
 	sections := map[string]map[string]string{}
 	for _, prop := range pmc.Properties {

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -128,6 +128,7 @@ func (runner *Runner) installOneAgent() error {
 	if err != nil {
 		return err
 	}
+	processModuleConfig = processModuleConfig.AddTenantUUID(runner.config.TenantUUID)
 	if err := runner.installer.UpdateProcessModuleConfig(config.AgentBinDirMount, processModuleConfig); err != nil {
 		return err
 	}

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -124,15 +124,22 @@ func (runner *Runner) installOneAgent() error {
 	if err != nil {
 		return err
 	}
-	processModuleConfig, err := runner.dtclient.GetProcessModuleConfig(0)
+	processModuleConfig, err := runner.getProcessModuleConfig()
 	if err != nil {
 		return err
 	}
-	processModuleConfig = processModuleConfig.AddTenantUUID(runner.config.TenantUUID)
 	if err := runner.installer.UpdateProcessModuleConfig(config.AgentBinDirMount, processModuleConfig); err != nil {
 		return err
 	}
 	return nil
+}
+
+func (runner *Runner) getProcessModuleConfig() (*dtclient.ProcessModuleConfig, error) {
+	processModuleConfig, err := runner.dtclient.GetProcessModuleConfig(0)
+	if err != nil {
+		return nil, err
+	}
+	return processModuleConfig.AddTenantUUID(runner.config.TenantUUID), nil
 }
 
 func (runner *Runner) configureInstallation() error {

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -274,7 +274,6 @@ func TestConfigureInstallation(t *testing.T) {
 }
 
 func TestGetProcessModuleConfig(t *testing.T) {
-
 	t.Run("add tenantUUID to process module config", func(t *testing.T) {
 		tenantAlias := "my-tenant"
 		runner := createMockedRunner(t)

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -280,8 +280,8 @@ func TestGetProcessModuleConfig(t *testing.T) {
 		runner := createMockedRunner(t)
 		runner.config.TenantUUID = tenantAlias
 		runner.dtclient.(*dtclient.MockDynatraceClient).
-		On("GetProcessModuleConfig", uint(0)).
-		Return(&testProcessModuleConfig, nil)
+			On("GetProcessModuleConfig", uint(0)).
+			Return(&testProcessModuleConfig, nil)
 
 		config, err := runner.getProcessModuleConfig()
 		require.NoError(t, err)
@@ -297,8 +297,8 @@ func TestGetProcessModuleConfig(t *testing.T) {
 	t.Run("error if api call fails", func(t *testing.T) {
 		runner := createMockedRunner(t)
 		runner.dtclient.(*dtclient.MockDynatraceClient).
-		On("GetProcessModuleConfig", uint(0)).
-		Return(&dtclient.ProcessModuleConfig{}, fmt.Errorf("BOOM"))
+			On("GetProcessModuleConfig", uint(0)).
+			Return(&dtclient.ProcessModuleConfig{}, fmt.Errorf("BOOM"))
 
 		config, err := runner.getProcessModuleConfig()
 		require.Error(t, err)

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -273,6 +273,39 @@ func TestConfigureInstallation(t *testing.T) {
 	})
 }
 
+func TestGetProcessModuleConfig(t *testing.T) {
+
+	t.Run("add tenantUUID to process module config", func(t *testing.T) {
+		tenantAlias := "my-tenant"
+		runner := createMockedRunner(t)
+		runner.config.TenantUUID = tenantAlias
+		runner.dtclient.(*dtclient.MockDynatraceClient).
+		On("GetProcessModuleConfig", uint(0)).
+		Return(&testProcessModuleConfig, nil)
+
+		config, err := runner.getProcessModuleConfig()
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		generalSection, ok := config.ToMap()["general"]
+		require.True(t, ok)
+		tenantUUID, ok := generalSection["tenant"]
+		require.True(t, ok)
+		assert.Equal(t, tenantAlias, tenantUUID)
+	})
+
+	t.Run("error if api call fails", func(t *testing.T) {
+		runner := createMockedRunner(t)
+		runner.dtclient.(*dtclient.MockDynatraceClient).
+		On("GetProcessModuleConfig", uint(0)).
+		Return(&dtclient.ProcessModuleConfig{}, fmt.Errorf("BOOM"))
+
+		config, err := runner.getProcessModuleConfig()
+		require.Error(t, err)
+		require.Nil(t, config)
+	})
+}
+
 func TestCreateContainerConfigurationFiles(t *testing.T) {
 	runner := createMockedRunner(t)
 	runner.config.HasHost = false


### PR DESCRIPTION
# Description

Incase the Dynatrace Environment api has an alias, then the operator will use the alias as the tenantUUID, however the customised oneagent archive downloaded from the tenant will have the actual non-aliased tenantUUID in the `ruxitagentproc.conf`. 

## How can this be tested?
Deploy the operator with application monitoring, and in the csi-driver or in an injected pod check the agent conf directory's ruxitagentproc.conf and _ruxitagentproc.conf. When using a Dynatrace Environment with an alias, the 2 files should have a different entry in the [general] section for [tenant]


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

