### PR TITLE
Make timeoutSeconds configurable for webhook configurations via values.yaml

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/mutatingwebhookconfiguration.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/mutatingwebhookconfiguration.yaml
@@ -23,7 +23,7 @@ webhooks:
   - name: webhook.pod.dynatrace.com
     reinvocationPolicy: IfNeeded
     failurePolicy: Ignore
-    timeoutSeconds: 2
+    timeoutSeconds: {{.Values.webhook.mutatingWebhook.timeoutSeconds}}
     rules:
       - apiGroups: [ "" ]
         apiVersions: [ "v1" ]
@@ -44,7 +44,7 @@ webhooks:
   - name: webhook.ns.dynatrace.com
     reinvocationPolicy: IfNeeded
     failurePolicy: Ignore
-    timeoutSeconds: 2
+    timeoutSeconds: {{.Values.webhook.mutatingWebhook.timeoutSeconds}}
     rules:
       - apiGroups: [ "" ]
         apiVersions: [ "v1" ]

--- a/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
@@ -40,7 +40,7 @@ webhooks:
         resources:
           - dynakubes
     name: webhook.dynatrace.com
-    timeoutSeconds: 10
+    timeoutSeconds: {{.Values.webhook.validatingWebhook.timeoutSeconds}}
     sideEffects: None
   - admissionReviewVersions:
       - v1
@@ -62,6 +62,6 @@ webhooks:
         resources:
           - edgeconnects
     name: edgeconnect.webhook.dynatrace.com
-    timeoutSeconds: 10
+    timeoutSeconds: {{.Values.webhook.validatingWebhook.timeoutSeconds}}
     sideEffects: None
 {{ end }}

--- a/config/helm/chart/default/tests/Common/webhook/mutatingwebhookconfiguration_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/mutatingwebhookconfiguration_test.yaml
@@ -54,3 +54,16 @@ tests:
                     path: /label-ns
                 admissionReviewVersions: [ "v1beta1", "v1" ]
                 sideEffects: None
+  - it: should change timeoutSeconds
+    set:
+      platform: kubernetes
+      webhook:
+        mutatingWebhook:
+          timeoutSeconds: 13
+    asserts:
+      - equal:
+          path: webhooks[0].timeoutSeconds
+          value: 13
+      - equal:
+          path: webhooks[1].timeoutSeconds
+          value: 13

--- a/config/helm/chart/default/tests/Common/webhook/validatingwebhookconfiguration_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/validatingwebhookconfiguration_test.yaml
@@ -1,0 +1,75 @@
+suite: test validating webhook configuration
+templates:
+  - Common/webhook/validatingwebhookconfiguration.yaml
+tests:
+  - it: should exist
+    set:
+      platform: kubernetes
+    asserts:
+      - isKind:
+          of: ValidatingWebhookConfiguration
+      - equal:
+          path: metadata.name
+          value: dynatrace-webhook
+      - isNotEmpty:
+          path: metadata.labels
+      - equal:
+          path: webhooks
+          value:
+            - admissionReviewVersions:
+                - v1
+                - v1beta1
+                - v1alpha1
+              clientConfig:
+                service:
+                  name: dynatrace-webhook
+                  namespace: NAMESPACE
+                  path: /validate
+              rules:
+                - operations:
+                    - CREATE
+                    - UPDATE
+                  apiGroups:
+                    - dynatrace.com
+                  apiVersions:
+                    - v1beta1
+                  resources:
+                    - dynakubes
+              name: webhook.dynatrace.com
+              timeoutSeconds: 10
+              sideEffects: None
+            - admissionReviewVersions:
+                - v1
+                - v1beta1
+                - v1alpha1
+              clientConfig:
+                service:
+                  name: dynatrace-webhook
+                  namespace: NAMESPACE
+                  path: /validate/edgeconnect
+              rules:
+                - operations:
+                    - CREATE
+                    - UPDATE
+                  apiGroups:
+                    - dynatrace.com
+                  apiVersions:
+                    - v1alpha1
+                  resources:
+                    - edgeconnects
+              name: edgeconnect.webhook.dynatrace.com
+              timeoutSeconds: 10
+              sideEffects: None
+  - it: should change timeoutSeconds
+    set:
+      platform: kubernetes
+      webhook:
+        validatingWebhook:
+          timeoutSeconds: 12
+    asserts:
+      - equal:
+          path: webhooks[0].timeoutSeconds
+          value: 12
+      - equal:
+          path: webhooks[1].timeoutSeconds
+          value: 12

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -53,6 +53,10 @@ operator:
     memory: 128Mi
 
 webhook:
+  validatingWebhook:
+    timeoutSeconds: 10
+  mutatingWebhook:
+    timeoutSeconds: 2
   hostNetwork: false
   nodeSelector: {}
   tolerations: []

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -53,10 +53,6 @@ operator:
     memory: 128Mi
 
 webhook:
-  validatingWebhook:
-    timeoutSeconds: 10
-  mutatingWebhook:
-    timeoutSeconds: 2
   hostNetwork: false
   nodeSelector: {}
   tolerations: []
@@ -82,6 +78,10 @@ webhook:
     cpu: 300m
     memory: 128Mi
   highAvailability: true
+  validatingWebhook:
+    timeoutSeconds: 10
+  mutatingWebhook:
+    timeoutSeconds: 2
 
 csidriver:
   enabled: false


### PR DESCRIPTION
## Description

Make timeoutSeconds configurable for webhook configurations via values.yaml

## How can this be tested?

Deploy the operator via helm and change the timeoutSeconds in the values.yaml -> check if the mutatingWebhookConfiguration and the validatingWebhookConfiguration has the correct value set


## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
