### PR TITLE
Remove wrong assumption in test comment

### DIFF
--- a/config/helm/chart/default/tests/Common/csi/clusterrole-csi_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/clusterrole-csi_test.yaml
@@ -2,7 +2,7 @@ suite: test clusterrole for the csi driver
 templates:
   - Common/csi/clusterrole-csi.yaml
 tests:
-  - it: should exist 2 by default (1 by node)
+  - it: should exist 2 by default
     asserts:
       - hasDocuments:
           count: 2

--- a/config/helm/chart/default/tests/Common/csi/csidriver_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/csidriver_test.yaml
@@ -2,7 +2,7 @@ suite: test csi driver resource
 templates:
   - Common/csi/csidriver.yaml
 tests:
-  - it: should exist 1 by default (1 by node)
+  - it: should exist 1 by default
     set:
       platform: kubernetes
     asserts:

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -5,7 +5,7 @@ chart:
 templates:
   - Common/csi/daemonset.yaml
 tests:
-  - it: should exist 1 by default (1 by node)
+  - it: should exist 1 by default
     set:
       platform: kubernetes
     asserts:

--- a/config/helm/chart/default/tests/Common/csi/role-csi_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/role-csi_test.yaml
@@ -2,7 +2,7 @@ suite: test role for the csi driver
 templates:
   - Common/csi/role-csi.yaml
 tests:
-  - it: should exist 2 by default (1 by node)
+  - it: should exist 2 by default
     asserts:
       - hasDocuments:
           count: 2


### PR DESCRIPTION
## Description

I wrote this comment wrong. Is not because of node count but because ofthe number of manifest documents.

## How can this be tested?

---

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
