### PR TITLE
Bump golang version to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Dynatrace/dynatrace-operator
 
-go 1.20
+go 1.21
 
 require (
 	github.com/container-storage-interface/spec v1.9.0


### PR DESCRIPTION
## Description

I will need the `slices` package in a different PR. It is not available in 1.20.

## How can this be tested?

The operator is built and works with no changes.

## Checklist

~- [ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
