### PR TITLE
Remove unnecessary build tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
         with:
           # renovate depName=github.com/golangci/golangci-lint
           version: v1.55.2
-          args: --build-tags containers_image_storage_stub,e2e --timeout 300s --out-${NO_FUTURE}format colored-line-number
+          args: --build-tags e2e --timeout 300s --out-${NO_FUTURE}format colored-line-number
 
   security:
     name: Code security scanning alerts

--- a/hack/build/create_go_build_tags.sh
+++ b/hack/build/create_go_build_tags.sh
@@ -8,22 +8,12 @@ fi
 needs_e2e_tag=$1
 
 go_build_tags=(
-    # Needed for the image library(https://github.com/containers/image), to use the open go implementation of gpgme. creating new signatures is not possible but we never do that
-    "containers_image_openpgp"
-
      # If CGO is enabled, certain standard libraries will also use CGO, these explicitly disallow that
     "osusergo"
     "netgo"
 
     # Disables the ability to add load extensions for sqlite3, needed to statically build when using the sqlite library. We never use extensions so its good to disable it.
     "sqlite_omit_load_extension"
-
-    # Removes the containers-storage/docker-daemon parts of the image library(https://github.com/containers/image) as we are not using it.
-    # More info about the disabled parts:
-    # - https://github.com/containers/image/blob/main/docs/containers-transports.5.md#containers-storagestorage-specifierimage-iddocker-referenceimage-id
-    # - https://github.com/containers/image/blob/main/docs/containers-transports.5.md#docker-daemondocker-referencealgodigest
-    "containers_image_storage_stub"
-    "containers_image_docker_daemon_stub"
 )
 
 if "${needs_e2e_tag}"; then


### PR DESCRIPTION
## Description

Since we recently we switched the image library we are using, we can remove the build tags we introduced specifically for this old library.

## How can this be tested?

Not really testable, build should work and the operator has to run as before

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
