### PR TITLE
WIP research logic to ensure secrets - single controller

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
@@ -42,18 +42,18 @@ rules:
       - secrets
     verbs:
       - create
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    resourceNames:
-      - dynatrace-dynakube-config
-      - dynatrace-data-ingest-endpoint
-    verbs:
-      - get
-      - list
-      - watch
-      - update
+  #- apiGroups:
+  #    - ""
+  #  resources:
+  #    - secrets
+  #  resourceNames:
+  #    - dynatrace-dynakube-config
+  #    - dynatrace-data-ingest-endpoint
+  #  verbs:
+  #    - get
+  #    - list
+  #    - watch
+  #    - update
   # data-ingest workload owner lookup
   - apiGroups:
       - ""

--- a/config/helm/chart/default/tests/Common/webhook/clusterrole-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/clusterrole-webhook_test.yaml
@@ -43,21 +43,21 @@ tests:
               - secrets
             verbs:
               - create
-      - contains:
-          path: rules
-          content:
-            apiGroups:
-              - ""
-            resourceNames:
-              - dynatrace-dynakube-config
-              - dynatrace-data-ingest-endpoint
-            resources:
-              - secrets
-            verbs:
-              - get
-              - list
-              - watch
-              - update
+      #- contains:
+      #    path: rules
+      #    content:
+      #      apiGroups:
+      #        - ""
+      #      resourceNames:
+      #        - dynatrace-dynakube-config
+      #        - dynatrace-data-ingest-endpoint
+      #      resources:
+      #        - secrets
+      #      verbs:
+      #        - get
+      #        - list
+      #        - watch
+      #        - update
       - contains:
           path: rules
           content:

--- a/src/controllers/dynakube/requestmapper/mapper.go
+++ b/src/controllers/dynakube/requestmapper/mapper.go
@@ -1,0 +1,148 @@
+package requestmapper
+
+import (
+	"time"
+
+	"github.com/Dynatrace/dynatrace-operator/src/mapper"
+	dtwebhook "github.com/Dynatrace/dynatrace-operator/src/webhook"
+	"github.com/go-logr/logr"
+	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// EnqueueDynakubeRequests enqueues Requests by running a transformation function that outputs a
+// DynaKube related reconcile.Requests on Namespace related Event. Namespace Events are filtered
+// out to avoid duplicated calls of Reconcile() handler related to the same activity (dynakube controller
+// adds labels to namespaces so namespace UPDATE events are received from Watches()).
+//
+// For UpdateEvents which contain both a new and old object, the transformation function is run on new
+// object and one Requests is enqueue.
+func EnqueueDynakubeRequests(namespaceName string, l *logr.Logger) handler.EventHandler {
+	return &enqueueDynakubeRequests{
+		namespaceName: namespaceName,
+		log:           l,
+	}
+}
+
+var _ handler.EventHandler = &enqueueDynakubeRequests{}
+
+type enqueueDynakubeRequests struct {
+	namespaceName string
+	log           *logr.Logger
+}
+
+func (e *enqueueDynakubeRequests) Create(_ context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	if evt.Object == nil {
+		e.log.Error(nil, "CREATE event received with no metadata", "event", evt)
+		return
+	}
+
+	labels := evt.Object.GetLabels()
+	if labels != nil {
+		if dynakubeName, ok := labels[dtwebhook.InjectionInstanceLabel]; ok {
+			e.log.Info("CREATE", "namespace", evt.Object.GetName(), "dynakube", dynakubeName)
+
+			e.enqueue(q, dynakubeName)
+			return
+		}
+	}
+	e.log.Info("CREATE - req canceled", "namespace", evt.Object.GetName())
+}
+
+func (e *enqueueDynakubeRequests) Update(_ context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) { // nolint:revive
+	if evt.ObjectOld == nil {
+		e.log.Error(nil, "UPDATE event received with no metadataOld", "event", evt)
+		return
+	}
+	if evt.ObjectNew == nil {
+		e.log.Error(nil, "UPDATE event received with no metadataNew ", "event", evt)
+		return
+	}
+
+	if evt.ObjectNew.GetDeletionTimestamp() != nil {
+		e.log.Info("UPDATE before DELETE - req canceled", "namespace", evt.ObjectNew.GetName())
+		return
+	}
+
+	injectionOld := false
+	injectionNew := false
+	dynakubeName := ""
+	labels := evt.ObjectOld.GetLabels()
+	if labels != nil {
+		if _, ok := labels[dtwebhook.InjectionInstanceLabel]; ok {
+			injectionOld = true
+		}
+	}
+	labels = evt.ObjectNew.GetLabels()
+	if labels != nil {
+		if name, ok := labels[dtwebhook.InjectionInstanceLabel]; ok {
+			injectionNew = true
+			dynakubeName = name
+		}
+	}
+
+	updatedViaCommand := false
+	annotations := evt.ObjectNew.GetAnnotations()
+	if annotations != nil {
+		if _, ok := annotations[mapper.UpdatedViaCommandAnnotation]; ok {
+			updatedViaCommand = true
+		}
+	}
+
+	if !injectionOld && injectionNew && !updatedViaCommand {
+		e.log.Info("UPDATE by dynakube - req canceled", "namespace", evt.ObjectNew.GetName())
+		// e.logUpdateEvent("UPDATE by dynakube - req canceled", evt)
+		return
+	}
+
+	if !injectionNew {
+		e.log.Info("UPDATE no injection - req canceled", "namespace", evt.ObjectNew.GetName())
+		// e.logUpdateEvent("UPDATE no injection - req canceled", evt)
+		return
+	}
+
+	e.log.Info("UPDATE", "namespace", evt.ObjectNew.GetName(), "dynakube", dynakubeName)
+	// e.logUpdateEvent("UPDATE", evt)
+
+	e.enqueue(q, dynakubeName)
+}
+
+func (e *enqueueDynakubeRequests) Delete(_ context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	if evt.Object == nil {
+		e.log.Error(nil, "DELETE event received with no metadata", "event", evt)
+		return
+	}
+	e.log.Info("DELETE - req canceled", "namespace", evt.Object.GetName())
+}
+
+func (e *enqueueDynakubeRequests) Generic(_ context.Context, evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	if evt.Object == nil {
+		e.log.Error(nil, "GENERIC event received with no metadata", "event", evt)
+		return
+	}
+	e.log.Info("GENERIC - req canceled", "namespace", evt.Object.GetName())
+}
+
+func (e *enqueueDynakubeRequests) enqueue(q workqueue.RateLimitingInterface, dynakubeName string) {
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      dynakubeName,
+			Namespace: e.namespaceName,
+		},
+	}
+	q.AddAfter(request, 20*time.Second)
+}
+
+/*
+func (e *enqueueDynakubeRequests) logUpdateEvent(msg string, evt event.UpdateEvent) {
+	e.log.Info(msg, "name", evt.ObjectNew.GetName(),
+		"labelsOld", evt.ObjectOld.GetLabels(), "labelsNew", evt.ObjectNew.GetLabels(),
+		"annotationsOld", evt.ObjectOld.GetAnnotations(), "annotationsNew", evt.ObjectNew.GetAnnotations(),
+		"createTimeOld", evt.ObjectOld.GetCreationTimestamp(), "createTimeNew", evt.ObjectNew.GetCreationTimestamp(),
+		"delTimeOld", evt.ObjectOld.GetDeletionTimestamp(), "delTimeNew", evt.ObjectNew.GetDeletionTimestamp())
+}
+*/

--- a/src/mapper/config.go
+++ b/src/mapper/config.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	UpdatedViaDynakubeAnnotation = "dynatrace.com/updated-via-operator"
+	UpdatedViaCommandAnnotation  = "dynatrace.com/updated-via-command"
 	ErrorConflictingNamespace    = "namespace matches two or more DynaKubes which is unsupported. " +
 		"refine the labels on your namespace metadata or DynaKube/CodeModules specification"
 )

--- a/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator.go
+++ b/src/webhook/mutation/pod_mutator/dataingest_mutation/mutator.go
@@ -44,10 +44,12 @@ func (mutator *DataIngestPodMutator) Mutate(request *dtwebhook.MutationRequest) 
 	if err != nil {
 		return err
 	}
-	err = mutator.ensureDataIngestSecret(request)
-	if err != nil {
-		return err
-	}
+	/*
+		err = mutator.ensureDataIngestSecret(request)
+		if err != nil {
+			return err
+		}
+	*/
 	setupVolumes(request.Pod)
 	mutateUserContainers(request.Pod)
 	updateInstallContainer(request.InstallContainer, workload)

--- a/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
+++ b/src/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
@@ -46,9 +46,11 @@ func (mutator *OneAgentPodMutator) Mutate(request *dtwebhook.MutationRequest) er
 	}
 
 	log.Info("injecting OneAgent into pod", "podName", request.PodName())
-	if err := mutator.ensureInitSecret(request); err != nil {
-		return err
-	}
+	/*
+		if err := mutator.ensureInitSecret(request); err != nil {
+			return err
+		}
+	*/
 
 	installerInfo := getInstallerInfo(request.Pod, request.DynaKube)
 	mutator.addVolumes(request.Pod, request.DynaKube)


### PR DESCRIPTION
## Description

Logic to ensure namespace secrets moved from pod mutator to dynakube controller. Dynakube controller listens to namespace events to make sure ingestendpoint and init secrets are created ASAP in monitored namespace.

The following scenarios do not trigger dynakube reconcile event:
- namespace CREATE event w/o matching selector label
- namespace UPDATE#1, UPDATE#2, DELETE sequence
- namespace UPDATE w/o `dynakube/instance` label
- namespace UPDATE because of controller doing mapping

Approach using [delaying event queue](https://github.com/Dynatrace/dynatrace-operator/blob/86c62db462e2d4aa7c8b7744de7a6a03d2ea5623/src/controllers/dynakube/requestmapper/mapper.go#L151) seems to be most promising so far:
- in case of incoming stream of events - we can limit the number of dynakube reconciliation calls to a specific number

Approach using [rate limited queue](https://github.com/Dynatrace/dynatrace-operator/blob/86c62db462e2d4aa7c8b7744de7a6a03d2ea5623/src/controllers/dynakube/requestmapper/mapper.go#L150):
- when incoming stream of namespace events starts the dynakube controller is called too often
From DefaultControllerRateLimiter src:
```
// DefaultControllerRateLimiter is a no-arg constructor for a default rate limiter for a workqueue.  It has
// both overall and per-item rate limiting.  The overall is a token bucket and the per-item is exponential
```

## How can this be tested?
Script to generate big amount of namespace events:
```
/bin/bash namespace.sh create
/bin/bash namespace.sh delete
/bin/bash namespace.sh verify
```
In case of my machine ~600 is still OK, 1000 running parallel processes -> other random processes die.

```
#!/bin/bash
if [ "${1}" == "create" ]; then
    
  for i in {1..500} ; do
    cat <<EOF | kubectl create -f - &
apiVersion: v1
kind: Namespace
metadata:
  labels:
    monitor: star
  name: sample-${i}
EOF
  done

elif [ "${1}" == "delete" ]; then

  for i in {1..500} ; do
    cat <<EOF | kubectl delete -f - &
apiVersion: v1
kind: Namespace
metadata:
  labels:
    monitor: star
  name: sample-${i}
EOF
  done

elif [ "${1}" == "verify" ]; then

  for i in {1..500} ; do
    /bin/bash ${0} verifybg sample-${i} &
  done

elif [ "${1}" == "verifybg" ]; then
    if ! kubectl -n ${2} get secrets/dynatrace-data-ingest-endpoint secrets/dynatrace-dynakube-config 2>/dev/null 1>&2 ; then
      echo "secret(s) not found in ${2}"
    else
      echo ${2}
    fi
fi
```

## Checklist

- [ ] Unit tests have been updated/added
- [ ] PR is labeled accordingly with a single label
- [ ] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
