### PR TITLE
Revert "Secrets are not created by dataingest/oneagent mutators (#1936)"

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
@@ -42,6 +42,18 @@ rules:
       - secrets
     verbs:
       - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - dynatrace-dynakube-config
+      - dynatrace-data-ingest-endpoint
+    verbs:
+      - get
+      - list
+      - watch
+      - update
   # data-ingest workload owner lookup
   - apiGroups:
       - ""

--- a/config/helm/chart/default/tests/Common/webhook/clusterrole-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/clusterrole-webhook_test.yaml
@@ -48,6 +48,21 @@ tests:
           content:
             apiGroups:
               - ""
+            resourceNames:
+              - dynatrace-dynakube-config
+              - dynatrace-data-ingest-endpoint
+            resources:
+              - secrets
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
             resources:
               - replicationcontrollers
             verbs:

--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator_test.go
@@ -135,6 +135,16 @@ func TestReinvoke(t *testing.T) {
 	})
 }
 
+func TestEnsureDataIngestSecret(t *testing.T) {
+	t.Run("shouldn't create init secret if already there", func(t *testing.T) {
+		mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
+		request := createTestMutationRequest(getTestDynakube(), nil)
+
+		err := mutator.ensureDataIngestSecret(request)
+		require.NoError(t, err)
+	})
+}
+
 func TestSetInjectedAnnotation(t *testing.T) {
 	t.Run("should add annotation to nil map", func(t *testing.T) {
 		request := createTestMutationRequest(nil, nil)

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
@@ -3,9 +3,12 @@ package oneagent_mutation
 import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/config"
+	"github.com/Dynatrace/dynatrace-operator/src/initgeneration"
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/src/webhook"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,6 +40,10 @@ func (mutator *OneAgentPodMutator) Injected(request *dtwebhook.BaseRequest) bool
 
 func (mutator *OneAgentPodMutator) Mutate(request *dtwebhook.MutationRequest) error {
 	log.Info("injecting OneAgent into pod", "podName", request.PodName())
+	if err := mutator.ensureInitSecret(request); err != nil {
+		return err
+	}
+
 	installerInfo := getInstallerInfo(request.Pod, request.DynaKube)
 	mutator.addVolumes(request.Pod, request.DynaKube)
 	mutator.configureInitContainer(request, installerInfo)
@@ -53,6 +60,24 @@ func (mutator *OneAgentPodMutator) Reinvoke(request *dtwebhook.ReinvocationReque
 	}
 	log.Info("reinvoking", "podName", request.PodName())
 	return mutator.reinvokeUserContainers(request)
+}
+
+func (mutator *OneAgentPodMutator) ensureInitSecret(request *dtwebhook.MutationRequest) error {
+	var initSecret corev1.Secret
+	secretObjectKey := client.ObjectKey{Name: config.AgentInitSecretName, Namespace: request.Namespace.Name}
+	if err := mutator.apiReader.Get(request.Context, secretObjectKey, &initSecret); k8serrors.IsNotFound(err) {
+		initGenerator := initgeneration.NewInitGenerator(mutator.client, mutator.apiReader, mutator.webhookNamespace)
+		err := initGenerator.GenerateForNamespace(request.Context, request.DynaKube, request.Namespace.Name)
+		if err != nil && !k8serrors.IsAlreadyExists(err) {
+			log.Info("failed to create the init secret before oneagent pod injection")
+			return err
+		}
+		log.Info("ensured that the init secret is present before oneagent pod injection")
+	} else if err != nil {
+		log.Info("failed to query the init secret before oneagent pod injection")
+		return errors.WithStack(err)
+	}
+	return nil
 }
 
 func containerIsInjected(container *corev1.Container) bool {

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
@@ -88,6 +88,16 @@ func TestGetVolumeMode(t *testing.T) {
 	})
 }
 
+func TestEnsureInitSecret(t *testing.T) {
+	t.Run("shouldn't create init secret if already there", func(t *testing.T) {
+		mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
+		request := createTestMutationRequest(getTestDynakube(), nil, getTestNamespace(nil))
+
+		err := mutator.ensureInitSecret(request)
+		require.NoError(t, err)
+	})
+}
+
 type mutateTestCase struct {
 	name                                   string
 	dynakube                               dynatracev1beta1.DynaKube


### PR DESCRIPTION
## Description

This reverts commit e4687783fd07489c86bef07dd7acf86883b3609f.
The commit cause  the sample app pod to be stuck in init for 30 minutes.

## How can this be tested?
Deploy CloudNative and a sample application. Application POD should be created immediately. `FailedMount` errors do not happen
`
Warning FailedMount 30s (x8 over 93s) kubelet MountVolume.SetUp failed for volume "injection-config" : secret "dynatrace-dynakube-config" not found
`

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
