### PR TITLE
Remove brew deps for markdownlint and use nodejs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,7 @@ jobs:
         uses: articulate/actions-markdownlint@87f495d21507d6844dc917a01e742eaaa45049c0 # v1.1.0
         with:
           config: .markdownlint.json
+          # renovate depName=github.com/igorshubovych/markdownlint-cli
           version: 0.36.0
 
   check-uncommitted-doc-changes:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,9 +123,7 @@ jobs:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version-file: "${{ github.workspace }}/go.mod"
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+      - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
       - name: Run make doc to see uncommitted changes
         run: make doc
       - name: Check for uncommitted changes

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -50,9 +50,8 @@ prerequisites/kustomize:
 KUSTOMIZE=$(shell hack/build/command.sh kustomize)
 
 ## Install 'markdownlint' if it is missing
-## `brew` is used, because otherwise we would need to install using `npm`.
 prerequisites/markdownlint:
-	brew install markdownlint-cli --quiet
+	npm install -g markdownlint-cli@$(markdownlint_cli_version)
 
 ## Install verktra/mockery
 prerequisites/mockery:


### PR DESCRIPTION
## Description

This PR removes brew, because using brew we can't control versions of packages.
Add missing renovate comment for GH action.

>Note: If you already using brew version:
```
# Run to uninstall
brew uninstall markdownlint-cli
```

## How can this be tested?

CI is green and you can upgrade or downgrade:
```
npm install -g markdownlint-cli@v0.36.0
markdownlint -V
0.36.0
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
