### PR TITLE
Enable CodeCov GitHub action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,10 @@ jobs:
         id: unittest
         run: |
           make go/test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   linting:
     name: Run linting

--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -30,5 +30,5 @@ go/lint: go/format go/vet go/golangci
 
 ## Runs all go unit tests and writes the coverprofile to cover.out
 go/test:
-	go test ./... -coverprofile cover.out -tags "$(shell ./hack/build/create_go_build_tags.sh false)"
+	go test ./... -coverprofile=coverage.txt -covermode=atomic -tags "$(shell ./hack/build/create_go_build_tags.sh false)"
 


### PR DESCRIPTION
## Description

Enable CodeCov on the repository.

- CodeCov app has been added to the dynatrace-operator repo
- CODECOV_TOKEN has been added aswell

[More details about the setup here](https://app.codecov.io/gh/Dynatrace/dynatrace-operator/new)

## How can this be tested?

CodeCov action is executed and passed on the PR

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
