### PR TITLE
Revert overwriting the tenantUUID in the ruxitagentproc.conf

### DIFF
--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -189,8 +189,7 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 
 	latestProcessModuleConfig = latestProcessModuleConfig.
 		AddHostGroup(dk.HostGroup()).
-		AddConnectionInfo(dk.Status.OneAgent.ConnectionInfoStatus, tenantToken).
-		AddTenantUUID(dynakubeMetadata.TenantUUID)
+		AddConnectionInfo(dk.Status.OneAgent.ConnectionInfoStatus, tenantToken)
 
 	var agentUpdater *agentUpdater
 	if dk.CodeModulesImage() != "" {

--- a/src/dtclient/processmoduleconfig.go
+++ b/src/dtclient/processmoduleconfig.go
@@ -112,11 +112,6 @@ func (pmc *ProcessModuleConfig) AddHostGroup(hostGroup string) *ProcessModuleCon
 	return pmc.Add(property)
 }
 
-func (pmc *ProcessModuleConfig) AddTenantUUID(tenantUUID string) *ProcessModuleConfig {
-	property := ProcessModuleProperty{Section: generalSectionName, Key: "tenant", Value: tenantUUID}
-	return pmc.Add(property)
-}
-
 func (pmc ProcessModuleConfig) ToMap() ConfMap {
 	sections := map[string]map[string]string{}
 	for _, prop := range pmc.Properties {

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -124,7 +124,7 @@ func (runner *Runner) installOneAgent() error {
 	if err != nil {
 		return err
 	}
-	processModuleConfig, err := runner.getProcessModuleConfig()
+	processModuleConfig, err := runner.dtclient.GetProcessModuleConfig(0)
 	if err != nil {
 		return err
 	}
@@ -132,14 +132,6 @@ func (runner *Runner) installOneAgent() error {
 		return err
 	}
 	return nil
-}
-
-func (runner *Runner) getProcessModuleConfig() (*dtclient.ProcessModuleConfig, error) {
-	processModuleConfig, err := runner.dtclient.GetProcessModuleConfig(0)
-	if err != nil {
-		return nil, err
-	}
-	return processModuleConfig.AddTenantUUID(runner.config.TenantUUID), nil
 }
 
 func (runner *Runner) configureInstallation() error {

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -273,38 +273,6 @@ func TestConfigureInstallation(t *testing.T) {
 	})
 }
 
-func TestGetProcessModuleConfig(t *testing.T) {
-	t.Run("add tenantUUID to process module config", func(t *testing.T) {
-		tenantAlias := "my-tenant"
-		runner := createMockedRunner(t)
-		runner.config.TenantUUID = tenantAlias
-		runner.dtclient.(*dtclient.MockDynatraceClient).
-			On("GetProcessModuleConfig", uint(0)).
-			Return(&testProcessModuleConfig, nil)
-
-		config, err := runner.getProcessModuleConfig()
-		require.NoError(t, err)
-		require.NotNil(t, config)
-
-		generalSection, ok := config.ToMap()["general"]
-		require.True(t, ok)
-		tenantUUID, ok := generalSection["tenant"]
-		require.True(t, ok)
-		assert.Equal(t, tenantAlias, tenantUUID)
-	})
-
-	t.Run("error if api call fails", func(t *testing.T) {
-		runner := createMockedRunner(t)
-		runner.dtclient.(*dtclient.MockDynatraceClient).
-			On("GetProcessModuleConfig", uint(0)).
-			Return(&dtclient.ProcessModuleConfig{}, fmt.Errorf("BOOM"))
-
-		config, err := runner.getProcessModuleConfig()
-		require.Error(t, err)
-		require.Nil(t, config)
-	})
-}
-
 func TestCreateContainerConfigurationFiles(t *testing.T) {
 	runner := createMockedRunner(t)
 	runner.config.HasHost = false


### PR DESCRIPTION
This reverts commit 49442b460811fd4e32930fd909c00611fa2528b4.

## Description

Revert of #1850

## How can this be tested?

Revert of #1850

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
