### PR TITLE
Add seccompProfile on the POD level

### DIFF
--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -106,6 +106,8 @@ spec:
         - emptyDir: { }
           name: tmp-cert-dir
       serviceAccountName: {{ .Release.Name }}
+      securityContext:
+        {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
       {{- if .Values.customPullSecret }}
       imagePullSecrets:
         - name: {{ .Values.customPullSecret }}

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -134,6 +134,8 @@ spec:
       {{- if (.Values.webhook).hostNetwork }}
       hostNetwork: true
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.webhook.podSecurityContext | nindent 8 }}
       {{- if .Values.customPullSecret }}
       imagePullSecrets:
         - name: {{ .Values.customPullSecret }}

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -139,6 +139,9 @@ tests:
             volumes:
               - emptyDir: { }
                 name: tmp-cert-dir
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
             serviceAccountName: RELEASE-NAME
             tolerations:
               - effect: NoSchedule
@@ -302,6 +305,9 @@ tests:
             volumes:
               - emptyDir: { }
                 name: tmp-cert-dir
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
             serviceAccountName: RELEASE-NAME
             tolerations:
               - effect: NoSchedule

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -153,6 +153,9 @@ tests:
                   capabilities:
                     drop:
                       - ALL
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
             serviceAccountName: dynatrace-webhook
 
   - it: should have tolerations if set
@@ -319,6 +322,9 @@ tests:
                   capabilities:
                     drop:
                       - ALL
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
             serviceAccountName: dynatrace-webhook
 
   - it: should not have imagePullSecrets defined in spec (without highavailabilty mode)
@@ -452,6 +458,9 @@ tests:
                   capabilities:
                     drop:
                       - ALL
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
             serviceAccountName: dynatrace-webhook
 
   - it: should have only OS node affinity on GKE Autopilot

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -45,6 +45,9 @@ operator:
         - ALL
     seccompProfile:
       type: RuntimeDefault
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
   requests:
     cpu: 50m
     memory: 64Mi
@@ -69,6 +72,9 @@ webhook:
     capabilities:
       drop:
         - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
   requests:
@@ -180,3 +186,4 @@ csidriver:
       limits:
         cpu: 20m
         memory: 30Mi
+

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -112,6 +112,11 @@ func (statefulSetBuilder Builder) addTemplateSpec(sts *appsv1.StatefulSet) {
 		ServiceAccountName: statefulSetBuilder.dynakube.ActiveGateServiceAccountName(),
 		Affinity:           nodeAffinity(),
 		Tolerations:        statefulSetBuilder.capability.Properties().Tolerations,
+		SecurityContext: &corev1.PodSecurityContext{
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
 		ImagePullSecrets: []corev1.LocalObjectReference{
 			{Name: statefulSetBuilder.dynakube.PullSecretName()},
 		},


### PR DESCRIPTION
## Description

Currently the `seccompProfile` is set on the container level only. Kyverno Policy prefers the profile to be set on the container level and the POD level.

`podSecurityContext` field has been added to `operator` and `webhook` sections of `values.yaml` file to make `seccompProfile` configurable on the POD level. 

In case of ActiveGate statefulset the `seccompProfile` field has been added on the POD level. It is hard-coded value.

Summarizing:
- `seccompProfile`s are defined on both levels (by default)
- `seccompProfile`s can be configured on both levels

## How can this be tested?
1) Use helm tests:
```
make test/helm
```

2) Modify `values.yaml` file and deploy the operator using `make deploy/kubernetes` command. Check if `seccompProfile`s are set accordingly to the `values.yaml`.

For example set the following value in the `values.yaml` file:
```
webhook:
  ...
  securityContext:
    seccompProfile:
      type: Unconfined
```
**Operator POD**:
```
kubectl -n dynatrace get -o json pod/dynatrace-operator-5586cf87f5-xzsm7 | jq -r '.spec.containers[] | .name, .securityContext.seccompProfile'

kubectl -n dynatrace get -o json pod/dynatrace-operator-5586cf87f5-xzsm7 | jq -r '.spec.securityContext.seccompProfile'
```
Output:
containers:
```
dynatrace-operator
{
  "type": "RuntimeDefault"
}
```
pod:
```
{
  "type": "RuntimeDefault"
}
```
**Webhook POD**:
```
kubectl -n dynatrace get -o json pod/dynatrace-webhook-6f769cc6fd-5gc8z | jq -r '.spec.containers[] | .name, .securityContext.seccompProfile'

kubectl -n dynatrace get -o json pod/dynatrace-webhook-6f769cc6fd-5gc8z | jq -r '.spec.securityContext.seccompProfile'
```
Output:
containers:
```
webhook
{
  "type": "Unconfined"
}
```
pod:
```
{
  "type": "RuntimeDefault"
}
```

3) Deploy simple Dynakube and check ActiveGate pod:
```
apiVersion: dynatrace.com/v1beta1
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: <api url>
  activeGate:
    capabilities:
      - routing
  oneAgent:
    cloudNativeFullStack: {}
```
**ActiveGate POD**:
```
 kubectl -n dynatrace get -o json pod/dynakube-activegate-0 | jq -r '.spec.containers[] | .name, .securityContext.seccompProfile'
 
 kubectl -n dynatrace get -o json pod/dynakube-activegate-0 | jq -r '.spec.securityContext.seccompProfile'
```
Output:
containers:
```
activegate
{
  "type": "RuntimeDefault"
}
```
pod:
```
{
  "type": "RuntimeDefault"
}
```


## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
