### PR TITLE
Keep namespace when running undeploy/helm

### DIFF
--- a/hack/make/deploy/helm.mk
+++ b/hack/make/deploy/helm.mk
@@ -15,4 +15,3 @@ deploy/helm: manifests/crd/helm
 undeploy/helm:
 	helm uninstall dynatrace-operator \
 			--namespace dynatrace
-	kubectl delete namespace dynatrace


### PR DESCRIPTION
## Description

In our e2e pipelines we have the operator's namespace prepared with secrets to access registries, however if we remove the namespace after each test, which is not intended.

## How can this be tested?

Run any e2e test, the namespace should remain there.

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
