### PR TITLE
Add missing service account for OLM installations

### DIFF
--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent-unprivileged.yaml
@@ -1,5 +1,5 @@
 {{- include "dynatrace-operator.platformRequired" . }}
-{{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
+{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description

With #1867 we removed the OpenshiftOrOLM check, however it got reintroduced, but due to cherry-pick conflict, we missed the oneAgent unprivileged clusterrole. This PR changes the check to the old format for this clusterrole

## How can this be tested?

`make manifests` creates the correct manifests

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
