### PR TITLE
Enable public registry e2e test

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -46,6 +46,7 @@ test/e2e/cloudnative/network: manifests/crd/helm
 test/e2e/cloudnative/proxy: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/cloudnative/proxy $(SKIPCLEANUP)
 
+## Runs public registry test only
 test/e2e/cloudnative/publicregistry: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/cloudnative/public_registry $(SKIPCLEANUP)
 


### PR DESCRIPTION
## Description

Operator e2e test should include the public registry e2e test by default.

## How can this be tested?

Run `make test/e2e`.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
