### PR TITLE
Fix release branch config for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,10 +24,10 @@
   "packageRules": [
     {
       "matchBaseBranches": [
-        "release-0.11",
         "release-0.12",
         "release-0.13",
         "release-0.14",
+        "release-0.15",
       ],
       "matchUpdateTypes": [
         "major",


### PR DESCRIPTION
## Description

Major and minor updates were not excluded from 0.15 branch, this is fixed with this PR

## How can this be tested?

Check renovate PRs after merging this PR

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
