### PR TITLE
Adds optional digest parameter for operator image to makefile 

### DIFF
--- a/hack/make/images.mk
+++ b/hack/make/images.mk
@@ -8,7 +8,14 @@ else
 	TAG ?= snapshot
 endif
 
-IMAGE_URI ?= "$(IMAGE):$(TAG)"
+#use the digest if digest is set
+ifeq ($(DIGEST),)
+	IMAGE_URI ?= "$(IMAGE):$(TAG)"
+else
+	IMAGE_URI ?= "$(IMAGE):$(TAG)@$(DIGEST)"
+endif
+
+
 
 ensure-tag-not-snapshot:
 ifeq ($(TAG), snapshot)


### PR DESCRIPTION
# Description

- changed the images.mk to use a digest if passed by caller

## How can this be tested?
- only via release pipeline in concourse


## Checklist
- [x] ~~Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

