### PR TITLE
Fix the flakey Istio e2e Test

### DIFF
--- a/test/scenarios/cloudnative/default/default.go
+++ b/test/scenarios/cloudnative/default/default.go
@@ -44,9 +44,6 @@ func Default(t *testing.T, istioEnabled bool) features.Feature {
 		setup.DeployOperatorViaMake(testDynakube.NeedsCSIDriver()))
 	steps.CreateSetupSteps(builder)
 
-	// Register dynakube install
-	assess.InstallDynakube(builder, &secretConfig, testDynakube)
-
 	// Register sample app install
 	namespaceBuilder := namespace.NewBuilder("cloudnative-sample")
 	if istioEnabled {
@@ -57,6 +54,9 @@ func Default(t *testing.T, istioEnabled bool) features.Feature {
 	sampleApp.WithNamespace(sampleNamespace)
 
 	builder.Assess("create sample namespace", sampleApp.InstallNamespace())
+
+	// Register dynakube install
+	assess.InstallDynakube(builder, &secretConfig, testDynakube)
 	builder.Assess("install sample app", sampleApp.Install())
 
 	// Register actual test


### PR DESCRIPTION
## Description

- fixes the Istio e2e test by creating the namespace of the SampleApp so the secret is in place when the oneagent init container is executed and subsequently checked in the test.

## How can this be tested?

run the Istio e2e test(s)

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
