### PR TITLE
Add limits to init container of CSI driver daemonset

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -59,6 +59,10 @@ spec:
         - csi-init
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        resources:
+          {{- if .Values.csidriver.csiInit.resources }}
+          {{- toYaml .Values.csidriver.csiInit.resources | nindent 10 }}
+          {{- end }}
         securityContext:
         {{- toYaml .Values.csidriver.csiInit.securityContext| nindent 10 }}
         volumeMounts:

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -101,6 +101,13 @@ tests:
               - csi-init
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 100Mi
+                limits:
+                  cpu: 50m
+                  memory: 100Mi
               securityContext:
                 runAsUser: 0
                 privileged: false
@@ -398,6 +405,29 @@ tests:
           path: spec.template.metadata.labels.testKey
           value: testValue
 
+  - it: should take resource limits from values file for init container
+    set:
+      csidriver.enabled: true
+      csidriver.csiInit.resources.requests.cpu: 123m
+      csidriver.csiInit.resources.requests.memory: 456Mi
+      csidriver.csiInit.resources.limits.cpu: 789m
+      csidriver.csiInit.resources.limits.memory: 122Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: csi-init
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.cpu
+          value: 123m
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.memory
+          value: 456Mi
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.cpu
+          value: 789m
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.memory
+          value: 122Mi
   - it: should take resource limits from values file for provisioner
     set:
       csidriver.enabled: true

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -106,6 +106,13 @@ csidriver:
         level: s0
       seccompProfile:
         type: RuntimeDefault
+    resources:
+      requests:
+        cpu: 50m
+        memory: 100Mi
+      limits:
+        cpu: 50m
+        memory: 100Mi
   server:
     securityContext:
       runAsUser: 0


### PR DESCRIPTION
## Description

As pointed out in #2173, the CSI driver daemonset is currently missing resource limits for the init container.
This PR adds them including the possibility to change them with helm values.

## How can this be tested?

Deploy this branch and check limits.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
