### PR TITLE
Make switch modes tests more reliable

### DIFF
--- a/test/scenarios/classic/switch_modes/install.go
+++ b/test/scenarios/classic/switch_modes/install.go
@@ -35,7 +35,7 @@ func Install(t *testing.T, name string) features.Feature {
 
 	sampleAppClassic := sampleapps.NewSampleDeployment(t, dynakubeClassicFullstack)
 	sampleAppClassic.WithName(sampleAppsClassicName)
-	featureBuilder.Assess("create sample app namespace", 	sampleAppClassic.InstallNamespace())
+	featureBuilder.Assess("create sample app namespace", sampleAppClassic.InstallNamespace())
 
 	// install operator and dynakube
 	assess.InstallDynatrace(featureBuilder, &secretConfig, dynakubeClassicFullstack)
@@ -49,7 +49,7 @@ func Install(t *testing.T, name string) features.Feature {
 	sampleAppCloudNative := sampleapps.NewSampleDeployment(t, dynakubeCloudNative)
 	sampleAppCloudNative.WithName(sampleAppsCloudNativeName)
 	sampleAppCloudNative.WithAnnotations(map[string]string{dtwebhook.AnnotationFailurePolicy: "fail"})
-	featureBuilder.Assess("create sample app namespace", 	sampleAppCloudNative.InstallNamespace())
+	featureBuilder.Assess("create sample app namespace", sampleAppCloudNative.InstallNamespace())
 
 	assess.InstallOperatorFromSource(featureBuilder, dynakubeCloudNative)
 	assess.UpdateDynakube(featureBuilder, dynakubeCloudNative)

--- a/test/scenarios/cloudnative/switch_modes/install.go
+++ b/test/scenarios/cloudnative/switch_modes/install.go
@@ -30,14 +30,15 @@ func Install(t *testing.T, name string) features.Feature {
 		ApiUrl(secretConfig.ApiUrl).
 		CloudNative(&dynatracev1beta1.CloudNativeFullStackSpec{})
 	dynakubeCloudNative := cloudNativeDynakubeBuilder.Build()
+	sampleAppCloudNative := sampleapps.NewSampleDeployment(t, dynakubeCloudNative)
+	sampleAppCloudNative.WithName(sampleAppsCloudNativeName)
+	featureBuilder.Assess("(cloudnative) create sample app namespace", sampleAppCloudNative.InstallNamespace())
 
 	// install operator and dynakube
 	assess.InstallDynatrace(featureBuilder, &secretConfig, dynakubeCloudNative)
 
 	// apply sample apps
-	sampleAppCloudNative := sampleapps.NewSampleDeployment(t, dynakubeCloudNative)
-	sampleAppCloudNative.WithName(sampleAppsCloudNativeName)
-	featureBuilder.Assess("install sample app", sampleAppCloudNative.Install())
+	featureBuilder.Assess("(cloudnative) install sample app", sampleAppCloudNative.Install())
 
 	// run cloud native test here
 	cloudnative.AssessSampleInitContainers(featureBuilder, sampleAppCloudNative)
@@ -45,12 +46,13 @@ func Install(t *testing.T, name string) features.Feature {
 	// switch to classic full stack
 	classicDynakubeBuilder := cloudNativeDynakubeBuilder.ResetOneAgent().ClassicFullstack(&dynatracev1beta1.HostInjectSpec{})
 	dynakubeClassicFullStack := classicDynakubeBuilder.Build()
+	sampleAppClassicFullStack := sampleapps.NewSampleDeployment(t, dynakubeClassicFullStack)
+	sampleAppClassicFullStack.WithName(sampleAppsClassicName)
+	featureBuilder.Assess("(classic) create sample app namespace", sampleAppClassicFullStack.InstallNamespace())
 	assess.UpdateDynakube(featureBuilder, dynakubeClassicFullStack)
 
 	// deploy sample apps
-	sampleAppClassicFullStack := sampleapps.NewSampleDeployment(t, dynakubeClassicFullStack)
-	sampleAppClassicFullStack.WithName(sampleAppsClassicName)
-	featureBuilder.Assess("install sample app", sampleAppClassicFullStack.Install())
+	featureBuilder.Assess("(classic) install sample app", sampleAppClassicFullStack.Install())
 
 	// tear down
 	featureBuilder.Teardown(sampleAppCloudNative.Uninstall())


### PR DESCRIPTION
## Description

Please include the following:

In all cloudnative tests where we use a sample app we create the sample app's namespace before deploying the `dynakube` to avoid a race condition to happen, which could cause our tests to run longer then we would want and sometimes timing out.
The new `switchmodes` tests however do not follow this pattern, and therefore are flaky.

## How can this be tested?

Run:
- `make test/e2e/classic/switchmodes`
-  `make test/e2e/cloudnative/switchmodes`

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
