### PR TITLE
Added errors handling logic to the EdgeConnect controller

### DIFF
--- a/pkg/clients/edgeconnect/client.go
+++ b/pkg/clients/edgeconnect/client.go
@@ -282,7 +282,7 @@ func (c *client) GetEdgeConnects(name string) (ListResponse, error) {
 		return ListResponse{}, err
 	}
 	req.URL.RawQuery = url.Values{
-		"add-fields": {"name"},
+		"add-fields": {"name,managedByDynatraceOperator"},
 		"filter":     {fmt.Sprintf("name='%s'", name)},
 	}.Encode()
 

--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -102,6 +102,11 @@ func (controller *Controller) Reconcile(ctx context.Context, request reconcile.R
 func (controller *Controller) reconcileEdgeConnectDeletion(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect) error {
 	log.Info("reconciling EdgeConnect deletion", "name", edgeConnect.Name, "namespace", edgeConnect.Namespace)
 
+	edgeConnectIdFromSecret, err := controller.getEdgeConnectIdFromClientSecret(ctx, edgeConnect)
+	if err != nil {
+		return err
+	}
+
 	edgeConnect.ObjectMeta.Finalizers = nil
 	if err := controller.client.Update(ctx, edgeConnect); err != nil {
 		return errors.WithStack(err)
@@ -112,18 +117,35 @@ func (controller *Controller) reconcileEdgeConnectDeletion(ctx context.Context, 
 		return err
 	}
 
-	edgeConnectId, err := controller.getEdgeConnectIdFromClientSecret(ctx, edgeConnect)
+	tenantEdgeConnect, err := getEdgeConnectByName(edgeConnectClient, edgeConnect.Name)
 	if err != nil {
 		return err
 	}
 
-	if edgeConnectId == "" {
-		// TODO: managedByDynatraceOperator attribute needed
+	switch {
+	case tenantEdgeConnect.ID == "":
+		log.Info("EdgeConnect not found on the tenant", "name", edgeConnect.Name)
+	case edgeConnectIdFromSecret == "":
 		log.Info("EdgeConnect client secret is missing")
-	} else {
-		if err := edgeConnectClient.DeleteEdgeConnect(edgeConnectId); err != nil {
+		return deleteEdgeConnectFromTenant(tenantEdgeConnect, edgeConnectClient)
+	default:
+		if tenantEdgeConnect.ID != edgeConnectIdFromSecret {
+			log.Info("EdgeConnect client secret contains invalid Id")
+		}
+		return deleteEdgeConnectFromTenant(tenantEdgeConnect, edgeConnectClient)
+	}
+
+	return nil
+}
+
+func deleteEdgeConnectFromTenant(tenantEdgeConnect edgeconnect.GetResponse, edgeConnectClient edgeconnect.Client) error {
+	if tenantEdgeConnect.ManagedByDynatraceOperator {
+		log.Info("deleting EdgeConnect", "name", tenantEdgeConnect.Name)
+		if err := edgeConnectClient.DeleteEdgeConnect(tenantEdgeConnect.ID); err != nil {
 			return err
 		}
+	} else {
+		return errors.Errorf("can't delete EdgeConnect (%s) from the tenant because it isn't managed by the Operator", tenantEdgeConnect.Name)
 	}
 	return nil
 }
@@ -268,7 +290,7 @@ func (controller *Controller) reconcileEdgeConnectProvisioner(ctx context.Contex
 		return err
 	}
 
-	edgeConnectId, err := getEdgeConnectIdByName(edgeConnectClient, edgeConnect.Name)
+	tenantEdgeConnect, err := getEdgeConnectByName(edgeConnectClient, edgeConnect.Name)
 	if err != nil {
 		return err
 	}
@@ -278,25 +300,23 @@ func (controller *Controller) reconcileEdgeConnectProvisioner(ctx context.Contex
 		return err
 	}
 
-	if edgeConnectId != "" {
+	if tenantEdgeConnect.ID != "" {
 		if edgeConnectIdFromSecret == "" {
 			log.Info("EdgeConnect has to be recreated due to missing secret")
-			// TODO: managedByDynatraceOperator attribute needed
-			if err := edgeConnectClient.DeleteEdgeConnect(edgeConnectId); err != nil {
+			if err := deleteEdgeConnectFromTenant(tenantEdgeConnect, edgeConnectClient); err != nil {
 				return err
 			}
-			edgeConnectId = ""
-		} else if edgeConnectId != edgeConnectIdFromSecret {
-			// TODO: managedByDynatraceOperator attribute needed
+			tenantEdgeConnect.ID = ""
+		} else if tenantEdgeConnect.ID != edgeConnectIdFromSecret {
 			log.Info("EdgeConnect has to be recreated due to invalid Id")
-			if err := edgeConnectClient.DeleteEdgeConnect(edgeConnectId); err != nil {
+			if err := deleteEdgeConnectFromTenant(tenantEdgeConnect, edgeConnectClient); err != nil {
 				return err
 			}
-			edgeConnectId = ""
+			tenantEdgeConnect.ID = ""
 		}
 	}
 
-	if edgeConnectId == "" {
+	if tenantEdgeConnect.ID == "" {
 		err := controller.createEdgeConnect(ctx, edgeConnectClient, edgeConnect)
 		if err != nil {
 			return err
@@ -365,20 +385,20 @@ func newEdgeConnectClient() func(ctx context.Context, edgeConnect *edgeconnectv1
 	}
 }
 
-func getEdgeConnectIdByName(edgeConnectClient edgeconnect.Client, name string) (string, error) {
+func getEdgeConnectByName(edgeConnectClient edgeconnect.Client, name string) (edgeconnect.GetResponse, error) {
 	ecs, err := edgeConnectClient.GetEdgeConnects(name)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return edgeconnect.GetResponse{}, errors.WithStack(err)
 	}
 
 	if len(ecs.EdgeConnects) > 1 {
-		return "", errors.New("many EdgeConnects have the same name")
+		return edgeconnect.GetResponse{}, errors.New("many EdgeConnects have the same name")
 	}
 
 	if len(ecs.EdgeConnects) > 0 {
-		return ecs.EdgeConnects[0].ID, nil
+		return ecs.EdgeConnects[0], nil
 	}
-	return "", nil
+	return edgeconnect.GetResponse{}, nil
 }
 
 func (controller *Controller) getEdgeConnectIdFromClientSecret(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect) (string, error) {

--- a/pkg/controllers/edgeconnect/controller_test.go
+++ b/pkg/controllers/edgeconnect/controller_test.go
@@ -597,10 +597,11 @@ func mockNewEdgeConnectClientUpdate(edgeConnectClient *mocksedgeconnect.Client) 
 			edgeconnect.ListResponse{
 				EdgeConnects: []edgeconnect.GetResponse{
 					{
-						ID:            testCreatedId,
-						Name:          testName,
-						HostPatterns:  testHostPatterns,
-						OauthClientId: testOauthClientId,
+						ID:                         testCreatedId,
+						Name:                       testName,
+						HostPatterns:               testHostPatterns,
+						OauthClientId:              testOauthClientId,
+						ManagedByDynatraceOperator: true,
 					},
 				},
 				TotalCount: 1,


### PR DESCRIPTION
## Description
Based on `managedByDynatraceOperator` attribute the EdgeConnect controller is able to properly handle errors:
- deleted edgeconnect client secret
- invalid EdgeConnect.ID on the tenant

## How can this be tested?
1) 
- deploy EdgeConnect (`provisioner` mode enabled)
- remember ID of EdgeConnect
- remove `-client` secret (`kubectl delete secret <name>-client`)
EdgeConnect on the tenant and the `-client` secret should be created from scratch so ID should be different

2)
- deploy EdgeConnect (`provisioner` mode enabled)
- change ID in the client secret (`kubectl edit secret <>-client`)
EdgeConnect on the tenant and the `-client` secret should be created from scratch so ID should be different
3)
- deploy EdgeConnect (`provisioner` mode enabled)
- remove `-client` secret
- delete EdgeConnect CR
EdgeConnect on the tenant should be also deleted
4) 
- create EdgeConnect on the tenant
- deploy EdgeConnect CR (`provisioner` mode enabled)
An error should be reported in the operator logs
```
{"level":"info","ts":"...","logger":"edgeconnect","msg":"can't delete EdgeConnect configuration from the tenant because it has been created manually by a user","name":"ec-test"}
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
