### PR TITLE
Add make target for running e2e tests on gke-autopilot

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -81,3 +81,22 @@ test/e2e/applicationmonitoring/withoutcsi: manifests/crd/helm
 test/e2e/supportarchive: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/support_archive $(SKIPCLEANUP)
 
+## Runs e2e tests on gke-autopilot
+test/e2e/gke-autopilot: manifests/kubernetes/gke-autopilot
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 30m -count=1 ./test/scenarios/applicationmonitoring $(SKIPCLEANUP)
+
+## Runs Application Monitoring default e2e test only on gke-autopilot
+test/e2e/gke-autopilot/applicationmonitoring/default: manifests/kubernetes/gke-autopilot
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/applicationmonitoring  -run ^TestApplicationMonitoring$  $(SKIPCLEANUP)
+
+## Runs Application Monitoring label versio detection e2e test only on gke-autopilot
+test/e2e/gke-autopilot/applicationmonitoring/labelversion: manifests/kubernetes/gke-autopilot
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 25m -count=1 ./test/scenarios/applicationmonitoring  -run ^TestLabelVersionDetection$  $(SKIPCLEANUP)
+
+## Runs Application Monitoring readonly csi-volume e2e test only on gke-autopilot
+test/e2e/gke-autopilot/applicationmonitoring/readonlycsivolume: manifests/kubernetes/gke-autopilot
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/applicationmonitoring  -run ^TestReadOnlyCSIVolume$  $(SKIPCLEANUP)
+
+## Runs Application Monitoring without CSI e2e test only on gke-autopilot
+test/e2e/gke-autopilot/applicationmonitoring/withoutcsi: manifests/kubernetes/gke-autopilot
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/applicationmonitoring  -run ^TestAppOnlyWithoutCSI$  $(SKIPCLEANUP)


### PR DESCRIPTION
## Description

With this the make targets for e2e tests are added. This works only for the following tests:
* applicationMonitoring/default
* appMon/withoutcsi
* appMon/labelversion
* appMon/readonlycsi **(NOTE: this test will not work with the current version of the operator, as there were problems with the whitelisting of the image and csi Driver initContainer, this will be fixed)**

## How can this be tested?

Create a gke-autopilot cluster and run the added make targets. But please be aware that the tests will only work after https://github.com/Dynatrace/dynatrace-operator/pull/2098 is merged.

## Checklist

- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
