### PR TITLE
Fix e2e otel secret creation

### DIFF
--- a/test/scenarios/istio/istio_test.go
+++ b/test/scenarios/istio/istio_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 	testEnv.BeforeEachTest(istio.AssertIstiodDeployment())
 	testEnv.Setup(
 		namespace.CreateForEnv(nsWithIstio),
-		tenant.CreateOtelSecret(nsWithIstio.Namespace),
+		tenant.CreateOtelSecret(nsWithIstio.Name),
 		operator.InstallViaMake(true),
 	)
 	// If we cleaned up during a fail-fast (aka.: /debug) it wouldn't be possible to investigate the error.


### PR DESCRIPTION
## Description

`nsWithIstio.Namespace` is empty, which caused the error: 
```
F1116 01:15:25.193648   12580 env.go:375] Setup failure: an empty namespace may not be set during creation
```

## How can this be tested?

run `make test/e2e/istio` and you have the otel secret setup locally 

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
