### PR TITLE
Enable new linter: perfsprint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -183,9 +183,10 @@ linters:
   - whitespace
   - unused
   - ineffassign
+  - perfsprint
 
 service:
-  golangci-lint-version: 1.51.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.55.x # use the fixed version to not introduce new linters unexpectedly
 
 issues:
   exclude-rules:

--- a/pkg/api/v1beta1/dynakube/feature_flags_test.go
+++ b/pkg/api/v1beta1/dynakube/feature_flags_test.go
@@ -3,6 +3,7 @@ package dynakube
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -271,7 +272,7 @@ func TestSyntheticMonitoringFlags(t *testing.T) {
 		dynaKube := DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					AnnotationFeatureSyntheticReplicas: fmt.Sprint(replicas),
+					AnnotationFeatureSyntheticReplicas: strconv.Itoa(int(replicas)),
 				},
 			},
 		}

--- a/pkg/api/v1beta1/dynakube/properties_test.go
+++ b/pkg/api/v1beta1/dynakube/properties_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package dynakube
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -498,7 +498,7 @@ func TestDynaKube_ShallUpdateActiveGateConnectionInfo(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			dk.ObjectMeta.Annotations = map[string]string{
-				AnnotationFeatureApiRequestThreshold: fmt.Sprintf("%d", test.featureFlagValue),
+				AnnotationFeatureApiRequestThreshold: strconv.Itoa(test.featureFlagValue),
 			}
 
 			lastRequestTime := timeProvider.Now().Add(time.Duration(test.lastRequestTimeDeltaMinutes) * time.Minute)

--- a/pkg/controllers/csi/metadata/correctness_test.go
+++ b/pkg/controllers/csi/metadata/correctness_test.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
@@ -17,7 +18,7 @@ import (
 func createTestDynakube(index int) Dynakube {
 	return Dynakube{
 		TenantUUID:             fmt.Sprintf("asc%d", index),
-		LatestVersion:          fmt.Sprintf("%d", 123*index),
+		LatestVersion:          strconv.Itoa(123 * index),
 		Name:                   fmt.Sprintf("dk%d", index),
 		ImageDigest:            fmt.Sprintf("sha256:%d", 123*index),
 		MaxFailedMountAttempts: index,

--- a/pkg/controllers/csi/metadata/sqlite_test.go
+++ b/pkg/controllers/csi/metadata/sqlite_test.go
@@ -130,7 +130,7 @@ func TestCreateTables(t *testing.T) {
 			if column == "MaxFailedMountAttempts" {
 				maxFailedMountAttempts, err := strconv.Atoi(*defaultValue)
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprint(dynatracev1beta1.DefaultMaxFailedCsiMountAttempts), *defaultValue)
+				assert.Equal(t, strconv.Itoa(dynatracev1beta1.DefaultMaxFailedCsiMountAttempts), *defaultValue)
 				assert.Equal(t, dynatracev1beta1.DefaultMaxFailedCsiMountAttempts, maxFailedMountAttempts)
 				assert.Equal(t, "1", notNull)
 			}

--- a/pkg/controllers/csi/provisioner/processmoduleconfig_test.go
+++ b/pkg/controllers/csi/provisioner/processmoduleconfig_test.go
@@ -2,8 +2,8 @@ package csiprovisioner
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
@@ -33,7 +33,7 @@ func createTestProcessModuleConfig(revision uint) *dtclient.ProcessModuleConfig 
 func createTestProcessModuleConfigCache(revision uint) processModuleConfigCache {
 	return processModuleConfigCache{
 		ProcessModuleConfig: createTestProcessModuleConfig(revision),
-		Hash:                fmt.Sprintf("%d", revision),
+		Hash:                strconv.FormatUint(uint64(revision), 10),
 	}
 }
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
@@ -1,7 +1,6 @@
 package statefulset
 
 import (
-	"fmt"
 	"reflect"
 	"strconv"
 	"testing"
@@ -431,7 +430,7 @@ func TestBuildCommonEnvs(t *testing.T) {
 	t.Run("synthetic capability", func(t *testing.T) {
 		dynaKube := getTestDynakube()
 		dynaKube.ObjectMeta.Annotations[dynatracev1beta1.AnnotationFeatureSyntheticLocationEntityId] = "doctored"
-		dynaKube.ObjectMeta.Annotations[dynatracev1beta1.AnnotationFeatureSyntheticReplicas] = fmt.Sprint(testReplicas)
+		dynaKube.ObjectMeta.Annotations[dynatracev1beta1.AnnotationFeatureSyntheticReplicas] = strconv.Itoa(int(testReplicas))
 		synCapability := capability.NewSyntheticCapability(&dynaKube)
 
 		builder := NewStatefulSetBuilder(


### PR DESCRIPTION
## Description

Enable new linter: perfsprint

Some context: 
>Sprint is the slowest way to convert small and big int to string, and on the other hand strconv. FormatInt is the fastest way to convert a int to string , strconv,Itoa is the second fastest way almost near to strconv. FormatInt. So hence prove that for either small or big always use strconv.

From benchmarks in https://dev.to/mavensingh/strconvitoa-vs-strconvformatint-vs-fmtsprintf-which-is-good-to-convert-int-to-string-in-golang-3iol#:~:text=Sprint%20is%20the%20slowest%20way,or%20big%20always%20use%20strconv.

## How can this be tested?

unit-tests

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
