### PR TITLE
Add podman if docker cli is missing

### DIFF
--- a/hack/build/build_image.sh
+++ b/hack/build/build_image.sh
@@ -19,7 +19,14 @@ out_image="${image}:${tag}"
 
 # directory required by docker copy command
 mkdir -p third_party_licenses
-docker build . -f ./Dockerfile -t "${out_image}" \
+
+if ! command -v docker
+  CONTAINER_CMD=docker
+then
+  CONTAINER_CMD=podman
+fi
+
+${CONTAINER_CMD} build . -f ./Dockerfile -t "${out_image}" \
   --build-arg "GO_LINKER_ARGS=${go_linker_args}" \
   --build-arg "GO_BUILD_TAGS=${go_build_tags}" \
   --label "quay.expires-after=14d"

--- a/hack/build/push_image.sh
+++ b/hack/build/push_image.sh
@@ -12,4 +12,11 @@ image=${1}
 tag=${2}
 
 out_image="${image}:${tag}"
-docker push "${out_image}"
+
+if ! command -v docker
+  CONTAINER_CMD=docker
+then
+  CONTAINER_CMD=podman
+fi
+
+${CONTAINER_CMD} push "${out_image}"


### PR DESCRIPTION
## Description

Add podman if docker cli is missing #2542


## How can this be tested?

run: `make images/build/push`

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
