### PR TITLE
Fix wrong cosign public key file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -340,7 +340,7 @@ jobs:
           COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
         run: |
           mkdir -p tmp
-          echo ${COSIGN_PUBLIC_KEY} > tmp/cosign.pub
+          echo ${COSIGN_PUBLIC_KEY} | base64 -d > tmp/cosign.pub
       - name: Create pre-release
         uses: softprops/action-gh-release@v1
         if: ${{ contains(github.ref, '-rc.') }}


### PR DESCRIPTION
## Description
 Current the cosign public key file was a file without multilines, but cosign verify expects a proper public certificate, which has multi-lines. We now store it base65 encoded in our GH secretes and decode it, when writing it the the release artefacts

## How can this be tested?

`cosign verify --key <path to your keyfile> dynatrace/dynatrace-operator:v0.15.0`

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
