### PR TITLE
Only get oneagent healthcheck when needed #2207

### DIFF
--- a/pkg/controllers/dynakube/version/reconciler.go
+++ b/pkg/controllers/dynakube/version/reconciler.go
@@ -62,15 +62,17 @@ func (reconciler *Reconciler) updateVersionStatuses(ctx context.Context, updater
 		if err != nil {
 			return err
 		}
-	}
 
-	healthConfig, err := GetOneAgentHealthConfig(ctx, reconciler.apiReader, reconciler.registryClient, reconciler.dynakube, reconciler.dynakube.OneAgentImage())
-	if err != nil {
-		log.Error(err, "could not set OneAgent healthcheck")
-	} else {
-		reconciler.dynakube.Status.OneAgent.Healthcheck = healthConfig
+		_, ok := updater.(*oneAgentUpdater)
+		if ok {
+			healthConfig, err := GetOneAgentHealthConfig(ctx, reconciler.apiReader, reconciler.registryClient, reconciler.dynakube, reconciler.dynakube.OneAgentImage())
+			if err != nil {
+				log.Error(err, "could not set OneAgent healthcheck")
+			} else {
+				reconciler.dynakube.Status.OneAgent.Healthcheck = healthConfig
+			}
+		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Description

cherry-pick of #2207

## How can this be tested?

same as #2207

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
