### PR TITLE
Adds startup-probe command

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	csiServer "github.com/Dynatrace/dynatrace-operator/src/cmd/csi/server"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/operator"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/standalone"
+	"github.com/Dynatrace/dynatrace-operator/src/cmd/startup_probe"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/support_archive"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/troubleshoot"
 	"github.com/Dynatrace/dynatrace-operator/src/cmd/webhook"
@@ -80,6 +81,10 @@ func createSupportArchiveCommandBuilder() support_archive.CommandBuilder {
 		SetConfigProvider(cmdConfig.NewKubeConfigProvider())
 }
 
+func createStartupProbe() startup_probe.CommandBuilder {
+	return startup_probe.NewCommandBuilder()
+}
+
 func rootCommand(_ *cobra.Command, _ []string) error {
 	return errors.New("operator binary must be called with one of the subcommands")
 }
@@ -96,6 +101,7 @@ func main() {
 		standalone.NewStandaloneCommand(),
 		createTroubleshootCommandBuilder().Build(),
 		createSupportArchiveCommandBuilder().Build(),
+		createStartupProbe().Build(),
 	)
 
 	err := cmd.Execute()

--- a/src/cmd/startup_probe/builder.go
+++ b/src/cmd/startup_probe/builder.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	uRL            = "kubernetes.default.svc.cluster.local"
+	hostname       = "kubernetes.default.svc.cluster.local"
 	use            = "startup-probe"
 	defaultTimeout = 5
 )
@@ -31,7 +31,7 @@ func NewCommandBuilder() CommandBuilder {
 func (builder CommandBuilder) Build() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  use,
-		Long: "query DNS server about " + uRL,
+		Long: "query DNS server about " + hostname,
 		RunE: builder.buildRun(),
 	}
 
@@ -48,12 +48,12 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 		f := func(_ *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutFlagValue)*time.Second)
 			defer cancel()
-			ips, err := net.DefaultResolver.LookupHost(ctx, uRL)
+			ips, err := net.DefaultResolver.LookupHost(ctx, hostname)
 			if err != nil {
 				return errors.WithMessagef(err, "DNS service not ready")
 			}
 			if len(ips) == 0 {
-				return errors.Errorf("no DNS record found for %s", uRL)
+				return errors.Errorf("no DNS record found for %s", hostname)
 			}
 			return nil
 		}

--- a/src/cmd/startup_probe/builder.go
+++ b/src/cmd/startup_probe/builder.go
@@ -1,0 +1,66 @@
+package startup_probe
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+)
+
+const (
+	uRL            = "kubernetes.default.svc.cluster.local"
+	use            = "startup-probe"
+	defaultTimeout = 5
+)
+
+var (
+	timeoutFlagValue = 5
+)
+
+type CommandBuilder struct {
+}
+
+func NewCommandBuilder() CommandBuilder {
+	return CommandBuilder{}
+}
+
+func (builder CommandBuilder) Build() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  use,
+		Long: "query DNS server about " + uRL,
+		RunE: builder.buildRun(),
+	}
+
+	cmd.PersistentFlags().IntVar(&timeoutFlagValue, "timeout", defaultTimeout, "specify a different timeout [s]")
+
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	return cmd
+}
+
+func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		f := func(_ *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutFlagValue)*time.Second)
+			defer cancel()
+			ips, err := net.DefaultResolver.LookupHost(ctx, uRL)
+			if err != nil {
+				return errors.WithMessagef(err, "DNS service not ready")
+			}
+			if len(ips) == 0 {
+				return errors.Errorf("no DNS record found for %s", uRL)
+			}
+			return nil
+		}
+		if err := f(cmd, args); err != nil {
+			fmt.Println(err)
+			os.Exit(1) //nolint
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
# Description

Added new `startup-probe` subcommand which tries to resolve `https://kubernetes.default.svc.cluster.local` hostname to make sure the DNS service is properly configured and running.
In case of success no message is printed.

## How can this be tested?
Create a deployment having:
- image: the operator image
- command: bash sleep command
- DNS configuration: for example invalid IP address of DNS server
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dns-setup
spec:
  selector:
    matchLabels:
      test: dns-setup
  replicas: 1
  revisionHistoryLimit: 0
  template:
    metadata:
      labels:
        test: dns-setup
    spec:
      containers:
      - name: test
        image: IMAGE URL
        imagePullPolicy: Always
        command:
        - /bin/bash
        args:
        - -c
        - "counter=1 ; while [ ${counter} -lt 10000 ] ; do echo ${counter} ; counter=$((counter + 1)) ; sleep 1 ; done"
        startupProbe:
          exec:
            command:
            - /usr/local/bin/dynatrace-operator
            - startup-probe
          periodSeconds: 10
          timeoutSeconds: 5
          failureThreshold: 1
      dnsPolicy: "None"
      dnsConfig:
        nameservers:
        - 10.100.16.213
        searches:
        - dynatrace.svc.cluster.local
        - svc.cluster.local
        - cluster.local
```
Check status of the test POD:
- startupProbe errors should be reported as events
- the `test` container is restarted 
```
 kubectl -n dynatrace describe pod/dns-setup-6546f9d55b-4qd9j
```



## Checklist
~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

