### PR TITLE
Add context parameter to webhook functions 

### DIFF
--- a/cmd/troubleshoot/dynakube.go
+++ b/cmd/troubleshoot/dynakube.go
@@ -31,7 +31,7 @@ func checkDynakube(ctx context.Context, baseLog logr.Logger, apiReader client.Re
 		return corev1.Secret{}, err
 	}
 
-	err = checkApiUrlSyntax(baseLog, dynakube)
+	err = checkApiUrlSyntax(ctx, baseLog, dynakube)
 	if err != nil {
 		return corev1.Secret{}, err
 	}
@@ -113,16 +113,16 @@ func checkIfDynatraceApiSecretHasApiToken(ctx context.Context, baseLog logr.Logg
 	return tokens, nil
 }
 
-func checkApiUrlSyntax(baseLog logr.Logger, dynakube *dynatracev1beta1.DynaKube) error {
+func checkApiUrlSyntax(ctx context.Context, baseLog logr.Logger, dynakube *dynatracev1beta1.DynaKube) error {
 	log := baseLog.WithName(dynakubeCheckLoggerName)
 
 	logInfof(log, "checking if syntax of API URL is valid")
 
 	dynakubevalidation.SetLogger(log)
-	if dynakubevalidation.NoApiUrl(nil, dynakube) != "" {
+	if dynakubevalidation.NoApiUrl(ctx, nil, dynakube) != "" {
 		return errors.New("API URL is invalid")
 	}
-	if dynakubevalidation.IsInvalidApiUrl(nil, dynakube) != "" {
+	if dynakubevalidation.IsInvalidApiUrl(ctx, nil, dynakube) != "" {
 		return errors.New("API URL is invalid")
 	}
 

--- a/cmd/troubleshoot/dynakube_test.go
+++ b/cmd/troubleshoot/dynakube_test.go
@@ -80,10 +80,10 @@ func TestDynakube(t *testing.T) {
 
 func TestApiUrl(t *testing.T) {
 	t.Run("valid ApiUrl", func(t *testing.T) {
-		assert.NoErrorf(t, checkApiUrlSyntax(getNullLogger(t), testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).build()), "invalid ApiUrl")
+		assert.NoErrorf(t, checkApiUrlSyntax(context.Background(), getNullLogger(t), testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testApiUrl).build()), "invalid ApiUrl")
 	})
 	t.Run("invalid ApiUrl", func(t *testing.T) {
-		assert.Errorf(t, checkApiUrlSyntax(getNullLogger(t), testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testOtherApiUrl).build()), "valid ApiUrl")
+		assert.Errorf(t, checkApiUrlSyntax(context.Background(), getNullLogger(t), testNewDynakubeBuilder(testNamespace, testDynakube).withApiUrl(testOtherApiUrl).build()), "valid ApiUrl")
 	})
 }
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
@@ -67,7 +67,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 }
 
 func (r *Reconciler) manageStatefulSet(ctx context.Context) error {
-	desiredSts, err := r.buildDesiredStatefulSet()
+	desiredSts, err := r.buildDesiredStatefulSet(ctx)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -94,8 +94,8 @@ func (r *Reconciler) manageStatefulSet(ctx context.Context) error {
 	return nil
 }
 
-func (r *Reconciler) buildDesiredStatefulSet() (*appsv1.StatefulSet, error) {
-	kubeUID, err := kubesystem.GetUID(r.apiReader)
+func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context) (*appsv1.StatefulSet, error) {
+	kubeUID, err := kubesystem.GetUID(ctx, r.apiReader)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
@@ -125,7 +125,7 @@ func TestReconcile_GetStatefulSet(t *testing.T) {
 	err := r.Reconcile(context.Background())
 	assert.NoError(t, err)
 
-	desiredSts, err := r.buildDesiredStatefulSet()
+	desiredSts, err := r.buildDesiredStatefulSet(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, desiredSts)
 
@@ -142,7 +142,7 @@ func TestReconcile_GetStatefulSet(t *testing.T) {
 
 func TestReconcile_CreateStatefulSetIfNotExists(t *testing.T) {
 	r := createDefaultReconciler(t)
-	desiredSts, err := r.buildDesiredStatefulSet()
+	desiredSts, err := r.buildDesiredStatefulSet(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, desiredSts)
 
@@ -157,7 +157,7 @@ func TestReconcile_CreateStatefulSetIfNotExists(t *testing.T) {
 
 func TestReconcile_UpdateStatefulSetIfOutdated(t *testing.T) {
 	r := createDefaultReconciler(t)
-	desiredSts, err := r.buildDesiredStatefulSet()
+	desiredSts, err := r.buildDesiredStatefulSet(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, desiredSts)
 
@@ -175,7 +175,7 @@ func TestReconcile_UpdateStatefulSetIfOutdated(t *testing.T) {
 	assert.False(t, updated)
 
 	r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: testValue}
-	desiredSts, err = r.buildDesiredStatefulSet()
+	desiredSts, err = r.buildDesiredStatefulSet(context.Background())
 	require.NoError(t, err)
 
 	updated, err = r.updateStatefulSetIfOutdated(context.Background(), desiredSts)
@@ -186,7 +186,7 @@ func TestReconcile_UpdateStatefulSetIfOutdated(t *testing.T) {
 func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 	t.Run("statefulset is deleted when old labels are used", func(t *testing.T) {
 		r := createDefaultReconciler(t)
-		desiredSts, err := r.buildDesiredStatefulSet()
+		desiredSts, err := r.buildDesiredStatefulSet(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, desiredSts)
 
@@ -204,7 +204,7 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 		assert.False(t, deleted)
 
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: testValue}
-		desiredSts, err = r.buildDesiredStatefulSet()
+		desiredSts, err = r.buildDesiredStatefulSet(context.Background())
 		require.NoError(t, err)
 
 		correctLabels := desiredSts.Spec.Selector.MatchLabels
@@ -219,7 +219,7 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 	})
 	t.Run("statefulset is not deleted when custom labels are used", func(t *testing.T) {
 		r := createDefaultReconciler(t)
-		appliedStatefulset, err := r.buildDesiredStatefulSet()
+		appliedStatefulset, err := r.buildDesiredStatefulSet(context.Background())
 
 		require.NoError(t, err)
 		require.NotNil(t, appliedStatefulset)
@@ -234,7 +234,7 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 
 		require.NoError(t, err)
 
-		desiredStatefulset, err := r.buildDesiredStatefulSet()
+		desiredStatefulset, err := r.buildDesiredStatefulSet(context.Background())
 
 		require.NoError(t, err)
 
@@ -305,7 +305,7 @@ func TestReconcile_GetActiveGateAuthTokenHash(t *testing.T) {
 func TestManageStatefulSet(t *testing.T) {
 	t.Run("do not delete statefulset if custom labels were added", func(t *testing.T) {
 		r := createDefaultReconciler(t)
-		desiredStatefulSet, err := r.buildDesiredStatefulSet()
+		desiredStatefulSet, err := r.buildDesiredStatefulSet(context.Background())
 
 		require.NoError(t, err)
 
@@ -331,7 +331,7 @@ func TestManageStatefulSet(t *testing.T) {
 	})
 	t.Run("delete statefulset if selector differs", func(t *testing.T) {
 		r := createDefaultReconciler(t)
-		desiredStatefulSet, err := r.buildDesiredStatefulSet()
+		desiredStatefulSet, err := r.buildDesiredStatefulSet(context.Background())
 
 		require.NoError(t, err)
 

--- a/pkg/controllers/dynakube/dynakube_controller.go
+++ b/pkg/controllers/dynakube/dynakube_controller.go
@@ -49,7 +49,7 @@ const (
 )
 
 func Add(mgr manager.Manager, _ string) error {
-	kubeSysUID, err := kubesystem.GetUID(mgr.GetAPIReader())
+	kubeSysUID, err := kubesystem.GetUID(context.Background(), mgr.GetAPIReader())
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -261,7 +261,7 @@ func (controller *Controller) reconcileDynaKube(ctx context.Context, dynakube *d
 	}
 
 	controller.setConditionTokenReady(dynakube)
-	err = status.SetDynakubeStatus(dynakube, controller.apiReader)
+	err = status.SetDynakubeStatus(ctx, dynakube, controller.apiReader)
 	if err != nil {
 		log.Info("could not update Dynakube status")
 		return err

--- a/pkg/controllers/dynakube/status/status.go
+++ b/pkg/controllers/dynakube/status/status.go
@@ -1,13 +1,15 @@
 package status
 
 import (
+	"context"
+
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func SetDynakubeStatus(dynakube *dynatracev1beta1.DynaKube, apiReader client.Reader) error {
-	uid, err := kubesystem.GetUID(apiReader)
+func SetDynakubeStatus(ctx context.Context, dynakube *dynatracev1beta1.DynaKube, apiReader client.Reader) error {
+	uid, err := kubesystem.GetUID(ctx, apiReader)
 	if err != nil {
 		log.Info("could not get cluster ID")
 		return err

--- a/pkg/controllers/dynakube/status/status_test.go
+++ b/pkg/controllers/dynakube/status/status_test.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
@@ -24,7 +25,7 @@ func TestSetDynakubeStatus(t *testing.T) {
 				UID:  testUUID,
 			},
 		})
-		err := SetDynakubeStatus(instance, clt)
+		err := SetDynakubeStatus(context.Background(), instance, clt)
 
 		assert.NoError(t, err)
 		assert.Equal(t, testUUID, instance.Status.KubeSystemUUID)
@@ -33,7 +34,7 @@ func TestSetDynakubeStatus(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{}
 		clt := fake.NewClient()
 
-		err := SetDynakubeStatus(instance, clt)
+		err := SetDynakubeStatus(context.Background(), instance, clt)
 		assert.EqualError(t, err, "namespaces \"kube-system\" not found")
 	})
 }

--- a/pkg/injection/namespace/initgeneration/initgeneration.go
+++ b/pkg/injection/namespace/initgeneration/initgeneration.go
@@ -107,7 +107,7 @@ func (g *InitGenerator) GenerateForDynakube(ctx context.Context, dk *dynatracev1
 
 // generate gets the necessary info the create the init secret data
 func (g *InitGenerator) generate(ctx context.Context, dk *dynatracev1beta1.DynaKube) (map[string][]byte, error) {
-	kubeSystemUID, err := kubesystem.GetUID(g.apiReader)
+	kubeSystemUID, err := kubesystem.GetUID(ctx, g.apiReader)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/util/kubesystem/kubesystem.go
+++ b/pkg/util/kubesystem/kubesystem.go
@@ -14,9 +14,9 @@ const (
 	olmSpecificAnnotation = "olm.operatorNamespace"
 )
 
-func GetUID(clt client.Reader) (types.UID, error) {
+func GetUID(ctx context.Context, clt client.Reader) (types.UID, error) {
 	kubeSystemNamespace := &corev1.Namespace{}
-	err := clt.Get(context.TODO(), client.ObjectKey{Name: Namespace}, kubeSystemNamespace)
+	err := clt.Get(ctx, client.ObjectKey{Name: Namespace}, kubeSystemNamespace)
 	if err != nil {
 		return "", errors.WithStack(err)
 	}

--- a/pkg/util/kubesystem/kubesystem_test.go
+++ b/pkg/util/kubesystem/kubesystem_test.go
@@ -1,6 +1,7 @@
 package kubesystem
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ func TestGetUID(t *testing.T) {
 				},
 			},
 		).Build()
-	uid, err := GetUID(fakeClient)
+	uid, err := GetUID(context.Background(), fakeClient)
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, uid)

--- a/pkg/webhook/mutation/namespace_mutator/mutator_test.go
+++ b/pkg/webhook/mutation/namespace_mutator/mutator_test.go
@@ -68,7 +68,7 @@ func TestInjection(t *testing.T) {
 				Operation: admissionv1.Create,
 			},
 		}
-		resp := inj.Handle(context.TODO(), req)
+		resp := inj.Handle(context.Background(), req)
 		assert.NoError(t, resp.Complete(req))
 		assert.True(t, resp.Allowed)
 
@@ -93,7 +93,7 @@ func TestInjection(t *testing.T) {
 				Operation: admissionv1.Create,
 			},
 		}
-		resp := inj.Handle(context.TODO(), req)
+		resp := inj.Handle(context.Background(), req)
 		assert.NoError(t, resp.Complete(req))
 		assert.True(t, resp.Allowed)
 
@@ -113,7 +113,7 @@ func TestInjection(t *testing.T) {
 				Operation: admissionv1.Create,
 			},
 		}
-		resp := inj.Handle(context.TODO(), req)
+		resp := inj.Handle(context.Background(), req)
 		assert.NoError(t, resp.Complete(req))
 		assert.True(t, resp.Allowed)
 
@@ -151,7 +151,7 @@ func TestInjection(t *testing.T) {
 				Operation: admissionv1.Update,
 			},
 		}
-		resp := inj.Handle(context.TODO(), req)
+		resp := inj.Handle(context.Background(), req)
 		assert.NoError(t, resp.Complete(req))
 		assert.True(t, resp.Allowed)
 
@@ -191,7 +191,7 @@ func TestInjection(t *testing.T) {
 				Operation: admissionv1.Update,
 			},
 		}
-		resp := inj.Handle(context.TODO(), req)
+		resp := inj.Handle(context.Background(), req)
 		assert.NoError(t, resp.Complete(req))
 		assert.True(t, resp.Allowed)
 

--- a/pkg/webhook/mutation/pod_mutator/dataingest_mutation/mutator_test.go
+++ b/pkg/webhook/mutation/pod_mutator/dataingest_mutation/mutator_test.go
@@ -185,7 +185,7 @@ func createTestMutationRequest(dynakube *dynatracev1beta1.DynaKube, annotations 
 		dynakube = &dynatracev1beta1.DynaKube{}
 	}
 	return dtwebhook.NewMutationRequest(
-		context.TODO(),
+		context.Background(),
 		*getTestNamespace(),
 		&corev1.Container{
 			Name: dtwebhook.InstallContainerName,

--- a/pkg/webhook/mutation/pod_mutator/dataingest_mutation/workload_test.go
+++ b/pkg/webhook/mutation/pod_mutator/dataingest_mutation/workload_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestFindRootOwnerOfPod(t *testing.T) {
-	ctx := context.TODO()
+	ctx := context.Background()
 	resourceName := "test"
 	namespaceName := "test"
 	t.Run("should find the root owner of the pod", func(t *testing.T) {

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
@@ -290,7 +290,7 @@ func createTestMutationRequest(dynakube *dynatracev1beta1.DynaKube, podAnnotatio
 		dynakube = &dynatracev1beta1.DynaKube{}
 	}
 	return dtwebhook.NewMutationRequest(
-		context.TODO(),
+		context.Background(),
 		namespace,
 		&corev1.Container{
 			Name: dtwebhook.InstallContainerName,

--- a/pkg/webhook/mutation/pod_mutator/pod_mutator_test.go
+++ b/pkg/webhook/mutation/pod_mutator/pod_mutator_test.go
@@ -117,7 +117,7 @@ func TestMutator(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := context.Background()
 			request := createTestAdmissionRequest(test.testPod)
 			// merge test objects with the test pod
 			objects := test.objects

--- a/pkg/webhook/mutation/pod_mutator/register.go
+++ b/pkg/webhook/mutation/pod_mutator/register.go
@@ -28,7 +28,7 @@ func registerInjectEndpoint(mgr manager.Manager, webhookNamespace string, webhoo
 	kubeClient := mgr.GetClient()
 	apiReader := mgr.GetAPIReader()
 
-	webhookPod, err := kubeobjects.GetPod(context.TODO(), apiReader, webhookPodName, webhookNamespace)
+	webhookPod, err := kubeobjects.GetPod(context.Background(), apiReader, webhookPodName, webhookNamespace)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func registerInjectEndpoint(mgr manager.Manager, webhookNamespace string, webhoo
 		return err
 	}
 
-	clusterID, err := getClusterID(apiReader)
+	clusterID, err := getClusterID(context.Background(), apiReader)
 	if err != nil {
 		return err
 	}
@@ -102,10 +102,10 @@ func getWebhookContainerImage(webhookPod corev1.Pod) (string, error) {
 	return webhookContainer.Image, nil
 }
 
-func getClusterID(apiReader client.Reader) (string, error) {
+func getClusterID(ctx context.Context, apiReader client.Reader) (string, error) {
 	var clusterUID types.UID
 	var err error
-	if clusterUID, err = kubesystem.GetUID(apiReader); err != nil {
+	if clusterUID, err = kubesystem.GetUID(ctx, apiReader); err != nil {
 		return "", errors.WithStack(err)
 	}
 	log.Info("got cluster UID", "clusterUID", clusterUID)

--- a/pkg/webhook/mutation/pod_mutator/request_test.go
+++ b/pkg/webhook/mutation/pod_mutator/request_test.go
@@ -37,7 +37,7 @@ func TestCreateMutationRequestBase(t *testing.T) {
 				getTestPod(),
 				dynakube,
 			})
-		mutationRequest, err := podWebhook.createMutationRequestBase(context.TODO(), *createTestAdmissionRequest(getTestPod()))
+		mutationRequest, err := podWebhook.createMutationRequestBase(context.Background(), *createTestAdmissionRequest(getTestPod()))
 		require.NoError(t, err)
 		require.NotNil(t, mutationRequest)
 
@@ -73,7 +73,7 @@ func TestGetNamespaceFromRequest(t *testing.T) {
 			[]client.Object{expected},
 		)
 
-		namespace, err := getNamespaceFromRequest(context.TODO(), podWebhook.apiReader, *createTestAdmissionRequest(getTestPod()))
+		namespace, err := getNamespaceFromRequest(context.Background(), podWebhook.apiReader, *createTestAdmissionRequest(getTestPod()))
 		require.NoError(t, err)
 		assert.Equal(t, expected.ObjectMeta, namespace.ObjectMeta)
 	})
@@ -96,7 +96,7 @@ func TestGetDynakube(t *testing.T) {
 			[]client.Object{expected},
 		)
 
-		dynakube, err := podWebhook.getDynakube(context.TODO(), testDynakubeName)
+		dynakube, err := podWebhook.getDynakube(context.Background(), testDynakubeName)
 		require.NoError(t, err)
 		assert.Equal(t, expected.ObjectMeta, dynakube.ObjectMeta)
 		assert.Equal(t, expected.Spec.OneAgent.CloudNativeFullStack, dynakube.Spec.OneAgent.CloudNativeFullStack)
@@ -104,7 +104,7 @@ func TestGetDynakube(t *testing.T) {
 }
 
 func createTestMutationRequest(dynakube *dynatracev1beta1.DynaKube) *dtwebhook.MutationRequest {
-	return dtwebhook.NewMutationRequest(context.TODO(), *getTestNamespace(), nil, getTestPod(), *dynakube)
+	return dtwebhook.NewMutationRequest(context.Background(), *getTestNamespace(), nil, getTestPod(), *dynakube)
 }
 
 func createTestAdmissionRequest(pod *corev1.Pod) *admission.Request {

--- a/pkg/webhook/validation/dynakube/activegate.go
+++ b/pkg/webhook/validation/dynakube/activegate.go
@@ -1,6 +1,7 @@
 package dynakube
 
 import (
+	"context"
 	"fmt"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
@@ -25,7 +26,7 @@ The synthetic capability can't be configured alongside other capabilities in the
 `
 )
 
-func conflictingActiveGateConfiguration(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func conflictingActiveGateConfiguration(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.DeprecatedActiveGateMode() && dynakube.ActiveGateMode() {
 		log.Info("requested dynakube has conflicting active gate configuration", "name", dynakube.Name, "namespace", dynakube.Namespace)
 		return errorConflictingActiveGateSections
@@ -33,7 +34,7 @@ func conflictingActiveGateConfiguration(dv *dynakubeValidator, dynakube *dynatra
 	return ""
 }
 
-func duplicateActiveGateCapabilities(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func duplicateActiveGateCapabilities(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.ActiveGateMode() {
 		capabilities := dynakube.Spec.ActiveGate.Capabilities
 		duplicateChecker := map[dynatracev1beta1.CapabilityDisplayName]bool{}
@@ -48,7 +49,7 @@ func duplicateActiveGateCapabilities(dv *dynakubeValidator, dynakube *dynatracev
 	return ""
 }
 
-func invalidActiveGateCapabilities(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func invalidActiveGateCapabilities(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.ActiveGateMode() {
 		capabilities := dynakube.Spec.ActiveGate.Capabilities
 		for _, capability := range capabilities {
@@ -61,7 +62,7 @@ func invalidActiveGateCapabilities(dv *dynakubeValidator, dynakube *dynatracev1b
 	return ""
 }
 
-func missingActiveGateMemoryLimit(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func missingActiveGateMemoryLimit(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.ActiveGateMode() &&
 		!dynakube.IsSyntheticMonitoringEnabled() &&
 		!memoryLimitSet(dynakube.Spec.ActiveGate.Resources) {
@@ -74,7 +75,7 @@ func memoryLimitSet(resources corev1.ResourceRequirements) bool {
 	return resources.Limits != nil && resources.Limits.Memory() != nil
 }
 
-func exclusiveSyntheticCapability(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func exclusiveSyntheticCapability(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.IsSyntheticMonitoringEnabled() && len(dynakube.Spec.ActiveGate.Capabilities) > 0 {
 		log.Info(
 			"requested dynakube has the synthetic active gate capability accompanied with others",

--- a/pkg/webhook/validation/dynakube/api_url.go
+++ b/pkg/webhook/validation/dynakube/api_url.go
@@ -1,6 +1,7 @@
 package dynakube
 
 import (
+	"context"
 	"net/url"
 	"strings"
 
@@ -18,7 +19,7 @@ const (
 	`
 )
 
-func NoApiUrl(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func NoApiUrl(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	apiUrl := dynakube.Spec.APIURL
 
 	if apiUrl == ExampleApiUrl {
@@ -34,7 +35,7 @@ func NoApiUrl(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string
 	return ""
 }
 
-func IsInvalidApiUrl(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func IsInvalidApiUrl(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	apiUrl := dynakube.Spec.APIURL
 
 	if !strings.HasSuffix(apiUrl, "/api") {

--- a/pkg/webhook/validation/dynakube/api_url_test.go
+++ b/pkg/webhook/validation/dynakube/api_url_test.go
@@ -1,6 +1,7 @@
 package dynakube
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -10,10 +11,10 @@ import (
 
 func TestHasApiUrl(t *testing.T) {
 	instance := &dynatracev1beta1.DynaKube{}
-	assert.Equal(t, errorNoApiUrl, NoApiUrl(nil, instance))
+	assert.Equal(t, errorNoApiUrl, NoApiUrl(context.Background(), nil, instance))
 
 	instance.Spec.APIURL = testApiUrl
-	assert.Empty(t, NoApiUrl(nil, instance))
+	assert.Empty(t, NoApiUrl(context.Background(), nil, instance))
 
 	t.Run(`happy path`, func(t *testing.T) {
 		assertAllowedResponse(t, &dynatracev1beta1.DynaKube{

--- a/pkg/webhook/validation/dynakube/config.go
+++ b/pkg/webhook/validation/dynakube/config.go
@@ -1,6 +1,8 @@
 package dynakube
 
 import (
+	"context"
+
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/logger"
 	"github.com/go-logr/logr"
@@ -10,7 +12,7 @@ const oneagentEnableVolumeStorageEnvVarName = "ONEAGENT_ENABLE_VOLUME_STORAGE"
 
 var log = logger.Factory.GetLogger("validation")
 
-type validator func(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string
+type validator func(ctx context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string
 
 var validators = []validator{
 	NoApiUrl,

--- a/pkg/webhook/validation/dynakube/csi_daemonset.go
+++ b/pkg/webhook/validation/dynakube/csi_daemonset.go
@@ -17,12 +17,12 @@ const (
 `
 )
 
-func missingCSIDaemonSet(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func missingCSIDaemonSet(ctx context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if !dynakube.NeedsCSIDriver() {
 		return ""
 	}
 	csiDaemonSet := appsv1.DaemonSet{}
-	err := dv.clt.Get(context.TODO(), types.NamespacedName{Name: dtcsi.DaemonSetName, Namespace: dynakube.Namespace}, &csiDaemonSet)
+	err := dv.clt.Get(ctx, types.NamespacedName{Name: dtcsi.DaemonSetName, Namespace: dynakube.Namespace}, &csiDaemonSet)
 	if k8serrors.IsNotFound(err) {
 		log.Info("requested dynakube uses csi driver, but csi driver is missing in the cluster", "name", dynakube.Name, "namespace", dynakube.Namespace)
 		return errorCSIRequired
@@ -32,7 +32,7 @@ func missingCSIDaemonSet(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaK
 	return ""
 }
 
-func disabledCSIForReadonlyCSIVolume(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func disabledCSIForReadonlyCSIVolume(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if !dynakube.NeedsCSIDriver() && dynakube.FeatureReadOnlyCsiVolume() {
 		log.Info("requested dynakube uses readonly csi volume, but csi driver is not enabled", "name", dynakube.Name, "namespace", dynakube.Namespace)
 		return errorCSIEnabledRequired

--- a/pkg/webhook/validation/dynakube/deprecation.go
+++ b/pkg/webhook/validation/dynakube/deprecation.go
@@ -1,6 +1,7 @@
 package dynakube
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -28,7 +29,7 @@ func getDeprecatedFeatureFlags() []string {
 	}
 }
 
-func deprecatedFeatureFlagFormat(_ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func deprecatedFeatureFlagFormat(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.Annotations == nil {
 		return ""
 	}
@@ -41,31 +42,31 @@ func deprecatedFeatureFlagFormat(_ *dynakubeValidator, dynakube *dynatracev1beta
 	return ""
 }
 
-func deprecatedFeatureFlagDisableActiveGateUpdates(_ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func deprecatedFeatureFlagDisableActiveGateUpdates(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	return warnIfDeprecatedIsUsed(dynakube, dynatracev1beta1.AnnotationFeatureActiveGateUpdates, dynatracev1beta1.AnnotationFeatureDisableActiveGateUpdates)
 }
 
-func deprecatedFeatureFlagDisableActiveGateRawImage(_ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func deprecatedFeatureFlagDisableActiveGateRawImage(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	return warnIfDeprecatedIsUsed(dynakube, dynatracev1beta1.AnnotationFeatureActiveGateRawImage, dynatracev1beta1.AnnotationFeatureDisableActiveGateRawImage)
 }
 
-func deprecatedFeatureFlagDisableHostsRequests(_ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func deprecatedFeatureFlagDisableHostsRequests(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	return warnIfDeprecatedIsUsed(dynakube, dynatracev1beta1.AnnotationFeatureHostsRequests, dynatracev1beta1.AnnotationFeatureDisableHostsRequests)
 }
 
-func deprecatedFeatureFlagDisableReadOnlyAgent(_ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func deprecatedFeatureFlagDisableReadOnlyAgent(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	return warnIfDeprecatedIsUsed(dynakube, dynatracev1beta1.AnnotationFeatureReadOnlyOneAgent, dynatracev1beta1.AnnotationFeatureDisableReadOnlyOneAgent)
 }
 
-func deprecatedFeatureFlagDisableWebhookReinvocationPolicy(_ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func deprecatedFeatureFlagDisableWebhookReinvocationPolicy(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	return warnIfDeprecatedIsUsed(dynakube, dynatracev1beta1.AnnotationFeatureWebhookReinvocationPolicy, dynatracev1beta1.AnnotationFeatureDisableWebhookReinvocationPolicy)
 }
 
-func deprecatedFeatureFlagDisableMetadataEnrichment(_ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func deprecatedFeatureFlagDisableMetadataEnrichment(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	return warnIfDeprecatedIsUsed(dynakube, dynatracev1beta1.AnnotationFeatureMetadataEnrichment, dynatracev1beta1.AnnotationFeatureDisableMetadataEnrichment)
 }
 
-func deprecatedFeatureFlag(_ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func deprecatedFeatureFlag(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	var featureFlags []string
 	for _, ff := range getDeprecatedFeatureFlags() {
 		if isDeprecatedFeatureFlagUsed(dynakube, ff) {

--- a/pkg/webhook/validation/dynakube/deprecation_test.go
+++ b/pkg/webhook/validation/dynakube/deprecation_test.go
@@ -1,6 +1,7 @@
 package dynakube
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -56,12 +57,12 @@ func testDeprecatedAnnotation(t *testing.T,
 
 	assert.Equal(t,
 		deprecatedAnnotationWarning(newAnnotation, oldAnnotation),
-		validatorFunc(nil, &dynakube))
+		validatorFunc(context.Background(), nil, &dynakube))
 
 	dynakube.Annotations = map[string]string{}
 
 	assert.Empty(t,
-		validatorFunc(nil, &dynakube))
+		validatorFunc(context.Background(), nil, &dynakube))
 }
 
 func TestDeprecatedAnnotationWarnings(t *testing.T) {

--- a/pkg/webhook/validation/dynakube/dynakube_name.go
+++ b/pkg/webhook/validation/dynakube/dynakube_name.go
@@ -1,6 +1,8 @@
 package dynakube
 
 import (
+	"context"
+
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -11,7 +13,7 @@ const (
 	`
 )
 
-func nameViolatesDNS1035(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func nameViolatesDNS1035(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	dynakubeName := dynakube.Name
 	var errs []string
 	if dynakubeName != "" {

--- a/pkg/webhook/validation/dynakube/istio.go
+++ b/pkg/webhook/validation/dynakube/istio.go
@@ -1,6 +1,8 @@
 package dynakube
 
 import (
+	"context"
+
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
@@ -11,7 +13,7 @@ const (
 	errorFailToInitIstioClient = `Failed to initialize istio client`
 )
 
-func noResourcesAvailable(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func noResourcesAvailable(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.Spec.EnableIstio {
 		istioClient, err := istio.NewClient(dv.cfg, scheme.Scheme, dynakube.Namespace)
 		if err != nil {

--- a/pkg/webhook/validation/dynakube/namespace_selector.go
+++ b/pkg/webhook/validation/dynakube/namespace_selector.go
@@ -16,11 +16,11 @@ Make sure you have a namespaceSelector doesn't conflict with other Dynakubes nam
 `
 )
 
-func conflictingNamespaceSelector(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func conflictingNamespaceSelector(ctx context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if !dynakube.NeedAppInjection() {
 		return ""
 	}
-	dkMapper := mapper.NewDynakubeMapper(context.TODO(), dv.clt, dv.apiReader, dynakube.Namespace, dynakube)
+	dkMapper := mapper.NewDynakubeMapper(ctx, dv.clt, dv.apiReader, dynakube.Namespace, dynakube)
 	_, err := dkMapper.MatchingNamespaces()
 	if err != nil && err.Error() == mapper.ErrorConflictingNamespace {
 		if dynakube.NamespaceSelector().MatchExpressions == nil && dynakube.NamespaceSelector().MatchLabels == nil {

--- a/pkg/webhook/validation/dynakube/oneagent.go
+++ b/pkg/webhook/validation/dynakube/oneagent.go
@@ -22,7 +22,7 @@ The conflicting Dynakube: %s
 	warningIneffectiveFeatureFlag = `Feature flag %s has no effect in classic full stack mode.`
 )
 
-func conflictingOneAgentConfiguration(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func conflictingOneAgentConfiguration(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	counter := 0
 	if dynakube.ApplicationMonitoringMode() {
 		counter += 1
@@ -43,19 +43,19 @@ func conflictingOneAgentConfiguration(dv *dynakubeValidator, dynakube *dynatrace
 	return ""
 }
 
-func conflictingReadOnlyFilesystemAndMultipleOsAgentsOnNode(_ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func conflictingReadOnlyFilesystemAndMultipleOsAgentsOnNode(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.FeatureDisableReadOnlyOneAgent() && dynakube.FeatureEnableMultipleOsAgentsOnNode() {
 		return "Multiple OsAgents require readonly host filesystem"
 	}
 	return ""
 }
 
-func conflictingNodeSelector(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func conflictingNodeSelector(ctx context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if !dynakube.NeedsOneAgent() || dynakube.FeatureEnableMultipleOsAgentsOnNode() {
 		return ""
 	}
 	validDynakubes := &dynatracev1beta1.DynaKubeList{}
-	if err := dv.clt.List(context.TODO(), validDynakubes); err != nil {
+	if err := dv.clt.List(ctx, validDynakubes); err != nil {
 		log.Info("error occurred while listing dynakubes", "err", err.Error())
 		return ""
 	}
@@ -75,7 +75,7 @@ func conflictingNodeSelector(dv *dynakubeValidator, dynakube *dynatracev1beta1.D
 	return ""
 }
 
-func imageFieldSetWithoutCSIFlag(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func imageFieldSetWithoutCSIFlag(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.ApplicationMonitoringMode() {
 		if !dynakube.NeedsCSIDriver() && len(dynakube.Spec.OneAgent.ApplicationMonitoring.CodeModulesImage) > 0 {
 			return errorImageFieldSetWithoutCSIFlag
@@ -102,7 +102,7 @@ func hasOneAgentVolumeStorageEnabled(dynakube *dynatracev1beta1.DynaKube) (isEna
 	return
 }
 
-func conflictingOneAgentVolumeStorageSettings(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func conflictingOneAgentVolumeStorageSettings(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	volumeStorageEnabled, volumeStorageSet := hasOneAgentVolumeStorageEnabled(dynakube)
 	if dynakube.NeedsReadOnlyOneAgents() && volumeStorageSet && !volumeStorageEnabled {
 		return errorVolumeStorageReadOnlyModeConflict
@@ -110,7 +110,7 @@ func conflictingOneAgentVolumeStorageSettings(dv *dynakubeValidator, dynakube *d
 	return ""
 }
 
-func ineffectiveReadOnlyHostFsFeatureFlag(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func ineffectiveReadOnlyHostFsFeatureFlag(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.ClassicFullStackMode() {
 		if _, hasOneAgentReadOnlyFeatureFlag := dynakube.Annotations[dynatracev1beta1.AnnotationFeatureReadOnlyOneAgent]; hasOneAgentReadOnlyFeatureFlag {
 			return readonlyHostFsFlagWarning(dynatracev1beta1.AnnotationFeatureReadOnlyOneAgent)

--- a/pkg/webhook/validation/dynakube/preview.go
+++ b/pkg/webhook/validation/dynakube/preview.go
@@ -1,6 +1,7 @@
 package dynakube
 
 import (
+	"context"
 	"fmt"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
@@ -12,7 +13,7 @@ const (
 	basePreviewWarning           = "PREVIEW features are NOT production ready and you may run into bugs."
 )
 
-func syntheticPreviewWarning(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func syntheticPreviewWarning(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.IsSyntheticMonitoringEnabled() {
 		log.Info(fmt.Sprintf("DynaKube with %s was applied, warning was provided.", capability.SyntheticName))
 		return fmt.Sprintf(featurePreviewWarningMessage, capability.SyntheticName)

--- a/pkg/webhook/validation/dynakube/proxy_url.go
+++ b/pkg/webhook/validation/dynakube/proxy_url.go
@@ -16,9 +16,9 @@ const (
 	errorMissingProxySecret = `Error occurred while reading PROXY secret indicated in the Dynakube specification`
 )
 
-func invalidActiveGateProxyUrl(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func invalidActiveGateProxyUrl(ctx context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.Spec.Proxy != nil {
-		proxyUrl, err := dynakube.Proxy(context.TODO(), dv.apiReader)
+		proxyUrl, err := dynakube.Proxy(ctx, dv.apiReader)
 		if err != nil {
 			return errors.Wrap(err, errorMissingProxySecret).Error()
 		}

--- a/pkg/webhook/validation/dynakube/synthetic.go
+++ b/pkg/webhook/validation/dynakube/synthetic.go
@@ -1,6 +1,7 @@
 package dynakube
 
 import (
+	"context"
 	"fmt"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
@@ -12,7 +13,7 @@ Make sure such a node is valid.
 `
 )
 
-func invalidSyntheticNodeType(dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+func invalidSyntheticNodeType(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	isTypeValid := func() bool {
 		switch dynakube.FeatureSyntheticNodeType() {
 		case dynatracev1beta1.SyntheticNodeXs,

--- a/pkg/webhook/validation/dynakube/validation_test.go
+++ b/pkg/webhook/validation/dynakube/validation_test.go
@@ -217,7 +217,7 @@ func handleRequest(t *testing.T, dynakube *dynatracev1beta1.DynaKube, other ...c
 	data, err := json.Marshal(*dynakube)
 	require.NoError(t, err)
 
-	return validator.Handle(context.TODO(), admission.Request{
+	return validator.Handle(context.Background(), admission.Request{
 		AdmissionRequest: v1.AdmissionRequest{
 			Name:      testName,
 			Namespace: testNamespace,

--- a/pkg/webhook/validation/edgeconnect/api_server.go
+++ b/pkg/webhook/validation/edgeconnect/api_server.go
@@ -1,6 +1,7 @@
 package edgeconnect
 
 import (
+	"context"
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
@@ -20,7 +21,7 @@ var (
 	}
 )
 
-func IsInvalidApiServer(_ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
+func IsInvalidApiServer(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
 	for _, suffix := range allowedSuffix {
 		if strings.HasSuffix(edgeConnect.Spec.ApiServer, suffix) {
 			hostnameWithDomains := strings.FieldsFunc(suffix,

--- a/pkg/webhook/validation/edgeconnect/api_server_test.go
+++ b/pkg/webhook/validation/edgeconnect/api_server_test.go
@@ -93,7 +93,7 @@ func handleRequest(t *testing.T, edgeConnect *edgeconnect.EdgeConnect, other ...
 	data, err := json.Marshal(*edgeConnect)
 	require.NoError(t, err)
 
-	return validator.Handle(context.TODO(), admission.Request{
+	return validator.Handle(context.Background(), admission.Request{
 		AdmissionRequest: v1.AdmissionRequest{
 			Name:      testName,
 			Namespace: testNamespace,

--- a/pkg/webhook/validation/edgeconnect/config.go
+++ b/pkg/webhook/validation/edgeconnect/config.go
@@ -1,13 +1,15 @@
 package edgeconnect
 
 import (
+	"context"
+
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/logger"
 )
 
 var log = logger.Factory.GetLogger("edgeconnect-validation")
 
-type validator func(dv *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string
+type validator func(ctx context.Context, dv *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string
 
 var validators = []validator{
 	IsInvalidApiServer,

--- a/pkg/webhook/validation/edgeconnect/validation.go
+++ b/pkg/webhook/validation/edgeconnect/validation.go
@@ -36,7 +36,7 @@ func AddEdgeConnectValidationWebhookToManager(manager ctrl.Manager) error {
 	return nil
 }
 
-func (validator *edgeconnectValidator) Handle(_ context.Context, request admission.Request) admission.Response {
+func (validator *edgeconnectValidator) Handle(ctx context.Context, request admission.Request) admission.Response {
 	log.Info("validating edgeconnect request", "name", request.Name, "namespace", request.Namespace)
 
 	edgeConnect := &edgeconnect.EdgeConnect{}
@@ -44,7 +44,7 @@ func (validator *edgeconnectValidator) Handle(_ context.Context, request admissi
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, errors.WithStack(err))
 	}
-	validationErrors := validator.runValidators(validators, edgeConnect)
+	validationErrors := validator.runValidators(ctx, validators, edgeConnect)
 	response := admission.Allowed("")
 	if len(validationErrors) > 0 {
 		response = admission.Denied(validation.SumErrors(validationErrors, "EdgeConnect"))
@@ -52,10 +52,10 @@ func (validator *edgeconnectValidator) Handle(_ context.Context, request admissi
 	return response
 }
 
-func (validator *edgeconnectValidator) runValidators(validators []validator, edgeConnect *edgeconnect.EdgeConnect) []string {
+func (validator *edgeconnectValidator) runValidators(ctx context.Context, validators []validator, edgeConnect *edgeconnect.EdgeConnect) []string {
 	results := []string{}
 	for _, validate := range validators {
-		if errMsg := validate(validator, edgeConnect); errMsg != "" {
+		if errMsg := validate(ctx, validator, edgeConnect); errMsg != "" {
 			results = append(results, errMsg)
 		}
 	}


### PR DESCRIPTION
## Description

Context is passed through webhook call-stack:
- CR validators have context parameter because some of them make requests to the K8S API
- `kubesystem.GetUID(..)` has context parameter because is called by validators and reconcilers and always should use correct context 
- `registerInjectEndpoint()`  uses `context.Background()` because no context is available
- in case of unit tests `context.Background()` is used


## How can this be tested?
- all unit tests PASS
- CN deployment + sample app is injected

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
