### PR TITLE
Improve helm unittest integration with renovate

### DIFF
--- a/hack/helm/install-unittest-plugin.sh
+++ b/hack/helm/install-unittest-plugin.sh
@@ -33,7 +33,7 @@ fi
 
 helm plugin uninstall unittest || true
 curl \
-  -L "https://github.com/helm-unittest/helm-unittest/releases/download/v${desired_version}/helm-unittest-${PLATFORM}-${ARCH}-${desired_version}.tgz" \
+  -L "https://github.com/helm-unittest/helm-unittest/releases/download/${desired_version}/helm-unittest-${PLATFORM}-${ARCH}-${desired_version//v}.tgz" \
   -o helm-unittest.tgz
 mkdir -p "${HELM_PLUGINS}/unittest"
 tar xzvf helm-unittest.tgz -C "${HELM_PLUGINS}/unittest"

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -13,7 +13,7 @@ mockery_version=v2.38.0
 # renovate depName=github.com/igorshubovych/markdownlint-cli
 markdownlint_cli_version=v0.37.0
 # renovate depName=github.com/helm-unittest/helm-unittest
-helmunittest_version=0.3.2
+helmunittest_version=v0.3.6
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
## Description

Improve helm-unittest renovate integration
 

## How can this be tested?


`helm plugin list` should show you latest helm-unittest:

```
helm plugin list
NAME            VERSION DESCRIPTION
unittest        0.3.6   Unit test for helm chart in YAML with ease to keep your chart functional and robust.
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
