### PR TITLE
Adds volume-profile label in openshift-csi manifest (#2010)

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/csidriver.yaml
+++ b/config/helm/chart/default/templates/Common/csi/csidriver.yaml
@@ -18,7 +18,7 @@ kind: CSIDriver
 metadata:
   name: csi.oneagent.dynatrace.com
   labels:
-    {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+    {{- if eq (include "dynatrace-operator.platform" .) "openshift" }}
     security.openshift.io/csi-ephemeral-volume-profile: "restricted"
     {{- end }}
     {{- include "dynatrace-operator.csiLabels" . | nindent 4 }}

--- a/config/helm/chart/default/tests/Common/csi/csidriver_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/csidriver_test.yaml
@@ -36,9 +36,20 @@ tests:
     set:
       platform: openshift
       csidriver.enabled: true
+      partial: false
     asserts:
       - isSubset:
           path: metadata.labels
           content:
             security.openshift.io/csi-ephemeral-volume-profile: "restricted"
 
+  - it: should contain correct labels for openshift manifest
+    set:
+      platform: openshift
+      csidriver.enabled: false
+      partial: csi
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            security.openshift.io/csi-ephemeral-volume-profile: "restricted"


### PR DESCRIPTION
## Description

Same as in #2010

## How can this be tested?

Same as in #2010

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
