### PR TITLE
Add infra-only mode to host monitoring sample

### DIFF
--- a/assets/samples/hostMonitoring.yaml
+++ b/assets/samples/hostMonitoring.yaml
@@ -135,7 +135,8 @@ spec:
       # For a list of available options, see https://www.dynatrace.com/support/help/shortlink/linux-custom-installation
       # For a list of the limitations for OneAgents in Docker, see https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
       #
-      # args: []
+      args:
+        - --set-infra-only=true
 
   # Configuration for ActiveGate instances.
   #


### PR DESCRIPTION
## Description

Host monitoring sample is updated such that it has infra-only mode enabled by default.

## How can this be tested?

## Checklist

- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
