### PR TITLE
Remove check before pull-secret generation

### DIFF
--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -204,7 +204,7 @@ func TestSetupTokensAndClient(t *testing.T) {
 			Name:      "this-is-a-name",
 			Namespace: "dynatrace",
 		},
-		Spec: dynatracev1beta1.DynaKubeSpec{APIURL: "this-is-an-api-url"},
+		Spec: dynatracev1beta1.DynaKubeSpec{APIURL: "https://test123.dev.dynatracelabs.com/api"},
 	}
 
 	t.Run("no tokens => error + condition", func(t *testing.T) {
@@ -253,6 +253,7 @@ func TestSetupTokensAndClient(t *testing.T) {
 		// There is also a pull-secret created here, however testing it here is a bit counterintuitive.
 		// TODO: Make the pull-secret reconciler mockable, so we can improve this test.
 		dynakube := dynakubeBase.DeepCopy()
+		dynakube.Spec.CustomPullSecret = "custom"
 		tokens := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      dynakube.Tokens(),

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -37,9 +37,9 @@ func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.S
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	/* TODO: Introduce cleanup, and also this is would not be needed every case,
-	if we don't want to do anything with images, then its not necessary,
-	but other parts of the code would also need to be updated to handle this scenario.
+	/* TODO: Introduce cleanup, and also, this would not be needed in every case,
+	if we don't want to do anything with images, then it's not necessary,
+	but other parts of the code must also be updated to handle this scenario.
 	*/
 	if r.dynakube.Spec.CustomPullSecret == "" {
 		err := r.reconcilePullSecret(ctx)

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -37,10 +37,10 @@ func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.S
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	if !r.dynakube.NeedsOneAgent() && !r.dynakube.NeedsActiveGate() {
-		return nil // TODO: Introduce cleanup
-	}
-
+	/* TODO: Introduce cleanup, and also this is would not be needed every case,
+	if we don't want to do anything with images, then its not necessary,
+	but other parts of the code would also need to be updated to handle this scenario.
+	*/
 	if r.dynakube.Spec.CustomPullSecret == "" {
 		err := r.reconcilePullSecret(ctx)
 		if err != nil {

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -20,32 +20,6 @@ const (
 )
 
 func TestReconciler_Reconcile(t *testing.T) {
-	t.Run("Skip in case not necessary", func(t *testing.T) {
-		dynakube := &dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: testNamespace,
-				Name:      testName,
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-			},
-		}
-		fakeClient := fake.NewClient()
-		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, dynakube, token.Tokens{
-			dtclient.DynatraceApiToken: token.Token{Value: testValue},
-		})
-
-		err := r.Reconcile(context.Background())
-
-		assert.NoError(t, err)
-
-		var pullSecret corev1.Secret
-		err = fakeClient.Get(context.Background(),
-			client.ObjectKey{Name: dynakube.PullSecretName(), Namespace: testNamespace},
-			&pullSecret)
-
-		assert.Error(t, err)
-	})
 	t.Run(`Create works with minimal setup`, func(t *testing.T) {
 		dynakube := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description
Remove a check that is meant to save a bit on requests by only creating the pull-secret when necessary, because in case of applicationMonitoring we don't really need it (unless codeModulesImage is used).

However other parts of the code requires this pull secret to be there, even its not used.
Fixing that would be take longer and should be done with lots of care.

So I remove this very minor "improvement" so that we don't break things

## How can this be tested?

Deploy `applicationMonitoring` dynakube

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
