### PR TITLE
Add release branch 0.15 to renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   "extends": [ "config:base" ],
   "labels": [ "dependencies" ],
   "digest": { "enabled": false },
-  "baseBranches": ["$default", "release-0.11", "release-0.12", "release-0.13", "release-0.14"],
+  "baseBranches": ["$default", "release-0.12", "release-0.13", "release-0.14", "release-0.15"],
   "enabledManagers": [ "regex", "dockerfile", "gomod", "github-actions" ],
   "regexManagers": [
     {


### PR DESCRIPTION
## Description

In order to get automatic dependency updates on the new release branch, we have to add the branch to the config

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
