### PR TITLE
Add context parameter to Reconcile function of the Reconciler interface

### DIFF
--- a/src/controllers/certificates/webhook_cert_controller_test.go
+++ b/src/controllers/certificates/webhook_cert_controller_test.go
@@ -254,7 +254,6 @@ func createTestSecret(_ *testing.T, certData map[string][]byte) *corev1.Secret {
 
 func prepareController(clt client.Client) (*WebhookCertificateController, reconcile.Request) {
 	rec := &WebhookCertificateController{
-		ctx:       context.TODO(),
 		client:    clt,
 		apiReader: clt,
 		namespace: testNamespace,

--- a/src/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -43,43 +43,43 @@ func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.S
 	}
 }
 
-func (r *Reconciler) Reconcile() error {
-	err := r.reconcileAuthTokenSecret()
+func (r *Reconciler) Reconcile(ctx context.Context) error {
+	err := r.reconcileAuthTokenSecret(ctx)
 	if err != nil {
 		return errors.WithMessage(err, "failed to create activeGateAuthToken secret")
 	}
 	return nil
 }
 
-func (r *Reconciler) reconcileAuthTokenSecret() error {
+func (r *Reconciler) reconcileAuthTokenSecret(ctx context.Context) error {
 	var secret corev1.Secret
-	err := r.apiReader.Get(context.TODO(),
+	err := r.apiReader.Get(ctx,
 		client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: r.dynakube.Namespace},
 		&secret)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			log.Info("creating activeGateAuthToken secret")
-			return r.ensureAuthTokenSecret()
+			return r.ensureAuthTokenSecret(ctx)
 		}
 		return errors.WithStack(err)
 	}
 	if isSecretOutdated(&secret) {
 		log.Info("activeGateAuthToken is outdated, creating new one")
-		if err := r.deleteSecret(&secret); err != nil {
+		if err := r.deleteSecret(ctx, &secret); err != nil {
 			return errors.WithStack(err)
 		}
-		return r.ensureAuthTokenSecret()
+		return r.ensureAuthTokenSecret(ctx)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) ensureAuthTokenSecret() error {
+func (r *Reconciler) ensureAuthTokenSecret(ctx context.Context) error {
 	agSecretData, err := r.getActiveGateAuthToken()
 	if err != nil {
 		return errors.WithMessagef(err, "failed to create secret '%s'", r.dynakube.ActiveGateAuthTokenSecret())
 	}
-	return r.createSecret(agSecretData)
+	return r.createSecret(ctx, agSecretData)
 }
 
 func (r *Reconciler) getActiveGateAuthToken() (map[string][]byte, error) {
@@ -92,7 +92,7 @@ func (r *Reconciler) getActiveGateAuthToken() (map[string][]byte, error) {
 	}, nil
 }
 
-func (r *Reconciler) createSecret(secretData map[string][]byte) error {
+func (r *Reconciler) createSecret(ctx context.Context, secretData map[string][]byte) error {
 	secretName := r.dynakube.ActiveGateAuthTokenSecret()
 	secret, err := kubeobjects.CreateSecret(r.scheme, r.dynakube,
 		kubeobjects.NewSecretNameModifier(secretName),
@@ -102,15 +102,15 @@ func (r *Reconciler) createSecret(secretData map[string][]byte) error {
 		return errors.WithStack(err)
 	}
 
-	err = r.client.Create(context.TODO(), secret)
+	err = r.client.Create(ctx, secret)
 	if err != nil {
 		return errors.Errorf("failed to create secret '%s': %v", secretName, err)
 	}
 	return nil
 }
 
-func (r *Reconciler) deleteSecret(secret *corev1.Secret) error {
-	if err := r.client.Delete(context.TODO(), secret); err != nil && !k8serrors.IsNotFound(err) {
+func (r *Reconciler) deleteSecret(ctx context.Context, secret *corev1.Secret) error {
+	if err := r.client.Delete(ctx, secret); err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	}
 	return nil

--- a/src/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
@@ -51,11 +51,11 @@ func newTestReconcilerWithInstance(client client.Client) *Reconciler {
 func TestReconcile(t *testing.T) {
 	t.Run(`reconcile auth token for first time`, func(t *testing.T) {
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var authToken corev1.Secret
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
 
 		assert.NotEmpty(t, authToken.Data[ActiveGateAuthTokenName])
 	})
@@ -73,11 +73,11 @@ func TestReconcile(t *testing.T) {
 			Build()
 
 		r := newTestReconcilerWithInstance(clt)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var authToken corev1.Secret
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
 
 		assert.NotEqual(t, authToken.Data[ActiveGateAuthTokenName], []byte(testToken))
 	})
@@ -95,11 +95,11 @@ func TestReconcile(t *testing.T) {
 			Build()
 		r := newTestReconcilerWithInstance(clt)
 
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var authToken corev1.Secret
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
 
 		assert.Equal(t, authToken.Data[ActiveGateAuthTokenName], []byte(testToken))
 	})

--- a/src/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
@@ -51,7 +51,7 @@ func newTestReconcilerWithInstance(client client.Client) *Reconciler {
 func TestReconcile(t *testing.T) {
 	t.Run(`reconcile auth token for first time`, func(t *testing.T) {
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var authToken corev1.Secret
@@ -73,7 +73,7 @@ func TestReconcile(t *testing.T) {
 			Build()
 
 		r := newTestReconcilerWithInstance(clt)
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var authToken corev1.Secret
@@ -95,7 +95,7 @@ func TestReconcile(t *testing.T) {
 			Build()
 		r := newTestReconcilerWithInstance(clt)
 
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var authToken corev1.Secret

--- a/src/controllers/dynakube/activegate/internal/capability/mock.go
+++ b/src/controllers/dynakube/activegate/internal/capability/mock.go
@@ -1,12 +1,15 @@
 package capability
 
-import "github.com/stretchr/testify/mock"
+import (
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/net/context"
+)
 
 type MockReconciler struct {
 	mock.Mock
 }
 
-func (m *MockReconciler) Reconcile() error {
+func (m *MockReconciler) Reconcile(_ context.Context) error {
 	args := m.Called()
 	return args.Error(0)
 }

--- a/src/controllers/dynakube/activegate/internal/capability/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/capability/reconciler_test.go
@@ -93,7 +93,7 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		mockStatefulSetReconciler.AssertCalled(t, "Reconcile")
 		mockCustompropertiesReconciler.AssertCalled(t, "Reconcile")
 		require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		mockStatefulSetReconciler.AssertCalled(t, "Reconcile")
 		mockCustompropertiesReconciler.AssertCalled(t, "Reconcile")
 		require.Error(t, err)
@@ -121,7 +121,7 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		mockCustompropertiesReconciler.AssertCalled(t, "Reconcile")
 		require.Error(t, err)
 	})
@@ -135,7 +135,7 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		require.Error(t, err)
 	})
 	t.Run(`service gets created`, func(t *testing.T) {
@@ -146,7 +146,7 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		mockStatefulSetReconciler.AssertCalled(t, "Reconcile")
 		mockCustompropertiesReconciler.AssertCalled(t, "Reconcile")
 		require.NoError(t, err)
@@ -166,7 +166,7 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		mockStatefulSetReconciler.AssertCalled(t, "Reconcile")
 		mockCustompropertiesReconciler.AssertCalled(t, "Reconcile")
 		require.NoError(t, err)
@@ -194,7 +194,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 		require.Error(t, err)
 		assert.NotNil(t, service)
 
-		err = r.createOrUpdateService()
+		err = r.createOrUpdateService(context.TODO())
 		require.NoError(t, err)
 
 		service = &corev1.Service{}
@@ -206,7 +206,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.createOrUpdateService()
+		err := r.createOrUpdateService(context.TODO())
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
@@ -216,7 +216,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 
 		service.Spec.Ports = []corev1.ServicePort{}
 
-		err = r.createOrUpdateService()
+		err = r.createOrUpdateService(context.TODO())
 		require.NoError(t, err)
 
 		actualService := &corev1.Service{}
@@ -234,7 +234,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.createOrUpdateService()
+		err := r.createOrUpdateService(context.TODO())
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
@@ -244,7 +244,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 
 		service.Labels = map[string]string{}
 
-		err = r.createOrUpdateService()
+		err = r.createOrUpdateService(context.TODO())
 		require.NoError(t, err)
 
 		actualService := &corev1.Service{}
@@ -269,7 +269,7 @@ func TestPortsAreOutdated(t *testing.T) {
 
 	desiredService := CreateService(r.dynakube, r.capability.ShortName())
 
-	err := r.Reconcile()
+	err := r.Reconcile(context.TODO())
 	require.NoError(t, err)
 
 	t.Run(`ports are detected as outdated`, func(t *testing.T) {
@@ -296,7 +296,7 @@ func TestLabelsAreOutdated(t *testing.T) {
 
 	desiredService := CreateService(r.dynakube, r.capability.ShortName())
 
-	err := r.Reconcile()
+	err := r.Reconcile(context.TODO())
 	require.NoError(t, err)
 
 	t.Run(`labels are detected as outdated`, func(t *testing.T) {

--- a/src/controllers/dynakube/activegate/internal/capability/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/capability/reconciler_test.go
@@ -93,7 +93,7 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		mockStatefulSetReconciler.AssertCalled(t, "Reconcile")
 		mockCustompropertiesReconciler.AssertCalled(t, "Reconcile")
 		require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		mockStatefulSetReconciler.AssertCalled(t, "Reconcile")
 		mockCustompropertiesReconciler.AssertCalled(t, "Reconcile")
 		require.Error(t, err)
@@ -121,7 +121,7 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		mockCustompropertiesReconciler.AssertCalled(t, "Reconcile")
 		require.Error(t, err)
 	})
@@ -135,7 +135,7 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.Error(t, err)
 	})
 	t.Run(`service gets created`, func(t *testing.T) {
@@ -146,13 +146,13 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		mockStatefulSetReconciler.AssertCalled(t, "Reconcile")
 		mockCustompropertiesReconciler.AssertCalled(t, "Reconcile")
 		require.NoError(t, err)
 
 		service := corev1.Service{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, &service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, &service)
 
 		assert.NotNil(t, service)
 		assert.NoError(t, err)
@@ -166,13 +166,13 @@ func TestReconcile(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		mockStatefulSetReconciler.AssertCalled(t, "Reconcile")
 		mockCustompropertiesReconciler.AssertCalled(t, "Reconcile")
 		require.NoError(t, err)
 
 		service := corev1.Service{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, &service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, &service)
 
 		assert.Empty(t, service)
 		assert.Error(t, err)
@@ -190,15 +190,15 @@ func TestCreateOrUpdateService(t *testing.T) {
 		verifyReconciler(t, r)
 
 		service := &corev1.Service{}
-		err := r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err := r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
 		require.Error(t, err)
 		assert.NotNil(t, service)
 
-		err = r.createOrUpdateService(context.TODO())
+		err = r.createOrUpdateService(context.Background())
 		require.NoError(t, err)
 
 		service = &corev1.Service{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 	})
@@ -206,22 +206,22 @@ func TestCreateOrUpdateService(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.createOrUpdateService(context.TODO())
+		err := r.createOrUpdateService(context.Background())
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 
 		service.Spec.Ports = []corev1.ServicePort{}
 
-		err = r.createOrUpdateService(context.TODO())
+		err = r.createOrUpdateService(context.Background())
 		require.NoError(t, err)
 
 		actualService := &corev1.Service{}
 
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, actualService)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, actualService)
 		require.NoError(t, err)
 		assert.NotNil(t, actualService)
 
@@ -234,22 +234,22 @@ func TestCreateOrUpdateService(t *testing.T) {
 		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler)
 		verifyReconciler(t, r)
 
-		err := r.createOrUpdateService(context.TODO())
+		err := r.createOrUpdateService(context.Background())
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 
 		service.Labels = map[string]string{}
 
-		err = r.createOrUpdateService(context.TODO())
+		err = r.createOrUpdateService(context.Background())
 		require.NoError(t, err)
 
 		actualService := &corev1.Service{}
 
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, actualService)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, actualService)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 
@@ -269,12 +269,12 @@ func TestPortsAreOutdated(t *testing.T) {
 
 	desiredService := CreateService(r.dynakube, r.capability.ShortName())
 
-	err := r.Reconcile(context.TODO())
+	err := r.Reconcile(context.Background())
 	require.NoError(t, err)
 
 	t.Run(`ports are detected as outdated`, func(t *testing.T) {
 		service := &corev1.Service{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 
@@ -296,12 +296,12 @@ func TestLabelsAreOutdated(t *testing.T) {
 
 	desiredService := CreateService(r.dynakube, r.capability.ShortName())
 
-	err := r.Reconcile(context.TODO())
+	err := r.Reconcile(context.Background())
 	require.NoError(t, err)
 
 	t.Run(`labels are detected as outdated`, func(t *testing.T) {
 		service := &corev1.Service{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 
@@ -313,7 +313,7 @@ func TestLabelsAreOutdated(t *testing.T) {
 	})
 	t.Run(`labelSelectors are detected as outdated`, func(t *testing.T) {
 		service := &corev1.Service{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 

--- a/src/controllers/dynakube/activegate/internal/customproperties/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/customproperties/reconciler_test.go
@@ -24,7 +24,7 @@ const (
 func TestReconciler_Reconcile(t *testing.T) {
 	t.Run(`Create works with minimal setup`, func(t *testing.T) {
 		r := NewReconciler(nil, nil, "", nil, &dynatracev1beta1.DynaKubeValueSource{})
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		assert.NoError(t, err)
 	})
 	t.Run(`Create creates custom properties secret`, func(t *testing.T) {
@@ -36,7 +36,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			}}
 		fakeClient := fake.NewClient(instance)
 		r := NewReconciler(fakeClient, instance, testOwner, scheme.Scheme, &valueSource)
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 
@@ -58,7 +58,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			}}
 		fakeClient := fake.NewClient(instance)
 		r := NewReconciler(fakeClient, instance, testOwner, scheme.Scheme, &valueSource)
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 
@@ -71,7 +71,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.Contains(t, customPropertiesSecret.Data, DataKey)
 		assert.Equal(t, customPropertiesSecret.Data[DataKey], []byte(testValue))
 
-		err = r.Reconcile()
+		err = r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 
@@ -84,7 +84,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.Equal(t, customPropertiesSecret.Data[DataKey], []byte(testValue))
 
 		r.customPropertiesSource.Value = testKey
-		err = r.Reconcile()
+		err = r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 

--- a/src/controllers/dynakube/activegate/internal/customproperties/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/customproperties/reconciler_test.go
@@ -24,7 +24,7 @@ const (
 func TestReconciler_Reconcile(t *testing.T) {
 	t.Run(`Create works with minimal setup`, func(t *testing.T) {
 		r := NewReconciler(nil, nil, "", nil, &dynatracev1beta1.DynaKubeValueSource{})
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		assert.NoError(t, err)
 	})
 	t.Run(`Create creates custom properties secret`, func(t *testing.T) {
@@ -36,12 +36,12 @@ func TestReconciler_Reconcile(t *testing.T) {
 			}}
 		fakeClient := fake.NewClient(instance)
 		r := NewReconciler(fakeClient, instance, testOwner, scheme.Scheme, &valueSource)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
 		var customPropertiesSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: r.buildCustomPropertiesName(testName), Namespace: testNamespace}, &customPropertiesSecret)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: r.buildCustomPropertiesName(testName), Namespace: testNamespace}, &customPropertiesSecret)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, customPropertiesSecret)
@@ -58,12 +58,12 @@ func TestReconciler_Reconcile(t *testing.T) {
 			}}
 		fakeClient := fake.NewClient(instance)
 		r := NewReconciler(fakeClient, instance, testOwner, scheme.Scheme, &valueSource)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
 		var customPropertiesSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: r.buildCustomPropertiesName(testName), Namespace: testNamespace}, &customPropertiesSecret)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: r.buildCustomPropertiesName(testName), Namespace: testNamespace}, &customPropertiesSecret)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, customPropertiesSecret)
@@ -71,11 +71,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.Contains(t, customPropertiesSecret.Data, DataKey)
 		assert.Equal(t, customPropertiesSecret.Data[DataKey], []byte(testValue))
 
-		err = r.Reconcile(context.TODO())
+		err = r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: r.buildCustomPropertiesName(testName), Namespace: testNamespace}, &customPropertiesSecret)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: r.buildCustomPropertiesName(testName), Namespace: testNamespace}, &customPropertiesSecret)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, customPropertiesSecret)
@@ -84,11 +84,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.Equal(t, customPropertiesSecret.Data[DataKey], []byte(testValue))
 
 		r.customPropertiesSource.Value = testKey
-		err = r.Reconcile(context.TODO())
+		err = r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: r.buildCustomPropertiesName(testName), Namespace: testNamespace}, &customPropertiesSecret)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: r.buildCustomPropertiesName(testName), Namespace: testNamespace}, &customPropertiesSecret)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, customPropertiesSecret)

--- a/src/controllers/dynakube/activegate/internal/proxy/reconciler.go
+++ b/src/controllers/dynakube/activegate/internal/proxy/reconciler.go
@@ -33,12 +33,12 @@ type Reconciler struct {
 	dynakube  *dynatracev1beta1.DynaKube
 }
 
-func (r *Reconciler) Reconcile() error {
+func (r *Reconciler) Reconcile(ctx context.Context) error {
 	if r.dynakube.NeedsActiveGateProxy() {
-		return r.generateForDynakube(context.TODO(), r.dynakube)
+		return r.generateForDynakube(ctx, r.dynakube)
 	}
 
-	return r.ensureDeleted(context.TODO(), r.dynakube)
+	return r.ensureDeleted(ctx, r.dynakube)
 }
 
 func NewReconciler(client client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube) *Reconciler {

--- a/src/controllers/dynakube/activegate/internal/proxy/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/proxy/reconciler_test.go
@@ -45,7 +45,7 @@ func newTestReconcilerWithInstance(client client.Client) *Reconciler {
 func TestReconcileWithoutProxy(t *testing.T) {
 	t.Run(`reconcile dynakube without proxy`, func(t *testing.T) {
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 
 		require.NoError(t, err)
 
@@ -64,7 +64,7 @@ func TestReconcileWithoutProxy(t *testing.T) {
 			},
 		}).Build()
 		r := newTestReconcilerWithInstance(testClient)
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 
 		require.NoError(t, err)
 
@@ -82,7 +82,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl(proxyUsername, proxyPassword, proxyHost, proxyPort)
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: proxyValue}
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
@@ -96,7 +96,7 @@ func TestReconcileProxyValue(t *testing.T) {
 	t.Run(`reconcile empty proxy Value`, func(t *testing.T) {
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: ""}
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
@@ -116,7 +116,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 
 	t.Run(`reconcile proxy ValueFrom`, func(t *testing.T) {
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{ValueFrom: customProxySecret}
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
@@ -129,7 +129,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 	})
 	t.Run(`Change of Proxy ValueFrom to Value`, func(t *testing.T) {
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{ValueFrom: customProxySecret}
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
@@ -142,7 +142,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 
 		r.dynakube.Spec.Proxy.ValueFrom = ""
 		r.dynakube.Spec.Proxy.Value = buildProxyUrl(proxyDifferentUsername, proxyPassword, proxyHost, proxyPort)
-		err = r.Reconcile()
+		err = r.Reconcile(context.TODO())
 
 		require.NoError(t, err)
 
@@ -155,7 +155,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 	})
 	t.Run(`reconcile proxy ValueFrom with non existing secret`, func(t *testing.T) {
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{ValueFrom: "secret"}
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 
 		require.Error(t, err)
 	})

--- a/src/controllers/dynakube/activegate/internal/proxy/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/proxy/reconciler_test.go
@@ -45,12 +45,12 @@ func newTestReconcilerWithInstance(client client.Client) *Reconciler {
 func TestReconcileWithoutProxy(t *testing.T) {
 	t.Run(`reconcile dynakube without proxy`, func(t *testing.T) {
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		require.Error(t, err)
 		assert.Empty(t, proxySecret)
@@ -64,12 +64,12 @@ func TestReconcileWithoutProxy(t *testing.T) {
 			},
 		}).Build()
 		r := newTestReconcilerWithInstance(testClient)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		require.Error(t, err)
 		assert.Empty(t, proxySecret)
@@ -82,11 +82,11 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl(proxyUsername, proxyPassword, proxyHost, proxyPort)
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: proxyValue}
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		assert.Equal(t, []byte(proxyPassword), proxySecret.Data[proxyPasswordField])
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
@@ -96,11 +96,11 @@ func TestReconcileProxyValue(t *testing.T) {
 	t.Run(`reconcile empty proxy Value`, func(t *testing.T) {
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: ""}
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		assert.Equal(t, []byte(nil), proxySecret.Data[proxyPasswordField])
 		assert.Equal(t, []byte(nil), proxySecret.Data[proxyPortField])
@@ -116,11 +116,11 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 
 	t.Run(`reconcile proxy ValueFrom`, func(t *testing.T) {
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{ValueFrom: customProxySecret}
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		assert.Equal(t, []byte(proxyPassword), proxySecret.Data[proxyPasswordField])
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
@@ -129,11 +129,11 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 	})
 	t.Run(`Change of Proxy ValueFrom to Value`, func(t *testing.T) {
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{ValueFrom: customProxySecret}
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+		r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		assert.Equal(t, []byte(proxyPassword), proxySecret.Data[proxyPasswordField])
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
@@ -142,11 +142,11 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 
 		r.dynakube.Spec.Proxy.ValueFrom = ""
 		r.dynakube.Spec.Proxy.Value = buildProxyUrl(proxyDifferentUsername, proxyPassword, proxyHost, proxyPort)
-		err = r.Reconcile(context.TODO())
+		err = r.Reconcile(context.Background())
 
 		require.NoError(t, err)
 
-		_ = r.client.Get(context.TODO(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
 
 		assert.Equal(t, []byte(proxyPassword), proxySecret.Data[proxyPasswordField])
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
@@ -155,7 +155,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 	})
 	t.Run(`reconcile proxy ValueFrom with non existing secret`, func(t *testing.T) {
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{ValueFrom: "secret"}
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		require.Error(t, err)
 	})

--- a/src/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
@@ -77,7 +77,7 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 func TestReconcile(t *testing.T) {
 	t.Run(`create stateful set`, func(t *testing.T) {
 		r := createDefaultReconciler(t)
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 
@@ -89,7 +89,7 @@ func TestReconcile(t *testing.T) {
 	})
 	t.Run(`update stateful set`, func(t *testing.T) {
 		r := createDefaultReconciler(t)
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 
@@ -100,7 +100,7 @@ func TestReconcile(t *testing.T) {
 		assert.NoError(t, err)
 
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: testValue}
-		err = r.Reconcile()
+		err = r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 
@@ -122,7 +122,7 @@ func TestReconcile(t *testing.T) {
 
 func TestReconcile_GetStatefulSet(t *testing.T) {
 	r := createDefaultReconciler(t)
-	err := r.Reconcile()
+	err := r.Reconcile(context.TODO())
 	assert.NoError(t, err)
 
 	desiredSts, err := r.buildDesiredStatefulSet()
@@ -135,7 +135,7 @@ func TestReconcile_GetStatefulSet(t *testing.T) {
 	err = controllerutil.SetControllerReference(r.dynakube, desiredSts, r.scheme)
 	require.NoError(t, err)
 
-	sts, err := r.getStatefulSet(desiredSts)
+	sts, err := r.getStatefulSet(context.TODO(), desiredSts)
 	assert.NoError(t, err)
 	assert.Equal(t, *desiredSts, *sts)
 }
@@ -146,11 +146,11 @@ func TestReconcile_CreateStatefulSetIfNotExists(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, desiredSts)
 
-	created, err := r.createStatefulSetIfNotExists(desiredSts)
+	created, err := r.createStatefulSetIfNotExists(context.TODO(), desiredSts)
 	assert.NoError(t, err)
 	assert.True(t, created)
 
-	created, err = r.createStatefulSetIfNotExists(desiredSts)
+	created, err = r.createStatefulSetIfNotExists(context.TODO(), desiredSts)
 	assert.NoError(t, err)
 	assert.False(t, created)
 }
@@ -161,16 +161,16 @@ func TestReconcile_UpdateStatefulSetIfOutdated(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, desiredSts)
 
-	updated, err := r.updateStatefulSetIfOutdated(desiredSts)
+	updated, err := r.updateStatefulSetIfOutdated(context.TODO(), desiredSts)
 	assert.Error(t, err)
 	assert.False(t, updated)
 	assert.True(t, k8serrors.IsNotFound(errors.Cause(err)))
 
-	created, err := r.createStatefulSetIfNotExists(desiredSts)
+	created, err := r.createStatefulSetIfNotExists(context.TODO(), desiredSts)
 	require.True(t, created)
 	require.NoError(t, err)
 
-	updated, err = r.updateStatefulSetIfOutdated(desiredSts)
+	updated, err = r.updateStatefulSetIfOutdated(context.TODO(), desiredSts)
 	assert.NoError(t, err)
 	assert.False(t, updated)
 
@@ -178,7 +178,7 @@ func TestReconcile_UpdateStatefulSetIfOutdated(t *testing.T) {
 	desiredSts, err = r.buildDesiredStatefulSet()
 	require.NoError(t, err)
 
-	updated, err = r.updateStatefulSetIfOutdated(desiredSts)
+	updated, err = r.updateStatefulSetIfOutdated(context.TODO(), desiredSts)
 	assert.NoError(t, err)
 	assert.True(t, updated)
 }
@@ -190,16 +190,16 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, desiredSts)
 
-		deleted, err := r.deleteStatefulSetIfSelectorChanged(desiredSts)
+		deleted, err := r.deleteStatefulSetIfSelectorChanged(context.TODO(), desiredSts)
 		assert.Error(t, err)
 		assert.False(t, deleted)
 		assert.True(t, k8serrors.IsNotFound(errors.Cause(err)))
 
-		created, err := r.createStatefulSetIfNotExists(desiredSts)
+		created, err := r.createStatefulSetIfNotExists(context.TODO(), desiredSts)
 		require.True(t, created)
 		require.NoError(t, err)
 
-		deleted, err = r.deleteStatefulSetIfSelectorChanged(desiredSts)
+		deleted, err = r.deleteStatefulSetIfSelectorChanged(context.TODO(), desiredSts)
 		assert.NoError(t, err)
 		assert.False(t, deleted)
 
@@ -213,7 +213,7 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 		assert.NoError(t, err)
 
 		desiredSts.Spec.Selector.MatchLabels = correctLabels
-		deleted, err = r.deleteStatefulSetIfSelectorChanged(desiredSts)
+		deleted, err = r.deleteStatefulSetIfSelectorChanged(context.TODO(), desiredSts)
 		assert.NoError(t, err)
 		assert.True(t, deleted)
 	})
@@ -224,7 +224,7 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, appliedStatefulset)
 
-		created, err := r.createStatefulSetIfNotExists(appliedStatefulset)
+		created, err := r.createStatefulSetIfNotExists(context.TODO(), appliedStatefulset)
 
 		require.True(t, created)
 		require.NoError(t, err)
@@ -238,7 +238,7 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 
 		require.NoError(t, err)
 
-		deleted, err := r.deleteStatefulSetIfSelectorChanged(desiredStatefulset)
+		deleted, err := r.deleteStatefulSetIfSelectorChanged(context.TODO(), desiredStatefulset)
 
 		assert.NoError(t, err)
 		assert.False(t, deleted)
@@ -309,10 +309,10 @@ func TestManageStatefulSet(t *testing.T) {
 
 		require.NoError(t, err)
 
-		err = r.manageStatefulSet()
+		err = r.manageStatefulSet(context.TODO())
 		assert.NoError(t, err)
 
-		actualStatefulSet, err := r.getStatefulSet(desiredStatefulSet)
+		actualStatefulSet, err := r.getStatefulSet(context.TODO(), desiredStatefulSet)
 		assert.NoError(t, err)
 		assert.NotNil(t, actualStatefulSet)
 
@@ -321,10 +321,10 @@ func TestManageStatefulSet(t *testing.T) {
 
 		require.NoError(t, err)
 
-		err = r.manageStatefulSet()
+		err = r.manageStatefulSet(context.TODO())
 		assert.NoError(t, err)
 
-		actualStatefulSet, err = r.getStatefulSet(desiredStatefulSet)
+		actualStatefulSet, err = r.getStatefulSet(context.TODO(), desiredStatefulSet)
 		assert.NoError(t, err)
 		assert.NotNil(t, actualStatefulSet)
 		assert.Contains(t, actualStatefulSet.Labels, testName)
@@ -335,10 +335,10 @@ func TestManageStatefulSet(t *testing.T) {
 
 		require.NoError(t, err)
 
-		err = r.manageStatefulSet()
+		err = r.manageStatefulSet(context.TODO())
 		assert.NoError(t, err)
 
-		actualStatefulSet, err := r.getStatefulSet(desiredStatefulSet)
+		actualStatefulSet, err := r.getStatefulSet(context.TODO(), desiredStatefulSet)
 		assert.NoError(t, err)
 		assert.NotNil(t, actualStatefulSet)
 
@@ -347,10 +347,10 @@ func TestManageStatefulSet(t *testing.T) {
 
 		require.NoError(t, err)
 
-		err = r.manageStatefulSet()
+		err = r.manageStatefulSet(context.TODO())
 		assert.NoError(t, err)
 
-		actualStatefulSet, err = r.getStatefulSet(desiredStatefulSet)
+		actualStatefulSet, err = r.getStatefulSet(context.TODO(), desiredStatefulSet)
 		assert.Error(t, err)
 		assert.Nil(t, actualStatefulSet)
 		assert.True(t, k8serrors.IsNotFound(err))

--- a/src/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
@@ -77,35 +77,35 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 func TestReconcile(t *testing.T) {
 	t.Run(`create stateful set`, func(t *testing.T) {
 		r := createDefaultReconciler(t)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
 		statefulSet := &appsv1.StatefulSet{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, statefulSet)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, statefulSet)
 
 		assert.NotNil(t, statefulSet)
 		assert.NoError(t, err)
 	})
 	t.Run(`update stateful set`, func(t *testing.T) {
 		r := createDefaultReconciler(t)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
 		statefulSet := &appsv1.StatefulSet{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, statefulSet)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, statefulSet)
 
 		assert.NotNil(t, statefulSet)
 		assert.NoError(t, err)
 
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: testValue}
-		err = r.Reconcile(context.TODO())
+		err = r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
 		newStatefulSet := &appsv1.StatefulSet{}
-		err = r.client.Get(context.TODO(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, newStatefulSet)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, newStatefulSet)
 
 		assert.NotNil(t, statefulSet)
 		assert.NoError(t, err)
@@ -122,7 +122,7 @@ func TestReconcile(t *testing.T) {
 
 func TestReconcile_GetStatefulSet(t *testing.T) {
 	r := createDefaultReconciler(t)
-	err := r.Reconcile(context.TODO())
+	err := r.Reconcile(context.Background())
 	assert.NoError(t, err)
 
 	desiredSts, err := r.buildDesiredStatefulSet()
@@ -135,7 +135,7 @@ func TestReconcile_GetStatefulSet(t *testing.T) {
 	err = controllerutil.SetControllerReference(r.dynakube, desiredSts, r.scheme)
 	require.NoError(t, err)
 
-	sts, err := r.getStatefulSet(context.TODO(), desiredSts)
+	sts, err := r.getStatefulSet(context.Background(), desiredSts)
 	assert.NoError(t, err)
 	assert.Equal(t, *desiredSts, *sts)
 }
@@ -146,11 +146,11 @@ func TestReconcile_CreateStatefulSetIfNotExists(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, desiredSts)
 
-	created, err := r.createStatefulSetIfNotExists(context.TODO(), desiredSts)
+	created, err := r.createStatefulSetIfNotExists(context.Background(), desiredSts)
 	assert.NoError(t, err)
 	assert.True(t, created)
 
-	created, err = r.createStatefulSetIfNotExists(context.TODO(), desiredSts)
+	created, err = r.createStatefulSetIfNotExists(context.Background(), desiredSts)
 	assert.NoError(t, err)
 	assert.False(t, created)
 }
@@ -161,16 +161,16 @@ func TestReconcile_UpdateStatefulSetIfOutdated(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, desiredSts)
 
-	updated, err := r.updateStatefulSetIfOutdated(context.TODO(), desiredSts)
+	updated, err := r.updateStatefulSetIfOutdated(context.Background(), desiredSts)
 	assert.Error(t, err)
 	assert.False(t, updated)
 	assert.True(t, k8serrors.IsNotFound(errors.Cause(err)))
 
-	created, err := r.createStatefulSetIfNotExists(context.TODO(), desiredSts)
+	created, err := r.createStatefulSetIfNotExists(context.Background(), desiredSts)
 	require.True(t, created)
 	require.NoError(t, err)
 
-	updated, err = r.updateStatefulSetIfOutdated(context.TODO(), desiredSts)
+	updated, err = r.updateStatefulSetIfOutdated(context.Background(), desiredSts)
 	assert.NoError(t, err)
 	assert.False(t, updated)
 
@@ -178,7 +178,7 @@ func TestReconcile_UpdateStatefulSetIfOutdated(t *testing.T) {
 	desiredSts, err = r.buildDesiredStatefulSet()
 	require.NoError(t, err)
 
-	updated, err = r.updateStatefulSetIfOutdated(context.TODO(), desiredSts)
+	updated, err = r.updateStatefulSetIfOutdated(context.Background(), desiredSts)
 	assert.NoError(t, err)
 	assert.True(t, updated)
 }
@@ -190,16 +190,16 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, desiredSts)
 
-		deleted, err := r.deleteStatefulSetIfSelectorChanged(context.TODO(), desiredSts)
+		deleted, err := r.deleteStatefulSetIfSelectorChanged(context.Background(), desiredSts)
 		assert.Error(t, err)
 		assert.False(t, deleted)
 		assert.True(t, k8serrors.IsNotFound(errors.Cause(err)))
 
-		created, err := r.createStatefulSetIfNotExists(context.TODO(), desiredSts)
+		created, err := r.createStatefulSetIfNotExists(context.Background(), desiredSts)
 		require.True(t, created)
 		require.NoError(t, err)
 
-		deleted, err = r.deleteStatefulSetIfSelectorChanged(context.TODO(), desiredSts)
+		deleted, err = r.deleteStatefulSetIfSelectorChanged(context.Background(), desiredSts)
 		assert.NoError(t, err)
 		assert.False(t, deleted)
 
@@ -209,11 +209,11 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 
 		correctLabels := desiredSts.Spec.Selector.MatchLabels
 		desiredSts.Spec.Selector.MatchLabels = map[string]string{"activegate": "dynakube"}
-		err = r.client.Update(context.TODO(), desiredSts)
+		err = r.client.Update(context.Background(), desiredSts)
 		assert.NoError(t, err)
 
 		desiredSts.Spec.Selector.MatchLabels = correctLabels
-		deleted, err = r.deleteStatefulSetIfSelectorChanged(context.TODO(), desiredSts)
+		deleted, err = r.deleteStatefulSetIfSelectorChanged(context.Background(), desiredSts)
 		assert.NoError(t, err)
 		assert.True(t, deleted)
 	})
@@ -224,13 +224,13 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, appliedStatefulset)
 
-		created, err := r.createStatefulSetIfNotExists(context.TODO(), appliedStatefulset)
+		created, err := r.createStatefulSetIfNotExists(context.Background(), appliedStatefulset)
 
 		require.True(t, created)
 		require.NoError(t, err)
 
 		appliedStatefulset.Labels[testName] = testValue
-		err = r.client.Update(context.TODO(), appliedStatefulset)
+		err = r.client.Update(context.Background(), appliedStatefulset)
 
 		require.NoError(t, err)
 
@@ -238,7 +238,7 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 
 		require.NoError(t, err)
 
-		deleted, err := r.deleteStatefulSetIfSelectorChanged(context.TODO(), desiredStatefulset)
+		deleted, err := r.deleteStatefulSetIfSelectorChanged(context.Background(), desiredStatefulset)
 
 		assert.NoError(t, err)
 		assert.False(t, deleted)
@@ -262,7 +262,7 @@ func TestReconcile_GetCustomPropertyHash(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, hash)
 
-	err = r.client.Create(context.TODO(), &corev1.Secret{
+	err = r.client.Create(context.Background(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -284,7 +284,7 @@ func TestReconcile_GetActiveGateAuthTokenHash(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, hash)
 
-	err = r.client.Create(context.TODO(), &corev1.Secret{
+	err = r.client.Create(context.Background(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.dynakube.ActiveGateAuthTokenSecret(),
 			Namespace: r.dynakube.Namespace,
@@ -309,22 +309,22 @@ func TestManageStatefulSet(t *testing.T) {
 
 		require.NoError(t, err)
 
-		err = r.manageStatefulSet(context.TODO())
+		err = r.manageStatefulSet(context.Background())
 		assert.NoError(t, err)
 
-		actualStatefulSet, err := r.getStatefulSet(context.TODO(), desiredStatefulSet)
+		actualStatefulSet, err := r.getStatefulSet(context.Background(), desiredStatefulSet)
 		assert.NoError(t, err)
 		assert.NotNil(t, actualStatefulSet)
 
 		actualStatefulSet.Labels[testName] = testValue
-		err = r.client.Update(context.TODO(), actualStatefulSet)
+		err = r.client.Update(context.Background(), actualStatefulSet)
 
 		require.NoError(t, err)
 
-		err = r.manageStatefulSet(context.TODO())
+		err = r.manageStatefulSet(context.Background())
 		assert.NoError(t, err)
 
-		actualStatefulSet, err = r.getStatefulSet(context.TODO(), desiredStatefulSet)
+		actualStatefulSet, err = r.getStatefulSet(context.Background(), desiredStatefulSet)
 		assert.NoError(t, err)
 		assert.NotNil(t, actualStatefulSet)
 		assert.Contains(t, actualStatefulSet.Labels, testName)
@@ -335,22 +335,22 @@ func TestManageStatefulSet(t *testing.T) {
 
 		require.NoError(t, err)
 
-		err = r.manageStatefulSet(context.TODO())
+		err = r.manageStatefulSet(context.Background())
 		assert.NoError(t, err)
 
-		actualStatefulSet, err := r.getStatefulSet(context.TODO(), desiredStatefulSet)
+		actualStatefulSet, err := r.getStatefulSet(context.Background(), desiredStatefulSet)
 		assert.NoError(t, err)
 		assert.NotNil(t, actualStatefulSet)
 
 		actualStatefulSet.Spec.Selector.MatchLabels["activegate"] = testValue
-		err = r.client.Update(context.TODO(), actualStatefulSet)
+		err = r.client.Update(context.Background(), actualStatefulSet)
 
 		require.NoError(t, err)
 
-		err = r.manageStatefulSet(context.TODO())
+		err = r.manageStatefulSet(context.Background())
 		assert.NoError(t, err)
 
-		actualStatefulSet, err = r.getStatefulSet(context.TODO(), desiredStatefulSet)
+		actualStatefulSet, err = r.getStatefulSet(context.Background(), desiredStatefulSet)
 		assert.Error(t, err)
 		assert.Nil(t, actualStatefulSet)
 		assert.True(t, k8serrors.IsNotFound(err))

--- a/src/controllers/dynakube/activegate/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/reconciler_test.go
@@ -58,7 +58,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			}}
 		fakeClient := fake.NewClient()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 	})
 	t.Run(`Create AG proxy secret`, func(t *testing.T) {
@@ -73,11 +73,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 		}
 		fakeClient := fake.NewClient()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testName + "-activegate-internal-proxy", Namespace: testNamespace}, &proxySecret)
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testName + "-activegate-internal-proxy", Namespace: testNamespace}, &proxySecret)
 		assert.NoError(t, err)
 	})
 	t.Run(`Create AG capability (creation and deletion)`, func(t *testing.T) {
@@ -94,19 +94,19 @@ func TestReconciler_Reconcile(t *testing.T) {
 		}
 		fakeClient := fake.NewClient(testKubeSystemNamespace)
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var service corev1.Service
-		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
 		require.NoError(t, err)
 
 		// remove AG from spec
 		instance.Spec.ActiveGate = dynatracev1beta1.ActiveGateSpec{}
-		err = r.Reconcile(context.TODO())
+		err = r.Reconcile(context.Background())
 		require.NoError(t, err)
 
-		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run("Reconcile DynaKube without Proxy after a DynaKube with proxy must not interfere with the second DKs Proxy Secret", func(t *testing.T) {
@@ -128,15 +128,15 @@ func TestReconciler_Reconcile(t *testing.T) {
 		}
 		fakeClient := fake.NewClient()
 		proxyReconciler := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynaKubeWithProxy, dtc)
-		err := proxyReconciler.Reconcile(context.TODO())
+		err := proxyReconciler.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		noProxyReconciler := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynaKubeNoProxy, dtc)
-		err = noProxyReconciler.Reconcile(context.TODO())
+		err = noProxyReconciler.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
-		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "proxyDk-activegate-internal-proxy", Namespace: testNamespace}, &proxySecret)
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "proxyDk-activegate-internal-proxy", Namespace: testNamespace}, &proxySecret)
 		assert.NoError(t, err)
 	})
 }
@@ -178,11 +178,11 @@ func TestServiceCreation(t *testing.T) {
 				capability,
 			}
 
-			err := reconciler.Reconcile(context.TODO())
+			err := reconciler.Reconcile(context.Background())
 			require.NoError(t, err)
 
 			if len(expectedPorts) == 0 {
-				err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: testServiceName, Namespace: testNamespace}, &corev1.Service{})
+				err = fakeClient.Get(context.Background(), client.ObjectKey{Name: testServiceName, Namespace: testNamespace}, &corev1.Service{})
 
 				assert.True(t, k8serrors.IsNotFound(err))
 				continue
@@ -203,7 +203,7 @@ func TestServiceCreation(t *testing.T) {
 			consts.HttpsServicePortName,
 		}
 
-		err := reconciler.Reconcile(context.TODO())
+		err := reconciler.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		activegateService := getTestActiveGateService(t, fakeClient)
@@ -225,7 +225,7 @@ func assertContainsAllPorts(t *testing.T, expectedPorts []string, servicePorts [
 
 func getTestActiveGateService(t *testing.T, fakeClient client.Client) corev1.Service {
 	var activegateService corev1.Service
-	err := fakeClient.Get(context.TODO(), client.ObjectKey{Name: testServiceName, Namespace: testNamespace}, &activegateService)
+	err := fakeClient.Get(context.Background(), client.ObjectKey{Name: testServiceName, Namespace: testNamespace}, &activegateService)
 
 	require.NoError(t, err)
 
@@ -242,13 +242,13 @@ func TestExclusiveSynMonitoring(t *testing.T) {
 	}
 	fakeClient := fake.NewClient(testKubeSystemNamespace)
 	reconciler := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, mockDtClient)
-	err := reconciler.Reconcile(context.TODO())
+	err := reconciler.Reconcile(context.Background())
 
 	require.NoError(t, err, "successfully reconciled for syn-mon")
 
 	var statefulSets appsv1.StatefulSetList
 	err = fakeClient.List(
-		context.TODO(),
+		context.Background(),
 		&statefulSets,
 		client.InNamespace(testNamespace))
 	require.NoError(t, err)
@@ -266,7 +266,7 @@ func TestExclusiveSynMonitoring(t *testing.T) {
 
 	var services corev1.ServiceList
 	err = fakeClient.List(
-		context.TODO(),
+		context.Background(),
 		&services,
 		client.InNamespace(testNamespace))
 	require.NoError(t, err)
@@ -305,7 +305,7 @@ func TestReconcile_ActivegateConfigMap(t *testing.T) {
 	t.Run(`create activegate ConfigMap`, func(t *testing.T) {
 		fakeClient := fake.NewClient(testKubeSystemNamespace)
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, mockDtClient)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actual corev1.ConfigMap

--- a/src/controllers/dynakube/activegate/reconciler_test.go
+++ b/src/controllers/dynakube/activegate/reconciler_test.go
@@ -57,8 +57,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 				Name:      testName,
 			}}
 		fakeClient := fake.NewClient()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, instance, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 	})
 	t.Run(`Create AG proxy secret`, func(t *testing.T) {
@@ -72,8 +72,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		fakeClient := fake.NewClient()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, instance, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
@@ -93,8 +93,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		fakeClient := fake.NewClient(testKubeSystemNamespace)
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, instance, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var service corev1.Service
@@ -103,7 +103,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 		// remove AG from spec
 		instance.Spec.ActiveGate = dynatracev1beta1.ActiveGateSpec{}
-		err = r.Reconcile()
+		err = r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
@@ -127,12 +127,12 @@ func TestReconciler_Reconcile(t *testing.T) {
 			Spec: dynatracev1beta1.DynaKubeSpec{},
 		}
 		fakeClient := fake.NewClient()
-		proxyReconciler := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynaKubeWithProxy, dtc)
-		err := proxyReconciler.Reconcile()
+		proxyReconciler := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynaKubeWithProxy, dtc)
+		err := proxyReconciler.Reconcile(context.TODO())
 		require.NoError(t, err)
 
-		noProxyReconciler := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynaKubeNoProxy, dtc)
-		err = noProxyReconciler.Reconcile()
+		noProxyReconciler := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynaKubeNoProxy, dtc)
+		err = noProxyReconciler.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var proxySecret corev1.Secret
@@ -173,12 +173,12 @@ func TestServiceCreation(t *testing.T) {
 
 		for capability, expectedPorts := range expectedCapabilityPorts {
 			fakeClient := fake.NewClient(testKubeSystemNamespace)
-			reconciler := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dynatraceClient)
+			reconciler := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dynatraceClient)
 			dynakube.Spec.ActiveGate.Capabilities = []dynatracev1beta1.CapabilityDisplayName{
 				capability,
 			}
 
-			err := reconciler.Reconcile()
+			err := reconciler.Reconcile(context.TODO())
 			require.NoError(t, err)
 
 			if len(expectedPorts) == 0 {
@@ -195,7 +195,7 @@ func TestServiceCreation(t *testing.T) {
 
 	t.Run("service exposes correct ports for multiple capabilities", func(t *testing.T) {
 		fakeClient := fake.NewClient(testKubeSystemNamespace)
-		reconciler := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dynatraceClient)
+		reconciler := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dynatraceClient)
 		dynakube.Spec.ActiveGate.Capabilities = []dynatracev1beta1.CapabilityDisplayName{
 			dynatracev1beta1.RoutingCapability.DisplayName,
 		}
@@ -203,7 +203,7 @@ func TestServiceCreation(t *testing.T) {
 			consts.HttpsServicePortName,
 		}
 
-		err := reconciler.Reconcile()
+		err := reconciler.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		activegateService := getTestActiveGateService(t, fakeClient)
@@ -241,8 +241,8 @@ func TestExclusiveSynMonitoring(t *testing.T) {
 		ObjectMeta: syntheticCapabilityObjectMeta,
 	}
 	fakeClient := fake.NewClient(testKubeSystemNamespace)
-	reconciler := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, mockDtClient)
-	err := reconciler.Reconcile()
+	reconciler := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, mockDtClient)
+	err := reconciler.Reconcile(context.TODO())
 
 	require.NoError(t, err, "successfully reconciled for syn-mon")
 
@@ -304,8 +304,8 @@ func TestReconcile_ActivegateConfigMap(t *testing.T) {
 
 	t.Run(`create activegate ConfigMap`, func(t *testing.T) {
 		fakeClient := fake.NewClient(testKubeSystemNamespace)
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, mockDtClient)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, mockDtClient)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actual corev1.ConfigMap

--- a/src/controllers/dynakube/connectioninfo/reconciler_test.go
+++ b/src/controllers/dynakube/connectioninfo/reconciler_test.go
@@ -51,8 +51,8 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 
 	t.Run(`store OneAgent connection info to DynaKube status`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
@@ -70,8 +70,8 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 		}
 		resetCachedTimestamps(&dynakube.Status)
 
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
@@ -87,8 +87,8 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 			},
 		}
 
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		assert.Equal(t, testOutdated, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
@@ -104,8 +104,8 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 			},
 		}
 
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
@@ -114,8 +114,8 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 
 	t.Run(`store ActiveGate connection info to DynaKube status`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
@@ -131,8 +131,8 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 			},
 		}
 		resetCachedTimestamps(&dynakube.Status)
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
@@ -148,8 +148,8 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 			},
 		}
 
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		assert.Equal(t, testOutdated, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
@@ -165,8 +165,8 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 			},
 		}
 
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
@@ -193,8 +193,8 @@ func TestReconcile_NoOneAgentCommunicationHosts(t *testing.T) {
 	}, nil)
 
 	fakeClient := fake.NewClientBuilder().Build()
-	r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-	err := r.Reconcile()
+	r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
+	err := r.Reconcile(context.TODO())
 	assert.ErrorIs(t, err, NoOneAgentCommunicationHostsError)
 
 	assert.Equal(t, testTenantUUID, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
@@ -252,8 +252,8 @@ func TestReconcile_ActivegateSecret(t *testing.T) {
 
 	t.Run(`create activegate secret`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
@@ -264,8 +264,8 @@ func TestReconcile_ActivegateSecret(t *testing.T) {
 	t.Run(`update activegate secret`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithObjects(buildActiveGateSecret(*dynakube, testOutdated)).Build()
 		resetCachedTimestamps(&dynakube.Status)
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
@@ -275,8 +275,8 @@ func TestReconcile_ActivegateSecret(t *testing.T) {
 	})
 	t.Run(`check activegate secret caches`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithObjects(buildActiveGateSecret(*dynakube, testOutdated)).Build()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
@@ -287,8 +287,8 @@ func TestReconcile_ActivegateSecret(t *testing.T) {
 	t.Run(`up to date activegate secret`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithObjects(buildActiveGateSecret(*dynakube, testTenantToken)).Build()
 
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 	})
 }
@@ -321,8 +321,8 @@ func TestReconcile_OneagentSecret(t *testing.T) {
 	t.Run(`create oneagent secret`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().Build()
 
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
@@ -337,8 +337,8 @@ func TestReconcile_OneagentSecret(t *testing.T) {
 		// we traveled 15 minutes into the future
 		resetCachedTimestamps(&dynakube.Status)
 
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
@@ -349,8 +349,8 @@ func TestReconcile_OneagentSecret(t *testing.T) {
 	t.Run(`update oneagent secret, check if caches are used`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithObjects(buildOneAgentTenantSecret(*dynakube, testOutdated)).Build()
 
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
@@ -361,8 +361,8 @@ func TestReconcile_OneagentSecret(t *testing.T) {
 	t.Run(`up to date oneagent secret`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithObjects(buildOneAgentTenantSecret(*dynakube, testTenantToken)).Build()
 
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 	})
 }

--- a/src/controllers/dynakube/connectioninfo/reconciler_test.go
+++ b/src/controllers/dynakube/connectioninfo/reconciler_test.go
@@ -52,7 +52,7 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 	t.Run(`store OneAgent connection info to DynaKube status`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().Build()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
@@ -71,7 +71,7 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 		resetCachedTimestamps(&dynakube.Status)
 
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
@@ -88,7 +88,7 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 		}
 
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		assert.Equal(t, testOutdated, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
@@ -105,7 +105,7 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 		}
 
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
@@ -115,7 +115,7 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 	t.Run(`store ActiveGate connection info to DynaKube status`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().Build()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
@@ -132,7 +132,7 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 		}
 		resetCachedTimestamps(&dynakube.Status)
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
@@ -149,7 +149,7 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 		}
 
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		assert.Equal(t, testOutdated, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
@@ -166,7 +166,7 @@ func TestReconcile_ConnectionInfo(t *testing.T) {
 		}
 
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		assert.Equal(t, testTenantUUID, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
@@ -194,7 +194,7 @@ func TestReconcile_NoOneAgentCommunicationHosts(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().Build()
 	r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, &dynakube, dtc)
-	err := r.Reconcile(context.TODO())
+	err := r.Reconcile(context.Background())
 	assert.ErrorIs(t, err, NoOneAgentCommunicationHostsError)
 
 	assert.Equal(t, testTenantUUID, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
@@ -253,11 +253,11 @@ func TestReconcile_ActivegateSecret(t *testing.T) {
 	t.Run(`create activegate secret`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().Build()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: dynakube.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: dynakube.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
 		require.NoError(t, err)
 		assert.Equal(t, []byte(testTenantToken), actualSecret.Data[TenantTokenName])
 	})
@@ -265,22 +265,22 @@ func TestReconcile_ActivegateSecret(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithObjects(buildActiveGateSecret(*dynakube, testOutdated)).Build()
 		resetCachedTimestamps(&dynakube.Status)
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: dynakube.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: dynakube.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
 		require.NoError(t, err)
 		assert.Equal(t, []byte(testTenantToken), actualSecret.Data[TenantTokenName])
 	})
 	t.Run(`check activegate secret caches`, func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithObjects(buildActiveGateSecret(*dynakube, testOutdated)).Build()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: dynakube.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: dynakube.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
 		require.NoError(t, err)
 		assert.Equal(t, []byte(testOutdated), actualSecret.Data[TenantTokenName])
 	})
@@ -288,7 +288,7 @@ func TestReconcile_ActivegateSecret(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithObjects(buildActiveGateSecret(*dynakube, testTenantToken)).Build()
 
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 	})
 }
@@ -322,11 +322,11 @@ func TestReconcile_OneagentSecret(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().Build()
 
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: dynakube.OneagentTenantSecret(), Namespace: testNamespace}, &actualSecret)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: dynakube.OneagentTenantSecret(), Namespace: testNamespace}, &actualSecret)
 		require.NoError(t, err)
 		assert.Equal(t, []byte(testTenantToken), actualSecret.Data[TenantTokenName])
 	})
@@ -338,11 +338,11 @@ func TestReconcile_OneagentSecret(t *testing.T) {
 		resetCachedTimestamps(&dynakube.Status)
 
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: dynakube.OneagentTenantSecret(), Namespace: testNamespace}, &actualSecret)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: dynakube.OneagentTenantSecret(), Namespace: testNamespace}, &actualSecret)
 		require.NoError(t, err)
 		assert.Equal(t, []byte(testTenantToken), actualSecret.Data[TenantTokenName])
 	})
@@ -350,11 +350,11 @@ func TestReconcile_OneagentSecret(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithObjects(buildOneAgentTenantSecret(*dynakube, testOutdated)).Build()
 
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: dynakube.OneagentTenantSecret(), Namespace: testNamespace}, &actualSecret)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: dynakube.OneagentTenantSecret(), Namespace: testNamespace}, &actualSecret)
 		require.NoError(t, err)
 		assert.Equal(t, []byte(testOutdated), actualSecret.Data[TenantTokenName])
 	})
@@ -362,7 +362,7 @@ func TestReconcile_OneagentSecret(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithObjects(buildOneAgentTenantSecret(*dynakube, testTenantToken)).Build()
 
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, dtc)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 	})
 }

--- a/src/controllers/dynakube/deploymentmetadata/reconciler_test.go
+++ b/src/controllers/dynakube/deploymentmetadata/reconciler_test.go
@@ -43,11 +43,11 @@ func TestReconcile(t *testing.T) {
 		dynakube := createTestDynakube(nil)
 		fakeClient := fake.NewClientBuilder().Build()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualConfigMap corev1.ConfigMap
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: GetDeploymentMetadataConfigMapName(testName), Namespace: testNamespace}, &actualConfigMap)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: GetDeploymentMetadataConfigMapName(testName), Namespace: testNamespace}, &actualConfigMap)
 		require.Error(t, err)
 	})
 	t.Run(`delete configmap, if no mode is configured`, func(t *testing.T) {
@@ -61,11 +61,11 @@ func TestReconcile(t *testing.T) {
 			},
 		).Build()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualConfigMap corev1.ConfigMap
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: GetDeploymentMetadataConfigMapName(testName), Namespace: testNamespace}, &actualConfigMap)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: GetDeploymentMetadataConfigMapName(testName), Namespace: testNamespace}, &actualConfigMap)
 		require.Error(t, err)
 	})
 
@@ -79,11 +79,11 @@ func TestReconcile(t *testing.T) {
 
 		fakeClient := fake.NewClientBuilder().Build()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualConfigMap corev1.ConfigMap
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: GetDeploymentMetadataConfigMapName(testName), Namespace: testNamespace}, &actualConfigMap)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: GetDeploymentMetadataConfigMapName(testName), Namespace: testNamespace}, &actualConfigMap)
 		require.NoError(t, err)
 		require.NotEmpty(t, actualConfigMap.Data)
 		assert.NotEmpty(t, actualConfigMap.Data[OneAgentMetadataKey])
@@ -101,11 +101,11 @@ func TestReconcile(t *testing.T) {
 
 		fakeClient := fake.NewClientBuilder().Build()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualConfigMap corev1.ConfigMap
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: GetDeploymentMetadataConfigMapName(testName), Namespace: testNamespace}, &actualConfigMap)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: GetDeploymentMetadataConfigMapName(testName), Namespace: testNamespace}, &actualConfigMap)
 		require.NoError(t, err)
 		require.NotEmpty(t, actualConfigMap.Data)
 		assert.NotEmpty(t, actualConfigMap.Data[ActiveGateMetadataKey])
@@ -125,11 +125,11 @@ func TestReconcile(t *testing.T) {
 
 		fakeClient := fake.NewClientBuilder().Build()
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		var actualConfigMap corev1.ConfigMap
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: GetDeploymentMetadataConfigMapName(testName), Namespace: testNamespace}, &actualConfigMap)
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: GetDeploymentMetadataConfigMapName(testName), Namespace: testNamespace}, &actualConfigMap)
 		require.NoError(t, err)
 		require.NotEmpty(t, actualConfigMap.Data)
 		assert.NotEmpty(t, actualConfigMap.Data[OneAgentMetadataKey])

--- a/src/controllers/dynakube/deploymentmetadata/reconciler_test.go
+++ b/src/controllers/dynakube/deploymentmetadata/reconciler_test.go
@@ -42,8 +42,8 @@ func TestReconcile(t *testing.T) {
 	t.Run(`don't create anything, if no mode is configured`, func(t *testing.T) {
 		dynakube := createTestDynakube(nil)
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualConfigMap corev1.ConfigMap
@@ -60,8 +60,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		).Build()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualConfigMap corev1.ConfigMap
@@ -78,8 +78,8 @@ func TestReconcile(t *testing.T) {
 			})
 
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualConfigMap corev1.ConfigMap
@@ -100,8 +100,8 @@ func TestReconcile(t *testing.T) {
 			})
 
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualConfigMap corev1.ConfigMap
@@ -124,8 +124,8 @@ func TestReconcile(t *testing.T) {
 			})
 
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
-		err := r.Reconcile()
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, *dynakube, clusterID)
+		err := r.Reconcile(context.TODO())
 		require.NoError(t, err)
 
 		var actualConfigMap corev1.ConfigMap

--- a/src/controllers/dynakube/dtpullsecret/generate_test.go
+++ b/src/controllers/dynakube/dtpullsecret/generate_test.go
@@ -1,7 +1,6 @@
 package dtpullsecret
 
 import (
-	"context"
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -41,7 +40,6 @@ func TestReconciler_GenerateData(t *testing.T) {
 		},
 	}
 	r := &Reconciler{
-		ctx:      context.Background(),
 		dynakube: dynakube,
 		tokens: token.Tokens{
 			dtclient.DynatracePaasToken: token.Token{Value: testPaasToken},

--- a/src/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/src/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -40,12 +40,12 @@ func TestReconciler_Reconcile(t *testing.T) {
 			On("GetOneAgentConnectionInfo").
 			Return(dtclient.OneAgentConnectionInfo{}, nil)
 
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
 		var pullSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(),
+		err = fakeClient.Get(context.Background(),
 			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
 			&pullSecret)
 
@@ -65,7 +65,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				CustomPullSecret: testValue,
 			}}
 		r := NewReconciler(nil, nil, nil, dynakube, nil)
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 	})
@@ -85,12 +85,12 @@ func TestReconciler_Reconcile(t *testing.T) {
 			dtclient.DynatraceApiToken: token.Token{Value: testValue},
 		})
 
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
 		var pullSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(),
+		err = fakeClient.Get(context.Background(),
 			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
 			&pullSecret)
 
@@ -117,27 +117,27 @@ func TestReconciler_Reconcile(t *testing.T) {
 			dtclient.DynatraceApiToken: token.Token{Value: testValue},
 		})
 
-		err := r.Reconcile(context.TODO())
+		err := r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
 		var pullSecret corev1.Secret
-		err = fakeClient.Get(context.TODO(),
+		err = fakeClient.Get(context.Background(),
 			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
 			&pullSecret)
 
 		assert.NoError(t, err)
 
 		pullSecret.Data = nil
-		err = fakeClient.Update(context.TODO(), &pullSecret)
+		err = fakeClient.Update(context.Background(), &pullSecret)
 
 		assert.NoError(t, err)
 
-		err = r.Reconcile(context.TODO())
+		err = r.Reconcile(context.Background())
 
 		assert.NoError(t, err)
 
-		err = fakeClient.Get(context.TODO(),
+		err = fakeClient.Get(context.Background(),
 			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
 			&pullSecret)
 

--- a/src/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/src/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -32,7 +32,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		fakeClient := fake.NewClient()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, token.Tokens{
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, token.Tokens{
 			dtclient.DynatraceApiToken: token.Token{Value: testValue},
 		})
 
@@ -40,7 +40,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			On("GetOneAgentConnectionInfo").
 			Return(dtclient.OneAgentConnectionInfo{}, nil)
 
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 
@@ -64,8 +64,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				CustomPullSecret: testValue,
 			}}
-		r := NewReconciler(context.TODO(), nil, nil, nil, dynakube, nil)
-		err := r.Reconcile()
+		r := NewReconciler(nil, nil, nil, dynakube, nil)
+		err := r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 	})
@@ -81,11 +81,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		fakeClient := fake.NewClient()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, token.Tokens{
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, token.Tokens{
 			dtclient.DynatraceApiToken: token.Token{Value: testValue},
 		})
 
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 
@@ -113,11 +113,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		fakeClient := fake.NewClient()
-		r := NewReconciler(context.TODO(), fakeClient, fakeClient, scheme.Scheme, dynakube, token.Tokens{
+		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, token.Tokens{
 			dtclient.DynatraceApiToken: token.Token{Value: testValue},
 		})
 
-		err := r.Reconcile()
+		err := r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 
@@ -133,7 +133,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 		assert.NoError(t, err)
 
-		err = r.Reconcile()
+		err = r.Reconcile(context.TODO())
 
 		assert.NoError(t, err)
 

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -263,14 +263,14 @@ func (controller *Controller) reconcileDynaKube(ctx context.Context, dynakube *d
 	}
 
 	err = dtpullsecret.
-		NewReconciler(ctx, controller.client, controller.apiReader, controller.scheme, dynakube, tokens).
-		Reconcile()
+		NewReconciler(controller.client, controller.apiReader, controller.scheme, dynakube, tokens).
+		Reconcile(ctx)
 	if err != nil {
 		log.Info("could not reconcile Dynatrace pull secret")
 		return err
 	}
 
-	err = deploymentmetadata.NewReconciler(ctx, controller.client, controller.apiReader, controller.scheme, *dynakube, controller.clusterID).Reconcile()
+	err = deploymentmetadata.NewReconciler(controller.client, controller.apiReader, controller.scheme, *dynakube, controller.clusterID).Reconcile(ctx)
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func (controller *Controller) reconcileDynaKube(ctx context.Context, dynakube *d
 }
 
 func (controller *Controller) reconcileConnectionInfo(ctx context.Context, dynakube *dynatracev1beta1.DynaKube, dynatraceClient dtclient.Client) error {
-	err := connectioninfo.NewReconciler(ctx, controller.client, controller.apiReader, controller.scheme, dynakube, dynatraceClient).Reconcile()
+	err := connectioninfo.NewReconciler(controller.client, controller.apiReader, controller.scheme, dynakube, dynatraceClient).Reconcile(ctx)
 
 	if errors.Is(err, connectioninfo.NoOneAgentCommunicationHostsError) {
 		// missing communication hosts is not an error per se and shall not stop reconciliation, just make sure next reconciliation is happening ASAP
@@ -394,8 +394,8 @@ func (controller *Controller) removeOneAgentDaemonSet(ctx context.Context, dynak
 }
 
 func (controller *Controller) reconcileActiveGate(ctx context.Context, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client) error {
-	reconciler := activegate.NewReconciler(ctx, controller.client, controller.apiReader, controller.scheme, dynakube, dtc)
-	err := reconciler.Reconcile()
+	reconciler := activegate.NewReconciler(controller.client, controller.apiReader, controller.scheme, dynakube, dtc)
+	err := reconciler.Reconcile(ctx)
 
 	if err != nil {
 		return errors.WithMessage(err, "failed to reconcile ActiveGate")

--- a/src/controllers/reconciler.go
+++ b/src/controllers/reconciler.go
@@ -1,5 +1,7 @@
 package controllers
 
+import "golang.org/x/net/context"
+
 type Reconciler interface {
-	Reconcile() error
+	Reconcile(ctx context.Context) error
 }


### PR DESCRIPTION
## Description

The `Reconcile(ctx)` function of `Reconciler` interface requires context parameter to enforce the use of the context.

ActiveGate Reconcilers used context.TODO() instead of top-level context. Now the context is passed along the call stack:
- authtoken
- capability
- customproperties
- proxy
- statefulset

Additionally the following Reconcilers also pass the context to functions that need it instead of keeping it in the Reconciler struct: 
- connectioninfo
- deploymentmetadata
- dtpullsecret
- webhook_cert_controller

## How can this be tested?
All e2e tests should PASS.

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
