### PR TITLE
Change helm upgrade to helm install in e2e tests

### DIFF
--- a/test/helpers/components/operator/installation.go
+++ b/test/helpers/components/operator/installation.go
@@ -61,9 +61,9 @@ func installViaHelm(t *testing.T, releaseTag string, withCsi bool, namespace str
 		t.Log("failed to add dynatrace helm chart repo", err)
 	}
 
-	err = manager.RunRepo(helm.WithArgs("update"))
+	err = manager.RunRepo(helm.WithArgs("install"))
 	if err != nil {
-		t.Fatal("failed to upgrade helm repo")
+		t.Fatal("failed to install helm repo")
 	}
 
 	err = manager.RunUpgrade(helm.WithName("dynatrace-operator"), helm.WithNamespace(namespace),


### PR DESCRIPTION
## Description

We use helm upgrade ... instead of helm install ... in every case, because helm upgrade will also just install what you want the same way as helm install would, but with the benefit that it won't fail if something is already there.

The problem/weirdness happens if helm upgrade fails.
Even if there was nothing there before, it will do a rollback, installing a previous version.
The problem with this is that in case of our e2e tests, when we want to run them one by one, with a clean environment each time, this "interaction" kinda breaks that and can/will cause following tests to also break.

## How can this be tested?

`make test/e2e/cloudnative/upgrade` should work and run successful

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
