### PR TITLE
Adds missing nodeAffinity settings for arm and ppcle support to the activeGate statefulset

### DIFF
--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -126,7 +126,7 @@ func (statefulSetBuilder Builder) addTemplateSpec(sts *appsv1.StatefulSet) {
 func buildTolerations(capability capability.Capability) []corev1.Toleration {
 	tolerations := make([]corev1.Toleration, len(capability.Properties().Tolerations))
 	copy(tolerations, capability.Properties().Tolerations)
-	tolerations = append(tolerations, kubeobjects.TolerationForAmd()...)
+	tolerations = append(tolerations, kubeobjects.TolerationForAllArches()...)
 	return tolerations
 }
 
@@ -222,7 +222,7 @@ func nodeAffinity() *corev1.Affinity {
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 				NodeSelectorTerms: []corev1.NodeSelectorTerm{
 					{
-						MatchExpressions: kubeobjects.AffinityNodeRequirement(),
+						MatchExpressions: kubeobjects.AffinityNodeRequirementForAllArches(),
 					},
 				},
 			},

--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
@@ -83,6 +83,36 @@ func TestGetBaseObjectMeta(t *testing.T) {
 		require.NotEmpty(t, sts.Spec.Template.Labels)
 		assert.Equal(t, expectedTemplateAnnotations, sts.Spec.Template.Annotations)
 	})
+	t.Run("default tolerations", func(t *testing.T) {
+		multiCapability := capability.NewMultiCapability(&dynakube)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		sts, _ := builder.CreateStatefulSet(nil)
+		expectedTolerations := []corev1.Toleration{
+			{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "amd64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "ppc64le",
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
+
+		require.NotEmpty(t, sts.Spec.Template.Spec.Tolerations)
+		assert.Contains(t, sts.Spec.Template.Spec.Tolerations, expectedTolerations[0])
+		assert.Contains(t, sts.Spec.Template.Spec.Tolerations, expectedTolerations[1])
+		assert.Contains(t, sts.Spec.Template.Spec.Tolerations, expectedTolerations[2])
+	})
 	t.Run("add annotations", func(t *testing.T) {
 		dynakube.Spec.ActiveGate.Annotations = map[string]string{
 			"test": "test",

--- a/src/controllers/dynakube/oneagent/daemonset/affinity.go
+++ b/src/controllers/dynakube/oneagent/daemonset/affinity.go
@@ -25,6 +25,6 @@ func (dsInfo *builderInfo) affinityNodeSelectorTerms() []corev1.NodeSelectorTerm
 
 func kubernetesArchOsSelectorTerm() corev1.NodeSelectorTerm {
 	return corev1.NodeSelectorTerm{
-		MatchExpressions: kubeobjects.AffinityNodeRequirementWithARM64(),
+		MatchExpressions: kubeobjects.AffinityNodeRequirementForAllArches(),
 	}
 }

--- a/src/kubeobjects/affinity.go
+++ b/src/kubeobjects/affinity.go
@@ -14,23 +14,25 @@ const (
 	linux   = "linux"
 )
 
-func AffinityNodeRequirement() []corev1.NodeSelectorRequirement {
-	return affinityNodeRequirementsForArches(amd64)
+func TolerationForAllArches() []corev1.Toleration {
+	return tolerationsForArches(amd64, arm64, ppc64le)
 }
 
-func TolerationForAmd() []corev1.Toleration {
-	return []corev1.Toleration{
-		{
+func AffinityNodeRequirementForAllArches() []corev1.NodeSelectorRequirement {
+	return affinityNodeRequirementsForArches(amd64, arm64, ppc64le)
+}
+
+func tolerationsForArches(arches ...string) []corev1.Toleration {
+	var tolerations []corev1.Toleration
+	for _, arch := range arches {
+		tolerations = append(tolerations, corev1.Toleration{
 			Key:      kubernetesArch,
 			Operator: corev1.TolerationOpEqual,
-			Value:    amd64,
+			Value:    arch,
 			Effect:   corev1.TaintEffectNoSchedule,
-		},
+		})
 	}
-}
-
-func AffinityNodeRequirementWithARM64() []corev1.NodeSelectorRequirement {
-	return affinityNodeRequirementsForArches(amd64, arm64, ppc64le)
+	return tolerations
 }
 
 func affinityNodeRequirementsForArches(arches ...string) []corev1.NodeSelectorRequirement {

--- a/src/kubeobjects/affinity.go
+++ b/src/kubeobjects/affinity.go
@@ -23,7 +23,7 @@ func AffinityNodeRequirementForAllArches() []corev1.NodeSelectorRequirement {
 }
 
 func tolerationsForArches(arches ...string) []corev1.Toleration {
-	var tolerations []corev1.Toleration
+	tolerations := make([]corev1.Toleration, len(arches))
 	for _, arch := range arches {
 		tolerations = append(tolerations, corev1.Toleration{
 			Key:      kubernetesArch,

--- a/src/kubeobjects/affinity_test.go
+++ b/src/kubeobjects/affinity_test.go
@@ -7,15 +7,33 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const nodeSelectorRequirements = 2
-
 func TestAffinityNodeRequirement(t *testing.T) {
-	assert.Equal(t, AffinityNodeRequirement(), affinityNodeRequirementsForArches(amd64))
-	assert.Equal(t, AffinityNodeRequirementWithARM64(), affinityNodeRequirementsForArches(amd64, arm64, ppc64le))
-	assert.Equal(t, len(AffinityNodeRequirement()), nodeSelectorRequirements)
+	assert.Equal(t, AffinityNodeRequirementForAllArches(), affinityNodeRequirementsForArches(amd64, arm64, ppc64le))
+	assert.Contains(t, AffinityNodeRequirementForAllArches(), linuxRequirement())
+}
 
-	assert.Contains(t, AffinityNodeRequirement(), linuxRequirement())
-	assert.Contains(t, AffinityNodeRequirementWithARM64(), linuxRequirement())
+func TestTolerationsForAllArches(t *testing.T) {
+	assert.Equal(t, TolerationForAllArches(), tolerationsForArches(amd64, arm64, ppc64le))
+	assert.Contains(t, TolerationForAllArches(), armToleration())
+	assert.Contains(t, TolerationForAllArches(), amdToleration())
+}
+
+func armToleration() corev1.Toleration {
+	return corev1.Toleration{
+		Key:      kubernetesArch,
+		Operator: corev1.TolerationOpEqual,
+		Value:    arm64,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+}
+
+func amdToleration() corev1.Toleration {
+	return corev1.Toleration{
+		Key:      kubernetesArch,
+		Operator: corev1.TolerationOpEqual,
+		Value:    amd64,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
 }
 
 func linuxRequirement() corev1.NodeSelectorRequirement {


### PR DESCRIPTION
## Description

Currently the operator fails to roll out ActiveGate instances on ARM nodes due to missing node affinity settings. This PR adds those to the statefulset.

## How can this be tested?

Get a cluster with a different architecture (i.e arm64)
Install the operator
Apply a Dynakube that rolls out an AG
Check if the AG pod is actually scheduled (may fail since the tenant registry only supports amd64 -> thats fine)

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
