### PR TITLE
Remove restriction to `cluster.local` domain for startup probe

### DIFF
--- a/cmd/startup_probe/builder.go
+++ b/cmd/startup_probe/builder.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	hostname       = "kubernetes.default.svc.cluster.local"
+	hostname       = "kubernetes.default.svc"
 	use            = "startup-probe"
 	defaultTimeout = 5
 )


### PR DESCRIPTION
## Description

Setting hostname for startup probe to `kubernetes.default.svc.cluster.local` has the unnecessary requirement of `cluster.local`, which disallows custom domains.

Fixes #2399 

## How can this be tested?

Startup probe should succeed.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
