### PR TITLE
Removes openshiftOrOlm check in helm manifests

### DIFF
--- a/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
@@ -1,5 +1,5 @@
 {{- include "dynatrace-operator.platformRequired" . }}
-{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
 
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/csi/clusterrole-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/clusterrole-csi.yaml
@@ -62,7 +62,7 @@ rules:
       - get
       - list
       - watch
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/csi/csidriver.yaml
+++ b/config/helm/chart/default/templates/Common/csi/csidriver.yaml
@@ -18,7 +18,7 @@ kind: CSIDriver
 metadata:
   name: csi.oneagent.dynatrace.com
   labels:
-    {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+    {{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
     security.openshift.io/csi-ephemeral-volume-profile: "restricted"
     {{- end }}
     {{- include "dynatrace-operator.csiLabels" . | nindent 4 }}

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
@@ -80,7 +80,7 @@ rules:
       - /livez
     verbs:
       - get
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-privileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-privileged.yaml
@@ -1,5 +1,5 @@
 {{- include "dynatrace-operator.platformRequired" . }}
-{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
@@ -1,5 +1,5 @@
 {{- include "dynatrace-operator.platformRequired" . }}
-{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
@@ -90,7 +90,7 @@ rules:
     verbs:
       - get
       - update
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
@@ -83,7 +83,7 @@ rules:
       - deploymentconfigs
     verbs:
       - get
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/_platform.tpl
+++ b/config/helm/chart/default/templates/_platform.tpl
@@ -28,15 +28,6 @@ Auto-detect the platform (if not set), according to the available APIVersions
 {{- end }}
 
 {{/*
-Exclude Kubernetes manifest not running on OLM
-*/}}
-{{- define "dynatrace-operator.openshiftOrOlm" -}}
-{{- if and (or (eq (include "dynatrace-operator.platform" .) "openshift") (.Values.olm)) (eq (include "dynatrace-operator.partial" .) "false") -}}
-    {{ default "true" }}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Check if platform is set to a valid one
 */}}
 {{- define "dynatrace-operator.platformIsValid" -}}

--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -6,7 +6,6 @@ manifests/kubernetes/csi:
 		--set partial="csi" \
 		--set platform="kubernetes" \
 		--set manifests=true \
-		--set olm="${OLM}" \
 		--set image="$(IMAGE_URI)" > "$(KUBERNETES_CSIDRIVER_YAML)"
 
 ## Generates a Kubernetes manifest with a CRD
@@ -16,7 +15,6 @@ manifests/kubernetes/core: manifests/crd/helm
 			--set installCRD=true \
 			--set platform="kubernetes" \
 			--set manifests=true \
-			--set olm="${OLM}" \
 			--set image="$(IMAGE_URI)" > "$(KUBERNETES_CORE_YAML)"
 
 ## Generates a Kubernetes manifest with a CRD for gke-autopilot
@@ -26,7 +24,6 @@ manifests/kubernetes/gke-autopilot: manifests/crd/helm
 			--set installCRD=true \
 			--set platform="gke-autopilot" \
 			--set manifests=true \
-			--set olm="${OLM}" \
 			--set image="$(IMAGE_URI)" > "$(KUBERNETES_AUTOPILOT_YAML)"
 
 ## Generates a manifest for Kubernetes including a CRD, a CSI driver deployment and a OLM version

--- a/hack/make/manifests/openshift.mk
+++ b/hack/make/manifests/openshift.mk
@@ -6,7 +6,6 @@ manifests/openshift/csi:
 		--set partial="csi" \
 		--set platform="openshift" \
 		--set manifests=true \
-		--set olm="${OLM}" \
 		--set createSecurityContextConstraints="true" \
 		--set image="$(IMAGE_URI)" > "$(OPENSHIFT_CSIDRIVER_YAML)"
 
@@ -17,7 +16,6 @@ manifests/openshift/core: manifests/crd/helm
 		--set installCRD=true \
 		--set platform="openshift" \
 		--set manifests=true \
-		--set olm="${OLM}" \
 		--set createSecurityContextConstraints="true" \
 		--set image="$(IMAGE_URI)" > "$(OPENSHIFT_CORE_YAML)"
 


### PR DESCRIPTION
# Description

As we have removed the custom SCCs, we should also remove the openshift or OLM check, as there is no need for it anymore. We can just check for the platform everywhere anyway.

## How can this be tested?
`make manifests` creates the correct manifests


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

