### PR TITLE
Add network zone to OneAgent and ActiveGate endpoints

### DIFF
--- a/src/dtclient/endpoints.go
+++ b/src/dtclient/endpoints.go
@@ -25,11 +25,19 @@ func (dtc *dynatraceClient) getAgentVersionsUrl(os, installerType, flavor, arch 
 }
 
 func (dtc *dynatraceClient) getOneAgentConnectionInfoUrl() string {
-	return fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dtc.url)
+	if dtc.networkZone != "" {
+		return fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo?networkZone=%s&defaultZoneFallback=true", dtc.url, dtc.networkZone)
+	} else {
+		return fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dtc.url)
+	}
 }
 
 func (dtc *dynatraceClient) getActiveGateConnectionInfoUrl() string {
-	return fmt.Sprintf("%s/v1/deployment/installer/gateway/connectioninfo", dtc.url)
+	if dtc.networkZone != "" {
+		return fmt.Sprintf("%s/v1/deployment/installer/gateway/connectioninfo?networkZone=%s", dtc.url, dtc.networkZone)
+	} else {
+		return fmt.Sprintf("%s/v1/deployment/installer/gateway/connectioninfo", dtc.url)
+	}
 }
 
 func (dtc *dynatraceClient) getHostsUrl() string {

--- a/src/dtclient/endpoints.go
+++ b/src/dtclient/endpoints.go
@@ -27,17 +27,15 @@ func (dtc *dynatraceClient) getAgentVersionsUrl(os, installerType, flavor, arch 
 func (dtc *dynatraceClient) getOneAgentConnectionInfoUrl() string {
 	if dtc.networkZone != "" {
 		return fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo?networkZone=%s&defaultZoneFallback=true", dtc.url, dtc.networkZone)
-	} else {
-		return fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dtc.url)
 	}
+	return fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dtc.url)
 }
 
 func (dtc *dynatraceClient) getActiveGateConnectionInfoUrl() string {
 	if dtc.networkZone != "" {
 		return fmt.Sprintf("%s/v1/deployment/installer/gateway/connectioninfo?networkZone=%s", dtc.url, dtc.networkZone)
-	} else {
-		return fmt.Sprintf("%s/v1/deployment/installer/gateway/connectioninfo", dtc.url)
 	}
+	return fmt.Sprintf("%s/v1/deployment/installer/gateway/connectioninfo", dtc.url)
 }
 
 func (dtc *dynatraceClient) getHostsUrl() string {

--- a/src/dtclient/endpoints_test.go
+++ b/src/dtclient/endpoints_test.go
@@ -1,0 +1,69 @@
+package dtclient
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/src/scheme/fake"
+)
+
+func Test_dynatraceClient_getOneAgentConnectionInfoUrl(t *testing.T) {
+	tests := []struct {
+		name        string
+		networkZone string
+		want        string
+	}{
+		{
+			name:        "with network zone",
+			networkZone: "mynetworkzone",
+			want:        "https://testenvironment.live.dynatrace.com/api/v1/deployment/installer/agent/connectioninfo?networkZone=mynetworkzone&defaultZoneFallback=true",
+		},
+		{
+			name:        "without network zone",
+			networkZone: "",
+			want:        "https://testenvironment.live.dynatrace.com/api/v1/deployment/installer/agent/connectioninfo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake.NewClient()
+			dtc := &dynatraceClient{
+				url:         "https://testenvironment.live.dynatrace.com/api",
+				networkZone: tt.networkZone,
+			}
+			if got := dtc.getOneAgentConnectionInfoUrl(); got != tt.want {
+				t.Errorf("dynatraceClient.getOneAgentConnectionInfoUrl() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_dynatraceClient_getActiveGateConnectionInfoUrl(t *testing.T) {
+	tests := []struct {
+		name        string
+		networkZone string
+		want        string
+	}{
+		{
+			name:        "with network zone",
+			networkZone: "mynetworkzone",
+			want:        "https://testenvironment.live.dynatrace.com/api/v1/deployment/installer/gateway/connectioninfo?networkZone=mynetworkzone",
+		},
+		{
+			name:        "without network zone",
+			networkZone: "",
+			want:        "https://testenvironment.live.dynatrace.com/api/v1/deployment/installer/gateway/connectioninfo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake.NewClient()
+			dtc := &dynatraceClient{
+				url:         "https://testenvironment.live.dynatrace.com/api",
+				networkZone: tt.networkZone,
+			}
+			if got := dtc.getActiveGateConnectionInfoUrl(); got != tt.want {
+				t.Errorf("dynatraceClient.getActiveGateConnectionInfoUrl() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

OneAgent and ActiveGate API endpoints now relate to the configured dynakube network zone

## How can this be tested?

- Unit tests
- Apply a dynakube with `spec.networkZone` property

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
