### PR TITLE
Fix location of version package

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -13,7 +13,7 @@ resources:
   group: dynatrace
   domain: com
   kind: DynaKube
-  path: github.com/Dynatrace/dynatrace-operator/src/api/v1alpha1
+  path: github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1
   version: v1alpha1
   webhooks:
     conversion: true
@@ -24,7 +24,7 @@ resources:
   group: dynatrace
   domain: com
   kind: DynaKube
-  path: github.com/Dynatrace/dynatrace-operator/src/api/v1beta1
+  path: github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1
   version: v1beta1
   controller: true
   webhooks:

--- a/hack/build/bundle.sh
+++ b/hack/build/bundle.sh
@@ -40,7 +40,7 @@ if [ -n "${BUNDLE_DEFAULT_CHANNEL}" ]; then
     SDK_PARAMS+=("${BUNDLE_DEFAULT_CHANNEL}")
 fi
 
-"${OPERATOR_SDK}" generate kustomize manifests -q --apis-dir ./src/api/
+"${OPERATOR_SDK}" generate kustomize manifests -q --apis-dir ./pkg/api/
 (cd "config/deploy/${PLATFORM}" && ${KUSTOMIZE} edit set image quay.io/dynatrace/dynatrace-operator:snapshot="${OLM_IMAGE}")
 "${KUSTOMIZE}" build "config/olm/${PLATFORM}" | "${OPERATOR_SDK}" generate bundle --overwrite --version "${VERSION}" "${SDK_PARAMS[@]}"
 "${OPERATOR_SDK}" bundle validate ./bundle

--- a/hack/build/create_go_linker_args.sh
+++ b/hack/build/create_go_linker_args.sh
@@ -11,9 +11,9 @@ commit=$2
 
 build_date="$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
 go_linker_args=(
-  "-X 'github.com/Dynatrace/dynatrace-operator/src/version.Version=${version}'"
-  "-X 'github.com/Dynatrace/dynatrace-operator/src/version.Commit=${commit}'"
-  "-X 'github.com/Dynatrace/dynatrace-operator/src/version.BuildDate=${build_date}'"
+  "-X 'github.com/Dynatrace/dynatrace-operator/pkg/version.Version=${version}'"
+  "-X 'github.com/Dynatrace/dynatrace-operator/pkg/version.Commit=${commit}'"
+  "-X 'github.com/Dynatrace/dynatrace-operator/pkg/version.BuildDate=${build_date}'"
   "-extldflags=-static -s -w"
 )
 echo "${go_linker_args[*]}"


### PR DESCRIPTION
## Description

Version package was moved to a different package and build still pointed to old location.

## How can this be tested?

Log output of Operator startup correctly shows version, commit hash and build date.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
