### PR TITLE
Clean up better in switchmode e2e tests

### DIFF
--- a/test/helpers/steps/assess/dynakube.go
+++ b/test/helpers/steps/assess/dynakube.go
@@ -37,6 +37,13 @@ func UpdateDynakube(builder *features.FeatureBuilder, testDynakube dynatracev1be
 	builder.Assess("dynakube updated", dynakube.Update(testDynakube))
 }
 
+func DeleteDynakube(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {
+	builder.Assess("dynakube deleted", dynakube.Delete(testDynakube))
+	if testDynakube.NeedsOneAgent() {
+		builder.Assess("oneagent pods stopped", oneagent.WaitForDaemonSetPodsDeletion(testDynakube))
+	}
+}
+
 func verifyDynakubeStartup(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {
 	if testDynakube.NeedsOneAgent() {
 		builder.Assess("oneagent started", oneagent.WaitForDaemonset(testDynakube))

--- a/test/helpers/steps/assess/operator.go
+++ b/test/helpers/steps/assess/operator.go
@@ -5,6 +5,7 @@ package assess
 import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/csi"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/webhook"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
@@ -27,6 +28,13 @@ func InstallOperatorFromRelease(builder *features.FeatureBuilder, testDynakube d
 	builder.Assess("create operator namespace", namespace.Create(namespace.NewBuilder(testDynakube.Namespace).Build()))
 	builder.Assess("operator manifests installed", operator.InstallViaHelm(releaseTag, testDynakube.NeedsCSIDriver(), "dynatrace"))
 	verifyOperatorDeployment(builder, testDynakube)
+}
+
+
+func AddClassicCleanUp(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {
+	builder.Assess("clean up OneAgent files from nodes", oneagent.CreateUninstallDaemonSet(testDynakube))
+	builder.Assess("wait for daemonset", oneagent.WaitForUninstallOneAgentDaemonset(testDynakube.Namespace))
+	builder.Assess("OneAgent files removed from nodes", oneagent.CleanUpEachNode(testDynakube.Namespace))
 }
 
 func verifyOperatorDeployment(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {

--- a/test/helpers/steps/assess/operator.go
+++ b/test/helpers/steps/assess/operator.go
@@ -30,7 +30,6 @@ func InstallOperatorFromRelease(builder *features.FeatureBuilder, testDynakube d
 	verifyOperatorDeployment(builder, testDynakube)
 }
 
-
 func AddClassicCleanUp(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {
 	builder.Assess("clean up OneAgent files from nodes", oneagent.CreateUninstallDaemonSet(testDynakube))
 	builder.Assess("wait for daemonset", oneagent.WaitForUninstallOneAgentDaemonset(testDynakube.Namespace))

--- a/test/helpers/steps/teardown/uninstall.go
+++ b/test/helpers/steps/teardown/uninstall.go
@@ -14,5 +14,5 @@ func UninstallManifest(builder *features.FeatureBuilder, deploymentPath string) 
 
 func UninstallDynatrace(builder *features.FeatureBuilder, testDynakube dynatracev1beta1.DynaKube) {
 	DeleteDynakube(builder, testDynakube)
-	UninstallOperatorFromSource(builder, testDynakube)
+	UninstallOperator(builder, testDynakube)
 }

--- a/test/scenarios/activegate/installation.go
+++ b/test/scenarios/activegate/installation.go
@@ -80,7 +80,7 @@ func Install(t *testing.T, proxySpec *dynatracev1beta1.DynaKubeProxy) features.F
 
 	// Register operator + dynakube uninstall
 	teardown.DeleteDynakube(builder, testDynakube)
-	teardown.UninstallOperatorFromSource(builder, testDynakube)
+	teardown.UninstallOperator(builder, testDynakube)
 
 	return builder.Feature()
 }

--- a/test/scenarios/applicationmonitoring/labelversiondetection.go
+++ b/test/scenarios/applicationmonitoring/labelversiondetection.go
@@ -144,7 +144,7 @@ func labelVersionDetection(t *testing.T) features.Feature {
 	checkBuildLabels(builder, sampleApps)
 	teardownSampleApplications(builder, sampleApps)
 	// Register operator uninstall
-	teardown.UninstallOperatorFromSource(builder, labelVersionDynakube)
+	teardown.UninstallOperator(builder, labelVersionDynakube)
 
 	return builder.Feature()
 }

--- a/test/scenarios/applicationmonitoring/without_csi.go
+++ b/test/scenarios/applicationmonitoring/without_csi.go
@@ -82,7 +82,7 @@ func withoutCSIDriver(t *testing.T) features.Feature {
 	builder.Assess("check injection of pods with random user", checkInjection(randomUserSample))
 
 	builder.Teardown(sampleApp.UninstallNamespace())
-	teardown.UninstallOperatorFromSource(builder, appOnlyDynakube)
+	teardown.UninstallOperator(builder, appOnlyDynakube)
 	return builder.Feature()
 }
 

--- a/test/scenarios/cloudnative/switch_modes/install.go
+++ b/test/scenarios/cloudnative/switch_modes/install.go
@@ -55,7 +55,10 @@ func Install(t *testing.T, name string) features.Feature {
 	// tear down
 	featureBuilder.Teardown(sampleAppCloudNative.Uninstall())
 	featureBuilder.Teardown(sampleAppClassicFullStack.Uninstall())
-	teardown.UninstallDynatrace(featureBuilder, dynakubeCloudNative)
+	teardown.DeleteDynakube(featureBuilder, dynakubeCloudNative)
+	teardown.AddCsiCleanUp(featureBuilder, dynakubeCloudNative)
+	teardown.AddClassicCleanUp(featureBuilder, dynakubeClassicFullStack)
+	teardown.UninstallOperatorFromSource(featureBuilder, dynakubeCloudNative)
 
 	return featureBuilder.Feature()
 }


### PR DESCRIPTION
## Description

We currently have the problem that the switchmode e2e test cases mess with the outcome of other tests ran after them.
In the switchmode e2e test cases we have to be extra careful when it comes to clean up.
As we are using both classic and cloudnative we have to clean up:
- the csi driver's filesystem due to the cloudnative part
    - not doing this might cause unpredictable behaviour in tests coming after this one 
- the run the uninstall.sh because of the classic part
   - this is extra important on CRIO (so mainly openshift) because not running the uninstall.sh here will cause other tests just to fail straight out.


Sidenote: The current "helpers" for generalizing the steps were not really designed for this, so I had to do some quick modifications there, but now they feel a bit like "abstraction for the sake of abstraction" which I am not a fan of.
So we should probably rethink them in a follow up, to be more explicit in each test.

## How can this be tested?
run (⚠️ on Openshift aswell)
 `make test/e2e/cloudnative/switchmodes`
 ` make test/e2e/classic/switchmodes`

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
