### PR TITLE
Use mod google container registry lib for connection test in troubleshoot command

### DIFF
--- a/src/cmd/troubleshoot/image.go
+++ b/src/cmd/troubleshoot/image.go
@@ -89,7 +89,9 @@ func tryImagePull(troubleshootCtx *troubleshootContext, image string) error {
 	defer func(dockerCfg *dockerconfig.DockerConfig, fs afero.Afero) {
 		_ = dockerCfg.Cleanup(fs)
 	}(dockerCfg, troubleshootCtx.fs)
+
 	dockerCfg.SetRegistryAuthSecret(&troubleshootCtx.pullSecret)
+
 	err = dockerCfg.StoreRequiredFiles(troubleshootCtx.context, troubleshootCtx.fs)
 	if err != nil {
 		return err
@@ -98,7 +100,6 @@ func tryImagePull(troubleshootCtx *troubleshootContext, image string) error {
 	keychain := dockerkeychain.NewDockerKeychain(dockerCfg.RegistryAuthPath, troubleshootCtx.fs)
 
 	transport, err := createTransport(troubleshootCtx.dynakube, troubleshootCtx.context, troubleshootCtx.apiReader, troubleshootCtx.httpClient)
-
 	if err != nil {
 		return err
 	}
@@ -111,8 +112,6 @@ func tryImagePull(troubleshootCtx *troubleshootContext, image string) error {
 }
 
 func createTransport(kube dynakube.DynaKube, ctx context.Context, apiReader client.Reader, troubleShootHttpClient *http.Client) (*http.Transport, error) {
-	// transport := http.DefaultTransport.(*http.Transport).Clone() // troubleshootCtx.httpClient.Transport.(*http.Transport).Clone()
-	// transport.TLSClientConfig.InsecureSkipVerify = true
 	var transport *http.Transport
 	if troubleShootHttpClient != nil && troubleShootHttpClient.Transport != nil {
 		transport = troubleShootHttpClient.Transport.(*http.Transport).Clone()

--- a/src/cmd/troubleshoot/image.go
+++ b/src/cmd/troubleshoot/image.go
@@ -93,7 +93,7 @@ func tryImagePull(troubleshootCtx *troubleshootContext, image string) error {
 	}
 
 	keychain := dockerkeychain.NewDockerKeychain(dockerCfg.RegistryAuthPath, troubleshootCtx.fs)
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := troubleshootCtx.httpClient.Transport.(*http.Transport).Clone()
 
 	var proxy string
 	if troubleshootCtx.dynakube.HasProxy() {

--- a/src/cmd/troubleshoot/image_test.go
+++ b/src/cmd/troubleshoot/image_test.go
@@ -33,7 +33,7 @@ func defaultAuths(server string) Auths {
 			server: Credentials{
 				Username: "ac",
 				Password: "dt",
-				Auth:     "ZW",
+				Auth:     "dGVzdC10b2tlbjp0ZXN0LXBhc3N3b3Jk",
 			},
 		},
 	}
@@ -380,7 +380,7 @@ func TestImageNotPullable(t *testing.T) {
 			if strings.Contains(test.name, "non-existing server") {
 				assert.Contains(t, logOutput, "no such host")
 			} else {
-				assert.Contains(t, logOutput, "reading manifest")
+				assert.Contains(t, logOutput, "Bad Request")
 			}
 
 			assert.NotContains(t, logOutput, "can be successfully pulled")


### PR DESCRIPTION
## Description

use to library `github.com/google/go-containerregistry` for testing the connectivity to the tenant. This lib also supports proxies thus the change.

## How can this be tested?

Deploy a dynakube and run troubleshoot command as in docs:
`kubectl exec deploy/dynatrace-operator -n dynatrace -- dynatrace-operator troubleshoot`

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
