### PR TITLE
Fixes wrong serviceAccount used for uninstall-daemonset in e2e tests

### DIFF
--- a/hack/build/bundle.sh
+++ b/hack/build/bundle.sh
@@ -27,7 +27,7 @@ if [ -z "${OPERATOR_SDK}" ]; then
 fi
 
 SDK_PARAMS=(
---extra-service-accounts dynatrace-dynakube-oneagent-unprivileged
+--extra-service-accounts dynatrace-dynakube-oneagent
 --extra-service-accounts dynatrace-kubernetes-monitoring
 --extra-service-accounts dynatrace-activegate
 )

--- a/test/testdata/oneagent/uninstall-oneagent.yaml
+++ b/test/testdata/oneagent/uninstall-oneagent.yaml
@@ -46,8 +46,8 @@ spec:
         volumeMounts:
         - mountPath: /mnt/root
           name: host-root
-      serviceAccount: dynatrace-dynakube-oneagent-privileged
-      serviceAccountName: dynatrace-dynakube-oneagent-privileged
+      serviceAccount: dynatrace-dynakube-oneagent
+      serviceAccountName: dynatrace-dynakube-oneagent
       volumes:
       - hostPath:
           path: /


### PR DESCRIPTION
# Description

As we remove the privileged and unprivileged oneAgent serviceAccount, we also have to use the newly created serviceAccount for our uninstall daemonset in order to have a proper cleanup after the classicFullStack e2e test. 

Currently it failed, as the uninstall-oneagent daemonset pods could not be scheduled as the serviceAccount it referenced (unprivileged) was not there.

## How can this be tested?
Run `make test/e2e/classic`


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

