### PR TITLE
Validate namespaceSelector.MatchExpression as well

### DIFF
--- a/pkg/webhook/validation/dynakube/config.go
+++ b/pkg/webhook/validation/dynakube/config.go
@@ -34,7 +34,7 @@ var validators = []validator{
 	invalidSyntheticNodeType,
 	nameViolatesDNS1035,
 	nameTooLong,
-	namespaceSelectorMatchLabelsViolateLabelSpec,
+	namespaceSelectorViolateLabelSpec,
 }
 
 var warnings = []validator{

--- a/pkg/webhook/validation/dynakube/namespace_selector.go
+++ b/pkg/webhook/validation/dynakube/namespace_selector.go
@@ -38,10 +38,8 @@ func conflictingNamespaceSelector(ctx context.Context, dv *dynakubeValidator, dy
 	return ""
 }
 
-func namespaceSelectorMatchLabelsViolateLabelSpec(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
-	matchLabels := dynakube.NamespaceSelector().MatchLabels
-
-	errs := validation.ValidateLabels(matchLabels, field.NewPath("spec", "namespaceSelector", "matchLabels"))
+func namespaceSelectorViolateLabelSpec(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+	errs := validation.ValidateLabelSelector(dynakube.NamespaceSelector(), validation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: false}, field.NewPath("spec", "namespaceSelector"))
 	if len(errs) == 0 {
 		return ""
 	}


### PR DESCRIPTION
## Description

We only validated the `matchLabels` part of the `namespaceSelector`, and we didn't care about the `matchExpression` part.

## How can this be tested?
In the `namespaceSelector` use label values that are not allowed by kubernetes,
then the dynakube should be denied via the validation webhook

Example label values:
```
			"name%",
			"name/",
			"AMuchTooLongLabelThatGoesOverSixtyThreeCharactersAndSoIsInvalidAccordingToSpec",
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
