### PR TITLE
Request raw codemodules from deployment API

### DIFF
--- a/src/dtclient/endpoints.go
+++ b/src/dtclient/endpoints.go
@@ -3,13 +3,13 @@ package dtclient
 import "fmt"
 
 func (dtc *dynatraceClient) getAgentUrl(os, installerType, flavor, arch, version string, technologies []string) string {
-	url := fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/version/%s?flavor=%s&arch=%s&bitness=64",
+	url := fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/version/%s?flavor=%s&arch=%s&bitness=64&skipMetadata=true",
 		dtc.url, os, installerType, version, flavor, arch)
 	return appendTechnologies(url, technologies)
 }
 
 func (dtc *dynatraceClient) getLatestAgentUrl(os, installerType, flavor, arch string, technologies []string) string {
-	url := fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/latest?bitness=64&flavor=%s&arch=%s",
+	url := fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/latest?bitness=64&flavor=%s&arch=%s&skipMetadata=true",
 		dtc.url, os, installerType, flavor, arch)
 	return appendTechnologies(url, technologies)
 }


### PR DESCRIPTION
## Description

When we skip the metadata when downloading a codemodule, the resulting zip will not contain the information necessary for the codemodule to connect to the Dynatrace Environment.

In https://github.com/Dynatrace/dynatrace-operator/pull/1954 we already made it that we override this information when mounting it to the user container, so we can safe space and download amount.

## How can this be tested?

2 things you can test:
- ApplicationMonitoring mode **without** CSI driver, not that much benefit here, but it should still "just" work
- Cloudnative or ApplicationMonitoring mode with CSI driver
   - Before testing, make sure you don't have anything under `/data/codemodules` on the nodes, just to make sure you don't have something there from a previous download
   -  After deploying the dynakube and the csi driver finished downloading, there should be something under `/data/codemodules`, and you should check that in the `data/codemodules/<version>/agent/conf/ruxitagentproc.conf` file there is no `tenant` or `tenantToken` present
   - Deploy sample apps, and check that they can connect to the Dynatrace Environment 

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
