### PR TITLE
Speed up retrying token fixing

### DIFF
--- a/pkg/controllers/dynakube/dynakube_controller_test.go
+++ b/pkg/controllers/dynakube/dynakube_controller_test.go
@@ -962,6 +962,7 @@ func TestTokenConditions(t *testing.T) {
 
 		assert.Error(t, err)
 		assertCondition(t, dynakube, dynatracev1beta1.TokenConditionType, metav1.ConditionFalse, dynatracev1beta1.ReasonTokenError, "secrets \"\" not found")
+		assert.Nil(t, dynakube.Status.LastTokenProbeTimestamp, "LastTokenProbeTimestamp should be Nil if token retrieval did not work.")
 	})
 	t.Run("token condition is set if token are valid", func(t *testing.T) {
 		dynakube := &dynatracev1beta1.DynaKube{

--- a/pkg/controllers/dynakube/dynatraceclient/builder.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder.go
@@ -117,24 +117,21 @@ func (dynatraceClientBuilder builder) BuildWithTokenVerification(dynaKubeStatus 
 }
 
 func (dynatraceClientBuilder builder) verifyTokenScopes(dynatraceClient dtclient.Client, dynaKubeStatus *dynatracev1beta1.DynaKubeStatus) error {
-	var err error
-
-	if dynatraceClientBuilder.dynakube.IsTokenScopeVerificationAllowed(timeprovider.New()) {
-		dynaKubeStatus.DynatraceApi.LastTokenScopeRequest = metav1.Now()
-		err = dynatraceClientBuilder.tokens.VerifyScopes(dynatraceClient)
-		log.Info("token verified")
-	} else {
+	if !dynatraceClientBuilder.dynakube.IsTokenScopeVerificationAllowed(timeprovider.New()) {
 		log.Info(dynatracev1beta1.GetCacheValidMessage(
 			"token verification",
 			dynaKubeStatus.DynatraceApi.LastTokenScopeRequest,
 			dynatraceClientBuilder.dynakube.FeatureApiRequestThreshold()))
-		err = lastErrorFromCondition(dynaKubeStatus)
+		return lastErrorFromCondition(dynaKubeStatus)
 	}
 
+	err := dynatraceClientBuilder.tokens.VerifyScopes(dynatraceClient)
 	if err != nil {
 		return err
 	}
 
+	log.Info("token verified")
+	dynaKubeStatus.DynatraceApi.LastTokenScopeRequest = metav1.Now()
 	return nil
 }
 


### PR DESCRIPTION
## Description

In case of a problem with the token we did only retry every 15 minutes to fix the token. By only setting the timestamp if a token could be validated we retry much more often until succeeded.

## How can this be tested?

Deploy a dynakube with a proxy pointing nowhere- if described the dynakube is in error state because it cannot get the token. Reapply the dynakube without the proxy and it should get immediately healed.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
