### PR TITLE
Upgrade the istio CR version to v1beta1

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -48,7 +48,7 @@ test/e2e/cloudnative/default: manifests/crd/helm
 
 ## Runs CloudNative istio e2e test only
 test/e2e/cloudnative/istio: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -args --labels "name=cloudnative-isito" $(SKIPCLEANUP)
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -args --labels "name=cloudnative-istio" $(SKIPCLEANUP)
 
 ## Runs CloudNative network problem e2e test only
 test/e2e/cloudnative/resilience: manifests/crd/helm

--- a/pkg/api/scheme/scheme.go
+++ b/pkg/api/scheme/scheme.go
@@ -22,7 +22,7 @@ import (
 	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1"
 	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
-	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -37,7 +37,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
 	utilruntime.Must(dynatracev1alpha1.AddToScheme(Scheme))
 	utilruntime.Must(dynatracev1beta1.AddToScheme(Scheme))
-	utilruntime.Must(istiov1alpha3.AddToScheme(Scheme))
+	utilruntime.Must(istiov1beta1.AddToScheme(Scheme))
 	utilruntime.Must(corev1.AddToScheme(Scheme))
 	utilruntime.Must(apiv1.AddToScheme(Scheme))
 	// +kubebuilder:scaffold:scheme

--- a/pkg/controllers/dynakube/dynakube_controller_test.go
+++ b/pkg/controllers/dynakube/dynakube_controller_test.go
@@ -1091,10 +1091,10 @@ func TestSetupIstio(t *testing.T) {
 		assert.NotNil(t, istioReconciler)
 
 		expectedName := istio.BuildNameForFQDNServiceEntry(dynakube.GetName(), istio.OperatorComponent)
-		serviceEntry, err := fakeIstio.NetworkingV1alpha3().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
+		serviceEntry, err := fakeIstio.NetworkingV1beta1().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
-		virtualService, err := fakeIstio.NetworkingV1alpha3().VirtualServices(dynakube.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
+		virtualService, err := fakeIstio.NetworkingV1beta1().VirtualServices(dynakube.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, virtualService)
 	})

--- a/pkg/controllers/dynakube/istio/client.go
+++ b/pkg/controllers/dynakube/istio/client.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/pkg/errors"
-	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istioclientset "istio.io/client-go/pkg/clientset/versioned"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,8 +52,8 @@ func (cl *Client) CheckIstioInstalled() (bool, error) {
 	return err == nil, err
 }
 
-func (cl *Client) GetVirtualService(ctx context.Context, name string) (*istiov1alpha3.VirtualService, error) {
-	virtualService, err := cl.IstioClientset.NetworkingV1alpha3().VirtualServices(cl.Owner.GetNamespace()).Get(ctx, name, metav1.GetOptions{})
+func (cl *Client) GetVirtualService(ctx context.Context, name string) (*istiov1beta1.VirtualService, error) {
+	virtualService, err := cl.IstioClientset.NetworkingV1beta1().VirtualServices(cl.Owner.GetNamespace()).Get(ctx, name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, nil
 	} else if err != nil {
@@ -63,7 +63,7 @@ func (cl *Client) GetVirtualService(ctx context.Context, name string) (*istiov1a
 	return virtualService, nil
 }
 
-func (cl *Client) CreateOrUpdateVirtualService(ctx context.Context, newVirtualService *istiov1alpha3.VirtualService) error {
+func (cl *Client) CreateOrUpdateVirtualService(ctx context.Context, newVirtualService *istiov1beta1.VirtualService) error {
 	if newVirtualService == nil {
 		return errors.New("can't create virtual service based on nil object")
 	}
@@ -94,11 +94,11 @@ func (cl *Client) CreateOrUpdateVirtualService(ctx context.Context, newVirtualSe
 	return cl.updateVirtualService(ctx, oldVirtualService, newVirtualService)
 }
 
-func (cl *Client) createVirtualService(ctx context.Context, virtualService *istiov1alpha3.VirtualService) error {
+func (cl *Client) createVirtualService(ctx context.Context, virtualService *istiov1beta1.VirtualService) error {
 	if virtualService == nil {
 		return errors.New("can't create virtual service based on nil object")
 	}
-	_, err := cl.IstioClientset.NetworkingV1alpha3().VirtualServices(cl.Owner.GetNamespace()).Create(ctx, virtualService, metav1.CreateOptions{})
+	_, err := cl.IstioClientset.NetworkingV1beta1().VirtualServices(cl.Owner.GetNamespace()).Create(ctx, virtualService, metav1.CreateOptions{})
 	if err != nil {
 		log.Info("failed to create virtual service", "name", virtualService.GetName(), "error", err.Error())
 		return errors.WithStack(err)
@@ -106,12 +106,12 @@ func (cl *Client) createVirtualService(ctx context.Context, virtualService *isti
 	return nil
 }
 
-func (cl *Client) updateVirtualService(ctx context.Context, oldVirtualService, newVirtualService *istiov1alpha3.VirtualService) error {
+func (cl *Client) updateVirtualService(ctx context.Context, oldVirtualService, newVirtualService *istiov1beta1.VirtualService) error {
 	if oldVirtualService == nil || newVirtualService == nil {
 		return errors.New("can't update service entry based on nil object")
 	}
 	newVirtualService.ObjectMeta.ResourceVersion = oldVirtualService.ObjectMeta.ResourceVersion
-	_, err := cl.IstioClientset.NetworkingV1alpha3().VirtualServices(cl.Owner.GetNamespace()).Update(ctx, newVirtualService, metav1.UpdateOptions{})
+	_, err := cl.IstioClientset.NetworkingV1beta1().VirtualServices(cl.Owner.GetNamespace()).Update(ctx, newVirtualService, metav1.UpdateOptions{})
 	if err != nil {
 		log.Info("failed to update virtual service", "name", newVirtualService.GetName(), "error", err.Error())
 		return errors.WithStack(err)
@@ -120,7 +120,7 @@ func (cl *Client) updateVirtualService(ctx context.Context, oldVirtualService, n
 }
 
 func (cl *Client) DeleteVirtualService(ctx context.Context, name string) error {
-	err := cl.IstioClientset.NetworkingV1alpha3().
+	err := cl.IstioClientset.NetworkingV1beta1().
 		VirtualServices(cl.Owner.GetNamespace()).
 		Delete(ctx, name, metav1.DeleteOptions{})
 	if !k8serrors.IsNotFound(err) {
@@ -130,8 +130,8 @@ func (cl *Client) DeleteVirtualService(ctx context.Context, name string) error {
 	return nil
 }
 
-func (cl *Client) GetServiceEntry(ctx context.Context, name string) (*istiov1alpha3.ServiceEntry, error) {
-	serviceEntry, err := cl.IstioClientset.NetworkingV1alpha3().ServiceEntries(cl.Owner.GetNamespace()).Get(ctx, name, metav1.GetOptions{})
+func (cl *Client) GetServiceEntry(ctx context.Context, name string) (*istiov1beta1.ServiceEntry, error) {
+	serviceEntry, err := cl.IstioClientset.NetworkingV1beta1().ServiceEntries(cl.Owner.GetNamespace()).Get(ctx, name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, nil
 	} else if err != nil {
@@ -141,7 +141,7 @@ func (cl *Client) GetServiceEntry(ctx context.Context, name string) (*istiov1alp
 	return serviceEntry, nil
 }
 
-func (cl *Client) CreateOrUpdateServiceEntry(ctx context.Context, newServiceEntry *istiov1alpha3.ServiceEntry) error {
+func (cl *Client) CreateOrUpdateServiceEntry(ctx context.Context, newServiceEntry *istiov1beta1.ServiceEntry) error {
 	if newServiceEntry == nil {
 		return errors.New("can't create service entry based on nil object")
 	}
@@ -171,12 +171,12 @@ func (cl *Client) CreateOrUpdateServiceEntry(ctx context.Context, newServiceEntr
 	return cl.updateServiceEntry(ctx, oldServiceEntry, newServiceEntry)
 }
 
-func (cl *Client) createServiceEntry(ctx context.Context, serviceEntry *istiov1alpha3.ServiceEntry) error {
+func (cl *Client) createServiceEntry(ctx context.Context, serviceEntry *istiov1beta1.ServiceEntry) error {
 	if serviceEntry == nil {
 		return errors.New("can't create service entry based on nil object")
 	}
 
-	_, err := cl.IstioClientset.NetworkingV1alpha3().ServiceEntries(cl.Owner.GetNamespace()).Create(ctx, serviceEntry, metav1.CreateOptions{})
+	_, err := cl.IstioClientset.NetworkingV1beta1().ServiceEntries(cl.Owner.GetNamespace()).Create(ctx, serviceEntry, metav1.CreateOptions{})
 	if err != nil {
 		log.Info("failed to create service entry", "name", serviceEntry.GetName(), "error", err.Error())
 		return errors.WithStack(err)
@@ -184,13 +184,13 @@ func (cl *Client) createServiceEntry(ctx context.Context, serviceEntry *istiov1a
 	return nil
 }
 
-func (cl *Client) updateServiceEntry(ctx context.Context, oldServiceEntry, newServiceEntry *istiov1alpha3.ServiceEntry) error {
+func (cl *Client) updateServiceEntry(ctx context.Context, oldServiceEntry, newServiceEntry *istiov1beta1.ServiceEntry) error {
 	if oldServiceEntry == nil || newServiceEntry == nil {
 		return errors.New("can't update service entry based on nil object")
 	}
 
 	newServiceEntry.ObjectMeta.ResourceVersion = oldServiceEntry.ObjectMeta.ResourceVersion
-	_, err := cl.IstioClientset.NetworkingV1alpha3().ServiceEntries(cl.Owner.GetNamespace()).Update(ctx, newServiceEntry, metav1.UpdateOptions{})
+	_, err := cl.IstioClientset.NetworkingV1beta1().ServiceEntries(cl.Owner.GetNamespace()).Update(ctx, newServiceEntry, metav1.UpdateOptions{})
 	if err != nil {
 		log.Info("failed to update service entry", "name", newServiceEntry.GetName(), "error", err.Error())
 		return errors.WithStack(err)
@@ -199,7 +199,7 @@ func (cl *Client) updateServiceEntry(ctx context.Context, oldServiceEntry, newSe
 }
 
 func (cl *Client) DeleteServiceEntry(ctx context.Context, name string) error {
-	err := cl.IstioClientset.NetworkingV1alpha3().
+	err := cl.IstioClientset.NetworkingV1beta1().
 		ServiceEntries(cl.Owner.GetNamespace()).
 		Delete(ctx, name, metav1.DeleteOptions{})
 	if !k8serrors.IsNotFound(err) {

--- a/pkg/controllers/dynakube/istio/client_test.go
+++ b/pkg/controllers/dynakube/istio/client_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	fakeistio "istio.io/client-go/pkg/clientset/versioned/fake"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,7 +77,7 @@ func TestCreateVirtualService(t *testing.T) {
 		err := client.createVirtualService(ctx, expectedVirtualService)
 
 		require.NoError(t, err)
-		serviceEntry, err := fakeClient.NetworkingV1alpha3().VirtualServices(expectedVirtualService.Namespace).Get(ctx, expectedVirtualService.Name, metav1.GetOptions{})
+		serviceEntry, err := fakeClient.NetworkingV1beta1().VirtualServices(expectedVirtualService.Namespace).Get(ctx, expectedVirtualService.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, expectedVirtualService.Name, serviceEntry.Name)
 		assert.Equal(t, expectedVirtualService.Namespace, serviceEntry.Namespace)
@@ -131,7 +131,7 @@ func TestUpdateVirtualService(t *testing.T) {
 		err := client.updateVirtualService(ctx, oldVirtualService, newVirtualService)
 
 		require.NoError(t, err)
-		updatedServiceEntry, err := fakeClient.NetworkingV1alpha3().VirtualServices(oldVirtualService.Namespace).Get(ctx, oldVirtualService.Name, metav1.GetOptions{})
+		updatedServiceEntry, err := fakeClient.NetworkingV1beta1().VirtualServices(oldVirtualService.Namespace).Get(ctx, oldVirtualService.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, newVirtualService.Name, updatedServiceEntry.Name)
 		assert.Equal(t, newVirtualService.Namespace, updatedServiceEntry.Namespace)
@@ -188,7 +188,7 @@ func TestCreateOrUpdateVirtualService(t *testing.T) {
 		require.NoError(t, err)
 		// Get, Create
 		assert.Len(t, fakeClient.Actions(), 2)
-		virtualService, err := fakeClient.NetworkingV1alpha3().VirtualServices(expectedVirtualService.Namespace).Get(ctx, expectedVirtualService.Name, metav1.GetOptions{})
+		virtualService, err := fakeClient.NetworkingV1beta1().VirtualServices(expectedVirtualService.Namespace).Get(ctx, expectedVirtualService.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, expectedVirtualService.Name, virtualService.Name)
 		assert.Equal(t, expectedVirtualService.Namespace, virtualService.Namespace)
@@ -213,7 +213,7 @@ func TestCreateOrUpdateVirtualService(t *testing.T) {
 		require.NoError(t, err)
 		// Get, Update
 		assert.Len(t, fakeClient.Actions(), 2)
-		updatedVirtualService, err := fakeClient.NetworkingV1alpha3().VirtualServices(oldVirtualService.Namespace).Get(ctx, oldVirtualService.Name, metav1.GetOptions{})
+		updatedVirtualService, err := fakeClient.NetworkingV1beta1().VirtualServices(oldVirtualService.Namespace).Get(ctx, oldVirtualService.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, newVirtualService.Name, updatedVirtualService.Name)
 		assert.Equal(t, newVirtualService.Namespace, updatedVirtualService.Namespace)
@@ -271,7 +271,7 @@ func TestDeleteVirtualService(t *testing.T) {
 		err := client.DeleteVirtualService(ctx, virtualService.Name)
 
 		require.NoError(t, err)
-		_, err = fakeClient.NetworkingV1alpha3().VirtualServices(virtualService.Namespace).Get(ctx, virtualService.Name, metav1.GetOptions{})
+		_, err = fakeClient.NetworkingV1beta1().VirtualServices(virtualService.Namespace).Get(ctx, virtualService.Name, metav1.GetOptions{})
 		require.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run("does not exist => no error", func(t *testing.T) {
@@ -339,7 +339,7 @@ func TestCreateServiceEntry(t *testing.T) {
 		err := client.createServiceEntry(ctx, expectedServiceEntry)
 
 		require.NoError(t, err)
-		serviceEntry, err := fakeClient.NetworkingV1alpha3().ServiceEntries(expectedServiceEntry.Namespace).Get(ctx, expectedServiceEntry.Name, metav1.GetOptions{})
+		serviceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(expectedServiceEntry.Namespace).Get(ctx, expectedServiceEntry.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, expectedServiceEntry.Name, serviceEntry.Name)
 		assert.Equal(t, expectedServiceEntry.Namespace, serviceEntry.Namespace)
@@ -393,7 +393,7 @@ func TestUpdateServiceEntry(t *testing.T) {
 		err := client.updateServiceEntry(ctx, oldServiceEntry, newServiceEntry)
 
 		require.NoError(t, err)
-		updatedServiceEntry, err := fakeClient.NetworkingV1alpha3().ServiceEntries(oldServiceEntry.Namespace).Get(ctx, oldServiceEntry.Name, metav1.GetOptions{})
+		updatedServiceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(oldServiceEntry.Namespace).Get(ctx, oldServiceEntry.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, newServiceEntry.Name, updatedServiceEntry.Name)
 		assert.Equal(t, newServiceEntry.Namespace, updatedServiceEntry.Namespace)
@@ -450,7 +450,7 @@ func TestCreateOrUpdateServiceEntry(t *testing.T) {
 		require.NoError(t, err)
 		// Get, Create
 		assert.Len(t, fakeClient.Actions(), 2)
-		serviceEntry, err := fakeClient.NetworkingV1alpha3().ServiceEntries(expectedServiceEntry.Namespace).Get(ctx, expectedServiceEntry.Name, metav1.GetOptions{})
+		serviceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(expectedServiceEntry.Namespace).Get(ctx, expectedServiceEntry.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, expectedServiceEntry.Name, serviceEntry.Name)
 		assert.Equal(t, expectedServiceEntry.Namespace, serviceEntry.Namespace)
@@ -475,7 +475,7 @@ func TestCreateOrUpdateServiceEntry(t *testing.T) {
 		require.NoError(t, err)
 		// Get, Update
 		assert.Len(t, fakeClient.Actions(), 2)
-		updatedServiceEntry, err := fakeClient.NetworkingV1alpha3().ServiceEntries(oldServiceEntry.Namespace).Get(ctx, oldServiceEntry.Name, metav1.GetOptions{})
+		updatedServiceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(oldServiceEntry.Namespace).Get(ctx, oldServiceEntry.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, newServiceEntry.Name, updatedServiceEntry.Name)
 		assert.Equal(t, newServiceEntry.Namespace, updatedServiceEntry.Namespace)
@@ -533,7 +533,7 @@ func TestDeleteServiceEntry(t *testing.T) {
 		err := client.DeleteServiceEntry(ctx, serviceEntry.Name)
 
 		require.NoError(t, err)
-		_, err = fakeClient.NetworkingV1alpha3().ServiceEntries(serviceEntry.Namespace).Get(ctx, serviceEntry.Name, metav1.GetOptions{})
+		_, err = fakeClient.NetworkingV1beta1().ServiceEntries(serviceEntry.Namespace).Get(ctx, serviceEntry.Name, metav1.GetOptions{})
 		require.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run("does not exist => no error", func(t *testing.T) {
@@ -556,8 +556,8 @@ func TestDeleteServiceEntry(t *testing.T) {
 	})
 }
 
-func createTestEmptyServiceEntry() *istiov1alpha3.ServiceEntry {
-	return &istiov1alpha3.ServiceEntry{
+func createTestEmptyServiceEntry() *istiov1beta1.ServiceEntry {
+	return &istiov1beta1.ServiceEntry{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
@@ -565,8 +565,8 @@ func createTestEmptyServiceEntry() *istiov1alpha3.ServiceEntry {
 	}
 }
 
-func createTestEmptyVirtualService() *istiov1alpha3.VirtualService {
-	return &istiov1alpha3.VirtualService{
+func createTestEmptyVirtualService() *istiov1beta1.VirtualService {
+	return &istiov1beta1.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",

--- a/pkg/controllers/dynakube/istio/config.go
+++ b/pkg/controllers/dynakube/istio/config.go
@@ -15,7 +15,7 @@ const (
 	OneAgentComponent   = "oneagent"
 	ActiveGateComponent = "activegate"
 	IstioGVRName        = "networking.istio.io"
-	IstioGVRVersion     = "v1alpha3"
+	IstioGVRVersion     = "v1beta1"
 )
 
 var (

--- a/pkg/controllers/dynakube/istio/reconciler_test.go
+++ b/pkg/controllers/dynakube/istio/reconciler_test.go
@@ -9,7 +9,7 @@ import (
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	fakeistio "istio.io/client-go/pkg/clientset/versioned/fake"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +51,7 @@ func TestReconcileIPServiceEntry(t *testing.T) {
 	dynakube := createTestDynaKube()
 
 	t.Run("empty communication host => delete if previously created", func(t *testing.T) {
-		serviceEntry := &istiov1alpha3.ServiceEntry{
+		serviceEntry := &istiov1beta1.ServiceEntry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      BuildNameForIPServiceEntry(dynakube.Name, component),
 				Namespace: dynakube.Namespace,
@@ -63,7 +63,7 @@ func TestReconcileIPServiceEntry(t *testing.T) {
 
 		err := reconciler.reconcileIPServiceEntry(ctx, nil, component)
 		require.NoError(t, err)
-		_, err = fakeClient.NetworkingV1alpha3().ServiceEntries(serviceEntry.Namespace).Get(ctx, serviceEntry.Name, metav1.GetOptions{})
+		_, err = fakeClient.NetworkingV1beta1().ServiceEntries(serviceEntry.Namespace).Get(ctx, serviceEntry.Name, metav1.GetOptions{})
 		require.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run("success", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestReconcileIPServiceEntry(t *testing.T) {
 		err := reconciler.reconcileIPServiceEntry(ctx, commHosts, component)
 		require.NoError(t, err)
 		expectedName := BuildNameForIPServiceEntry(dynakube.Name, component)
-		serviceEntry, err := fakeClient.NetworkingV1alpha3().ServiceEntries(dynakube.Namespace).Get(ctx, expectedName, metav1.GetOptions{})
+		serviceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(dynakube.Namespace).Get(ctx, expectedName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
 	})
@@ -102,13 +102,13 @@ func TestReconcileFQDNServiceEntry(t *testing.T) {
 	owner := createTestDynaKube()
 
 	t.Run("empty communication host => delete if previously created", func(t *testing.T) {
-		serviceEntry := &istiov1alpha3.ServiceEntry{
+		serviceEntry := &istiov1beta1.ServiceEntry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      BuildNameForFQDNServiceEntry(owner.GetName(), component),
 				Namespace: owner.GetNamespace(),
 			},
 		}
-		virtualService := &istiov1alpha3.VirtualService{
+		virtualService := &istiov1beta1.VirtualService{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      BuildNameForFQDNServiceEntry(owner.GetName(), component),
 				Namespace: owner.GetNamespace(),
@@ -120,9 +120,9 @@ func TestReconcileFQDNServiceEntry(t *testing.T) {
 
 		err := reconciler.reconcileFQDNServiceEntry(ctx, nil, component)
 		require.NoError(t, err)
-		_, err = fakeClient.NetworkingV1alpha3().ServiceEntries(serviceEntry.Namespace).Get(ctx, serviceEntry.Name, metav1.GetOptions{})
+		_, err = fakeClient.NetworkingV1beta1().ServiceEntries(serviceEntry.Namespace).Get(ctx, serviceEntry.Name, metav1.GetOptions{})
 		require.True(t, k8serrors.IsNotFound(err))
-		_, err = fakeClient.NetworkingV1alpha3().VirtualServices(serviceEntry.Namespace).Get(ctx, virtualService.Name, metav1.GetOptions{})
+		_, err = fakeClient.NetworkingV1beta1().VirtualServices(serviceEntry.Namespace).Get(ctx, virtualService.Name, metav1.GetOptions{})
 		require.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run("success", func(t *testing.T) {
@@ -136,10 +136,10 @@ func TestReconcileFQDNServiceEntry(t *testing.T) {
 		err := reconciler.reconcileFQDNServiceEntry(ctx, commHosts, component)
 		require.NoError(t, err)
 		expectedName := BuildNameForFQDNServiceEntry(owner.GetName(), component)
-		serviceEntry, err := fakeClient.NetworkingV1alpha3().ServiceEntries(owner.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
+		serviceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(owner.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
-		virtualService, err := fakeClient.NetworkingV1alpha3().VirtualServices(owner.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
+		virtualService, err := fakeClient.NetworkingV1beta1().VirtualServices(owner.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, virtualService)
 	})
@@ -185,10 +185,10 @@ func TestReconcileAPIUrl(t *testing.T) {
 		err := reconciler.ReconcileAPIUrl(ctx, dynakube)
 		require.NoError(t, err)
 		expectedName := BuildNameForFQDNServiceEntry(dynakube.GetName(), OperatorComponent)
-		serviceEntry, err := fakeClient.NetworkingV1alpha3().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
+		serviceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
-		virtualService, err := fakeClient.NetworkingV1alpha3().VirtualServices(dynakube.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
+		virtualService, err := fakeClient.NetworkingV1beta1().VirtualServices(dynakube.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, virtualService)
 	})
@@ -222,23 +222,23 @@ func TestReconcileOneAgentCommunicationHosts(t *testing.T) {
 		err := reconciler.ReconcileCommunicationHosts(ctx, dynakube)
 		require.NoError(t, err)
 		expectedFQDNName := BuildNameForFQDNServiceEntry(dynakube.GetName(), OneAgentComponent)
-		serviceEntry, err := fakeClient.NetworkingV1alpha3().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedFQDNName, metav1.GetOptions{})
+		serviceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedFQDNName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
 		assert.Contains(t, fmt.Sprintf("%v", serviceEntry), "something.test.io")
 
 		expectedFQDNName = BuildNameForFQDNServiceEntry(dynakube.GetName(), ActiveGateComponent)
-		serviceEntry, err = fakeClient.NetworkingV1alpha3().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedFQDNName, metav1.GetOptions{})
+		serviceEntry, err = fakeClient.NetworkingV1beta1().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedFQDNName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
 		assert.Contains(t, fmt.Sprintf("%v", serviceEntry), "abcd123.some.activegate.endpointurl.com")
 
-		virtualService, err := fakeClient.NetworkingV1alpha3().VirtualServices(dynakube.GetNamespace()).Get(ctx, expectedFQDNName, metav1.GetOptions{})
+		virtualService, err := fakeClient.NetworkingV1beta1().VirtualServices(dynakube.GetNamespace()).Get(ctx, expectedFQDNName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, virtualService)
 
 		expectedIPName := BuildNameForIPServiceEntry(dynakube.GetName(), OneAgentComponent)
-		serviceEntry, err = fakeClient.NetworkingV1alpha3().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedIPName, metav1.GetOptions{})
+		serviceEntry, err = fakeClient.NetworkingV1beta1().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedIPName, metav1.GetOptions{})
 
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)

--- a/pkg/controllers/dynakube/istio/serviceentry.go
+++ b/pkg/controllers/dynakube/istio/serviceentry.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	istio "istio.io/api/networking/v1alpha3"
-	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istio "istio.io/api/networking/v1beta1"
+	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -24,7 +24,7 @@ func BuildNameForFQDNServiceEntry(ownerName, component string) string {
 	return ownerName + "-fqdn-" + component
 }
 
-func buildServiceEntryFQDNs(meta metav1.ObjectMeta, hostHosts []dtclient.CommunicationHost) *istiov1alpha3.ServiceEntry {
+func buildServiceEntryFQDNs(meta metav1.ObjectMeta, hostHosts []dtclient.CommunicationHost) *istiov1beta1.ServiceEntry {
 	hosts := make([]string, len(hostHosts))
 	portSet := make(map[uint32]bool)
 	var ports []*istio.ServicePort
@@ -42,7 +42,7 @@ func buildServiceEntryFQDNs(meta metav1.ObjectMeta, hostHosts []dtclient.Communi
 			portSet[commHost.Port] = true
 		}
 	}
-	return &istiov1alpha3.ServiceEntry{
+	return &istiov1beta1.ServiceEntry{
 		ObjectMeta: meta,
 		Spec: istio.ServiceEntry{
 			Hosts:      hosts,
@@ -53,7 +53,7 @@ func buildServiceEntryFQDNs(meta metav1.ObjectMeta, hostHosts []dtclient.Communi
 	}
 }
 
-func buildServiceEntryIPs(meta metav1.ObjectMeta, commHosts []dtclient.CommunicationHost) *istiov1alpha3.ServiceEntry {
+func buildServiceEntryIPs(meta metav1.ObjectMeta, commHosts []dtclient.CommunicationHost) *istiov1beta1.ServiceEntry {
 	var ports []*istio.ServicePort
 	portSet := make(map[uint32]bool)
 	addresses := make([]string, len(commHosts))
@@ -70,7 +70,7 @@ func buildServiceEntryIPs(meta metav1.ObjectMeta, commHosts []dtclient.Communica
 		}
 	}
 
-	return &istiov1alpha3.ServiceEntry{
+	return &istiov1beta1.ServiceEntry{
 		ObjectMeta: meta,
 		Spec: istio.ServiceEntry{
 			Hosts:      []string{ignoredSubdomain},

--- a/pkg/controllers/dynakube/istio/serviceentry_test.go
+++ b/pkg/controllers/dynakube/istio/serviceentry_test.go
@@ -7,8 +7,8 @@ import (
 
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
-	istio "istio.io/api/networking/v1alpha3"
-	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istio "istio.io/api/networking/v1beta1"
+	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -27,7 +27,7 @@ func TestServiceEntryGeneration(t *testing.T) {
 	)
 
 	t.Run(`generate with hostname`, func(t *testing.T) {
-		expected := &istiov1alpha3.ServiceEntry{
+		expected := &istiov1beta1.ServiceEntry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -61,7 +61,7 @@ func TestServiceEntryGeneration(t *testing.T) {
 		assert.NotEqualValues(t, expected, result)
 	})
 	t.Run(`generate with two different hostnames and same port`, func(t *testing.T) {
-		expected := &istiov1alpha3.ServiceEntry{
+		expected := &istiov1beta1.ServiceEntry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -93,7 +93,7 @@ func TestServiceEntryGeneration(t *testing.T) {
 	})
 	t.Run(`generate with Ip`, func(t *testing.T) {
 		const testIp = "42.42.42.42"
-		expected := &istiov1alpha3.ServiceEntry{
+		expected := &istiov1beta1.ServiceEntry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -132,7 +132,7 @@ func TestServiceEntryGeneration(t *testing.T) {
 			testIp  = "42.42.42.42"
 			testIp1 = "42.42.42.43"
 		)
-		expected := &istiov1alpha3.ServiceEntry{
+		expected := &istiov1beta1.ServiceEntry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -201,8 +201,8 @@ func TestBuildServiceEntryIp(t *testing.T) {
 	assert.NotEqualValues(t, expected, result)
 }
 
-func buildExpectedServiceEntryForHostname(_ *testing.T) *istiov1alpha3.ServiceEntry {
-	return &istiov1alpha3.ServiceEntry{
+func buildExpectedServiceEntryForHostname(_ *testing.T) *istiov1beta1.ServiceEntry {
+	return &istiov1beta1.ServiceEntry{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -221,8 +221,8 @@ func buildExpectedServiceEntryForHostname(_ *testing.T) *istiov1alpha3.ServiceEn
 	}
 }
 
-func buildExpectedServiceEntryForIp(_ *testing.T) *istiov1alpha3.ServiceEntry {
-	return &istiov1alpha3.ServiceEntry{
+func buildExpectedServiceEntryForIp(_ *testing.T) *istiov1beta1.ServiceEntry {
+	return &istiov1beta1.ServiceEntry{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,

--- a/pkg/controllers/dynakube/istio/virtualservice.go
+++ b/pkg/controllers/dynakube/istio/virtualservice.go
@@ -4,8 +4,8 @@ import (
 	"net"
 
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	istio "istio.io/api/networking/v1alpha3"
-	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istio "istio.io/api/networking/v1beta1"
+	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,7 +14,7 @@ const (
 	protocolHttps = "https"
 )
 
-func buildVirtualService(meta metav1.ObjectMeta, commHosts []dtclient.CommunicationHost) *istiov1alpha3.VirtualService {
+func buildVirtualService(meta metav1.ObjectMeta, commHosts []dtclient.CommunicationHost) *istiov1beta1.VirtualService {
 	var nonIPhosts []dtclient.CommunicationHost
 
 	for _, commHost := range commHosts {
@@ -26,7 +26,7 @@ func buildVirtualService(meta metav1.ObjectMeta, commHosts []dtclient.Communicat
 		return nil
 	}
 
-	return &istiov1alpha3.VirtualService{
+	return &istiov1beta1.VirtualService{
 		ObjectMeta: meta,
 		Spec:       buildVirtualServiceSpec(nonIPhosts),
 	}

--- a/pkg/controllers/dynakube/istio/virtualservice_test.go
+++ b/pkg/controllers/dynakube/istio/virtualservice_test.go
@@ -6,8 +6,8 @@ import (
 
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
-	istio "istio.io/api/networking/v1alpha3"
-	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istio "istio.io/api/networking/v1beta1"
+	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -29,7 +29,7 @@ func TestVirtualServiceGeneration(t *testing.T) {
 	)
 
 	t.Run("generate for tls connection", func(t *testing.T) {
-		expected := &istiov1alpha3.VirtualService{
+		expected := &istiov1beta1.VirtualService{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -60,7 +60,7 @@ func TestVirtualServiceGeneration(t *testing.T) {
 		assert.EqualValues(t, expected, result)
 	})
 	t.Run("generate for http connection", func(t *testing.T) {
-		expected := &istiov1alpha3.VirtualService{
+		expected := &istiov1beta1.VirtualService{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,

--- a/test/helpers/istio/install.go
+++ b/test/helpers/istio/install.go
@@ -131,7 +131,7 @@ func checkVirtualServiceForApiUrl(dynakube dynatracev1beta1.DynaKube) features.F
 		apiHost := apiUrlCommunicationHost(t, dynakube)
 		serviceName := istio.BuildNameForFQDNServiceEntry(dynakube.Name, istio.OperatorComponent)
 
-		virtualService, err := istioClient(t, envConfig.Client().RESTConfig()).NetworkingV1alpha3().VirtualServices(dynakube.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		virtualService, err := istioClient(t, envConfig.Client().RESTConfig()).NetworkingV1beta1().VirtualServices(dynakube.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
 		require.Nil(t, err, "istio: failed to get '%s' virtual service object", serviceName)
 
 		require.NotEmpty(t, virtualService.ObjectMeta.OwnerReferences)
@@ -149,7 +149,7 @@ func checkServiceEntryForApiUrl(dynakube dynatracev1beta1.DynaKube) features.Fun
 		apiHost := apiUrlCommunicationHost(t, dynakube)
 		serviceName := istio.BuildNameForFQDNServiceEntry(dynakube.Name, istio.OperatorComponent)
 
-		serviceEntry, err := istioClient(t, envConfig.Client().RESTConfig()).NetworkingV1alpha3().ServiceEntries(dynakube.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		serviceEntry, err := istioClient(t, envConfig.Client().RESTConfig()).NetworkingV1beta1().ServiceEntries(dynakube.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
 		require.Nil(t, err, "istio: failed to get '%s' service entry object", serviceName)
 
 		require.NotEmpty(t, serviceEntry.ObjectMeta.OwnerReferences)


### PR DESCRIPTION
## Description
There are `v1beta1` versions of `ServiceEntry`, `VirtualService` CR's available. The operator still uses `v1alpha3` version of the isito CR's and it should be updated.

## How can this be tested?
Install operator with istio enabled from the `main` branch (using `make deploy..` command). Deploy CloudNative Dynakube. Install/update operator from the PR's branch (using `make deploy..` command). After update is finished the `ServiceEntries` and `VirtualServices` should have the same contents (endpoints may be in a different order).

Istio e2e tests should PASS.
```
make test/e2e/istio
```

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
