### PR TITLE
Prevent duplicates from oneAgent connection info resp

### DIFF
--- a/src/dtclient/communication_hosts_test.go
+++ b/src/dtclient/communication_hosts_test.go
@@ -2,6 +2,7 @@ package dtclient
 
 import (
 	"net/http"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,11 +44,14 @@ func TestReadCommunicationHosts(t *testing.T) {
 		m, err := readFromString(goodCommunicationEndpointsResponse)
 		if assert.NoError(t, err) {
 			expected := []CommunicationHost{
-				{Protocol: "https", Host: "example.live.dynatrace.com", Port: 443},
-				{Protocol: "https", Host: "managedhost.com", Port: 9999},
 				{Protocol: "https", Host: "10.0.0.1", Port: 8000},
+				{Protocol: "https", Host: "example.live.dynatrace.com", Port: 443},
 				{Protocol: "http", Host: "insecurehost", Port: 80},
+				{Protocol: "https", Host: "managedhost.com", Port: 9999},
 			}
+			sort.Slice(m.CommunicationHosts, func(i, j int) bool {
+				return m.CommunicationHosts[i].Host < m.CommunicationHosts[j].Host
+			})
 			assert.Equal(t, expected, m.CommunicationHosts)
 		}
 	}

--- a/src/dtclient/oneagent_connection_info_test.go
+++ b/src/dtclient/oneagent_connection_info_test.go
@@ -19,6 +19,12 @@ func Test_GetOneAgentConnectionInfo(t *testing.T) {
 		CommunicationEndpoints:          []string{testCommunicationEndpoint},
 		FormattedCommunicationEndpoints: testCommunicationEndpoint,
 	}
+	oneAgentJsonResponseWithDups := &oneAgentConnectionInfoJsonResponse{
+		TenantUUID:                      testTenantUUID,
+		TenantToken:                     testTenantToken,
+		CommunicationEndpoints:          []string{testCommunicationEndpoint, testCommunicationEndpoint},
+		FormattedCommunicationEndpoints: testCommunicationEndpoint,
+	}
 
 	expectedOneAgentConnectionInfo := OneAgentConnectionInfo{
 		ConnectionInfo: ConnectionInfo{
@@ -37,6 +43,17 @@ func Test_GetOneAgentConnectionInfo(t *testing.T) {
 
 	t.Run("no network zone", func(t *testing.T) {
 		dynatraceServer, dynatraceClient := createTestDynatraceServer(t, connectionInfoServerHandler(oneAgentConnectionInfoEndpoint, oneAgentJsonResponse), "")
+		defer dynatraceServer.Close()
+
+		connectionInfo, err := dynatraceClient.GetOneAgentConnectionInfo()
+		assert.NoError(t, err)
+		assert.NotNil(t, connectionInfo)
+
+		assert.Equal(t, expectedOneAgentConnectionInfo, connectionInfo)
+	})
+
+	t.Run("with duplicates", func(t *testing.T) {
+		dynatraceServer, dynatraceClient := createTestDynatraceServer(t, connectionInfoServerHandler(oneAgentConnectionInfoEndpoint, oneAgentJsonResponseWithDups), "")
 		defer dynatraceServer.Close()
 
 		connectionInfo, err := dynatraceClient.GetOneAgentConnectionInfo()


### PR DESCRIPTION
## Description

Please include the following:

- A meaningful PR title [guidelines](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#use-imperative-mood-in-your-commit-message-subject)
- A summary of the change
- Which issue is fixed (if there is one)
- Relevant motivation and context

## How can this be tested?

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

## Checklist

- [ ] Unit tests have been updated/added
- [ ] PR is labeled accordingly with a single label
- [ ] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
