### PR TITLE
Fix not appearing hosts when using application monitoring

### DIFF
--- a/src/standalone/files.go
+++ b/src/standalone/files.go
@@ -23,18 +23,11 @@ k8s_containername %s
 k8s_basepodname %s
 k8s_namespace %s
 `
-	k8ConfContentFormatString = `k8s_node_name %s
-k8s_cluster_id %s
-`
+
 	k8NodeNameFormatString = `k8s_node_name %s
 `
 
 	k8ClusterIDFormatString = `k8s_cluster_id %s
-`
-
-	hostConfContentFormatString = `[host]
-tenant %s
-isCloudNativeFullStack true
 `
 
 	jsonEnrichmentContentFormatString = `{
@@ -71,13 +64,6 @@ func (runner *Runner) getBaseConfContent(container containerInfo) string {
 	)
 }
 
-func (runner *Runner) getK8ConfContent() string {
-	return fmt.Sprintf(k8ConfContentFormatString,
-		runner.env.K8NodeName,
-		runner.config.ClusterID,
-	)
-}
-
 func (runner *Runner) getK8SNodeName() string {
 	return fmt.Sprintf(k8NodeNameFormatString,
 		runner.env.K8NodeName,
@@ -87,12 +73,6 @@ func (runner *Runner) getK8SNodeName() string {
 func (runner *Runner) getK8SClusterID() string {
 	return fmt.Sprintf(k8ClusterIDFormatString,
 		runner.env.K8ClusterID,
-	)
-}
-
-func (runner *Runner) getHostConfContent() string {
-	return fmt.Sprintf(hostConfContentFormatString,
-		runner.hostTenant,
 	)
 }
 

--- a/src/standalone/files.go
+++ b/src/standalone/files.go
@@ -26,6 +26,12 @@ k8s_namespace %s
 	k8ConfContentFormatString = `k8s_node_name %s
 k8s_cluster_id %s
 `
+	k8NodeNameFormatString = `k8s_node_name %s
+`
+
+	k8ClusterIDFormatString = `k8s_cluster_id %s
+`
+
 	hostConfContentFormatString = `[host]
 tenant %s
 isCloudNativeFullStack true
@@ -69,6 +75,18 @@ func (runner *Runner) getK8ConfContent() string {
 	return fmt.Sprintf(k8ConfContentFormatString,
 		runner.env.K8NodeName,
 		runner.config.ClusterID,
+	)
+}
+
+func (runner *Runner) getK8SNodeName() string {
+	return fmt.Sprintf(k8NodeNameFormatString,
+		runner.env.K8NodeName,
+	)
+}
+
+func (runner *Runner) getK8SClusterID() string {
+	return fmt.Sprintf(k8ClusterIDFormatString,
+		runner.env.K8ClusterID,
 	)
 }
 

--- a/src/standalone/run.go
+++ b/src/standalone/run.go
@@ -210,12 +210,14 @@ func (runner *Runner) createContainerConfigurationFiles() error {
 		confFilePath := filepath.Join(config.AgentShareDirMount, fmt.Sprintf(config.AgentContainerConfFilenameTemplate, container.Name))
 		content := runner.getBaseConfContent(container)
 
-		log.Info("adding k8s fields")
-		content += runner.getK8ConfContent()
+		log.Info("adding k8s cluster id")
+		content += runner.getK8SClusterID()
 
 		if runner.hostTenant != config.AgentNoHostTenant {
-			log.Info("adding hostTenant field")
-			content += runner.getHostConfContent()
+			if runner.config.TenantUUID == runner.hostTenant {
+				log.Info("adding k8s node name")
+				content += runner.getK8SNodeName()
+			}
 		}
 		if err := runner.createConfFile(confFilePath, content); err != nil {
 			return err

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -306,11 +306,7 @@ k8s_poduid TEST_K8S_PODUID
 k8s_containername TEST_CONTAINER_%d_NAME
 k8s_basepodname TEST_K8S_BASEPODNAME
 k8s_namespace TEST_K8S_NAMESPACE
-k8s_node_name TEST_K8S_NODE_NAME
-k8s_cluster_id id
-[host]
-tenant 
-isCloudNativeFullStack true
+k8s_cluster_id TEST_K8S_CLUSTER_ID
 `
 
 	runner := createMockedRunner(t)


### PR DESCRIPTION
## Description

Currently we have the problem that when writing the whole k8s config content into `container.conf` and using `applicationMonitoring` the injected sample apps do not show up in the UI as hosts. This is probably because of the k8s node name being written although it not being existent. With this fix now there is a distinction made and the node name is only written when `cloudNativeFullStack` is used. K8s cluster id on the other hand is still written always.

## How can this be tested?

- deploy operator
- apply dynakube with applicationMonitoring
- deploy sample apps and inject into them
- check if sample apps are listed as hosts in the UI

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
