### PR TITLE
Default injection failure policy to force

### DIFF
--- a/pkg/api/v1beta1/dynakube/feature_flags.go
+++ b/pkg/api/v1beta1/dynakube/feature_flags.go
@@ -354,13 +354,14 @@ func (dk *DynaKube) FeatureSyntheticLocationEntityId() string {
 }
 
 func (dk *DynaKube) FeatureInjectionFailurePolicy() string {
-	if dk.getFeatureFlagRaw(AnnotationInjectionFailurePolicy) == failPhrase {
+	switch phrase := dk.getFeatureFlagRaw(AnnotationInjectionFailurePolicy); phrase {
+	case failPhrase:
 		return failPhrase
-	}
-	if dk.getFeatureFlagRaw(AnnotationInjectionFailurePolicy) == forcePhrase {
+	case silentPhrase:
+		return silentPhrase
+	default:
 		return forcePhrase
 	}
-	return silentPhrase
 }
 
 func (dk *DynaKube) FeaturePublicRegistry() bool {

--- a/pkg/api/v1beta1/dynakube/feature_flags_test.go
+++ b/pkg/api/v1beta1/dynakube/feature_flags_test.go
@@ -291,7 +291,7 @@ func TestDefaultEnabledFeatureFlags(t *testing.T) {
 	assert.True(t, dynakube.FeatureActiveGateReadOnlyFilesystem())
 	assert.True(t, dynakube.FeatureAutomaticKubernetesApiMonitoring())
 	assert.True(t, dynakube.FeatureAutomaticInjection())
-	assert.True(t, dynakube.FeatureInjectionFailurePolicy() == "silent")
+	assert.True(t, dynakube.FeatureInjectionFailurePolicy() == "force")
 
 	assert.False(t, dynakube.FeatureDisableActiveGateUpdates())
 	assert.False(t, dynakube.FeatureDisableHostsRequests())
@@ -308,8 +308,8 @@ func TestInjectionFailurePolicy(t *testing.T) {
 		failPhrase:   failPhrase,
 		silentPhrase: silentPhrase,
 		forcePhrase:  forcePhrase,
-		"Fail":       silentPhrase,
-		"other":      silentPhrase,
+		"Fail":       forcePhrase,
+		"other":      forcePhrase,
 	}
 	for configuredMode, expectedMode := range modes {
 		t.Run(`injection failure policy: `+configuredMode, func(t *testing.T) {

--- a/pkg/webhook/mutation/pod_mutator/init_container_test.go
+++ b/pkg/webhook/mutation/pod_mutator/init_container_test.go
@@ -144,7 +144,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		assert.True(t, env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "fail")
 		assert.False(t, env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "silent")
 	})
-	t.Run("should set default failure policy to silent", func(t *testing.T) {
+	t.Run("should set default failure policy to force", func(t *testing.T) {
 		dynakube := getTestDynakube()
 		dynakube.Annotations = map[string]string{dynatracev1beta1.AnnotationInjectionFailurePolicy: "test"}
 		pod := getTestPod()
@@ -154,7 +154,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
 
 		assert.False(t, env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "fail")
-		assert.True(t, env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "silent")
+		assert.True(t, env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "force")
 	})
 	t.Run("should take silent as failure policy if set explicitly", func(t *testing.T) {
 		dynakube := getTestDynakube()


### PR DESCRIPTION
## Description

This PR change default value of `feature.dynatrace.com/injection-failure-policy` to `force`.

## How can this be tested?

unittests

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
