### PR TITLE
Respect oneagent-no-proxy feature-flag in application monitoring

### DIFF
--- a/src/initgeneration/initgeneration.go
+++ b/src/initgeneration/initgeneration.go
@@ -135,9 +135,13 @@ func (g *InitGenerator) createSecretConfigForDynaKube(ctx context.Context, dynak
 		return nil, errors.WithMessage(err, "failed to query tokens")
 	}
 
-	proxy, err := dynakube.Proxy(ctx, g.apiReader)
-	if err != nil {
-		return nil, errors.WithStack(err)
+	var proxy string
+	var err error
+	if dynakube.NeedsOneAgentProxy() {
+		proxy, err = dynakube.Proxy(ctx, g.apiReader)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
 	}
 
 	trustedCAs, err := dynakube.TrustedCAs(ctx, g.apiReader)

--- a/src/initgeneration/initgeneration_test.go
+++ b/src/initgeneration/initgeneration_test.go
@@ -281,7 +281,7 @@ func TestCreateSecretConfigForDynaKube(t *testing.T) {
 		proxyValue := "proxy-test-value"
 		setProxy(dynakube, proxyValue)
 		setAnnotation(dynakube, map[string]string{
-			dynatracev1beta1.AnnotationFeatureOneAgentIgnoreProxy:"true",
+			dynatracev1beta1.AnnotationFeatureOneAgentIgnoreProxy: "true",
 		})
 
 		testNamespace := createTestInjectedNamespace(dynakube, "test")


### PR DESCRIPTION
## Description
Fixes the use of `feature.dynatrace.com/oneagent-ignore-proxy: "true"` in case of application-monitoring without CSI driver.

We already respect this in the daemonset of the agent and the csi-driver.


## How can this be tested?

Set the `feature.dynatrace.com/oneagent-ignore-proxy: "true"`
Set a proxy in the dynakube
Deploy application-monitoring without CSI-driver
Check that the sample app's ruxitagentproc.conf contains empty proxy field

## Checklist
- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
