### PR TITLE
Add missing usage of EdgeConnect Spec for: Env, Resources, NodeSelector, Toleration, TopologySpreadConstraints

### DIFF
--- a/src/controllers/edgeconnect/deployment/deployment.go
+++ b/src/controllers/edgeconnect/deployment/deployment.go
@@ -60,13 +60,7 @@ func New(instance *edgeconnectv1alpha1.EdgeConnect) *appsv1.Deployment {
 }
 
 func prepareContainerEnvVars(instance *edgeconnectv1alpha1.EdgeConnect) []corev1.EnvVar {
-	var envVars []corev1.EnvVar
-
-	if len(instance.Spec.Env) > 0 {
-		envVars = instance.Spec.Env
-	}
-
-	mandatoryEnvVars := []corev1.EnvVar{
+	defaultEnvVars := []corev1.EnvVar{
 		{
 			Name:  consts.EnvEdgeConnectName,
 			Value: instance.ObjectMeta.Name,
@@ -88,16 +82,19 @@ func prepareContainerEnvVars(instance *edgeconnectv1alpha1.EdgeConnect) []corev1
 	// Since HostRestrictions is optional we should not pass empty env var
 	// otherwise edge-connect will fail
 	if instance.Spec.HostRestrictions != "" {
-		mandatoryEnvVars = append(mandatoryEnvVars, corev1.EnvVar{
+		defaultEnvVars = append(defaultEnvVars, corev1.EnvVar{
 			Name:  consts.EnvEdgeConnectRestrictHostsTo,
 			Value: instance.Spec.HostRestrictions,
 		})
 	}
 
-	for _, envVar := range mandatoryEnvVars {
-		envVars = kubeobjects.AddOrUpdate(envVars, envVar)
+	if len(instance.Spec.Env) > 0 {
+		for _, envVar := range instance.Spec.Env {
+			defaultEnvVars = kubeobjects.AddOrUpdate(defaultEnvVars, envVar)
+		}
 	}
-	return envVars
+
+	return defaultEnvVars
 }
 
 func buildAppLabels(instance *edgeconnectv1alpha1.EdgeConnect) *kubeobjects.AppLabels {

--- a/src/controllers/edgeconnect/deployment/deployment.go
+++ b/src/controllers/edgeconnect/deployment/deployment.go
@@ -42,6 +42,9 @@ func New(instance *edgeconnectv1alpha1.EdgeConnect) *appsv1.Deployment {
 					ServiceAccountName:            consts.EdgeConnectServiceAccountName,
 					TerminationGracePeriodSeconds: address.Of(int64(30)),
 					Volumes:                       []corev1.Volume{prepareVolume(instance)},
+					NodeSelector:                  instance.Spec.NodeSelector,
+					Tolerations:                   instance.Spec.Tolerations,
+					TopologySpreadConstraints:     instance.Spec.TopologySpreadConstraints,
 				},
 			},
 			Strategy: appsv1.DeploymentStrategy{
@@ -57,7 +60,13 @@ func New(instance *edgeconnectv1alpha1.EdgeConnect) *appsv1.Deployment {
 }
 
 func prepareContainerEnvVars(instance *edgeconnectv1alpha1.EdgeConnect) []corev1.EnvVar {
-	envVars := []corev1.EnvVar{
+	var envVars []corev1.EnvVar
+
+	if len(instance.Spec.Env) > 0 {
+		envVars = instance.Spec.Env
+	}
+
+	mandatoryEnvVars := []corev1.EnvVar{
 		{
 			Name:  consts.EnvEdgeConnectName,
 			Value: instance.ObjectMeta.Name,
@@ -79,10 +88,14 @@ func prepareContainerEnvVars(instance *edgeconnectv1alpha1.EdgeConnect) []corev1
 	// Since HostRestrictions is optional we should not pass empty env var
 	// otherwise edge-connect will fail
 	if instance.Spec.HostRestrictions != "" {
-		envVars = append(envVars, corev1.EnvVar{
+		mandatoryEnvVars = append(mandatoryEnvVars, corev1.EnvVar{
 			Name:  consts.EnvEdgeConnectRestrictHostsTo,
 			Value: instance.Spec.HostRestrictions,
 		})
+	}
+
+	for _, envVar := range mandatoryEnvVars {
+		envVars = kubeobjects.AddOrUpdate(envVars, envVar)
 	}
 	return envVars
 }
@@ -110,10 +123,7 @@ func edgeConnectContainer(instance *edgeconnectv1alpha1.EdgeConnect) corev1.Cont
 		Image:           instance.Status.Version.ImageID,
 		ImagePullPolicy: corev1.PullAlways,
 		Env:             prepareContainerEnvVars(instance),
-		Resources: corev1.ResourceRequirements{
-			Requests: kubeobjects.NewResources("100m", "128Mi"),
-			Limits:   kubeobjects.NewResources("100m", "128Mi"),
-		},
+		Resources:       prepareResourceRequirements(instance),
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: address.Of(false),
 			Privileged:               address.Of(false),
@@ -140,5 +150,23 @@ func prepareVolume(instance *edgeconnectv1alpha1.EdgeConnect) corev1.Volume {
 				},
 			},
 		},
+	}
+}
+
+func prepareResourceRequirements(instance *edgeconnectv1alpha1.EdgeConnect) corev1.ResourceRequirements {
+	limits := kubeobjects.NewResources("100m", "128Mi")
+	requests := kubeobjects.NewResources("100m", "128Mi")
+
+	if instance.Spec.Resources.Limits != nil {
+		limits = instance.Spec.Resources.Limits
+	}
+
+	if instance.Spec.Resources.Requests != nil {
+		limits = instance.Spec.Resources.Requests
+	}
+
+	return corev1.ResourceRequirements{
+		Requests: requests,
+		Limits:   limits,
 	}
 }

--- a/src/controllers/edgeconnect/deployment/deployment.go
+++ b/src/controllers/edgeconnect/deployment/deployment.go
@@ -162,7 +162,7 @@ func prepareResourceRequirements(instance *edgeconnectv1alpha1.EdgeConnect) core
 	}
 
 	if instance.Spec.Resources.Requests != nil {
-		limits = instance.Spec.Resources.Requests
+		requests = instance.Spec.Resources.Requests
 	}
 
 	return corev1.ResourceRequirements{

--- a/src/controllers/edgeconnect/deployment/deployment.go
+++ b/src/controllers/edgeconnect/deployment/deployment.go
@@ -88,10 +88,8 @@ func prepareContainerEnvVars(instance *edgeconnectv1alpha1.EdgeConnect) []corev1
 		})
 	}
 
-	if len(instance.Spec.Env) > 0 {
-		for _, envVar := range instance.Spec.Env {
-			defaultEnvVars = kubeobjects.AddOrUpdate(defaultEnvVars, envVar)
-		}
+	for _, envVar := range instance.Spec.Env {
+		defaultEnvVars = kubeobjects.AddOrUpdate(defaultEnvVars, envVar)
 	}
 
 	return defaultEnvVars

--- a/src/controllers/edgeconnect/deployment/deployment_test.go
+++ b/src/controllers/edgeconnect/deployment/deployment_test.go
@@ -180,7 +180,7 @@ func Test_prepareResourceRequirements(t *testing.T) {
 		},
 	}
 
-	t.Run("Check limits requirements set correctly", func(t *testing.T) {
+	t.Run("Check limits requirements are set correctly", func(t *testing.T) {
 		customResources := corev1.ResourceRequirements{
 			Limits: kubeobjects.NewResources("500m", "256Mi"),
 		}
@@ -189,5 +189,16 @@ func Test_prepareResourceRequirements(t *testing.T) {
 		assert.Equal(t, customResources.Limits, resourceRequirements.Limits)
 		// check that we use default requests when not provided
 		assert.Equal(t, kubeobjects.NewResources("100m", "128Mi"), resourceRequirements.Requests)
+	})
+
+	t.Run("Check requests in requirements are set correctly", func(t *testing.T) {
+		customResources := corev1.ResourceRequirements{
+			Requests: kubeobjects.NewResources("500m", "256Mi"),
+		}
+		testEdgeConnect.Spec.Resources = customResources
+		resourceRequirements := prepareResourceRequirements(testEdgeConnect)
+		assert.Equal(t, customResources.Requests, resourceRequirements.Requests)
+		// check that we use default requests when not provided
+		assert.Equal(t, kubeobjects.NewResources("100m", "128Mi"), resourceRequirements.Limits)
 	})
 }

--- a/src/controllers/edgeconnect/deployment/deployment_test.go
+++ b/src/controllers/edgeconnect/deployment/deployment_test.go
@@ -91,11 +91,11 @@ func Test_prepareContainerEnvVars(t *testing.T) {
 		envVars := prepareContainerEnvVars(instance)
 
 		assert.Equal(t, envVars, []corev1.EnvVar{
-			{Name: "DEBUG", Value: "true"},
 			{Name: consts.EnvEdgeConnectName, Value: testName},
 			{Name: consts.EnvEdgeConnectApiEndpointHost, Value: "abc12345.dynatrace.com"},
 			{Name: consts.EnvEdgeConnectOauthEndpoint, Value: "https://sso-dev.dynatracelabs.com/sso/oauth2/token"},
 			{Name: consts.EnvEdgeConnectOauthResource, Value: "urn:dtenvironment:test12345"},
+			{Name: "DEBUG", Value: "true"},
 		})
 	})
 	t.Run("Create all env vars for simple edgeconnect deployment", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR fixes the absence of a few missing fields from CRD that are landed correctly yo deployment:

Missing fields:
* Env
* resources
* NodeSelector
* Tolerations
* TopologySpreadConstraints

## How can this be tested?

```
kubectl apply -f - <<EOF
apiVersion: dynatrace.com/v1alpha1
kind: EdgeConnect
metadata:
  name: andrii-test
  namespace: dynatrace
spec:
  apiServer: "<tenant>.dev.apps.dynatracelabs.com"
  oauth:
    clientSecret: edge-connect-client-secret
    endpoint: https://<sso-url-here>/sso/oauth2/token
    resource: urn:dtenvironment:<tenant>
 env: 
   - name: DEBUG
     value: "true"
EOF
```

Check env vars of the pod has DEBUG=true:
```
k get pods andrii-test-5d894dbcf9-wn8p5 -o=jsonpath='{range .items[*]}{.spec.containers[*].env}' | jq
[
  {
    "name": "DEBUG",
    "value": "true"
  },
  {
    "name": "EDGE_CONNECT_NAME",
    "value": "andrii-test"
  },
  {
    "name": "EDGE_CONNECT_API_ENDPOINT_HOST",
    "value": "duc19273.dev.apps.dynatracelabs.com"
  },
  {
    "name": "EDGE_CONNECT_OAUTH__ENDPOINT",
    "value": "https://sso-dev.dynatracelabs.com/sso/oauth2/token"
  },
  {
    "name": "EDGE_CONNECT_OAUTH__RESOURCE",
    "value": "urn:dtenvironment:duc19273"
  }
]
➜  dynatrace-operator git:(improve-edgeconnect-deployment)
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
