### PR TITLE
Change check for adding scc permission to csi clusterrole

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/clusterrole-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/clusterrole-csi.yaml
@@ -62,7 +62,7 @@ rules:
       - get
       - list
       - watch
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (eq (include "dynatrace-operator.platform" .) "openshift") }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/tests/Common/csi/clusterrole-csi_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/clusterrole-csi_test.yaml
@@ -72,6 +72,33 @@ tests:
                 - get
                 - list
                 - watch
+
+  - it: ClusterRole should exist with extra permissions for openshift-csi.yaml
+    documentIndex: 0
+    set:
+      platform: openshift
+      csidriver.enabled: true
+      partial: csi
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: dynatrace-oneagent-csi-driver
+      - isNotEmpty:
+          path: metadata.labels
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - security.openshift.io
+            resourceNames:
+              - privileged
+            resources:
+              - securitycontextconstraints
+            verbs:
+              - use
+
   - it: ClusterRole should exist with extra permissions for openshift
     documentIndex: 0
     set:


### PR DESCRIPTION
## Description

Currently our CSI Driver clusterrole lacks access to the privileged SCC, which blocks creation of CSI pods. The problem is that the check for adding the privileged SCC access is wrong an excludes the case where partial is set to csi.

## How can this be tested?

Run make manifests and check openshift-csi.yaml if it contains the correct permissions for accessing the privileged SCC

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
