### PR TITLE
Stabilises Codemodules e2e Test

### DIFF
--- a/test/helpers/kubeobjects/namespace/namespace.go
+++ b/test/helpers/kubeobjects/namespace/namespace.go
@@ -79,7 +79,7 @@ func Create(namespace corev1.Namespace) features.Func {
 		err := envConfig.Client().Resources().Create(ctx, &namespace)
 		if err != nil {
 			if k8serrors.IsAlreadyExists(err) {
-				err = nil
+				err = envConfig.Client().Resources().Update(ctx, &namespace)
 			}
 			require.NoError(t, err)
 		}

--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -88,7 +88,8 @@ func DeleteProxy() features.Func {
 func CutOffDynatraceNamespace(builder *features.FeatureBuilder, proxySpec *dynatracev1beta1.DynaKubeProxy) {
 	if proxySpec != nil {
 		builder.Assess("cut off dynatrace namespace", manifests.InstallFromFile(dynatraceNetworkPolicy))
-		builder.WithTeardown("uninstalling outbound traffice pod", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+		builder.WithTeardown("uninstalling outbound traffic pod", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+```suggestion
 			return DeletePod(ctx, t, config, "dynatrace", curlPodNameDynatraceOutboundTraffic)
 		})
 	}

--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -106,7 +106,11 @@ func DeletePod(ctx context.Context, t *testing.T, config *envconf.Config, namesp
 	resources := config.Client().Resources()
 	err := resources.Delete(ctx, podToDelete)
 
-	if err != nil {
+	if k8serror.IsNotFound(err) {
+	  return ctx
+	}
+	require.NoError(t, err)  
+	  
 		if k8serrors.IsNotFound(err) {
 			err = nil
 		}

--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -5,12 +5,8 @@ package proxy
 import (
 	"context"
 	"fmt"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"path"
 	"path/filepath"
-	"sigs.k8s.io/e2e-framework/klient/wait"
-	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
@@ -28,7 +24,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
@@ -89,7 +89,6 @@ func CutOffDynatraceNamespace(builder *features.FeatureBuilder, proxySpec *dynat
 	if proxySpec != nil {
 		builder.Assess("cut off dynatrace namespace", manifests.InstallFromFile(dynatraceNetworkPolicy))
 		builder.WithTeardown("uninstalling outbound traffic pod", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-```suggestion
 			return DeletePod(ctx, t, config, "dynatrace", curlPodNameDynatraceOutboundTraffic)
 		})
 	}
@@ -106,17 +105,10 @@ func DeletePod(ctx context.Context, t *testing.T, config *envconf.Config, namesp
 	resources := config.Client().Resources()
 	err := resources.Delete(ctx, podToDelete)
 
-	if k8serror.IsNotFound(err) {
-	  return ctx
-	}
-	require.NoError(t, err)  
-	  
-		if k8serrors.IsNotFound(err) {
-			err = nil
-		}
-		require.NoError(t, err)
+	if k8serrors.IsNotFound(err) {
 		return ctx
 	}
+	require.NoError(t, err)
 
 	err = wait.For(conditions.New(resources).ResourceDeleted(podToDelete))
 	require.NoError(t, err)

--- a/test/scenarios/cloudnative/codemodules/codemodules.go
+++ b/test/scenarios/cloudnative/codemodules/codemodules.go
@@ -123,16 +123,14 @@ func withProxy(t *testing.T, proxySpec *dynatracev1beta1.DynaKubeProxy) features
 	secretConfigs := tenant.GetMultiTenantSecret(t)
 	require.Len(t, secretConfigs, 2)
 
-	dynakubeBuilder := dynakube.NewBuilder().
+	cloudNativeDynakube := dynakube.NewBuilder().
 		WithDefaultObjectMeta().
 		Name("cloudnative-codemodules-with-proxy").
 		WithDynakubeNamespaceSelector().
 		ApiUrl(secretConfigs[0].ApiUrl).
 		CloudNative(codeModulesCloudNativeSpec()).
 		WithIstio().
-		Proxy(proxySpec)
-
-	cloudNativeDynakube := dynakubeBuilder.Build()
+		Proxy(proxySpec).Build()
 
 	namespaceBuilder := namespace.NewBuilder("codemodules-sample-with-proxy")
 	labels := cloudNativeDynakube.NamespaceSelector().MatchLabels


### PR DESCRIPTION
## Description

- adds labeling of existing namespaces
- cleans up cut-off pod

## How can this be tested?

run codemodules with proxy e2e test/

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
