### PR TITLE
Enable Activegate http endpoint for metrics-ingest capability

### DIFF
--- a/assets/calico/activegate-policy.yaml
+++ b/assets/calico/activegate-policy.yaml
@@ -20,7 +20,11 @@ spec:
     - protocol: TCP
       port: 9999
     - protocol: TCP
+      port: 9998
+    - protocol: TCP
       port: 443
+    - protocol: TCP
+      port: 80
   egress:
   # Allow DNS lookup
   - to:

--- a/src/controllers/dynakube/activegate/consts/consts.go
+++ b/src/controllers/dynakube/activegate/consts/consts.go
@@ -13,6 +13,9 @@ const (
 	HttpsServicePortName    = "https"
 	HttpsServicePort        = 443
 	HttpsContainerPort      = 9999
+	HttpServicePortName     = "http"
+	HttpServicePort         = 80
+	HttpContainerPort       = 9998
 
 	AuthTokenSecretVolumeName = "ag-authtoken-secret"
 	AuthTokenMountPoint       = connectioninfo.TokenBasePath + "/auth-token"
@@ -23,6 +26,7 @@ const (
 	EnvDtNetworkZone     = "DT_NETWORK_ZONE"
 	EnvDtGroup           = "DT_GROUP"
 	EnvDtDnsEntryPoint   = "DT_DNS_ENTRY_POINT"
+	EnvDtHttpPort        = "DT_HTTP_PORT"
 
 	AnnotationActiveGateConfigurationHash = dynatracev1beta1.InternalFlagPrefix + "activegate-configuration-hash"
 	AnnotationActiveGateContainerAppArmor = "container.apparmor.security.beta.kubernetes.io/" + ActiveGateContainerName

--- a/src/controllers/dynakube/activegate/internal/capability/service.go
+++ b/src/controllers/dynakube/activegate/internal/capability/service.go
@@ -22,6 +22,14 @@ func CreateService(dynakube *dynatracev1beta1.DynaKube, feature string) *corev1.
 				TargetPort: intstr.FromString(consts.HttpsServicePortName),
 			},
 		)
+		if dynakube.IsMetricsIngestActiveGateEnabled() {
+			ports = append(ports, corev1.ServicePort{
+				Name:       consts.HttpServicePortName,
+				Protocol:   corev1.ProtocolTCP,
+				Port:       consts.HttpServicePort,
+				TargetPort: intstr.FromString(consts.HttpServicePortName),
+			})
+		}
 	}
 
 	coreLabels := kubeobjects.NewCoreLabels(dynakube.Name, kubeobjects.ActiveGateComponentLabel)

--- a/src/controllers/dynakube/activegate/internal/capability/service_test.go
+++ b/src/controllers/dynakube/activegate/internal/capability/service_test.go
@@ -38,6 +38,13 @@ func TestCreateService(t *testing.T) {
 		Port:       consts.HttpsServicePort,
 		TargetPort: intstr.FromString(consts.HttpsServicePortName),
 	}
+	agHttpPort := corev1.ServicePort{
+		Name:       consts.HttpServicePortName,
+		Protocol:   corev1.ProtocolTCP,
+		Port:       consts.HttpServicePort,
+		TargetPort: intstr.FromString(consts.HttpServicePortName),
+	}
+
 	t.Run("check service name, labels and selector", func(t *testing.T) {
 		instance := testCreateInstance()
 		service := CreateService(instance, testComponentFeature)
@@ -64,7 +71,17 @@ func TestCreateService(t *testing.T) {
 		assert.Equal(t, expectedSelector, serviceSpec.Selector)
 	})
 
-	t.Run("check AG service if metrics ingest enabled", func(t *testing.T) {
+	t.Run("check AG service if metrics-ingest disabled", func(t *testing.T) {
+		instance := testCreateInstance()
+		kubeobjects.SwitchCapability(instance, dynatracev1beta1.RoutingCapability, true)
+
+		service := CreateService(instance, testComponentFeature)
+		ports := service.Spec.Ports
+
+		assert.Contains(t, ports, agHttpsPort)
+		assert.NotContains(t, ports, agHttpPort)
+	})
+	t.Run("check AG service if metrics-ingest enabled", func(t *testing.T) {
 		instance := testCreateInstance()
 		kubeobjects.SwitchCapability(instance, dynatracev1beta1.MetricsIngestCapability, true)
 
@@ -72,5 +89,6 @@ func TestCreateService(t *testing.T) {
 		ports := service.Spec.Ports
 
 		assert.Contains(t, ports, agHttpsPort)
+		assert.Contains(t, ports, agHttpPort)
 	})
 }

--- a/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
@@ -42,12 +42,19 @@ func (mod ServicePortModifier) Modify(sts *appsv1.StatefulSet) error {
 }
 
 func (mod ServicePortModifier) getPorts() []corev1.ContainerPort {
-	return []corev1.ContainerPort{
+	ports := []corev1.ContainerPort{
 		{
 			Name:          consts.HttpsServicePortName,
 			ContainerPort: consts.HttpsContainerPort,
 		},
 	}
+	if mod.dynakube.IsMetricsIngestActiveGateEnabled() {
+		ports = append(ports, corev1.ContainerPort{
+			Name:          consts.HttpServicePortName,
+			ContainerPort: consts.HttpContainerPort,
+		})
+	}
+	return ports
 }
 
 func (mod ServicePortModifier) getEnvs() []corev1.EnvVar {

--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -1,6 +1,8 @@
 package statefulset
 
 import (
+	"strconv"
+
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/activegate/consts"
@@ -204,6 +206,10 @@ func (statefulSetBuilder Builder) buildCommonEnvs() []corev1.EnvVar {
 	}
 	if statefulSetBuilder.dynakube.Spec.NetworkZone != "" {
 		envs = append(envs, corev1.EnvVar{Name: consts.EnvDtNetworkZone, Value: statefulSetBuilder.dynakube.Spec.NetworkZone})
+	}
+
+	if statefulSetBuilder.dynakube.IsMetricsIngestActiveGateEnabled() {
+		envs = append(envs, corev1.EnvVar{Name: consts.EnvDtHttpPort, Value: strconv.Itoa(consts.HttpContainerPort)})
 	}
 
 	return envs

--- a/src/controllers/dynakube/activegate/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/reconciler_test.go
@@ -163,6 +163,7 @@ func TestServiceCreation(t *testing.T) {
 			},
 			dynatracev1beta1.MetricsIngestCapability.DisplayName: {
 				consts.HttpsServicePortName,
+				consts.HttpServicePortName,
 			},
 			dynatracev1beta1.DynatraceApiCapability.DisplayName: {
 				consts.HttpsServicePortName,

--- a/src/ingestendpoint/secret.go
+++ b/src/ingestendpoint/secret.go
@@ -197,5 +197,5 @@ func metricsIngestUrlForClusterActiveGate(dk *dynatracev1beta1.DynaKube) (string
 	}
 
 	serviceName := capability.BuildServiceName(dk.Name, consts.MultiActiveGateName)
-	return fmt.Sprintf("https://%s.%s/e/%s/api/v2/metrics/ingest", serviceName, dk.Namespace, tenant), nil
+	return fmt.Sprintf("http://%s.%s/e/%s/api/v2/metrics/ingest", serviceName, dk.Namespace, tenant), nil
 }

--- a/src/ingestendpoint/secret_test.go
+++ b/src/ingestendpoint/secret_test.go
@@ -35,10 +35,10 @@ DT_METRICS_INGEST_API_TOKEN=updated-test-data-ingest-token
 DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
 `
 
-	testDataIngestSecretLocalAGWithMetrics = `DT_METRICS_INGEST_URL=https://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
+	testDataIngestSecretLocalAGWithMetrics = `DT_METRICS_INGEST_URL=http://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
 DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
 `
-	testUpdatedApiUrlDataIngestSecretLocalAgWithMetrics = `DT_METRICS_INGEST_URL=https://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
+	testUpdatedApiUrlDataIngestSecretLocalAgWithMetrics = `DT_METRICS_INGEST_URL=http://dynakube-activegate.dynatrace/e/tenant/api/v2/metrics/ingest
 DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
 `
 

--- a/test/scenarios/activegate/installation.go
+++ b/test/scenarios/activegate/installation.go
@@ -93,9 +93,21 @@ func assessActiveGate(builder *features.FeatureBuilder, testDynakube *dynatracev
 		builder.Assess("ActiveGate uses proxy", checkIfProxyUsed(testDynakube))
 	}
 	builder.Assess("ActiveGate containers have mount points", checkMountPoints(testDynakube))
-	builder.Assess("ActiveGate query via AG service", sampleapps.InstallActiveGateCurlPod(*testDynakube))
-	builder.Assess("ActiveGate query is completed", sampleapps.WaitForActiveGateCurlPod(*testDynakube))
-	builder.Assess("ActiveGate service is running", sampleapps.CheckActiveGateCurlResult(*testDynakube))
+
+	assessActiveGateHttpsEndpoint(builder, testDynakube)
+	assessActiveGateHttpEndpoint(builder, testDynakube)
+}
+
+func assessActiveGateHttpsEndpoint(builder *features.FeatureBuilder, testDynakube *dynatracev1beta1.DynaKube) {
+	builder.Assess("ActiveGate HTTPS query via AG service", sampleapps.InstallActiveGateCurlPod(*testDynakube))
+	builder.Assess("ActiveGate HTTPS query is completed", sampleapps.WaitForActiveGateCurlPod(sampleapps.CurlPodNameActivegateHttps, *testDynakube))
+	builder.Assess("ActiveGate HTTPS service is running", sampleapps.CheckActiveGateCurlResult(sampleapps.CurlPodNameActivegateHttps, *testDynakube))
+}
+
+func assessActiveGateHttpEndpoint(builder *features.FeatureBuilder, testDynakube *dynatracev1beta1.DynaKube) {
+	builder.Assess("ActiveGate HTTP query via AG service", sampleapps.InstallActiveGateHttpCurlPod(*testDynakube))
+	builder.Assess("ActiveGate HTTP query is completed", sampleapps.WaitForActiveGateCurlPod(sampleapps.CurlPodNameActivegateHttp, *testDynakube))
+	builder.Assess("ActiveGate HTTP service is running", sampleapps.CheckActiveGateCurlResult(sampleapps.CurlPodNameActivegateHttp, *testDynakube))
 }
 
 func checkIfAgHasContainers(testDynakube *dynatracev1beta1.DynaKube) features.Func {


### PR DESCRIPTION
# Description
ActiveGate HTTP port is opened if `metrics-ingest` capability is enabled. 
Changes applied to the `activegate` container:
- added DT_HTTP_PORT environment variable
- added TCP port 9998

Changes applied to the AG service:
- added HTTP port (80)

## How can this be tested?
Run `test/e2e/activegate` test. The test uses `curl` command to get AG status from the HTTP endpoint.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

