### PR TITLE
Add network.md and refactor calico network policies

### DIFF
--- a/assets/calico/activegate-policy.yaml
+++ b/assets/calico/activegate-policy.yaml
@@ -21,10 +21,6 @@ spec:
       port: 9999
     - protocol: TCP
       port: 9998
-    - protocol: TCP
-      port: 443
-    - protocol: TCP
-      port: 80
   egress:
   # Allow DNS lookup
   - to:

--- a/assets/calico/dynatrace-policies.yaml
+++ b/assets/calico/dynatrace-policies.yaml
@@ -7,6 +7,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: dynatrace-operator
+      app.kubernetes.io/managed-by: dynatrace-operator
   policyTypes:
     - Ingress
     - Egress
@@ -18,51 +19,38 @@ spec:
     ports:
     # from webhook ports
     - protocol: TCP
-      port: 8383   
+      port: 8383
     - protocol: TCP
       port: 8384
     - protocol: TCP
       port: 8443
-    - protocol: TCP
-      port: 443
     # from operator ports
     - protocol: TCP
       port: 8080
     - protocol: TCP
       port: 10080
-    - protocol: TCP
-      port: 80
-    # from oneagent ports
-    - protocol: TCP
-      port: 50000
-      endPort: 50005
   egress:
   - to:
     # to any ip
     - ipBlock:
         cidr: 0.0.0.0/0
     ports:
+    # to external via HTTPS
+    - protocol: TCP
+      port: 443
     # to webhook ports
     - protocol: TCP
-      port: 8383   
+      port: 8383
     - protocol: TCP
       port: 8384
     - protocol: TCP
       port: 8443
-    - protocol: TCP
-      port: 443    
     # to operator ports
     - protocol: TCP
       port: 8080
     - protocol: TCP
       port: 10080
-    - protocol: TCP
-      port: 80
-    # to oneagent ports
-    - protocol: TCP
-      port: 50000
-      endPort: 50005
-  # Allow DNS lookup 
+  # Allow DNS lookup
   - to:
     - namespaceSelector:
         matchLabels:

--- a/assets/calico/dynatrace-policies.yaml
+++ b/assets/calico/dynatrace-policies.yaml
@@ -17,6 +17,11 @@ spec:
     - ipBlock:
         cidr: 0.0.0.0/0
     ports:
+    # default HTTP/HTTPS
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 443
     # from webhook ports
     - protocol: TCP
       port: 8383
@@ -29,13 +34,18 @@ spec:
       port: 8080
     - protocol: TCP
       port: 10080
+    # csi driver provisioner port
+    - protocol: TCP
+      port: 10090
   egress:
   - to:
     # to any ip
     - ipBlock:
         cidr: 0.0.0.0/0
     ports:
-    # to external via HTTPS
+    # default HTTP/HTTPS
+    - protocol: TCP
+      port: 80
     - protocol: TCP
       port: 443
     # to webhook ports

--- a/doc/network.md
+++ b/doc/network.md
@@ -1,14 +1,13 @@
-- [Operator network](#operator-network)
-  - [Kubernetes network policies](#kubernetes-network-policies)
-  - [Used ports](#used-ports)
-    - [Ingress](#ingress)
-      - [dynatrace-operator](#dynatrace-operator)
-      - [activegate](#activegate)
-    - [Egress](#egress)
-      - [dynatrace-operator](#dynatrace-operator-1)
-      - [kube-system](#kube-system)
-
 # Operator network
+
+- [Kubernetes network policies](#kubernetes-network-policies)
+- [Used ports](#used-ports)
+  - [Ingress](#ingress)
+    - [dynatrace-operator](#dynatrace-operator)
+    - [activegate](#activegate)
+  - [Egress](#egress)
+    - [dynatrace-operator](#dynatrace-operator-1)
+    - [kube-system](#kube-system)
 
 ## Kubernetes network policies
 

--- a/doc/network.md
+++ b/doc/network.md
@@ -23,6 +23,9 @@ All network policies in compliance with the operator can be found in `assets/cal
 
 ### Ingress
 
+- `TCP 80`: Default HTTP
+- `TCP 443`: Default HTTPS
+
 #### dynatrace-operator
 
 - `TCP 8383`: Webhook server metrics
@@ -36,7 +39,14 @@ All network policies in compliance with the operator can be found in `assets/cal
 - `TCP 9999`: HTTPS container port
 - `TCP 9998`: HTTP container port
 
+#### csi-driver
+
+- `TCP 10090`: CSI-Driver provisioner
+
 ### Egress
+
+- `TCP 80`: Default HTTP
+- `TCP 443`: Default HTTPS
 
 #### dynatrace-operator
 
@@ -45,7 +55,6 @@ All network policies in compliance with the operator can be found in `assets/cal
 - `TCP 8443`: Webhook server port
 - `TCP 8080`: CSI-Driver server metrics
 - `TCP 10080`: CSI-Driver probe
-- `TCP 443`: External via HTTPS
 
 #### kube-system
 

--- a/doc/network.md
+++ b/doc/network.md
@@ -1,0 +1,53 @@
+- [Operator network](#operator-network)
+  - [Kubernetes network policies](#kubernetes-network-policies)
+  - [Used ports](#used-ports)
+    - [Ingress](#ingress)
+      - [dynatrace-operator](#dynatrace-operator)
+      - [activegate](#activegate)
+    - [Egress](#egress)
+      - [dynatrace-operator](#dynatrace-operator-1)
+      - [kube-system](#kube-system)
+
+# Operator network
+
+## Kubernetes network policies
+
+All network policies in compliance with the operator can be found in `assets/calico`.
+
+- [activegate-policy.yaml](assets/calico/activegate-policy.yaml)
+- [activegate-policy-external-only.yaml](assets/calico/agent-policy-external-only.yaml)
+- [agent-policy.yaml](assets/calico/agent-policy.yaml)
+- [dynatrace-policies.yaml](assets/calico/dynatrace-policies.yaml)
+
+## Used ports
+
+### Ingress
+
+#### dynatrace-operator
+
+- `TCP 8383`: Webhook server metrics
+- `TCP 8384`: Webhook server validation
+- `TCP 8443`: Webhook server port
+- `TCP 8080`: CSI-Driver server metrics
+- `TCP 10080`: CSI-Driver probe
+
+#### activegate
+
+- `TCP 9999`: HTTPS container port
+- `TCP 9998`: HTTP container port
+
+### Egress
+
+#### dynatrace-operator
+
+- `TCP 8383`: Webhook server metrics
+- `TCP 8384`: Webhook server validation
+- `TCP 8443`: Webhook server port
+- `TCP 8080`: CSI-Driver server metrics
+- `TCP 10080`: CSI-Driver probe
+- `TCP 443`: External via HTTPS
+
+#### kube-system
+
+- `TCP 53`: Allow DNS lookup
+- `UPD 53`: Allow DNS lookup


### PR DESCRIPTION
## Description

Rework the existing network policies using the minimum ports.

New documentation under doc/network.md.

## How can this be tested?

> [!NOTE]
> I would appreciate some help here as I'm not really sure if everything works as expected while running the operator with the network policies. As far as I can see in my cluster, everything is green and no errors.

- Apply assets/calico/dynatrace-policies.yaml
- Apply assets/calico/activegate-policy.yaml
- Running operator locally with a CloudNativeFullStack dynakube and seeing no errors on the pods/logs.

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
