### PR TITLE
Name envConfig *envconf.Config in similar manner in all occurencies

### DIFF
--- a/test/helpers/components/activegate/installation.go
+++ b/test/helpers/components/activegate/installation.go
@@ -30,8 +30,8 @@ func GetActiveGatePodName(testDynakube *dynatracev1beta1.DynaKube, component str
 	return fmt.Sprintf("%s-0", GetActiveGateStateFulSetName(testDynakube, component))
 }
 
-func ReadActiveGateLog(ctx context.Context, t *testing.T, environmentConfig *envconf.Config, testDynakube *dynatracev1beta1.DynaKube, component string) string {
-	return logs.ReadLog(ctx, t, environmentConfig, testDynakube.Namespace, GetActiveGatePodName(testDynakube, component), consts.ActiveGateContainerName)
+func ReadActiveGateLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, testDynakube *dynatracev1beta1.DynaKube, component string) string {
+	return logs.ReadLog(ctx, t, envConfig, testDynakube.Namespace, GetActiveGatePodName(testDynakube, component), consts.ActiveGateContainerName)
 }
 
 func Get(ctx context.Context, resource *resources.Resources, dynakube dynatracev1beta1.DynaKube) (appsv1.StatefulSet, error) {

--- a/test/helpers/components/csi/daemonset.go
+++ b/test/helpers/components/csi/daemonset.go
@@ -30,8 +30,8 @@ func Get(ctx context.Context, resource *resources.Resources, namespace string) (
 }
 
 func CleanUpEachPod(namespace string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resource := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resource := envConfig.Client().Resources()
 		require.NoError(t, daemonset.NewQuery(ctx, resource, client.ObjectKey{
 			Name:      DaemonSetName,
 			Namespace: namespace,

--- a/test/helpers/components/dynakube/dynakube.go
+++ b/test/helpers/components/dynakube/dynakube.go
@@ -162,27 +162,27 @@ func (dynakubeBuilder Builder) Build() dynatracev1beta1.DynaKube {
 }
 
 func Create(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		require.NoError(t, dynatracev1beta1.AddToScheme(environmentConfig.Client().Resources().GetScheme()))
-		require.NoError(t, environmentConfig.Client().Resources().Create(ctx, &dynakube))
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		require.NoError(t, dynatracev1beta1.AddToScheme(envConfig.Client().Resources().GetScheme()))
+		require.NoError(t, envConfig.Client().Resources().Create(ctx, &dynakube))
 		return ctx
 	}
 }
 
 func Update(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		require.NoError(t, dynatracev1beta1.AddToScheme(environmentConfig.Client().Resources().GetScheme()))
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		require.NoError(t, dynatracev1beta1.AddToScheme(envConfig.Client().Resources().GetScheme()))
 		var dk dynatracev1beta1.DynaKube
-		require.NoError(t, environmentConfig.Client().Resources().Get(ctx, dynakube.Name, dynakube.Namespace, &dk))
+		require.NoError(t, envConfig.Client().Resources().Get(ctx, dynakube.Name, dynakube.Namespace, &dk))
 		dynakube.ResourceVersion = dk.ResourceVersion
-		require.NoError(t, environmentConfig.Client().Resources().Update(ctx, &dynakube))
+		require.NoError(t, envConfig.Client().Resources().Update(ctx, &dynakube))
 		return ctx
 	}
 }
 
 func Delete(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 
 		err := dynatracev1beta1.AddToScheme(resources.GetScheme())
 		require.NoError(t, err)
@@ -205,8 +205,8 @@ func Delete(dynakube dynatracev1beta1.DynaKube) features.Func {
 }
 
 func WaitForDynakubePhase(dynakube dynatracev1beta1.DynaKube, phase dynatracev1beta1.DynaKubePhaseType) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 
 		err := wait.For(conditions.New(resources).ResourceMatch(&dynakube, func(object k8s.Object) bool {
 			dynakube, isDynakube := object.(*dynatracev1beta1.DynaKube)

--- a/test/helpers/components/oneagent/daemonset.go
+++ b/test/helpers/components/oneagent/daemonset.go
@@ -46,11 +46,11 @@ func Get(ctx context.Context, resource *resources.Resources, dynakube dynatracev
 }
 
 func CreateUninstallDaemonSet(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		uninstallDaemonSet := manifests.ObjectFromFile[*appsv1.DaemonSet](t, uninstallOneAgentDaemonSetPath)
 		uninstallDaemonSet.Namespace = dynakube.Namespace
 		uninstallDaemonSet.Spec.Template.Spec.Tolerations = dynakube.Spec.OneAgent.ClassicFullStack.Tolerations
-		resource := environmentConfig.Client().Resources()
+		resource := envConfig.Client().Resources()
 		require.NoError(t, resource.Create(ctx, uninstallDaemonSet))
 		return ctx
 	}
@@ -61,8 +61,8 @@ func WaitForUninstallOneAgentDaemonset(namespace string) features.Func {
 }
 
 func CleanUpEachNode(namespace string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resource := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resource := envConfig.Client().Resources()
 		require.NoError(t, daemonset.NewQuery(ctx, resource, client.ObjectKey{
 			Name:      uninstallOneAgentDaemonSetName,
 			Namespace: namespace,

--- a/test/helpers/components/operator/installation.go
+++ b/test/helpers/components/operator/installation.go
@@ -21,7 +21,7 @@ const (
 )
 
 func InstallViaMake(withCSI bool) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		rootDir := project.RootDir()
 		execMakeCommand(t, rootDir, "install", fmt.Sprintf("ENABLE_CSI=%t", withCSI))
 		return ctx
@@ -29,14 +29,14 @@ func InstallViaMake(withCSI bool) features.Func {
 }
 
 func InstallViaHelm(releaseTag string, withCsi bool, namespace string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		installViaHelm(t, releaseTag, withCsi, namespace)
 		return ctx
 	}
 }
 
 func UninstallViaMake(withCSI bool) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		rootDir := project.RootDir()
 		execMakeCommand(t, rootDir, "undeploy/helm", fmt.Sprintf("ENABLE_CSI=%t", withCSI))
 		return ctx

--- a/test/helpers/istio/install.go
+++ b/test/helpers/istio/install.go
@@ -47,24 +47,24 @@ func enforceIstio() bool {
 	return os.Getenv(enforceIstioEnv) == "true"
 }
 
-func AddIstioNetworkAttachment(namespace corev1.Namespace) func(ctx context.Context, environmentConfig *envconf.Config, t *testing.T) (context.Context, error) {
-	return func(ctx context.Context, environmentConfig *envconf.Config, t *testing.T) (context.Context, error) {
+func AddIstioNetworkAttachment(namespace corev1.Namespace) func(ctx context.Context, envConfig *envconf.Config, t *testing.T) (context.Context, error) {
+	return func(ctx context.Context, envConfig *envconf.Config, t *testing.T) (context.Context, error) {
 		if !platform.NewResolver().IsOpenshift(t) {
 			return ctx, nil
 		}
 		for key, value := range InjectionLabel {
 			if namespace.Labels[key] == value {
-				ctx = manifests.InstallFromFile(networkAttachmentPath, decoder.MutateNamespace(namespace.Name))(ctx, t, environmentConfig)
+				ctx = manifests.InstallFromFile(networkAttachmentPath, decoder.MutateNamespace(namespace.Name))(ctx, t, envConfig)
 			}
 		}
 		return ctx, nil
 	}
 }
 
-func AssertIstioNamespace() func(ctx context.Context, environmentConfig *envconf.Config, t *testing.T) (context.Context, error) {
-	return func(ctx context.Context, environmentConfig *envconf.Config, t *testing.T) (context.Context, error) {
+func AssertIstioNamespace() func(ctx context.Context, envConfig *envconf.Config, t *testing.T) (context.Context, error) {
+	return func(ctx context.Context, envConfig *envconf.Config, t *testing.T) (context.Context, error) {
 		var namespace corev1.Namespace
-		err := environmentConfig.Client().Resources().Get(ctx, istioNamespace, "", &namespace)
+		err := envConfig.Client().Resources().Get(ctx, istioNamespace, "", &namespace)
 		if err != nil && !enforceIstio() {
 			t.Skip("skipping istio test, istio namespace is not present")
 			return ctx, nil
@@ -73,10 +73,10 @@ func AssertIstioNamespace() func(ctx context.Context, environmentConfig *envconf
 	}
 }
 
-func AssertIstiodDeployment() func(ctx context.Context, environmentConfig *envconf.Config, t *testing.T) (context.Context, error) {
-	return func(ctx context.Context, environmentConfig *envconf.Config, t *testing.T) (context.Context, error) {
+func AssertIstiodDeployment() func(ctx context.Context, envConfig *envconf.Config, t *testing.T) (context.Context, error) {
+	return func(ctx context.Context, envConfig *envconf.Config, t *testing.T) (context.Context, error) {
 		var deployment appsv1.Deployment
-		err := environmentConfig.Client().Resources().Get(ctx, "istiod", "istio-system", &deployment)
+		err := envConfig.Client().Resources().Get(ctx, "istiod", "istio-system", &deployment)
 		if err != nil && !enforceIstio() {
 			t.Skip("skipping istio test, istiod deployment is not present")
 			return ctx, nil
@@ -93,8 +93,8 @@ func AssessIstio(builder *features.FeatureBuilder, testDynakube dynatracev1beta1
 }
 
 func checkSampleAppIstioInitContainers(sampleApp base.App, testDynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		pods := sampleApp.GetPods(ctx, t, resources)
 		assertIstioInitContainer(t, pods, testDynakube)
 		return ctx
@@ -102,8 +102,8 @@ func checkSampleAppIstioInitContainers(sampleApp base.App, testDynakube dynatrac
 }
 
 func checkOperatorIstioInitContainers(testDynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		var pods corev1.PodList
 		require.NoError(t, resources.WithNamespace(testDynakube.Namespace).List(ctx, &pods))
 
@@ -150,11 +150,11 @@ func determineIstioInitContainerName(t *testing.T) string {
 }
 
 func checkVirtualServiceForApiUrl(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		apiHost := apiUrlCommunicationHost(t)
 		serviceName := istio.BuildNameForEndpoint(dynakube.Name, []dtclient.CommunicationHost{apiHost})
 
-		virtualService, err := istioClient(t, environmentConfig.Client().RESTConfig()).NetworkingV1alpha3().VirtualServices(dynakube.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		virtualService, err := istioClient(t, envConfig.Client().RESTConfig()).NetworkingV1alpha3().VirtualServices(dynakube.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
 		require.Nil(t, err, "istio: failed to get '%s' virtual service object", serviceName)
 
 		require.NotEmpty(t, virtualService.ObjectMeta.OwnerReferences)
@@ -168,11 +168,11 @@ func checkVirtualServiceForApiUrl(dynakube dynatracev1beta1.DynaKube) features.F
 }
 
 func checkServiceEntryForApiUrl(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		apiHost := apiUrlCommunicationHost(t)
 		serviceName := istio.BuildNameForEndpoint(dynakube.Name, []dtclient.CommunicationHost{apiHost})
 
-		serviceEntry, err := istioClient(t, environmentConfig.Client().RESTConfig()).NetworkingV1alpha3().ServiceEntries(dynakube.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		serviceEntry, err := istioClient(t, envConfig.Client().RESTConfig()).NetworkingV1alpha3().ServiceEntries(dynakube.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
 		require.Nil(t, err, "istio: failed to get '%s' service entry object", serviceName)
 
 		require.NotEmpty(t, serviceEntry.ObjectMeta.OwnerReferences)

--- a/test/helpers/kubeobjects/daemonset/wait.go
+++ b/test/helpers/kubeobjects/daemonset/wait.go
@@ -17,8 +17,8 @@ import (
 )
 
 func WaitFor(name string, namespace string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		err := wait.For(conditions.New(resources).ResourceMatch(&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/test/helpers/kubeobjects/deployment/wait.go
+++ b/test/helpers/kubeobjects/deployment/wait.go
@@ -18,8 +18,8 @@ import (
 )
 
 func WaitFor(name string, namespace string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		deployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/test/helpers/kubeobjects/manifests/installation.go
+++ b/test/helpers/kubeobjects/manifests/installation.go
@@ -21,12 +21,12 @@ import (
 )
 
 func InstallFromFile(path string, options ...decoder.DecodeOption) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		kubernetesManifest, err := os.Open(path)
 		defer func() { require.NoError(t, kubernetesManifest.Close()) }()
 		require.NoError(t, err)
 
-		resources := environmentConfig.Client().Resources()
+		resources := envConfig.Client().Resources()
 		require.NoError(t, decoder.DecodeEach(ctx, kubernetesManifest, decoder.IgnoreErrorHandler(decoder.CreateHandler(resources), k8serrors.IsAlreadyExists), options...))
 
 		return ctx
@@ -34,12 +34,12 @@ func InstallFromFile(path string, options ...decoder.DecodeOption) features.Func
 }
 
 func UninstallFromFile(path string, options ...decoder.DecodeOption) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		kubernetesManifest, err := os.Open(path)
 		defer func() { require.NoError(t, kubernetesManifest.Close()) }()
 		require.NoError(t, err)
 
-		resources := environmentConfig.Client().Resources()
+		resources := envConfig.Client().Resources()
 		require.NoError(t, decoder.DecodeEach(ctx, kubernetesManifest, decoder.IgnoreErrorHandler(decoder.DeleteHandler(resources), k8serrors.IsNotFound), options...))
 
 		return ctx
@@ -47,9 +47,9 @@ func UninstallFromFile(path string, options ...decoder.DecodeOption) features.Fu
 }
 
 func InstallFromUrls(yamlUrls []string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		for _, yamlUrl := range yamlUrls {
-			installFromSingleUrl(t, ctx, environmentConfig, yamlUrl)
+			installFromSingleUrl(t, ctx, envConfig, yamlUrl)
 		}
 
 		return ctx
@@ -57,28 +57,28 @@ func InstallFromUrls(yamlUrls []string) features.Func {
 }
 
 func UninstallFromUrls(yamlUrls []string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		for _, yamlUrl := range yamlUrls {
-			uninstallFromSingleUrl(t, ctx, environmentConfig, yamlUrl)
+			uninstallFromSingleUrl(t, ctx, envConfig, yamlUrl)
 		}
 
 		return ctx
 	}
 }
 
-func installFromSingleUrl(t *testing.T, ctx context.Context, environmentConfig *envconf.Config, yamlUrl string) {
+func installFromSingleUrl(t *testing.T, ctx context.Context, envConfig *envconf.Config, yamlUrl string) {
 	manifestReader, err := httpGetResponseReader(yamlUrl)
 	require.NoError(t, err, "could not fetch yaml")
 
-	resources := environmentConfig.Client().Resources()
+	resources := envConfig.Client().Resources()
 	require.NoError(t, decoder.DecodeEach(ctx, manifestReader, decoder.IgnoreErrorHandler(decoder.CreateHandler(resources), k8serrors.IsAlreadyExists)))
 }
 
-func uninstallFromSingleUrl(t *testing.T, ctx context.Context, environmentConfig *envconf.Config, yamlUrl string) {
+func uninstallFromSingleUrl(t *testing.T, ctx context.Context, envConfig *envconf.Config, yamlUrl string) {
 	manifestReader, err := httpGetResponseReader(yamlUrl)
 	require.NoError(t, err, "could not fetch yaml")
 
-	resources := environmentConfig.Client().Resources()
+	resources := envConfig.Client().Resources()
 	require.NoError(t, decoder.DecodeEach(ctx, manifestReader, decoder.IgnoreErrorHandler(decoder.DeleteHandler(resources), k8serrors.IsNotFound)))
 }
 

--- a/test/helpers/kubeobjects/namespace/namespace.go
+++ b/test/helpers/kubeobjects/namespace/namespace.go
@@ -47,14 +47,14 @@ func (namespaceBuilder Builder) Build() corev1.Namespace {
 }
 
 func Delete(namespaceName string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		namespace := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespaceName,
 			},
 		}
 
-		err := environmentConfig.Client().Resources().Delete(ctx, &namespace, func(options *metav1.DeleteOptions) {
+		err := envConfig.Client().Resources().Delete(ctx, &namespace, func(options *metav1.DeleteOptions) {
 			options.GracePeriodSeconds = address.Of[int64](0)
 		})
 
@@ -66,7 +66,7 @@ func Delete(namespaceName string) features.Func {
 			return ctx
 		}
 
-		resources := environmentConfig.Client().Resources()
+		resources := envConfig.Client().Resources()
 		err = wait.For(conditions.New(resources).ResourceDeleted(&namespace))
 		require.NoError(t, err)
 
@@ -75,8 +75,8 @@ func Delete(namespaceName string) features.Func {
 }
 
 func Create(namespace corev1.Namespace) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		err := environmentConfig.Client().Resources().Create(ctx, &namespace)
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		err := envConfig.Client().Resources().Create(ctx, &namespace)
 		if err != nil {
 			if k8serrors.IsAlreadyExists(err) {
 				err = nil
@@ -84,7 +84,7 @@ func Create(namespace corev1.Namespace) features.Func {
 			require.NoError(t, err)
 		}
 
-		ctx, _ = istio.AddIstioNetworkAttachment(namespace)(ctx, environmentConfig, t)
+		ctx, _ = istio.AddIstioNetworkAttachment(namespace)(ctx, envConfig, t)
 		return ctx
 	}
 }

--- a/test/helpers/kubeobjects/pod/wait.go
+++ b/test/helpers/kubeobjects/pod/wait.go
@@ -20,8 +20,8 @@ import (
 type ConditionFunction func(object k8s.Object) bool
 
 func WaitForCondition(name string, namespace string, conditionFunction ConditionFunction, timeout time.Duration) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 
 		err := wait.For(conditions.New(resources).ResourceMatch(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -44,8 +44,8 @@ func WaitFor(name string, namespace string) features.Func {
 }
 
 func WaitForPodsDeletionWithOwner(ownerName string, namespace string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		targetPods := GetPodsForOwner(ctx, t, resources, ownerName, namespace)
 
 		err := wait.For(conditions.New(resources).ResourcesDeleted(&targetPods))
@@ -55,8 +55,8 @@ func WaitForPodsDeletionWithOwner(ownerName string, namespace string) features.F
 }
 
 func WaitForPodsWithOwner(ownerName string, namespace string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		targetPods := GetPodsForOwner(ctx, t, resources, ownerName, namespace)
 		for _, pod := range targetPods.Items {
 			podCopy := pod

--- a/test/helpers/kubeobjects/statefulset/wait.go
+++ b/test/helpers/kubeobjects/statefulset/wait.go
@@ -18,8 +18,8 @@ import (
 )
 
 func WaitFor(name string, namespace string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		err := wait.For(conditions.New(resources).ResourceMatch(&appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/test/helpers/logs/logs.go
+++ b/test/helpers/logs/logs.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-func ReadLog(ctx context.Context, t *testing.T, environmentConfig *envconf.Config, namespace, podName, containerName string) string { //nolint:revive
-	resources := environmentConfig.Client().Resources()
+func ReadLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, namespace, podName, containerName string) string { //nolint:revive
+	resources := envConfig.Client().Resources()
 
 	var pod corev1.Pod
 	require.NoError(t, resources.WithNamespace(namespace).Get(ctx, podName, namespace, &pod))

--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -55,8 +55,8 @@ func installProxySCC(builder *features.FeatureBuilder, t *testing.T) {
 }
 
 func DeleteProxy() features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		return namespace.Delete(proxyNamespaceName)(ctx, t, environmentConfig)
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		return namespace.Delete(proxyNamespaceName)(ctx, t, envConfig)
 	}
 }
 

--- a/test/helpers/sampleapps/base/sampleapp.go
+++ b/test/helpers/sampleapps/base/sampleapp.go
@@ -28,8 +28,8 @@ type App interface {
 
 	Install() features.Func
 	Uninstall() features.Func
-	Restart(ctx context.Context, t *testing.T, config *envconf.Config) context.Context
-	RestartHalf(ctx context.Context, t *testing.T, config *envconf.Config) context.Context
+	Restart(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context
+	RestartHalf(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context
 	InstallNamespace() features.Func
 	UninstallNamespace() features.Func
 

--- a/test/helpers/sampleapps/curl.go
+++ b/test/helpers/sampleapps/curl.go
@@ -40,23 +40,23 @@ const (
 )
 
 func InstallActiveGateCurlPod(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		serviceUrl := getActiveGateServiceUrl(dynakube)
 		curlTarget := fmt.Sprintf("%s/%s", serviceUrl, activeGateEndpoint)
 
 		curlPod := NewCurlPodBuilder(CurlPodNameActivegateHttps, curlNamespace(dynakube), curlTarget).WithProxy(dynakube).Build()
-		require.NoError(t, environmentConfig.Client().Resources().Create(ctx, curlPod))
+		require.NoError(t, envConfig.Client().Resources().Create(ctx, curlPod))
 		return ctx
 	}
 }
 
 func InstallActiveGateHttpCurlPod(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		serviceUrl := getActiveGateHttpServiceUrl(dynakube)
 		curlTarget := fmt.Sprintf("%s/%s", serviceUrl, activeGateEndpoint)
 
 		curlPod := NewCurlPodBuilder(CurlPodNameActivegateHttp, curlNamespace(dynakube), curlTarget).WithProxy(dynakube).Build()
-		require.NoError(t, environmentConfig.Client().Resources().Create(ctx, curlPod))
+		require.NoError(t, envConfig.Client().Resources().Create(ctx, curlPod))
 		return ctx
 	}
 }
@@ -66,8 +66,8 @@ func WaitForActiveGateCurlPod(podName string, dynakube dynatracev1beta1.DynaKube
 }
 
 func CheckActiveGateCurlResult(podName string, dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 
 		logStream := getCurlPodLogStream(ctx, t, resources, podName, curlNamespace(dynakube))
 		logs.AssertContains(t, logStream, "RUNNING")
@@ -111,10 +111,10 @@ func getCurlPodLogStream(ctx context.Context, t *testing.T, resources *resources
 }
 
 func InstallCutOffCurlPod(podName, namespaceName, curlTarget string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		// if curl command can't connect to the host, returns 28 after 131[s] by default
 		curlPod := NewCurlPodBuilder(podName, namespaceName, curlTarget).WithRestartPolicy(corev1.RestartPolicyNever).WithParameters("--connect-timeout", strconv.Itoa(connectionTimeout)).Build()
-		require.NoError(t, environmentConfig.Client().Resources().Create(ctx, curlPod))
+		require.NoError(t, envConfig.Client().Resources().Create(ctx, curlPod))
 		return ctx
 	}
 }

--- a/test/helpers/sampleapps/deployment.go
+++ b/test/helpers/sampleapps/deployment.go
@@ -87,16 +87,16 @@ func (app SampleDeployment) GetPods(ctx context.Context, t *testing.T, resource 
 	return pod.GetPodsForOwner(ctx, t, resource, replicaset.Name, app.Namespace().Name)
 }
 
-func (app SampleDeployment) RestartHalf(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-	return app.doRestart(ctx, t, config, restartHalf)
+func (app SampleDeployment) RestartHalf(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+	return app.doRestart(ctx, t, envConfig, restartHalf)
 }
 
-func (app SampleDeployment) Restart(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-	return app.doRestart(ctx, t, config, restart)
+func (app SampleDeployment) Restart(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+	return app.doRestart(ctx, t, envConfig, restart)
 }
 
-func (app SampleDeployment) doRestart(ctx context.Context, t *testing.T, config *envconf.Config, restartFunc restartFunc) context.Context {
-	resource := config.Client().Resources()
+func (app SampleDeployment) doRestart(ctx context.Context, t *testing.T, envConfig *envconf.Config, restartFunc restartFunc) context.Context {
+	resource := envConfig.Client().Resources()
 	pods := app.GetPods(ctx, t, resource)
 
 	restartFunc(t, ctx, pods, resource)

--- a/test/helpers/sampleapps/pod.go
+++ b/test/helpers/sampleapps/pod.go
@@ -62,16 +62,16 @@ func (app SamplePod) GetPods(ctx context.Context, t *testing.T, resource *resour
 	return corev1.PodList{Items: []corev1.Pod{*pod}}
 }
 
-func (app SamplePod) RestartHalf(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-	return app.doRestart(ctx, t, config, restartHalf)
+func (app SamplePod) RestartHalf(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+	return app.doRestart(ctx, t, envConfig, restartHalf)
 }
 
-func (app SamplePod) Restart(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-	return app.doRestart(ctx, t, config, restart)
+func (app SamplePod) Restart(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+	return app.doRestart(ctx, t, envConfig, restart)
 }
 
-func (app SamplePod) doRestart(ctx context.Context, t *testing.T, config *envconf.Config, restartFunc restartFunc) context.Context {
-	resource := config.Client().Resources()
+func (app SamplePod) doRestart(ctx context.Context, t *testing.T, envConfig *envconf.Config, restartFunc restartFunc) context.Context {
+	resource := envConfig.Client().Resources()
 	restartFunc(t, ctx, app.GetPods(ctx, t, resource), resource)
 
 	pod := app.Build().(*corev1.Pod)

--- a/test/helpers/tenant/secrets.go
+++ b/test/helpers/tenant/secrets.go
@@ -80,7 +80,7 @@ func GetMultiTenantSecret(t *testing.T) []Secret {
 }
 
 func CreateTenantSecret(secretConfig Secret, dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		defaultSecret := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      dynakube.Name,
@@ -91,10 +91,10 @@ func CreateTenantSecret(secretConfig Secret, dynakube dynatracev1beta1.DynaKube)
 			},
 		}
 
-		err := environmentConfig.Client().Resources().Create(ctx, &defaultSecret)
+		err := envConfig.Client().Resources().Create(ctx, &defaultSecret)
 
 		if k8serrors.IsAlreadyExists(err) {
-			require.NoError(t, environmentConfig.Client().Resources().Update(ctx, &defaultSecret))
+			require.NoError(t, envConfig.Client().Resources().Update(ctx, &defaultSecret))
 			return ctx
 		}
 

--- a/test/scenarios/activegate/installation.go
+++ b/test/scenarios/activegate/installation.go
@@ -111,8 +111,8 @@ func assessActiveGateHttpEndpoint(builder *features.FeatureBuilder, testDynakube
 }
 
 func checkIfAgHasContainers(testDynakube *dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 
 		var activeGatePod corev1.Pod
 		require.NoError(t, resources.WithNamespace(testDynakube.Namespace).Get(ctx, activegate.GetActiveGatePodName(testDynakube, agComponentName), testDynakube.Namespace, &activeGatePod))
@@ -129,24 +129,24 @@ func checkIfAgHasContainers(testDynakube *dynatracev1beta1.DynaKube) features.Fu
 }
 
 func checkActiveModules(testDynakube *dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		log := activegate.ReadActiveGateLog(ctx, t, environmentConfig, testDynakube, agComponentName)
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		log := activegate.ReadActiveGateLog(ctx, t, envConfig, testDynakube, agComponentName)
 		assertExpectedModulesAreActive(t, log)
 		return ctx
 	}
 }
 
 func checkIfProxyUsed(testDynakube *dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		log := activegate.ReadActiveGateLog(ctx, t, environmentConfig, testDynakube, agComponentName)
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		log := activegate.ReadActiveGateLog(ctx, t, envConfig, testDynakube, agComponentName)
 		assertProxyUsed(t, log, testDynakube.Spec.Proxy.Value)
 		return ctx
 	}
 }
 
 func checkMountPoints(testDynakube *dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 
 		var activeGatePod corev1.Pod
 		require.NoError(t, resources.Get(ctx, activegate.GetActiveGatePodName(testDynakube, agComponentName), testDynakube.Namespace, &activeGatePod))
@@ -249,8 +249,8 @@ func assessReadOnlyActiveGate(builder *features.FeatureBuilder, testDynakube *dy
 }
 
 func checkReadOnlySettings(testDynakube *dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 
 		var activeGatePod corev1.Pod
 		require.NoError(t, resources.WithNamespace(testDynakube.Namespace).Get(ctx, activegate.GetActiveGatePodName(testDynakube, agComponentName), testDynakube.Namespace, &activeGatePod))

--- a/test/scenarios/applicationmonitoring/dataingest.go
+++ b/test/scenarios/applicationmonitoring/dataingest.go
@@ -78,11 +78,11 @@ func dataIngest(t *testing.T) features.Feature {
 }
 
 func podHasOnlyDataIngestInitContainer(samplePod sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		testPod := samplePod.Get(ctx, t, environmentConfig.Client().Resources()).(*corev1.Pod)
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		testPod := samplePod.Get(ctx, t, envConfig.Client().Resources()).(*corev1.Pod)
 
 		assessOnlyDataIngestIsInjected(t)(*testPod)
-		assessPodHasDataIngestFile(ctx, t, environmentConfig.Client().Resources(), *testPod)
+		assessPodHasDataIngestFile(ctx, t, envConfig.Client().Resources(), *testPod)
 
 		return ctx
 	}
@@ -96,8 +96,8 @@ func assessPodHasDataIngestFile(ctx context.Context, t *testing.T, resource *res
 }
 
 func deploymentPodsHaveOnlyDataIngestInitContainer(sampleApp sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		query := deployment.NewQuery(ctx, environmentConfig.Client().Resources(), client.ObjectKey{
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		query := deployment.NewQuery(ctx, envConfig.Client().Resources(), client.ObjectKey{
 			Name:      sampleApp.Name(),
 			Namespace: sampleApp.Namespace().Name,
 		})
@@ -105,7 +105,7 @@ func deploymentPodsHaveOnlyDataIngestInitContainer(sampleApp sample.App) feature
 
 		require.NoError(t, err)
 
-		err = query.ForEachPod(assessDeploymentHasDataIngestFile(ctx, t, environmentConfig.Client().Resources(), sampleApp.Name()))
+		err = query.ForEachPod(assessDeploymentHasDataIngestFile(ctx, t, envConfig.Client().Resources(), sampleApp.Name()))
 
 		require.NoError(t, err)
 

--- a/test/scenarios/applicationmonitoring/labelversiondetection.go
+++ b/test/scenarios/applicationmonitoring/labelversiondetection.go
@@ -168,8 +168,8 @@ func checkBuildLabels(builder *features.FeatureBuilder, sampleApps []sample.App)
 }
 
 func assertBuildLabels(sampleApp sample.App, expectedBuildLabels map[string]buildLabel) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		pods := sampleApp.GetPods(ctx, t, resources)
 
 		for _, podItem := range pods.Items {
@@ -183,7 +183,7 @@ func assertBuildLabels(sampleApp sample.App, expectedBuildLabels map[string]buil
 
 			assertReferences(t, &podItem, sampleApp, expectedBuildLabels)
 
-			assertValues(ctx, t, environmentConfig.Client().Resources(), podItem, sampleApp, expectedBuildLabels)
+			assertValues(ctx, t, envConfig.Client().Resources(), podItem, sampleApp, expectedBuildLabels)
 		}
 
 		return ctx

--- a/test/scenarios/applicationmonitoring/read_only_csi_volume.go
+++ b/test/scenarios/applicationmonitoring/read_only_csi_volume.go
@@ -59,8 +59,8 @@ func readOnlyCSIVolume(t *testing.T) features.Feature {
 }
 
 func checkInitContainerEnvVar(sampleApp sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		pods := sampleApp.GetPods(ctx, t, resources)
 
 		for _, podItem := range pods.Items {
@@ -76,8 +76,8 @@ func checkInitContainerEnvVar(sampleApp sample.App) features.Func {
 }
 
 func checkMountedVolumes(sampleApp sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 
 		err := deployment.NewQuery(ctx, resources, client.ObjectKey{
 			Name:      sampleApp.Name(),

--- a/test/scenarios/applicationmonitoring/without_csi.go
+++ b/test/scenarios/applicationmonitoring/without_csi.go
@@ -87,8 +87,8 @@ func withoutCSIDriver(t *testing.T) features.Feature {
 }
 
 func checkInjection(deployment sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resource := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resource := envConfig.Client().Resources()
 		samplePods := deployment.GetPods(ctx, t, resource)
 
 		require.NotNil(t, samplePods)
@@ -102,8 +102,8 @@ func checkInjection(deployment sample.App) features.Func {
 }
 
 func checkAlreadyInjected(deployment sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resource := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resource := envConfig.Client().Resources()
 		samplePods := deployment.GetPods(ctx, t, resource)
 
 		require.NotNil(t, samplePods)

--- a/test/scenarios/cloudnative/codemodules/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules/codemodules.go
@@ -138,8 +138,8 @@ func codeModulesAppInjectSpec() *dynatracev1beta1.AppInjectionSpec {
 }
 
 func imageHasBeenDownloaded(namespace string) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resource := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resource := envConfig.Client().Resources()
 		clientset, err := kubernetes.NewForConfig(resource.GetConfig())
 		require.NoError(t, err)
 
@@ -170,13 +170,13 @@ func imageHasBeenDownloaded(namespace string) features.Func {
 }
 
 func measureDiskUsage(namespace string, storageMap map[string]int) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resource := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resource := envConfig.Client().Resources()
 		err := daemonset.NewQuery(ctx, resource, client.ObjectKey{
 			Name:      csi.DaemonSetName,
 			Namespace: namespace,
 		}).ForEachPod(func(podItem corev1.Pod) {
-			diskUsage := getDiskUsage(ctx, t, environmentConfig.Client().Resources(), podItem, provisionerContainerName, dataPath)
+			diskUsage := getDiskUsage(ctx, t, envConfig.Client().Resources(), podItem, provisionerContainerName, dataPath)
 			storageMap[podItem.Name] = diskUsage
 		})
 		require.NoError(t, err)
@@ -185,13 +185,13 @@ func measureDiskUsage(namespace string, storageMap map[string]int) features.Func
 }
 
 func diskUsageDoesNotIncrease(namespace string, storageMap map[string]int) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resource := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resource := envConfig.Client().Resources()
 		err := daemonset.NewQuery(ctx, resource, client.ObjectKey{
 			Name:      csi.DaemonSetName,
 			Namespace: namespace,
 		}).ForEachPod(func(podItem corev1.Pod) {
-			diskUsage := getDiskUsage(ctx, t, environmentConfig.Client().Resources(), podItem, provisionerContainerName, dataPath)
+			diskUsage := getDiskUsage(ctx, t, envConfig.Client().Resources(), podItem, provisionerContainerName, dataPath)
 			assert.InDelta(t, storageMap[podItem.Name], diskUsage, diskUsageKiBDelta)
 		})
 		require.NoError(t, err)
@@ -217,8 +217,8 @@ func getDiskUsage(ctx context.Context, t *testing.T, resource *resources.Resourc
 }
 
 func volumesAreMountedCorrectly(sampleApp sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resource := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resource := envConfig.Client().Resources()
 		err := deployment.NewQuery(ctx, resource, client.ObjectKey{
 			Name:      sampleApp.Name(),
 			Namespace: sampleApp.Namespace().Name,
@@ -235,7 +235,7 @@ func volumesAreMountedCorrectly(sampleApp sample.App) features.Func {
 			require.NoError(t, err)
 			assert.NotEmpty(t, executionResult.StdOut.String())
 
-			diskUsage := getDiskUsage(ctx, t, environmentConfig.Client().Resources(), podItem, sampleApp.ContainerName(), webhook.DefaultInstallPath)
+			diskUsage := getDiskUsage(ctx, t, envConfig.Client().Resources(), podItem, sampleApp.ContainerName(), webhook.DefaultInstallPath)
 			assert.Greater(t, diskUsage, 0)
 		})
 

--- a/test/scenarios/cloudnative/disabled_auto_injection/disabled_auto_injection.go
+++ b/test/scenarios/cloudnative/disabled_auto_injection/disabled_auto_injection.go
@@ -68,8 +68,8 @@ func assessSampleInitContainersDisabled(builder *features.FeatureBuilder, sample
 }
 
 func checkInitContainersNotInjected(sampleApp sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 
 		pods := sampleApp.GetPods(ctx, t, resources)
 		require.NotEmpty(t, pods.Items)

--- a/test/scenarios/cloudnative/install.go
+++ b/test/scenarios/cloudnative/install.go
@@ -25,8 +25,8 @@ func AssessSampleInitContainers(builder *features.FeatureBuilder, sampleApp samp
 }
 
 func checkInitContainers(sampleApp sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 
 		pods := sampleApp.GetPods(ctx, t, resources)
 		require.NotEmpty(t, pods.Items)

--- a/test/scenarios/cloudnative/network/network_problems.go
+++ b/test/scenarios/cloudnative/network/network_problems.go
@@ -79,8 +79,8 @@ func networkProblems(t *testing.T) features.Feature {
 }
 
 func checkForDummyVolume(sampleApp sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		pods := sampleApp.GetPods(ctx, t, resources)
 
 		for _, podItem := range pods.Items {

--- a/test/scenarios/cloudnative/proxy/proxy.go
+++ b/test/scenarios/cloudnative/proxy/proxy.go
@@ -80,8 +80,8 @@ func withProxy(t *testing.T, proxySpec *dynatracev1beta1.DynaKubeProxy) features
 }
 
 func checkOneAgentEnvVars(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		err := daemonset.NewQuery(ctx, resources, client.ObjectKey{
 			Name:      dynakube.OneAgentDaemonsetName(),
 			Namespace: dynakube.Namespace,
@@ -98,8 +98,8 @@ func checkOneAgentEnvVars(dynakube dynatracev1beta1.DynaKube) features.Func {
 }
 
 func checkSampleInitContainerEnvVars(sampleApp sample.App) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		pods := sampleApp.GetPods(ctx, t, resources)
 
 		for _, podItem := range pods.Items {

--- a/test/scenarios/cloudnative/public_registry/public_registry.go
+++ b/test/scenarios/cloudnative/public_registry/public_registry.go
@@ -59,8 +59,8 @@ func publicRegistry(t *testing.T) features.Feature {
 }
 
 func checkDynakubeStatus(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		var dk dynatracev1beta1.DynaKube
 
 		err := dynatracev1beta1.AddToScheme(resources.GetScheme())
@@ -89,8 +89,8 @@ func checkDynakubeStatus(dynakube dynatracev1beta1.DynaKube) features.Func {
 }
 
 func checkPublicRegistryUsage(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		var dk dynatracev1beta1.DynaKube
 
 		err := dynatracev1beta1.AddToScheme(resources.GetScheme())
@@ -114,8 +114,8 @@ func checkPublicRegistryUsage(dynakube dynatracev1beta1.DynaKube) features.Func 
 }
 
 func checkCSIProvisionerEvent(dynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		resources := environmentConfig.Client().Resources()
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
 		clientset, err := kubernetes.NewForConfig(resources.GetConfig())
 		require.NoError(t, err)
 

--- a/test/scenarios/cloudnative/specific_agent_version/specific_agent_version.go
+++ b/test/scenarios/cloudnative/specific_agent_version/specific_agent_version.go
@@ -69,8 +69,8 @@ func getAvailableVersions(secret tenant.Secret, t *testing.T) []string {
 }
 
 func assessVersionChecks(testDynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		daemonset, err := oneagent.Get(ctx, environmentConfig.Client().Resources(), testDynakube)
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		daemonset, err := oneagent.Get(ctx, envConfig.Client().Resources(), testDynakube)
 		require.NoError(t, err)
 		require.Contains(t, daemonset.Spec.Template.Spec.Containers[0].Image, testDynakube.OneAgentVersion())
 		return ctx

--- a/test/scenarios/support_archive/install.go
+++ b/test/scenarios/support_archive/install.go
@@ -70,15 +70,15 @@ func supportArchiveExecution(t *testing.T) features.Feature {
 }
 
 func testSupportArchiveCommand(testDynakube dynatracev1beta1.DynaKube) features.Func {
-	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		result := executeSupportArchiveCommand(ctx, t, environmentConfig, "--stdout", testDynakube.Namespace)
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		result := executeSupportArchiveCommand(ctx, t, envConfig, "--stdout", testDynakube.Namespace)
 		require.NotNil(t, result)
 
 		zipReader, err := zip.NewReader(bytes.NewReader(result.StdOut.Bytes()), int64(result.StdOut.Len()))
 
 		require.NoError(t, err)
 
-		requiredFiles := collectRequiredFiles(t, ctx, environmentConfig.Client().Resources(), testDynakube)
+		requiredFiles := collectRequiredFiles(t, ctx, envConfig.Client().Resources(), testDynakube)
 		for _, file := range zipReader.File {
 			requiredFiles = assertFile(t, requiredFiles, *file)
 		}
@@ -89,8 +89,8 @@ func testSupportArchiveCommand(testDynakube dynatracev1beta1.DynaKube) features.
 	}
 }
 
-func executeSupportArchiveCommand(ctx context.Context, t *testing.T, environmentConfig *envconf.Config, cmdLineArguments, namespace string) *pod.ExecutionResult { //nolint:revive
-	environmentResources := environmentConfig.Client().Resources()
+func executeSupportArchiveCommand(ctx context.Context, t *testing.T, envConfig *envconf.Config, cmdLineArguments, namespace string) *pod.ExecutionResult { //nolint:revive
+	environmentResources := envConfig.Client().Resources()
 
 	pods := pod.List(t, ctx, environmentResources, namespace)
 	require.NotNil(t, pods.Items)
@@ -101,7 +101,7 @@ func executeSupportArchiveCommand(ctx context.Context, t *testing.T, environment
 
 	require.Len(t, operatorPods, 1)
 
-	executionResult, err := pod.Exec(ctx, environmentConfig.Client().Resources(),
+	executionResult, err := pod.Exec(ctx, envConfig.Client().Resources(),
 		operatorPods[0],
 		operator.DeploymentName,
 		"/usr/local/bin/dynatrace-operator",


### PR DESCRIPTION
## Description

Please include the following:

This PR renames all `*envconf.Config` into single name convention.

## How can this be tested?

Run all e2e tests :) 

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
