### PR TITLE
Fix trustedCA handling for image registries

### DIFF
--- a/src/controllers/csi/provisioner/agent_test.go
+++ b/src/controllers/csi/provisioner/agent_test.go
@@ -227,7 +227,7 @@ func TestUpdateAgent(t *testing.T) {
 		dockerJsonPath := path.Join(dockerconfig.TmpPath, dockerconfig.RegistryAuthDir, dk.Name)
 		checkFilesCreatedAndCleanedUp(t, updater, dockerJsonPath, dockerconfigjsonContent)
 
-		caFilePath := path.Join(dockerconfig.TmpPath, dockerconfig.CADir, dk.Name)
+		caFilePath := path.Join(dockerconfig.TmpPath, dockerconfig.CADir, dk.Name, dockerconfig.TrustedCertFileName)
 		checkFilesCreatedAndCleanedUp(t, updater, caFilePath, customCertContent)
 	})
 }

--- a/src/dockerconfig/docker_config.go
+++ b/src/dockerconfig/docker_config.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	TmpPath         = "/tmp/dynatrace-operator"
-	CADir           = "ca"
-	TrustedCertFileName      = "custom.crt"
-	RegistryAuthDir = "dockerconf"
+	TmpPath             = "/tmp/dynatrace-operator"
+	CADir               = "ca"
+	TrustedCertFileName = "custom.crt"
+	RegistryAuthDir     = "dockerconf"
 )
 
 type DockerConfig struct {

--- a/src/dockerconfig/docker_config.go
+++ b/src/dockerconfig/docker_config.go
@@ -15,6 +15,7 @@ import (
 const (
 	TmpPath         = "/tmp/dynatrace-operator"
 	CADir           = "ca"
+	TrustedCertFileName      = "custom.crt"
 	RegistryAuthDir = "dockerconf"
 )
 
@@ -113,7 +114,8 @@ func (config *DockerConfig) storeTrustedCAs(ctx context.Context, fs afero.Afero)
 		return err
 	}
 
-	if err := saveFile(customCAs, fs, config.TrustedCertsPath); err != nil {
+	tmpCertFilePath := path.Join(config.TrustedCertsPath, TrustedCertFileName)
+	if err := saveFile(customCAs, fs, tmpCertFilePath); err != nil {
 		log.Info("failed to store custom certificates", "dynakube", config.Dynakube.Name)
 		return err
 	}

--- a/src/dockerconfig/docker_config_test.go
+++ b/src/dockerconfig/docker_config_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
@@ -190,6 +191,6 @@ func testPullSecret(t *testing.T, withCaCerts, customPullSecret, injectedPullSec
 
 	checkFileContents(t, fs, dockerConfig.RegistryAuthPath, registryAuthContent)
 	if withCaCerts {
-		checkFileContents(t, fs, dockerConfig.TrustedCertsPath, testValue)
+		checkFileContents(t, fs, filepath.Join(dockerConfig.TrustedCertsPath, TrustedCertFileName), testValue)
 	}
 }


### PR DESCRIPTION
# Description
For the image library to use TrustedCAs they need to be stored on the filesystem and provide the directory to the library before contacting the registry.

There was a recent refactor in that area of the code, that broke the filepath, causing the provided path to be a file instead of a directory.

## How can this be tested?
You need a registry that needs a trustedCA, and provide said trustedCA to the operator and everything should work


## Checklist
- [x] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

