### PR TITLE
Add helm-package upload to OCI registry

### DIFF
--- a/.github/actions/build-helm/action.yaml
+++ b/.github/actions/build-helm/action.yaml
@@ -1,8 +1,8 @@
 name: Build Helm packages
 description: Builds the helm packages
 inputs:
-  version:
-    description: The version of the operator that should be deployed
+  version_without_prefix:
+    description: The version of the operator that should be deployed without the leading 'v' character
     required: true
   github-token:
     description: Token used to fetch the current helm version
@@ -26,4 +26,4 @@ runs:
         token: ${{ inputs.github-token }}
     - name: Generate helm-package
       shell: bash
-      run: hack/build/ci/generate-helm-package.sh "${{ inputs.secring }}" "${{ inputs.passphrase }}" "${{ inputs.output-dir }}" "${{ inputs.version }}"
+      run: hack/build/ci/generate-helm-package.sh "${{ inputs.secring }}" "${{ inputs.passphrase }}" "${{ inputs.output-dir }}" "${{ inputs.version_without_prefix }}"

--- a/.github/actions/upload-helm/action.yaml
+++ b/.github/actions/upload-helm/action.yaml
@@ -1,0 +1,61 @@
+name: Upload helm package
+description: Upload the helm package
+inputs:
+  registry-username:
+    description: Username for the OCI registry
+    required: true
+  registry-password:
+    description: Password for the OCI registry
+    required: true
+  registry-url:
+    description: URL for the OCI registry
+    required: true
+    default: registry.hub.docker.com
+  registry-namespace:
+    description: Repository in the OCI registry
+    required: true
+    default: dynatrace
+  image-base-url:
+    description: Base URL for the image
+    required: true
+    default: docker.io
+  helm-repository-name:
+    description: Repository used in the OCI registry, be aware that helm upload does infer this from the helm package name itself
+    required: true
+    default: dynatrace-operator
+  version:
+    description: The version of the helm package to upload
+    required: true
+  version-without-prefix:
+    description: The version of the helm package to upload without the leading 'v' character
+    required: true
+  cosign-private-key:
+    description: Private key used to sign the helm package
+    required: true
+  cosign-password:
+    description: Password used to encrypt the private key
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+  - name: Upload helm package to OCI registry
+    id: push-helm-to-OCI
+    shell: bash
+    run: |
+      helm registry login -u "${{ inputs.registry-username }}" -p "${{ inputs.registry-password }}" "${{ inputs.registry-url }}"
+      hack/build/ci/push-helm-chart.sh \
+        "./helm-pkg/dynatrace-operator-${{ inputs.version-without-prefix }}.tgz" \
+        "oci://${{ inputs.registry-url }}/${{ inputs.registry-namespace }}"
+  - name: Login to Registry
+    uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+    with:
+      registry: docker.io
+      username: ${{ inputs.registry-username }}
+      password: ${{ inputs.registry-password }}
+  - name: Sign OCI package with cosign
+    uses: ./.github/actions/sign-image
+    with:
+      image: "${{ inputs.image-base-url }}/${{ inputs.registry-namespace }}/${{ inputs.helm-repository-name }}:${{ inputs.version }}@${{ steps.push-helm-to-OCI.outputs.digest }}"
+      signing-key: ${{ inputs.cosign-private-key }}
+      signing-password: ${{ inputs.cosign-password }}

--- a/.github/actions/upload-helm/action.yaml
+++ b/.github/actions/upload-helm/action.yaml
@@ -50,7 +50,7 @@ runs:
   - name: Login to Registry
     uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
     with:
-      registry: docker.io
+      registry: ${{ inputs.image-base-url }}
       username: ${{ inputs.registry-username }}
       password: ${{ inputs.registry-password }}
   - name: Sign OCI package with cosign

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -248,6 +248,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -290,6 +291,28 @@ jobs:
           secring: ${{ secrets.HELM_SECRING }}
           passphrase: ${{ secrets.HELM_PASSPHRASE }}
           output-dir: "./helm-pkg"
+      - name: Upload helm package to OCI registry
+        id: pushHelmChart
+        if: ${{ !contains(github.ref, '-rc.') }}
+        shell: bash
+        run: |
+          helm registry login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" registry.hub.docker.com
+          hack/build/ci/push-helm-chart.sh \
+            "./helm-pkg/dynatrace-operator-${{ needs.prepare.outputs.version_without_prefix }}.tgz" \
+            "oci://registry.hub.docker.com/dynatrace"
+      - name: Login to Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Sign package with cosign
+        if: ${{ !contains(github.ref, '-rc.') }}
+        uses: ./.github/actions/sign-image
+        with:
+          image: "docker.io/dynatrace/dynatrace-operator:${{ needs.prepare.outputs.version }}@${{ steps.pushHelmChart.outputs.digest }}"
+          signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Prepare cosign.pub artifact
         env:
           COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -283,7 +283,6 @@ jobs:
           mv config/deploy/kubernetes/kubernetes-all.yaml config/deploy/kubernetes/kubernetes.yaml
           mv config/deploy/openshift/openshift-all.yaml config/deploy/openshift/openshift.yaml
       - name: Build helm packages
-        if: ${{ !contains(github.ref, '-rc.') }}
         uses: ./.github/actions/build-helm
         with:
           version_without_prefix: ${{ needs.prepare.outputs.version_without_prefix }}
@@ -293,7 +292,6 @@ jobs:
           output-dir: "./helm-pkg"
       - name: Upload helm package to OCI registry
         id: pushHelmChart
-        if: ${{ !contains(github.ref, '-rc.') }}
         shell: bash
         run: |
           helm registry login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" registry.hub.docker.com
@@ -306,8 +304,7 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Sign package with cosign
-        if: ${{ !contains(github.ref, '-rc.') }}
+      - name: Sign OCI package with cosign
         uses: ./.github/actions/sign-image
         with:
           image: "docker.io/dynatrace/dynatrace-operator:${{ needs.prepare.outputs.version }}@${{ steps.pushHelmChart.outputs.digest }}"
@@ -328,6 +325,8 @@ jobs:
             tmp/cosign.pub
             config/deploy/kubernetes/kubernetes.yaml
             config/deploy/openshift/openshift.yaml
+            helm-pkg/dynatrace-operator-${{ needs.prepare.outputs.version_without_prefix }}.tgz
+            helm-pkg/dynatrace-operator-${{ needs.prepare.outputs.version_without_prefix }}.tgz.prov
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
           draft: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -291,7 +291,7 @@ jobs:
           passphrase: ${{ secrets.HELM_PASSPHRASE }}
           output-dir: "./helm-pkg"
       - name: Upload helm package to OCI registry
-        id: pushHelmChart
+        id: push-helm-to-OCI
         shell: bash
         run: |
           helm registry login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" registry.hub.docker.com
@@ -307,7 +307,7 @@ jobs:
       - name: Sign OCI package with cosign
         uses: ./.github/actions/sign-image
         with:
-          image: "docker.io/dynatrace/dynatrace-operator:${{ needs.prepare.outputs.version }}@${{ steps.pushHelmChart.outputs.digest }}"
+          image: "docker.io/dynatrace/dynatrace-operator:${{ needs.prepare.outputs.version }}@${{ steps.push-helm-to-OCI.outputs.digest }}"
           signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Prepare cosign.pub artifact
@@ -383,8 +383,8 @@ jobs:
       id-token: write
 
     steps:
-      - name: Push tag to synk
-        id: pushToSnyk
+      - name: Push tag to snyk
+        id: push-to-snyk
         uses: fjogeleit/http-request-action@v1
         with:
           url: 'https://api.snyk.io/v1/org/${{ secrets.SNYK_ORGANIZATION_ID }}/integrations/${{ secrets.SNYK_INTEGRATION_ID }}/import'
@@ -393,5 +393,5 @@ jobs:
           data: '{ "target": { "name": "${{ secrets.DOCKERHUB_REPOSITORY }}:${{ needs.prepare.outputs.version }}" }}'
       - name: Show Response
         run: |
-          echo ${{ steps.pushToSnyk.outputs.response }}
-          echo ${{ steps.pushToSnyk.outputs.headers }}
+          echo ${{ steps.push-to-snyk.outputs.response }}
+          echo ${{ steps.push-to-snyk.outputs.headers }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -290,26 +290,15 @@ jobs:
           secring: ${{ secrets.HELM_SECRING }}
           passphrase: ${{ secrets.HELM_PASSPHRASE }}
           output-dir: "./helm-pkg"
-      - name: Upload helm package to OCI registry
-        id: push-helm-to-OCI
-        shell: bash
-        run: |
-          helm registry login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" registry.hub.docker.com
-          hack/build/ci/push-helm-chart.sh \
-            "./helm-pkg/dynatrace-operator-${{ needs.prepare.outputs.version_without_prefix }}.tgz" \
-            "oci://registry.hub.docker.com/dynatrace"
-      - name: Login to Registry
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      - name: Upload and sign helm package to dockerhub
+        uses: ./.github/actions/upload-helm
         with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Sign OCI package with cosign
-        uses: ./.github/actions/sign-image
-        with:
-          image: "docker.io/dynatrace/dynatrace-operator:${{ needs.prepare.outputs.version }}@${{ steps.push-helm-to-OCI.outputs.digest }}"
-          signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          signing-password: ${{ secrets.COSIGN_PASSWORD }}
+          registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          version: ${{ needs.prepare.outputs.version }}
+          version-without-prefix: ${{ needs.prepare.outputs.version_without_prefix }}
+          cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          cosign-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Prepare cosign.pub artifact
         env:
           COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -325,8 +325,6 @@ jobs:
             tmp/cosign.pub
             config/deploy/kubernetes/kubernetes.yaml
             config/deploy/openshift/openshift.yaml
-            helm-pkg/dynatrace-operator-${{ needs.prepare.outputs.version_without_prefix }}.tgz
-            helm-pkg/dynatrace-operator-${{ needs.prepare.outputs.version_without_prefix }}.tgz.prov
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
           draft: true

--- a/hack/build/ci/push-helm-chart.sh
+++ b/hack/build/ci/push-helm-chart.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+readonly PATH_TO_HELM_CHART="${1}"
+readonly REGISTRY_URL="${2}"
+
+output=$(helm push "${PATH_TO_HELM_CHART}" "${REGISTRY_URL}" 2>&1)
+exit_status=$?
+
+if [ $exit_status -eq 0 ]; then
+  digest=$(echo "$output" | awk '/Digest:/ {print $2}')
+  echo "digest=$digest" >> $GITHUB_OUTPUT
+else
+  echo "Command failed with exit status $exit_status. Error: $output"
+  exit $exit_status
+fi


### PR DESCRIPTION
## Description

This PR: 
- Fixes bug in the release pipeline where the parameters were named in the wrong way
- Add steps for upload and sign the helm-package to OCI registry

## How can this be tested?

Run release steps and check in OCI registry if packages are there

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
