### PR TITLE
Fix the broken links in the networking doc

### DIFF
--- a/doc/network.md
+++ b/doc/network.md
@@ -13,10 +13,10 @@
 
 All network policies in compliance with the operator can be found in `assets/calico`.
 
-- [activegate-policy.yaml](assets/calico/activegate-policy.yaml)
-- [activegate-policy-external-only.yaml](assets/calico/agent-policy-external-only.yaml)
-- [agent-policy.yaml](assets/calico/agent-policy.yaml)
-- [dynatrace-policies.yaml](assets/calico/dynatrace-policies.yaml)
+- [activegate-policy.yaml](../assets/calico/activegate-policy.yaml)
+- [activegate-policy-external-only.yaml](../assets/calico/agent-policy-external-only.yaml)
+- [agent-policy.yaml](../assets/calico/agent-policy.yaml)
+- [dynatrace-policies.yaml](../assets/calico/dynatrace-policies.yaml)
 
 ## Used ports
 


### PR DESCRIPTION
## Description

Links to the calico yaml files in the networking.md file are fixed in this PR.

## How can this be tested?

Browse to [links](https://github.com/Dynatrace/dynatrace-operator/blob/main/doc/network.md#kubernetes-network-policies)

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
