### PR TITLE
Add skipCertCheck to image library

### DIFF
--- a/pkg/oci/registry/client.go
+++ b/pkg/oci/registry/client.go
@@ -199,6 +199,15 @@ func addCertificates(transport *http.Transport, trustedCAs []byte) (*http.Transp
 	return transport, nil
 }
 
+func addSkipCertCheck(transport *http.Transport, skipCertCheck bool) *http.Transport {
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{} // nolint:gosec
+	}
+	transport.TLSClientConfig.InsecureSkipVerify = skipCertCheck
+
+	return transport
+}
+
 // PrepareTransportForDynaKube creates default http transport and add proxy or trustedCAs if any
 func PrepareTransportForDynaKube(ctx context.Context, apiReader client.Reader, transport *http.Transport, dynakube *dynatracev1beta1.DynaKube) (*http.Transport, error) {
 	var (
@@ -233,6 +242,8 @@ func PrepareTransportForDynaKube(ctx context.Context, apiReader client.Reader, t
 			return nil, err
 		}
 	}
+
+	transport = addSkipCertCheck(transport, dynakube.Spec.SkipCertCheck)
 
 	return transport, nil
 }


### PR DESCRIPTION
## Description

Currently the skipCert Check parameter is not correctly propagated to the image library. Which means that the dtclient transport uses correctly the skipCert Check parameter but the version reconciler fails to get the image manifest in case of untrusted/self-signed certificase


## How can this be tested?

Create a dynakube with skipCertCheck enabled, check if it is enabled for the communication with the image library

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
