### PR TITLE
Add no-proxy to image library transport

### DIFF
--- a/src/controllers/dynakube/version/image_hash.go
+++ b/src/controllers/dynakube/version/image_hash.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"golang.org/x/net/http/httpproxy"
 	"net/http"
 	"net/url"
 
@@ -87,10 +88,13 @@ func PrepareTransport(ctx context.Context, apiReader client.Reader, transport *h
 			log.Info("invalid proxy spec", "proxy", proxy)
 			return nil, errors.WithStack(err)
 		}
-
-		transport.Proxy = func(req *http.Request) (*url.URL, error) {
-			return proxyUrl, nil
+		proxyConfig := httpproxy.Config{
+			HTTPProxy:  proxyUrl.String(),
+			HTTPSProxy: proxyUrl.String(),
+			NoProxy:    dynakube.FeatureNoProxy(),
 		}
+
+		transport.Proxy = proxyWrapper(proxyConfig)
 	}
 
 	if dynakube.Spec.TrustedCAs != "" {
@@ -100,6 +104,12 @@ func PrepareTransport(ctx context.Context, apiReader client.Reader, transport *h
 		}
 	}
 	return transport, nil
+}
+
+func proxyWrapper(proxyConfig httpproxy.Config) func(req *http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		return proxyConfig.ProxyFunc()(req.URL)
+	}
 }
 
 func AddCertificates(ctx context.Context, apiReader client.Reader, transport *http.Transport, dynakube *dynatracev1beta1.DynaKube) (*http.Transport, error) {

--- a/src/controllers/dynakube/version/image_hash.go
+++ b/src/controllers/dynakube/version/image_hash.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"golang.org/x/net/http/httpproxy"
 	"net/http"
 	"net/url"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/src/registry"
 	containerv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
+	"golang.org/x/net/http/httpproxy"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 


### PR DESCRIPTION
## Description

Currently we have the problem that the no-proxy feature flag is not used for the image library traffic. Therefore its not possible to add NO_Proxy values for this kind of communication. Especially when having customImages it can lead to problems.

## How can this be tested?

Create a Dynakube with a Proxy and set NoProxy value to the target of the customImage, check if the image manifest can be accessed without accessing the proxy

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
