### PR TITLE
Fixed specific agent version e2e test (old version equal new version)

### DIFF
--- a/src/version/semantic.go
+++ b/src/version/semantic.go
@@ -84,3 +84,15 @@ func IsDowngrade(prev string, curr string) (bool, error) {
 	comp := CompareSemanticVersions(parsedPrev, parsedCurr)
 	return comp > 0, nil
 }
+
+// AreDevBuildsInTheSameSprint returns:
+//
+//	true:  if both versions describe the same sprint and DEV phase (release == 0)
+//	false: otherwise
+func AreDevBuildsInTheSameSprint(a SemanticVersion, b SemanticVersion) bool {
+	if a.major == b.major && a.minor == b.minor && a.release == 0 && b.release == 0 {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
# Description

The `specific-agent-version` e2e test needs 2 different versions to simulate an update. Update happens if versions relate to different sprints or different releases in the same sprint, otherwise versions are considered  equal by the update mechanism and no action is performed.
For example:
- 1.256.0.11112233-445566 and 1.256.0.11112233-778899 are "equal"
- 1.256.0.11112233-445566 and 1.256.1.11112233-778899 are different
- 1.256.0.11112233-445566 and 1.257.0.11112233-778899 are different

The lower version returned by `specificAgentVersion` function meets the above requirement now. The test fails if such a different version can not be found.

## How can this be tested?
The `specific-agent-version` e2e test should PASS started by our pipelines. 

## Checklist
~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

