### PR TITLE
Revert oneagent-ready fail safe and increase timeout

### DIFF
--- a/test/helpers/kubeobjects/daemonset/wait.go
+++ b/test/helpers/kubeobjects/daemonset/wait.go
@@ -27,7 +27,7 @@ func WaitFor(name string, namespace string) env.Func {
 			daemonset, isDaemonset := object.(*appsv1.DaemonSet)
 			return isDaemonset && daemonset.Status.DesiredNumberScheduled == daemonset.Status.UpdatedNumberScheduled &&
 				daemonset.Status.DesiredNumberScheduled == daemonset.Status.NumberReady
-		}), wait.WithTimeout(5*time.Minute))
+		}), wait.WithTimeout(10*time.Minute))
 		return ctx, err
 	}
 }

--- a/test/helpers/kubeobjects/daemonset/wait.go
+++ b/test/helpers/kubeobjects/daemonset/wait.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/logger"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
@@ -14,11 +13,6 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
-)
-
-var (
-	log     = logger.Factory.GetLogger("main")
-	timeout = 5 * time.Minute
 )
 
 func WaitFor(name string, namespace string) env.Func {
@@ -33,11 +27,7 @@ func WaitFor(name string, namespace string) env.Func {
 			daemonset, isDaemonset := object.(*appsv1.DaemonSet)
 			return isDaemonset && daemonset.Status.DesiredNumberScheduled == daemonset.Status.UpdatedNumberScheduled &&
 				daemonset.Status.DesiredNumberScheduled == daemonset.Status.NumberReady
-		}), wait.WithTimeout(timeout))
-		// Workaround to make OCP tests pass on 'oneagent_started' step
-		if err != nil {
-			log.Info("WARNING: OneAgent deamonset timed out getting ready (%ss) [%s]", timeout, err)
-		}
-		return ctx, nil
+		}), wait.WithTimeout(5*time.Minute))
+		return ctx, err
 	}
 }


### PR DESCRIPTION
## Description

Revert previous commit and increase e2e oneagent-ready timeout to 10 min

## How can this be tested?

Trigger OCP pipelines after merging and hopefully they pass

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
