### PR TITLE
Replicate connectionInfo to injected namespaces

### DIFF
--- a/src/controllers/csi/provisioner/controller.go
+++ b/src/controllers/csi/provisioner/controller.go
@@ -214,9 +214,7 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(ctx context.Cont
 
 	latestProcessModuleConfig = latestProcessModuleConfig.
 		AddHostGroup(dk.HostGroup()).
-		AddConnectionInfo(dk.Status.OneAgent.ConnectionInfoStatus, tenantToken).
-		AddTenantUUID(dynakubeMetadata.TenantUUID)
-
+		AddConnectionInfo(dk.Status.OneAgent.ConnectionInfoStatus, tenantToken)
 	latestProcessModuleConfigCache = newProcessModuleConfigCache(latestProcessModuleConfig)
 
 	if dk.NeedsOneAgentProxy() {

--- a/src/initgeneration/initgeneration.go
+++ b/src/initgeneration/initgeneration.go
@@ -182,7 +182,7 @@ func (g *InitGenerator) getTenantToken(ctx context.Context, dynakube *dynatracev
 	if err != nil {
 		return "", err
 	}
-	return secret.StringData[connectioninfo.TenantTokenName], err
+	return string(secret.Data[connectioninfo.TenantTokenName]), err
 }
 
 func getPaasToken(tokens corev1.Secret) string {

--- a/src/initgeneration/initgeneration.go
+++ b/src/initgeneration/initgeneration.go
@@ -151,11 +151,6 @@ func (g *InitGenerator) createSecretConfigForDynaKube(ctx context.Context, dynak
 		return nil, errors.WithStack(err)
 	}
 
-	tenantUUID, err := dynakube.TenantUUIDFromApiUrl()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
 	tenantToken, err := g.getTenantToken(ctx, dynakube)
 	if err != nil {
 		return nil, err
@@ -172,7 +167,6 @@ func (g *InitGenerator) createSecretConfigForDynaKube(ctx context.Context, dynak
 		NetworkZone:         dynakube.Spec.NetworkZone,
 		TrustedCAs:          string(trustedCAs),
 		SkipCertCheck:       dynakube.Spec.SkipCertCheck,
-		TenantUUID:          tenantUUID,
 		HasHost:             dynakube.CloudNativeFullstackMode(),
 		MonitoringNodes:     hostMonitoringNodes,
 		TlsCert:             tlsCert,
@@ -210,11 +204,7 @@ func getAPIToken(tokens corev1.Secret) string {
 //
 // Checks all the dynakubes with host-monitoring against all the nodes (using the nodeSelector), creating the above mentioned mapping.
 func (g *InitGenerator) getHostMonitoringNodes(dk *dynatracev1beta1.DynaKube) (map[string]string, error) {
-	tenantUUID, err := dk.TenantUUIDFromApiUrl()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
+	tenantUUID := dk.Status.OneAgent.ConnectionInfoStatus.TenantUUID
 	imNodes := map[string]string{}
 	if !dk.CloudNativeFullstackMode() {
 		return imNodes, nil

--- a/src/initgeneration/initgeneration_test.go
+++ b/src/initgeneration/initgeneration_test.go
@@ -403,7 +403,6 @@ func testForCorrectContent(t *testing.T, secret *corev1.Secret) {
 		NoProxy:             testNoProxy,
 		TrustedCAs:          testCAValue,
 		ClusterID:           string(kubesystemUID),
-		TenantUUID:          testTenantUUID,
 		MonitoringNodes:     imNodes,
 		HasHost:             true,
 		TlsCert:             "testing",

--- a/src/initgeneration/initgeneration_test.go
+++ b/src/initgeneration/initgeneration_test.go
@@ -3,10 +3,12 @@ package initgeneration
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/config"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/src/standalone"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/src/webhook"
@@ -15,403 +17,530 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	operatorNamespace        = "dynatrace"
-	testNamespaceName        = "namespace"
-	testOtherNamespaceName   = "other-namespace"
-	testDynakubeComplexName  = "dynakubeComplex"
-	testDynakubeSimpleName   = "dynakubeSimple"
-	testTokensName           = "kitchen-sink"
-	testApiUrl               = "https://test-url/e/" + testTenantUUID + "/api"
-	testProxy                = "testproxy.com"
-	testNoProxy              = "noproxy.com,nopeproxy.com"
-	testtrustCAsCM           = "testtrustedCAsConfigMap"
-	testCAValue              = "somecertificate"
-	testTenantUUID           = "abc12345"
-	kubesystemNamespace      = "kube-system"
-	kubesystemUID            = types.UID("42")
-	testNode1Name            = "node1"
-	testNode2Name            = "node2"
-	testNodeWithSelectorName = "nodeWselector"
-)
-
-var (
-	testSelectorLabels  = map[string]string{"test": "label"}
-	testDynakubeComplex = &dynatracev1beta1.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testDynakubeComplexName,
-			Namespace: operatorNamespace,
-			Annotations: map[string]string{
-				dynatracev1beta1.AnnotationFeatureNoProxy: testNoProxy,
-			},
-		},
-		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL:     testApiUrl,
-			Proxy:      &dynatracev1beta1.DynaKubeProxy{Value: testProxy},
-			TrustedCAs: testtrustCAsCM,
-			Tokens:     testTokensName,
-			OneAgent: dynatracev1beta1.OneAgentSpec{
-				CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
-					HostInjectSpec: dynatracev1beta1.HostInjectSpec{
-						Args: []string{
-							"--something=else",
-							"",
-						},
-					},
-				}},
-			ActiveGate: dynatracev1beta1.ActiveGateSpec{
-				Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-					dynatracev1beta1.KubeMonCapability.DisplayName,
-				},
-				TlsSecretName: "testing",
-			},
-		},
-		Status: dynatracev1beta1.DynaKubeStatus{
-			OneAgent: dynatracev1beta1.OneAgentStatus{
-				Instances: map[string]dynatracev1beta1.OneAgentInstance{
-					testNode1Name: {},
-				},
-			},
-		},
-	}
-
-	testDynakubeSimple = &dynatracev1beta1.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{Name: testDynakubeSimpleName, Namespace: operatorNamespace},
-		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL:   testApiUrl,
-			OneAgent: dynatracev1beta1.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{}},
-		},
-		Status: dynatracev1beta1.DynaKubeStatus{
-			OneAgent: dynatracev1beta1.OneAgentStatus{
-				Instances: map[string]dynatracev1beta1.OneAgentInstance{
-					testNode2Name: {},
-				},
-			},
-		},
-	}
-
-	testDynakubeWithSelector = &dynatracev1beta1.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{Name: testDynakubeSimpleName, Namespace: operatorNamespace},
-		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL: testApiUrl,
-			OneAgent: dynatracev1beta1.OneAgentSpec{
-				CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
-					HostInjectSpec: dynatracev1beta1.HostInjectSpec{
-						NodeSelector: testSelectorLabels,
-					},
-				},
-			},
-		},
-		Status: dynatracev1beta1.DynaKubeStatus{
-			OneAgent: dynatracev1beta1.OneAgentStatus{
-				Instances: map[string]dynatracev1beta1.OneAgentInstance{
-					testNodeWithSelectorName: {},
-				},
-			},
-		},
-	}
-
-	caConfigMap = &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: testtrustCAsCM, Namespace: operatorNamespace},
-		Data: map[string]string{
-			dynatracev1beta1.TrustedCAKey: testCAValue,
-		},
-	}
-
-	testSecretDynakubeComplex = &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: testTokensName, Namespace: operatorNamespace},
-		Data:       map[string][]byte{"paasToken": []byte("42"), "apiToken": []byte("84")},
-	}
-
-	testSecretDynakubeComplexOnlyApi = &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: testTokensName, Namespace: operatorNamespace},
-		Data:       map[string][]byte{"apiToken": []byte("42")},
-	}
-
-	testTlsSecretDynakubeComplex = &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "testing", Namespace: operatorNamespace},
-		Data:       map[string][]byte{dynatracev1beta1.TlsCertKey: []byte("testing")},
-	}
-
-	testSecretDynakubeSimple = &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: testDynakubeSimpleName, Namespace: operatorNamespace},
-		Data:       map[string][]byte{"paasToken": []byte("42"), "apiToken": []byte("84")},
-	}
-
-	kubeNamespace = &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: kubesystemNamespace, UID: kubesystemUID},
-	}
-
-	testNode1 = &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: testNode1Name},
-	}
-
-	testNode2 = &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: testNode2Name},
-	}
-
-	testNodeWithLabels = &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   testNodeWithSelectorName,
-			Labels: testSelectorLabels,
-		},
-	}
+	kubesystemNamespace = "kube-system"
+	kubesystemUID       = types.UID("42")
 )
 
 func TestGenerateForNamespace(t *testing.T) {
-	t.Run("Add secret for namespace (dynakube with all the fields)", func(t *testing.T) {
-		testNamespace := corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   testNamespaceName,
-				Labels: map[string]string{dtwebhook.InjectionInstanceLabel: testDynakubeComplex.Name},
-			},
-		}
-		clt := fake.NewClient(testDynakubeComplex, &testNamespace, testSecretDynakubeComplex, kubeNamespace, caConfigMap, testTlsSecretDynakubeComplex, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace)
+	t.Run("Add secret for namespace (dynakube with all relevant fields)", func(t *testing.T) {
+		dynakube := createDynakube()
 
-		err := ig.GenerateForNamespace(context.TODO(), *testDynakubeComplex, testNamespace.Name)
-		assert.NoError(t, err)
+		// setup tokens
+		apiToken := "api-test"
+		paasToken := "paas-test"
+		apiTokenSecret := createApiTokenSecret(dynakube, apiToken, paasToken)
+		tenantToken := "tenant-test"
+		tenantTokenSecret := createTenantTokenSecret(dynakube, tenantToken)
 
-		var initSecret corev1.Secret
-		err = clt.Get(context.TODO(), types.NamespacedName{Name: config.AgentInitSecretName, Namespace: testNamespace.Name}, &initSecret)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(initSecret.Data))
-		secretConfig, ok := initSecret.Data[config.AgentInitSecretConfigField]
-		assert.True(t, ok)
-		assert.NotNil(t, secretConfig)
-		proxy, ok := initSecret.Data[dynatracev1beta1.ProxyKey]
-		assert.True(t, ok)
-		assert.NotNil(t, proxy)
-		assert.Equal(t, testProxy, string(proxy))
+		// add TrustedCA
+		setTrustedCA(dynakube, "ca-configmap")
+		caValue := "ca-test"
+		caConfigMap := createTestCaConfigMap(dynakube, caValue)
+
+		// add Proxy
+		proxyValue := "proxy-test-value"
+		setProxy(dynakube, proxyValue)
+
+		// add TLS secret
+		setTlsSecret(dynakube, "tls-test")
+		tlsValue := "tls-test-value"
+		tlsSecret := createTestTlsSecret(dynakube, tlsValue)
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClient(dynakube, testNamespace, apiTokenSecret, tenantTokenSecret, getKubeNamespace(), caConfigMap, tlsSecret)
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		err := ig.GenerateForNamespace(context.TODO(), *dynakube, testNamespace.Name)
+		require.NoError(t, err)
+
+		initSecret := retrieveInitSecret(t, clt, testNamespace.Name)
+		checkSecretConfigExists(t, initSecret)
+		checkProxy(t, initSecret, proxyValue)
 	})
 	t.Run("Add secret for namespace (simple dynakube)", func(t *testing.T) {
-		testNamespace := corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   testNamespaceName,
-				Labels: map[string]string{dtwebhook.InjectionInstanceLabel: testDynakubeSimple.Name},
-			},
-		}
-		clt := fake.NewClient(testDynakubeSimple, &testNamespace, testSecretDynakubeSimple, kubeNamespace, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace)
+		dynakube := createDynakube()
 
-		err := ig.GenerateForNamespace(context.TODO(), *testDynakubeSimple, testNamespace.Name)
-		assert.NoError(t, err)
+		// setup tokens
+		apiToken := "api-test"
+		apiTokenSecret := createApiTokenSecret(dynakube, apiToken, apiToken)
+		tenantToken := "tenant-test"
+		tenantTokenSecret := createTenantTokenSecret(dynakube, tenantToken)
 
-		var initSecret corev1.Secret
-		err = clt.Get(context.TODO(), types.NamespacedName{Name: config.AgentInitSecretName, Namespace: testNamespace.Name}, &initSecret)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(initSecret.Data))
-		secretConfig, ok := initSecret.Data[config.AgentInitSecretConfigField]
-		assert.True(t, ok)
-		assert.NotNil(t, secretConfig)
-		proxy, ok := initSecret.Data[dynatracev1beta1.ProxyKey]
-		assert.True(t, ok)
-		assert.NotNil(t, proxy)
-		assert.Empty(t, proxy)
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClient(dynakube, testNamespace, apiTokenSecret, tenantTokenSecret, getKubeNamespace())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		err := ig.GenerateForNamespace(context.TODO(), *dynakube, testNamespace.Name)
+		require.NoError(t, err)
+
+		initSecret := retrieveInitSecret(t, clt, testNamespace.Name)
+		checkSecretConfigExists(t, initSecret)
+		checkProxy(t, initSecret, "")
 	})
 }
 
 func TestGenerateForDynakube(t *testing.T) {
 	t.Run("Add secret for namespace (dynakube with all the fields)", func(t *testing.T) {
-		dk := testDynakubeComplex.DeepCopy()
-		testNamespace := corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   testNamespaceName,
-				Labels: map[string]string{dtwebhook.InjectionInstanceLabel: testDynakubeComplex.Name},
-			},
-		}
-		clt := fake.NewClientWithIndex(&testNamespace, testSecretDynakubeComplex, kubeNamespace, caConfigMap, testTlsSecretDynakubeComplex, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace)
+		dynakube := createDynakube()
 
-		err := ig.GenerateForDynakube(context.TODO(), dk)
-		assert.NoError(t, err)
+		// setup tokens
+		apiToken := "api-test"
+		paasToken := "paas-test"
+		apiTokenSecret := createApiTokenSecret(dynakube, apiToken, paasToken)
+		tenantToken := "tenant-test"
+		tenantTokenSecret := createTenantTokenSecret(dynakube, tenantToken)
 
-		var initSecret corev1.Secret
-		err = clt.Get(context.TODO(), types.NamespacedName{Name: config.AgentInitSecretName, Namespace: testNamespace.Name}, &initSecret)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(initSecret.Data))
-		secretConfig, ok := initSecret.Data[config.AgentInitSecretConfigField]
-		assert.True(t, ok)
-		assert.NotNil(t, secretConfig)
-		proxy, ok := initSecret.Data[dynatracev1beta1.ProxyKey]
-		assert.True(t, ok)
-		assert.NotNil(t, proxy)
-		assert.Equal(t, testProxy, string(proxy))
+		// add TrustedCA
+		setTrustedCA(dynakube, "ca-configmap")
+		caValue := "ca-test"
+		caConfigMap := createTestCaConfigMap(dynakube, caValue)
+
+		// add Proxy
+		proxyValue := "proxy-test-value"
+		setProxy(dynakube, proxyValue)
+
+		// add TLS secret
+		setTlsSecret(dynakube, "tls-test")
+		tlsValue := "tls-test-value"
+		tlsSecret := createTestTlsSecret(dynakube, tlsValue)
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret, tenantTokenSecret, getKubeNamespace(), caConfigMap, tlsSecret)
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		err := ig.GenerateForDynakube(context.TODO(), dynakube)
+		require.NoError(t, err)
+
+		initSecret := retrieveInitSecret(t, clt, testNamespace.Name)
+		checkSecretConfigExists(t, initSecret)
+		checkProxy(t, initSecret, proxyValue)
 	})
 	t.Run("Add secret for namespace (simple dynakube)", func(t *testing.T) {
-		dk := testDynakubeSimple.DeepCopy()
-		testNamespace := corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   testNamespaceName,
-				Labels: map[string]string{dtwebhook.InjectionInstanceLabel: testDynakubeSimple.Name},
-			},
-		}
-		clt := fake.NewClientWithIndex(&testNamespace, testSecretDynakubeSimple, kubeNamespace, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace)
+		dynakube := createDynakube()
+		// setup tokens
+		apiToken := "api-test"
+		apiTokenSecret := createApiTokenSecret(dynakube, apiToken, apiToken)
+		tenantToken := "tenant-test"
+		tenantTokenSecret := createTenantTokenSecret(dynakube, tenantToken)
 
-		err := ig.GenerateForDynakube(context.TODO(), dk)
-		assert.NoError(t, err)
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret, tenantTokenSecret, getKubeNamespace())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
 
-		var initSecret corev1.Secret
-		err = clt.Get(context.TODO(), types.NamespacedName{Name: config.AgentInitSecretName, Namespace: testNamespace.Name}, &initSecret)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(initSecret.Data))
-		secretConfig, ok := initSecret.Data[config.AgentInitSecretConfigField]
-		assert.True(t, ok)
-		assert.NotNil(t, secretConfig)
-		proxy, ok := initSecret.Data[dynatracev1beta1.ProxyKey]
-		assert.True(t, ok)
-		assert.NotNil(t, proxy)
-		assert.Empty(t, proxy)
+		err := ig.GenerateForDynakube(context.TODO(), dynakube)
+		require.NoError(t, err)
+
+		initSecret := retrieveInitSecret(t, clt, testNamespace.Name)
+		checkSecretConfigExists(t, initSecret)
+		checkProxy(t, initSecret, "")
 	})
 	t.Run("Add secret to multiple namespaces (simple dynakube)", func(t *testing.T) {
-		dk := testDynakubeSimple.DeepCopy()
-		testNamespace := corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   testNamespaceName,
-				Labels: map[string]string{dtwebhook.InjectionInstanceLabel: testDynakubeSimple.Name},
-			},
-		}
-		testOtherNamespace := corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   testOtherNamespaceName,
-				Labels: map[string]string{dtwebhook.InjectionInstanceLabel: testDynakubeSimple.Name},
-			},
-		}
-		clt := fake.NewClientWithIndex(&testNamespace, &testOtherNamespace, testSecretDynakubeSimple, kubeNamespace, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace)
+		dynakube := createDynakube()
+		// setup tokens
+		apiToken := "api-test"
+		apiTokenSecret := createApiTokenSecret(dynakube, apiToken, apiToken)
+		tenantToken := "tenant-test"
+		tenantTokenSecret := createTenantTokenSecret(dynakube, tenantToken)
 
-		err := ig.GenerateForDynakube(context.TODO(), dk)
-		assert.NoError(t, err)
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testOtherNamespace := createTestInjectedNamespace(dynakube, "test-other")
+		clt := fake.NewClientWithIndex(testNamespace, testOtherNamespace, apiTokenSecret, tenantTokenSecret, getKubeNamespace())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
 
-		var initSecret corev1.Secret
-		err = clt.Get(context.TODO(), types.NamespacedName{Name: config.AgentInitSecretName, Namespace: testNamespace.Name}, &initSecret)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(initSecret.Data))
-		secretConfig, ok := initSecret.Data[config.AgentInitSecretConfigField]
-		assert.True(t, ok)
-		assert.NotNil(t, secretConfig)
-		proxy, ok := initSecret.Data[dynatracev1beta1.ProxyKey]
-		assert.True(t, ok)
-		assert.NotNil(t, proxy)
-		assert.Empty(t, proxy)
+		err := ig.GenerateForDynakube(context.TODO(), dynakube)
+		require.NoError(t, err)
 
-		err = clt.Get(context.TODO(), types.NamespacedName{Name: config.AgentInitSecretName, Namespace: testOtherNamespace.Name}, &initSecret)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(initSecret.Data))
-		secretConfig, ok = initSecret.Data[config.AgentInitSecretConfigField]
-		assert.True(t, ok)
-		assert.NotNil(t, secretConfig)
-		proxy, ok = initSecret.Data[dynatracev1beta1.ProxyKey]
-		assert.True(t, ok)
-		assert.NotNil(t, proxy)
-		assert.Empty(t, proxy)
+		initSecret := retrieveInitSecret(t, clt, testNamespace.Name)
+		checkSecretConfigExists(t, initSecret)
+		checkProxy(t, initSecret, "")
+
+		initSecret = retrieveInitSecret(t, clt, testOtherNamespace.Name)
+		checkSecretConfigExists(t, initSecret)
+		checkProxy(t, initSecret, "")
 	})
 }
 
 func TestGetInfraMonitoringNodes(t *testing.T) {
-	t.Run("Get IMNodes using nodes", func(t *testing.T) {
-		clt := fake.NewClient(testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace)
+	t.Run("Get Monitoring Nodes using nodes", func(t *testing.T) {
+		node1 := createTestNode("node-1", nil)
+		node2 := createTestNode("node-2", nil)
+		dynakube := createDynakube()
+		tenantUUID := dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID
+
+		clt := fake.NewClient(node1, node2)
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
 		ig.canWatchNodes = true
-		imNodes, err := ig.getHostMonitoringNodes(testDynakubeSimple)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(imNodes))
-		assert.Equal(t, testTenantUUID, imNodes[testNode1Name])
-		assert.Equal(t, testTenantUUID, imNodes[testNode2Name])
+		monitoringNodes, err := ig.getHostMonitoringNodes(dynakube)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(monitoringNodes))
+		assert.Equal(t, tenantUUID, monitoringNodes[node1.Name])
+		assert.Equal(t, tenantUUID, monitoringNodes[node2.Name])
 	})
-	t.Run("Get IMNodes from dynakubes (without node access)", func(t *testing.T) {
+	t.Run("Get Monitoring Nodes from dynakubes (without node access)", func(t *testing.T) {
+		node1 := createTestNode("node-1", nil)
+		node2 := createTestNode("node-2", nil)
+		dynakube := createDynakube()
+		setNodesToInstances(dynakube, node1.Name, node2.Name)
+		tenantUUID := dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID
+
 		clt := fake.NewClient()
-		ig := NewInitGenerator(clt, clt, operatorNamespace)
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
 		ig.canWatchNodes = false
-		imNodes, err := ig.getHostMonitoringNodes(testDynakubeSimple)
-		assert.NoError(t, err)
-		assert.Equal(t, 1, len(imNodes))
-		assert.Equal(t, testTenantUUID, imNodes[testNode2Name])
+		monitoringNodes, err := ig.getHostMonitoringNodes(dynakube)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(monitoringNodes))
+		assert.Equal(t, tenantUUID, monitoringNodes[node1.Name])
+		assert.Equal(t, tenantUUID, monitoringNodes[node2.Name])
 	})
-	t.Run("Get IMNodes from dynakubes with nodeSelector", func(t *testing.T) {
-		clt := fake.NewClient(testNodeWithLabels, testNode1, testNode2)
-		ig := NewInitGenerator(clt, clt, operatorNamespace)
+	t.Run("Get Monitoring Nodes from dynakubes with nodeSelector", func(t *testing.T) {
+		node1 := createTestNode("node-1", nil)
+		node2 := createTestNode("node-2", nil)
+		labeledNode := createTestNode("node-labeled", getTestSelectorLabels())
+		dynakube := createDynakube()
+		setNodesSelector(dynakube, getTestSelectorLabels())
+		tenantUUID := dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID
+
+		clt := fake.NewClient(labeledNode, node1, node2)
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
 		ig.canWatchNodes = true
-		imNodes, err := ig.getHostMonitoringNodes(testDynakubeWithSelector)
-		assert.NoError(t, err)
-		assert.Equal(t, 3, len(imNodes))
-		assert.Equal(t, config.AgentNoHostTenant, imNodes[testNode1Name])
-		assert.Equal(t, config.AgentNoHostTenant, imNodes[testNode2Name])
+		monitoringNodes, err := ig.getHostMonitoringNodes(dynakube)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(monitoringNodes))
+		assert.Equal(t, tenantUUID, monitoringNodes[labeledNode.Name])
+		assert.Equal(t, config.AgentNoHostTenant, monitoringNodes[node1.Name])
+		assert.Equal(t, config.AgentNoHostTenant, monitoringNodes[node2.Name])
 	})
 }
 
-func TestPrepareSecretConfigForDynaKube(t *testing.T) {
-	t.Run("Create SecretConfig with correct content", func(t *testing.T) {
-		testForCorrectContent(t, testSecretDynakubeComplex)
-	})
-	t.Run("Create SecretConfig with correct content, if only apiToken is provided", func(t *testing.T) {
-		testForCorrectContent(t, testSecretDynakubeComplexOnlyApi)
-	})
-	t.Run("Initial connect retry is set correctly", testInitialConnectRetrySetCorrectly)
-}
+func TestCreateSecretConfigForDynaKube(t *testing.T) {
+	baseDynakube := createDynakube()
 
-func testInitialConnectRetrySetCorrectly(t *testing.T) {
-	dynakube := &dynatracev1beta1.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testDynakubeSimpleName,
-			Namespace: operatorNamespace,
-		},
-		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL: testApiUrl,
-		},
-	}
-	clt := fake.NewClient(testSecretDynakubeSimple, caConfigMap, testTlsSecretDynakubeComplex)
-	initGenerator := InitGenerator{
-		client:    clt,
-		namespace: operatorNamespace,
-	}
-	secretConfig, err := initGenerator.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, map[string]string{})
+	apiToken := "api-test"
+	paasToken := "paas-test"
+	apiTokenSecret := createApiTokenSecret(baseDynakube, apiToken, paasToken)
+	tenantToken := "tenant-test"
+	tenantTokenSecret := createTenantTokenSecret(baseDynakube, tenantToken)
 
-	require.NoError(t, err)
-	assert.Equal(t, -1, secretConfig.InitialConnectRetry)
-
-	dynakube.Annotations = map[string]string{
-		dynatracev1beta1.AnnotationFeatureOneAgentInitialConnectRetry: "30",
-	}
-	secretConfig, err = initGenerator.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, map[string]string{})
-
-	require.NoError(t, err)
-	assert.Equal(t, 30, secretConfig.InitialConnectRetry)
-}
-
-func testForCorrectContent(t *testing.T, secret *corev1.Secret) {
-	dk := testDynakubeComplex.DeepCopy()
-	testNamespace := corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   testNamespaceName,
-			Labels: map[string]string{dtwebhook.InjectionInstanceLabel: testDynakubeComplex.Name},
-		},
-	}
-	clt := fake.NewClient(&testNamespace, secret, caConfigMap, testTlsSecretDynakubeComplex)
-	ig := NewInitGenerator(clt, clt, operatorNamespace)
-	imNodes := map[string]string{testNode1Name: testTenantUUID, testNode2Name: testTenantUUID}
-	secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dk, kubesystemUID, imNodes)
-	assert.NoError(t, err)
-	expectedConfig := standalone.SecretConfig{
-		ApiUrl:              dk.Spec.APIURL,
-		ApiToken:            string(secret.Data["apiToken"]),
-		SkipCertCheck:       dk.Spec.SkipCertCheck,
-		Proxy:               testProxy,
-		NoProxy:             testNoProxy,
-		TrustedCAs:          testCAValue,
+	baseExpectedSecretConfig := &standalone.SecretConfig{
+		ApiUrl:              baseDynakube.ApiUrl(),
+		ApiToken:            apiToken,
+		PaasToken:           paasToken,
+		TenantToken:         tenantToken,
+		ConnectionInfo:      baseDynakube.Status.OneAgent.ConnectionInfoStatus,
 		ClusterID:           string(kubesystemUID),
-		MonitoringNodes:     imNodes,
+		Proxy:               "",
+		NoProxy:             "",
+		NetworkZone:         "",
+		TrustedCAs:          "",
+		SkipCertCheck:       false,
 		HasHost:             true,
-		TlsCert:             "testing",
+		MonitoringNodes:     nil,
+		TlsCert:             "",
+		HostGroup:           "",
 		InitialConnectRetry: -1,
 	}
-	if content, ok := secret.Data["paasToken"]; ok {
-		expectedConfig.PaasToken = string(content)
-	} else {
-		expectedConfig.PaasToken = expectedConfig.ApiToken
+
+	t.Run("Create SecretConfig with default content", func(t *testing.T) {
+		dynakube := baseDynakube.DeepCopy()
+		expectedSecretConfig := *baseExpectedSecretConfig
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), tenantTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSecretConfig, *secretConfig)
+	})
+
+	t.Run("Create SecretConfig with trustedCA", func(t *testing.T) {
+		dynakube := baseDynakube.DeepCopy()
+		expectedSecretConfig := *baseExpectedSecretConfig
+		setTrustedCA(dynakube, "ca-configmap")
+		caValue := "ca-test"
+		caConfigMap := createTestCaConfigMap(dynakube, caValue)
+		expectedSecretConfig.TrustedCAs = caValue
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), tenantTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy(), caConfigMap.DeepCopy())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSecretConfig, *secretConfig)
+	})
+
+	t.Run("Create SecretConfig with proxy", func(t *testing.T) {
+		dynakube := baseDynakube.DeepCopy()
+		expectedSecretConfig := *baseExpectedSecretConfig
+		proxyValue := "proxy-test-value"
+		setProxy(dynakube, proxyValue)
+		expectedSecretConfig.Proxy = proxyValue
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), tenantTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSecretConfig, *secretConfig)
+	})
+
+	t.Run("Create SecretConfig with no-proxy", func(t *testing.T) {
+		dynakube := baseDynakube.DeepCopy()
+		expectedSecretConfig := *baseExpectedSecretConfig
+		proxyValue := "proxy-test-value"
+		setNoProxy(dynakube, proxyValue)
+		expectedSecretConfig.NoProxy = proxyValue
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), tenantTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSecretConfig, *secretConfig)
+	})
+
+	t.Run("Create SecretConfig with initial connect retry", func(t *testing.T) {
+		dynakube := baseDynakube.DeepCopy()
+		expectedSecretConfig := *baseExpectedSecretConfig
+		retryValue := "123"
+		setInitialConnectRetry(dynakube, retryValue)
+		expectedSecretConfig.InitialConnectRetry = 123
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), tenantTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSecretConfig, *secretConfig)
+	})
+
+	t.Run("Create SecretConfig with tlsSecret", func(t *testing.T) {
+		dynakube := baseDynakube.DeepCopy()
+		setTlsSecret(dynakube, "tls-test")
+		expectedSecretConfig := *baseExpectedSecretConfig
+		tlsValue := "tls-test-value"
+		tlsSecret := createTestTlsSecret(dynakube, tlsValue)
+		expectedSecretConfig.TlsCert = tlsValue
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), tenantTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy(), tlsSecret)
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSecretConfig, *secretConfig)
+	})
+
+	t.Run("Create SecretConfig with networkZone", func(t *testing.T) {
+		dynakube := baseDynakube.DeepCopy()
+		expectedSecretConfig := *baseExpectedSecretConfig
+		networkZone := "test-network"
+		dynakube.Spec.NetworkZone = networkZone
+		expectedSecretConfig.NetworkZone = networkZone
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), tenantTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSecretConfig, *secretConfig)
+	})
+
+	t.Run("Create SecretConfig with skipCertCheck", func(t *testing.T) {
+		dynakube := baseDynakube.DeepCopy()
+		expectedSecretConfig := *baseExpectedSecretConfig
+		dynakube.Spec.SkipCertCheck = true
+		expectedSecretConfig.SkipCertCheck = true
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), tenantTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSecretConfig, *secretConfig)
+	})
+
+	t.Run("Create SecretConfig with monitoring node", func(t *testing.T) {
+		dynakube := baseDynakube.DeepCopy()
+		expectedSecretConfig := *baseExpectedSecretConfig
+		monitoringNodes := map[string]string{
+			"node-1": "tenant-1",
+		}
+		expectedSecretConfig.MonitoringNodes = monitoringNodes
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), tenantTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, monitoringNodes)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSecretConfig, *secretConfig)
+	})
+}
+
+func getTestSelectorLabels() map[string]string {
+	return map[string]string{"test": "label"}
+}
+
+func createDynakube() *dynatracev1beta1.DynaKube {
+	return &dynatracev1beta1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "dynakube-test",
+			Namespace:   "dynatrace-test",
+			Annotations: map[string]string{},
+		},
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			APIURL: "https://test-url/e/tenant/api",
+			Tokens: "dynakube-test",
+			OneAgent: dynatracev1beta1.OneAgentSpec{
+				CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
+					HostInjectSpec: dynatracev1beta1.HostInjectSpec{},
+				}},
+		},
+		Status: dynatracev1beta1.DynaKubeStatus{
+			OneAgent: dynatracev1beta1.OneAgentStatus{
+				ConnectionInfoStatus: dynatracev1beta1.OneAgentConnectionInfoStatus{
+					ConnectionInfoStatus: dynatracev1beta1.ConnectionInfoStatus{
+						TenantUUID:  "test-tenant",
+						Endpoints:   "beep.com;bop.com",
+						LastRequest: metav1.Time{},
+					},
+				},
+			},
+		},
 	}
-	assert.Equal(t, &expectedConfig, secretConfig)
+}
+
+func setProxy(dynakube *dynatracev1beta1.DynaKube, value string) {
+	dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: value}
+}
+
+func setTrustedCA(dynakube *dynatracev1beta1.DynaKube, value string) {
+	dynakube.Spec.TrustedCAs = value
+}
+
+func checkProxy(t *testing.T, generatedSecret corev1.Secret, expectedValue string) {
+	proxy, ok := generatedSecret.Data[dynatracev1beta1.ProxyKey]
+	require.True(t, ok)
+	assert.NotNil(t, proxy)
+	assert.Equal(t, expectedValue, string(proxy))
+}
+
+func setNoProxy(dynakube *dynatracev1beta1.DynaKube, value string) {
+	dynakube.Annotations[dynatracev1beta1.AnnotationFeatureNoProxy] = value
+}
+
+func setInitialConnectRetry(dynakube *dynatracev1beta1.DynaKube, value string) {
+	dynakube.Annotations[dynatracev1beta1.AnnotationFeatureOneAgentInitialConnectRetry] = value
+}
+
+func setTlsSecret(dynakube *dynatracev1beta1.DynaKube, value string) {
+	dynakube.Spec.ActiveGate = dynatracev1beta1.ActiveGateSpec{
+		Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+			dynatracev1beta1.KubeMonCapability.DisplayName,
+		},
+		TlsSecretName: value,
+	}
+}
+
+func setNodesToInstances(dynakube *dynatracev1beta1.DynaKube, nodeNames ...string) {
+	instances := map[string]dynatracev1beta1.OneAgentInstance{}
+	for _, name := range nodeNames {
+		instances[name] = dynatracev1beta1.OneAgentInstance{}
+	}
+	dynakube.Status.OneAgent.Instances = instances
+}
+
+func setNodesSelector(dynakube *dynatracev1beta1.DynaKube, selector map[string]string) {
+	dynakube.Spec.OneAgent.CloudNativeFullStack.NodeSelector = selector
+}
+
+func createTestCaConfigMap(dynakube *dynatracev1beta1.DynaKube, value string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: dynakube.Spec.TrustedCAs, Namespace: dynakube.Namespace},
+		Data: map[string]string{
+			dynatracev1beta1.TrustedCAKey: value,
+		},
+	}
+}
+
+func createTestTlsSecret(dynakube *dynatracev1beta1.DynaKube, value string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: dynakube.Spec.ActiveGate.TlsSecretName, Namespace: dynakube.Namespace},
+		Data:       map[string][]byte{dynatracev1beta1.TlsCertKey: []byte(value)},
+	}
+}
+
+func getKubeNamespace() *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: kubesystemNamespace, UID: kubesystemUID},
+	}
+}
+
+func createApiTokenSecret(dynakube *dynatracev1beta1.DynaKube, apiToken, paasToken string) *corev1.Secret {
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: dynakube.Name, Namespace: dynakube.Namespace},
+		Data:       map[string][]byte{},
+	}
+	if apiToken != "" {
+		tokenSecret.Data["apiToken"] = []byte(apiToken)
+	}
+	if paasToken != "" {
+		tokenSecret.Data["paasToken"] = []byte(paasToken)
+	}
+	return tokenSecret
+}
+
+func createTenantTokenSecret(dynakube *dynatracev1beta1.DynaKube, value string) *corev1.Secret {
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: dynakube.OneagentTenantSecret(), Namespace: dynakube.Namespace},
+		Data: map[string][]byte{
+			connectioninfo.TenantTokenName: []byte(value),
+		},
+	}
+	return tokenSecret
+}
+
+func createTestNode(name string, selector map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: selector,
+		},
+	}
+}
+
+func createTestInjectedNamespace(dynakube *dynatracev1beta1.DynaKube, name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{dtwebhook.InjectionInstanceLabel: dynakube.Name},
+		},
+	}
+}
+
+func retrieveInitSecret(t *testing.T, clt client.Client, namespaceName string) corev1.Secret {
+	var initSecret corev1.Secret
+	err := clt.Get(context.TODO(), types.NamespacedName{Name: config.AgentInitSecretName, Namespace: namespaceName}, &initSecret)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(initSecret.Data))
+	return initSecret
+}
+
+func checkSecretConfigExists(t *testing.T, initSecret corev1.Secret) {
+	secretConfig, ok := initSecret.Data[config.AgentInitSecretConfigField]
+	require.True(t, ok)
+	require.NotNil(t, secretConfig)
+	var parsedConfig standalone.SecretConfig
+	err := json.Unmarshal(secretConfig, &parsedConfig)
+	require.NoError(t, err)
 }

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -210,7 +210,7 @@ func (runner *Runner) createContainerConfigurationFiles() error {
 		confFilePath := filepath.Join(config.AgentShareDirMount, fmt.Sprintf(config.AgentContainerConfFilenameTemplate, container.Name))
 		content := runner.getBaseConfContent(container)
 		if runner.hostTenant != config.AgentNoHostTenant {
-			if runner.config.TenantUUID == runner.hostTenant {
+			if runner.config.ConnectionInfo.TenantUUID == runner.hostTenant {
 				log.Info("adding k8s fields")
 				content += runner.getK8ConfContent()
 			}

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -145,8 +145,8 @@ func (runner *Runner) getProcessModuleConfig() (*dtclient.ProcessModuleConfig, e
 	if runner.config.Proxy != "" {
 		processModuleConfig.AddProxy(runner.config.Proxy)
 	}
-
-	return processModuleConfig.AddTenantUUID(runner.config.TenantUUID), nil
+	processModuleConfig = processModuleConfig.AddConnectionInfo(runner.config.ConnectionInfo, runner.config.TenantToken)
+	return processModuleConfig, nil
 }
 
 func (runner *Runner) configureInstallation() error {

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -13,15 +13,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testProcessModuleConfig = dtclient.ProcessModuleConfig{
-	Revision: 0,
-	Properties: []dtclient.ProcessModuleProperty{
-		{
-			Section: "test",
-			Key:     "test",
-			Value:   "test",
+func getTestProcessModuleConfig() *dtclient.ProcessModuleConfig{
+	return &dtclient.ProcessModuleConfig{
+		Revision: 0,
+		Properties: []dtclient.ProcessModuleProperty{
+			{
+				Section: "test",
+				Key:     "test",
+				Value:   "test",
+			},
 		},
-	},
+	}
 }
 
 func TestNewRunner(t *testing.T) {
@@ -123,7 +125,7 @@ func TestInstallOneAgent(t *testing.T) {
 		runner.fs.Create(filepath.Join(config.AgentBinDirMount, "agent/conf/ruxitagentproc.conf"))
 		runner.dtclient.(*dtclient.MockDynatraceClient).
 			On("GetProcessModuleConfig", uint(0)).
-			Return(&testProcessModuleConfig, nil)
+			Return(getTestProcessModuleConfig(), nil)
 		runner.installer.(*installer.Mock).
 			On("InstallAgent", config.AgentBinDirMount).
 			Return(true, nil)
@@ -146,7 +148,7 @@ func TestInstallOneAgent(t *testing.T) {
 		runner := createMockedRunner(t)
 		runner.dtclient.(*dtclient.MockDynatraceClient).
 			On("GetProcessModuleConfig", uint(0)).
-			Return(&testProcessModuleConfig, nil)
+			Return(getTestProcessModuleConfig(), nil)
 		runner.installer.(*installer.Mock).
 			On("InstallAgent", config.AgentBinDirMount).
 			Return(true, nil)
@@ -176,7 +178,7 @@ func TestRun(t *testing.T) {
 	runner.env.DataIngestInjected = true
 	runner.dtclient.(*dtclient.MockDynatraceClient).
 		On("GetProcessModuleConfig", uint(0)).
-		Return(&testProcessModuleConfig, nil)
+		Return(getTestProcessModuleConfig(), nil)
 
 	t.Run("no install, just config generation", func(t *testing.T) {
 		runner.fs = prepReadOnlyCSIFilesystem(t, afero.NewMemMapFs())
@@ -264,13 +266,13 @@ func TestConfigureInstallation(t *testing.T) {
 }
 
 func TestGetProcessModuleConfig(t *testing.T) {
-	t.Run("add tenantUUID to process module config", func(t *testing.T) {
-		tenantAlias := "my-tenant"
+	t.Run("configure to process module config", func(t *testing.T) {
 		runner := createMockedRunner(t)
-		runner.config.TenantUUID = tenantAlias
+		runner.config.TenantToken = "test-token"
+		runner.config.ConnectionInfo = getTestConnectionInfo()
 		runner.dtclient.(*dtclient.MockDynatraceClient).
 			On("GetProcessModuleConfig", uint(0)).
-			Return(&testProcessModuleConfig, nil)
+			Return(getTestProcessModuleConfig(), nil)
 
 		config, err := runner.getProcessModuleConfig()
 		require.NoError(t, err)
@@ -280,7 +282,14 @@ func TestGetProcessModuleConfig(t *testing.T) {
 		require.True(t, ok)
 		tenantUUID, ok := generalSection["tenant"]
 		require.True(t, ok)
-		assert.Equal(t, tenantAlias, tenantUUID)
+		assert.Equal(t, runner.config.ConnectionInfo.TenantUUID, tenantUUID)
+		tenantToken, ok := generalSection["tenantToken"]
+		require.True(t, ok)
+		assert.Equal(t, runner.config.TenantToken, tenantToken)
+		serverAddress, ok := generalSection["serverAddress"]
+		require.True(t, ok)
+		assert.Contains(t, serverAddress, runner.config.ConnectionInfo.Endpoints)
+
 	})
 
 	t.Run("error if api call fails", func(t *testing.T) {

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -308,7 +308,7 @@ func TestGetProcessModuleConfig(t *testing.T) {
 		runner.config.Proxy = proxy
 		runner.dtclient.(*dtclient.MockDynatraceClient).
 			On("GetProcessModuleConfig", uint(0)).
-			Return(&testProcessModuleConfig, nil)
+			Return(getTestProcessModuleConfig(), nil)
 
 		config, err := runner.getProcessModuleConfig()
 		require.NoError(t, err)

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getTestProcessModuleConfig() *dtclient.ProcessModuleConfig{
+func getTestProcessModuleConfig() *dtclient.ProcessModuleConfig {
 	return &dtclient.ProcessModuleConfig{
 		Revision: 0,
 		Properties: []dtclient.ProcessModuleProperty{
@@ -289,7 +289,6 @@ func TestGetProcessModuleConfig(t *testing.T) {
 		serverAddress, ok := generalSection["serverAddress"]
 		require.True(t, ok)
 		assert.Contains(t, serverAddress, runner.config.ConnectionInfo.Endpoints)
-
 	})
 
 	t.Run("error if api call fails", func(t *testing.T) {

--- a/src/standalone/secret.go
+++ b/src/standalone/secret.go
@@ -23,7 +23,6 @@ type SecretConfig struct {
 	SkipCertCheck bool   `json:"skipCertCheck"`
 
 	// For the injection
-	TenantUUID          string                                        `json:"tenantUUID"`
 	TenantToken         string                                        `json:"tenantToken"`
 	HasHost             bool                                          `json:"hasHost"`
 	MonitoringNodes     map[string]string                             `json:"monitoringNodes"`

--- a/src/standalone/secret.go
+++ b/src/standalone/secret.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path/filepath"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/config"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -22,12 +23,14 @@ type SecretConfig struct {
 	SkipCertCheck bool   `json:"skipCertCheck"`
 
 	// For the injection
-	TenantUUID          string            `json:"tenantUUID"`
-	HasHost             bool              `json:"hasHost"`
-	MonitoringNodes     map[string]string `json:"monitoringNodes"`
-	TlsCert             string            `json:"tlsCert"`
-	HostGroup           string            `json:"hostGroup"`
-	InitialConnectRetry int               `json:"initialConnectRetry"`
+	TenantUUID          string                                        `json:"tenantUUID"`
+	TenantToken         string                                        `json:"tenantToken"`
+	HasHost             bool                                          `json:"hasHost"`
+	MonitoringNodes     map[string]string                             `json:"monitoringNodes"`
+	TlsCert             string                                        `json:"tlsCert"`
+	HostGroup           string                                        `json:"hostGroup"`
+	InitialConnectRetry int                                           `json:"initialConnectRetry"`
+	ConnectionInfo      dynatracev1beta1.OneAgentConnectionInfoStatus `json:"connectionInfo"`
 
 	// For the enrichment
 	ClusterID string `json:"clusterID"`

--- a/src/standalone/secret_test.go
+++ b/src/standalone/secret_test.go
@@ -7,49 +7,67 @@ import (
 	"path/filepath"
 	"testing"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/src/config"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	testApiUrl    = "test.com"
-	testApiToken  = "testy"
-	testPaasToken = "testz"
+	testApiUrl      = "test.com"
+	testApiToken    = "testy"
+	testPaasToken   = "testz"
+	testTenantToken = "token"
 
 	testProxy       = "proxy"
 	testNoProxy     = "no-proxy"
 	testNetworkZone = "zone"
 	testTrustedCA   = "secret"
 
-	testTenantUUID = "test"
 	testNodeName   = "node1"
 	testTlsCert    = "tls"
 	testHostGroup  = "group"
 	testClusterID  = "id"
 
+	testTenantUUID = "test"
+	testEndpoints = "beep.com;bop.com"
+
 	testInitialConnectRetry = 30
 )
 
-var testSecretConfig = SecretConfig{
-	ApiUrl:        testApiUrl,
-	ApiToken:      testApiToken,
-	PaasToken:     testPaasToken,
-	Proxy:         testProxy,
-	NoProxy:       testNoProxy,
-	NetworkZone:   testNetworkZone,
-	TrustedCAs:    testTrustedCA,
-	SkipCertCheck: true,
-	TenantUUID:    testTenantUUID,
-	HasHost:       true,
-	MonitoringNodes: map[string]string{
-		testNodeName: testTenantUUID,
-	},
-	TlsCert:             testTlsCert,
-	HostGroup:           testHostGroup,
-	ClusterID:           testClusterID,
-	InitialConnectRetry: testInitialConnectRetry,
+func getTestSecretConfig() *SecretConfig {
+	return &SecretConfig{
+		ApiUrl:        testApiUrl,
+		ApiToken:      testApiToken,
+		PaasToken:     testPaasToken,
+		TenantToken:   testTenantToken,
+		ConnectionInfo: getTestConnectionInfo(),
+		Proxy:         testProxy,
+		NoProxy:       testNoProxy,
+		NetworkZone:   testNetworkZone,
+		TrustedCAs:    testTrustedCA,
+		SkipCertCheck: true,
+		HasHost:       true,
+		MonitoringNodes: map[string]string{
+			testNodeName: testTenantUUID,
+		},
+		TlsCert:             testTlsCert,
+		HostGroup:           testHostGroup,
+		ClusterID:           testClusterID,
+		InitialConnectRetry: testInitialConnectRetry,
+	}
+}
+
+func getTestConnectionInfo() dynatracev1beta1.OneAgentConnectionInfoStatus {
+	return dynatracev1beta1.OneAgentConnectionInfoStatus{
+		ConnectionInfoStatus: dynatracev1beta1.ConnectionInfoStatus{
+			TenantUUID: testTenantUUID,
+			Endpoints: testEndpoints,
+			LastRequest: metav1.Time{},
+		},
+	}
 }
 
 func TestNewSecretConfigViaFs(t *testing.T) {
@@ -63,11 +81,12 @@ func TestNewSecretConfigViaFs(t *testing.T) {
 	assert.Equal(t, testApiUrl, config.ApiUrl)
 	assert.Equal(t, testApiToken, config.ApiToken)
 	assert.Equal(t, testPaasToken, config.PaasToken)
+	assert.Equal(t, testTenantToken, config.TenantToken)
+	assert.Equal(t, getTestConnectionInfo(), config.ConnectionInfo)
 	assert.Equal(t, testProxy, config.Proxy)
 	assert.Equal(t, testNetworkZone, config.NetworkZone)
 	assert.Equal(t, testTrustedCA, config.TrustedCAs)
 	assert.True(t, config.SkipCertCheck)
-	assert.Equal(t, testTenantUUID, config.TenantUUID)
 	assert.True(t, config.HasHost)
 	assert.Equal(t, testTlsCert, config.TlsCert)
 	assert.Equal(t, testHostGroup, config.HostGroup)
@@ -84,7 +103,7 @@ func prepTestFs(t *testing.T) afero.Fs {
 	require.NoError(t, err)
 	require.NotNil(t, file)
 
-	rawJson, err := json.Marshal(testSecretConfig)
+	rawJson, err := json.Marshal(getTestSecretConfig())
 	require.NoError(t, err)
 
 	_, err = file.Write(rawJson)

--- a/src/standalone/secret_test.go
+++ b/src/standalone/secret_test.go
@@ -26,30 +26,30 @@ const (
 	testNetworkZone = "zone"
 	testTrustedCA   = "secret"
 
-	testNodeName   = "node1"
-	testTlsCert    = "tls"
-	testHostGroup  = "group"
-	testClusterID  = "id"
+	testNodeName  = "node1"
+	testTlsCert   = "tls"
+	testHostGroup = "group"
+	testClusterID = "id"
 
 	testTenantUUID = "test"
-	testEndpoints = "beep.com;bop.com"
+	testEndpoints  = "beep.com;bop.com"
 
 	testInitialConnectRetry = 30
 )
 
 func getTestSecretConfig() *SecretConfig {
 	return &SecretConfig{
-		ApiUrl:        testApiUrl,
-		ApiToken:      testApiToken,
-		PaasToken:     testPaasToken,
-		TenantToken:   testTenantToken,
+		ApiUrl:         testApiUrl,
+		ApiToken:       testApiToken,
+		PaasToken:      testPaasToken,
+		TenantToken:    testTenantToken,
 		ConnectionInfo: getTestConnectionInfo(),
-		Proxy:         testProxy,
-		NoProxy:       testNoProxy,
-		NetworkZone:   testNetworkZone,
-		TrustedCAs:    testTrustedCA,
-		SkipCertCheck: true,
-		HasHost:       true,
+		Proxy:          testProxy,
+		NoProxy:        testNoProxy,
+		NetworkZone:    testNetworkZone,
+		TrustedCAs:     testTrustedCA,
+		SkipCertCheck:  true,
+		HasHost:        true,
 		MonitoringNodes: map[string]string{
 			testNodeName: testTenantUUID,
 		},
@@ -63,8 +63,8 @@ func getTestSecretConfig() *SecretConfig {
 func getTestConnectionInfo() dynatracev1beta1.OneAgentConnectionInfoStatus {
 	return dynatracev1beta1.OneAgentConnectionInfoStatus{
 		ConnectionInfoStatus: dynatracev1beta1.ConnectionInfoStatus{
-			TenantUUID: testTenantUUID,
-			Endpoints: testEndpoints,
+			TenantUUID:  testTenantUUID,
+			Endpoints:   testEndpoints,
 			LastRequest: metav1.Time{},
 		},
 	}


### PR DESCRIPTION
## Description

We forgot to provide the information needed for the codemodules to communicate (tenant token + endpoints) in case no CSI driver is used.

To be able to do this, we have replicate this information to all the injected namespaces, in the already existing `dynatrace-dynakube-config` secret.

As a side effect, this change also fixes the issue with the tenant alias, as the connectionInfo contains the correct tenant. (this part needs further testing, to check if we need to do anything extra)

## How can this be tested?

Deploy application monitoring without csi and inject sample apps.
Tipp: If you use a proxy, in the log of the proxy it will show up how the calls to "localhost" will fail, as the codemodule will try to use the proxy to reach "localhost", which is its default communication endpoint if none is provided.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
