### PR TITLE
Only use skipMetadata=true with csiDriver

### DIFF
--- a/src/controllers/csi/provisioner/install.go
+++ b/src/controllers/csi/provisioner/install.go
@@ -104,6 +104,7 @@ func getUrlProperties(targetVersion string, pathResolver metadata.PathResolver) 
 		Flavor:        arch.Flavor,
 		Technologies:  []string{"all"},
 		TargetVersion: targetVersion,
+		SkipMetadata:  true,
 		PathResolver:  pathResolver,
 	}
 }

--- a/src/dtclient/agent_version.go
+++ b/src/dtclient/agent_version.go
@@ -24,12 +24,12 @@ func (dtc *dynatraceClient) GetEntityIDForIP(ip string) (string, error) {
 }
 
 // GetLatestAgent gets the latest agent package for the given OS and installer type.
-func (dtc *dynatraceClient) GetLatestAgent(os, installerType, flavor, arch string, technologies []string, writer io.Writer) error {
+func (dtc *dynatraceClient) GetLatestAgent(os, installerType, flavor, arch string, technologies []string, skipMetadata bool, writer io.Writer) error {
 	if len(os) == 0 || len(installerType) == 0 {
 		return errors.New("os or installerType is empty")
 	}
 
-	url := dtc.getLatestAgentUrl(os, installerType, flavor, arch, technologies)
+	url := dtc.getLatestAgentUrl(os, installerType, flavor, arch, technologies, skipMetadata)
 	md5, err := dtc.makeRequestForBinary(url, dynatracePaaSToken, writer)
 	if err == nil {
 		log.Info("downloaded agent file", "os", os, "type", installerType, "flavor", flavor, "arch", arch, "technologies", technologies, "md5", md5)
@@ -76,12 +76,12 @@ func (dtc *dynatraceClient) GetAgentVersions(os, installerType, flavor, arch str
 	return response.AvailableVersions, errors.WithStack(err)
 }
 
-func (dtc *dynatraceClient) GetAgent(os, installerType, flavor, arch, version string, technologies []string, writer io.Writer) error {
+func (dtc *dynatraceClient) GetAgent(os, installerType, flavor, arch, version string, technologies []string, skipMetadata bool, writer io.Writer) error {
 	if len(os) == 0 || len(installerType) == 0 {
 		return errors.New("os or installerType is empty")
 	}
 
-	url := dtc.getAgentUrl(os, installerType, flavor, arch, version, technologies)
+	url := dtc.getAgentUrl(os, installerType, flavor, arch, version, technologies, skipMetadata)
 	md5, err := dtc.makeRequestForBinary(url, dynatracePaaSToken, writer)
 	if err == nil {
 		log.Info("downloaded agent file", "os", os, "type", installerType, "flavor", flavor, "arch", arch, "technologies", technologies, "md5", md5)

--- a/src/dtclient/agent_version_test.go
+++ b/src/dtclient/agent_version_test.go
@@ -157,7 +157,7 @@ func TestGetLatestAgent(t *testing.T) {
 		file, err := afero.TempFile(fs, "client", "installer")
 		require.NoError(t, err)
 
-		err = dtc.GetLatestAgent(OsUnix, InstallerTypePaaS, arch.FlavorMultidistro, "arch", nil, file)
+		err = dtc.GetLatestAgent(OsUnix, InstallerTypePaaS, arch.FlavorMultidistro, "arch", nil, false, file)
 		require.NoError(t, err)
 
 		resp, err := afero.ReadFile(fs, file.Name())
@@ -169,7 +169,7 @@ func TestGetLatestAgent(t *testing.T) {
 		file, err := afero.TempFile(fs, "client", "installer")
 		require.NoError(t, err)
 
-		err = dtc.GetLatestAgent(OsUnix, InstallerTypePaaS, arch.FlavorMultidistro, "invalid", nil, file)
+		err = dtc.GetLatestAgent(OsUnix, InstallerTypePaaS, arch.FlavorMultidistro, "invalid", nil, false, file)
 		require.Error(t, err)
 	})
 }
@@ -180,7 +180,7 @@ func TestDynatraceClient_GetAgent(t *testing.T) {
 		defer dynatraceServer.Close()
 
 		readWriter := &memoryReadWriter{data: make([]byte, len(versionedAgentResponse))}
-		err := dtc.GetAgent(OsUnix, InstallerTypePaaS, "", "", "", nil, readWriter)
+		err := dtc.GetAgent(OsUnix, InstallerTypePaaS, "", "", "", nil, false, readWriter)
 
 		assert.NoError(t, err)
 		assert.Equal(t, versionedAgentResponse, string(readWriter.data))
@@ -190,7 +190,7 @@ func TestDynatraceClient_GetAgent(t *testing.T) {
 		defer dynatraceServer.Close()
 
 		readWriter := &memoryReadWriter{data: make([]byte, len(versionedAgentResponse))}
-		err := dtc.GetAgent(OsUnix, InstallerTypePaaS, "", "", "", nil, readWriter)
+		err := dtc.GetAgent(OsUnix, InstallerTypePaaS, "", "", "", nil, false, readWriter)
 
 		assert.EqualError(t, err, "dynatrace server error 400: test-error")
 	})

--- a/src/dtclient/client.go
+++ b/src/dtclient/client.go
@@ -32,10 +32,10 @@ type Client interface {
 	GetLatestAgentVersion(os, installerType string) (string, error)
 
 	// GetLatestAgent returns a reader with the contents of the download. Must be closed by caller.
-	GetLatestAgent(os, installerType, flavor, arch string, technologies []string, writer io.Writer) error
+	GetLatestAgent(os, installerType, flavor, arch string, technologies []string, skipMetadata bool, writer io.Writer) error
 
 	// GetAgent downloads a specific agent version and writes it to the given io.Writer
-	GetAgent(os, installerType, flavor, arch, version string, technologies []string, writer io.Writer) error
+	GetAgent(os, installerType, flavor, arch, version string, technologies []string, skipMetadata bool, writer io.Writer) error
 
 	// GetAgentViaInstallerUrl downloads the agent from the user specified URL and writes it to the given io.Writer
 	GetAgentViaInstallerUrl(url string, writer io.Writer) error

--- a/src/dtclient/endpoints.go
+++ b/src/dtclient/endpoints.go
@@ -2,15 +2,15 @@ package dtclient
 
 import "fmt"
 
-func (dtc *dynatraceClient) getAgentUrl(os, installerType, flavor, arch, version string, technologies []string) string {
-	url := fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/version/%s?flavor=%s&arch=%s&bitness=64&skipMetadata=true",
-		dtc.url, os, installerType, version, flavor, arch)
+func (dtc *dynatraceClient) getAgentUrl(os, installerType, flavor, arch, version string, technologies []string, skipMetadata bool) string {
+	url := fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/version/%s?flavor=%s&arch=%s&bitness=64&skipMetadata=%t",
+		dtc.url, os, installerType, version, flavor, arch, skipMetadata)
 	return appendTechnologies(url, technologies)
 }
 
-func (dtc *dynatraceClient) getLatestAgentUrl(os, installerType, flavor, arch string, technologies []string) string {
-	url := fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/latest?bitness=64&flavor=%s&arch=%s&skipMetadata=true",
-		dtc.url, os, installerType, flavor, arch)
+func (dtc *dynatraceClient) getLatestAgentUrl(os, installerType, flavor, arch string, technologies []string, skipMetadata bool) string {
+	url := fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/latest?bitness=64&flavor=%s&arch=%s&skipMetadata=%t",
+		dtc.url, os, installerType, flavor, arch, skipMetadata)
 	return appendTechnologies(url, technologies)
 }
 

--- a/src/dtclient/mock_client.go
+++ b/src/dtclient/mock_client.go
@@ -36,12 +36,12 @@ func (o *MockDynatraceClient) GetLatestAgentVersion(os, installerType string) (s
 	return args.String(0), args.Error(1)
 }
 
-func (o *MockDynatraceClient) GetLatestAgent(os, installerType, flavor, arch string, technologies []string, writer io.Writer) error {
+func (o *MockDynatraceClient) GetLatestAgent(os, installerType, flavor, arch string, technologies []string, skipMetadata bool, writer io.Writer) error {
 	args := o.Called(os, installerType, flavor, arch, technologies, writer)
 	return args.Error(0)
 }
 
-func (o *MockDynatraceClient) GetAgent(os, installerType, flavor, arch, version string, technologies []string, writer io.Writer) error {
+func (o *MockDynatraceClient) GetAgent(os, installerType, flavor, arch, version string, technologies []string, skipMetadata bool, writer io.Writer) error {
 	args := o.Called(os, installerType, flavor, arch, version, technologies, writer)
 	return args.Error(0)
 }

--- a/src/installer/url/download.go
+++ b/src/installer/url/download.go
@@ -31,6 +31,7 @@ func (installer Installer) downloadLatestOneAgent(tmpFile afero.File) error {
 		installer.props.Flavor,
 		installer.props.Arch,
 		installer.props.Technologies,
+		installer.props.SkipMetadata,
 		tmpFile,
 	)
 }
@@ -44,6 +45,7 @@ func (installer Installer) downloadOneAgentWithVersion(tmpFile afero.File) error
 		installer.props.Arch,
 		installer.props.TargetVersion,
 		installer.props.Technologies,
+		installer.props.SkipMetadata,
 		tmpFile,
 	)
 

--- a/src/installer/url/installer.go
+++ b/src/installer/url/installer.go
@@ -23,6 +23,7 @@ type Properties struct {
 	TargetVersion string
 	Technologies  []string
 	Url           string // if this is set all settings before it will be ignored
+	SkipMetadata  bool
 
 	PathResolver metadata.PathResolver
 }

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -60,6 +60,7 @@ func NewRunner(fs afero.Fs) (*Runner, error) {
 				Technologies:  env.InstallerTech,
 				TargetVersion: targetVersion,
 				Url:           env.InstallerUrl,
+				SkipMetadata:  false,
 				PathResolver:  metadata.PathResolver{RootDir: config.AgentBinDirMount},
 			},
 		)


### PR DESCRIPTION
## Description
Incase of applicationMonitoring without CSI driver we shouldn't use the "raw" codemodules as they don't provide much if any efficiency improvements, and we would need to do connectionInfo duplication (see https://github.com/Dynatrace/dynatrace-operator/pull/1977) in each injected namespace which would just add complexity and not much more.

## How can this be tested?
Scenario 1.: Test applicationMonitoring without CSI driver, check that the codemodules can connect when injected into sample apps.
Scenario 2.: Doable check that I didn't break what I did in: https://github.com/Dynatrace/dynatrace-operator/pull/1963

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
