### PR TITLE
Removes default tolerations for activeGate pods

### DIFF
--- a/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/src/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -111,7 +111,7 @@ func (statefulSetBuilder Builder) addTemplateSpec(sts *appsv1.StatefulSet) {
 		NodeSelector:       statefulSetBuilder.capability.Properties().NodeSelector,
 		ServiceAccountName: statefulSetBuilder.dynakube.ActiveGateServiceAccountName(),
 		Affinity:           nodeAffinity(),
-		Tolerations:        buildTolerations(statefulSetBuilder.capability),
+		Tolerations:        statefulSetBuilder.capability.Properties().Tolerations,
 		ImagePullSecrets: []corev1.LocalObjectReference{
 			{Name: statefulSetBuilder.dynakube.PullSecretName()},
 		},
@@ -121,13 +121,6 @@ func (statefulSetBuilder Builder) addTemplateSpec(sts *appsv1.StatefulSet) {
 		TopologySpreadConstraints: statefulSetBuilder.buildTopologySpreadConstraints(statefulSetBuilder.capability),
 	}
 	sts.Spec.Template.Spec = podSpec
-}
-
-func buildTolerations(capability capability.Capability) []corev1.Toleration {
-	tolerations := make([]corev1.Toleration, len(capability.Properties().Tolerations))
-	copy(tolerations, capability.Properties().Tolerations)
-	tolerations = append(tolerations, kubeobjects.TolerationForSupportedArches()...)
-	return tolerations
 }
 
 func (statefulSetBuilder Builder) buildTopologySpreadConstraints(capability capability.Capability) []corev1.TopologySpreadConstraint {

--- a/src/kubeobjects/affinity.go
+++ b/src/kubeobjects/affinity.go
@@ -14,25 +14,8 @@ const (
 	linux   = "linux"
 )
 
-func TolerationForSupportedArches() []corev1.Toleration {
-	return tolerationsForArches(amd64, arm64, ppc64le)
-}
-
 func AffinityNodeRequirementForSupportedArches() []corev1.NodeSelectorRequirement {
 	return affinityNodeRequirementsForArches(amd64, arm64, ppc64le)
-}
-
-func tolerationsForArches(arches ...string) []corev1.Toleration {
-	tolerations := make([]corev1.Toleration, 0)
-	for _, arch := range arches {
-		tolerations = append(tolerations, corev1.Toleration{
-			Key:      kubernetesArch,
-			Operator: corev1.TolerationOpEqual,
-			Value:    arch,
-			Effect:   corev1.TaintEffectNoSchedule,
-		})
-	}
-	return tolerations
 }
 
 func affinityNodeRequirementsForArches(arches ...string) []corev1.NodeSelectorRequirement {

--- a/src/kubeobjects/affinity_test.go
+++ b/src/kubeobjects/affinity_test.go
@@ -12,30 +12,6 @@ func TestAffinityNodeRequirement(t *testing.T) {
 	assert.Contains(t, AffinityNodeRequirementForSupportedArches(), linuxRequirement())
 }
 
-func TestTolerationsForAllArches(t *testing.T) {
-	assert.Equal(t, TolerationForSupportedArches(), tolerationsForArches(amd64, arm64, ppc64le))
-	assert.Contains(t, TolerationForSupportedArches(), armToleration())
-	assert.Contains(t, TolerationForSupportedArches(), amdToleration())
-}
-
-func armToleration() corev1.Toleration {
-	return corev1.Toleration{
-		Key:      kubernetesArch,
-		Operator: corev1.TolerationOpEqual,
-		Value:    arm64,
-		Effect:   corev1.TaintEffectNoSchedule,
-	}
-}
-
-func amdToleration() corev1.Toleration {
-	return corev1.Toleration{
-		Key:      kubernetesArch,
-		Operator: corev1.TolerationOpEqual,
-		Value:    amd64,
-		Effect:   corev1.TaintEffectNoSchedule,
-	}
-}
-
 func linuxRequirement() corev1.NodeSelectorRequirement {
 	return corev1.NodeSelectorRequirement{
 		Key:      kubernetesOS,


### PR DESCRIPTION
## Description

We should not set default tolerations to the activeGate statefulset, as we have a dedicated dynakube field to set them.

## How can this be tested?

Deploy the operator -> Apply a DynaKube with an activeGate and without custom tolerations -> check if tolerations field is empty

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
