### PR TITLE
Only check the actual activegate container for mounts in e2e test

### DIFF
--- a/test/features/activegate/activegate.go
+++ b/test/features/activegate/activegate.go
@@ -329,7 +329,11 @@ func assertReadOnlyVolumeMounts(t *testing.T, activeGatePod corev1.Pod) {
 		},
 	}
 
-	for _, r := range expectedVolumeMounts {
-		assert.Contains(t, activeGatePod.Spec.Containers[0].VolumeMounts, r)
+	for _, container := range activeGatePod.Spec.Containers {
+		if container.Name == consts.ActiveGateContainerName {
+			for _, r := range expectedVolumeMounts {
+				assert.Contains(t, container.VolumeMounts, r)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Description

For some reason this used to work, don't really know how.
But in this test case it can be that we inject the activegate with istio, which adds a sidecar, so directly accessing the `Container` array is risky 😅 

## How can this be tested?

`make test/e2e/activegate/proxy` passes

## Checklist

- ~[x] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
