### PR TITLE
fail more silently when there is NO otel-config secret

### DIFF
--- a/pkg/util/otel/otel.go
+++ b/pkg/util/otel/otel.go
@@ -22,7 +22,7 @@ func Start(ctx context.Context, otelServiceName string, apiReader client.Reader,
 	endpoint, apiToken, err := getOtelConfig(ctx, apiReader, webhookNamespace)
 
 	if err != nil {
-		log.Error(err, "failed to read OpenTelementry config secret")
+		log.Info("failed to read OpenTelementry config secret", "err", err.Error())
 		return setupNoopOTel()
 	}
 


### PR DESCRIPTION
## Description

We should fail more silently when there is NO otel-config secret

## How can this be tested?

Run operator without otel-secret:

Before:

```
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator {"error":"secrets \"dynatrace-operator-otel-config\" not found","level":"error","logger":"open-telemetry","msg":"failed to read OpenTelementry config secret","stacktrace":"secrets \"dynatrace-operator-otel-config\" not found
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret.Query.Get
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret/secret.go:35
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator github.com/Dynatrace/dynatrace-operator/pkg/util/otel.getOtelConfig
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   github.com/Dynatrace/dynatrace-operator/pkg/util/otel/otel.go:93
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator github.com/Dynatrace/dynatrace-operator/pkg/util/otel.Start
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   github.com/Dynatrace/dynatrace-operator/pkg/util/otel/otel.go:22
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator github.com/Dynatrace/dynatrace-operator/cmd/operator.CommandBuilder.runOperatorManager
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   github.com/Dynatrace/dynatrace-operator/cmd/operator/builder.go:181
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator github.com/Dynatrace/dynatrace-operator/cmd/operator.CommandBuilder.runInPod
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   github.com/Dynatrace/dynatrace-operator/cmd/operator/builder.go:153
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator main.main.CommandBuilder.Build.CommandBuilder.buildRun.func1
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   github.com/Dynatrace/dynatrace-operator/cmd/operator/builder.go:134
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator github.com/spf13/cobra.(*Command).execute
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   github.com/spf13/cobra@v1.8.0/command.go:983
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator github.com/spf13/cobra.(*Command).ExecuteC
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   github.com/spf13/cobra@v1.8.0/command.go:1115
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator github.com/spf13/cobra.(*Command).Execute
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   github.com/spf13/cobra@v1.8.0/command.go:1039
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator main.main
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   github.com/Dynatrace/dynatrace-operator/cmd/main.go:115
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator runtime.main
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator   runtime/proc.go:267
dynatrace-operator-f4448bb68-6bxkb dynatrace-operator runtime.goexit
```

**After:**
```
{"level":"info","ts":"2023-11-22T16:10:55.140+0100","logger":"main","msg":"Wait completed, proceeding to shutdown the manager"}
{"level":"info","ts":"2023-11-22T16:10:55.564+0100","logger":"open-telemetry","msg":"failed to read OpenTelementry config secret","err":"secrets \"dynatrace-operator-otel-config\" not found"}
{"level":"info","ts":"2023-11-22T16:10:55.564+0100","logger":"open-telemetry","msg":"use Noop providers for OpenTelemetry"}
{"level":"info","ts":"2023-11-22T16:10:55.564+0100","logger":"main.controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2023-11-22T16:10:55.564+0100","logger":"main.controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
{"level":"info","ts":"2023-11-22T16:10:55.564+0100","logger":"main","msg":"starting server","kind":"health probe","addr":"[::]:10080"}

```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
