### PR TITLE
Fix duplicated ClusterRole for Openshift

### DIFF
--- a/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
@@ -1,5 +1,6 @@
 {{- include "dynatrace-operator.platformRequired" . }}
 {{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
+{{- if ne (include "dynatrace-operator.partial" .) "csi" }}
 
 # Copyright 2021 Dynatrace LLC
 
@@ -45,4 +46,5 @@ roleRef:
   kind: ClusterRole
   name: dynatrace-activegate
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}
 {{- end -}}

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent.yaml
@@ -1,5 +1,6 @@
 {{- include "dynatrace-operator.platformRequired" . }}
 {{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
+{{- if ne (include "dynatrace-operator.partial" .) "csi" }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,4 +44,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: dynatrace-dynakube-oneagent
+{{ end }}
 {{ end }}

--- a/config/helm/chart/default/tests/Common/activegate/clusterrole-activegate_test.yaml
+++ b/config/helm/chart/default/tests/Common/activegate/clusterrole-activegate_test.yaml
@@ -1,0 +1,11 @@
+suite: test clusterrole for activegate
+templates:
+  - Common/activegate/clusterrole-activegate.yaml
+tests:
+  - it: ClusterRole and ClusterRoleBinding are not rendered for csi
+    set:
+      platform: openshift
+      partial: csi
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/config/helm/chart/default/tests/Common/oneagent/clusterrole-oneagent_test.yaml
+++ b/config/helm/chart/default/tests/Common/oneagent/clusterrole-oneagent_test.yaml
@@ -42,3 +42,10 @@ tests:
           value: dynatrace-dynakube-oneagent
       - isNotEmpty:
           path: metadata.labels
+  - it: ClusterRole and ClusterRoleBinding are not rendered for csi
+    set:
+      platform: openshift
+      partial: csi
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/hack/make/manifests/openshift.mk
+++ b/hack/make/manifests/openshift.mk
@@ -6,7 +6,6 @@ manifests/openshift/csi:
 		--set partial="csi" \
 		--set platform="openshift" \
 		--set manifests=true \
-		--set createSecurityContextConstraints="true" \
 		--set image="$(IMAGE_URI)" > "$(OPENSHIFT_CSIDRIVER_YAML)"
 
 ## Generates an OpenShift manifest with a CRD
@@ -16,7 +15,6 @@ manifests/openshift/core: manifests/crd/helm
 		--set installCRD=true \
 		--set platform="openshift" \
 		--set manifests=true \
-		--set createSecurityContextConstraints="true" \
 		--set image="$(IMAGE_URI)" > "$(OPENSHIFT_CORE_YAML)"
 
 ## Generates a manifest for OpenShift including a CRD and a CSI driver deployment


### PR DESCRIPTION
Fix #1921

## Description
In case of Openshift we need additional permissions to use Security Context Constraints, which are currently generated twice, once in the openshift.yaml and once in the openshift-csi.yaml. This PR removes this duplicity.

## How can this be tested?
Check out open [Github Issue on this topics](https://github.com/Dynatrace/dynatrace-operator/issues/1921):
- Generate manifests using `make manifests/openshift`
- Check openshift-csi.yaml
- CSI specific configuration contains Activegate and Oneagent ClusterRole(Binding)

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

