### PR TITLE
Research OpenFeature API for OneAgent multi version support (non-working PoC)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/open-feature/go-sdk v1.9.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
 github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/open-feature/go-sdk v1.9.0 h1:1Nyj+XNHfL0rRGZgGCbZ29CHDD57PQJL7Q/2ZbW/E8c=
+github.com/open-feature/go-sdk v1.9.0/go.mod h1:n5BM4DfvIiKaWWquZnL/yVihcGM5aLsz7rNYE3BkXAM=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc4 h1:oOxKUJWnFC4YGHCCMNql1x4YaDfYBTS5Y4x/Cgeo1E0=

--- a/pkg/util/feature/OneAgnetConfigMapSample.yaml
+++ b/pkg/util/feature/OneAgnetConfigMapSample.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-oneagent-features
+data:
+
+#EvaluationContext: per OneAgent version a file mount?
+#     |
+#<----+----->
+  oneagent-v1.properties: |
+    param1=1
+    param2=sampletext
+  oneagent-v2.properties: |
+    param1=2
+    param2=text
+
+
+---
+#perator pod snippet to mount ConfigMap
+volumeMounts:
+  - name: oneagent-features
+    mountPath: "/supported-oneagent-versions"
+    readOnly: true
+volumes:
+  # You set volumes at the Pod level, then mount them into containers inside that Pod
+  - name: config
+    configMap:
+      # Provide the name of the ConfigMap you want to mount.
+      name: oneagent-features
+      # An array of keys from the ConfigMap to create as files
+      items:
+        - key: "oneagent-v1.properties"
+          path: "oneagent-v1.properties"
+        - key: "oneagent-v2.properties"
+          path: "oneagent-v2.properties"

--- a/pkg/util/feature/config_map_feature_provider.go
+++ b/pkg/util/feature/config_map_feature_provider.go
@@ -1,0 +1,103 @@
+package feature
+
+import (
+	"context"
+	"fmt"
+	"github.com/open-feature/go-sdk/openfeature"
+	"google.golang.org/appengine/log"
+	"strconv"
+)
+
+// ConfigMapFeatureProvider implements the OpenFeatureProvider interface
+type ConfigMapFeatureProvider struct {
+	// cach the file contents?
+
+}
+
+var _ openfeature.FeatureProvider = &ConfigMapFeatureProvider{}
+
+func (k *ConfigMapFeatureProvider) Metadata() openfeature.Metadata {
+	// return information about supported OneAgent versions?
+	panic("implement me")
+}
+
+func (k *ConfigMapFeatureProvider) BooleanEvaluation(ctx context.Context, flag string, defaultValue bool, evalCtx openfeature.FlattenedContext) openfeature.BoolResolutionDetail {
+	oneagentVersion := evalCtx[openfeature.TargetingKey].(string)
+	if !oneagentVersionSupported(oneagentVersion) {
+		log.Warningf(ctx, "Oneagent Version %s not supported", oneagentVersion)
+		return openfeature.BoolResolutionDetail{
+			Value:                    defaultValue,
+			ProviderResolutionDetail: generateOneAgentVersionNotSupportedResultionDetail(),
+		}
+	}
+	err, stringValue := getFlag(ctx, oneagentVersion, flag)
+	if err != nil {
+		// handle error
+		return openfeature.BoolResolutionDetail{}
+	}
+	// return happy path
+	return createBoolResolutionDetail(stringValue)
+}
+
+func createBoolResolutionDetail(value string) openfeature.BoolResolutionDetail {
+	boolValue, err := strconv.ParseBool(value)
+
+	if err != nil {
+		fmt.Println("Error:", err)
+		return generateConversionErrorResolutionDetail(value)
+	}
+	return openfeature.BoolResolutionDetail{
+		Value:                    boolValue,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{},
+	}
+}
+
+func generateConversionErrorResolutionDetail(value string) openfeature.BoolResolutionDetail {
+	return openfeature.BoolResolutionDetail{} // fill in error msg
+}
+
+func getFlag(ctx context.Context, version string, flag string) (error, string) {
+	// load file for oneagnetVersion
+	// looks up flag
+	// return stringValue if found; err otherwise
+	return nil, ""
+}
+
+func oneagentVersionSupported(version string) bool {
+	// iterate over all .property files mounted in the /supported-oneagent-versions dir
+	return true
+}
+
+func generateOneAgentVersionNotSupportedResultionDetail() openfeature.ProviderResolutionDetail {
+	return openfeature.ProviderResolutionDetail{
+		ResolutionError: openfeature.ResolutionError{},
+		Reason:          "OneAgent version not supported",
+		Variant:         "",
+		FlagMetadata:    nil,
+	}
+}
+
+func (k *ConfigMapFeatureProvider) StringEvaluation(ctx context.Context, flag string, defaultValue string, evalCtx openfeature.FlattenedContext) openfeature.StringResolutionDetail {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (k *ConfigMapFeatureProvider) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, evalCtx openfeature.FlattenedContext) openfeature.FloatResolutionDetail {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (k *ConfigMapFeatureProvider) IntEvaluation(ctx context.Context, flag string, defaultValue int64, evalCtx openfeature.FlattenedContext) openfeature.IntResolutionDetail {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (k *ConfigMapFeatureProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue interface{}, evalCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (k *ConfigMapFeatureProvider) Hooks() []openfeature.Hook {
+	// TODO implement me
+	panic("implement me")
+}


### PR DESCRIPTION
## Description

a possible solution on how to use K8s ConfigMaps to model differences in OneAgent multi version support.
One possibility would be to mount one property file for each supported version and determine supported versions by listing all mounted files.

Solution includes a quick mockup of a ConfigMap, some addition to the operator pod to mount the CM. A very drafty FeatureProvider implementation showcases how flags are made available from the CM via the OpenFeature API.

## How can this be tested?

not intended to be run- just for discussion.

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
