### PR TITLE
Make installCRD default in values.yaml

### DIFF
--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -25,7 +25,7 @@ imageRef:
   tag: "" #defaults to chart version
 
 customPullSecret: ""
-installCRD: false
+installCRD: true
 
 operator:
   nodeSelector: {}


### PR DESCRIPTION
## Description

Please include the following:

As we recently have received several problems that were created because the customer didn't update the CRDs. This is mainly a problem in helm because you specifically have to opt in with the "installCRD: true" option.

## How can this be tested?

Install the helm chart with default values file -> check if CRD is installed

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
