### PR TITLE
Change ubi9-micro to multi-arch image in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=1 CGO_CFLAGS="-O2 -Wno-return-local-addr" \
     go build -tags "${GO_BUILD_TAGS}" -trimpath -ldflags="${GO_LINKER_ARGS}" \
     -o ./build/_output/bin/dynatrace-operator ./src/cmd/
 
-FROM registry.access.redhat.com/ubi9-micro:9.2@sha256:21daf4c8bea788f6114822ab2d4a23cca6c682bdccc8aa7cae1124bcd8002066 AS base
+FROM registry.access.redhat.com/ubi9-micro:9.2@sha256:d14ac3ae12148f838511d08261e1569fb2a54da4c54a817aea7f16c1c9078f0b AS base
 FROM registry.access.redhat.com/ubi9:9.2@sha256:089bd3b82a78ac45c0eed231bb58bfb43bfcd0560d9bba240fc6355502c92976 AS dependency
 RUN mkdir -p /tmp/rootfs-dependency
 COPY --from=base / /tmp/rootfs-dependency


### PR DESCRIPTION
## Description

Change ubi9-micro to multi-arch image in dockerfile

## How can this be tested?

Build for arm64, amd64 and ppc64le should work

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
