### PR TITLE
Add own feature flag for enforcementMode (#2444)

### DIFF
--- a/pkg/api/v1beta1/dynakube/feature_flags.go
+++ b/pkg/api/v1beta1/dynakube/feature_flags.go
@@ -92,6 +92,7 @@ const (
 	AnnotationFeatureLabelVersionDetection = AnnotationFeaturePrefix + "label-version-detection"
 	AnnotationInjectionFailurePolicy       = AnnotationFeaturePrefix + "injection-failure-policy"
 	AnnotationFeatureInitContainerSeccomp  = AnnotationFeaturePrefix + "init-container-seccomp-profile"
+	AnnotationFeatureEnforcementMode       = AnnotationFeaturePrefix + "enforcement-mode"
 
 	// CSI
 	AnnotationFeatureMaxFailedCsiMountAttempts = AnnotationFeaturePrefix + "max-csi-mount-attempts"
@@ -110,7 +111,6 @@ const (
 	truePhrase   = "true"
 	silentPhrase = "silent"
 	failPhrase   = "fail"
-	forcePhrase  = "force"
 
 	// synthetic node types
 	SyntheticNodeXs = "XS"
@@ -354,14 +354,10 @@ func (dk *DynaKube) FeatureSyntheticLocationEntityId() string {
 }
 
 func (dk *DynaKube) FeatureInjectionFailurePolicy() string {
-	switch phrase := dk.getFeatureFlagRaw(AnnotationInjectionFailurePolicy); phrase {
-	case failPhrase:
+	if dk.getFeatureFlagRaw(AnnotationInjectionFailurePolicy) == failPhrase {
 		return failPhrase
-	case silentPhrase:
-		return silentPhrase
-	default:
-		return forcePhrase
 	}
+	return silentPhrase
 }
 
 func (dk *DynaKube) FeaturePublicRegistry() bool {
@@ -384,4 +380,10 @@ func (dk *DynaKube) FeatureSyntheticReplicas() int32 {
 
 func (dk *DynaKube) FeatureInitContainerSeccomp() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureInitContainerSeccomp) == truePhrase
+}
+
+// FeatureEnforcementMode is a feature flag to control how the initContainer
+// sets the tenantUUID to the container.conf file (always vs if oneAgent is present)
+func (dk *DynaKube) FeatureEnforcementMode() bool {
+	return dk.getFeatureFlagRaw(AnnotationFeatureEnforcementMode) != falsePhrase
 }

--- a/pkg/api/v1beta1/dynakube/feature_flags_test.go
+++ b/pkg/api/v1beta1/dynakube/feature_flags_test.go
@@ -291,7 +291,7 @@ func TestDefaultEnabledFeatureFlags(t *testing.T) {
 	assert.True(t, dynakube.FeatureActiveGateReadOnlyFilesystem())
 	assert.True(t, dynakube.FeatureAutomaticKubernetesApiMonitoring())
 	assert.True(t, dynakube.FeatureAutomaticInjection())
-	assert.True(t, dynakube.FeatureInjectionFailurePolicy() == "force")
+	assert.True(t, dynakube.FeatureInjectionFailurePolicy() == "silent")
 
 	assert.False(t, dynakube.FeatureDisableActiveGateUpdates())
 	assert.False(t, dynakube.FeatureDisableHostsRequests())
@@ -307,9 +307,6 @@ func TestInjectionFailurePolicy(t *testing.T) {
 	modes := map[string]string{
 		failPhrase:   failPhrase,
 		silentPhrase: silentPhrase,
-		forcePhrase:  forcePhrase,
-		"Fail":       forcePhrase,
-		"other":      forcePhrase,
 	}
 	for configuredMode, expectedMode := range modes {
 		t.Run(`injection failure policy: `+configuredMode, func(t *testing.T) {

--- a/pkg/injection/namespace/initgeneration/initgeneration.go
+++ b/pkg/injection/namespace/initgeneration/initgeneration.go
@@ -171,6 +171,7 @@ func (g *InitGenerator) createSecretConfigForDynaKube(ctx context.Context, dynak
 		HostGroup:           dynakube.HostGroup(),
 		ClusterID:           string(kubeSystemUID),
 		InitialConnectRetry: dynakube.FeatureAgentInitialConnectRetry(),
+		EnforcementMode:     dynakube.FeatureEnforcementMode(),
 	}, nil
 }
 

--- a/pkg/injection/namespace/initgeneration/initgeneration_test.go
+++ b/pkg/injection/namespace/initgeneration/initgeneration_test.go
@@ -228,6 +228,7 @@ func TestCreateSecretConfigForDynaKube(t *testing.T) {
 		TlsCert:             "",
 		HostGroup:           "",
 		InitialConnectRetry: -1,
+		EnforcementMode:     true,
 	}
 
 	t.Run("Create SecretConfig with default content", func(t *testing.T) {

--- a/pkg/injection/startup/env.go
+++ b/pkg/injection/startup/env.go
@@ -15,7 +15,6 @@ const (
 	trueStatement = "true"
 	silentPhrase  = "silent"
 	failPhrase    = "fail"
-	forcePhrase   = "force"
 )
 
 type containerInfo struct {
@@ -143,8 +142,6 @@ func (env *environment) addFailurePolicy() error {
 	switch failurePolicy {
 	case failPhrase:
 		env.FailurePolicy = failPhrase
-	case forcePhrase:
-		env.FailurePolicy = forcePhrase
 	default:
 		env.FailurePolicy = silentPhrase
 	}

--- a/pkg/injection/startup/env_test.go
+++ b/pkg/injection/startup/env_test.go
@@ -125,7 +125,6 @@ func TestFailurePolicyModes(t *testing.T) {
 	modes := map[string]string{
 		failPhrase:   failPhrase,
 		silentPhrase: silentPhrase,
-		forcePhrase:  forcePhrase,
 		"Fail":       silentPhrase,
 		"other":      silentPhrase,
 	}

--- a/pkg/injection/startup/run.go
+++ b/pkg/injection/startup/run.go
@@ -110,7 +110,7 @@ func (runner *Runner) setHostTenant() error {
 	log.Info("setting host tenant")
 	runner.hostTenant = consts.AgentNoHostTenant
 	if runner.config.HasHost {
-		if runner.env.FailurePolicy == forcePhrase {
+		if runner.config.EnforcementMode {
 			runner.hostTenant = runner.config.TenantUUID
 			log.Info("host tenant set to TenantUUID")
 		} else {

--- a/pkg/injection/startup/run_test.go
+++ b/pkg/injection/startup/run_test.go
@@ -119,14 +119,14 @@ func TestSetHostTenant(t *testing.T) {
 		assert.Equal(t, consts.AgentNoHostTenant, runner.hostTenant)
 	})
 	t.Run("set hostTenant to TenantUUID", func(t *testing.T) {
-		runner.env.FailurePolicy = forcePhrase
 		runner.config.HasHost = true
 		runner.config.TenantUUID = testTenantUUID
+		runner.config.EnforcementMode = false
+		runner.config.MonitoringNodes = nil
 
 		err := runner.setHostTenant()
 
-		require.NoError(t, err)
-		assert.Equal(t, testTenantUUID, runner.hostTenant)
+		require.Error(t, err)
 	})
 }
 

--- a/pkg/injection/startup/secret.go
+++ b/pkg/injection/startup/secret.go
@@ -28,6 +28,7 @@ type SecretConfig struct {
 	TlsCert             string            `json:"tlsCert"`
 	HostGroup           string            `json:"hostGroup"`
 	InitialConnectRetry int               `json:"initialConnectRetry"`
+	EnforcementMode     bool              `json:"enforcementMode"`
 
 	// For the enrichment
 	ClusterID string `json:"clusterID"`

--- a/pkg/webhook/mutation/pod_mutator/init_container_test.go
+++ b/pkg/webhook/mutation/pod_mutator/init_container_test.go
@@ -144,7 +144,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		assert.True(t, env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "fail")
 		assert.False(t, env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "silent")
 	})
-	t.Run("should set default failure policy to force", func(t *testing.T) {
+	t.Run("should set default failure policy to silent", func(t *testing.T) {
 		dynakube := getTestDynakube()
 		dynakube.Annotations = map[string]string{dynatracev1beta1.AnnotationInjectionFailurePolicy: "test"}
 		pod := getTestPod()
@@ -154,7 +154,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
 
 		assert.False(t, env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "fail")
-		assert.True(t, env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "force")
+		assert.True(t, env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value == "silent")
 	})
 	t.Run("should take silent as failure policy if set explicitly", func(t *testing.T) {
 		dynakube := getTestDynakube()


### PR DESCRIPTION
## Description

Same as in: https://github.com/Dynatrace/dynatrace-operator/pull/2444

## How can this be tested?

Same as in: https://github.com/Dynatrace/dynatrace-operator/pull/2444

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
