### PR TITLE
Make Dynakube args and env vars override default operator values on main branch

### DIFF
--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -199,7 +199,6 @@ func (statefulSetBuilder Builder) buildCommonEnvs() []corev1.EnvVar {
 			},
 		}},
 	}
-	envs = append(envs, statefulSetBuilder.capability.Properties().Env...)
 
 	if statefulSetBuilder.capability.Properties().Group != "" {
 		envs = append(envs, corev1.EnvVar{Name: consts.EnvDtGroup, Value: statefulSetBuilder.capability.Properties().Group})
@@ -211,6 +210,8 @@ func (statefulSetBuilder Builder) buildCommonEnvs() []corev1.EnvVar {
 	if statefulSetBuilder.dynakube.IsMetricsIngestActiveGateEnabled() {
 		envs = append(envs, corev1.EnvVar{Name: consts.EnvDtHttpPort, Value: strconv.Itoa(consts.HttpContainerPort)})
 	}
+
+	envs = append(envs, statefulSetBuilder.capability.Properties().Env...)
 
 	return envs
 }

--- a/src/controllers/dynakube/oneagent/daemonset/arguments.go
+++ b/src/controllers/dynakube/oneagent/daemonset/arguments.go
@@ -10,11 +10,11 @@ import (
 func (dsInfo *builderInfo) arguments() []string {
 	args := make([]string, 0)
 
-	args = dsInfo.appendHostInjectArgs(args)
 	args = dsInfo.appendProxyArg(args)
 	args = dsInfo.appendNetworkZoneArg(args)
 	args = appendOperatorVersionArg(args)
 	args = appendImmutableImageArgs(args)
+	args = dsInfo.appendHostInjectArgs(args)
 
 	return args
 }

--- a/src/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -53,6 +53,19 @@ func TestArguments(t *testing.T) {
 		assert.NotEmpty(t, podSpecs.Containers)
 		assert.Contains(t, podSpecs.Containers[0].Args, testValue)
 	})
+	t.Run("when injected arguments are provided then they are appended at the end of the arguments", func(t *testing.T) {
+
+		args := []string{testValue}
+		builder := builderInfo{
+			dynakube:       &dynatracev1beta1.DynaKube{},
+			hostInjectSpec: &dynatracev1beta1.HostInjectSpec{Args: args},
+		}
+
+		arguments := builder.arguments()
+		expectedDefaultArguments := appendImmutableImageArgs(appendOperatorVersionArg([]string{}))
+		expectedDefaultArguments = append(expectedDefaultArguments, testValue)
+		assert.Equal(t, expectedDefaultArguments, arguments)
+	})
 }
 
 func TestPodSpec_Arguments(t *testing.T) {

--- a/src/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -54,7 +54,6 @@ func TestArguments(t *testing.T) {
 		assert.Contains(t, podSpecs.Containers[0].Args, testValue)
 	})
 	t.Run("when injected arguments are provided then they are appended at the end of the arguments", func(t *testing.T) {
-
 		args := []string{testValue}
 		builder := builderInfo{
 			dynakube:       &dynatracev1beta1.DynaKube{},

--- a/src/controllers/dynakube/oneagent/daemonset/env_vars_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/env_vars_test.go
@@ -51,6 +51,37 @@ func TestEnvironmentVariables(t *testing.T) {
 		assertProxyEnv(t, envVars, dynakube)
 		assertReadOnlyEnv(t, envVars)
 	})
+	t.Run("when injected envvars are provided then they will not be overridden", func(t *testing.T) {
+		potentiallyOverriddenEnvVars := []corev1.EnvVar{
+			{Name: dtNodeName, Value: testValue},
+			{Name: dtClusterId, Value: testValue},
+			{Name: deploymentmetadata.EnvDtDeploymentMetadata, Value: testValue},
+			{Name: deploymentmetadata.EnvDtOperatorVersion, Value: testValue},
+			{Name: connectioninfo.EnvDtTenant, Value: testValue},
+			{Name: proxy, Value: testValue},
+			{Name: oneagentReadOnlyMode, Value: testValue},
+		}
+		builder := builderInfo{
+			dynakube:       &dynatracev1beta1.DynaKube{},
+			hostInjectSpec: &dynatracev1beta1.HostInjectSpec{Env: potentiallyOverriddenEnvVars},
+		}
+		envVars := builder.environmentVariables()
+
+		assertEnvVarNameAndValue(t, envVars, dtNodeName, testValue)
+		assertEnvVarNameAndValue(t, envVars, dtClusterId, testValue)
+		assertEnvVarNameAndValue(t, envVars, deploymentmetadata.EnvDtDeploymentMetadata, testValue)
+		assertEnvVarNameAndValue(t, envVars, deploymentmetadata.EnvDtOperatorVersion, testValue)
+		assertEnvVarNameAndValue(t, envVars, connectioninfo.EnvDtTenant, testValue)
+		assertEnvVarNameAndValue(t, envVars, proxy, testValue)
+		assertEnvVarNameAndValue(t, envVars, oneagentReadOnlyMode, testValue)
+
+	})
+}
+
+func assertEnvVarNameAndValue(t *testing.T, envVars []corev1.EnvVar, name, value string) {
+	env := kubeobjects.FindEnvVar(envVars, name)
+	assert.Equal(t, name, env.Name)
+	assert.Equal(t, value, (*env).Value)
 }
 
 func TestAddNodeNameEnv(t *testing.T) {

--- a/src/controllers/dynakube/oneagent/daemonset/env_vars_test.go
+++ b/src/controllers/dynakube/oneagent/daemonset/env_vars_test.go
@@ -74,14 +74,13 @@ func TestEnvironmentVariables(t *testing.T) {
 		assertEnvVarNameAndValue(t, envVars, connectioninfo.EnvDtTenant, testValue)
 		assertEnvVarNameAndValue(t, envVars, proxy, testValue)
 		assertEnvVarNameAndValue(t, envVars, oneagentReadOnlyMode, testValue)
-
 	})
 }
 
 func assertEnvVarNameAndValue(t *testing.T, envVars []corev1.EnvVar, name, value string) {
 	env := kubeobjects.FindEnvVar(envVars, name)
 	assert.Equal(t, name, env.Name)
-	assert.Equal(t, value, (*env).Value)
+	assert.Equal(t, value, env.Value)
 }
 
 func TestAddNodeNameEnv(t *testing.T) {


### PR DESCRIPTION
## Description

change the ordering of environment and argument processing in statefulset and ActiveGate to always have customer arguments and env vars take highest precedence.

## How can this be tested?

ActiveGate:

- override any of the following arguments should be reflected in the OneAgent: tenant, server, network-zone, operator-version, proxy

statefulset:

- set env vars and verify: DT_GROUP, DT_NETWORK_ZONE, DT_HTTP_PORT

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)