### PR TITLE
Update hostMonitoring sample to use new command

### DIFF
--- a/assets/samples/hostMonitoring.yaml
+++ b/assets/samples/hostMonitoring.yaml
@@ -136,7 +136,7 @@ spec:
       # For a list of the limitations for OneAgents in Docker, see https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
       #
       args:
-        - --set-infra-only=true
+        - --set-monitoring-mode=infra
 
   # Configuration for ActiveGate instances.
   #


### PR DESCRIPTION
## Description

In https://github.com/Dynatrace/dynatrace-operator/pull/2301 we updated the hostMonitoring sample with the command: `--set-infra-only `
This command is actually deprecated, so with this the sample is updated with: `--set-monitoring-mode`

## How can this be tested?

## Checklist

- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
