### PR TITLE
Respect oneagent-no-proxy feature-flag in application monitoring

### DIFF
--- a/src/initgeneration/initgeneration.go
+++ b/src/initgeneration/initgeneration.go
@@ -135,9 +135,13 @@ func (g *InitGenerator) createSecretConfigForDynaKube(ctx context.Context, dynak
 		return nil, errors.WithMessage(err, "failed to query tokens")
 	}
 
-	proxy, err := dynakube.Proxy(ctx, g.apiReader)
-	if err != nil {
-		return nil, errors.WithStack(err)
+	var proxy string
+	var err error
+	if dynakube.NeedsOneAgentProxy() {
+		proxy, err = dynakube.Proxy(ctx, g.apiReader)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
 	}
 
 	trustedCAs, err := dynakube.TrustedCAs(ctx, g.apiReader)

--- a/src/initgeneration/initgeneration_test.go
+++ b/src/initgeneration/initgeneration_test.go
@@ -275,6 +275,24 @@ func TestCreateSecretConfigForDynaKube(t *testing.T) {
 		assert.Equal(t, expectedSecretConfig, *secretConfig)
 	})
 
+	t.Run("Create SecretConfig without proxy if feature-flag is set", func(t *testing.T) {
+		dynakube := baseDynakube.DeepCopy()
+		expectedSecretConfig := *baseExpectedSecretConfig
+		proxyValue := "proxy-test-value"
+		setProxy(dynakube, proxyValue)
+		setAnnotation(dynakube, map[string]string{
+			dynatracev1beta1.AnnotationFeatureOneAgentIgnoreProxy: "true",
+		})
+
+		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
+		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, kubesystemUID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSecretConfig, *secretConfig)
+	})
+
 	t.Run("Create SecretConfig with no-proxy", func(t *testing.T) {
 		dynakube := baseDynakube.DeepCopy()
 		expectedSecretConfig := *baseExpectedSecretConfig
@@ -408,6 +426,10 @@ func createDynakube() *dynatracev1beta1.DynaKube {
 
 func setProxy(dynakube *dynatracev1beta1.DynaKube, value string) {
 	dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: value}
+}
+
+func setAnnotation(dynakube *dynatracev1beta1.DynaKube, value map[string]string) {
+	dynakube.ObjectMeta.Annotations = value
 }
 
 func setTrustedCA(dynakube *dynatracev1beta1.DynaKube, value string) {


### PR DESCRIPTION
## Description

cherry pick of #2009

## How can this be tested?

same as #2009

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
