### PR TITLE
Add the Helm OCI repository in the Helm README

### DIFF
--- a/config/helm/chart/default/README.md
+++ b/config/helm/chart/default/README.md
@@ -16,6 +16,7 @@ Install the Dynatrace Operator via Helm by running the following commands.
 > [official help page](https://www.dynatrace.com/support/help/shortlink/k8s-helm)
 
 #### For versions older than 0.15.0
+
 Add `dynatrace` helm repository:
 
 ```console
@@ -35,7 +36,6 @@ Install `dynatrace-operator` helm chart using the OCI repository and create the 
 ```console
 helm install dynatrace-operator oci://docker.io/dynatrace/dynatrace-operator  -n dynatrace --create-namespace --atomic
 ```
-
 
 ## Uninstall chart
 

--- a/config/helm/chart/default/README.md
+++ b/config/helm/chart/default/README.md
@@ -15,6 +15,7 @@ Install the Dynatrace Operator via Helm by running the following commands.
 > For instructions on how to install the dynatrace-operator on Openshift, head to the
 > [official help page](https://www.dynatrace.com/support/help/shortlink/k8s-helm)
 
+#### For versions older than 0.15.0
 Add `dynatrace` helm repository:
 
 ```console
@@ -26,6 +27,15 @@ Install `dynatrace-operator` helm chart and create the corresponding `dynatrace`
 ```console
 helm install dynatrace-operator dynatrace/dynatrace-operator -n dynatrace --create-namespace --atomic
 ```
+
+#### For versions 0.15.0 and after
+
+Install `dynatrace-operator` helm chart using the OCI repository and create the corresponding `dynatrace` namespace:
+
+```console
+helm install dynatrace-operator oci://docker.io/dynatrace/dynatrace-operator  -n dynatrace --create-namespace --atomic
+```
+
 
 ## Uninstall chart
 


### PR DESCRIPTION
## Description

We want to point our ArtifactHub to the "new" OCI repository we use for our Helm releases.
Because ArtifactHub displays the README, we need to make sure that it mentions the OCI repository and from which version its available.

~⚠️ Only merge after our ArtifactHub repo has been updated to use the OCI url~ (this actually shouldn't matter)

## How can this be tested?

Read the README 😅

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
