### PR TITLE
Improve markdowncli-lint integration with renovate

### DIFF
--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -50,7 +50,7 @@ KUSTOMIZE=$(shell hack/build/command.sh kustomize)
 ## Install 'markdownlint' if it is missing
 ## `brew` is used, because otherwise we would need to install using `npm`.
 prerequisites/markdownlint:
-	brew install markdownlint-cli@$(markdownlint_cli_version) --quiet
+	brew install markdownlint-cli@$(markdownlint_cli_version:v=) --quiet
 
 ## Install verktra/mockery
 prerequisites/mockery:


### PR DESCRIPTION
## Description

Improve markdowncli-lint integration with renovate

## How can this be tested?

Run: `make prerequisites/markdownlint`

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
