### PR TITLE
add install mockery to prerequisites

### DIFF
--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -19,7 +19,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 ## Install all prerequisites
-prerequisites: prerequisites/kustomize prerequisites/controller-gen prerequisites/setup-pre-commit prerequisites/helm prerequisites/markdownlint
+prerequisites: prerequisites/kustomize prerequisites/controller-gen prerequisites/setup-pre-commit prerequisites/helm prerequisites/markdownlint prerequisites/mockery
 
 ## Installs 'kustomize' if it is missing
 prerequisites/kustomize:


### PR DESCRIPTION
## Description

Add install mockery if you run `make prerequisites`

## How can this be tested?

Remove mockery and run `make prerequisites`

## Checklist

~- [ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
