### PR TITLE
Adds correct version comment for trivy action to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -225,7 +225,7 @@ jobs:
           hack/build/ci/get-image-digest.sh
       - name: Create sbom for ${{matrix.registry}}
         id: sbom
-        uses: aquasecurity/trivy-action@41f05d9ecffa2ed3f1580af306000f734b733e54 # v0.11.2
+        uses: aquasecurity/trivy-action@41f05d9ecffa2ed3f1580af306000f734b733e54 # 0.11.2
         with:
           image-ref: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{steps.operator-digest.outputs.digest}}
           format: 'cyclonedx'


### PR DESCRIPTION
# Description

Adds correct version comment for trivy action without the v prefix, as trivy creates tags without the v.
This currently prevents renovate to get the correct digest for that version: see [Error Logs](https://developer.mend.io/github/Dynatrace/dynatrace-operator/-/job/fffc50e4-8836-41a1-9309-f3e4482ab344)


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

