### PR TITLE
Add missing CRD to GitHub actions release pipeline 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -312,6 +312,7 @@ jobs:
           body_path: ./CHANGELOG.md
           files: |
             tmp/cosign.pub
+            config/deploy/dynatrace-operator-crd.yaml
             config/deploy/kubernetes/kubernetes.yaml
             config/deploy/openshift/openshift.yaml
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -325,6 +326,7 @@ jobs:
           body_path: ./CHANGELOG.md
           files: |
             tmp/cosign.pub
+            config/deploy/dynatrace-operator-crd.yaml
             config/deploy/kubernetes/kubernetes.yaml
             config/deploy/kubernetes/kubernetes-csi.yaml
             config/deploy/kubernetes/gke-autopilot.yaml


### PR DESCRIPTION
## Description

The CRD file was missing when the release was automatically created.
This fix updates the pipeline to include the release file. 

## How can this be tested?

Run the release pipeline and check for `dynatrace-operator-crd.yaml` in the created release.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
