### PR TITLE
Replace cover.out occurrences with new coverage.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,8 @@ anaconda-mode/
 *.dylib
 # Test binary, build with 'go test -c'
 *.test
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
+# Output of the go coverage tool
+coverage.txt
 ### Vim ###
 # swap
 .sw[a-p]

--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -28,7 +28,7 @@ go/golangci:
 ## Runs all the linting tools
 go/lint: go/format go/vet go/golangci
 
-## Runs all go unit tests and writes the coverprofile to cover.out
+## Runs all go unit tests and writes the coverprofile to coverage.txt
 go/test:
 	go test ./... -coverprofile=coverage.txt -covermode=atomic -tags "$(shell ./hack/build/create_go_build_tags.sh false)"
 


### PR DESCRIPTION
## Description

With a previous PR, we changed the output unit tests file from `cover.out` to `coverage.txt`. We missed adding it to gitignore.

## How can this be tested?

---

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
