### PR TITLE
Add default oneagent initial retry in case of istio

### DIFF
--- a/pkg/api/v1beta1/dynakube/feature_flags.go
+++ b/pkg/api/v1beta1/dynakube/feature_flags.go
@@ -119,8 +119,9 @@ const (
 )
 
 const (
-	DefaultMaxFailedCsiMountAttempts  = 10
-	DefaultMinRequestThresholdMinutes = 15
+	DefaultMaxFailedCsiMountAttempts        = 10
+	DefaultMinRequestThresholdMinutes       = 15
+	IstioDefaultOneAgentInitialConnectRetry = 6000
 )
 
 var (
@@ -309,7 +310,15 @@ func (dk *DynaKube) FeatureLabelVersionDetection() bool {
 
 // FeatureAgentInitialConnectRetry is a feature flag to configure startup delay of standalone agents
 func (dk *DynaKube) FeatureAgentInitialConnectRetry() int {
-	return dk.getFeatureFlagInt(AnnotationFeatureOneAgentInitialConnectRetry, -1)
+	defaultValue := -1
+	ffValue := dk.getFeatureFlagInt(AnnotationFeatureOneAgentInitialConnectRetry, defaultValue)
+
+	// In case of istio, we want to have a longer initial delay for codemodules to ensure the DT service is created consistently
+	if ffValue == defaultValue && dk.Spec.EnableIstio {
+		ffValue = IstioDefaultOneAgentInitialConnectRetry
+	}
+
+	return ffValue
 }
 
 func (dk *DynaKube) FeatureOneAgentPrivileged() bool {

--- a/pkg/api/v1beta1/dynakube/feature_flags_test.go
+++ b/pkg/api/v1beta1/dynakube/feature_flags_test.go
@@ -319,3 +319,27 @@ func TestInjectionFailurePolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentInitialConnectRetry(t *testing.T) {
+	t.Run("default => not set", func(t *testing.T) {
+		dynakube := createDynakubeEmptyDynakube()
+
+		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		require.Equal(t, -1, initialRetry)
+	})
+	t.Run("istio default => set", func(t *testing.T) {
+		dynakube := createDynakubeEmptyDynakube()
+		dynakube.Spec.EnableIstio = true
+
+		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		require.Equal(t, IstioDefaultOneAgentInitialConnectRetry, initialRetry)
+	})
+	t.Run("istio default can be overruled", func(t *testing.T) {
+		dynakube := createDynakubeEmptyDynakube()
+		dynakube.Spec.EnableIstio = true
+		dynakube.Annotations[AnnotationFeatureOneAgentInitialConnectRetry] = "5"
+
+		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		require.Equal(t, 5, initialRetry)
+	})
+}


### PR DESCRIPTION
## Description
When istio is injected alongside the oneagent codemodules then the DT service is created a bit inconsistently, that can hinder automated testing, so increasing the initial retry will make them consistent.

## How can this be tested?
Dynakube with `enableIstio: true`, in a injected sample app's namespace the `dynatrace-dynakube-config` secret should have a `initialConnectRetry` set. (so not -1)

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
