### PR TITLE
Make seccomp field configurable for components

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -35,7 +35,9 @@ spec:
         kubectl.kubernetes.io/default-container: provisioner
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
         {{- if and (eq (default false .Values.apparmor) true) (ne (include "dynatrace-operator.platform" .) "openshift") }}
-        container.apparmor.security.beta.kubernetes.io/driver: runtime/default
+        container.apparmor.security.beta.kubernetes.io/csi-init: runtime/default
+        container.apparmor.security.beta.kubernetes.io/server: runtime/default
+        container.apparmor.security.beta.kubernetes.io/provisioner: runtime/default
         container.apparmor.security.beta.kubernetes.io/registrar: runtime/default
         container.apparmor.security.beta.kubernetes.io/liveness-probe: runtime/default
         {{- end}}
@@ -64,7 +66,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml .Values.csidriver.csi_init.securityContext.seccompProfile | nindent 12 }}
           seLinuxOptions:
             level: s0
         volumeMounts:
@@ -119,7 +121,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml .Values.csidriver.server.securityContext.seccompProfile | nindent 12 }}
           seLinuxOptions:
             level: s0
         terminationMessagePath: /dev/termination-log
@@ -176,7 +178,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml .Values.csidriver.provisioner.securityContext.seccompProfile | nindent 12 }}
           seLinuxOptions:
             level: s0
         terminationMessagePath: /dev/termination-log
@@ -213,7 +215,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml .Values.csidriver.registrar.securityContext.seccompProfile | nindent 12 }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -246,7 +248,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml .Values.csidriver.livenessprobe.securityContext.seccompProfile | nindent 12 }}
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -60,15 +60,7 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         securityContext:
-          runAsUser: 0
-          privileged: false
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          seccompProfile:
-          {{- toYaml .Values.csidriver.csi_init.securityContext.seccompProfile | nindent 12 }}
-          seLinuxOptions:
-            level: s0
+        {{- toYaml .Values.csidriver.csiInit.securityContext| nindent 10 }}
         volumeMounts:
         - mountPath: /data
           name: data-dir
@@ -115,15 +107,7 @@ spec:
           {{- toYaml .Values.csidriver.server.resources | nindent 10 }}
           {{- end }}
         securityContext:
-          runAsUser: 0
-          privileged: true # Needed for mountPropagation
-          allowPrivilegeEscalation: true # Needed for privileged
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          seccompProfile:
-          {{- toYaml .Values.csidriver.server.securityContext.seccompProfile | nindent 12 }}
-          seLinuxOptions:
-            level: s0
+        {{- toYaml .Values.csidriver.server.securityContext | nindent 10 }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -172,15 +156,7 @@ spec:
           {{- toYaml .Values.csidriver.provisioner.resources | nindent 10 }}
           {{- end }}
         securityContext:
-          runAsUser: 0
-          privileged: true # Needed for mountPropagation
-          allowPrivilegeEscalation: true # Needed for privileged
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          seccompProfile:
-          {{- toYaml .Values.csidriver.provisioner.securityContext.seccompProfile | nindent 12 }}
-          seLinuxOptions:
-            level: s0
+        {{- toYaml .Values.csidriver.provisioner.securityContext | nindent 10 }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -210,12 +186,7 @@ spec:
           {{- toYaml .Values.csidriver.registrar.resources | nindent 10 }}
           {{- end }}
         securityContext:
-          runAsUser: 0
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          seccompProfile:
-          {{- toYaml .Values.csidriver.registrar.securityContext.seccompProfile | nindent 12 }}
+        {{- toYaml .Values.csidriver.registrar.securityContext | nindent 10 }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -242,13 +213,7 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         securityContext:
-          runAsUser: 0
-          privileged: false
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          seccompProfile:
-          {{- toYaml .Values.csidriver.livenessprobe.securityContext.seccompProfile | nindent 12 }}
+        {{- toYaml .Values.csidriver.livenessprobe.securityContext| nindent 10 }}
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -83,17 +83,7 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 10
           securityContext:
-            seccompProfile:
-            {{- toYaml .Values.operator.securityContext.seccompProfile | nindent 14 }}
-            privileged: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 1001
-            runAsGroup: 1001
-            capabilities:
-              drop:
-                - ALL
+          {{- toYaml .Values.operator.securityContext | nindent 12 }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -84,7 +84,7 @@ spec:
             periodSeconds: 10
           securityContext:
             seccompProfile:
-              type: RuntimeDefault
+            {{- toYaml .Values.operator.securityContext.seccompProfile | nindent 14 }}
             privileged: false
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -129,17 +129,7 @@ spec:
             - name: certs-dir
               mountPath: /tmp/k8s-webhook-server/serving-certs/
           securityContext:
-            seccompProfile:
-            {{- toYaml .Values.webhook.securityContext.seccompProfile | nindent 14 }}
-            privileged: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 1001
-            runAsGroup: 1001
-            capabilities:
-              drop:
-                - ALL
+          {{- toYaml .Values.webhook.securityContext | nindent 12 }}
       serviceAccountName: dynatrace-webhook
       {{- if (.Values.webhook).hostNetwork }}
       hostNetwork: true

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -130,7 +130,7 @@ spec:
               mountPath: /tmp/k8s-webhook-server/serving-certs/
           securityContext:
             seccompProfile:
-              type: RuntimeDefault
+            {{- toYaml .Values.webhook.securityContext.seccompProfile | nindent 14 }}
             privileged: false
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -95,7 +95,7 @@ csidriver:
       operator: Exists
   labels: []
   annotations: []
-  csi_init:
+  csiInit:
     securityContext:
       runAsUser: 0
       privileged: false

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -34,6 +34,15 @@ operator:
   annotations: []
   apparmor: false
   securityContext:
+    privileged: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    capabilities:
+      drop:
+        - ALL
     seccompProfile:
       type: RuntimeDefault
   requests:
@@ -51,6 +60,15 @@ webhook:
   annotations: []
   apparmor: false
   securityContext:
+    privileged: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    capabilities:
+      drop:
+        - ALL
     seccompProfile:
       type: RuntimeDefault
   requests:
@@ -79,10 +97,24 @@ csidriver:
   annotations: []
   csi_init:
     securityContext:
+      runAsUser: 0
+      privileged: false
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      seLinuxOptions:
+        level: s0
       seccompProfile:
         type: RuntimeDefault
   server:
     securityContext:
+      runAsUser: 0
+      privileged: true # Needed for mountPropagation
+      allowPrivilegeEscalation: true # Needed for privileged
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      seLinuxOptions:
+        level: s0
       seccompProfile:
         type: RuntimeDefault
     resources:
@@ -94,6 +126,13 @@ csidriver:
         memory: 100Mi
   provisioner:
     securityContext:
+      runAsUser: 0
+      privileged: true # Needed for mountPropagation
+      allowPrivilegeEscalation: true # Needed for privileged
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      seLinuxOptions:
+        level: s0
       seccompProfile:
         type: RuntimeDefault
     resources:
@@ -105,6 +144,10 @@ csidriver:
         memory: 100Mi
   registrar:
     securityContext:
+      runAsUser: 0
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
       seccompProfile:
         type: RuntimeDefault
     resources:
@@ -116,6 +159,11 @@ csidriver:
         memory: 30Mi
   livenessprobe:
     securityContext:
+      runAsUser: 0
+      privileged: false
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
       seccompProfile:
         type: RuntimeDefault
     resources:
@@ -125,6 +173,3 @@ csidriver:
       limits:
         cpu: 20m
         memory: 30Mi
-
-securityContextConstraints:
-  enabled: true # Only applicable for Openshift

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -33,6 +33,9 @@ operator:
   labels: []
   annotations: []
   apparmor: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   requests:
     cpu: 50m
     memory: 64Mi
@@ -47,6 +50,9 @@ webhook:
   labels: []
   annotations: []
   apparmor: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   requests:
     cpu: 300m
     memory: 128Mi
@@ -71,7 +77,14 @@ csidriver:
       operator: Exists
   labels: []
   annotations: []
+  csi_init:
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
   server:
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
     resources:
       requests:
         cpu: 50m
@@ -80,6 +93,9 @@ csidriver:
         cpu: 50m
         memory: 100Mi
   provisioner:
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
     resources:
       requests:
         cpu: 300m
@@ -88,6 +104,9 @@ csidriver:
         cpu: 300m
         memory: 100Mi
   registrar:
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
     resources:
       requests:
         cpu: 20m
@@ -96,6 +115,9 @@ csidriver:
         cpu: 20m
         memory: 30Mi
   livenessprobe:
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
     resources:
       requests:
         cpu: 20m


### PR DESCRIPTION
## Description

Makes the seccomp field in the security context of our components configurable via helm

## How can this be tested?

Play with the seccomp fields in the values.yaml. 

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
