### PR TITLE
Make renovate pin versions of markdownlint-cli and helm unittest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,5 +82,15 @@
         "$default"
       ],
     },
+    {
+      "matchPackageNames": ["markdownlint-cli"],
+      "pinVersions": true,
+      "enabled": true
+    },
+    {
+      "packageNames": ["helm-unittest"],
+      "enabled": true,
+      "pinVersions": true,
+    }
   ],
 }

--- a/hack/helm/install-unittest-plugin.sh
+++ b/hack/helm/install-unittest-plugin.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
+desired_version="$1"
+
 ### reintroduced curl due to github rate-limiting our downloads via api calls!   ####
 ### -> unit tests failed as plugin could not be installed correctly              ####
 
 HELM_PLUGINS="$(helm env HELM_PLUGINS)"
-desired_version="$1"
+
 architecture="$(uname -m)"
 os="$(uname -s)"
 

--- a/hack/helm/install-unittest-plugin.sh
+++ b/hack/helm/install-unittest-plugin.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
-desired_version="0.3.2"
-
-
 ### reintroduced curl due to github rate-limiting our downloads via api calls!   ####
 ### -> unit tests failed as plugin could not be installed correctly              ####
 
 HELM_PLUGINS="$(helm env HELM_PLUGINS)"
-
+desired_version="$1"
 architecture="$(uname -m)"
 os="$(uname -s)"
 

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -10,6 +10,10 @@ gci_version=v0.11.2
 golang_tools_version=v0.16.0
 # renovate depName=github.com/vektra/mockery
 mockery_version=v2.38.0
+# renovate depName=github.com/igorshubovych/markdownlint-cli
+markdownlint_cli_version=v0.35.0
+# renovate depName=github.com/helm-unittest/helm-unittest
+helmunittest_version=v0.3.2
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -36,7 +40,7 @@ prerequisites/go-linting:
 ## Install 'helm' if it is missing
 ## TODO: Have version accessible by renovate?
 prerequisites/helm-unittest:
-	hack/helm/install-unittest-plugin.sh
+	hack/helm/install-unittest-plugin.sh $(helmunittest_version)
 
 ## Installs 'kustomize' if it is missing
 prerequisites/kustomize:
@@ -45,9 +49,8 @@ KUSTOMIZE=$(shell hack/build/command.sh kustomize)
 
 ## Install 'markdownlint' if it is missing
 ## `brew` is used, because otherwise we would need to install using `npm`.
-## TODO: Pin version
 prerequisites/markdownlint:
-	brew install markdownlint-cli --quiet
+	brew install markdownlint-cli@$(markdownlint_cli_version) --quiet
 
 ## Install verktra/mockery
 prerequisites/mockery:

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -13,7 +13,7 @@ mockery_version=v2.38.0
 # renovate depName=github.com/igorshubovych/markdownlint-cli
 markdownlint_cli_version=v0.35.0
 # renovate depName=github.com/helm-unittest/helm-unittest
-helmunittest_version=v0.3.2
+helmunittest_version=0.3.2
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
## Description

With this renovate also deals witth the versions of `markdownlint cli` and `helm unittest plugin`.

## How can this be tested?

You can have a lookt at the PRs generated by renovate on my fork: https://github.com/waodim/dynatrace-operator/pulls

## Checklist

- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
