### PR TITLE
Add ppc64le to image manifest on release

### DIFF
--- a/hack/build/ci/create-manifest.sh
+++ b/hack/build/ci/create-manifest.sh
@@ -12,10 +12,11 @@ multiplatform=$3
 
 if [ "$multiplatform" == "true" ]
 then
-  echo "Creating manifest for AMD and ARM images"
+  echo "Creating manifest for AMD, ARM and PPC64LE images"
   docker pull "${image_name}:${image_tag}-amd64"
   docker pull "${image_name}:${image_tag}-arm64"
-  docker manifest create "${image_name}:${image_tag}" "${image_name}:${image_tag}-arm64" "${image_name}:${image_tag}-amd64"
+  docker pull "${image_name}:${image_tag}-ppc64le"
+  docker manifest create "${image_name}:${image_tag}" "${image_name}:${image_tag}-arm64" "${image_name}:${image_tag}-amd64" "${image_name}:${image_tag}-ppc64le"
 else
   echo "Creating manifest for the AMD image "
   docker pull "${image_name}:${image_tag}-amd64"


### PR DESCRIPTION
# Description
Manifest should contain additional supported architecture, `ppc64le`, if images are built in CI.

## How can this be tested?
Push multi platform image and create manifest using `create-manifest.sh`

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

