### PR TITLE
Fix operator behavior related to `503 ServiceUnavailable` DynatraceApi error

### DIFF
--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -2,7 +2,6 @@ package dynakube
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dtpullsecret"
+	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dynatraceapi"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/dynatraceclient"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/istio"
 	"github.com/Dynatrace/dynatrace-operator/src/controllers/dynakube/oneagent"
@@ -129,7 +129,7 @@ func (controller *Controller) setRequeueAfterIfNewIsShorter(requeueAfter time.Du
 
 func isDynatraceAPIUnreachable(err error) bool {
 	var serverErr dtclient.ServerError
-	if errors.As(err, &serverErr) && (serverErr.Code == http.StatusTooManyRequests || serverErr.Code == http.StatusServiceUnavailable) {
+	if dynatraceapi.IsUnreachable(err) {
 		log.Info("dynaTrace API server is unavailable or request limit reached! trying again in one minute",
 			"errorCode", serverErr.Code, "errorMessage", serverErr.Message)
 		return true

--- a/src/controllers/dynakube/dynakube_controller.go
+++ b/src/controllers/dynakube/dynakube_controller.go
@@ -160,7 +160,10 @@ func (controller *Controller) reconcile(ctx context.Context, dynaKube *dynatrace
 		}
 	}
 
-	return reconcile.Result{RequeueAfter: controller.requeueAfter}, err
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{RequeueAfter: controller.requeueAfter}, nil
 }
 
 func (controller *Controller) getDynakubeOrUnmap(ctx context.Context, dkName, dkNamespace string) (*dynatracev1beta1.DynaKube, error) {

--- a/src/controllers/dynakube/dynatraceapi/status.go
+++ b/src/controllers/dynakube/dynatraceapi/status.go
@@ -26,3 +26,11 @@ func StatusCode(err error) int {
 	}
 	return 0
 }
+
+func Message(err error) string {
+	var serverErr dtclient.ServerError
+	if errors.As(err, &serverErr) {
+		return serverErr.Message
+	}
+	return ""
+}

--- a/src/controllers/dynakube/dynatraceapi/status.go
+++ b/src/controllers/dynakube/dynatraceapi/status.go
@@ -7,6 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	NoError = 0
+)
+
 func IsUnreachable(err error) bool {
 	var serverErr dtclient.ServerError
 	if errors.As(err, &serverErr) && (serverErr.Code == http.StatusTooManyRequests || serverErr.Code == http.StatusServiceUnavailable) {

--- a/src/controllers/dynakube/dynatraceapi/status.go
+++ b/src/controllers/dynakube/dynatraceapi/status.go
@@ -1,0 +1,24 @@
+package dynatraceapi
+
+import (
+	"net/http"
+
+	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
+	"github.com/pkg/errors"
+)
+
+func IsUnreachable(err error) bool {
+	var serverErr dtclient.ServerError
+	if errors.As(err, &serverErr) && (serverErr.Code == http.StatusTooManyRequests || serverErr.Code == http.StatusServiceUnavailable) {
+		return true
+	}
+	return false
+}
+
+func StatusCode(err error) int {
+	var serverErr dtclient.ServerError
+	if errors.As(err, &serverErr) {
+		return serverErr.Code
+	}
+	return 0
+}

--- a/src/controllers/dynakube/token/tokens.go
+++ b/src/controllers/dynakube/token/tokens.go
@@ -99,7 +99,7 @@ func (tokens Tokens) VerifyValues() error {
 
 func concatErrors(errs []error) error {
 	concatenatedError := ""
-	apiError := 0
+	apiStatus := dynatraceapi.NoError
 
 	for index, err := range errs {
 		concatenatedError += err.Error()
@@ -108,14 +108,14 @@ func concatErrors(errs []error) error {
 			concatenatedError += "\n\t"
 		}
 
-		if apiError == 0 && dynatraceapi.IsUnreachable(err) {
-			apiError = dynatraceapi.StatusCode(err)
+		if apiStatus == dynatraceapi.NoError && dynatraceapi.IsUnreachable(err) {
+			apiStatus = dynatraceapi.StatusCode(err)
 		}
 	}
 
-	if apiError != 0 {
+	if apiStatus != dynatraceapi.NoError {
 		return dtclient.ServerError{
-			Code:    apiError,
+			Code:    apiStatus,
 			Message: concatenatedError,
 		}
 	}

--- a/src/controllers/dynakube/token/tokens_test.go
+++ b/src/controllers/dynakube/token/tokens_test.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"net/http"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/src/api/v1beta1/dynakube"
@@ -160,4 +161,60 @@ func testVerifyTokenValues(t *testing.T) {
 
 	assert.NoError(t, validTokens.VerifyValues())
 	assert.EqualError(t, invalidTokens.VerifyValues(), "value of token 'whitespaces' contains whitespaces at the beginning or end of the value")
+}
+
+func TestConcatErrors(t *testing.T) {
+	stringError1 := errors.New("error 1")
+	stringError2 := errors.New("error 2")
+	serviceUnavailableError := dtclient.ServerError{
+		Code:    http.StatusServiceUnavailable,
+		Message: "ServiceUnavailable",
+	}
+	tooManyRequestsError := dtclient.ServerError{
+		Code:    http.StatusTooManyRequests,
+		Message: "TooManyRequests",
+	}
+
+	t.Run("string errors", func(t *testing.T) {
+		valueErrors := []error{
+			stringError1,
+			stringError2,
+		}
+		err := concatErrors(valueErrors)
+		assert.EqualError(t, err, "error 1\n\terror 2")
+	})
+	t.Run("string + ServiceUnavailable errors", func(t *testing.T) {
+		valueErrors := []error{
+			stringError1,
+			serviceUnavailableError,
+		}
+		err := concatErrors(valueErrors)
+		assert.EqualError(t, err, "dynatrace server error 503: error 1\n\tdynatrace server error 503: ServiceUnavailable")
+	})
+	t.Run("string + TooManyRequests errors", func(t *testing.T) {
+		valueErrors := []error{
+			stringError1,
+			tooManyRequestsError,
+		}
+		err := concatErrors(valueErrors)
+		assert.EqualError(t, err, "dynatrace server error 429: error 1\n\tdynatrace server error 429: TooManyRequests")
+	})
+	t.Run("string + ServiceUnavailable + TooManyRequests errors", func(t *testing.T) {
+		valueErrors := []error{
+			stringError1,
+			serviceUnavailableError,
+			tooManyRequestsError,
+		}
+		err := concatErrors(valueErrors)
+		assert.EqualError(t, err, "dynatrace server error 503: error 1\n\tdynatrace server error 503: ServiceUnavailable\n\tdynatrace server error 429: TooManyRequests")
+	})
+	t.Run("string + TooManyRequests + ServiceUnavailable errors", func(t *testing.T) {
+		valueErrors := []error{
+			stringError1,
+			tooManyRequestsError,
+			serviceUnavailableError,
+		}
+		err := concatErrors(valueErrors)
+		assert.EqualError(t, err, "dynatrace server error 429: error 1\n\tdynatrace server error 429: TooManyRequests\n\tdynatrace server error 503: ServiceUnavailable")
+	})
 }


### PR DESCRIPTION
## Description
The Operator doesn't handle `ServiceUnavailable` and `TooManyRequests` DynatraceApi errors properly thus Dynakube Reconciler in not called as often as it should be in such a case (after a minute).

The root cause is  `concatErrors(errs []error)` function which concatenates error messages into a single string error so the information that `ServerError` has been encountered is lost.

The fixed logic returns an instance of ServerError if any of concatenated errors was ServerError. The disadvantage of this solution is that part of the final message is duplicated:
`dynatrace server error 503: error 1\n\tdynatrace server error 503: ServiceUnavailable`
It would be better to report:
`error 1\n\tdynatrace server error 503: ServiceUnavailable`

Finally `isDynatraceAPIUnreachable(err error)` function is able to recognize DynatraceApi errors and handle them properly.

## How can this be tested?
We can't force the server to return 503 so I tested the fix using unit tests and debugged a small application consisting of investigated code and basic http server returning 503 response.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
