### PR TITLE
Add managed-by-operator parameter when creating edgeConnect resources

### DIFF
--- a/pkg/clients/edgeconnect/client.go
+++ b/pkg/clients/edgeconnect/client.go
@@ -154,9 +154,9 @@ func (c *client) getServerResponseData(response *http.Response) ([]byte, error) 
 
 // GetEdgeConnect returns edge connect if it exists
 func (c *client) GetEdgeConnect(edgeConnectId string) (GetResponse, error) {
-	url := c.getEdgeConnectUrl(edgeConnectId)
+	edgeConnectUrl := c.getEdgeConnectUrl(edgeConnectId)
 
-	resp, err := c.httpClient.Get(url)
+	resp, err := c.httpClient.Get(edgeConnectUrl)
 	defer utils.CloseBodyAfterRequest(resp)
 
 	if err != nil {
@@ -179,7 +179,7 @@ func (c *client) GetEdgeConnect(edgeConnectId string) (GetResponse, error) {
 
 // UpdateEdgeConnect updates existing edge connect hostPatterns and oauthClientId
 func (c *client) UpdateEdgeConnect(edgeConnectId, name string, hostPatterns []string, oauthClientId string) error {
-	url := c.getEdgeConnectUrl(edgeConnectId)
+	edgeConnectUrl := c.getEdgeConnectUrl(edgeConnectId)
 
 	body := NewRequest(name, hostPatterns, oauthClientId)
 	payloadBuf := new(bytes.Buffer)
@@ -188,7 +188,7 @@ func (c *client) UpdateEdgeConnect(edgeConnectId, name string, hostPatterns []st
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodPut, url, payloadBuf)
+	req, err := http.NewRequest(http.MethodPut, edgeConnectUrl, payloadBuf)
 	if err != nil {
 		return err
 	}
@@ -216,9 +216,9 @@ func (c *client) UpdateEdgeConnect(edgeConnectId, name string, hostPatterns []st
 
 // DeleteEdgeConnect deletes edge connect using DELETE method for give edgeConnectId
 func (c *client) DeleteEdgeConnect(edgeConnectId string) error {
-	url := c.getEdgeConnectUrl(edgeConnectId)
+	edgeConnectUrl := c.getEdgeConnectUrl(edgeConnectId)
 
-	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	req, err := http.NewRequest(http.MethodDelete, edgeConnectUrl, nil)
 	if err != nil {
 		return err
 	}
@@ -275,9 +275,9 @@ func (c *client) CreateEdgeConnect(name string, hostPatterns []string, oauthClie
 
 // GetEdgeConnects returns list of edge connects
 func (c *client) GetEdgeConnects(name string) (ListResponse, error) {
-	ecUrl := c.getEdgeConnectsUrl()
+	edgeConnectsUrl := c.getEdgeConnectsUrl()
 
-	req, err := http.NewRequest("GET", ecUrl, nil)
+	req, err := http.NewRequest("GET", edgeConnectsUrl, nil)
 	if err != nil {
 		return ListResponse{}, err
 	}

--- a/pkg/clients/edgeconnect/client.go
+++ b/pkg/clients/edgeconnect/client.go
@@ -181,11 +181,7 @@ func (c *client) GetEdgeConnect(edgeConnectId string) (GetResponse, error) {
 func (c *client) UpdateEdgeConnect(edgeConnectId, name string, hostPatterns []string, oauthClientId string) error {
 	url := c.getEdgeConnectUrl(edgeConnectId)
 
-	body := &Request{
-		Name:          name,
-		HostPatterns:  hostPatterns,
-		OauthClientId: oauthClientId,
-	}
+	body := NewRequest(name, hostPatterns, oauthClientId)
 	payloadBuf := new(bytes.Buffer)
 	err := json.NewEncoder(payloadBuf).Encode(body)
 	if err != nil {
@@ -247,20 +243,16 @@ func (c *client) DeleteEdgeConnect(edgeConnectId string) error {
 
 // CreateEdgeConnect creates new edge connect
 func (c *client) CreateEdgeConnect(name string, hostPatterns []string, oauthClientId string) (CreateResponse, error) {
-	url := c.getEdgeConnectsUrl()
+	edgeConnectsUrl := c.getEdgeConnectsUrl()
 
-	body := &Request{
-		Name:          name,
-		HostPatterns:  hostPatterns,
-		OauthClientId: oauthClientId,
-	}
+	body := NewRequest(name, hostPatterns, oauthClientId)
 	payloadBuf := new(bytes.Buffer)
 	err := json.NewEncoder(payloadBuf).Encode(body)
 	if err != nil {
 		return CreateResponse{}, err
 	}
 
-	resp, err := c.httpClient.Post(url, contentTypeJSON, payloadBuf)
+	resp, err := c.httpClient.Post(edgeConnectsUrl, contentTypeJSON, payloadBuf)
 	defer utils.CloseBodyAfterRequest(resp)
 
 	if err != nil {

--- a/pkg/clients/edgeconnect/edgeconnect.go
+++ b/pkg/clients/edgeconnect/edgeconnect.go
@@ -20,12 +20,13 @@ type Instance struct {
 }
 
 type GetResponse struct {
-	ID               string           `json:"id,omitempty"`
-	Name             string           `json:"name"`
-	HostPatterns     []string         `json:"hostPatterns"`
-	OauthClientId    string           `json:"oauthClientId"`
-	ModificationInfo ModificationInfo `json:"modificationInfo"`
-	Metadata         Metadata         `json:"metadata"`
+	ID                         string           `json:"id,omitempty"`
+	Name                       string           `json:"name"`
+	HostPatterns               []string         `json:"hostPatterns"`
+	OauthClientId              string           `json:"oauthClientId"`
+	ModificationInfo           ModificationInfo `json:"modificationInfo"`
+	Metadata                   Metadata         `json:"metadata"`
+	ManagedByDynatraceOperator bool             `json:"managedByDynatraceOperator,omitempty"`
 }
 
 type ListResponse struct {
@@ -34,18 +35,29 @@ type ListResponse struct {
 }
 
 type CreateResponse struct {
-	ID                  string           `json:"id,omitempty"`
-	Name                string           `json:"name"`
-	HostPatterns        []string         `json:"hostPatterns"`
-	OauthClientId       string           `json:"oauthClientId"`
-	OauthClientSecret   string           `json:"oauthClientSecret"`
-	OauthClientResource string           `json:"oauthClientResource"`
-	ModificationInfo    ModificationInfo `json:"modificationInfo"`
-	Metadata            Metadata         `json:"metadata"`
+	ID                         string           `json:"id,omitempty"`
+	Name                       string           `json:"name"`
+	HostPatterns               []string         `json:"hostPatterns"`
+	OauthClientId              string           `json:"oauthClientId"`
+	OauthClientSecret          string           `json:"oauthClientSecret"`
+	OauthClientResource        string           `json:"oauthClientResource"`
+	ModificationInfo           ModificationInfo `json:"modificationInfo"`
+	Metadata                   Metadata         `json:"metadata"`
+	ManagedByDynatraceOperator bool             `json:"managedByDynatraceOperator,omitempty"`
 }
 
 type Request struct {
-	Name          string   `json:"name"`
-	HostPatterns  []string `json:"hostPatterns"`
-	OauthClientId string   `json:"oauthClientId,omitempty"`
+	Name                       string   `json:"name"`
+	HostPatterns               []string `json:"hostPatterns"`
+	OauthClientId              string   `json:"oauthClientId,omitempty"`
+	ManagedByDynatraceOperator bool     `json:"managedByDynatraceOperator,omitempty"`
+}
+
+func NewRequest(name string, hostPatterns []string, oauthClientId string) *Request {
+	return &Request{
+		Name:                       name,
+		HostPatterns:               hostPatterns,
+		OauthClientId:              oauthClientId,
+		ManagedByDynatraceOperator: true,
+	}
 }


### PR DESCRIPTION
## Description

This PR adds an additional parameter to the create and update request of the edge connect client to tell the tenant that the request originated from the operator.

## How can this be tested?

- Run unit tests or 
- create edge connect and check if the parameter is there in the tenant

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
