### PR TITLE
Add missing ports for ActiveGate network policy

### DIFF
--- a/assets/calico/activegate-policy.yaml
+++ b/assets/calico/activegate-policy.yaml
@@ -21,6 +21,10 @@ spec:
       port: 9999
     - protocol: TCP
       port: 9998
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 80
   egress:
   # Allow DNS lookup
   - to:


### PR DESCRIPTION
## Description

Just noticed that these two ports (that I removed in a previous PR) were needed for ActiveGate in order to start a cluster from scratch.

Before, ActiveGate was never ready because it wasn't able to use 443 port.

## How can this be tested?

Fresh install a cluster with the operator and a dynakube having the activegate-policy and dynatrace-policies installed.

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
