### PR TITLE
Always set 'RunAsNonRoot' explicitly on init container

### DIFF
--- a/src/webhook/mutation/pod_mutator/init_container.go
+++ b/src/webhook/mutation/pod_mutator/init_container.go
@@ -89,9 +89,7 @@ func combineSecurityContexts(baseSecurityCtx corev1.SecurityContext, pod corev1.
 		baseSecurityCtx.RunAsGroup = containerSecurityCtx.RunAsGroup
 	}
 
-	if isNonRoot(&baseSecurityCtx) {
-		baseSecurityCtx.RunAsNonRoot = address.Of(true)
-	}
+	baseSecurityCtx.RunAsNonRoot = address.Of(isNonRoot(&baseSecurityCtx))
 
 	return &baseSecurityCtx
 }

--- a/src/webhook/mutation/pod_mutator/init_container_test.go
+++ b/src/webhook/mutation/pod_mutator/init_container_test.go
@@ -113,7 +113,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		require.NotNil(t, initContainer.SecurityContext.RunAsGroup)
 		assert.Equal(t, *testUser, *initContainer.SecurityContext.RunAsGroup)
 	})
-	t.Run("should not set RunAsNonRoot if root user is used", func(t *testing.T) {
+	t.Run("should set RunAsNonRoot if root user is used", func(t *testing.T) {
 		dynakube := getTestDynakube()
 		pod := getTestPod()
 		pod.Spec.Containers[0].SecurityContext.RunAsUser = address.Of(rootUserGroup)
@@ -123,7 +123,8 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 
 		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
 
-		assert.Nil(t, initContainer.SecurityContext.RunAsNonRoot)
+		assert.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
+		assert.False(t, *initContainer.SecurityContext.RunAsNonRoot)
 
 		require.NotNil(t, *initContainer.SecurityContext.RunAsUser)
 		assert.Equal(t, *initContainer.SecurityContext.RunAsUser, rootUserGroup)

--- a/src/webhook/mutation/pod_mutator/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/pod_mutator_test.go
@@ -155,7 +155,8 @@ func TestHandlePodMutation(t *testing.T) {
 		require.NotNil(t, initSecurityContext.ReadOnlyRootFilesystem)
 		assert.True(t, *initSecurityContext.ReadOnlyRootFilesystem)
 
-		assert.Nil(t, initSecurityContext.RunAsNonRoot)
+		assert.NotNil(t, initSecurityContext.RunAsNonRoot)
+		assert.False(t, *initSecurityContext.RunAsNonRoot)
 
 		assert.Equal(t, mutationRequest.Pod.Spec.InitContainers[1].Resources, testResourceRequirements)
 		assert.Equal(t, "true", mutationRequest.Pod.Annotations[dtwebhook.AnnotationDynatraceInjected])

--- a/src/webhook/mutation/pod_mutator/pod_mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/pod_mutator_test.go
@@ -156,7 +156,7 @@ func TestHandlePodMutation(t *testing.T) {
 		assert.True(t, *initSecurityContext.ReadOnlyRootFilesystem)
 
 		assert.NotNil(t, initSecurityContext.RunAsNonRoot)
-		assert.False(t, *initSecurityContext.RunAsNonRoot)
+		assert.True(t, *initSecurityContext.RunAsNonRoot)
 
 		assert.Equal(t, mutationRequest.Pod.Spec.InitContainers[1].Resources, testResourceRequirements)
 		assert.Equal(t, "true", mutationRequest.Pod.Annotations[dtwebhook.AnnotationDynatraceInjected])

--- a/src/webhook/mutation/pod_mutator/request_test.go
+++ b/src/webhook/mutation/pod_mutator/request_test.go
@@ -20,9 +20,11 @@ import (
 
 const testUser int64 = 420
 
-var testSecurityContext = &corev1.SecurityContext{
-	RunAsUser:  address.Of(testUser),
-	RunAsGroup: address.Of(testUser),
+func getTestSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		RunAsUser:  address.Of(testUser),
+		RunAsGroup: address.Of(testUser),
+	}
 }
 
 func TestCreateMutationRequestBase(t *testing.T) {
@@ -128,7 +130,7 @@ func getTestPod() *corev1.Pod {
 				{
 					Name:            "container",
 					Image:           "alpine",
-					SecurityContext: testSecurityContext,
+					SecurityContext: getTestSecurityContext(),
 				},
 			},
 			InitContainers: []corev1.Container{


### PR DESCRIPTION
Fix #1894 

## Description

Always set `RunAsNonRoot` explicitly on webhook's init container. Before it was only set when its value was `true`.
This caused `Init:CreateContainerConfigError` status on some cases.

## How to reproduce this
- Deploy the operator in cloudNativeFullStack or applicationMonitoring
- Deploy the deployment sample below
- Check the pods status (kubectl get pod php-musl-.. -n sample -o yaml
- See the error message

<details>
<summary>Deployment sample</summary>

```
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: php-musl
  name: 02-php-musl
  namespace: sample
spec:
  replicas: 2
  selector:
    matchLabels:
      app: php-musl
  strategy:
    type: Recreate
  template:
    metadata:
      annotations:
        oneagent.dynatrace.com/technologies: php
        oneagent.dynatrace.com/flavor: musl
        oneagent.dynatrace.com/failure-policy: fail
      labels:
        app: php-musl
    spec:
      securityContext:
        runAsNonRoot: true
      containers:
        - image: docker.io/php:fpm-alpine
          securityContext:
            runAsUser: 0
            runAsGroup: 0
          imagePullPolicy: Always
          livenessProbe:
            failureThreshold: 3
            tcpSocket:
              port: 9000
            initialDelaySeconds: 600
            periodSeconds: 30
            successThreshold: 1
            timeoutSeconds: 2
          name: app
          env:
            - name: DT_DEBUGFLAGS
              value: debugBootstrapNative=true
          ports:
            - containerPort: 9000
              protocol: TCP
          readinessProbe:
            failureThreshold: 3
            tcpSocket:
              port: 9000
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 1
          resources:
            requests:
              memory: 64Mi
            limits:
              memory: 128Mi
      restartPolicy: Always
      terminationGracePeriodSeconds: 30
```

</details>

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)