### PR TITLE
Fix e2e proxy.yaml for latest openshift

### DIFF
--- a/test/testdata/network/proxy.yaml
+++ b/test/testdata/network/proxy.yaml
@@ -6,6 +6,9 @@ metadata:
     dynatrace.com/inject: "false"
   labels:
     app: squid
+    pod-security.kubernetes.io/privileged: warn
+    pod-security.kubernetes.io/baseline: warn
+    pod-security.kubernetes.io/restricted: warn
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -90,7 +93,6 @@ spec:
             port: 3128
           initialDelaySeconds: 15
           periodSeconds: 10
-
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
## Description
Newer versions of openshift enforces the Pod Security Admissions, just added a few labels to the proxy namespace, so that it wont be blocked, as its only for e2e tests

## How can this be tested?

`make test/e2e/activegate/proxy` (on openshift 4.14)

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
