### PR TITLE
Fixes broken link to support lifecycle in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ our [official help page](https://www.dynatrace.com/support/help/shortlink/kubern
 As the Dynatrace Operator is provided by Dynatrace Incorporated, support is provided by the Dynatrace Support team, as described on the [support page](https://support.dynatrace.com/).
 Github issues will also be considered on a case-by-case basis regardless of support contracts and commercial relationships with Dynatrace.
 
-The [Dynatrace support lifecycle for Kubernetes and Openshift](https://www.dynatrace.com/support/help/shortlink/support-model-kubernetes) can be found in the official technology support pages.
+The [Dynatrace support lifecycle for Kubernetes and Openshift](https://www.dynatrace.com/support/help/shortlink/support-model-k8s-ocp) can be found in the official technology support pages.
 
 ## Quick Start
 


### PR DESCRIPTION
# Description

Currently the link the the support lifecycle page is broken within our Readme.

This has been discovered by #1904 


## Checklist
- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

