### PR TITLE
Fixup: curl service unavailable during proxy e2e tests

### DIFF
--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -38,7 +38,7 @@ const (
 	curlPodNameDynatraceInboundTraffic  = "dynatrace-inbound-traffic"
 	curlPodNameDynatraceOutboundTraffic = "dynatrace-outbound-traffic"
 
-	internetUrl = "dynatrace.com"
+	internetUrl = "https://wwww.dynatrace.com"
 )
 
 var (


### PR DESCRIPTION
## Description

FIxup e2e test: Oneagent doesn't get ready in 300s in OCP e2e tests:

*Context* we use dynatrace.com as host to test absence of internet in during e2e tests. Sometimes it's flaky and returns 502.
```
curl dynatrace.com --verbose --head --fail
*   Trying 52.29.248.2:80...
* Connected to dynatrace.com (52.29.248.2) port 80
> HEAD / HTTP/1.1
> Host: dynatrace.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 503 Service Unavailable: Back-end server is at capacity
HTTP/1.1 503 Service Unavailable: Back-end server is at capacity
< Connection: keep-alive
Connection: keep-alive

* The requested URL returned error: 503
* Closing connection
curl: (22) The requested URL returned error: 503
```

Better solution is to use explicitly https and www:

```
curl https://www.dynatrace.com --insecure --head --fail
HTTP/2 200
content-type: text/html
content-length: 117368
date: Wed, 10 Jan 2024 14:48:11 GMT
last-modified: Wed, 10 Jan 2024 14:41:38 GMT
etag: "e63d330d9565f78f903674c90502a2c7"
x-amz-server-side-encryption: AES256
x-amz-version-id: cv7DgJIIBN4bTIGZ_kfSDnlUfSRn3KH6
accept-ranges: bytes
server: AmazonS3
vary: Accept-Encoding
x-cache: Hit from cloudfront
via: 1.1 76c315f993ceca1d67416a80c715a4ce.cloudfront.net (CloudFront)
x-amz-cf-pop: VIE50-P2
x-amz-cf-id: MifxWxJQrhmhgVnu17H7F2bS2u5459n0s10UhRIvrItaWUpGfmSIuw==
age: 12501
x-xss-protection: 1; mode=block
x-frame-options: DENY
content-security-policy: frame-ancestors 'self' *.dynatrace.org *.dynatrace.com *.dynatrace.cn
strict-transport-security: max-age=31536000; includeSubDomains
vary: Origin
```
## How can this be tested?

Run `make test/e2e/istio` few times in the row.

## Checklist

~- [ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
