### PR TITLE
Set logger for controller-runtime.

### DIFF
--- a/test/scenarios/activegate/basic/activegate_test.go
+++ b/test/scenarios/activegate/basic/activegate_test.go
@@ -5,14 +5,17 @@ package activegatebasic
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios/activegate"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-activegate-basic"))
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }

--- a/test/scenarios/activegate/proxy/activegate_test.go
+++ b/test/scenarios/activegate/proxy/activegate_test.go
@@ -5,16 +5,20 @@ package activegateproxy
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/proxy"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios/activegate"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-activegate-proxy"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.BeforeEachTest(istio.AssertIstioNamespace())
 	testEnvironment.BeforeEachTest(istio.AssertIstiodDeployment())

--- a/test/scenarios/applicationmonitoring/applicationmonitoring_test.go
+++ b/test/scenarios/applicationmonitoring/applicationmonitoring_test.go
@@ -5,13 +5,16 @@ package applicationmonitoring
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-application-monitoring"))
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }

--- a/test/scenarios/classic/classic_test.go
+++ b/test/scenarios/classic/classic_test.go
@@ -5,13 +5,17 @@ package classic
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-classic-fullstack"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }

--- a/test/scenarios/classic/switch_modes/switch_modes_test.go
+++ b/test/scenarios/classic/switch_modes/switch_modes_test.go
@@ -5,13 +5,17 @@ package switch_modes
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-classic-fullstack-switch-modes"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }

--- a/test/scenarios/cloudnative/basic/cloudnative_test.go
+++ b/test/scenarios/cloudnative/basic/cloudnative_test.go
@@ -5,13 +5,16 @@ package basic
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-cloudnative-basic"))
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }

--- a/test/scenarios/cloudnative/codemodules/cloudnative_test.go
+++ b/test/scenarios/cloudnative/codemodules/cloudnative_test.go
@@ -5,15 +5,18 @@ package codemodules
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/proxy"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-cloudnative-codemodules"))
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }

--- a/test/scenarios/cloudnative/disabled_auto_injection/cloudnative_test.go
+++ b/test/scenarios/cloudnative/disabled_auto_injection/cloudnative_test.go
@@ -5,13 +5,17 @@ package disabled_auto_injection
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-cloudnative-auto-injection"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }

--- a/test/scenarios/cloudnative/istio/cloudnative_test.go
+++ b/test/scenarios/cloudnative/istio/cloudnative_test.go
@@ -5,16 +5,20 @@ package cloudnativeistio
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios/cloudnative/basic"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios/cloudnative/codemodules"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-cloudnative-istio"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.BeforeEachTest(istio.AssertIstioNamespace())
 	testEnvironment.BeforeEachTest(istio.AssertIstiodDeployment())

--- a/test/scenarios/cloudnative/network/cloudnative_test.go
+++ b/test/scenarios/cloudnative/network/cloudnative_test.go
@@ -5,14 +5,18 @@ package network
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-cloudnative-network"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.BeforeEachTest(istio.AssertIstioNamespace())
 	testEnvironment.BeforeEachTest(istio.AssertIstiodDeployment())

--- a/test/scenarios/cloudnative/proxy/cloudnative_test.go
+++ b/test/scenarios/cloudnative/proxy/cloudnative_test.go
@@ -5,15 +5,19 @@ package cloudnativeproxy
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/proxy"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-cloudnative-proxy"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.BeforeEachTest(istio.AssertIstioNamespace())
 	testEnvironment.BeforeEachTest(istio.AssertIstiodDeployment())

--- a/test/scenarios/cloudnative/public_registry/cloudnative_test.go
+++ b/test/scenarios/cloudnative/public_registry/cloudnative_test.go
@@ -5,13 +5,17 @@ package public_registry
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-cloudnative-public-registry"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }

--- a/test/scenarios/cloudnative/specific_agent_version/cloudnative_test.go
+++ b/test/scenarios/cloudnative/specific_agent_version/cloudnative_test.go
@@ -5,13 +5,17 @@ package specific_agent_version
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-cloudnative-agent-version"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }

--- a/test/scenarios/cloudnative/switch_modes/switch_modes_test.go
+++ b/test/scenarios/cloudnative/switch_modes/switch_modes_test.go
@@ -5,13 +5,17 @@ package switch_modes
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-cloudnative-switch-modes"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }

--- a/test/scenarios/cloudnative/upgrade/cloudnative_test.go
+++ b/test/scenarios/cloudnative/upgrade/cloudnative_test.go
@@ -5,13 +5,17 @@ package cloudnative
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 var testEnvironment env.Environment
 
 func TestMain(m *testing.M) {
+	log.SetLogger(logger.Factory.GetLogger("e2e-cloudnative-upgrade"))
+
 	testEnvironment = environment.Get()
 	testEnvironment.Run(m)
 }


### PR DESCRIPTION
## Description

Set a proper logger for controller-runtime in E2E tests. Otherwise, the E2E logs are spammed with messages about a missing logger.

## How can this be tested?

Run E2E tests and check that output doesn't contain messages like:
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
```

## Checklist
- [n/a] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
