### PR TITLE
Removes metrics-ingest preview warning

### DIFF
--- a/src/webhook/validation/activegate_test.go
+++ b/src/webhook/validation/activegate_test.go
@@ -37,7 +37,7 @@ func TestConflictingActiveGateConfiguration(t *testing.T) {
 			},
 		})
 
-		assertAllowedResponseWithWarnings(t, 3, &dynatracev1beta1.DynaKube{
+		assertAllowedResponseWithWarnings(t, 1, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,

--- a/src/webhook/validation/config.go
+++ b/src/webhook/validation/config.go
@@ -34,7 +34,6 @@ var validators = []validator{
 
 var warnings = []validator{
 	deprecatedFeatureFlagFormat,
-	metricIngestPreviewWarning,
 	missingActiveGateMemoryLimit,
 	deprecatedFeatureFlagDisableActiveGateUpdates,
 	deprecatedFeatureFlagDisableActiveGateRawImage,

--- a/src/webhook/validation/preview.go
+++ b/src/webhook/validation/preview.go
@@ -12,18 +12,6 @@ const (
 	basePreviewWarning           = "PREVIEW features are NOT production ready and you may run into bugs."
 )
 
-func metricIngestPreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
-	return warnOnCapabilityIfActive(dynatracev1beta1.MetricsIngestCapability.DisplayName, dynakube)
-}
-
-func warnOnCapabilityIfActive(capability dynatracev1beta1.CapabilityDisplayName, dynakube *dynatracev1beta1.DynaKube) string {
-	if dynakube.IsActiveGateMode(capability) {
-		log.Info(fmt.Sprintf("DynaKube with %s was applied, warning was provided.", capability))
-		return fmt.Sprintf(featurePreviewWarningMessage, capability)
-	}
-	return ""
-}
-
 func syntheticPreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.IsSyntheticMonitoringEnabled() {
 		log.Info(fmt.Sprintf("DynaKube with %s was applied, warning was provided.", capability.SyntheticName))

--- a/src/webhook/validation/validation_test.go
+++ b/src/webhook/validation/validation_test.go
@@ -60,7 +60,7 @@ var dummyNamespace2 = corev1.Namespace{
 
 func TestDynakubeValidator_Handle(t *testing.T) {
 	t.Run(`valid dynakube specs`, func(t *testing.T) {
-		assertAllowedResponseWithWarnings(t, 3, &dynatracev1beta1.DynaKube{
+		assertAllowedResponseWithWarnings(t, 1, &dynatracev1beta1.DynaKube{
 			ObjectMeta: defaultDynakubeObjectMeta,
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				APIURL: testApiUrl,


### PR DESCRIPTION
# Description

The `metrics-ingest` capability is no longer in the PREVIEW stage. Related warning message has been removed.

## How can this be tested?
Deploy a Dynakube with ActiveGate and `metrics-ingest` capability enabled. No warning related to `metrics-ingest` is printed.

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)

