### PR TITLE
Add no-proxy to image library transport

### DIFF
--- a/pkg/oci/registry/client.go
+++ b/pkg/oci/registry/client.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"golang.org/x/net/http/httpproxy"
 	"net/http"
 	"net/url"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
+	"golang.org/x/net/http/httpproxy"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/pkg/oci/registry/client.go
+++ b/pkg/oci/registry/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"golang.org/x/net/http/httpproxy"
 	"net/http"
 	"net/url"
 
@@ -164,16 +165,25 @@ func BuildImageIDWithTagAndDigest(taggedRef name.Tag, digest digest.Digest) stri
 	return fmt.Sprintf("%s%s%s", taggedRef.String(), DigestDelimiter, digest.String())
 }
 
-func addProxy(transport *http.Transport, proxy string) (*http.Transport, error) {
+func addProxy(transport *http.Transport, proxy string, noProxy string) (*http.Transport, error) {
 	proxyUrl, err := url.Parse(proxy)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	transport.Proxy = func(req *http.Request) (*url.URL, error) {
-		return proxyUrl, nil
+	proxyConfig := httpproxy.Config{
+		HTTPProxy:  proxyUrl.String(),
+		HTTPSProxy: proxyUrl.String(),
+		NoProxy:    noProxy,
 	}
+	transport.Proxy = proxyWrapper(proxyConfig)
 	return transport, nil
+}
+
+func proxyWrapper(proxyConfig httpproxy.Config) func(req *http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		return proxyConfig.ProxyFunc()(req.URL)
+	}
 }
 
 func addCertificates(transport *http.Transport, trustedCAs []byte) (*http.Transport, error) {
@@ -211,7 +221,7 @@ func PrepareTransportForDynaKube(ctx context.Context, apiReader client.Reader, t
 	}
 
 	if proxy != "" {
-		transport, err = addProxy(transport, proxy)
+		transport, err = addProxy(transport, proxy, dynakube.FeatureNoProxy())
 		if err != nil {
 			return nil, errors.WithMessage(err, "failed to add proxy to default transport")
 		}

--- a/pkg/oci/registry/client_test.go
+++ b/pkg/oci/registry/client_test.go
@@ -1,0 +1,61 @@
+package registry
+
+import (
+	"context"
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestProxy(t *testing.T) {
+	proxyRawURL := "proxy.url"
+	t.Run("set NO_PROXY", func(t *testing.T) {
+		instance := &dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "Dynakube",
+				Namespace: "dynatrace",
+				Annotations: map[string]string{
+					dynatracev1beta1.AnnotationFeatureNoProxy: "working.url,url.working",
+				},
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				Proxy:  &dynatracev1beta1.DynaKubeProxy{Value: proxyRawURL},
+				APIURL: "https://testApiUrl.dev.dynatracelabs.com/api",
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{},
+				},
+			},
+		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport, err := PrepareTransportForDynaKube(context.TODO(), nil, transport, instance)
+
+		assert.NoError(t, err)
+
+		checkProxyForUrl(t, *transport, proxyRawURL, "http://working.url", true)
+		checkProxyForUrl(t, *transport, proxyRawURL, "https://working.url", true)
+
+		checkProxyForUrl(t, *transport, proxyRawURL, "http://url.working", true)
+		checkProxyForUrl(t, *transport, proxyRawURL, "https://url.working", true)
+
+		checkProxyForUrl(t, *transport, proxyRawURL, "http://proxied.url", false)
+		checkProxyForUrl(t, *transport, proxyRawURL, "https://proxied.url", false)
+	})
+}
+
+func checkProxyForUrl(t *testing.T, transport http.Transport, proxyRawURL, targetRawURL string, noProxy bool) {
+	targetURL, err := url.Parse(targetRawURL)
+	require.NoError(t, err)
+
+	url, err := transport.Proxy(&http.Request{URL: targetURL})
+	require.NoError(t, err)
+	if !noProxy {
+		require.NotNil(t, url)
+		assert.Equal(t, proxyRawURL, url.Host)
+	} else {
+		require.Nil(t, url)
+	}
+}

--- a/pkg/oci/registry/client_test.go
+++ b/pkg/oci/registry/client_test.go
@@ -2,13 +2,14 @@ package registry
 
 import (
 	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
-	"net/url"
-	"testing"
 )
 
 func TestProxy(t *testing.T) {


### PR DESCRIPTION
## Description

Currently we have the problem that the no-proxy feature flag is not used for the image library traffic. Therefore its not possible to add NO_Proxy values for this kind of communication. Especially when having customImages it can lead to problems.

## How can this be tested?

Create a Dynakube with a Proxy and set NoProxy value to the target of the customImage, check if the image manifest can be accessed without accessing the proxy

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
