### PR TITLE
Disable label-version-detection feature by default (#2011)

### DIFF
--- a/src/api/v1beta1/dynakube/feature_flags.go
+++ b/src/api/v1beta1/dynakube/feature_flags.go
@@ -295,7 +295,7 @@ func (dk *DynaKube) FeatureActiveGateAuthToken() bool {
 
 // FeatureLabelVersionDetection is a feature flag to enable injecting additional environment variables based on user labels
 func (dk *DynaKube) FeatureLabelVersionDetection() bool {
-	return dk.getFeatureFlagRaw(AnnotationFeatureLabelVersionDetection) != falsePhrase
+	return dk.getFeatureFlagRaw(AnnotationFeatureLabelVersionDetection) == truePhrase
 }
 
 // FeatureAgentInitialConnectRetry is a feature flag to configure startup delay of standalone agents

--- a/src/api/v1beta1/dynakube/feature_flags_test.go
+++ b/src/api/v1beta1/dynakube/feature_flags_test.go
@@ -290,7 +290,6 @@ func TestDefaultEnabledFeatureFlags(t *testing.T) {
 	assert.True(t, dynakube.FeatureActiveGateReadOnlyFilesystem())
 	assert.True(t, dynakube.FeatureAutomaticKubernetesApiMonitoring())
 	assert.True(t, dynakube.FeatureAutomaticInjection())
-	assert.True(t, dynakube.FeatureLabelVersionDetection())
 	assert.True(t, dynakube.FeatureInjectionFailurePolicy() == "silent")
 
 	assert.False(t, dynakube.FeatureDisableActiveGateUpdates())
@@ -298,4 +297,5 @@ func TestDefaultEnabledFeatureFlags(t *testing.T) {
 	assert.False(t, dynakube.FeatureDisableReadOnlyOneAgent())
 	assert.False(t, dynakube.FeatureDisableWebhookReinvocationPolicy())
 	assert.False(t, dynakube.FeatureDisableMetadataEnrichment())
+	assert.False(t, dynakube.FeatureLabelVersionDetection())
 }

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/containers_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/containers_test.go
@@ -75,7 +75,7 @@ func TestMutateUserContainers(t *testing.T) {
 		{
 			name:                               "add envs and volume mounts (simple dynakube)",
 			dynakube:                           *getTestDynakube(),
-			expectedAdditionalEnvCount:         4, // 1 deployment-metadata + 1 preload + 1 dt_release_version + 1 dt_release_product
+			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 3, // 3 oneagent mounts(preload,bin,conf)
 		},
 		{
@@ -87,7 +87,7 @@ func TestMutateUserContainers(t *testing.T) {
 		{
 			name:                               "add envs and volume mounts (readonly-csi)",
 			dynakube:                           *getTestReadOnlyCSIDynakube(),
-			expectedAdditionalEnvCount:         4, // 1 deployment-metadata + 1 preload + 1 dt_release_version + 1 dt_release_product
+			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 6, // 3 oneagent mounts(preload,bin,conf) +3 oneagent mounts for readonly csi (agent-conf,data-storage,agent-log)
 		},
 	}
@@ -114,7 +114,7 @@ func TestReinvokeUserContainers(t *testing.T) {
 		{
 			name:                               "add envs and volume mounts (simple dynakube)",
 			dynakube:                           *getTestDynakube(),
-			expectedAdditionalEnvCount:         4, // 1 deployment-metadata + 1 preload + 1 dt_release_version + 1 dt_release_product
+			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 3, // 3 oneagent mounts(preload,bin,conf)
 		},
 		{
@@ -126,7 +126,7 @@ func TestReinvokeUserContainers(t *testing.T) {
 		{
 			name:                               "add envs and volume mounts (readonly-csi)",
 			dynakube:                           *getTestReadOnlyCSIDynakube(),
-			expectedAdditionalEnvCount:         4, // 1 deployment-metadata + 1 preload + 1 dt_release_version + 1 dt_release_product
+			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 6, // 3 oneagent mounts(preload,bin,conf) +3 oneagent mounts for readonly csi (agent-conf,data-storage,agent-log)
 		},
 	}

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
@@ -112,7 +112,7 @@ func TestMutate(t *testing.T) {
 		{
 			name:                                   "basic, should mutate the pod and init container in the request",
 			dynakube:                               *getTestDynakube(),
-			expectedAdditionalEnvCount:             4, // 1 deployment-metadata + 1 preload + 1 dt_release_version + 1 dt_release_product
+			expectedAdditionalEnvCount:             2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeCount:          3, // bin, share, injection-config
 			expectedAdditionalVolumeMountCount:     3, // 3 oneagent mounts(preload,bin,conf)
 			expectedAdditionalInitVolumeMountCount: 3, // bin, share, injection-config
@@ -128,7 +128,7 @@ func TestMutate(t *testing.T) {
 		{
 			name:                                   "basic + readonly-csi, should mutate the pod and init container in the request",
 			dynakube:                               *getTestReadOnlyCSIDynakube(),
-			expectedAdditionalEnvCount:             4, // 1 deployment-metadata + 1 preload + 1 dt_release_version + 1 dt_release_product
+			expectedAdditionalEnvCount:             2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeCount:          6, // bin, share, injection-config +  agent-conf, data-storage, agent-log
 			expectedAdditionalVolumeMountCount:     6, // 3 oneagent mounts(preload,bin,conf) +3 oneagent mounts for readonly csi (agent-conf,data-storage,agent-log)
 			expectedAdditionalInitVolumeMountCount: 4, // bin, share, injection-config, agent-conf
@@ -177,7 +177,7 @@ func TestReinvoke(t *testing.T) {
 		{
 			name:                               "basic, should mutate the pod and init container in the request",
 			dynakube:                           *getTestDynakube(),
-			expectedAdditionalEnvCount:         4, // 1 deployment-metadata + 1 preload + 1 dt_release_version + 1 dt_release_product
+			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 3, // 3 oneagent mounts(preload,bin,conf)
 		},
 		{
@@ -189,7 +189,7 @@ func TestReinvoke(t *testing.T) {
 		{
 			name:                               "basic + readonly-csi, should mutate the pod and init container in the request",
 			dynakube:                           *getTestReadOnlyCSIDynakube(),
-			expectedAdditionalEnvCount:         4, // 1 deployment-metadata + 1 preload + 1 dt_release_version + 1 dt_release_product
+			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 6, // 3 oneagent mounts(preload,bin,conf) +3 oneagent mounts for readonly csi (agent-conf,data-storage,agent-log)
 		},
 	}


### PR DESCRIPTION
## Description

Same as #2011

## How can this be tested?

Same as #2011

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
