### PR TITLE
Use image index digest instead of plain image digest

### DIFF
--- a/pkg/oci/registry/client.go
+++ b/pkg/oci/registry/client.go
@@ -95,7 +95,7 @@ var _ ClientBuilder = NewClient
 func (c *Client) GetImageVersion(ctx context.Context, imageName string) (ImageVersion, error) {
 	ref, err := name.ParseReference(imageName)
 	if err != nil {
-		return ImageVersion{}, fmt.Errorf("parsing reference %q: %w", imageName, err)
+		return ImageVersion{}, errors.WithMessagef(err, "parsing reference %q", imageName)
 	}
 
 	options := []remote.Option{
@@ -108,13 +108,13 @@ func (c *Client) GetImageVersion(ctx context.Context, imageName string) (ImageVe
 
 	descriptor, err := remote.Get(ref, options...)
 	if err != nil {
-		return ImageVersion{}, fmt.Errorf("getting reference %q: %w", ref, err)
+		return ImageVersion{}, errors.WithMessagef(err, "getting reference %q", ref)
 	}
 
 	// TODO: does not work for indexes which contain schema v1 manifests
 	img, err := descriptor.Image()
 	if err != nil {
-		return ImageVersion{}, fmt.Errorf("descriptor.Image(): %w", err)
+		return ImageVersion{}, errors.WithMessagef(err, "descriptor.Image()")
 	}
 
 	// use image digest as a fallback
@@ -128,12 +128,12 @@ func (c *Client) GetImageVersion(ctx context.Context, imageName string) (ImageVe
 
 	dig, err := digestFn()
 	if err != nil {
-		return ImageVersion{}, fmt.Errorf("img.Digest(): %w", err)
+		return ImageVersion{}, errors.WithMessagef(err, "could not get image digest")
 	}
 
 	cf, err := img.ConfigFile()
 	if err != nil {
-		return ImageVersion{}, fmt.Errorf("img.ConfigFile: %w", err)
+		return ImageVersion{}, errors.WithMessagef(err, "img.ConfigFile")
 	}
 
 	return ImageVersion{

--- a/pkg/oci/registry/client.go
+++ b/pkg/oci/registry/client.go
@@ -116,10 +116,21 @@ func (c *Client) GetImageVersion(ctx context.Context, imageName string) (ImageVe
 	if err != nil {
 		return ImageVersion{}, fmt.Errorf("descriptor.Image(): %w", err)
 	}
-	dig, err := img.Digest()
+
+	// use image digest as a fallback
+	digestFn := img.Digest
+
+	// try to get image manifest to cover multi arch images
+	digestSrc, err := descriptor.ImageIndex()
+	if err == nil {
+		digestFn = digestSrc.Digest
+	}
+
+	dig, err := digestFn()
 	if err != nil {
 		return ImageVersion{}, fmt.Errorf("img.Digest(): %w", err)
 	}
+
 	cf, err := img.ConfigFile()
 	if err != nil {
 		return ImageVersion{}, fmt.Errorf("img.ConfigFile: %w", err)

--- a/pkg/oci/registry/client.go
+++ b/pkg/oci/registry/client.go
@@ -121,9 +121,9 @@ func (c *Client) GetImageVersion(ctx context.Context, imageName string) (ImageVe
 	digestFn := img.Digest
 
 	// try to get image manifest to cover multi arch images
-	digestSrc, err := descriptor.ImageIndex()
+	imageIndex, err := descriptor.ImageIndex()
 	if err == nil {
-		digestFn = digestSrc.Digest
+		digestFn = imageIndex.Digest
 	}
 
 	dig, err := digestFn()


### PR DESCRIPTION
## Description

Currently the image digest for AMD64 images is used in OneAgent daemonsets. This causes errors if OneAgents should be rolled out on nodes with architectures other than amd64.

Instead of using the digest of the amd64 image the operator shall use the digest of the image index, that points to an image manifest containing images for all supported architectures.

## How can this be tested?

- setup a K8s cluster with arm and amd nodes
- build and deploy a multi-arch operator
- create a dynakube with proper tolerations for one agent pods:
```
       tolerations:
        - effect: NoSchedule
          key: kubernetes.io/arch
          value: arm64
          operator: Equal
```
- deploy DynaKube
- check that OneAgents can properly start on arm nodes

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
