### PR TITLE
Removes creation of secrets by POD mutators

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
@@ -42,18 +42,6 @@ rules:
       - secrets
     verbs:
       - create
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    resourceNames:
-      - dynatrace-dynakube-config
-      - dynatrace-data-ingest-endpoint
-    verbs:
-      - get
-      - list
-      - watch
-      - update
   # data-ingest workload owner lookup
   - apiGroups:
       - ""

--- a/config/helm/chart/default/tests/Common/webhook/clusterrole-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/clusterrole-webhook_test.yaml
@@ -48,21 +48,6 @@ tests:
           content:
             apiGroups:
               - ""
-            resourceNames:
-              - dynatrace-dynakube-config
-              - dynatrace-data-ingest-endpoint
-            resources:
-              - secrets
-            verbs:
-              - get
-              - list
-              - watch
-              - update
-      - contains:
-          path: rules
-          content:
-            apiGroups:
-              - ""
             resources:
               - replicationcontrollers
             verbs:

--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator.go
@@ -1,12 +1,9 @@
 package dataingest_mutation
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/src/config"
-	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/src/ingestendpoint"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/src/webhook"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,10 +41,6 @@ func (mutator *DataIngestPodMutator) Mutate(request *dtwebhook.MutationRequest) 
 	if err != nil {
 		return err
 	}
-	err = mutator.ensureDataIngestSecret(request)
-	if err != nil {
-		return err
-	}
 	setupVolumes(request.Pod)
 	mutateUserContainers(request.Pod)
 	updateInstallContainer(request.InstallContainer, workload)
@@ -61,32 +54,6 @@ func (mutator *DataIngestPodMutator) Reinvoke(request *dtwebhook.ReinvocationReq
 	}
 	log.Info("reinvoking", "podName", request.PodName())
 	return reinvokeUserContainers(request.Pod)
-}
-
-func (mutator *DataIngestPodMutator) ensureDataIngestSecret(request *dtwebhook.MutationRequest) error {
-	endpointGenerator := dtingestendpoint.NewEndpointSecretGenerator(mutator.client, mutator.apiReader, mutator.webhookNamespace)
-
-	var endpointSecret corev1.Secret
-	err := mutator.apiReader.Get(
-		request.Context,
-		client.ObjectKey{
-			Name:      config.EnrichmentEndpointSecretName,
-			Namespace: request.Namespace.Name,
-		},
-		&endpointSecret)
-	if k8serrors.IsNotFound(err) {
-		err := endpointGenerator.GenerateForNamespace(request.Context, request.DynaKube.Name, request.Namespace.Name)
-		if err != nil && !k8serrors.IsAlreadyExists(err) {
-			log.Info("failed to create the data-ingest endpoint secret before pod injection")
-			return err
-		}
-		log.Info("ensured that the data-ingest endpoint secret is present before pod injection")
-	} else if err != nil {
-		log.Info("failed to query the data-ingest endpoint secret before pod injection")
-		return err
-	}
-
-	return nil
 }
 
 func setInjectedAnnotation(pod *corev1.Pod) {

--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator_test.go
@@ -135,16 +135,6 @@ func TestReinvoke(t *testing.T) {
 	})
 }
 
-func TestEnsureDataIngestSecret(t *testing.T) {
-	t.Run("shouldn't create init secret if already there", func(t *testing.T) {
-		mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
-		request := createTestMutationRequest(getTestDynakube(), nil)
-
-		err := mutator.ensureDataIngestSecret(request)
-		require.NoError(t, err)
-	})
-}
-
 func TestSetInjectedAnnotation(t *testing.T) {
 	t.Run("should add annotation to nil map", func(t *testing.T) {
 		request := createTestMutationRequest(nil, nil)

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
@@ -88,16 +88,6 @@ func TestGetVolumeMode(t *testing.T) {
 	})
 }
 
-func TestEnsureInitSecret(t *testing.T) {
-	t.Run("shouldn't create init secret if already there", func(t *testing.T) {
-		mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
-		request := createTestMutationRequest(getTestDynakube(), nil, getTestNamespace(nil))
-
-		err := mutator.ensureInitSecret(request)
-		require.NoError(t, err)
-	})
-}
-
 type mutateTestCase struct {
 	name                                   string
 	dynakube                               dynatracev1beta1.DynaKube


### PR DESCRIPTION
## Description

Due to performance reasons POD mutators shouldn't create `data-ingest-endpoint` or `dynatrace-dynakube-config` secrets. These secrets are created by the namespace webhook or the operator in the reconciliation loop.
POD mutating process should be generally much faster but in rare cases creation of an application POD may take a few minutes.

## How can this be tested?
Deploy CloudNative and a sample application. Application POD should be created either immediately or after a few minutes at most. An event similar to this one should be reported on the application POD in such a case:
`
Warning FailedMount 30s (x8 over 93s) kubelet MountVolume.SetUp failed for volume "injection-config" : secret "dynatrace-dynakube-config" not found
`
Such a scenario also can be easily reproduced if `dynatrace-dynakube-config` secret and the application pod are deleted. Application Deployment tries to re-create the POD then
`
NAME                             READY   STATUS     RESTARTS   AGE
pod/sample-app-6b9dd7d484-9vzkz   0/1     Init:0/1   0          81s
`
waiting until secrets can be mounted properly.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
