### PR TITLE
Always Add ClusterId EnvVar To Pods

### DIFF
--- a/src/standalone/env.go
+++ b/src/standalone/env.go
@@ -87,6 +87,7 @@ func (env *environment) getCommonFieldSetters() []func() error {
 		env.addK8PodName,
 		env.addK8PodUID,
 		env.addK8Namespace,
+		env.addK8ClusterID,
 	}
 }
 
@@ -105,7 +106,6 @@ func (env *environment) getDataIngestFieldSetters() []func() error {
 	return append(env.getCommonFieldSetters(),
 		env.addWorkloadKind,
 		env.addWorkloadName,
-		env.addK8ClusterID,
 	)
 }
 

--- a/src/standalone/env_test.go
+++ b/src/standalone/env_test.go
@@ -110,8 +110,8 @@ func TestNewEnv(t *testing.T) {
 		assert.NotEmpty(t, env.K8PodUID)
 		assert.NotEmpty(t, env.K8BasePodName)
 		assert.NotEmpty(t, env.K8Namespace)
+		assert.NotEmpty(t, env.K8ClusterID)
 
-		assert.Empty(t, env.K8ClusterID)
 		assert.Empty(t, env.WorkloadKind)
 		assert.Empty(t, env.WorkloadName)
 
@@ -141,6 +141,7 @@ func prepOneAgentTestEnv(t *testing.T) func() {
 		config.K8sBasePodNameEnv,
 		config.K8sNamespaceEnv,
 		config.AgentInstallPathEnv,
+		config.K8sClusterIDEnv,
 	}
 	for i := 1; i <= 5; i++ {
 		envs = append(envs, fmt.Sprintf(config.AgentContainerNameEnvTemplate, i))


### PR DESCRIPTION
## Description

When the DynaKube feature flag `feature.dynatrace.com/automatic-injection` was set to false to use `oneagent.dynatrace.com/inject: "true"` on a pod, the pod did not get the env var `K8S_CLUSTER_ID` injected. This resulted in the OneAgent not being able to generate a correct host identifier which then lead to a pod not being visible in the UI.
This PR fixes that issue.

## How can this be tested?

create a DynaKube with `feature.dynatrace.com/automatic-injection: "false"` and a sample app with `oneagent.dynatrace.com/inject: "true"`.
Then `/var/lib/dynatrace/oneagent/agent/config/container.conf` should contain a valid cluster ID.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
