### PR TITLE
Adds volume-profile label in openshift-csi manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -270,8 +270,8 @@ jobs:
           hack/build/ci/generate-release-notes.sh
       - name: Generate manifests
         run: |
-          export IMAGE= ${{ matrix.url }}/${{ secrets[matrix.repository] }}
-          export TAG=$(echo "${{ github.ref }}" | awk -F"/" '{print $3}')
+          export "IMAGE=${{ matrix.url }}/${{ secrets[matrix.repository] }}"
+          export "TAG=$(echo "${{ github.ref }}" | awk -F"/" '{print $3}')"
           make manifests
       - name: Generate CRD
         run: make manifests/crd/release

--- a/config/helm/chart/default/templates/Common/csi/csidriver.yaml
+++ b/config/helm/chart/default/templates/Common/csi/csidriver.yaml
@@ -18,7 +18,7 @@ kind: CSIDriver
 metadata:
   name: csi.oneagent.dynatrace.com
   labels:
-    {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+    {{- if eq (include "dynatrace-operator.platform" .) "openshift" }}
     security.openshift.io/csi-ephemeral-volume-profile: "restricted"
     {{- end }}
     {{- include "dynatrace-operator.csiLabels" . | nindent 4 }}

--- a/config/helm/chart/default/tests/Common/csi/csidriver_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/csidriver_test.yaml
@@ -36,6 +36,7 @@ tests:
     set:
       platform: openshift
       csidriver.enabled: true
+      partial: false
     asserts:
       - isSubset:
           path: metadata.labels

--- a/config/helm/chart/default/tests/Common/csi/csidriver_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/csidriver_test.yaml
@@ -42,3 +42,13 @@ tests:
           content:
             security.openshift.io/csi-ephemeral-volume-profile: "restricted"
 
+  - it: should contain correct labels for openshift manifest
+    set:
+      platform: openshift
+      csidriver.enabled: false
+      partial: csi
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            security.openshift.io/csi-ephemeral-volume-profile: "restricted"


### PR DESCRIPTION
## Description

Currently the CSI manifests on OCP are missing the "csi-ephemeral-volume-profile" label. The check is wrong to add it, when the manifests are generated, as the check expects "partial" to be false, but it actually is "csi" in case of openshift-csi.yaml.

## How can this be tested?

make manifests -> should generate an openshift-csi.yaml that has the CSIDriver resource and the label on it

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
