### PR TITLE
Add validator to check dynakube name for leading digits

### DIFF
--- a/src/webhook/validation/dynakube/config.go
+++ b/src/webhook/validation/dynakube/config.go
@@ -30,7 +30,7 @@ var validators = []validator{
 	imageFieldSetWithoutCSIFlag,
 	conflictingOneAgentVolumeStorageSettings,
 	invalidSyntheticNodeType,
-	nameStartsWithDigit,
+	nameViolatesDNS1035,
 }
 
 var warnings = []validator{

--- a/src/webhook/validation/dynakube/config.go
+++ b/src/webhook/validation/dynakube/config.go
@@ -30,6 +30,7 @@ var validators = []validator{
 	imageFieldSetWithoutCSIFlag,
 	conflictingOneAgentVolumeStorageSettings,
 	invalidSyntheticNodeType,
+	nameStartsWithDigit,
 }
 
 var warnings = []validator{

--- a/src/webhook/validation/dynakube/dynakube_name.go
+++ b/src/webhook/validation/dynakube/dynakube_name.go
@@ -13,7 +13,10 @@ const (
 
 func nameStartsWithDigit(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	dynakubeName := dynakube.Name
-	firstChar := rune(dynakubeName[0])
+	var firstChar rune
+	if dynakubeName != "" {
+		firstChar = rune(dynakubeName[0])
+	}
 
 	if unicode.IsDigit(firstChar) {
 		return errorDigitInName

--- a/src/webhook/validation/dynakube/dynakube_name.go
+++ b/src/webhook/validation/dynakube/dynakube_name.go
@@ -1,9 +1,8 @@
 package dynakube
 
 import (
-	"unicode"
-
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1/dynakube"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -13,14 +12,13 @@ const (
 
 func nameStartsWithDigit(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	dynakubeName := dynakube.Name
-	var firstChar rune
+	var errs []string
 	if dynakubeName != "" {
-		firstChar = rune(dynakubeName[0])
+		errs = validation.IsDNS1035Label(dynakubeName)
 	}
 
-	if unicode.IsDigit(firstChar) {
-		return errorDigitInName
+	if len(errs) == 0 {
+		return ""
 	}
-
-	return ""
+	return errorDigitInName
 }

--- a/src/webhook/validation/dynakube/dynakube_name.go
+++ b/src/webhook/validation/dynakube/dynakube_name.go
@@ -6,11 +6,12 @@ import (
 )
 
 const (
-	errorDigitInName = `The DynaKube's specification has an invalid name: It starts with a digit.
+	errorNoDNS1053Label = `The DynaKube's specification has an invalid name: It violates DNS-1035.
+    [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]
 	`
 )
 
-func nameStartsWithDigit(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func nameViolatesDNS1035(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	dynakubeName := dynakube.Name
 	var errs []string
 	if dynakubeName != "" {
@@ -20,5 +21,5 @@ func nameStartsWithDigit(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaK
 	if len(errs) == 0 {
 		return ""
 	}
-	return errorDigitInName
+	return errorNoDNS1053Label
 }

--- a/src/webhook/validation/dynakube/dynakube_name.go
+++ b/src/webhook/validation/dynakube/dynakube_name.go
@@ -1,0 +1,23 @@
+package dynakube
+
+import (
+	"unicode"
+
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1/dynakube"
+)
+
+const (
+	errorDigitInName = `The DynaKube's specification has an invalid name: It starts with a digit.
+	`
+)
+
+func nameStartsWithDigit(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+	dynakubeName := dynakube.Name
+	firstChar := rune(dynakubeName[0])
+
+	if unicode.IsDigit(firstChar) {
+		return errorDigitInName
+	}
+
+	return ""
+}

--- a/src/webhook/validation/dynakube/dynakube_name.go
+++ b/src/webhook/validation/dynakube/dynakube_name.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	errorNoDNS1053Label = `The DynaKube's specification has an invalid name: It violates DNS-1035.
+	errorNoDNS1053Label = `The DynaKube's specification violates DNS-1035.
     [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]
 	`
 )

--- a/src/webhook/validation/dynakube/dynakube_name_test.go
+++ b/src/webhook/validation/dynakube/dynakube_name_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNameStartsWithDigit(t *testing.T) {
 	t.Run(`dynakube name starts with digit`, func(t *testing.T) {
-		assertDeniedResponse(t, []string{errorDigitInName}, &dynatracev1beta1.DynaKube{
+		assertDeniedResponse(t, []string{errorNoDNS1053Label}, &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "1dynakube",
 			},

--- a/src/webhook/validation/dynakube/dynakube_name_test.go
+++ b/src/webhook/validation/dynakube/dynakube_name_test.go
@@ -1,0 +1,26 @@
+package dynakube
+
+import (
+	"testing"
+
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1/dynakube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNameStartsWithDigit(t *testing.T) {
+	t.Run(`dynakube name starts with digit`, func(t *testing.T) {
+		assertDeniedResponse(t, []string{errorDigitInName}, &dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "1dynakube",
+			},
+		})
+		assertAllowedResponse(t, &dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dynakube",
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: "https://tenantid.doma.in/api",
+			},
+		})
+	})
+}


### PR DESCRIPTION
## Description

With this a new validator is added that checks. whether a `dynakube` is applied that starts with a digit. This should be prohibited, as then also services etc. would be created with a leading digit. There are rules for service names that need to conform to DNS-1035 labels and cannot start with numbers.

## How can this be tested?

Apply a `dynakube` with a name that starts with a digit.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
