### PR TITLE
Fix operator behavior related to 503 ServiceUnavailable DynatraceApi error

### DIFF
--- a/src/controllers/dynakube/dynatraceapi/status.go
+++ b/src/controllers/dynakube/dynatraceapi/status.go
@@ -1,0 +1,36 @@
+package dynatraceapi
+
+import (
+	"net/http"
+
+	"github.com/Dynatrace/dynatrace-operator/src/dtclient"
+	"github.com/pkg/errors"
+)
+
+const (
+	NoError = 0
+)
+
+func IsUnreachable(err error) bool {
+	var serverErr dtclient.ServerError
+	if errors.As(err, &serverErr) && (serverErr.Code == http.StatusTooManyRequests || serverErr.Code == http.StatusServiceUnavailable) {
+		return true
+	}
+	return false
+}
+
+func StatusCode(err error) int {
+	var serverErr dtclient.ServerError
+	if errors.As(err, &serverErr) {
+		return serverErr.Code
+	}
+	return 0
+}
+
+func Message(err error) string {
+	var serverErr dtclient.ServerError
+	if errors.As(err, &serverErr) {
+		return serverErr.Message
+	}
+	return ""
+}


### PR DESCRIPTION
## Description
cherry-pick of [fix](https://github.com/Dynatrace/dynatrace-operator/pull/2158)

## How can this be tested?

We can't force the server to return 503 so I tested the fix using unit tests and debugged a small application consisting of investigated code and basic http server returning 503 response.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
