### PR TITLE
Remove codeModulesImage e2e test isito parts

### DIFF
--- a/test/scenarios/cloudnative/codemodules/codemodules_test.go
+++ b/test/scenarios/cloudnative/codemodules/codemodules_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestCodeModulesImage(t *testing.T) {
-	testEnvironment.Test(t, InstallFromImage(t, false))
+	testEnvironment.Test(t, InstallFromImage(t))
 }
 
 func TestCodeModulesWithProxy(t *testing.T) {

--- a/test/scenarios/cloudnative/istio/istio_test.go
+++ b/test/scenarios/cloudnative/istio/istio_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/logger"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
-	"github.com/Dynatrace/dynatrace-operator/test/scenarios/cloudnative/codemodules"
 	_default "github.com/Dynatrace/dynatrace-operator/test/scenarios/cloudnative/default"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
@@ -28,5 +27,4 @@ func TestMain(m *testing.M) {
 
 func TestIstioIntegration(t *testing.T) {
 	testEnvironment.Test(t, _default.Default(t, true))
-	testEnvironment.Test(t, codemodules.InstallFromImage(t, true))
 }


### PR DESCRIPTION
## Description

For some reason we can run the codeModulesImage e2e with an `istio: true` arg, which does not really make sense.
- The istio integration does not involve the codeModulesImage field, as the would require us to create a serviceEntry/virtualService for the custom image registry the customer may use to store the codeModulesImage.
- This test does nothing really with istio, other then make it inject our components, but we do not configure it to do anything.


## How can this be tested?

`make test/e2e/cloudnative/codemodules` still exists
`make test/e2e/cloudnative/istio` doesn't take that long (as we no longer run the codeModulesImage e2e test here)

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
