### PR TITLE
Add startupProbe to csi-provisioner and operator pod

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -104,6 +104,7 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
+        {{- include "dynatrace-operator.startupProbe" . | nindent 8 }}
         ports:
         - containerPort: 10080
           name: livez

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -82,6 +82,7 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 10
+          {{- include "dynatrace-operator.startupProbe" . | nindent 10 }}
           securityContext:
             seccompProfile:
               type: RuntimeDefault

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -47,3 +47,15 @@ Check if we are generating only a part of the yamls
 	    {{- printf "false" -}}
 	{{- end -}}
 {{- end -}}
+
+{{- define "dynatrace-operator.startupProbe" -}}
+startupProbe:
+  exec:
+    command:
+    - /usr/local/bin/dynatrace-operator
+    - startup-probe
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 1
+{{- println }}
+{{- end -}}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -163,6 +163,14 @@ tests:
                   periodSeconds: 5
                   successThreshold: 1
                   timeoutSeconds: 1
+                startupProbe:
+                  exec:
+                    command:
+                      - /usr/local/bin/dynatrace-operator
+                      - startup-probe
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 1
                 name: server
                 ports:
                   - containerPort: 10080

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -101,6 +101,14 @@ tests:
                     scheme: HTTP
                   initialDelaySeconds: 15
                   periodSeconds: 10
+                startupProbe:
+                  exec:
+                    command:
+                      - /usr/local/bin/dynatrace-operator
+                      - startup-probe
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 1
                 securityContext:
                   seccompProfile:
                     type: RuntimeDefault
@@ -256,6 +264,14 @@ tests:
                     scheme: HTTP
                   initialDelaySeconds: 15
                   periodSeconds: 10
+                startupProbe:
+                  exec:
+                    command:
+                      - /usr/local/bin/dynatrace-operator
+                      - startup-probe
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 1
                 securityContext:
                   seccompProfile:
                     type: RuntimeDefault


### PR DESCRIPTION
## Description

This PR adds startupProbe to csi-provisioner and operator pod

**what is startupProbe?**
> A startup probe verifies whether the application within a container is started. Startup probes run before any other probe, and, unless it finishes successfully, disables other probes. If a container fails its startup probe, then the container is killed and follows the pod’s restartPolicy.
> This type of probe is only executed at startup, unlike readiness probes, which are run periodically.
> The startup probe is configured in the spec.containers.startupprobe attribute of the pod configuration.


## How can this be tested?

Deploy current branch to cluster and see new startupProbe:
```
k get pods dynatrace-oneagent-csi-driver-qr8wg -o jsonpath={.spec.containers} | jq -r '.[].startupProbe'
{
  "exec": {
    "command": [
      "/usr/local/bin/dynatrace-operator",
      "startup-probe"
    ]
  },
  "failureThreshold": 1,
  "periodSeconds": 10,
  "successThreshold": 1,
  "timeoutSeconds": 5
}

k get pods dynatrace-operator-89b95477c-zsrxf -o jsonpath={.spec.containers} | jq -r '.[].startupProbe'
{
  "exec": {
    "command": [
      "/usr/local/bin/dynatrace-operator",
      "startup-probe"
    ]
  },
  "failureThreshold": 1,
  "periodSeconds": 10,
  "successThreshold": 1,
  "timeoutSeconds": 5
}
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
