### PR TITLE
Always write cluster id to container.conf

### DIFF
--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -209,11 +209,11 @@ func (runner *Runner) createContainerConfigurationFiles() error {
 		log.Info("creating conf file for container", "container", container)
 		confFilePath := filepath.Join(config.AgentShareDirMount, fmt.Sprintf(config.AgentContainerConfFilenameTemplate, container.Name))
 		content := runner.getBaseConfContent(container)
+
+		log.Info("adding k8s fields")
+		content += runner.getK8ConfContent()
+
 		if runner.hostTenant != config.AgentNoHostTenant {
-			if runner.config.TenantUUID == runner.hostTenant {
-				log.Info("adding k8s fields")
-				content += runner.getK8ConfContent()
-			}
 			log.Info("adding hostTenant field")
 			content += runner.getHostConfContent()
 		}


### PR DESCRIPTION
## Description
Always write the cluster id to the container.conf file independent of any host monitoring OneAgent being present on the node  ore not.

## How can this be tested?

* Deploy operator
* Deploy application monitoring DynaKube
* Deploy sample app
* Shell into app pod
* cat /var/lib/dynatrace/oneagent/agent/config/container.conf
  * make sure that `k8s_cluster_id` and `k8s_node_name` entries are present

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
