### PR TITLE
Add automatic k8s cluster monitoring annotation to dynakube samples

### DIFF
--- a/assets/samples/applicationMonitoring.yaml
+++ b/assets/samples/applicationMonitoring.yaml
@@ -3,6 +3,9 @@ kind: DynaKube
 metadata:
   name: dynakube
   namespace: dynatrace
+  # Automatically connect the kubernetes api to the dynatrace tenant endpoint to enable kubernetes monitoring.
+  annotations:
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
 spec:
   # Dynatrace apiUrl including the `/api` path at the end.
   # For SaaS, set `ENVIRONMENTID` to your environment ID.

--- a/assets/samples/classicFullStack.yaml
+++ b/assets/samples/classicFullStack.yaml
@@ -3,6 +3,9 @@ kind: DynaKube
 metadata:
   name: dynakube
   namespace: dynatrace
+  # Automatically connect the kubernetes api to the dynatrace tenant endpoint to enable kubernetes monitoring.
+  annotations:
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
 spec:
   # Dynatrace apiUrl including the `/api` path at the end.
   # For SaaS, set `ENVIRONMENTID` to your environment ID.

--- a/assets/samples/cloudNativeFullStack.yaml
+++ b/assets/samples/cloudNativeFullStack.yaml
@@ -3,6 +3,9 @@ kind: DynaKube
 metadata:
   name: dynakube
   namespace: dynatrace
+  # Automatically connect the kubernetes api to the dynatrace tenant endpoint to enable kubernetes monitoring.
+  annotations:
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
 spec:
   # Dynatrace apiUrl including the `/api` path at the end.
   # For SaaS, set `ENVIRONMENTID` to your environment ID.

--- a/assets/samples/hostMonitoring.yaml
+++ b/assets/samples/hostMonitoring.yaml
@@ -3,6 +3,9 @@ kind: DynaKube
 metadata:
   name: dynakube
   namespace: dynatrace
+  # Automatically connect the kubernetes api to the dynatrace tenant endpoint to enable kubernetes monitoring.
+  annotations:
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
 spec:
   # Dynatrace apiUrl including the `/api` path at the end.
   # For SaaS, set `ENVIRONMENTID` to your environment ID.

--- a/assets/samples/multipleDynakubes.yaml
+++ b/assets/samples/multipleDynakubes.yaml
@@ -3,6 +3,9 @@ kind: DynaKube
 metadata:
   name: dynakube-application-monitoring
   namespace: dynatrace
+  # Automatically connect the kubernetes api to the dynatrace tenant endpoint to enable kubernetes monitoring.
+  annotations:
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
 spec:
   # Dynatrace apiUrl including the `/api` path at the end.
   # For SaaS, set `ENVIRONMENTID` to your environment ID.


### PR DESCRIPTION
# Description

Updated the sample yaml files.

Fixes #1857 

## How can this be tested?
- deploy a dynakube from the sample.
- the k8s cluster should be visible in the tenant ui automatically.


## Checklist
- [x] ~~Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

