### PR TITLE
Add unique label to e2e test namespace for support archive test

### DIFF
--- a/test/scenarios/support_archive/install.go
+++ b/test/scenarios/support_archive/install.go
@@ -42,19 +42,21 @@ func supportArchiveExecution(t *testing.T) features.Feature {
 	builder := features.New("support archive execution")
 	secretConfig := tenant.GetSingleTenantSecret(t)
 
+	injectLabels := map[string]string{
+		"inject": "me",
+	}
+
 	dynakubeBuilder := dynakube.NewBuilder().
 		WithDefaultObjectMeta().
 		NamespaceSelector(metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"kubernetes.io/metadata.name": testAppNameInjected,
-			},
+			MatchLabels: injectLabels,
 		}).
 		ApiUrl(secretConfig.ApiUrl).
 		CloudNative(&dynatracev1beta1.CloudNativeFullStackSpec{})
 	testDynakube := dynakubeBuilder.Build()
 
 	// Register sample namespace creat and delete
-	builder.Assess("create sample injected namespace", namespace.Create(namespace.NewBuilder(testAppNameInjected).Build()))
+	builder.Assess("create sample injected namespace", namespace.Create(namespace.NewBuilder(testAppNameInjected).WithLabels(injectLabels).Build()))
 	builder.Assess("create sample not injected namespace", namespace.Create(namespace.NewBuilder(testAppNameNotInjected).Build()))
 	builder.Teardown(namespace.Delete(testAppNameInjected))
 	builder.Teardown(namespace.Delete(testAppNameNotInjected))

--- a/test/scenarios/support_archive/install.go
+++ b/test/scenarios/support_archive/install.go
@@ -232,10 +232,11 @@ func getRequiredDynaKubeFiles(testDynakube dynatracev1beta1.DynaKube) []string {
 
 func assertFile(t *testing.T, requiredFiles []string, hdr tar.Header) []string {
 	index := slices.IndexFunc(requiredFiles, func(file string) bool { return file == hdr.Name })
-	assert.NotEqualf(t, -1, index, "Found unexpected file %s.", hdr.Name)
 
 	if index != -1 {
 		requiredFiles = slices.Delete(requiredFiles, index, index+1)
+	} else {
+		t.Log("unexpected file found", "filename:", hdr.Name)
 	}
 
 	assert.NotZerof(t, hdr.Size, "File %s is empty.", hdr.Name)


### PR DESCRIPTION
# Description
On older kubernetes versions (like 1.20) the `"kubernetes.io/metadata.name"` label is not present on namespaces, so we don't rely on them during the support-archive e2e test. (it fails otherwise)
 
Also removed the assert for unexpected files, so if am unexpected restart happens this test will not break.

## How can this be tested?
Run `make test/e2e/supportarchive/debug` on a kubernetes 1.20 cluster


## Checklist
- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

