### PR TITLE
Only get oneagent healthcheck when needed

### DIFF
--- a/src/controllers/dynakube/version/reconciler.go
+++ b/src/controllers/dynakube/version/reconciler.go
@@ -62,15 +62,17 @@ func (reconciler *Reconciler) updateVersionStatuses(ctx context.Context, updater
 		if err != nil {
 			return err
 		}
-	}
 
-	healthConfig, err := GetOneAgentHealthConfig(ctx, reconciler.apiReader, registry.NewClient(), reconciler.dynakube, reconciler.dynakube.OneAgentImage())
-	if err != nil {
-		log.Error(err, "could not set OneAgent healthcheck")
-	} else {
-		reconciler.dynakube.Status.OneAgent.Healthcheck = healthConfig
+		_, ok := updater.(*oneAgentUpdater)
+		if ok {
+			healthConfig, err := GetOneAgentHealthConfig(ctx, reconciler.apiReader, registry.NewClient(), reconciler.dynakube, reconciler.dynakube.OneAgentImage())
+			if err != nil {
+				log.Error(err, "could not set OneAgent healthcheck")
+			} else {
+				reconciler.dynakube.Status.OneAgent.Healthcheck = healthConfig
+			}
+		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Description

Bit of context:
- The current way the `version` package works is not optimal.
- So this is just a quick fix to mitigate the problem, otherwise it would require a major rethinking, which we shouldn't do last minute.

So what is actually is happening:
To decide which part of the status needs update we filter our list of `updaters`, [this filtering happens based on different things](https://github.com/Dynatrace/dynatrace-operator/blob/81e3e388426e2a74164549fe89bb5e7c2be61913/src/controllers/dynakube/version/reconciler.go#L89-L109).
After the filtering, we run all of them that remain.

The Bug: If there was any kind of `updater`, we checked/updated the healthcheck for the oneagent, which is not great.
- This didn't happen often, as we update all the `Statuses` in one go most of the time, they only get updated separately in case you are turning features on/off in staged fashion.

The Fix:
- We do a type check and only update the healthcheck in case the `oneagentUpdater` is the updater that we are running, its ugly but good enough for now.

## How can this be tested?

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
