### PR TITLE
Add markdownlint CI check and refactor md files

### DIFF
--- a/.github/pre-commit
+++ b/.github/pre-commit
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 # Check linting and unit tests before commiting
-# if linting failes the commit will be aborted and the linting will start auto fixing
+# if linting fails the commit will be aborted and the linting will start auto fixing
 # if unit tests fail the commit will be aborted
 
 # Linting
 
 echo Shell: "${SHELL}"
+
+echo Linting markdown files...
+make markdown/lint
 
 ## this will retrieve all of the .go files that have been
 ## changed since the last commit
@@ -25,6 +28,7 @@ else
         git add "${file}"
     done
 fi
+
 
 make go/golangci
 res=${?}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,17 @@ jobs:
           version: v1.54.2
           args: --build-tags containers_image_storage_stub,e2e --timeout 300s --out-${NO_FUTURE}format colored-line-number
 
+  markdown-lint:
+    name: Lint markdown files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Lint markdown files
+        uses: docker://avtodev/markdown-lint:v1
+        with:
+          args: './**.md'
+
   prepare:
     name: Prepare properties
     runs-on: ubuntu-latest

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
+    "MD029": false,
     "MD024": false,
     "MD013": false,
     "MD041": false

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,4 @@
 {
-    "MD029": false,
     "MD024": false,
     "MD013": false,
     "MD041": false

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,10 @@
 # Architecture
+
 This document describes the high-level architecture of `Dynatrace Operator`.
 If you want to familiarize yourself with the code base, you are just in the right place!
 
 ## Bird's Eye View
+
 ```mermaid
 graph LR
     A[fa:fa-user User] -->|creates| B(fa:fa-file CR)
@@ -21,93 +23,121 @@ graph LR
 On a very high level, what the operator does is for a given `CustomResource`(CR) provided by the user, the `Operator` will deploy _one or several_ Dynatrace components into the Kubernetes Environment.
 
 A bit more specifically:
+
 - A `CustomResource`(CR) is configured by the user, where they provide what features or components they want to use, and provide some minimal configuration in the CR so the `Dynatrace Operator` knows what to deploy and how to configure it.
 - The `Operator` not only deploys the different Dynatrace components, but also keeps them up to date.
-   - The `CustomResource`(CR) defines a state, the `Dynatrace Operator` enforces it, makes it happen.
+  - The `CustomResource`(CR) defines a state, the `Dynatrace Operator` enforces it, makes it happen.
 
 ### Dynatrace Operator components
 
 The `Dynatrace Operator` is not a single Pod, it consists of multiple components, encompassing several Kubernetes concepts.
 
 #### Operator
+
 This component/pod is the one that _reacts to_ the creation/update/delete of our`CustomResource(s)`, causing the `Operator` to _reconcile_.
 A _reconcile_ just means that it will check what is in the `CustomResource(s)` and according to that creates/updates/deletes resources in the Kubernetes environment. (So the state of the Kubernetes Environment matches the state described in the `CR`)
 
 Relevant links:
+
 - [Operator Pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
 
 #### Webhook
+
 This component/pod is the one that _intercepts_ creation/update/delete of Kubernetes Resources (only those that are relevant), then either mutates or validates them.
+
 - Validation: We only use it for our `CustomResource(s)`, it's meant to catch known misconfigurations. If the validation webhook detects a problem, the user is warned, the change is denied and rolled back, like nothing happened.
 - Mutation: Used to modify Kubernetes Resources "in flight", so the Resource will be created/updated in the cluster like if it was applied with added modifications.
-   - We have 2 use-cases for this:
-      - Seamlessly modifying user resources with the necessary configuration needed for Dynatrace observability features to work.
-      - Handle time/timing sensitive minor modifications (labeling, annotating) of user resources, which is meant to help the `Operator` perform more reliably and timely.
+  - We have 2 use-cases for this:
+    - Seamlessly modifying user resources with the necessary configuration needed for Dynatrace observability features to work.
+    - Handle time/timing sensitive minor modifications (labeling, annotating) of user resources, which is meant to help the `Operator` perform more reliably and timely.
 
 Relevant links:
+
 - [What are webhooks?](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks)
 
 #### Init Container
+
 Some configurations need to happen on the container filesystem level, like setting up a volume or creating/updating configuration files.
 To achieve this we add our init-container (using the `Webhook`) to user Pods. As init-containers run before any other container, we can setup the environment of user containers to enable Dynatrace observability features.
 
 Relevant links:
+
 - [Init Containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 
 #### CSI-Driver
+
 A component that is present on all nodes, meant to provide volumes (based on the node's filesystem) to make the capabilities provided by the `Operator` to use less disk space and be more performant.
 
 Relevant links:
+
 - [CSI volume](https://kubernetes.io/docs/concepts/storage/volumes/#csi)
 
 ## Code Map
+
 > TODO: Improve folder structure before documenting it more deeply, as its kind of a mess now. If I didn't mention it now, then I probably don't like its current location.
 
 ### `config`
+
 Contains the `.yaml` files that are need to deploy the `Operator` and it`s components into a Kubernetes cluster.
+
 - most `.yaml` files are part of the Helm chart
 - other `.yaml` files are relevant for different marketplaces
+
 ### `hack`
+
 Collection of scripts used for:
+
 - CI tasks
 - Development (build,push,deploy,test, etc...)
 
 ### `hack/make`
+
 Where the `make` targets are defined. We don't have a single makefile with all the targets as it would be quite large.
 
 ### `test`
+
 E2E testing code. Unit tests are NOT found here, they are in the same module that they are testing, as that is the Golang convention.
 
 ### `src/api`
+
 Contains the `CustomResourceDefinitions`(CRDs) as Golang `structs` that the `Operator` reacts to. The `CustomResourceDefinition` yaml files are generated based on these `structs`.
 
 ### `src/cmd`
+
 Where the entry points for every `Operator` subcommand is found. The `Operator` is not a single container, but we still use the same image for all our containers, to simplify the caching for Kubernetes and mirroring of the `Operator` image in private registries. So each component has its own subcommand.
 
 ### `src/controllers`
+
 A Controller is a component that listens/reacts to some Kubernetes Resource. The `Operator` has several of these.
 
 ### `src/controllers/certificates`
+
 The `Operator` creates and maintains certificates that are meant to be used by the webhooks. Certificates are required for a webhook to work in kubernetes, and hard coding certificates into the release of the `Operator` is not an option, the same is true for requiring the user to setup `cert-manager` to create/manage certs for the webhooks.
 
 ### `src/controllers/csi/driver`
+
 Main logic for the CSI-Driver's `server` container. Implements the CSI gRPC interface, and handles each mount request.
 
 ### `src/controllers/csi/provisioner`
+
 Main logic for the CSI-Driver's `provisioner` container. Handles the setting up the environment(filesystem) on the node, so the `server` container can complete its task quickly without making any external requests.
 
 ### `src/controllers/dynakube` and `src/controllers/edgeconnect`
+
 Main logic for the 2 `CustomResources`es the `Operator` currently has.
 
 ### `src/controllers/node`
+
 The `Operator` keeps track of the nodes in the Kubernetes cluster, this is necessary to notice intentional node shutdowns so the `Operator` can notify the `Dynatrace Environment` about it. Otherwise the `Dynatrace Environment` would produce warnings when a node is shutdown even when it was intentional.
 
 ### `src/webhook/mutation`
+
 Mutation webhooks meant for intercepting user Kubernetes Resources, so they can be updated in the instant the updates are required.
 
 ### `src/webhook/validation`
+
 Validation webhooks meant for intercepting our `CustomResources` managed by the users, is they can be checked for well-know misconfigurations and warn the user if any problems found.
 
 ### `src/standalone`
-Main logic for the init-container injected by the `Operator`.
 
+Main logic for the init-container injected by the `Operator`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
   - [Remove all Dynatrace pods in force mode (useful debugging E2E tests)](#remove-all-dynatrace-pods-in-force-mode-useful-debugging-e2e-tests)
   - [Copy CSI driver database to localhost for introspection via sqlite command](#copy-csi-driver-database-to-localhost-for-introspection-via-sqlite-command)
   - [Add debug suffix on E2E tests to avoid removing pods](#add-debug-suffix-on-e2e-tests-to-avoid-removing-pods)
-  - [Debug cluster nodes by opening a shell prompt (details here)](#debug-cluster-nodes-by-opening-a-shell-prompt-details-here)
+  - [Debug cluster nodes by opening a shell prompt (details here)](#debug-cluster-nodes-by-opening-a-shell-prompt)
 
 ## Steps
 
@@ -90,7 +90,9 @@ kubectl cp dynatrace/dynatrace-oneagent-csi-driver-<something>:/data/csi.db csi.
 make test/e2e/cloudnative/proxy/debug
 ```
 
-### Debug cluster nodes by opening a shell prompt ([details here](https://www.psaggu.com/upstream-contribution/2021/05/04/notes.html))
+### Debug cluster nodes by opening a shell prompt
+
+[Details here](https://www.psaggu.com/upstream-contribution/2021/05/04/notes.html)
 
 ```sh
 oc debug node/<node-name>

--- a/HACKING.md
+++ b/HACKING.md
@@ -10,14 +10,15 @@
 There are automatic builds from the master branch. The latest development build can be installed as follows:
 
 #### Kubernetes
+
 ```sh
-$ make deploy/kubernetes
+make deploy/kubernetes
 ```
 
 #### OpenShift
 
 ```sh
-$ make deploy/openshift
+make deploy/openshift
 ```
 
 #### Tests
@@ -25,5 +26,5 @@ $ make deploy/openshift
 The unit tests can be executed as follows:
 
 ```sh
-$ make go/test
+make go/test
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Dynatrace Operator
+
 [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/Dynatrace/dynatrace-operator)
 [![CI](https://github.com/Dynatrace/dynatrace-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/Dynatrace/dynatrace-operator/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/Dynatrace/dynatrace-operator/parse/branch/main/graph/badge.svg)](https://codecov.io/gh/Dynatrace/dynatrace-operator)
@@ -42,13 +43,14 @@ objects like permissions, custom resources and corresponding StatefulSets.
 To create the namespace and apply the operator run the following commands
 
 ```sh
-$ kubectl create namespace dynatrace
-$ kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes.yaml
+kubectl create namespace dynatrace
+kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes.yaml
 ```
 
 If using `cloudNativeFullStack` or `applicationMonitoring` with CSI driver, the following command is required as well:
+
 ```sh
-$ kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes-csi.yaml
+kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes-csi.yaml
 ```
 
 A secret holding tokens for authenticating to the Dynatrace cluster needs to be created upfront. Create access tokens of
@@ -59,7 +61,7 @@ to [Create user-generated access tokens](https://www.dynatrace.com/support/help/
 The token scopes required by the Dynatrace Operator are documented on our [official help page](https://www.dynatrace.com/support/help/shortlink/full-stack-dto-k8#tokens)
 
 ```sh
-$ kubectl -n dynatrace create secret generic dynakube --from-literal="apiToken=DYNATRACE_API_TOKEN" --from-literal="dataIngestToken=DATA_INGEST_TOKEN"
+kubectl -n dynatrace create secret generic dynakube --from-literal="apiToken=DYNATRACE_API_TOKEN" --from-literal="dataIngestToken=DATA_INGEST_TOKEN"
 ```
 
 #### Create `DynaKube` custom resource for ActiveGate and OneAgent rollout
@@ -75,13 +77,13 @@ The recommended approach is using classic Fullstack injection to roll out Dynatr
 In case you want to have adjustments please have a look at [our DynaKube Custom Resource examples](assets/samples).
 
 Save one of the sample configurations, change the API url to your environment and apply it to your cluster.
+
 ```sh
-$ kubectl apply -f cr.yaml
+kubectl apply -f cr.yaml
 ```
 
 For detailed instructions see
 our [official help page](https://www.dynatrace.com/support/help/shortlink/full-stack-dto-k8).
-
 
 ## Uninstall dynatrace-operator
 
@@ -89,13 +91,15 @@ our [official help page](https://www.dynatrace.com/support/help/shortlink/full-s
 > head to the [official help page](https://www.dynatrace.com/support/help/shortlink/full-stack-dto-k8#uninstall-dynatrace-operator)
 
 Clean-up all Dynatrace Operator specific objects:
+
 ```sh
-$ kubectl delete -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes.yaml
+kubectl delete -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes.yaml
 ```
 
 If the CSI driver was installed, the following command is required as well:
+
 ```sh
-$ kubectl delete -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes-csi.yaml
+kubectl delete -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes-csi.yaml
 ```
 
 ## Hacking

--- a/config/helm/README.md
+++ b/config/helm/README.md
@@ -1,10 +1,10 @@
-# Tool Prerequisites
+## Tool Prerequisites
 
 * Install mpdev, see [google documentation](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/tool-prerequisites.md) for more information
 * Create an empty GKE cluster
 * Apply Googles Application CRD, see [google documentation](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/tool-prerequisites.md) for more information
 
-# Installation
+## Installation
 
 * Run `hack/gcr/deployer-image.sh` to build and push a new deployer image containing the helm charts
 * Run `hack/gcr/deploy.sh` to deploy the deployer image

--- a/config/helm/chart/default/README.md
+++ b/config/helm/chart/default/README.md
@@ -5,6 +5,7 @@ The Dynatrace Operator supports rollout and lifecycle of various Dynatrace compo
 This Helm Chart requires Helm 3.
 
 ## Quick Start
+
 Migration instructions can be found in the [official help page](https://www.dynatrace.com/support/help/shortlink/k8s-dto-helm#migrate).
 
 Install the Dynatrace Operator via Helm by running the following commands.
@@ -15,19 +16,23 @@ Install the Dynatrace Operator via Helm by running the following commands.
 > [official help page](https://www.dynatrace.com/support/help/shortlink/k8s-helm)
 
 Add `dynatrace` helm repository:
-```
+
+```console
 helm repo add dynatrace https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/main/config/helm/repos/stable
 ```
 
 Install `dynatrace-operator` helm chart and create the corresponding `dynatrace` namespace:
+
 ```console
 helm install dynatrace-operator dynatrace/dynatrace-operator -n dynatrace --create-namespace --atomic
 ```
 
 ## Uninstall chart
+
 > Full instructions can be found in the [official help page](https://www.dynatrace.com/support/help/shortlink/k8s-helm#uninstall-dynatrace-operator)
 
 Uninstall the Dynatrace Operator by running the following command:
+
 ```console
 helm uninstall dynatrace-operator -n dynatrace
 ```

--- a/config/olm/README.md
+++ b/config/olm/README.md
@@ -3,12 +3,13 @@
 If you want to know what is actually happening in the background before testing, go to the `What is actually happening` section.
 
 Prerequisites:
+
 - [operator-sdk](https://sdk.operatorframework.io/docs/installation/)
 - [opm](https://docs.openshift.com/container-platform/4.6/cli_reference/opm-cli.html)
 - docker or podman
 
-
 Steps:
+
 1. Get an Openshift cluster that has OLM, and use `oc login` on it
 2. If want you want to test but there is no bundle yet => run `make bundle`
    - example: `make bundle PLATFORM=openshift VERSION=0.6.0`
@@ -22,11 +23,13 @@ Steps:
    - (the UI approach is more reliable)
 
 ## How to test an upgrade
+
 **IMPORTANT: Check the `replaces` field in the `ClusterServiceVersion` so that the upgrade actually happens**
 
 Testing an upgrade can't be fully automated (it would be very flaky).
 
 So the basic workflow is:
+
 1. Deploy the version you are upgrading from. (follow the steps above)
 2. **(if it doesn't exist)** Create a the bundle for the version you want to upgrade to.
 3. In `hack/setup_olm_catalog.sh` there is commented out line, READ IT and update the script accordingly.
@@ -35,8 +38,8 @@ So the basic workflow is:
 4. Run `make test-olm` (with the same args as the `make bundle` + TAG)
 5. Look at cluster, monitor if the upgrade is successful.
 
-
 ## What is actually happening
+
 **DISCLAIMER: This is only a quick and simple explanation more detailed description [here](https://olm.operatorframework.io/docs/tasks/creating-a-catalog/)**
 
 First lets understand each part we are creating.
@@ -45,7 +48,12 @@ First lets understand each part we are creating.
   - We generate this from the manifests (crd included)
   - Can be considered as an "OLM Release"
   - It creates the following file structure
-  ```
+    - `manifests` contains all the Kubernetes / Openshift yamls that will be deployed by OLM
+      - Most of our *normal* yamls are moved into the `ClusterServiceVersion`.
+    - `metadata` contains some metadata used by OLM, not very interesting
+    - `bundle-{VERSION}.Dockerfile` is the docker file for creating the `catalog` image for the bundle/release.
+
+```sh
   config/olm/{PLATFORM}/
       |
       |----- {VERSION}/
@@ -56,11 +64,7 @@ First lets understand each part we are creating.
       |
       |
       |---- bundle-{VERSION}.Dockerfile
-  ```
-   - `manifests` contains all the Kubernetes / Openshift yamls that will be deployed by OLM
-      - Most of our *normal* yamls are moved into the `ClusterServiceVersion`.
-   - `metadata` contains some metadata used by OLM, not very interesting
-   - `bundle-{VERSION}.Dockerfile` is the docker file for creating the `catalog` image for the bundle/release.
+```
 
 - What is a `catalog`:
   - A container image that contains the contents of a bundle, + is labeled with the metadata of the bundle.
@@ -72,6 +76,7 @@ First lets understand each part we are creating.
   - Referenced in the `CatalogSource` resources, which is used by OLM to list what can be installed and do the upgrades when possible.
 
 So `hack/setup_olm_catalog.sh` (used by `make test/olm`) does the following:
+
 1. Creates/pushes `catalog` image for specified bundle
 2. Creates/pushes `index` image (by adding the `catalog` to it)
    - can add a new `catalog` to an existing `index` which creates a new `index`

--- a/doc/coding-style-guide.md
+++ b/doc/coding-style-guide.md
@@ -27,7 +27,9 @@
 - Avoid returning responses (e.g., reconcile.Result, admission.Patched) in anything but Reconcile or Handle functions.
 
 ## Function Parameter and Return-Value Order
+
 Ordering of **function parameters** should be:
+
 1. Convention
    - example: `ctx context.Context`
 2. Interfaces
@@ -211,4 +213,4 @@ So here are some basic guidelines:
 
 [Common guidelines](https://github.com/golang/go/wiki/CodeReview)
 
-*// TODO*
+// TODO

--- a/doc/isito.md
+++ b/doc/isito.md
@@ -3,6 +3,7 @@
 For the `operator` and it's deployed components to work in an _istio environment_ in `REGISTRY_ONLY` mode it naturally needs a few `ServiceEntries` and `VirtualServices`.
 
 We can differentiate between 2 "sources" of endpoints/hosts we have to worry about:
+
 1. The `APIURL` defined in the `DynaKube`.
     - The operator uses to communicate with the Dynatrace Environment.
     - Should be handled before anything, otherwise the use would have to configure istio for this url.
@@ -11,11 +12,11 @@ We can differentiate between 2 "sources" of endpoints/hosts we have to worry abo
     - May dynamically change overtime, **main reason** for the integration. (otherwise there could be a "setup once" solution, no fancy operator required)
 
 We can also differentiate between 2 "types" of endpoints/hosts, which is important because you can't mix them in a `ServiceEntry`, you have to create 1 for each type: (A `ServiceEntry` can have multiple hosts listed in it, but has to be the same "type")
+
 1. IP based
     - Needs **no** corresponding `VirtualService`
 2. FQDN(Fully qualified domain name) based
     - Needs corresponding `VirtualService`
-
 
 ```mermaid
 ---

--- a/hack/doc/README.md
+++ b/hack/doc/README.md
@@ -1,9 +1,10 @@
 # role-permissions2md - YAML to Markdown converter for operator permissions
 
-This script can be used to create a table containing permissions needed by components of the Dynatrace Kubernetes Operator. The resulting tables can be used as input for our public documentation here: https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring/dt-component-permissions#dto
+This script can be used to create a table containing permissions needed by components of the Dynatrace Kubernetes Operator. The resulting tables can be used as input for our public documentation [here](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring/dt-component-permissions#dto)
 
 Pre-requisites:
-```
+
+```sh
 python3
 pip install pyyaml
 ```
@@ -12,7 +13,7 @@ pip install pyyaml
 
 It's best to use the `openshift-all.yaml` manifest to cover all our needs. OpenShift needs the most permissions.
 
-```
+```sh
 # local dev repo - direct call
 # Create python virtual env
 python3 -m venv venv

--- a/hack/helm/google-marketplace/README.md
+++ b/hack/helm/google-marketplace/README.md
@@ -5,6 +5,7 @@ It grabs your current selected gcloud project, an application name and a version
 Afterwards it applies the application CRD (from Google) and uses mpdev (needs to be part of $PATH) to deploy that new deployer image to your current Kubernetes cluster.
 
 The following environment variables needs to be provided:
+
 * gcloud project (REGISTRY bases on this)
 * APP_NAME (defaults to "dynatrace-operator")
 * VERSION (tag of the docker image - defaults to "test")

--- a/hack/make/markdown.mk
+++ b/hack/make/markdown.mk
@@ -1,0 +1,3 @@
+## Runs markdownlint using existing .markdownlint.json config file through all .md files in the project
+markdown/lint:
+	markdownlint .

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -17,7 +17,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 ## Install all prerequisites
-prerequisites: prerequisites/kustomize prerequisites/controller-gen prerequisites/setup-pre-commit prerequisites/helm
+prerequisites: prerequisites/kustomize prerequisites/controller-gen prerequisites/setup-pre-commit prerequisites/helm prerequisites/markdownlint
 
 ## Installs 'kustomize' if it is missing
 prerequisites/kustomize:
@@ -40,3 +40,7 @@ prerequisites/setup-pre-commit:
 ## Install 'helm' if it is missing
 prerequisites/helm:
 	hack/helm/install-unittest-plugin.sh
+
+## Install 'markdownlint' if it is missing
+prerequisites/markdownlint:
+	brew install markdownlint-cli --quiet

--- a/test/scenarios/README.md
+++ b/test/scenarios/README.md
@@ -1,4 +1,5 @@
 ### Table of contents
+
 - Active Gate
   - [basic](#activegate---basic)
   - [proxy](#activegate---proxy)
@@ -14,72 +15,92 @@
 - [Support Archive](#supportarchive)
 
 # ActiveGate - basic
+
 ## Prerequisites
 
 ## Setup
+
 OneAgent disabled
 
 ## Goals
+
 Verification if ActiveGate is rolled out successfully. All ActiveGate
 capabilities are enabled in Dynakube. The test checks if related *Gateway*
 modules are active and that the *Gateway* process is reachable via *Gateway service*.
 
 # ActiveGate - proxy
+
 ## Prerequisites
+
 istio service mesh
 
 ## Setup
+
 OneAgent disabled
 
 ## Goals
+
 Verification if ActiveGate is rolled out successfully. All ActiveGate
 capabilities are enabled in Dynakube. The test checks if ActiveGate is able to
 communicate over a http proxy, related *Gateway* modules are active and that
 the *Gateway* process is reachable via *Gateway service*.
 
 # ApplicationMonitoring
+
 ## Prerequisites
 
 ## Setup
+
 ApplicationMonitoring deployment without CSI driver
 
 ## Goals
+
 ### Data Ingest
+
 Verification of the data ingest part of the operator. The test checks that
 enrichment variables are added to the initContainer and dt_metadata.json
 file contains required fields.
 
 ### Build Label Propagation
+
 Verification that build labels are created and set accordingly. The test checks:
+
 - default behavior - feature flag exists, but no additional configuration so the default variables are added
 - custom mapping - feature flag exists, with additional configuration so all 4 build variables are added
 - preserved values of existing variables - build variables exist, feature flag exists, with additional configuration, values of build variables not get overwritten
 - incorrect custom mapping - invalid name of BUILD VERSION label, reference exists but actual label doesn't exist
 
 # Classic
+
 ## Prerequisites
 
 ## Setup
+
 ClassicFullStack deployment
 
 ## Goals
+
 Verification of classic-fullstack deployment. Sample application Deployment is
 installed and restarted to check if OneAgent is injected and can communicate
 with the *Dynatrace Cluster*.
 
 # CloudNative - basic
+
 ## Prerequisites
 
 ## Setup
+
 CloudNative deployment with CSI driver
 
 ## Goals
 
 ### Install
+
 Verification that OneAgent is injected to sample application pods and can
 communicate with the *Dynatrace Cluster*.
 
 ### Upgrade
+
 Verification that a *released version* can be updated to the *current version*.
 The exact number of *released version* is updated manually. The *released
 version* is installed using configuration files from GitHub.
@@ -88,10 +109,12 @@ Sample application Deployment is installed and restarted to check if OneAgent is
 injected and can communicate with the *Dynatrace Cluster*.
 
 ### CodeModules
+
 Verification that the storage in the CSI driver directory does not increase when
 there are multiple tenants and pods which are monitored.
 
 ### Specific Agent Version
+
 Verification that the operator is able to set agent version which is given via
 the dynakube. Upgrading to a newer version of agent is also tested.
 
@@ -99,13 +122,17 @@ Sample application Deployment is installed and restarted to check if OneAgent is
 injected and VERSION environment variable is correct.
 
 # CloudNative - istio
+
 ## Prerequisites
+
 istio service mesh
 
 ## Setup
+
 CloudNative deployment with CSI driver
 
 ## Goals
+
 Verify that the operator is working as expected when istio service mesh is
 installed and pre-configured on the cluster.
 
@@ -115,13 +142,17 @@ installed and pre-configured on the cluster.
 4) [Specific Agent Version](#specific-agent-version)
 
 # CloudNative - network
+
 ## Prerequisites
+
 istio service mesh
 
 ## Setup
+
 CloudNative deployment with CSI driver
 
 ## Goals
+
 Verification that the CSI driver is able to recover from network issues, when
 using cloudNative and code modules image.
 
@@ -131,13 +162,17 @@ checks if init container was attached, run successfully and that the sample
 pods are up and running.
 
 # CloudNative - proxy
+
 ## Prerequisites
+
 istio service mesh
 
 ## Setup
+
 CloudNative deployment with CSI driver
 
 ## Goals
+
 Verification that the operator and all deployed OneAgents are able to communicate
 over a http proxy.
 
@@ -146,27 +181,35 @@ the local cluster. Sample application is installed. The test checks if DT_PROXY 
 variable is defined in the *dynakube-oneagent* container and the *application container*.
 
 # SupportArchive
+
 ## Prerequisites
 
 ## Setup
+
 DTO with CSI driver
 
 ## Goals
+
 Verification if support-archive package created by the support-archive command and printed
 to the standard output is a valid tar.gz package and contains required *operator-version.txt*
 file.
 
 # Synthetic - monolocation
+
 ## Prerequisites
+
 Define from a tenant a synthetic private location attributed with a browser monitor.
 
 ## Setup
+
 Specify the entities IDs for the prerequisites in `single-tenant.yaml`.
 
 ## Goals
+
 The test suite requires the operator to set up an **Active Gate** focused on the observability and a **synthetic location** apt to complete a browser visit.
 
 Particularly it applies a `DynaKubes` for the **Active Gate** and one for **location**. Then it searches the container logs for:
+
 1. Observability modules specific for **Active Gate**,
 2. The location ordinal and the synthetic module for the supplementary **Active Gate**,
 3. **VUC** with the running status,

--- a/test/testdata/secrets-samples/README.md
+++ b/test/testdata/secrets-samples/README.md
@@ -1,4 +1,5 @@
 # Secrets
+
 The tests need connection info to tenants.
 The secrets need to be placed inside a yaml under `/test/testdata/secrets/`.
 Samples of the files can be found in this directory.


### PR DESCRIPTION
## Description

Add [Markdownlint](https://github.com/DavidAnson/markdownlint) GH action on CI.

Fix all existing lint errors in `.md` files.

`.markdownlint.json` config file was already introduced before.

Commands added:

- `make markdown/lint`
- `make prerequisites/markdownlint`

I also set the pre-commit hook to run the linter

## How can this be tested?

Introduce a lint error in a .md file and trigger the action. The PR should get blocked.

You can see I tested that in my commit "Test" of this PR.

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
