### PR TITLE
Pass proxy to codemodules via ruxitagentproc.conf instead of env vari…

### DIFF
--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -220,7 +220,7 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 	latestProcessModuleConfigCache = newProcessModuleConfigCache(latestProcessModuleConfig)
 
 	if dk.NeedsOneAgentProxy() {
-		proxy, err := provisioner.getAgentProxy(ctx, dk)
+		proxy, err := dk.Proxy(ctx, provisioner.apiReader)
 		if err != nil {
 			return nil, false, err
 		}
@@ -264,24 +264,6 @@ func (provisioner *OneAgentProvisioner) getAgentTenantToken(ctx context.Context,
 	}
 
 	return string(token), nil
-}
-
-func (provisioner *OneAgentProvisioner) getAgentProxy(ctx context.Context, dk *dynatracev1beta1.DynaKube) (string, error) {
-	if dk.Spec.Proxy.Value != "" {
-		return dk.Spec.Proxy.Value, nil
-	}
-	query := kubeobjects.NewSecretQuery(ctx, provisioner.client, provisioner.apiReader, log)
-	secret, err := query.Get(types.NamespacedName{Namespace: dk.Namespace, Name: dk.Spec.Proxy.ValueFrom})
-	if err != nil {
-		return "", errors.Wrapf(err, "proxy secret %s/%s not found", dk.Namespace, dk.Spec.Proxy.ValueFrom)
-	}
-
-	proxy, ok := secret.Data[dynatracev1beta1.ProxyKey]
-	if !ok {
-		return "", errors.Errorf("proxy not found in secret %s/%s", dk.Namespace, dk.Spec.Proxy.ValueFrom)
-	}
-
-	return string(proxy), nil
 }
 
 func (provisioner *OneAgentProvisioner) handleMetadata(ctx context.Context, dk *dynatracev1beta1.DynaKube) (*metadata.Dynakube, metadata.Dynakube, error) {

--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -273,12 +273,12 @@ func (provisioner *OneAgentProvisioner) getAgentProxy(ctx context.Context, dk *d
 	query := kubeobjects.NewSecretQuery(ctx, provisioner.client, provisioner.apiReader, log)
 	secret, err := query.Get(types.NamespacedName{Namespace: dk.Namespace, Name: dk.Spec.Proxy.ValueFrom})
 	if err != nil {
-		return "", errors.Wrapf(err, "Proxy secret %s/%s not found", dk.Namespace, dk.Spec.Proxy.ValueFrom)
+		return "", errors.Wrapf(err, "proxy secret %s/%s not found", dk.Namespace, dk.Spec.Proxy.ValueFrom)
 	}
 
 	proxy, ok := secret.Data[dynatracev1beta1.ProxyKey]
 	if !ok {
-		return "", errors.Errorf("Proxy not found in secret %s/%s", dk.Namespace, dk.Spec.Proxy.ValueFrom)
+		return "", errors.Errorf("proxy not found in secret %s/%s", dk.Namespace, dk.Spec.Proxy.ValueFrom)
 	}
 
 	return string(proxy), nil

--- a/src/controllers/csi/provisioner/controller_test.go
+++ b/src/controllers/csi/provisioner/controller_test.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -650,86 +649,4 @@ func TestHandleMetadata(t *testing.T) {
 	require.NotNil(t, dynakubeMetadata)
 	require.NotNil(t, oldMetadata)
 	require.Equal(t, 5, dynakubeMetadata.MaxFailedMountAttempts)
-}
-
-func TestOneAgentProvisioner_getAgentProxy(t *testing.T) {
-	const proxy = "dummy-proxy"
-	const proxySecret = "proxy-secret"
-	type fields struct {
-		client    client.Client
-		apiReader client.Reader
-	}
-	type args struct {
-		ctx context.Context
-		dk  *dynatracev1beta1.DynaKube
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    string
-		wantErr bool
-	}{
-		{
-			name: "get proxy from value",
-			fields: fields{
-				client:    fake.NewClient(),
-				apiReader: fake.NewClient(),
-			},
-			args: args{
-				ctx: context.TODO(),
-				dk: &dynatracev1beta1.DynaKube{
-					Spec: dynatracev1beta1.DynaKubeSpec{
-						Proxy: &dynatracev1beta1.DynaKubeProxy{
-							Value: proxy,
-						},
-					},
-				},
-			},
-			want:    proxy,
-			wantErr: false,
-		},
-		{
-			name: "get proxy from secret",
-			fields: fields{
-				client: fake.NewClient(),
-				apiReader: fake.NewClient(&v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: proxySecret,
-					},
-					Data: map[string][]byte{
-						dynatracev1beta1.ProxyKey: []byte(proxy),
-					},
-				}),
-			},
-			args: args{
-				ctx: context.TODO(),
-				dk: &dynatracev1beta1.DynaKube{
-					Spec: dynatracev1beta1.DynaKubeSpec{
-						Proxy: &dynatracev1beta1.DynaKubeProxy{
-							ValueFrom: proxySecret,
-						},
-					},
-				},
-			},
-			want:    proxy,
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			provisioner := &OneAgentProvisioner{
-				client:    tt.fields.client,
-				apiReader: tt.fields.apiReader,
-			}
-			got, err := provisioner.getAgentProxy(tt.args.ctx, tt.args.dk)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("OneAgentProvisioner.getAgentProxy() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("OneAgentProvisioner.getAgentProxy() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }

--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -117,6 +117,11 @@ func (pmc *ProcessModuleConfig) AddTenantUUID(tenantUUID string) *ProcessModuleC
 	return pmc.Add(property)
 }
 
+func (pmc *ProcessModuleConfig) AddProxy(proxy string) *ProcessModuleConfig {
+	property := ProcessModuleProperty{Section: generalSectionName, Key: "proxy", Value: proxy}
+	return pmc.Add(property)
+}
+
 func (pmc ProcessModuleConfig) ToMap() ConfMap {
 	sections := map[string]map[string]string{}
 	for _, prop := range pmc.Properties {

--- a/src/dtclient/processmoduleconfig_test.go
+++ b/src/dtclient/processmoduleconfig_test.go
@@ -3,6 +3,7 @@ package dtclient
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -283,4 +284,53 @@ func TestAdd(t *testing.T) {
 			Value:   testValue,
 		})
 	})
+}
+
+func TestProcessModuleConfig_AddProxy(t *testing.T) {
+	const proxy = "dummy-proxy"
+	type fields struct {
+		Revision   uint
+		Properties []ProcessModuleProperty
+	}
+	type args struct {
+		proxy string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *ProcessModuleConfig
+	}{
+		{
+			name: "add proxy to process module config",
+			fields: fields{
+				Revision:   0,
+				Properties: []ProcessModuleProperty{},
+			},
+			args: args{
+				proxy: proxy,
+			},
+			want: &ProcessModuleConfig{
+				Revision: 0,
+				Properties: []ProcessModuleProperty{
+					{
+						Section: generalSectionName,
+						Key:     "proxy",
+						Value:   proxy,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pmc := &ProcessModuleConfig{
+				Revision:   tt.fields.Revision,
+				Properties: tt.fields.Properties,
+			}
+			if got := pmc.AddProxy(tt.args.proxy); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ProcessModuleConfig.AddProxy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/src/dtclient/processmoduleconfig_test.go
+++ b/src/dtclient/processmoduleconfig_test.go
@@ -3,7 +3,6 @@ package dtclient
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -328,7 +327,7 @@ func TestProcessModuleConfig_AddProxy(t *testing.T) {
 				Revision:   tt.fields.Revision,
 				Properties: tt.fields.Properties,
 			}
-			if got := pmc.AddProxy(tt.args.proxy); !reflect.DeepEqual(got, tt.want) {
+			if got := pmc.AddProxy(tt.args.proxy); !assert.Equal(t, got, tt.want) {
 				t.Errorf("ProcessModuleConfig.AddProxy() = %v, want %v", got, tt.want)
 			}
 		})

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -141,6 +141,11 @@ func (runner *Runner) getProcessModuleConfig() (*dtclient.ProcessModuleConfig, e
 	if err != nil {
 		return nil, err
 	}
+
+	if runner.config.Proxy != "" {
+		processModuleConfig.AddProxy(runner.config.Proxy)
+	}
+
 	return processModuleConfig.AddTenantUUID(runner.config.TenantUUID), nil
 }
 

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -293,6 +293,25 @@ func TestGetProcessModuleConfig(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, config)
 	})
+
+	t.Run("add proxy to process module config", func(t *testing.T) {
+		const proxy = "dummy-proxy"
+		runner := createMockedRunner(t)
+		runner.config.Proxy = proxy
+		runner.dtclient.(*dtclient.MockDynatraceClient).
+			On("GetProcessModuleConfig", uint(0)).
+			Return(&testProcessModuleConfig, nil)
+
+		config, err := runner.getProcessModuleConfig()
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		generalSection, ok := config.ToMap()["general"]
+		require.True(t, ok)
+		value, ok := generalSection["proxy"]
+		require.True(t, ok)
+		assert.Equal(t, proxy, value)
+	})
 }
 
 func TestCreateContainerConfigurationFiles(t *testing.T) {

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/containers.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/containers.go
@@ -75,10 +75,6 @@ func (mutator *OneAgentPodMutator) addOneAgentToContainer(request *dtwebhook.Rei
 		addCurlOptionsVolumeMount(container)
 	}
 
-	if dynakube.NeedsOneAgentProxy() {
-		addProxyEnv(container)
-	}
-
 	if dynakube.Spec.NetworkZone != "" {
 		addNetworkZoneEnv(container, dynakube.Spec.NetworkZone)
 	}

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/containers_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/containers_test.go
@@ -81,7 +81,7 @@ func TestMutateUserContainers(t *testing.T) {
 		{
 			name:                               "add envs and volume mounts (complex dynakube)",
 			dynakube:                           *getTestComplexDynakube(),
-			expectedAdditionalEnvCount:         6, //  1 proxy + 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
+			expectedAdditionalEnvCount:         5, // 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
 			expectedAdditionalVolumeMountCount: 5, // 3 oneagent mounts(preload,bin,conf) + 1 cert mount + 1 curl-options
 		},
 		{
@@ -120,7 +120,7 @@ func TestReinvokeUserContainers(t *testing.T) {
 		{
 			name:                               "add envs and volume mounts (complex dynakube)",
 			dynakube:                           *getTestComplexDynakube(),
-			expectedAdditionalEnvCount:         6, //  1 proxy + 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
+			expectedAdditionalEnvCount:         5, // 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
 			expectedAdditionalVolumeMountCount: 5, // 3 oneagent mounts(preload,bin,conf) + 1 cert mount + 1 curl-options
 		},
 		{

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/env.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/env.go
@@ -66,21 +66,6 @@ func addVersionDetectionEnvs(container *corev1.Container, labelMapping VersionLa
 	}
 }
 
-func addProxyEnv(container *corev1.Container) {
-	container.Env = append(container.Env,
-		corev1.EnvVar{
-			Name: proxyEnv,
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: config.AgentInitSecretName,
-					},
-					Key: dynatracev1beta1.ProxyKey,
-				},
-			},
-		})
-}
-
 func addInstallerInitEnvs(initContainer *corev1.Container, installer installerInfo, dynakube dynatracev1beta1.DynaKube) {
 	initContainer.Env = append(initContainer.Env,
 		corev1.EnvVar{Name: config.AgentInstallerFlavorEnv, Value: installer.flavor},

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/env_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/env_test.go
@@ -87,17 +87,6 @@ func TestAddNetworkZoneEnv(t *testing.T) {
 	})
 }
 
-func TestAddProxyEnv(t *testing.T) {
-	t.Run("Add proxy env", func(t *testing.T) {
-		container := &corev1.Container{}
-
-		addProxyEnv(container)
-
-		require.Len(t, container.Env, 1)
-		assert.IsType(t, container.Env[0].ValueFrom, &corev1.EnvVarSource{})
-	})
-}
-
 func TestAddInstallerInitEnvs(t *testing.T) {
 	t.Run("Add installer init env", func(t *testing.T) {
 		container := &corev1.Container{}

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
@@ -120,7 +120,7 @@ func TestMutate(t *testing.T) {
 		{
 			name:                                   "everything turned on, should mutate the pod and init container in the request",
 			dynakube:                               *getTestComplexDynakube(),
-			expectedAdditionalEnvCount:             6, // 1 proxy + 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
+			expectedAdditionalEnvCount:             5, // 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
 			expectedAdditionalVolumeCount:          3, // bin, share, injection-config
 			expectedAdditionalVolumeMountCount:     5, // 3 oneagent mounts(preload,bin,conf) + 1 cert mount + 1 curl-options
 			expectedAdditionalInitVolumeMountCount: 3, // bin, share, injection-config
@@ -183,7 +183,7 @@ func TestReinvoke(t *testing.T) {
 		{
 			name:                               "everything turned on, should mutate the pod and init container in the request",
 			dynakube:                           *getTestComplexDynakube(),
-			expectedAdditionalEnvCount:         6, // 1 proxy + 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
+			expectedAdditionalEnvCount:         5, // 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
 			expectedAdditionalVolumeMountCount: 5, // 3 oneagent mounts(preload,bin,conf) + 1 cert mount + 1 curl-options
 		},
 		{


### PR DESCRIPTION
## Description

Remove proxy env var passed to codemodules. Pass proxy through `ruxitagentproc.conf` instead (section `general`, key `proxy`).

## How can this be tested?

- Deploy a cloudNativeFullStack dynakube with a proxy.
- Deploy a new pod in the cluster (e.g. alpine linux)
- Get into the shell of that pod container and find the ruxitagentproc.conf file
- Check that it contains the proxy value (see pic)

![image](https://github.com/Dynatrace/dynatrace-operator/assets/61692514/02d64ae3-0970-43a1-b9d3-8b3cffe5dde0)

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
