### PR TITLE
Fix empty secret config incase of dataIngest

### DIFF
--- a/pkg/injection/startup/run.go
+++ b/pkg/injection/startup/run.go
@@ -32,15 +32,14 @@ func NewRunner(fs afero.Fs) (*Runner, error) {
 		return nil, err
 	}
 
-	var secretConfig *SecretConfig
+	secretConfig, err := newSecretConfigViaFs(fs)
+	if err != nil {
+		return nil, err
+	}
+
 	var client dtclient.Client
 	var oneAgentInstaller installer.Installer
 	if env.OneAgentInjected {
-		secretConfig, err = newSecretConfigViaFs(fs)
-		if err != nil {
-			return nil, err
-		}
-
 		client, err = newDTClientBuilder(secretConfig).createClient()
 		if err != nil {
 			return nil, err

--- a/pkg/injection/startup/run_test.go
+++ b/pkg/injection/startup/run_test.go
@@ -65,7 +65,7 @@ func TestNewRunner(t *testing.T) {
 		assert.NotNil(t, runner.fs)
 		assert.NotNil(t, runner.env)
 		assert.Nil(t, runner.dtclient)
-		assert.Nil(t, runner.config)
+		assert.NotNil(t, runner.config)
 		assert.Nil(t, runner.installer)
 		assert.Empty(t, runner.hostTenant)
 	})


### PR DESCRIPTION
## Description

Fix empty secret config incase of dataIngest

## How can this be tested?

Create a Dynakube with application Monitoring -> disable injection of oneAgent and just enable data ingest -> everything should work

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
