### PR TITLE
Add golangci-lint gh action to renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,7 +17,7 @@
     {
       "fileMatch": [ "(^|/|\\.)ci.yaml$" ],
       "matchStrings": [
-        "golangci\\/golangci-lint-action@(.+\\n+\\s+\\w+.?\\n\\s+)version\\:\\sv(?<currentValue>.*)"
+        "golangci\\/golangci-lint-action@((.|\\n)*)version\\:\\sv(?<currentValue>.*)"
       ],
       "depNameTemplate": "golangci-lint",
       "datasourceTemplate": "go"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,15 @@
         "depName=(?<depName>.*?)\\s.*?_version=(?<currentValue>.*)\\s"
       ],
       "datasourceTemplate": "go"
-    }
+    },
+    {
+      "fileMatch": [ "(^|/|\\.)ci.yaml$" ],
+      "matchStrings": [
+        "golangci\\/golangci-lint-action@(.+\\n+\\s+\\w+.?\\n\\s+)version\\:\\sv(?<currentValue>.*)"
+      ],
+      "depNameTemplate": "golangci-lint",
+      "datasourceTemplate": "go"
+    },
   ],
   "packageRules": [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,13 +15,12 @@
       "datasourceTemplate": "go"
     },
     {
-      "fileMatch": [ "(^|/|\\.)ci.yaml$" ],
+      "fileMatch": [ "(^|/|\\.)ci.yaml$"],
       "matchStrings": [
-        "golangci\\/golangci-lint-action@((.|\\n)*)version\\:\\sv(?<currentValue>.*)"
+        "depName=(?<depName>.*?)\\s.*?version\\:\\s(?<currentValue>.*)\\s",
       ],
-      "depNameTemplate": "golangci-lint",
       "datasourceTemplate": "go"
-    },
+    }
   ],
   "packageRules": [
     {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         with:
+          # renovate depName=github.com/golangci/golangci-lint
           version: v1.51.1
           args: --build-tags containers_image_storage_stub,e2e --timeout 300s --out-${NO_FUTURE}format colored-line-number
 


### PR DESCRIPTION
## Description

Currently we updating golangci-lint only in makefiles, this PR updates logic, so we update it in GH version too.

## How can this be tested?

Please include some guiding steps on how to test this change during a review.

Tested in my fork:
https://github.com/andriisoldatenko/dynatrace-operator/pull/5


## Checklist

~- [ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
