### PR TITLE
Skip helm index file creation incase of pre-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -302,6 +302,7 @@ jobs:
         with:
           body_path: ./CHANGELOG.md
           files: |
+            tmp/cosign.pub
             config/deploy/kubernetes/kubernetes.yaml
             config/deploy/openshift/openshift.yaml
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -327,12 +328,14 @@ jobs:
           draft: true
           fail_on_unmatched_files: true
       - name: Update index helm file
+        if: ${{ !contains(github.ref, '-rc.') }}
         env:
           VERSION_WITHOUT_PREFIX: ${{ needs.prepare.outputs.version_without_prefix }}
         run: |
           echo "Updating Helm repo index"
           hack/build/ci/generate-new-helm-index-yaml.sh "helm-pkg" ${{ needs.prepare.outputs.version_without_prefix }}
       - name: Create pull request for adding helm index to main branch
+        if: ${{ !contains(github.ref, '-rc.') }}
         uses: peter-evans/create-pull-request@v5
         with:
           base: main


### PR DESCRIPTION
## Description

The last pre-release action was trying to create a new helm index file, which is incorrect, as we are not releasing the helm-chart on a pre-release.

## How can this be tested?

Fork the operator repo -> push a tag in the following format (vX.X.X-rcX) -> check if the helm manifest and index file creation is skipped

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
