### PR TITLE
Add the image digest in manifests created by GitHub action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -279,7 +279,7 @@ jobs:
 
   release:
     name: Create release
-    needs: [prepare, build, attach-sbom]
+    needs: [prepare, build, attach-sbom, manifest]
     environment: Release
     permissions:
       contents: write
@@ -311,10 +311,10 @@ jobs:
         run: |
           make manifests/crd/release CHART_VERSION="${VERSION_WITHOUT_PREFIX}"
 
-          make manifests/kubernetes/olm IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}"
-          make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}"
-          make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}"
-          make manifests/openshift IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}"
+          make manifests/kubernetes/olm IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
+          make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
+          make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
+          make manifests/openshift IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
       - name: Rename manifests if pre-release
         if: ${{ contains(github.ref, '-rc.') }}
         run: |


### PR DESCRIPTION
## Description

Images in our release manifests are referenced using version@sha.. tag. For example:
```
image: public.ecr.aws/dynatrace/dynatrace-operator:v1.2.3@sha256:2f24a7e4295d4b005730d00e5952acb543ab1371b751f5a1e7bf1c65543a4807
```
`release` job uses SHA provided by `manifest` job. 

## How can this be tested?

I use forked project. See [Kubernetes](https://github.com/abcxyzdef123654/dynatrace-operator/releases/download/v1.2.3/kubernetes.yaml) / [Openshift](https://github.com/abcxyzdef123654/dynatrace-operator/releases/download/v1.2.3/openshift.yaml) manifests.

kubernetes.yaml:
```
kind: Deployment
metadata:
  name: dynatrace-operator
spec:
  template:
    spec:
      containers:
        - name: dynatrace-operator
          image: public.ecr.aws/dynatrace/dynatrace-operator:v1.2.3@sha256:2f24a7e4295d4b005730d00e5952acb543ab1371b751f5a1e7bf1c65543a4807
          
kind: Deployment
metadata:
  name: dynatrace-webhook
spec:
  template:
    spec:
      containers:
        - name: webhook
          image: public.ecr.aws/dynatrace/dynatrace-operator:v1.2.3@sha256:2f24a7e4295d4b005730d00e5952acb543ab1371b751f5a1e7bf1c65543a4807          
...
```

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
