### PR TITLE
Fix generate manifests step in pre release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -270,8 +270,8 @@ jobs:
           hack/build/ci/generate-release-notes.sh
       - name: Generate manifests
         run: |
-          export IMAGE= ${{ matrix.url }}/${{ secrets[matrix.repository] }}
-          export TAG=$(echo "${{ github.ref }}" | awk -F"/" '{print $3}')
+          export "IMAGE=${{ matrix.url }}/${{ secrets[matrix.repository] }}"
+          export "TAG=$(echo "${{ github.ref }}" | awk -F"/" '{print $3}')"
           make manifests
       - name: Generate CRD
         run: make manifests/crd/release


### PR DESCRIPTION
## Description

Generate manifests failed due to whitespaces in the commands. 
This PR removes them.

## How can this be tested?

Run generate manifests step in the CI

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
