### PR TITLE
Adds 'force' injection failure policy

### DIFF
--- a/src/api/v1beta1/dynakube/feature_flags.go
+++ b/src/api/v1beta1/dynakube/feature_flags.go
@@ -109,6 +109,7 @@ const (
 	truePhrase   = "true"
 	silentPhrase = "silent"
 	failPhrase   = "fail"
+	forcePhrase  = "force"
 
 	// synthetic node types
 	SyntheticNodeXs = "XS"
@@ -340,6 +341,9 @@ func (dk *DynaKube) FeatureSyntheticLocationEntityId() string {
 func (dk *DynaKube) FeatureInjectionFailurePolicy() string {
 	if dk.getFeatureFlagRaw(AnnotationInjectionFailurePolicy) == failPhrase {
 		return failPhrase
+	}
+	if dk.getFeatureFlagRaw(AnnotationInjectionFailurePolicy) == forcePhrase {
+		return forcePhrase
 	}
 	return silentPhrase
 }

--- a/src/api/v1beta1/dynakube/feature_flags_test.go
+++ b/src/api/v1beta1/dynakube/feature_flags_test.go
@@ -299,3 +299,22 @@ func TestDefaultEnabledFeatureFlags(t *testing.T) {
 	assert.False(t, dynakube.FeatureDisableMetadataEnrichment())
 	assert.False(t, dynakube.FeatureLabelVersionDetection())
 }
+
+func TestInjectionFailurePolicy(t *testing.T) {
+	dynakube := createDynakubeEmptyDynakube()
+
+	modes := map[string]string{
+		failPhrase:   failPhrase,
+		silentPhrase: silentPhrase,
+		forcePhrase:  forcePhrase,
+		"Fail":       silentPhrase,
+		"other":      silentPhrase,
+	}
+	for configuredMode, expectedMode := range modes {
+		t.Run(`injection failure policy: `+configuredMode, func(t *testing.T) {
+			dynakube.Annotations[AnnotationInjectionFailurePolicy] = configuredMode
+
+			assert.Equal(t, expectedMode, dynakube.FeatureInjectionFailurePolicy())
+		})
+	}
+}

--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -11,7 +11,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-const trueStatement = "true"
+const (
+	trueStatement = "true"
+	silentPhrase  = "silent"
+	failPhrase    = "fail"
+	forcePhrase   = "force"
+)
 
 type containerInfo struct {
 	Name  string `json:"name"`
@@ -20,7 +25,7 @@ type containerInfo struct {
 
 type environment struct {
 	Mode          config.InstallMode `json:"mode"`
-	FailurePolicy bool               `json:"failurePolicy"`
+	FailurePolicy string             `json:"failurePolicy"`
 	InstallerUrl  string             `json:"installerUrl"`
 
 	InstallerFlavor string          `json:"installerFlavor"`
@@ -135,7 +140,14 @@ func (env *environment) addFailurePolicy() error {
 	if err != nil {
 		return err
 	}
-	env.FailurePolicy = failurePolicy == "fail"
+	switch failurePolicy {
+	case failPhrase:
+		env.FailurePolicy = failPhrase
+	case forcePhrase:
+		env.FailurePolicy = forcePhrase
+	default:
+		env.FailurePolicy = silentPhrase
+	}
 	return nil
 }
 

--- a/src/standalone/run_test.go
+++ b/src/standalone/run_test.go
@@ -73,19 +73,19 @@ func TestNewRunner(t *testing.T) {
 func TestConsumeErrorIfNecessary(t *testing.T) {
 	runner := createMockedRunner(t)
 	t.Run("no error thrown", func(t *testing.T) {
-		runner.env.FailurePolicy = false
+		runner.env.FailurePolicy = silentPhrase
 		err := runner.Run()
 		assert.Nil(t, err)
 	})
 	t.Run("error thrown, but consume error", func(t *testing.T) {
 		runner.env.K8NodeName = "" // create artificial error
-		runner.env.FailurePolicy = false
+		runner.env.FailurePolicy = silentPhrase
 		err := runner.Run()
 		assert.Nil(t, err)
 	})
 	t.Run("error thrown, but don't consume error", func(t *testing.T) {
 		runner.env.K8NodeName = "" // create artificial error
-		runner.env.FailurePolicy = true
+		runner.env.FailurePolicy = failPhrase
 		err := runner.Run()
 		assert.NotNil(t, err)
 	})
@@ -116,6 +116,16 @@ func TestSetHostTenant(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, config.AgentNoHostTenant, runner.hostTenant)
+	})
+	t.Run("set hostTenant to TenantUUID", func(t *testing.T) {
+		runner.env.FailurePolicy = forcePhrase
+		runner.config.HasHost = true
+		runner.config.TenantUUID = testTenantUUID
+
+		err := runner.setHostTenant()
+
+		require.NoError(t, err)
+		assert.Equal(t, testTenantUUID, runner.hostTenant)
 	})
 }
 


### PR DESCRIPTION
## Description
The `oneagent-install` initContainer either just swallow the error (if failure policy is set to `silent`) or is stuck in CrashLoopBackOff (if failure policy is set to `fail`) if the correct `hostTenant` can not be set (based on `monitoringNodes`).
To solve this problem `force` injection failure policy has been added. The new policy ignores the `monitoringNodes` when it comes to setting the `hostTenant`. The tenant from dynakube is used instead.

## How can this be tested?
Install sample app:
```
cat test/testdata/sample-app/pod-base.yaml | sed "s/metadata:/metadata:\r\n  annotations:\r\n    oneagent.dynatrace.com\/failure-policy: force/" | kubectl -n <namespace> apply -f -
```
The following message should be printed to log:
`kubectl -n <namespace> logs -c install-oneagent pod/php-sample`
```
{"level":"info","ts":"2023-10-03T08:55:53.512Z","logger":"standalone-init","msg":"setting host tenant"}
--> {"level":"info","ts":"2023-10-03T08:55:53.512Z","logger":"standalone-init","msg":"host tenant set to TenantUUID"}
{"level":"info","ts":"2023-10-03T08:55:53.512Z","logger":"standalone-init","msg":"successfully set host tenant","hostTenant":"abc12345"}
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
