### PR TITLE
Minor fixes for the e2e tests

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -57,8 +57,8 @@ test/e2e/cloudnative/switchmodes: manifests/crd/helm
 test/e2e/cloudnative/upgrade: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/cloudnative/upgrade $(SKIPCLEANUP)
 
-## Runs Application Monitoring default e2e test only
-test/e2e/applicationmonitoring/default: manifests/crd/helm
+## Runs Application Monitoring dataingest e2e test only
+test/e2e/applicationmonitoring/dataingest: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)"  -count=1 ./test/scenarios/applicationmonitoring  -run ^TestDataIngest$  $(SKIPCLEANUP)
 
 ## Runs Application Monitoring label versio detection e2e test only
@@ -81,8 +81,8 @@ test/e2e/supportarchive: manifests/crd/helm
 test/e2e/gke-autopilot: manifests/kubernetes/gke-autopilot
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 30m -count=1 ./test/scenarios/applicationmonitoring $(SKIPCLEANUP)
 
-## Runs Application Monitoring default e2e test only on gke-autopilot
-test/e2e/gke-autopilot/applicationmonitoring/default: manifests/kubernetes/gke-autopilot
+## Runs Application Monitoring dataingest e2e test only on gke-autopilot
+test/e2e/gke-autopilot/applicationmonitoring/dataingest: manifests/kubernetes/gke-autopilot
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -count=1 ./test/scenarios/applicationmonitoring  -run ^TestDataIngest$  $(SKIPCLEANUP)
 
 ## Runs Application Monitoring label versio detection e2e test only on gke-autopilot

--- a/test/scenarios/cloudnative/codemodules/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules/codemodules.go
@@ -264,9 +264,6 @@ func withProxyCA(t *testing.T, proxySpec *dynatracev1beta1.DynaKubeProxy) featur
 
 func codeModulesCloudNativeSpec() *dynatracev1beta1.CloudNativeFullStackSpec {
 	return &dynatracev1beta1.CloudNativeFullStackSpec{
-		HostInjectSpec: dynatracev1beta1.HostInjectSpec{
-			Args: []string{"INTERNAL_OVERRIDE_CHECKS=downgrade"},
-		},
 		AppInjectionSpec: *codeModulesAppInjectSpec(),
 	}
 }

--- a/test/scenarios/cloudnative/codemodules/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules/codemodules.go
@@ -107,7 +107,9 @@ func InstallFromImage(t *testing.T, istioEnabled bool) features.Feature {
 	// Register dynakube install
 	steps := setup.NewEnvironmentSetup(
 		setup.CreateNamespaceWithoutTeardown(operatorNamespaceBuilder.Build()),
-		setup.DeployOperatorViaMake(cloudNativeDynakube.NeedsCSIDriver()))
+		setup.DeployOperatorViaMake(cloudNativeDynakube.NeedsCSIDriver()),
+		setup.CreateDynakube(secretConfigs[0], cloudNativeDynakube),
+	)
 	steps.CreateSetupSteps(builder)
 
 	// Register sample app install
@@ -127,7 +129,6 @@ func InstallFromImage(t *testing.T, istioEnabled bool) features.Feature {
 
 	// Register sample, dynakube and operator uninstall
 	builder.Teardown(sampleApp.UninstallNamespace())
-	teardown.DeleteDynakube(builder, cloudNativeDynakube)
 	steps.CreateTeardownSteps(builder)
 
 	return builder.Feature()

--- a/test/scenarios/cloudnative/network_problems/network_problems.go
+++ b/test/scenarios/cloudnative/network_problems/network_problems.go
@@ -51,6 +51,7 @@ func networkProblems(t *testing.T) features.Feature {
 	sampleApp := sampleapps.NewSampleDeployment(t, testDynakube)
 	sampleApp.WithNamespace(sampleNamespace)
 	builder.Assess("create sample namespace", sampleApp.InstallNamespace())
+	builder.Teardown(sampleApp.UninstallNamespace())
 
 	setup.CreateFeatureEnvironment(builder,
 		setup.CreateNamespaceWithoutTeardown(namespace.NewBuilder(testDynakube.Namespace).WithLabels(istio.InjectionLabel).Build()),
@@ -63,8 +64,6 @@ func networkProblems(t *testing.T) features.Feature {
 
 	// Register actual test
 	builder.Assess("check for dummy volume", checkForDummyVolume(sampleApp))
-
-	builder.Teardown(sampleApp.UninstallNamespace())
 
 	return builder.Feature()
 }


### PR DESCRIPTION
## Description

Things I fixed: (you can just look at the commits, they have the same comments 😅 )
- Fix CodeModulesImage e2e test
   - The 1.  dynakube (cloudNativeDynakube) was not created
- Fix csi resilience e2e test
   - Sample namespace has to removed before the operator, so the csi-driver can be unmount the sample app
- Remove ill advised oneAgent arg
    - This is a "secret" arg for allowing downgrades, however AFAIK it can cause weird behaviour

## How can this be tested?

Run the effected tests I fixed:
- `make test/e2e/cloudnative/codemodules`
- `make test/e2e/cloudnative/network`

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
