### PR TITLE
Update latest release version in upgrade e2e tests

### DIFF
--- a/test/scenarios/release/release_test.go
+++ b/test/scenarios/release/release_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 	testEnv = env.NewWithConfig(cfg)
 	testEnv.Setup(
 		tenant.CreateOtelSecret(operator.DefaultNamespace),
-		operator.InstallViaHelm("0.14.1", true, operator.DefaultNamespace), // TODO: Make the version not hard-coded, but always use the previous version. Using git is not an option because pipeline does not pull the whole git repo.
+		operator.InstallViaHelm("0.15.0", true, operator.DefaultNamespace), // TODO: Make the version not hard-coded, but always use the previous version. Using git is not an option because pipeline does not pull the whole git repo.
 	)
 	// If we cleaned up during a fail-fast (aka.: /debug) it wouldn't be possible to investigate the error.
 	if !cfg.FailFast() {


### PR DESCRIPTION
## Description

As we don't fetch the latest release version automatically yet, it has to be updated manually. 

## How can this be tested?

Run `make test/e2e/cloudnative/upgrade`

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
