### PR TITLE
Use pod label to filter for operator components in support archive

### DIFF
--- a/src/cmd/support_archive/builder_test.go
+++ b/src/cmd/support_archive/builder_test.go
@@ -1,0 +1,42 @@
+package support_archive
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetAppName(t *testing.T) {
+	const alternativeOperatorName = "renamed-operator"
+	const alternativeNamespace = "weirednamespacename"
+
+	fakeClientSet := fake.NewSimpleClientset(
+		&corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      alternativeOperatorName,
+				Namespace: alternativeNamespace,
+				Labels: map[string]string{
+					kubeobjects.AppNameLabel: alternativeOperatorName,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "container1"},
+					{Name: "container2"},
+				},
+			},
+		})
+
+	os.Setenv(kubeobjects.EnvPodName, alternativeOperatorName)
+	assert.Equal(t, alternativeOperatorName, getAppNameLabel(context.TODO(), fakeClientSet.CoreV1().Pods(alternativeNamespace)))
+}

--- a/src/cmd/support_archive/logs.go
+++ b/src/cmd/support_archive/logs.go
@@ -20,9 +20,10 @@ type logCollector struct {
 
 	context context.Context
 	pods    clientgocorev1.PodInterface
+	appName string
 }
 
-func newLogCollector(context context.Context, log logr.Logger, supportArchive tarball, pods clientgocorev1.PodInterface) collector { //nolint:revive // argument-limit doesn't apply to constructors
+func newLogCollector(context context.Context, log logr.Logger, supportArchive tarball, pods clientgocorev1.PodInterface, appName string) collector { //nolint:revive // argument-limit doesn't apply to constructors
 	return logCollector{
 		collectorCommon: collectorCommon{
 			log:            log,
@@ -30,6 +31,7 @@ func newLogCollector(context context.Context, log logr.Logger, supportArchive ta
 		},
 		context: context,
 		pods:    pods,
+		appName: appName,
 	}
 }
 
@@ -63,7 +65,7 @@ func (collector logCollector) getPodList() (*corev1.PodList, error) {
 		TypeMeta: metav1.TypeMeta{
 			Kind: "pod",
 		},
-		LabelSelector: fmt.Sprintf("%s=%s", kubeobjects.AppNameLabel, "dynatrace-operator"),
+		LabelSelector: fmt.Sprintf("%s=%s", kubeobjects.AppNameLabel, collector.appName),
 	}
 	podList, err := collector.pods.List(collector.context, listOptions)
 	if err != nil {

--- a/src/cmd/support_archive/logs_test.go
+++ b/src/cmd/support_archive/logs_test.go
@@ -47,7 +47,11 @@ func TestLogCollector(t *testing.T) {
 		tarWriter: tar.NewWriter(&tarBuffer),
 	}
 
-	logCollector := newLogCollector(context.TODO(), newSupportArchiveLogger(&logBuffer), supportArchive, fakeClientSet.CoreV1().Pods("dynatrace"))
+	logCollector := newLogCollector(context.TODO(),
+		newSupportArchiveLogger(&logBuffer),
+		supportArchive,
+		fakeClientSet.CoreV1().Pods("dynatrace"),
+		defaultOperatorAppName)
 
 	require.NoError(t, logCollector.Do())
 
@@ -101,7 +105,11 @@ func TestLogCollectorPodListError(t *testing.T) {
 	mockedPods.EXPECT().
 		List(context, createPodListOptions()).
 		Return(nil, assert.AnError)
-	logCollector := newLogCollector(context, newSupportArchiveLogger(&logBuffer), supportArchive, mockedPods)
+	logCollector := newLogCollector(context,
+		newSupportArchiveLogger(&logBuffer),
+		supportArchive,
+		mockedPods,
+		defaultOperatorAppName)
 	require.Error(t, logCollector.Do())
 }
 
@@ -132,7 +140,7 @@ func TestLogCollectorGetPodFail(t *testing.T) {
 		Get(context, "pod2", metav1.GetOptions{}).
 		Return(nil, assert.AnError)
 
-	logCollector := newLogCollector(context, newSupportArchiveLogger(&logBuffer), supportArchive, mockedPods)
+	logCollector := newLogCollector(context, newSupportArchiveLogger(&logBuffer), supportArchive, mockedPods, defaultOperatorAppName)
 	require.NoError(t, logCollector.Do())
 }
 
@@ -199,7 +207,7 @@ func TestLogCollectorGetLogsFail(t *testing.T) {
 		NotBefore(getLogsPod2Container2Call).
 		Return(nil, assert.AnError)
 
-	logCollector := newLogCollector(context, newSupportArchiveLogger(&logBuffer), supportArchive, mockedPods)
+	logCollector := newLogCollector(context, newSupportArchiveLogger(&logBuffer), supportArchive, mockedPods, defaultOperatorAppName)
 	require.NoError(t, logCollector.Do())
 
 	assert.Contains(t, logBuffer.String(), "Unable to retrieve log stream for pod pod1, container container1")
@@ -257,7 +265,7 @@ func TestLogCollectorNoAbortOnError(t *testing.T) {
 		NotBefore(getLogsPod2Container2Call).
 		Return(nil, assert.AnError)
 
-	logCollector := newLogCollector(context, newSupportArchiveLogger(&logBuffer), supportArchive, mockedPods)
+	logCollector := newLogCollector(context, newSupportArchiveLogger(&logBuffer), supportArchive, mockedPods, defaultOperatorAppName)
 	require.NoError(t, logCollector.Do())
 
 	supportArchive.tarWriter.Close()
@@ -287,7 +295,7 @@ func createPod(name string) *corev1.Pod {
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				kubeobjects.AppNameLabel: "dynatrace-operator",
+				kubeobjects.AppNameLabel: defaultOperatorAppName,
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/src/cmd/support_archive/resource_query.go
+++ b/src/cmd/support_archive/resource_query.go
@@ -23,11 +23,11 @@ type resourceQuery struct {
 	filters          []client.ListOption
 }
 
-func getQueries(namespace string) []resourceQuery {
+func getQueries(namespace string, appName string) []resourceQuery {
 	allQueries := make([]resourceQuery, 0)
 	allQueries = append(allQueries, getInjectedNamespaceQueryGroup().getQueries()...)
 	allQueries = append(allQueries, getOperatorNamespaceQueryGroup(namespace).getQueries()...)
-	allQueries = append(allQueries, getOperatorComponentsQueryGroup(namespace).getQueries()...)
+	allQueries = append(allQueries, getOperatorComponentsQueryGroup(namespace, appName).getQueries()...)
 	allQueries = append(allQueries, getDynakubesQueryGroup(namespace).getQueries()...)
 	return allQueries
 }
@@ -58,7 +58,7 @@ func getOperatorNamespaceQueryGroup(namespace string) resourceQueryGroup {
 	}
 }
 
-func getOperatorComponentsQueryGroup(namespace string) resourceQueryGroup {
+func getOperatorComponentsQueryGroup(namespace string, appName string) resourceQueryGroup {
 	return resourceQueryGroup{
 		resources: []schema.GroupVersionKind{
 			toGroupVersionKind(appsv1.SchemeGroupVersion, appsv1.Deployment{}),
@@ -70,7 +70,7 @@ func getOperatorComponentsQueryGroup(namespace string) resourceQueryGroup {
 		},
 		filters: []client.ListOption{
 			client.MatchingLabels{
-				kubeobjects.AppNameLabel: "dynatrace-operator",
+				kubeobjects.AppNameLabel: appName,
 			},
 			client.InNamespace(namespace),
 		},

--- a/src/cmd/support_archive/resource_query_test.go
+++ b/src/cmd/support_archive/resource_query_test.go
@@ -9,7 +9,7 @@ import (
 const namespace = "dynatrace"
 
 func TestObjectQuerySyntax(t *testing.T) {
-	queries := getQueries(namespace)
+	queries := getQueries(namespace, defaultOperatorAppName)
 	assert.Len(t, queries, 9)
 
 	for _, query := range queries {

--- a/src/cmd/support_archive/resources.go
+++ b/src/cmd/support_archive/resources.go
@@ -19,10 +19,11 @@ type k8sResourceCollector struct {
 	collectorCommon
 	context   context.Context
 	namespace string
+	appName   string
 	apiReader client.Reader
 }
 
-func newK8sObjectCollector(context context.Context, log logr.Logger, supportArchive tarball, namespace string, apiReader client.Reader) collector { //nolint:revive // argument-limit doesn't apply to constructors
+func newK8sObjectCollector(context context.Context, log logr.Logger, supportArchive tarball, namespace string, appName string, apiReader client.Reader) collector { //nolint:revive // argument-limit doesn't apply to constructors
 	return k8sResourceCollector{
 		collectorCommon: collectorCommon{
 			log:            log,
@@ -30,6 +31,7 @@ func newK8sObjectCollector(context context.Context, log logr.Logger, supportArch
 		},
 		context:   context,
 		namespace: namespace,
+		appName:   appName,
 		apiReader: apiReader,
 	}
 }
@@ -37,7 +39,7 @@ func newK8sObjectCollector(context context.Context, log logr.Logger, supportArch
 func (collector k8sResourceCollector) Do() error {
 	logInfof(collector.log, "Starting K8S resource collection")
 
-	for _, query := range getQueries(collector.namespace) {
+	for _, query := range getQueries(collector.namespace, collector.appName) {
 		resourceList, err := collector.readObjectsList(query.groupVersionKind, query.filters)
 		if err != nil {
 			logErrorf(collector.log, err, "could not get manifest for %s", query.groupVersionKind.String())

--- a/src/cmd/support_archive/resources_test.go
+++ b/src/cmd/support_archive/resources_test.go
@@ -93,7 +93,7 @@ func TestManifestCollector_Success(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	require.NoError(t, newK8sObjectCollector(ctx, log, supportArchive, testOperatorNamespace, clt).Do())
+	require.NoError(t, newK8sObjectCollector(ctx, log, supportArchive, testOperatorNamespace, defaultOperatorAppName, clt).Do())
 
 	expectedFiles := []string{
 		fmt.Sprintf("%s/namespace-some-app-namespace%s", InjectedNamespacesManifestsDirectoryName, manifestExtension),
@@ -132,7 +132,7 @@ func TestManifestCollector_NoManifestsAvailable(t *testing.T) {
 
 	ctx := context.TODO()
 
-	err := newK8sObjectCollector(ctx, log, supportArchive, testOperatorNamespace, clt).Do()
+	err := newK8sObjectCollector(ctx, log, supportArchive, testOperatorNamespace, defaultOperatorAppName, clt).Do()
 	require.NoError(t, err)
 
 	tarReader := tar.NewReader(&tarBuffer)
@@ -144,7 +144,7 @@ func TestManifestCollector_PartialCollectionOnMissingResources(t *testing.T) {
 	logBuffer := bytes.Buffer{}
 	log := newSupportArchiveLogger(&logBuffer)
 
-	queries := getQueries(testOperatorNamespace)
+	queries := getQueries(testOperatorNamespace, defaultOperatorAppName)
 	require.Len(t, queries, 9)
 
 	clt := fake.NewClientWithIndex(
@@ -174,7 +174,7 @@ func TestManifestCollector_PartialCollectionOnMissingResources(t *testing.T) {
 		tarWriter: tar.NewWriter(&tarBuffer),
 	}
 
-	collector := newK8sObjectCollector(context, log, supportArchive, testOperatorNamespace, clt)
+	collector := newK8sObjectCollector(context, log, supportArchive, testOperatorNamespace, defaultOperatorAppName, clt)
 	require.NoError(t, collector.Do())
 
 	tarReader := tar.NewReader(&tarBuffer)


### PR DESCRIPTION
# Description

Replace the hardcoded filter `app.kubernetes.io/name=dynatrace-operator` for operator components by using the label value from the pod the support archive sub command is running in.


## How can this be tested?
Install the operator via helm using a custom name, run the support archive subcommand and see if operator pod logs and operator manifests are collected correctly.


## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

