### PR TITLE
Refactor existing and add missing CRD annotations

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: dynakubes.dynatrace.com
 spec:
   group: dynatrace.com
@@ -3375,12 +3375,13 @@ spec:
                   want to skip certification validation checks.
                 type: boolean
               tokens:
-                description: Name of the secret holding the tokens.
+                description: Name of the secret holding the tokens used for connecting
+                  to Dynatrace.
                 type: string
               trustedCAs:
                 description: 'Adds custom RootCAs from a configmap. Put the certificate
                   under certs within your configmap. Note: Applies only to Dynatrace
-                  Operator, not to ActiveGate.'
+                  Operator and OneAgent, not to ActiveGate.'
                 type: string
             required:
             - apiUrl
@@ -3395,14 +3396,14 @@ spec:
                     description: Information about Active Gate's connections
                     properties:
                       endpoints:
-                        description: Available tenant endpoints
+                        description: Available connection endpoints
                         type: string
                       lastRequest:
                         description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantUUID:
-                        description: UUID from the tenant
+                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:
@@ -3546,14 +3547,14 @@ spec:
                           type: object
                         type: array
                       endpoints:
-                        description: Available tenant endpoints
+                        description: Available connection endpoints
                         type: string
                       lastRequest:
                         description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantUUID:
-                        description: UUID from the tenant
+                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: dynakubes.dynatrace.com
 spec:
   group: dynatrace.com
@@ -1067,13 +1067,12 @@ spec:
             description: DynaKubeSpec defines the desired state of DynaKube
             properties:
               activeGate:
-                description: General configuration about ActiveGate instances
+                description: General configuration about ActiveGate instances.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Adds additional annotations to the ActiveGate
-                      pods'
+                    description: Adds additional annotations to the ActiveGate pods
                     type: object
                   capabilities:
                     description: Activegate capabilities enabled (routing, kubernetes-monitoring,
@@ -1082,21 +1081,24 @@ spec:
                       type: string
                     type: array
                   customProperties:
-                    description: 'Optional: Add a custom properties file by providing
-                      it as a value or reference it from a secret If referenced from
-                      a secret, make sure the key is called ''customProperties'''
+                    description: Add a custom properties file by providing it as a
+                      value or reference it from a secret If referenced from a secret,
+                      make sure the key is called 'customProperties'
                     properties:
                       value:
+                        description: Custom properties value.
+                        nullable: true
                         type: string
                       valueFrom:
+                        description: Custom properties secret.
+                        nullable: true
                         type: string
                     type: object
                   dnsPolicy:
-                    description: 'Optional: Sets DNS Policy for the ActiveGate pods'
+                    description: Sets DNS Policy for the ActiveGate pods
                     type: string
                   env:
-                    description: 'Optional: List of environment variables to set for
-                      the ActiveGate'
+                    description: List of environment variables to set for the ActiveGate
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -1210,38 +1212,35 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: 'Optional: Set activation group for ActiveGate'
+                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: 'Optional: the ActiveGate container image. Defaults
-                      to the latest ActiveGate image provided by the registry on the
-                      tenant'
+                    description: The ActiveGate container image. Defaults to the latest
+                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Adds additional labels for the ActiveGate
-                      pods'
+                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Node selector to control the selection
-                      of nodes'
+                    description: Node selector to control the selection of nodes
                     type: object
                   priorityClassName:
-                    description: 'Optional: If specified, indicates the pod''s priority.
-                      Name must be defined by creating a PriorityClass object with
-                      that name. If not specified the setting will be removed from
-                      the StatefulSet.'
+                    description: If specified, indicates the pod's priority. Name
+                      must be defined by creating a PriorityClass object with that
+                      name. If not specified the setting will be removed from the
+                      StatefulSet.
                     type: string
                   replicas:
                     description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: 'Optional: define resources requests and limits for
-                      single ActiveGate pods'
+                    description: Define resources requests and limits for single ActiveGate
+                      pods
                     properties:
                       claims:
                         description: "Claims lists the names of resources, defined
@@ -1289,14 +1288,13 @@ spec:
                         type: object
                     type: object
                   tlsSecretName:
-                    description: 'Optional: the name of a secret containing ActiveGate
-                      TLS cert+key and password. If not set, self-signed certificate
-                      is used. server.p12: certificate+key pair in pkcs12 format password:
-                      passphrase to read server.p12'
+                    description: 'The name of a secret containing ActiveGate TLS cert+key
+                      and password. If not set, self-signed certificate is used. server.p12:
+                      certificate+key pair in pkcs12 format password: passphrase to
+                      read server.p12'
                     type: string
                   tolerations:
-                    description: 'Optional: set tolerations for the ActiveGatePods
-                      pods'
+                    description: Set tolerations for the ActiveGatePods pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using
@@ -1337,8 +1335,8 @@ spec:
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: 'Optional: Adds TopologySpreadConstraints for the
-                      ActiveGate pods'
+                    description: Adds TopologySpreadConstraints for the ActiveGate
+                      pods
                     items:
                       description: TopologySpreadConstraint specifies how to spread
                         matching pods among the given topology.
@@ -1513,35 +1511,46 @@ spec:
                     type: array
                 type: object
               apiUrl:
-                description: Location of the Dynatrace API to connect to, including
-                  your specific environment UUID
+                description: Dynatrace apiUrl, including the /api path at the end.
+                  For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed,
+                  change the apiUrl address. For instructions on how to determine
+                  the environment ID and how to configure the apiUrl address, see
+                  Environment ID (https://www.dynatrace.com/support/help/get-started/monitoring-environment/environment-id).
                 type: string
               customPullSecret:
-                description: 'Optional: Pull secret for your private registry'
+                description: Defines a custom pull secret in case you use a private
+                  registry when pulling images from the Dynatrace environment. To
+                  define a custom pull secret and learn about the expected behavior,
+                  see Configure customPullSecret (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring/dto-config-options-k8s#custompullsecret).
                 type: string
               enableIstio:
-                description: If enabled, Istio on the cluster will be configured automatically
-                  to allow access to the Dynatrace environment
+                description: When enabled, and if Istio is installed on the Kubernetes
+                  environment, Dynatrace Operator will create the corresponding VirtualService
+                  and ServiceEntry objects to allow access to the Dynatrace Cluster
+                  from the OneAgent or ActiveGate. Disabled by default.
                 type: boolean
               kubernetesMonitoring:
-                description: 'Deprecated: Configuration for Kubernetes Monitoring'
+                description: Configuration for Kubernetes Monitoring
                 properties:
                   customProperties:
-                    description: 'Optional: Add a custom properties file by providing
-                      it as a value or reference it from a secret If referenced from
-                      a secret, make sure the key is called ''customProperties'''
+                    description: Add a custom properties file by providing it as a
+                      value or reference it from a secret If referenced from a secret,
+                      make sure the key is called 'customProperties'
                     properties:
                       value:
+                        description: Custom properties value.
+                        nullable: true
                         type: string
                       valueFrom:
+                        description: Custom properties secret.
+                        nullable: true
                         type: string
                     type: object
                   enabled:
                     description: Enables Capability
                     type: boolean
                   env:
-                    description: 'Optional: List of environment variables to set for
-                      the ActiveGate'
+                    description: List of environment variables to set for the ActiveGate
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -1655,32 +1664,29 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: 'Optional: Set activation group for ActiveGate'
+                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: 'Optional: the ActiveGate container image. Defaults
-                      to the latest ActiveGate image provided by the registry on the
-                      tenant'
+                    description: The ActiveGate container image. Defaults to the latest
+                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Adds additional labels for the ActiveGate
-                      pods'
+                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Node selector to control the selection
-                      of nodes'
+                    description: Node selector to control the selection of nodes
                     type: object
                   replicas:
                     description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: 'Optional: define resources requests and limits for
-                      single ActiveGate pods'
+                    description: Define resources requests and limits for single ActiveGate
+                      pods
                     properties:
                       claims:
                         description: "Claims lists the names of resources, defined
@@ -1728,8 +1734,7 @@ spec:
                         type: object
                     type: object
                   tolerations:
-                    description: 'Optional: set tolerations for the ActiveGatePods
-                      pods'
+                    description: Set tolerations for the ActiveGatePods pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using
@@ -1770,8 +1775,8 @@ spec:
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: 'Optional: Adds TopologySpreadConstraints for the
-                      ActiveGate pods'
+                    description: Adds TopologySpreadConstraints for the ActiveGate
+                      pods
                     items:
                       description: TopologySpreadConstraint specifies how to spread
                         matching pods among the given topology.
@@ -1946,9 +1951,10 @@ spec:
                     type: array
                 type: object
               namespaceSelector:
-                description: 'Optional: set a namespace selector to limit which namespaces
-                  are monitored By default, all namespaces will be monitored Has no
-                  effect during classicFullStack and hostMonitoring mode'
+                description: Applicable only for applicationMonitoring or cloudNativeFullStack
+                  configuration types. The namespaces where you want Dynatrace Operator
+                  to inject. For more information, see Configure monitoring for namespaces
+                  and pods (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring/dto-config-options-k8s#annotate).
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1993,25 +1999,27 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               networkZone:
-                description: 'Optional: Sets Network Zone for OneAgent and ActiveGate
-                  pods'
+                description: Sets a network zone for the OneAgent and ActiveGate pods.
                 type: string
               oneAgent:
-                description: General configuration about OneAgent instances
+                description: General configuration about OneAgent instances. You can't
+                  enable more than one module (classicFullStack, cloudNativeFullStack,
+                  hostMonitoring, or applicationMonitoring).
                 properties:
                   applicationMonitoring:
-                    description: 'Optional: enable application-only monitoring and
-                      change its settings Cannot be used in conjunction with cloud-native
-                      fullstack monitoring, classic fullstack monitoring or host monitoring'
+                    description: dynatrace-webhook injects into application pods based
+                      on labeled namespaces. Has an optional CSI driver per node via
+                      DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       codeModulesImage:
-                        description: 'Optional: the Dynatrace installer container
-                          image'
+                        description: The OneAgent image that is used to inject into
+                          Pods.
                         type: string
                       initResources:
-                        description: 'Optional: define resources requests and limits
-                          for the initContainer'
+                        description: Define resources requests and limits for the
+                          initContainer. For details, see Managing resources for containers
+                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
                             description: "Claims lists the names of resources, defined
@@ -2060,44 +2068,44 @@ spec:
                             type: object
                         type: object
                       useCSIDriver:
-                        description: 'Optional: If you want to use CSIDriver; disable
-                          if your cluster does not have ''nodes'' to fall back to
-                          the volume approach.'
+                        description: Set if you want to use the CSIDriver. Don't enable
+                          it if you do not have access to Kubernetes nodes or if you
+                          lack privileges.
                         type: boolean
                       version:
-                        description: 'Optional: If specified, indicates the OneAgent
-                          version to use Defaults to latest Example: {major.minor.release}
-                          - 1.200.0'
+                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   classicFullStack:
-                    description: 'Optional: enable classic fullstack monitoring and
-                      change its settings Cannot be used in conjunction with cloud-native
-                      fullstack monitoring, application monitoring or host monitoring'
+                    description: Has a single OneAgent per node via DaemonSet. Injection
+                      is performed via the same OneAgent DaemonSet.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional annotations to the
-                          OneAgent pods'
+                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: 'Optional: Arguments to the OneAgent installer'
+                        description: Set additional arguments to the OneAgent installer.
+                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
+                          For the list of limitations, see Limitations (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/docker/set-up-dynatrace-oneagent-as-docker-container#limitations).
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: 'Optional: Enables automatic restarts of OneAgent
-                          pods in case a new version is available Defaults to true'
+                        description: Disables automatic restarts of OneAgent pods
+                          in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
+                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: 'Optional: Sets DNS Policy for the OneAgent pods'
+                        description: Set the DNS Policy for OneAgent pods. For details,
+                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: 'Optional: List of environment variables to set
-                          for the installer'
+                        description: Set additional environment variables for the
+                          OneAgent pods.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -2215,25 +2223,27 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: 'Optional: the Dynatrace installer container
-                          image Defaults to the registry on the tenant for both Kubernetes
-                          and for OpenShift'
+                        description: Use a custom OneAgent Docker image. Defaults
+                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional labels for the OneAgent
-                          pods'
+                        description: Your defined labels for OneAgent pods in order
+                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Node selector to control the selection of nodes
-                          (optional)
+                        description: Specify the node selector that controls on which
+                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: 'Optional: define resources requests and limits
-                          for single pods'
+                        description: 'Resource settings for OneAgent container. Consumption
+                          of the OneAgent heavily depends on the workload to monitor.
+                          You can use the default settings in the CR. Note: resource.requests
+                          shows the values needed to run; resource.limits shows the
+                          maximum limits for the pod.'
                         properties:
                           claims:
                             description: "Claims lists the names of resources, defined
@@ -2282,13 +2292,13 @@ spec:
                             type: object
                         type: object
                       priorityClassName:
-                        description: 'Optional: If specified, indicates the pod''s
-                          priority. Name must be defined by creating a PriorityClass
-                          object with that name. If not specified the setting will
-                          be removed from the DaemonSet.'
+                        description: Assign a priority class to the OneAgent pods.
+                          By default, no class is set. For details, see Pod Priority
+                          and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: 'Optional: set tolerations for the OneAgent pods'
+                        description: Tolerations to include with the OneAgent DaemonSet.
+                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
                           description: The pod this Toleration is attached to tolerates
                             any taint that matches the triple <key,value,effect> using
@@ -2330,43 +2340,44 @@ spec:
                           type: object
                         type: array
                       version:
-                        description: 'Optional: If specified, indicates the OneAgent
-                          version to use Defaults to latest Example: {major.minor.release}
-                          - 1.200.0'
+                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   cloudNativeFullStack:
-                    description: 'Optional: enable cloud-native fullstack monitoring
-                      and change its settings Cannot be used in conjunction with classic
-                      fullstack monitoring, application monitoring or host monitoring'
+                    description: Has a single OneAgent per node via DaemonSet. dynatrace-webhook
+                      injects into application pods based on labeled namespaces. Has
+                      a CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional annotations to the
-                          OneAgent pods'
+                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: 'Optional: Arguments to the OneAgent installer'
+                        description: Set additional arguments to the OneAgent installer.
+                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
+                          For the list of limitations, see Limitations (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/docker/set-up-dynatrace-oneagent-as-docker-container#limitations).
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: 'Optional: Enables automatic restarts of OneAgent
-                          pods in case a new version is available Defaults to true'
+                        description: Disables automatic restarts of OneAgent pods
+                          in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
+                          Enabled by default.
                         type: boolean
                       codeModulesImage:
-                        description: 'Optional: the Dynatrace installer container
-                          image'
+                        description: The OneAgent image that is used to inject into
+                          Pods.
                         type: string
                       dnsPolicy:
-                        description: 'Optional: Sets DNS Policy for the OneAgent pods'
+                        description: Set the DNS Policy for OneAgent pods. For details,
+                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: 'Optional: List of environment variables to set
-                          for the installer'
+                        description: Set additional environment variables for the
+                          OneAgent pods.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -2484,13 +2495,13 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: 'Optional: the Dynatrace installer container
-                          image Defaults to the registry on the tenant for both Kubernetes
-                          and for OpenShift'
+                        description: Use a custom OneAgent Docker image. Defaults
+                          to the image from the Dynatrace cluster.
                         type: string
                       initResources:
-                        description: 'Optional: define resources requests and limits
-                          for the initContainer'
+                        description: Define resources requests and limits for the
+                          initContainer. For details, see Managing resources for containers
+                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
                             description: "Claims lists the names of resources, defined
@@ -2541,18 +2552,21 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional labels for the OneAgent
-                          pods'
+                        description: Your defined labels for OneAgent pods in order
+                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Node selector to control the selection of nodes
-                          (optional)
+                        description: Specify the node selector that controls on which
+                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: 'Optional: define resources requests and limits
-                          for single pods'
+                        description: 'Resource settings for OneAgent container. Consumption
+                          of the OneAgent heavily depends on the workload to monitor.
+                          You can use the default settings in the CR. Note: resource.requests
+                          shows the values needed to run; resource.limits shows the
+                          maximum limits for the pod.'
                         properties:
                           claims:
                             description: "Claims lists the names of resources, defined
@@ -2601,13 +2615,13 @@ spec:
                             type: object
                         type: object
                       priorityClassName:
-                        description: 'Optional: If specified, indicates the pod''s
-                          priority. Name must be defined by creating a PriorityClass
-                          object with that name. If not specified the setting will
-                          be removed from the DaemonSet.'
+                        description: Assign a priority class to the OneAgent pods.
+                          By default, no class is set. For details, see Pod Priority
+                          and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: 'Optional: set tolerations for the OneAgent pods'
+                        description: Tolerations to include with the OneAgent DaemonSet.
+                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
                           description: The pod this Toleration is attached to tolerates
                             any taint that matches the triple <key,value,effect> using
@@ -2649,39 +2663,39 @@ spec:
                           type: object
                         type: array
                       version:
-                        description: 'Optional: If specified, indicates the OneAgent
-                          version to use Defaults to latest Example: {major.minor.release}
-                          - 1.200.0'
+                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   hostMonitoring:
-                    description: 'Optional: enable host monitoring and change its
-                      settings Cannot be used in conjunction with cloud-native fullstack
-                      monitoring, classic fullstack monitoring or application monitoring'
+                    description: Has a single OneAgent per node via DaemonSet. Doesn't
+                      inject into application pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional annotations to the
-                          OneAgent pods'
+                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: 'Optional: Arguments to the OneAgent installer'
+                        description: Set additional arguments to the OneAgent installer.
+                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
+                          For the list of limitations, see Limitations (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/docker/set-up-dynatrace-oneagent-as-docker-container#limitations).
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: 'Optional: Enables automatic restarts of OneAgent
-                          pods in case a new version is available Defaults to true'
+                        description: Disables automatic restarts of OneAgent pods
+                          in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
+                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: 'Optional: Sets DNS Policy for the OneAgent pods'
+                        description: Set the DNS Policy for OneAgent pods. For details,
+                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: 'Optional: List of environment variables to set
-                          for the installer'
+                        description: Set additional environment variables for the
+                          OneAgent pods.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -2799,25 +2813,27 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: 'Optional: the Dynatrace installer container
-                          image Defaults to the registry on the tenant for both Kubernetes
-                          and for OpenShift'
+                        description: Use a custom OneAgent Docker image. Defaults
+                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional labels for the OneAgent
-                          pods'
+                        description: Your defined labels for OneAgent pods in order
+                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Node selector to control the selection of nodes
-                          (optional)
+                        description: Specify the node selector that controls on which
+                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: 'Optional: define resources requests and limits
-                          for single pods'
+                        description: 'Resource settings for OneAgent container. Consumption
+                          of the OneAgent heavily depends on the workload to monitor.
+                          You can use the default settings in the CR. Note: resource.requests
+                          shows the values needed to run; resource.limits shows the
+                          maximum limits for the pod.'
                         properties:
                           claims:
                             description: "Claims lists the names of resources, defined
@@ -2866,13 +2882,13 @@ spec:
                             type: object
                         type: object
                       priorityClassName:
-                        description: 'Optional: If specified, indicates the pod''s
-                          priority. Name must be defined by creating a PriorityClass
-                          object with that name. If not specified the setting will
-                          be removed from the DaemonSet.'
+                        description: Assign a priority class to the OneAgent pods.
+                          By default, no class is set. For details, see Pod Priority
+                          and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: 'Optional: set tolerations for the OneAgent pods'
+                        description: Tolerations to include with the OneAgent DaemonSet.
+                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
                           description: The pod this Toleration is attached to tolerates
                             any taint that matches the triple <key,value,effect> using
@@ -2914,40 +2930,46 @@ spec:
                           type: object
                         type: array
                       version:
-                        description: 'Optional: If specified, indicates the OneAgent
-                          version to use Defaults to latest Example: {major.minor.release}
-                          - 1.200.0'
+                        description: The OneAgent version to be used.
                         type: string
                     type: object
                 type: object
               proxy:
-                description: 'Optional: Set custom proxy settings either directly
-                  or from a secret with the field ''proxy'''
+                description: 'Set custom proxy settings either directly or from a
+                  secret with the field proxy. Note: Applies to Dynatrace Operator,
+                  ActiveGate, and OneAgents.'
                 properties:
                   value:
+                    description: Proxy URL. It has preference over ValueFrom.
+                    nullable: true
                     type: string
                   valueFrom:
+                    description: Secret containing proxy URL.
+                    nullable: true
                     type: string
                 type: object
               routing:
-                description: 'Deprecated: Configuration for Routing'
+                description: Configuration for Routing
                 properties:
                   customProperties:
-                    description: 'Optional: Add a custom properties file by providing
-                      it as a value or reference it from a secret If referenced from
-                      a secret, make sure the key is called ''customProperties'''
+                    description: Add a custom properties file by providing it as a
+                      value or reference it from a secret If referenced from a secret,
+                      make sure the key is called 'customProperties'
                     properties:
                       value:
+                        description: Custom properties value.
+                        nullable: true
                         type: string
                       valueFrom:
+                        description: Custom properties secret.
+                        nullable: true
                         type: string
                     type: object
                   enabled:
                     description: Enables Capability
                     type: boolean
                   env:
-                    description: 'Optional: List of environment variables to set for
-                      the ActiveGate'
+                    description: List of environment variables to set for the ActiveGate
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -3061,32 +3083,29 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: 'Optional: Set activation group for ActiveGate'
+                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: 'Optional: the ActiveGate container image. Defaults
-                      to the latest ActiveGate image provided by the registry on the
-                      tenant'
+                    description: The ActiveGate container image. Defaults to the latest
+                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Adds additional labels for the ActiveGate
-                      pods'
+                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Node selector to control the selection
-                      of nodes'
+                    description: Node selector to control the selection of nodes
                     type: object
                   replicas:
                     description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: 'Optional: define resources requests and limits for
-                      single ActiveGate pods'
+                    description: Define resources requests and limits for single ActiveGate
+                      pods
                     properties:
                       claims:
                         description: "Claims lists the names of resources, defined
@@ -3134,8 +3153,7 @@ spec:
                         type: object
                     type: object
                   tolerations:
-                    description: 'Optional: set tolerations for the ActiveGatePods
-                      pods'
+                    description: Set tolerations for the ActiveGatePods pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using
@@ -3176,8 +3194,8 @@ spec:
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: 'Optional: Adds TopologySpreadConstraints for the
-                      ActiveGate pods'
+                    description: Adds TopologySpreadConstraints for the ActiveGate
+                      pods
                     items:
                       description: TopologySpreadConstraint specifies how to spread
                         matching pods among the given topology.
@@ -3352,16 +3370,17 @@ spec:
                     type: array
                 type: object
               skipCertCheck:
-                description: Disable certificate validation checks for installer download
-                  and API communication
+                description: Disable certificate check for the connection between
+                  Dynatrace Operator and the Dynatrace Cluster. Set to true if you
+                  want to skip certification validation checks.
                 type: boolean
               tokens:
-                description: Credentials for the DynaKube to connect back to Dynatrace.
+                description: Name of the secret holding the tokens.
                 type: string
               trustedCAs:
-                description: 'Optional: Adds custom RootCAs from a configmap This
-                  property only affects certificates used to communicate with the
-                  Dynatrace API. The property is not applied to the ActiveGate'
+                description: 'Adds custom RootCAs from a configmap. Put the certificate
+                  under certs within your configmap. Note: Applies only to Dynatrace
+                  Operator, not to ActiveGate.'
                 type: string
             required:
             - apiUrl
@@ -3370,37 +3389,51 @@ spec:
             description: DynaKubeStatus defines the observed state of DynaKube
             properties:
               activeGate:
+                description: Observed state of ActiveGate
                 properties:
                   connectionInfoStatus:
+                    description: Information about Active Gate's connections
                     properties:
                       endpoints:
+                        description: Available tenant endpoints
                         type: string
                       lastRequest:
+                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantUUID:
+                        description: UUID from the tenant
                         type: string
                     type: object
                   imageID:
+                    description: Image ID
                     type: string
                   lastProbeTimestamp:
+                    description: Time of the last probe check
                     format: date-time
                     type: string
                   source:
+                    description: Source registry of the image
                     type: string
                   version:
+                    description: Image version
                     type: string
                 type: object
               codeModules:
+                description: Observed state of Code Modules
                 properties:
                   imageID:
+                    description: Image ID
                     type: string
                   lastProbeTimestamp:
+                    description: Time of the last probe check
                     format: date-time
                     type: string
                   source:
+                    description: Source registry of the image
                     type: string
                   version:
+                    description: Image version
                     type: string
                 type: object
               conditions:
@@ -3474,8 +3507,10 @@ spec:
                   type: object
                 type: array
               dynatraceApi:
+                description: Observed state of Dynatrace API
                 properties:
                   lastTokenScopeRequest:
+                    description: Time of the last token request
                     format: date-time
                     type: string
                 type: object
@@ -3484,55 +3519,71 @@ spec:
                   cluster
                 type: string
               lastTokenProbeTimestamp:
-                description: 'Deprecated: use DynatraceApiStatus.LastTokenScopeRequest
-                  instead LastTokenProbeTimestamp tracks when the last request for
-                  the API token validity was sent'
+                description: LastTokenProbeTimestamp tracks when the last request
+                  for the API token validity was sent
                 format: date-time
                 type: string
               oneAgent:
+                description: Observed state of OneAgent
                 properties:
                   connectionInfoStatus:
+                    description: Information about OneAgent's connections
                     properties:
                       communicationHosts:
+                        description: List of communication hosts
                         items:
                           properties:
                             host:
+                              description: Host domain
                               type: string
                             port:
+                              description: Connection port
                               format: int32
                               type: integer
                             protocol:
+                              description: Connection protocol
                               type: string
                           type: object
                         type: array
                       endpoints:
+                        description: Available tenant endpoints
                         type: string
                       lastRequest:
+                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantUUID:
+                        description: UUID from the tenant
                         type: string
                     type: object
                   imageID:
+                    description: Image ID
                     type: string
                   instances:
                     additionalProperties:
                       properties:
                         ipAddress:
+                          description: IP address of the pod
                           type: string
                         podName:
+                          description: Name of the OneAgent pod
                           type: string
                       type: object
+                    description: List of deployed OneAgent instances
                     type: object
                   lastInstanceStatusUpdate:
+                    description: Time of the last instance status update
                     format: date-time
                     type: string
                   lastProbeTimestamp:
+                    description: Time of the last probe check
                     format: date-time
                     type: string
                   source:
+                    description: Source registry of the image
                     type: string
                   version:
+                    description: Image version
                     type: string
                 type: object
               phase:
@@ -3540,15 +3591,20 @@ spec:
                   ...)
                 type: string
               synthetic:
+                description: Observed state of Synthetic
                 properties:
                   imageID:
+                    description: Image ID
                     type: string
                   lastProbeTimestamp:
+                    description: Time of the last probe check
                     format: date-time
                     type: string
                   source:
+                    description: Source registry of the image
                     type: string
                   version:
+                    description: Image version
                     type: string
                 type: object
               updatedTimestamp:

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1294,7 +1294,7 @@ spec:
                       read server.p12'
                     type: string
                   tolerations:
-                    description: Set tolerations for the ActiveGatePods pods
+                    description: Set tolerations for the ActiveGate pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using
@@ -1734,7 +1734,7 @@ spec:
                         type: object
                     type: object
                   tolerations:
-                    description: Set tolerations for the ActiveGatePods pods
+                    description: Set tolerations for the ActiveGate pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using
@@ -3153,7 +3153,7 @@ spec:
                         type: object
                     type: object
                   tolerations:
-                    description: Set tolerations for the ActiveGatePods pods
+                    description: Set tolerations for the ActiveGate pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -1306,7 +1306,7 @@ spec:
                       read server.p12'
                     type: string
                   tolerations:
-                    description: Set tolerations for the ActiveGatePods pods
+                    description: Set tolerations for the ActiveGate pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using
@@ -1746,7 +1746,7 @@ spec:
                         type: object
                     type: object
                   tolerations:
-                    description: Set tolerations for the ActiveGatePods pods
+                    description: Set tolerations for the ActiveGate pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using
@@ -3165,7 +3165,7 @@ spec:
                         type: object
                     type: object
                   tolerations:
-                    description: Set tolerations for the ActiveGatePods pods
+                    description: Set tolerations for the ActiveGate pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -3387,12 +3387,13 @@ spec:
                   want to skip certification validation checks.
                 type: boolean
               tokens:
-                description: Name of the secret holding the tokens.
+                description: Name of the secret holding the tokens used for connecting
+                  to Dynatrace.
                 type: string
               trustedCAs:
                 description: 'Adds custom RootCAs from a configmap. Put the certificate
                   under certs within your configmap. Note: Applies only to Dynatrace
-                  Operator, not to ActiveGate.'
+                  Operator and OneAgent, not to ActiveGate.'
                 type: string
             required:
             - apiUrl
@@ -3407,14 +3408,14 @@ spec:
                     description: Information about Active Gate's connections
                     properties:
                       endpoints:
-                        description: Available tenant endpoints
+                        description: Available connection endpoints
                         type: string
                       lastRequest:
                         description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantUUID:
-                        description: UUID from the tenant
+                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:
@@ -3558,14 +3559,14 @@ spec:
                           type: object
                         type: array
                       endpoints:
-                        description: Available tenant endpoints
+                        description: Available connection endpoints
                         type: string
                       lastRequest:
                         description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantUUID:
-                        description: UUID from the tenant
+                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -1079,13 +1079,12 @@ spec:
             description: DynaKubeSpec defines the desired state of DynaKube
             properties:
               activeGate:
-                description: General configuration about ActiveGate instances
+                description: General configuration about ActiveGate instances.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Adds additional annotations to the ActiveGate
-                      pods'
+                    description: Adds additional annotations to the ActiveGate pods
                     type: object
                   capabilities:
                     description: Activegate capabilities enabled (routing, kubernetes-monitoring,
@@ -1094,21 +1093,24 @@ spec:
                       type: string
                     type: array
                   customProperties:
-                    description: 'Optional: Add a custom properties file by providing
-                      it as a value or reference it from a secret If referenced from
-                      a secret, make sure the key is called ''customProperties'''
+                    description: Add a custom properties file by providing it as a
+                      value or reference it from a secret If referenced from a secret,
+                      make sure the key is called 'customProperties'
                     properties:
                       value:
+                        description: Custom properties value.
+                        nullable: true
                         type: string
                       valueFrom:
+                        description: Custom properties secret.
+                        nullable: true
                         type: string
                     type: object
                   dnsPolicy:
-                    description: 'Optional: Sets DNS Policy for the ActiveGate pods'
+                    description: Sets DNS Policy for the ActiveGate pods
                     type: string
                   env:
-                    description: 'Optional: List of environment variables to set for
-                      the ActiveGate'
+                    description: List of environment variables to set for the ActiveGate
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -1222,38 +1224,35 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: 'Optional: Set activation group for ActiveGate'
+                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: 'Optional: the ActiveGate container image. Defaults
-                      to the latest ActiveGate image provided by the registry on the
-                      tenant'
+                    description: The ActiveGate container image. Defaults to the latest
+                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Adds additional labels for the ActiveGate
-                      pods'
+                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Node selector to control the selection
-                      of nodes'
+                    description: Node selector to control the selection of nodes
                     type: object
                   priorityClassName:
-                    description: 'Optional: If specified, indicates the pod''s priority.
-                      Name must be defined by creating a PriorityClass object with
-                      that name. If not specified the setting will be removed from
-                      the StatefulSet.'
+                    description: If specified, indicates the pod's priority. Name
+                      must be defined by creating a PriorityClass object with that
+                      name. If not specified the setting will be removed from the
+                      StatefulSet.
                     type: string
                   replicas:
                     description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: 'Optional: define resources requests and limits for
-                      single ActiveGate pods'
+                    description: Define resources requests and limits for single ActiveGate
+                      pods
                     properties:
                       claims:
                         description: "Claims lists the names of resources, defined
@@ -1301,14 +1300,13 @@ spec:
                         type: object
                     type: object
                   tlsSecretName:
-                    description: 'Optional: the name of a secret containing ActiveGate
-                      TLS cert+key and password. If not set, self-signed certificate
-                      is used. server.p12: certificate+key pair in pkcs12 format password:
-                      passphrase to read server.p12'
+                    description: 'The name of a secret containing ActiveGate TLS cert+key
+                      and password. If not set, self-signed certificate is used. server.p12:
+                      certificate+key pair in pkcs12 format password: passphrase to
+                      read server.p12'
                     type: string
                   tolerations:
-                    description: 'Optional: set tolerations for the ActiveGatePods
-                      pods'
+                    description: Set tolerations for the ActiveGatePods pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using
@@ -1349,8 +1347,8 @@ spec:
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: 'Optional: Adds TopologySpreadConstraints for the
-                      ActiveGate pods'
+                    description: Adds TopologySpreadConstraints for the ActiveGate
+                      pods
                     items:
                       description: TopologySpreadConstraint specifies how to spread
                         matching pods among the given topology.
@@ -1525,35 +1523,46 @@ spec:
                     type: array
                 type: object
               apiUrl:
-                description: Location of the Dynatrace API to connect to, including
-                  your specific environment UUID
+                description: Dynatrace apiUrl, including the /api path at the end.
+                  For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed,
+                  change the apiUrl address. For instructions on how to determine
+                  the environment ID and how to configure the apiUrl address, see
+                  Environment ID (https://www.dynatrace.com/support/help/get-started/monitoring-environment/environment-id).
                 type: string
               customPullSecret:
-                description: 'Optional: Pull secret for your private registry'
+                description: Defines a custom pull secret in case you use a private
+                  registry when pulling images from the Dynatrace environment. To
+                  define a custom pull secret and learn about the expected behavior,
+                  see Configure customPullSecret (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring/dto-config-options-k8s#custompullsecret).
                 type: string
               enableIstio:
-                description: If enabled, Istio on the cluster will be configured automatically
-                  to allow access to the Dynatrace environment
+                description: When enabled, and if Istio is installed on the Kubernetes
+                  environment, Dynatrace Operator will create the corresponding VirtualService
+                  and ServiceEntry objects to allow access to the Dynatrace Cluster
+                  from the OneAgent or ActiveGate. Disabled by default.
                 type: boolean
               kubernetesMonitoring:
-                description: 'Deprecated: Configuration for Kubernetes Monitoring'
+                description: Configuration for Kubernetes Monitoring
                 properties:
                   customProperties:
-                    description: 'Optional: Add a custom properties file by providing
-                      it as a value or reference it from a secret If referenced from
-                      a secret, make sure the key is called ''customProperties'''
+                    description: Add a custom properties file by providing it as a
+                      value or reference it from a secret If referenced from a secret,
+                      make sure the key is called 'customProperties'
                     properties:
                       value:
+                        description: Custom properties value.
+                        nullable: true
                         type: string
                       valueFrom:
+                        description: Custom properties secret.
+                        nullable: true
                         type: string
                     type: object
                   enabled:
                     description: Enables Capability
                     type: boolean
                   env:
-                    description: 'Optional: List of environment variables to set for
-                      the ActiveGate'
+                    description: List of environment variables to set for the ActiveGate
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -1667,32 +1676,29 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: 'Optional: Set activation group for ActiveGate'
+                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: 'Optional: the ActiveGate container image. Defaults
-                      to the latest ActiveGate image provided by the registry on the
-                      tenant'
+                    description: The ActiveGate container image. Defaults to the latest
+                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Adds additional labels for the ActiveGate
-                      pods'
+                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Node selector to control the selection
-                      of nodes'
+                    description: Node selector to control the selection of nodes
                     type: object
                   replicas:
                     description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: 'Optional: define resources requests and limits for
-                      single ActiveGate pods'
+                    description: Define resources requests and limits for single ActiveGate
+                      pods
                     properties:
                       claims:
                         description: "Claims lists the names of resources, defined
@@ -1740,8 +1746,7 @@ spec:
                         type: object
                     type: object
                   tolerations:
-                    description: 'Optional: set tolerations for the ActiveGatePods
-                      pods'
+                    description: Set tolerations for the ActiveGatePods pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using
@@ -1782,8 +1787,8 @@ spec:
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: 'Optional: Adds TopologySpreadConstraints for the
-                      ActiveGate pods'
+                    description: Adds TopologySpreadConstraints for the ActiveGate
+                      pods
                     items:
                       description: TopologySpreadConstraint specifies how to spread
                         matching pods among the given topology.
@@ -1958,9 +1963,10 @@ spec:
                     type: array
                 type: object
               namespaceSelector:
-                description: 'Optional: set a namespace selector to limit which namespaces
-                  are monitored By default, all namespaces will be monitored Has no
-                  effect during classicFullStack and hostMonitoring mode'
+                description: Applicable only for applicationMonitoring or cloudNativeFullStack
+                  configuration types. The namespaces where you want Dynatrace Operator
+                  to inject. For more information, see Configure monitoring for namespaces
+                  and pods (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring/dto-config-options-k8s#annotate).
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -2005,25 +2011,27 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               networkZone:
-                description: 'Optional: Sets Network Zone for OneAgent and ActiveGate
-                  pods'
+                description: Sets a network zone for the OneAgent and ActiveGate pods.
                 type: string
               oneAgent:
-                description: General configuration about OneAgent instances
+                description: General configuration about OneAgent instances. You can't
+                  enable more than one module (classicFullStack, cloudNativeFullStack,
+                  hostMonitoring, or applicationMonitoring).
                 properties:
                   applicationMonitoring:
-                    description: 'Optional: enable application-only monitoring and
-                      change its settings Cannot be used in conjunction with cloud-native
-                      fullstack monitoring, classic fullstack monitoring or host monitoring'
+                    description: dynatrace-webhook injects into application pods based
+                      on labeled namespaces. Has an optional CSI driver per node via
+                      DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       codeModulesImage:
-                        description: 'Optional: the Dynatrace installer container
-                          image'
+                        description: The OneAgent image that is used to inject into
+                          Pods.
                         type: string
                       initResources:
-                        description: 'Optional: define resources requests and limits
-                          for the initContainer'
+                        description: Define resources requests and limits for the
+                          initContainer. For details, see Managing resources for containers
+                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
                             description: "Claims lists the names of resources, defined
@@ -2072,44 +2080,44 @@ spec:
                             type: object
                         type: object
                       useCSIDriver:
-                        description: 'Optional: If you want to use CSIDriver; disable
-                          if your cluster does not have ''nodes'' to fall back to
-                          the volume approach.'
+                        description: Set if you want to use the CSIDriver. Don't enable
+                          it if you do not have access to Kubernetes nodes or if you
+                          lack privileges.
                         type: boolean
                       version:
-                        description: 'Optional: If specified, indicates the OneAgent
-                          version to use Defaults to latest Example: {major.minor.release}
-                          - 1.200.0'
+                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   classicFullStack:
-                    description: 'Optional: enable classic fullstack monitoring and
-                      change its settings Cannot be used in conjunction with cloud-native
-                      fullstack monitoring, application monitoring or host monitoring'
+                    description: Has a single OneAgent per node via DaemonSet. Injection
+                      is performed via the same OneAgent DaemonSet.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional annotations to the
-                          OneAgent pods'
+                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: 'Optional: Arguments to the OneAgent installer'
+                        description: Set additional arguments to the OneAgent installer.
+                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
+                          For the list of limitations, see Limitations (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/docker/set-up-dynatrace-oneagent-as-docker-container#limitations).
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: 'Optional: Enables automatic restarts of OneAgent
-                          pods in case a new version is available Defaults to true'
+                        description: Disables automatic restarts of OneAgent pods
+                          in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
+                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: 'Optional: Sets DNS Policy for the OneAgent pods'
+                        description: Set the DNS Policy for OneAgent pods. For details,
+                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: 'Optional: List of environment variables to set
-                          for the installer'
+                        description: Set additional environment variables for the
+                          OneAgent pods.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -2227,25 +2235,27 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: 'Optional: the Dynatrace installer container
-                          image Defaults to the registry on the tenant for both Kubernetes
-                          and for OpenShift'
+                        description: Use a custom OneAgent Docker image. Defaults
+                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional labels for the OneAgent
-                          pods'
+                        description: Your defined labels for OneAgent pods in order
+                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Node selector to control the selection of nodes
-                          (optional)
+                        description: Specify the node selector that controls on which
+                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: 'Optional: define resources requests and limits
-                          for single pods'
+                        description: 'Resource settings for OneAgent container. Consumption
+                          of the OneAgent heavily depends on the workload to monitor.
+                          You can use the default settings in the CR. Note: resource.requests
+                          shows the values needed to run; resource.limits shows the
+                          maximum limits for the pod.'
                         properties:
                           claims:
                             description: "Claims lists the names of resources, defined
@@ -2294,13 +2304,13 @@ spec:
                             type: object
                         type: object
                       priorityClassName:
-                        description: 'Optional: If specified, indicates the pod''s
-                          priority. Name must be defined by creating a PriorityClass
-                          object with that name. If not specified the setting will
-                          be removed from the DaemonSet.'
+                        description: Assign a priority class to the OneAgent pods.
+                          By default, no class is set. For details, see Pod Priority
+                          and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: 'Optional: set tolerations for the OneAgent pods'
+                        description: Tolerations to include with the OneAgent DaemonSet.
+                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
                           description: The pod this Toleration is attached to tolerates
                             any taint that matches the triple <key,value,effect> using
@@ -2342,43 +2352,44 @@ spec:
                           type: object
                         type: array
                       version:
-                        description: 'Optional: If specified, indicates the OneAgent
-                          version to use Defaults to latest Example: {major.minor.release}
-                          - 1.200.0'
+                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   cloudNativeFullStack:
-                    description: 'Optional: enable cloud-native fullstack monitoring
-                      and change its settings Cannot be used in conjunction with classic
-                      fullstack monitoring, application monitoring or host monitoring'
+                    description: Has a single OneAgent per node via DaemonSet. dynatrace-webhook
+                      injects into application pods based on labeled namespaces. Has
+                      a CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional annotations to the
-                          OneAgent pods'
+                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: 'Optional: Arguments to the OneAgent installer'
+                        description: Set additional arguments to the OneAgent installer.
+                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
+                          For the list of limitations, see Limitations (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/docker/set-up-dynatrace-oneagent-as-docker-container#limitations).
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: 'Optional: Enables automatic restarts of OneAgent
-                          pods in case a new version is available Defaults to true'
+                        description: Disables automatic restarts of OneAgent pods
+                          in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
+                          Enabled by default.
                         type: boolean
                       codeModulesImage:
-                        description: 'Optional: the Dynatrace installer container
-                          image'
+                        description: The OneAgent image that is used to inject into
+                          Pods.
                         type: string
                       dnsPolicy:
-                        description: 'Optional: Sets DNS Policy for the OneAgent pods'
+                        description: Set the DNS Policy for OneAgent pods. For details,
+                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: 'Optional: List of environment variables to set
-                          for the installer'
+                        description: Set additional environment variables for the
+                          OneAgent pods.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -2496,13 +2507,13 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: 'Optional: the Dynatrace installer container
-                          image Defaults to the registry on the tenant for both Kubernetes
-                          and for OpenShift'
+                        description: Use a custom OneAgent Docker image. Defaults
+                          to the image from the Dynatrace cluster.
                         type: string
                       initResources:
-                        description: 'Optional: define resources requests and limits
-                          for the initContainer'
+                        description: Define resources requests and limits for the
+                          initContainer. For details, see Managing resources for containers
+                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
                             description: "Claims lists the names of resources, defined
@@ -2553,18 +2564,21 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional labels for the OneAgent
-                          pods'
+                        description: Your defined labels for OneAgent pods in order
+                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Node selector to control the selection of nodes
-                          (optional)
+                        description: Specify the node selector that controls on which
+                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: 'Optional: define resources requests and limits
-                          for single pods'
+                        description: 'Resource settings for OneAgent container. Consumption
+                          of the OneAgent heavily depends on the workload to monitor.
+                          You can use the default settings in the CR. Note: resource.requests
+                          shows the values needed to run; resource.limits shows the
+                          maximum limits for the pod.'
                         properties:
                           claims:
                             description: "Claims lists the names of resources, defined
@@ -2613,13 +2627,13 @@ spec:
                             type: object
                         type: object
                       priorityClassName:
-                        description: 'Optional: If specified, indicates the pod''s
-                          priority. Name must be defined by creating a PriorityClass
-                          object with that name. If not specified the setting will
-                          be removed from the DaemonSet.'
+                        description: Assign a priority class to the OneAgent pods.
+                          By default, no class is set. For details, see Pod Priority
+                          and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: 'Optional: set tolerations for the OneAgent pods'
+                        description: Tolerations to include with the OneAgent DaemonSet.
+                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
                           description: The pod this Toleration is attached to tolerates
                             any taint that matches the triple <key,value,effect> using
@@ -2661,39 +2675,39 @@ spec:
                           type: object
                         type: array
                       version:
-                        description: 'Optional: If specified, indicates the OneAgent
-                          version to use Defaults to latest Example: {major.minor.release}
-                          - 1.200.0'
+                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   hostMonitoring:
-                    description: 'Optional: enable host monitoring and change its
-                      settings Cannot be used in conjunction with cloud-native fullstack
-                      monitoring, classic fullstack monitoring or application monitoring'
+                    description: Has a single OneAgent per node via DaemonSet. Doesn't
+                      inject into application pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional annotations to the
-                          OneAgent pods'
+                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: 'Optional: Arguments to the OneAgent installer'
+                        description: Set additional arguments to the OneAgent installer.
+                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
+                          For the list of limitations, see Limitations (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/docker/set-up-dynatrace-oneagent-as-docker-container#limitations).
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: 'Optional: Enables automatic restarts of OneAgent
-                          pods in case a new version is available Defaults to true'
+                        description: Disables automatic restarts of OneAgent pods
+                          in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
+                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: 'Optional: Sets DNS Policy for the OneAgent pods'
+                        description: Set the DNS Policy for OneAgent pods. For details,
+                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: 'Optional: List of environment variables to set
-                          for the installer'
+                        description: Set additional environment variables for the
+                          OneAgent pods.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -2811,25 +2825,27 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: 'Optional: the Dynatrace installer container
-                          image Defaults to the registry on the tenant for both Kubernetes
-                          and for OpenShift'
+                        description: Use a custom OneAgent Docker image. Defaults
+                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Optional: Adds additional labels for the OneAgent
-                          pods'
+                        description: Your defined labels for OneAgent pods in order
+                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Node selector to control the selection of nodes
-                          (optional)
+                        description: Specify the node selector that controls on which
+                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: 'Optional: define resources requests and limits
-                          for single pods'
+                        description: 'Resource settings for OneAgent container. Consumption
+                          of the OneAgent heavily depends on the workload to monitor.
+                          You can use the default settings in the CR. Note: resource.requests
+                          shows the values needed to run; resource.limits shows the
+                          maximum limits for the pod.'
                         properties:
                           claims:
                             description: "Claims lists the names of resources, defined
@@ -2878,13 +2894,13 @@ spec:
                             type: object
                         type: object
                       priorityClassName:
-                        description: 'Optional: If specified, indicates the pod''s
-                          priority. Name must be defined by creating a PriorityClass
-                          object with that name. If not specified the setting will
-                          be removed from the DaemonSet.'
+                        description: Assign a priority class to the OneAgent pods.
+                          By default, no class is set. For details, see Pod Priority
+                          and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: 'Optional: set tolerations for the OneAgent pods'
+                        description: Tolerations to include with the OneAgent DaemonSet.
+                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
                           description: The pod this Toleration is attached to tolerates
                             any taint that matches the triple <key,value,effect> using
@@ -2926,40 +2942,46 @@ spec:
                           type: object
                         type: array
                       version:
-                        description: 'Optional: If specified, indicates the OneAgent
-                          version to use Defaults to latest Example: {major.minor.release}
-                          - 1.200.0'
+                        description: The OneAgent version to be used.
                         type: string
                     type: object
                 type: object
               proxy:
-                description: 'Optional: Set custom proxy settings either directly
-                  or from a secret with the field ''proxy'''
+                description: 'Set custom proxy settings either directly or from a
+                  secret with the field proxy. Note: Applies to Dynatrace Operator,
+                  ActiveGate, and OneAgents.'
                 properties:
                   value:
+                    description: Proxy URL. It has preference over ValueFrom.
+                    nullable: true
                     type: string
                   valueFrom:
+                    description: Secret containing proxy URL.
+                    nullable: true
                     type: string
                 type: object
               routing:
-                description: 'Deprecated: Configuration for Routing'
+                description: Configuration for Routing
                 properties:
                   customProperties:
-                    description: 'Optional: Add a custom properties file by providing
-                      it as a value or reference it from a secret If referenced from
-                      a secret, make sure the key is called ''customProperties'''
+                    description: Add a custom properties file by providing it as a
+                      value or reference it from a secret If referenced from a secret,
+                      make sure the key is called 'customProperties'
                     properties:
                       value:
+                        description: Custom properties value.
+                        nullable: true
                         type: string
                       valueFrom:
+                        description: Custom properties secret.
+                        nullable: true
                         type: string
                     type: object
                   enabled:
                     description: Enables Capability
                     type: boolean
                   env:
-                    description: 'Optional: List of environment variables to set for
-                      the ActiveGate'
+                    description: List of environment variables to set for the ActiveGate
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -3073,32 +3095,29 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: 'Optional: Set activation group for ActiveGate'
+                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: 'Optional: the ActiveGate container image. Defaults
-                      to the latest ActiveGate image provided by the registry on the
-                      tenant'
+                    description: The ActiveGate container image. Defaults to the latest
+                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Adds additional labels for the ActiveGate
-                      pods'
+                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: 'Optional: Node selector to control the selection
-                      of nodes'
+                    description: Node selector to control the selection of nodes
                     type: object
                   replicas:
                     description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: 'Optional: define resources requests and limits for
-                      single ActiveGate pods'
+                    description: Define resources requests and limits for single ActiveGate
+                      pods
                     properties:
                       claims:
                         description: "Claims lists the names of resources, defined
@@ -3146,8 +3165,7 @@ spec:
                         type: object
                     type: object
                   tolerations:
-                    description: 'Optional: set tolerations for the ActiveGatePods
-                      pods'
+                    description: Set tolerations for the ActiveGatePods pods
                     items:
                       description: The pod this Toleration is attached to tolerates
                         any taint that matches the triple <key,value,effect> using
@@ -3188,8 +3206,8 @@ spec:
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: 'Optional: Adds TopologySpreadConstraints for the
-                      ActiveGate pods'
+                    description: Adds TopologySpreadConstraints for the ActiveGate
+                      pods
                     items:
                       description: TopologySpreadConstraint specifies how to spread
                         matching pods among the given topology.
@@ -3364,16 +3382,17 @@ spec:
                     type: array
                 type: object
               skipCertCheck:
-                description: Disable certificate validation checks for installer download
-                  and API communication
+                description: Disable certificate check for the connection between
+                  Dynatrace Operator and the Dynatrace Cluster. Set to true if you
+                  want to skip certification validation checks.
                 type: boolean
               tokens:
-                description: Credentials for the DynaKube to connect back to Dynatrace.
+                description: Name of the secret holding the tokens.
                 type: string
               trustedCAs:
-                description: 'Optional: Adds custom RootCAs from a configmap This
-                  property only affects certificates used to communicate with the
-                  Dynatrace API. The property is not applied to the ActiveGate'
+                description: 'Adds custom RootCAs from a configmap. Put the certificate
+                  under certs within your configmap. Note: Applies only to Dynatrace
+                  Operator, not to ActiveGate.'
                 type: string
             required:
             - apiUrl
@@ -3382,37 +3401,51 @@ spec:
             description: DynaKubeStatus defines the observed state of DynaKube
             properties:
               activeGate:
+                description: Observed state of ActiveGate
                 properties:
                   connectionInfoStatus:
+                    description: Information about Active Gate's connections
                     properties:
                       endpoints:
+                        description: Available tenant endpoints
                         type: string
                       lastRequest:
+                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantUUID:
+                        description: UUID from the tenant
                         type: string
                     type: object
                   imageID:
+                    description: Image ID
                     type: string
                   lastProbeTimestamp:
+                    description: Time of the last probe check
                     format: date-time
                     type: string
                   source:
+                    description: Source registry of the image
                     type: string
                   version:
+                    description: Image version
                     type: string
                 type: object
               codeModules:
+                description: Observed state of Code Modules
                 properties:
                   imageID:
+                    description: Image ID
                     type: string
                   lastProbeTimestamp:
+                    description: Time of the last probe check
                     format: date-time
                     type: string
                   source:
+                    description: Source registry of the image
                     type: string
                   version:
+                    description: Image version
                     type: string
                 type: object
               conditions:
@@ -3486,8 +3519,10 @@ spec:
                   type: object
                 type: array
               dynatraceApi:
+                description: Observed state of Dynatrace API
                 properties:
                   lastTokenScopeRequest:
+                    description: Time of the last token request
                     format: date-time
                     type: string
                 type: object
@@ -3496,55 +3531,71 @@ spec:
                   cluster
                 type: string
               lastTokenProbeTimestamp:
-                description: 'Deprecated: use DynatraceApiStatus.LastTokenScopeRequest
-                  instead LastTokenProbeTimestamp tracks when the last request for
-                  the API token validity was sent'
+                description: LastTokenProbeTimestamp tracks when the last request
+                  for the API token validity was sent
                 format: date-time
                 type: string
               oneAgent:
+                description: Observed state of OneAgent
                 properties:
                   connectionInfoStatus:
+                    description: Information about OneAgent's connections
                     properties:
                       communicationHosts:
+                        description: List of communication hosts
                         items:
                           properties:
                             host:
+                              description: Host domain
                               type: string
                             port:
+                              description: Connection port
                               format: int32
                               type: integer
                             protocol:
+                              description: Connection protocol
                               type: string
                           type: object
                         type: array
                       endpoints:
+                        description: Available tenant endpoints
                         type: string
                       lastRequest:
+                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantUUID:
+                        description: UUID from the tenant
                         type: string
                     type: object
                   imageID:
+                    description: Image ID
                     type: string
                   instances:
                     additionalProperties:
                       properties:
                         ipAddress:
+                          description: IP address of the pod
                           type: string
                         podName:
+                          description: Name of the OneAgent pod
                           type: string
                       type: object
+                    description: List of deployed OneAgent instances
                     type: object
                   lastInstanceStatusUpdate:
+                    description: Time of the last instance status update
                     format: date-time
                     type: string
                   lastProbeTimestamp:
+                    description: Time of the last probe check
                     format: date-time
                     type: string
                   source:
+                    description: Source registry of the image
                     type: string
                   version:
+                    description: Image version
                     type: string
                 type: object
               phase:
@@ -3552,15 +3603,20 @@ spec:
                   ...)
                 type: string
               synthetic:
+                description: Observed state of Synthetic
                 properties:
                   imageID:
+                    description: Image ID
                     type: string
                   lastProbeTimestamp:
+                    description: Time of the last probe check
                     format: date-time
                     type: string
                   source:
+                    description: Source registry of the image
                     type: string
                   version:
+                    description: Image version
                     type: string
                 type: object
               updatedTimestamp:

--- a/src/api/v1beta1/activegate_types.go
+++ b/src/api/v1beta1/activegate_types.go
@@ -116,7 +116,7 @@ type CapabilityProperties struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Node Selector",order=35,xDescriptors="urn:alm:descriptor:com.tectonic.ui:selector:Node"
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
-	// Set tolerations for the ActiveGatePods pods
+	// Set tolerations for the ActiveGate pods
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tolerations",order=36,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`

--- a/src/api/v1beta1/activegate_types.go
+++ b/src/api/v1beta1/activegate_types.go
@@ -59,22 +59,26 @@ type ActiveGateSpec struct {
 
 	CapabilityProperties `json:",inline"`
 
-	// Optional: the name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
+	// The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
 	// server.p12: certificate+key pair in pkcs12 format
 	// password: passphrase to read server.p12
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TlsSecretName",order=10,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	TlsSecretName string `json:"tlsSecretName,omitempty"`
 
-	// Optional: Sets DNS Policy for the ActiveGate pods
+	// Sets DNS Policy for the ActiveGate pods
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="DNS Policy",order=24,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
 
-	// Optional: If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
+	// If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
 	// name. If not specified the setting will be removed from the StatefulSet.
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Priority Class name",order=23,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:PriorityClass"}
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
-	// Optional: Adds additional annotations to the ActiveGate pods
+	// Adds additional annotations to the ActiveGate pods
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Annotations",order=27,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
@@ -87,42 +91,51 @@ type CapabilityProperties struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Replicas",order=30,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount"
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Optional: the ActiveGate container image. Defaults to the latest ActiveGate image provided by the registry on the tenant
+	// The ActiveGate container image. Defaults to the latest ActiveGate image provided by the registry on the tenant
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=10,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Image string `json:"image,omitempty"`
 
-	// Optional: Set activation group for ActiveGate
+	// Set activation group for ActiveGate
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Activation group",order=31,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Group string `json:"group,omitempty"`
 
-	// Optional: Add a custom properties file by providing it as a value or reference it from a secret
+	// Add a custom properties file by providing it as a value or reference it from a secret
+	// +optional
 	// If referenced from a secret, make sure the key is called 'customProperties'
 	CustomProperties *DynaKubeValueSource `json:"customProperties,omitempty"`
 
-	// Optional: define resources requests and limits for single ActiveGate pods
+	// Define resources requests and limits for single ActiveGate pods
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",order=34,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
-	// Optional: Node selector to control the selection of nodes
+	// Node selector to control the selection of nodes
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Node Selector",order=35,xDescriptors="urn:alm:descriptor:com.tectonic.ui:selector:Node"
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
-	// Optional: set tolerations for the ActiveGatePods pods
+	// Set tolerations for the ActiveGatePods pods
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tolerations",order=36,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
-	// Optional: Adds additional labels for the ActiveGate pods
+	// Adds additional labels for the ActiveGate pods
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Labels",order=37,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Labels map[string]string `json:"labels,omitempty"`
 
-	// Optional: List of environment variables to set for the ActiveGate
+	// List of environment variables to set for the ActiveGate
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Environment variables",order=39,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:hidden"}
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Environment variables"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:com.tectonic.ui:text"
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
-	// Optional: Adds TopologySpreadConstraints for the ActiveGate pods
+	// Adds TopologySpreadConstraints for the ActiveGate pods
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="topologySpreadConstraints",order=40,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:hidden"}
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 }

--- a/src/api/v1beta1/dynakube_status.go
+++ b/src/api/v1beta1/dynakube_status.go
@@ -70,7 +70,7 @@ type ConnectionInfoStatus struct {
 }
 
 type OneAgentConnectionInfoStatus struct {
-	// Information about the connected tenant
+	// Information for communicating with the tenant
 	ConnectionInfoStatus `json:",inline"`
 
 	// List of communication hosts

--- a/src/api/v1beta1/dynakube_status.go
+++ b/src/api/v1beta1/dynakube_status.go
@@ -19,8 +19,8 @@ type DynaKubeStatus struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.statusDescriptors.x-descriptors="urn:alm:descriptor:text"
 	UpdatedTimestamp metav1.Time `json:"updatedTimestamp,omitempty"`
 
-	// Deprecated: use DynatraceApiStatus.LastTokenScopeRequest instead
 	// LastTokenProbeTimestamp tracks when the last request for the API token validity was sent
+	// +kubebuilder:deprecatedversion:warning="Use DynatraceApiStatus.LastTokenScopeRequest instead"
 	LastTokenProbeTimestamp *metav1.Time `json:"lastTokenProbeTimestamp,omitempty"`
 
 	// KubeSystemUUID contains the UUID of the current Kubernetes cluster
@@ -29,14 +29,24 @@ type DynaKubeStatus struct {
 	// Conditions includes status about the current state of the instance
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	ActiveGate   ActiveGateStatus   `json:"activeGate,omitempty"`
-	OneAgent     OneAgentStatus     `json:"oneAgent,omitempty"`
-	CodeModules  CodeModulesStatus  `json:"codeModules,omitempty"`
-	Synthetic    SyntheticStatus    `json:"synthetic,omitempty"`
+	// Observed state of ActiveGate
+	ActiveGate ActiveGateStatus `json:"activeGate,omitempty"`
+
+	// Observed state of OneAgent
+	OneAgent OneAgentStatus `json:"oneAgent,omitempty"`
+
+	// Observed state of Code Modules
+	CodeModules CodeModulesStatus `json:"codeModules,omitempty"`
+
+	// Observed state of Synthetic
+	Synthetic SyntheticStatus `json:"synthetic,omitempty"`
+
+	// Observed state of Dynatrace API
 	DynatraceApi DynatraceApiStatus `json:"dynatraceApi,omitempty"`
 }
 
 type DynatraceApiStatus struct {
+	// Time of the last token request
 	LastTokenScopeRequest metav1.Time `json:"lastTokenScopeRequest,omitempty"`
 }
 
@@ -49,24 +59,38 @@ func GetCacheValidMessage(functionName string, lastRequestTimestamp metav1.Time,
 }
 
 type ConnectionInfoStatus struct {
-	TenantUUID  string      `json:"tenantUUID,omitempty"`
-	Endpoints   string      `json:"endpoints,omitempty"`
+	// UUID from the tenant
+	TenantUUID string `json:"tenantUUID,omitempty"`
+
+	// Available tenant endpoints
+	Endpoints string `json:"endpoints,omitempty"`
+
+	// Time of the last connection request
 	LastRequest metav1.Time `json:"lastRequest,omitempty"`
 }
 
 type OneAgentConnectionInfoStatus struct {
+	// Information about the connected tenant
 	ConnectionInfoStatus `json:",inline"`
-	CommunicationHosts   []CommunicationHostStatus `json:"communicationHosts,omitempty"`
+
+	// List of communication hosts
+	CommunicationHosts []CommunicationHostStatus `json:"communicationHosts,omitempty"`
 }
 
 type ActiveGateConnectionInfoStatus struct {
+	// Information about Active Gate's connections
 	ConnectionInfoStatus `json:",inline"`
 }
 
 type CommunicationHostStatus struct {
+	// Connection protocol
 	Protocol string `json:"protocol,omitempty"`
-	Host     string `json:"host,omitempty"`
-	Port     uint32 `json:"port,omitempty"`
+
+	// Host domain
+	Host string `json:"host,omitempty"`
+
+	// Connection port
+	Port uint32 `json:"port,omitempty"`
 }
 
 type VersionSource string
@@ -79,14 +103,23 @@ const (
 )
 
 type VersionStatus struct {
-	Source             VersionSource `json:"source,omitempty"`
-	ImageID            string        `json:"imageID,omitempty"`
-	Version            string        `json:"version,omitempty"`
-	LastProbeTimestamp *metav1.Time  `json:"lastProbeTimestamp,omitempty"`
+	// Source registry of the image
+	Source VersionSource `json:"source,omitempty"`
+
+	// Image ID
+	ImageID string `json:"imageID,omitempty"`
+
+	// Image version
+	Version string `json:"version,omitempty"`
+
+	// Time of the last probe check
+	LastProbeTimestamp *metav1.Time `json:"lastProbeTimestamp,omitempty"`
 }
 
 type ActiveGateStatus struct {
-	VersionStatus        `json:",inline"`
+	VersionStatus `json:",inline"`
+
+	// Information about Active Gate's connections
 	ConnectionInfoStatus ActiveGateConnectionInfoStatus `json:"connectionInfoStatus,omitempty"`
 }
 
@@ -97,15 +130,21 @@ type CodeModulesStatus struct {
 type OneAgentStatus struct {
 	VersionStatus `json:",inline"`
 
+	// List of deployed OneAgent instances
 	Instances map[string]OneAgentInstance `json:"instances,omitempty"`
 
+	// Time of the last instance status update
 	LastInstanceStatusUpdate *metav1.Time `json:"lastInstanceStatusUpdate,omitempty"`
 
+	// Information about OneAgent's connections
 	ConnectionInfoStatus OneAgentConnectionInfoStatus `json:"connectionInfoStatus,omitempty"`
 }
 
 type OneAgentInstance struct {
-	PodName   string `json:"podName,omitempty"`
+	// Name of the OneAgent pod
+	PodName string `json:"podName,omitempty"`
+
+	// IP address of the pod
 	IPAddress string `json:"ipAddress,omitempty"`
 }
 

--- a/src/api/v1beta1/dynakube_status.go
+++ b/src/api/v1beta1/dynakube_status.go
@@ -59,7 +59,7 @@ func GetCacheValidMessage(functionName string, lastRequestTimestamp metav1.Time,
 }
 
 type ConnectionInfoStatus struct {
-	// UUID from the tenant
+	// UUID of the tenant, received from the tenant
 	TenantUUID string `json:"tenantUUID,omitempty"`
 
 	// Available tenant endpoints

--- a/src/api/v1beta1/dynakube_status.go
+++ b/src/api/v1beta1/dynakube_status.go
@@ -62,7 +62,7 @@ type ConnectionInfoStatus struct {
 	// UUID of the tenant, received from the tenant
 	TenantUUID string `json:"tenantUUID,omitempty"`
 
-	// Available tenant endpoints
+	// Available connection endpoints
 	Endpoints string `json:"endpoints,omitempty"`
 
 	// Time of the last connection request

--- a/src/api/v1beta1/dynakube_types.go
+++ b/src/api/v1beta1/dynakube_types.go
@@ -82,7 +82,7 @@ type DynaKubeSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="API URL",order=1,xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	APIURL string `json:"apiUrl"`
 
-	// Name of the secret holding the tokens.
+	// Name of the secret holding the tokens used for connecting to Dynatrace.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tenant specific secrets",order=2,xDescriptors="urn:alm:descriptor:io.kubernetes:Secret"
 	Tokens string `json:"tokens,omitempty"`

--- a/src/api/v1beta1/dynakube_types.go
+++ b/src/api/v1beta1/dynakube_types.go
@@ -100,7 +100,7 @@ type DynaKubeSpec struct {
 	Proxy *DynaKubeProxy `json:"proxy,omitempty"`
 
 	// Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
-	// Note: Applies only to Dynatrace Operator, not to ActiveGate.
+	// Note: Applies only to Dynatrace Operator and OneAgent, not to ActiveGate.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Trusted CAs",order=6,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:ConfigMap"}
 	TrustedCAs string `json:"trustedCAs,omitempty"`

--- a/src/api/v1beta1/dynakube_types.go
+++ b/src/api/v1beta1/dynakube_types.go
@@ -28,17 +28,25 @@ const (
 )
 
 type DynaKubeProxy struct {
+	// Proxy URL. It has preference over ValueFrom.
+	// +nullable
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Proxy value",order=32,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Value string `json:"value,omitempty"`
 
+	// Secret containing proxy URL.
+	// +nullable
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Proxy secret",order=33,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:Secret"}
 	ValueFrom string `json:"valueFrom,omitempty"`
 }
 
 type DynaKubeValueSource struct {
+	// Custom properties value.
+	// +nullable
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Custom properties value",order=32,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Value string `json:"value,omitempty"`
 
+	// Custom properties secret.
+	// +nullable
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Custom properties secret",order=33,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:Secret"}
 	ValueFrom string `json:"valueFrom,omitempty"`
 }
@@ -68,62 +76,77 @@ type DynaKube struct {
 type DynaKubeSpec struct {
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 
-	// Location of the Dynatrace API to connect to, including your specific environment UUID
+	// Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
+	// For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.com/support/help/get-started/monitoring-environment/environment-id).
 	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="API URL",order=1,xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	APIURL string `json:"apiUrl"`
 
-	// Credentials for the DynaKube to connect back to Dynatrace.
+	// Name of the secret holding the tokens.
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tenant specific secrets",order=2,xDescriptors="urn:alm:descriptor:io.kubernetes:Secret"
 	Tokens string `json:"tokens,omitempty"`
 
-	// Optional: Pull secret for your private registry
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Custom PullSecret",order=8,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:Secret"}
-	CustomPullSecret string `json:"customPullSecret,omitempty"`
-
-	// Disable certificate validation checks for installer download and API communication
+	// Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.
+	// Set to true if you want to skip certification validation checks.
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Skip Certificate Check",order=3,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	SkipCertCheck bool `json:"skipCertCheck,omitempty"`
 
-	// Optional: Set custom proxy settings either directly or from a secret with the field 'proxy'
+	// Set custom proxy settings either directly or from a secret with the field proxy.
+	// Note: Applies to Dynatrace Operator, ActiveGate, and OneAgents.
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Proxy",order=3,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Proxy *DynaKubeProxy `json:"proxy,omitempty"`
 
-	// Optional: Adds custom RootCAs from a configmap
-	// This property only affects certificates used to communicate with the Dynatrace API.
-	// The property is not applied to the ActiveGate
+	// Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
+	// Note: Applies only to Dynatrace Operator, not to ActiveGate.
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Trusted CAs",order=6,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:ConfigMap"}
 	TrustedCAs string `json:"trustedCAs,omitempty"`
 
-	// Optional: Sets Network Zone for OneAgent and ActiveGate pods
+	// Sets a network zone for the OneAgent and ActiveGate pods.
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Network Zone",order=7,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	NetworkZone string `json:"networkZone,omitempty"`
 
-	// If enabled, Istio on the cluster will be configured automatically to allow access to the Dynatrace environment
+	// Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.
+	// To define a custom pull secret and learn about the expected behavior, see Configure customPullSecret
+	// (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring/dto-config-options-k8s#custompullsecret).
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Custom PullSecret",order=8,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:Secret"}
+	CustomPullSecret string `json:"customPullSecret,omitempty"`
+
+	// When enabled, and if Istio is installed on the Kubernetes environment, Dynatrace Operator will create the corresponding
+	// VirtualService and ServiceEntry objects to allow access to the Dynatrace Cluster from the OneAgent or ActiveGate.
+	// Disabled by default.
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Istio automatic management",order=9,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	EnableIstio bool `json:"enableIstio,omitempty"`
 
-	// Optional: set a namespace selector to limit which namespaces are monitored
-	// By default, all namespaces will be monitored
-	// Has no effect during classicFullStack and hostMonitoring mode
+	// Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
+	// For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring/dto-config-options-k8s#annotate).
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Namespace Selector",order=17,xDescriptors="urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Namespace"
 	NamespaceSelector metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 
-	// General configuration about OneAgent instances
+	// General configuration about OneAgent instances.
+	// You can't enable more than one module (classicFullStack, cloudNativeFullStack, hostMonitoring, or applicationMonitoring).
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OneAgent",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	OneAgent OneAgentSpec `json:"oneAgent,omitempty"`
 
-	// General configuration about ActiveGate instances
+	// General configuration about ActiveGate instances.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ActiveGate",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	ActiveGate ActiveGateSpec `json:"activeGate,omitempty"`
 
-	//  Deprecated: Configuration for Routing
+	// Configuration for Routing
+	// +kubebuilder:deprecatedversion:warning="Deprecated property"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Routing"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	Routing RoutingSpec `json:"routing,omitempty"`
 
-	//  Deprecated: Configuration for Kubernetes Monitoring
+	// Configuration for Kubernetes Monitoring
+	// +kubebuilder:deprecatedversion:warning="Deprecated property"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Kubernetes Monitoring"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:text"

--- a/src/api/v1beta1/oneagent_types.go
+++ b/src/api/v1beta1/oneagent_types.go
@@ -7,25 +7,26 @@ import (
 type OneAgentMode string
 
 type OneAgentSpec struct {
-	// Optional: enable classic fullstack monitoring and change its settings
-	// Cannot be used in conjunction with cloud-native fullstack monitoring, application monitoring or host monitoring
+	// Has a single OneAgent per node via DaemonSet.
+	// Injection is performed via the same OneAgent DaemonSet.
 	// +nullable
 	ClassicFullStack *HostInjectSpec `json:"classicFullStack,omitempty"`
 
-	// Optional: enable application-only monitoring and change its settings
-	// Cannot be used in conjunction with cloud-native fullstack monitoring, classic fullstack monitoring or host monitoring
+	// Has a single OneAgent per node via DaemonSet.
+	// dynatrace-webhook injects into application pods based on labeled namespaces.
+	// Has a CSI driver per node via DaemonSet to provide binaries to pods.
+	// +nullable
+	CloudNativeFullStack *CloudNativeFullStackSpec `json:"cloudNativeFullStack,omitempty"`
+
+	// dynatrace-webhook injects into application pods based on labeled namespaces.
+	// Has an optional CSI driver per node via DaemonSet to provide binaries to pods.
 	// +nullable
 	ApplicationMonitoring *ApplicationMonitoringSpec `json:"applicationMonitoring,omitempty"`
 
-	// Optional: enable host monitoring and change its settings
-	// Cannot be used in conjunction with cloud-native fullstack monitoring, classic fullstack monitoring or application monitoring
+	// Has a single OneAgent per node via DaemonSet.
+	// Doesn't inject into application pods.
 	// +nullable
 	HostMonitoring *HostInjectSpec `json:"hostMonitoring,omitempty"`
-
-	// Optional: enable cloud-native fullstack monitoring and change its settings
-	// Cannot be used in conjunction with classic fullstack monitoring, application monitoring or host monitoring
-	// +nullable
-	CloudNativeFullStack *CloudNativeFullStackSpec `json:"cloudNativeFullStack,omitempty"`
 }
 
 type CloudNativeFullStackSpec struct {
@@ -35,80 +36,96 @@ type CloudNativeFullStackSpec struct {
 
 type HostInjectSpec struct {
 
-	// Node selector to control the selection of nodes (optional)
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Node Selector",order=17,xDescriptors="urn:alm:descriptor:com.tectonic.ui:selector:Node"
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// The OneAgent version to be used.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OneAgent version",order=11,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	Version string `json:"version,omitempty"`
 
-	// Optional: If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-	// name. If not specified the setting will be removed from the DaemonSet.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Priority Class name",order=23,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:PriorityClass"}
-	PriorityClassName string `json:"priorityClassName,omitempty"`
+	// Use a custom OneAgent Docker image. Defaults to the image from the Dynatrace cluster.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=12,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	Image string `json:"image,omitempty"`
 
-	// Optional: set tolerations for the OneAgent pods
+	// Tolerations to include with the OneAgent DaemonSet. For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tolerations",order=18,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
-	// Optional: define resources requests and limits for single pods
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",order=20,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
-	OneAgentResources corev1.ResourceRequirements `json:"oneAgentResources,omitempty"`
+	// Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
+	// Enabled by default.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Automatically update Agent",order=13,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoUpdate *bool `json:"autoUpdate,omitempty"`
 
-	// Optional: Arguments to the OneAgent installer
+	// Set the DNS Policy for OneAgent pods. For details, see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="DNS Policy",order=24,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
+
+	// Add custom OneAgent annotations.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Annotations",order=27,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Your defined labels for OneAgent pods in order to structure workloads as desired.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Labels",order=26,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Set additional environment variables for the OneAgent pods.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OneAgent environment variable installer arguments",order=22,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:hidden"}
+	Env []corev1.EnvVar `json:"env,omitempty"`
+
+	// Set additional arguments to the OneAgent installer.
+	// For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
+	// For the list of limitations, see Limitations (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/docker/set-up-dynatrace-oneagent-as-docker-container#limitations).
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OneAgent installer arguments",order=21,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:hidden"}
 	// +listType=set
 	Args []string `json:"args,omitempty"`
 
-	// Optional: List of environment variables to set for the installer
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OneAgent environment variable installer arguments",order=22,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:hidden"}
-	Env []corev1.EnvVar `json:"env,omitempty"`
+	// Specify the node selector that controls on which nodes OneAgent will be deployed.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Node Selector",order=17,xDescriptors="urn:alm:descriptor:com.tectonic.ui:selector:Node"
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
-	// Optional: Enables automatic restarts of OneAgent pods in case a new version is available
-	// Defaults to true
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Automatically update Agent",order=13,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	AutoUpdate *bool `json:"autoUpdate,omitempty"`
+	// Assign a priority class to the OneAgent pods. By default, no class is set.
+	// For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Priority Class name",order=23,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:PriorityClass"}
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 
-	// Optional: Sets DNS Policy for the OneAgent pods
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="DNS Policy",order=24,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
-	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
-
-	// Optional: Adds additional annotations to the OneAgent pods
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Annotations",order=27,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
-	Annotations map[string]string `json:"annotations,omitempty"`
-
-	// Optional: Adds additional labels for the OneAgent pods
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Labels",order=26,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
-	Labels map[string]string `json:"labels,omitempty"`
-
-	// Optional: the Dynatrace installer container image
-	// Defaults to the registry on the tenant for both Kubernetes and for OpenShift
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",order=12,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
-	Image string `json:"image,omitempty"`
-
-	// Optional: If specified, indicates the OneAgent version to use
-	// Defaults to latest
-	// Example: {major.minor.release} - 1.200.0
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OneAgent version",order=11,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
-	Version string `json:"version,omitempty"`
+	// Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
+	// Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",order=20,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	OneAgentResources corev1.ResourceRequirements `json:"oneAgentResources,omitempty"`
 }
 
 type ApplicationMonitoringSpec struct {
 	AppInjectionSpec `json:",inline"`
 
-	// Optional: If specified, indicates the OneAgent version to use
-	// Defaults to latest
-	// Example: {major.minor.release} - 1.200.0
+	// The OneAgent version to be used.
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OneAgent version",order=11,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Version string `json:"version,omitempty"`
 
-	// Optional: If you want to use CSIDriver; disable if your cluster does not have 'nodes' to fall back to the volume approach.
+	// Set if you want to use the CSIDriver. Don't enable it if you do not have access to Kubernetes nodes or if you lack privileges.
+	// +optional
 	UseCSIDriver *bool `json:"useCSIDriver,omitempty"`
 }
 
 type AppInjectionSpec struct {
-	// Optional: define resources requests and limits for the initContainer
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",order=15,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
-	InitResources *corev1.ResourceRequirements `json:"initResources,omitempty"`
 
-	// Optional: the Dynatrace installer container image
+	// The OneAgent image that is used to inject into Pods.
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="CodeModulesImage",order=12,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	CodeModulesImage string `json:"codeModulesImage,omitempty"`
+
+	// Define resources requests and limits for the initContainer. For details, see Managing resources for containers
+	// (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",order=15,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	InitResources *corev1.ResourceRequirements `json:"initResources,omitempty"`
 }


### PR DESCRIPTION
## Description

- Update dynakube CRD descriptions to align with the [official documentation](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring/dto-parameters-k8s). 
- Replace "Optional:" and "Deprecated:" text with the respective Kubebuilder annotations `+optional` and `+kubebuilder:deprecatedversion:warning=""`.
- Add missing descriptions on all dynakube.status fields. 

## How can this be tested?

`kubectl explain dynakube.spec` and all subpaths
`kubectl explain dynakube.status` and all subpaths

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
