### PR TITLE
Remove network zone from ActiveGate API endpoint

### DIFF
--- a/src/dtclient/endpoints.go
+++ b/src/dtclient/endpoints.go
@@ -32,9 +32,6 @@ func (dtc *dynatraceClient) getOneAgentConnectionInfoUrl() string {
 }
 
 func (dtc *dynatraceClient) getActiveGateConnectionInfoUrl() string {
-	if dtc.networkZone != "" {
-		return fmt.Sprintf("%s/v1/deployment/installer/gateway/connectioninfo?networkZone=%s", dtc.url, dtc.networkZone)
-	}
 	return fmt.Sprintf("%s/v1/deployment/installer/gateway/connectioninfo", dtc.url)
 }
 

--- a/src/dtclient/endpoints_test.go
+++ b/src/dtclient/endpoints_test.go
@@ -46,7 +46,7 @@ func Test_dynatraceClient_getActiveGateConnectionInfoUrl(t *testing.T) {
 		{
 			name:        "with network zone",
 			networkZone: "mynetworkzone",
-			want:        "https://testenvironment.live.dynatrace.com/api/v1/deployment/installer/gateway/connectioninfo?networkZone=mynetworkzone",
+			want:        "https://testenvironment.live.dynatrace.com/api/v1/deployment/installer/gateway/connectioninfo",
 		},
 		{
 			name:        "without network zone",


### PR DESCRIPTION
## Description

As discussed, we should not use network zone for the ActiveGate API endpoint.

## How can this be tested?

- Unit tests

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
