### PR TITLE
Reduce allowed version in Dockerfile to require only two digits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,7 @@
       "matchManagers": ["dockerfile"],
       "commitMessagePrefix": "Docker:",
       "enabled": true,
-      "allowedVersions": "/^v?[0-9]+\\.[0-9]+(\\.[0-9]+)*?$/"
+      "allowedVersions": "/^v?[0-9]+\\.[0-9]+(\\.[0-9]+)*$/"
     },
     {
       "matchManagers": ["gomod"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,7 @@
       "matchManagers": ["dockerfile"],
       "commitMessagePrefix": "Docker:",
       "enabled": true,
-      "allowedVersions": "/^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
+      "allowedVersions": "/^v?[0-9]+\\.[0-9]+(\\.[0-9]+)*?$/"
     },
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
## Description
Updates for UBI9 base images weren't happening as RedHat changed their naming to x.y instead of x.y.z 
Changed renovate config to only require at least two digits for versions in Dockerfile.
Also make sure that versions with and without 'v' prefix are accepted (e.g. v2.10.0 and 2.10.0)

## How can this be tested?
Can only be tested on a fork. 
* Install renovate on fork
* Copy changes of renovate config to fork
* Decrease used versions of _all_ dependencies in Dockerfile (golang, UBI9, liveness, registrar)
* Check Dependency Dashboard and PRs on fork to see if all dependencies get updated again

You can see this change in action here: https://github.com/StefanHauth/dynatrace-operator/issues/4

## Checklist

- [n/a] Unit tests have been updated/added
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
