### PR TITLE
Fix self deleting owner reference in created istio CRs

### DIFF
--- a/pkg/controllers/dynakube/dynakube_controller.go
+++ b/pkg/controllers/dynakube/dynakube_controller.go
@@ -194,7 +194,7 @@ func (controller *Controller) setupIstio(ctx context.Context, dynakube *dynatrac
 	if !dynakube.Spec.EnableIstio {
 		return nil, nil
 	}
-	istioClient, err := controller.istioClientBuilder(controller.config, controller.scheme, dynakube.Namespace)
+	istioClient, err := controller.istioClientBuilder(controller.config, controller.scheme, dynakube)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to initialize istio client")
 	}

--- a/pkg/controllers/dynakube/dynakube_controller_test.go
+++ b/pkg/controllers/dynakube/dynakube_controller_test.go
@@ -1100,7 +1100,7 @@ func TestSetupIstio(t *testing.T) {
 }
 
 func fakeIstioClientBuilder(t *testing.T, fakeIstio *fakeistio.Clientset, isIstioInstalled bool) istio.ClientBuilder {
-	return func(_ *rest.Config, scheme *runtime.Scheme, namespace string) (*istio.Client, error) {
+	return func(_ *rest.Config, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube) (*istio.Client, error) {
 		if isIstioInstalled == true {
 			fakeDiscovery, ok := fakeIstio.Discovery().(*fakediscovery.FakeDiscovery)
 			fakeDiscovery.Resources = []*metav1.APIResourceList{{GroupVersion: istio.IstioGVR}}
@@ -1111,7 +1111,7 @@ func fakeIstioClientBuilder(t *testing.T, fakeIstio *fakeistio.Clientset, isIsti
 		return &istio.Client{
 			IstioClientset: fakeIstio,
 			Scheme:         scheme,
-			Namespace:      namespace,
+			Dynakube:       dynakube,
 		}, nil
 	}
 }

--- a/pkg/controllers/dynakube/dynakube_controller_test.go
+++ b/pkg/controllers/dynakube/dynakube_controller_test.go
@@ -1100,7 +1100,7 @@ func TestSetupIstio(t *testing.T) {
 }
 
 func fakeIstioClientBuilder(t *testing.T, fakeIstio *fakeistio.Clientset, isIstioInstalled bool) istio.ClientBuilder {
-	return func(_ *rest.Config, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube) (*istio.Client, error) {
+	return func(_ *rest.Config, scheme *runtime.Scheme, owner metav1.Object) (*istio.Client, error) {
 		if isIstioInstalled == true {
 			fakeDiscovery, ok := fakeIstio.Discovery().(*fakediscovery.FakeDiscovery)
 			fakeDiscovery.Resources = []*metav1.APIResourceList{{GroupVersion: istio.IstioGVR}}
@@ -1111,7 +1111,7 @@ func fakeIstioClientBuilder(t *testing.T, fakeIstio *fakeistio.Clientset, isIsti
 		return &istio.Client{
 			IstioClientset: fakeIstio,
 			Scheme:         scheme,
-			Dynakube:       dynakube,
+			Owner:          owner,
 		}, nil
 	}
 }

--- a/pkg/controllers/dynakube/istio/client_test.go
+++ b/pkg/controllers/dynakube/istio/client_test.go
@@ -24,7 +24,7 @@ func newTestingClient(fakeClient *fakeistio.Clientset, namespace string) *Client
 	return &Client{
 		IstioClientset: fakeClient,
 		Scheme:         scheme.Scheme,
-		Dynakube:       testDynakube,
+		Owner:          testDynakube,
 	}
 }
 

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -32,7 +32,7 @@ func (r *Reconciler) ReconcileAPIUrl(ctx context.Context, dynakube *dynatracev1b
 		return err
 	}
 
-	err = r.reconcileCommunicationHosts(ctx, dynakube, []dtclient.CommunicationHost{apiHost}, OperatorComponent)
+	err = r.reconcileCommunicationHosts(ctx, []dtclient.CommunicationHost{apiHost}, OperatorComponent)
 	if err != nil {
 		return errors.WithMessage(err, "error reconciling config for Dynatrace API URL")
 	}
@@ -48,21 +48,21 @@ func (r *Reconciler) ReconcileCommunicationHosts(ctx context.Context, dynakube *
 	}
 
 	oneAgentCommunicationHosts := connectioninfo.GetOneAgentCommunicationHosts(dynakube)
-	err := r.reconcileCommunicationHostsForComponent(ctx, dynakube, oneAgentCommunicationHosts, OneAgentComponent)
+	err := r.reconcileCommunicationHostsForComponent(ctx, oneAgentCommunicationHosts, OneAgentComponent)
 	if err != nil {
 		return err
 	}
 
 	activeGateEndpoints := connectioninfo.GetActiveGateEndpointsAsCommunicationHosts(dynakube)
-	err = r.reconcileCommunicationHostsForComponent(ctx, dynakube, activeGateEndpoints, ActiveGateComponent)
+	err = r.reconcileCommunicationHostsForComponent(ctx, activeGateEndpoints, ActiveGateComponent)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (r *Reconciler) reconcileCommunicationHostsForComponent(ctx context.Context, dynakube *dynatracev1beta1.DynaKube, comHosts []dtclient.CommunicationHost, componentName string) error {
-	err := r.reconcileCommunicationHosts(ctx, dynakube, comHosts, componentName)
+func (r *Reconciler) reconcileCommunicationHostsForComponent(ctx context.Context, comHosts []dtclient.CommunicationHost, componentName string) error {
+	err := r.reconcileCommunicationHosts(ctx, comHosts, componentName)
 	if err != nil {
 		return errors.WithMessage(err, "error reconciling config for Dynatrace communication hosts")
 	}
@@ -70,15 +70,15 @@ func (r *Reconciler) reconcileCommunicationHostsForComponent(ctx context.Context
 	return nil
 }
 
-func (r *Reconciler) reconcileCommunicationHosts(ctx context.Context, owner metav1.Object, comHosts []dtclient.CommunicationHost, component string) error {
+func (r *Reconciler) reconcileCommunicationHosts(ctx context.Context, comHosts []dtclient.CommunicationHost, component string) error {
 	ipHosts, fqdnHosts := splitCommunicationHost(comHosts)
 
-	err := r.reconcileIPServiceEntry(ctx, owner, ipHosts, component)
+	err := r.reconcileIPServiceEntry(ctx, ipHosts, component)
 	if err != nil {
 		return err
 	}
 
-	err = r.reconcileFQDNServiceEntry(ctx, owner, fqdnHosts, component)
+	err = r.reconcileFQDNServiceEntry(ctx, fqdnHosts, component)
 	if err != nil {
 		return err
 	}
@@ -96,10 +96,8 @@ func splitCommunicationHost(comHosts []dtclient.CommunicationHost) (ipHosts, fqd
 	return
 }
 
-func (r *Reconciler) reconcileIPServiceEntry(ctx context.Context, owner metav1.Object, ipHosts []dtclient.CommunicationHost, component string) error {
-	if owner == nil {
-		return errors.New("unable to create service entry for IPs if owner is nil")
-	}
+func (r *Reconciler) reconcileIPServiceEntry(ctx context.Context, ipHosts []dtclient.CommunicationHost, component string) error {
+	owner := r.client.Dynakube
 	entryName := BuildNameForIPServiceEntry(owner.GetName(), component)
 	if len(ipHosts) != 0 {
 		meta := buildObjectMeta(
@@ -109,7 +107,7 @@ func (r *Reconciler) reconcileIPServiceEntry(ctx context.Context, owner metav1.O
 		)
 
 		serviceEntry := buildServiceEntryIPs(meta, ipHosts)
-		err := r.client.CreateOrUpdateServiceEntry(ctx, owner, serviceEntry)
+		err := r.client.CreateOrUpdateServiceEntry(ctx, serviceEntry)
 		if err != nil {
 			return err
 		}
@@ -123,10 +121,8 @@ func (r *Reconciler) reconcileIPServiceEntry(ctx context.Context, owner metav1.O
 	return nil
 }
 
-func (r *Reconciler) reconcileFQDNServiceEntry(ctx context.Context, owner metav1.Object, fqdnHosts []dtclient.CommunicationHost, component string) error {
-	if owner == nil {
-		return errors.New("unable to create service entry and virtual service for Hosts if owner is nil")
-	}
+func (r *Reconciler) reconcileFQDNServiceEntry(ctx context.Context, fqdnHosts []dtclient.CommunicationHost, component string) error {
+	owner := r.client.Dynakube
 	entryName := BuildNameForFQDNServiceEntry(owner.GetName(), component)
 	if len(fqdnHosts) != 0 {
 		meta := buildObjectMeta(
@@ -136,13 +132,13 @@ func (r *Reconciler) reconcileFQDNServiceEntry(ctx context.Context, owner metav1
 		)
 
 		serviceEntry := buildServiceEntryFQDNs(meta, fqdnHosts)
-		err := r.client.CreateOrUpdateServiceEntry(ctx, owner, serviceEntry)
+		err := r.client.CreateOrUpdateServiceEntry(ctx, serviceEntry)
 		if err != nil {
 			return err
 		}
 
 		virtualService := buildVirtualService(meta, fqdnHosts)
-		err = r.client.CreateOrUpdateVirtualService(ctx, owner, virtualService)
+		err = r.client.CreateOrUpdateVirtualService(ctx, virtualService)
 		if err != nil {
 			return err
 		}

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -97,7 +97,7 @@ func splitCommunicationHost(comHosts []dtclient.CommunicationHost) (ipHosts, fqd
 }
 
 func (r *Reconciler) reconcileIPServiceEntry(ctx context.Context, ipHosts []dtclient.CommunicationHost, component string) error {
-	owner := r.client.Dynakube
+	owner := r.client.Owner
 	entryName := BuildNameForIPServiceEntry(owner.GetName(), component)
 	if len(ipHosts) != 0 {
 		meta := buildObjectMeta(
@@ -122,7 +122,7 @@ func (r *Reconciler) reconcileIPServiceEntry(ctx context.Context, ipHosts []dtcl
 }
 
 func (r *Reconciler) reconcileFQDNServiceEntry(ctx context.Context, fqdnHosts []dtclient.CommunicationHost, component string) error {
-	owner := r.client.Dynakube
+	owner := r.client.Owner
 	entryName := BuildNameForFQDNServiceEntry(owner.GetName(), component)
 	if len(fqdnHosts) != 0 {
 		meta := buildObjectMeta(

--- a/pkg/webhook/validation/dynakube/istio.go
+++ b/pkg/webhook/validation/dynakube/istio.go
@@ -15,7 +15,7 @@ const (
 
 func noResourcesAvailable(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
 	if dynakube.Spec.EnableIstio {
-		istioClient, err := istio.NewClient(dv.cfg, scheme.Scheme, dynakube.Namespace)
+		istioClient, err := istio.NewClient(dv.cfg, scheme.Scheme, dynakube)
 		if err != nil {
 			return errorFailToInitIstioClient
 		}


### PR DESCRIPTION
## Description

Fixes a problem where owner references of created istio CRs were deleted after they were updated.

In addition refactors the istio client implementation to keep a reference to the owner directly, as one instance is anyway always using the same owner.

## How can this be tested?

- create dynakube without active gate section and istio enabled
- check if service entries were created and have owner references
- update dynakube to have an active gate section 
- service entries should be updated and not loose the owner reference
- do the same for virtual services

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
