### PR TITLE
Update e2e tests for unconfigured codemodules scenarios

### DIFF
--- a/test/helpers/components/codemodules/codemodules.go
+++ b/test/helpers/components/codemodules/codemodules.go
@@ -1,0 +1,50 @@
+//go:build e2e
+
+package codemodules
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/shell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	RuxitAgentProcFile     = "ruxitagentproc.conf"
+	DaemonSetCSIdriverName = "dynatrace-oneagent-csi-driver"
+)
+
+func CheckRuxitAgentProcFileHasNoConnInfo(testDynakube dynatracev1beta1.DynaKube) features.Func {
+	return func(ctx context.Context, t *testing.T, e *envconf.Config) context.Context {
+		resources := e.Client().Resources()
+
+		var dk dynatracev1beta1.DynaKube
+		require.NoError(t, e.Client().Resources().Get(ctx, testDynakube.Name, testDynakube.Namespace, &dk))
+
+		err := daemonset.NewQuery(ctx, resources, client.ObjectKey{
+			Name:      DaemonSetCSIdriverName,
+			Namespace: testDynakube.Namespace,
+		}).ForEachPod(func(podItem corev1.Pod) {
+			// /data/codemodules/1.273.0.20230719-145632/agent/conf/ruxitagentproc.conf
+			dir := filepath.Join("/data", "codemodules", dk.CodeModulesVersion(), "agent", "conf", RuxitAgentProcFile)
+			readFileCommand := shell.ReadFile(dir)
+			result, err := pod.Exec(ctx, resources, podItem, "provisioner", readFileCommand...)
+			require.NoError(t, err)
+			assert.NotContains(t, result.StdOut.String(), "tenant")
+			assert.NotContains(t, result.StdOut.String(), "tenantToken")
+		})
+
+		require.NoError(t, err)
+		return ctx
+	}
+}

--- a/test/helpers/components/codemodules/codemodules.go
+++ b/test/helpers/components/codemodules/codemodules.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/csi"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/shell"
@@ -20,8 +21,7 @@ import (
 )
 
 const (
-	RuxitAgentProcFile     = "ruxitagentproc.conf"
-	DaemonSetCSIdriverName = "dynatrace-oneagent-csi-driver"
+	RuxitAgentProcFile = "ruxitagentproc.conf"
 )
 
 func CheckRuxitAgentProcFileHasNoConnInfo(testDynakube dynatracev1beta1.DynaKube) features.Func {
@@ -32,7 +32,7 @@ func CheckRuxitAgentProcFileHasNoConnInfo(testDynakube dynatracev1beta1.DynaKube
 		require.NoError(t, e.Client().Resources().Get(ctx, testDynakube.Name, testDynakube.Namespace, &dk))
 
 		err := daemonset.NewQuery(ctx, resources, client.ObjectKey{
-			Name:      DaemonSetCSIdriverName,
+			Name:      csi.DaemonSetName,
 			Namespace: testDynakube.Namespace,
 		}).ForEachPod(func(podItem corev1.Pod) {
 			// /data/codemodules/1.273.0.20230719-145632/agent/conf/ruxitagentproc.conf

--- a/test/scenarios/applicationmonitoring/read_only_csi_volume.go
+++ b/test/scenarios/applicationmonitoring/read_only_csi_volume.go
@@ -4,6 +4,7 @@ package applicationmonitoring
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
@@ -12,6 +13,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/src/webhook"
 	"github.com/Dynatrace/dynatrace-operator/src/webhook/mutation/pod_mutator/oneagent_mutation"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/codemodules"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
@@ -28,8 +30,6 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
-
-const ruxitAgentProcFile = "ruxitagentproc.conf"
 
 var readOnlyInjection = map[string]string{dynatracev1beta1.AnnotationFeatureReadOnlyCsiVolume: "true"}
 
@@ -50,6 +50,7 @@ func readOnlyCSIVolume(t *testing.T) features.Feature {
 	builder.Assess("install sample deployment and wait till ready", sampleDeployment.Install())
 	builder.Assess("check init container env var", checkInitContainerEnvVar(sampleDeployment))
 	builder.Assess("check mounted volumes", checkMountedVolumes(sampleDeployment))
+	builder.Assess(fmt.Sprintf("check %s has no conn info", codemodules.RuxitAgentProcFile), codemodules.CheckRuxitAgentProcFileHasNoConnInfo(testDynakube))
 
 	builder.WithTeardown("removing sample namespace", sampleDeployment.UninstallNamespace())
 
@@ -87,7 +88,7 @@ func checkMountedVolumes(sampleApp sample.App) features.Func {
 			result, err := pod.Exec(ctx, resources, podItem, sampleApp.Namespace().Name, listCommand...)
 
 			require.NoError(t, err)
-			assert.Contains(t, result.StdOut.String(), ruxitAgentProcFile)
+			assert.Contains(t, result.StdOut.String(), codemodules.RuxitAgentProcFile)
 		})
 		require.NoError(t, err)
 		return ctx

--- a/test/scenarios/cloudnative/basic/install.go
+++ b/test/scenarios/cloudnative/basic/install.go
@@ -3,8 +3,10 @@
 package basic
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/codemodules"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
@@ -58,6 +60,8 @@ func Install(t *testing.T, istioEnabled bool) features.Feature {
 	if istioEnabled {
 		istio.AssessIstio(builder, testDynakube, sampleApp)
 	}
+
+	builder.Assess(fmt.Sprintf("check %s has no conn info", codemodules.RuxitAgentProcFile), codemodules.CheckRuxitAgentProcFileHasNoConnInfo(testDynakube))
 
 	// Register sample, dynakube and operator uninstall
 	builder.Teardown(sampleApp.UninstallNamespace())

--- a/test/scenarios/cloudnative/codemodules/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules/codemodules.go
@@ -109,6 +109,7 @@ func CodeModules(t *testing.T, istioEnabled bool) features.Feature {
 	if istioEnabled {
 		istio.AssessIstio(builder, cloudNativeDynakube, sampleApp)
 	}
+
 	builder.Assess("codemodules have been downloaded", imageHasBeenDownloaded(cloudNativeDynakube.Namespace))
 	builder.Assess("checking storage used", measureDiskUsage(appDynakube.Namespace, storageMap))
 	assess.InstallDynakube(builder, &secretConfigs[1], appDynakube)


### PR DESCRIPTION
## Description

Please include the following:

This PR updates e2e test with new check.

## How can this be tested?

```
make test/e2e/cloudnative
make test/e2e/applicationmonitoring
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
