### PR TITLE
Generate different notes for a pre-release and release version

### DIFF
--- a/hack/build/ci/generate-release-notes.sh
+++ b/hack/build/ci/generate-release-notes.sh
@@ -10,35 +10,56 @@ pre_release_warning="> ⚠️ This is a pre-release, which has no official suppo
 > Release notes for ${tag_without_prerelease} will be published in our official documentation.
 "
 
-default_notes="### Installation
-
-For information on how to install the [latest dynatrace-operator](https://github.com/Dynatrace/dynatrace-operator/releases/latest) please visit our [official Documentation](https://www.dynatrace.com/support/help/shortlink/full-stack-dto-k8).
-
-<details>
-  <summary>Upgrade/Install instructions</summary>
-
-#### Kubernetes
-\`\`\`sh
-kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/download/${tag}/kubernetes.yaml
-\`\`\`
-
-#### Openshift
-\`\`\`sh
-oc apply -f https://github.com/Dynatrace/dynatrace-operator/releases/download/${tag}/openshift.yaml
-\`\`\`
-
-</details>
-
-### Features
+pre_release_footer="### Features
 
 <features-go-here>
 
 
 _Full changelog will be published with the final release, including bugfixes and further smaller improvements!_"
 
-rm -f $output_file
-if [ "$pre_release" = true ] ; then
-  echo "$pre_release_warning" >> $output_file
+release_footer="### What's Changed
+Release Notes can be found in our [official Documentation](https://docs.dynatrace.com/docs/whats-new/release-notes/dynatrace-operator)."
+
+footer=""
+
+kubernetes_manifests="kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/download/${tag}/kubernetes.yaml"
+openshift_manifests="oc apply -f https://github.com/Dynatrace/dynatrace-operator/releases/download/${tag}/openshift.yaml"
+
+if [ "${pre_release}" = false ] ; then
+  kubernetes_manifests="${kubernetes_manifests}
+kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/download/${tag}/kubernetes-csi.yaml"
+  openshift_manifests="${openshift_manifests}
+oc apply -f https://github.com/Dynatrace/dynatrace-operator/releases/download/${tag}/openshift-csi.yaml"
+
+  footer="${release_footer}"
+else
+  footer="${pre_release_footer}"
 fi
 
-echo "$default_notes" >> $output_file
+default_notes="### Installation
+
+For information on how to install the [latest dynatrace-operator](https://github.com/Dynatrace/dynatrace-operator/releases/latest) please visit our [official Documentation](https://docs.dynatrace.com/docs/setup-and-configuration/setup-on-k8s/installation).
+
+<details>
+  <summary>Upgrade/Install instructions</summary>
+
+#### Kubernetes
+\`\`\`sh
+${kubernetes_manifests}
+\`\`\`
+
+#### Openshift
+\`\`\`sh
+${openshift_manifests}
+\`\`\`
+
+</details>
+
+${footer}"
+
+rm -f "${output_file}"
+if [ "$pre_release" = true ] ; then
+  echo "$pre_release_warning" >> "${output_file}"
+fi
+
+echo "$default_notes" >> "${output_file}"


### PR DESCRIPTION
## Description

Currently the `generate_release_notes.sh` has incorrect release notes for the actual real release. The release notes are missing the *-csi.yaml manifests in the instructions how to install/update. These manifests are not release during a pre-release.

Fixed script:
- generates specific release-notes for `pre-release` and `release` versions
- the documentation links are updated and point to the new documentation
- `release` notes have `What's Changed` section and `pre-release` notes have `Features` section

## How can this be tested?
- generate CHANGELOG.md file in `pre-release` mode:
```
 (export GITHUB_REF_NAME="1.2.3" ; export PRE_RELEASE=true ; ./generate-release-notes.sh)
```
- generate CHANGELOG.md file in `release` mode:
```
 (export GITHUB_REF_NAME="1.2.3" ;  ./generate-release-notes.sh)
```

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
