### PR TITLE
add init config volume to mutated pods in any case

### DIFF
--- a/pkg/webhook/mutation/pod_mutator/config.go
+++ b/pkg/webhook/mutation/pod_mutator/config.go
@@ -5,10 +5,11 @@ import (
 )
 
 const (
-	injectEvent          = "Inject"
-	updatePodEvent       = "UpdatePod"
-	IncompatibleCRDEvent = "IncompatibleCRDPresent"
-	missingDynakubeEvent = "MissingDynakube"
+	injectEvent               = "Inject"
+	updatePodEvent            = "UpdatePod"
+	IncompatibleCRDEvent      = "IncompatibleCRDPresent"
+	missingDynakubeEvent      = "MissingDynakube"
+	injectionConfigVolumeName = "injection-config"
 
 	defaultUser   int64 = 1001
 	defaultGroup  int64 = 1001

--- a/pkg/webhook/mutation/pod_mutator/init_container.go
+++ b/pkg/webhook/mutation/pod_mutator/init_container.go
@@ -30,6 +30,9 @@ func createInstallInitContainerBase(webhookImage string, pod *corev1.Pod, dynaku
 		},
 		SecurityContext: securityContextForInitContainer(pod, dynakube),
 		Resources:       initContainerResources(dynakube),
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: injectionConfigVolumeName, MountPath: consts.AgentConfigDirMount},
+		},
 	}
 }
 

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/config.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/config.go
@@ -19,9 +19,8 @@ const (
 	releaseStageEnv        = "DT_RELEASE_STAGE"
 	releaseBuildVersionEnv = "DT_RELEASE_BUILD_VERSION"
 
-	OneAgentBinVolumeName     = "oneagent-bin"
-	oneAgentShareVolumeName   = "oneagent-share"
-	injectionConfigVolumeName = "injection-config"
+	OneAgentBinVolumeName   = "oneagent-bin"
+	oneAgentShareVolumeName = "oneagent-share"
 
 	oneAgentCustomKeysPath = "/var/lib/dynatrace/oneagent/agent/customkeys"
 	customCertFileName     = "custom.pem"

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/mutator.go
@@ -64,7 +64,6 @@ func (mutator *OneAgentPodMutator) Mutate(ctx context.Context, request *dtwebhoo
 	mutator.configureInitContainer(request, installerInfo)
 	mutator.setContainerCount(request.InstallContainer, len(request.Pod.Spec.Containers))
 	mutator.mutateUserContainers(request)
-	addInjectionConfigVolumeMount(request.InstallContainer)
 	setInjectedAnnotation(request.Pod)
 	return nil
 }

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/mutator_test.go
@@ -104,25 +104,25 @@ func TestMutate(t *testing.T) {
 			name:                                   "basic, should mutate the pod and init container in the request",
 			dynakube:                               *getTestDynakube(),
 			expectedAdditionalEnvCount:             2, // 1 deployment-metadata + 1 preload
-			expectedAdditionalVolumeCount:          3, // bin, share, injection-config
+			expectedAdditionalVolumeCount:          2, // bin, share, injection-config
 			expectedAdditionalVolumeMountCount:     3, // 3 oneagent mounts(preload,bin,conf)
-			expectedAdditionalInitVolumeMountCount: 3, // bin, share, injection-config
+			expectedAdditionalInitVolumeMountCount: 2, // bin, share
 		},
 		{
 			name:                                   "everything turned on, should mutate the pod and init container in the request",
 			dynakube:                               *getTestComplexDynakube(),
 			expectedAdditionalEnvCount:             5, // 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
-			expectedAdditionalVolumeCount:          3, // bin, share, injection-config
+			expectedAdditionalVolumeCount:          2, // bin, share
 			expectedAdditionalVolumeMountCount:     5, // 3 oneagent mounts(preload,bin,conf) + 1 cert mount + 1 curl-options
-			expectedAdditionalInitVolumeMountCount: 3, // bin, share, injection-config
+			expectedAdditionalInitVolumeMountCount: 2, // bin, share
 		},
 		{
 			name:                                   "basic + readonly-csi, should mutate the pod and init container in the request",
 			dynakube:                               *getTestReadOnlyCSIDynakube(),
 			expectedAdditionalEnvCount:             2, // 1 deployment-metadata + 1 preload
-			expectedAdditionalVolumeCount:          6, // bin, share, injection-config +  agent-conf, data-storage, agent-log
+			expectedAdditionalVolumeCount:          5, // bin, share +  agent-conf, data-storage, agent-log
 			expectedAdditionalVolumeMountCount:     6, // 3 oneagent mounts(preload,bin,conf) +3 oneagent mounts for readonly csi (agent-conf,data-storage,agent-log)
-			expectedAdditionalInitVolumeMountCount: 4, // bin, share, injection-config, agent-conf
+			expectedAdditionalInitVolumeMountCount: 3, // bin, share, agent-conf
 		},
 	}
 

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/volumes.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/volumes.go
@@ -14,7 +14,6 @@ import (
 )
 
 func (mutator *OneAgentPodMutator) addVolumes(pod *corev1.Pod, dynakube dynatracev1beta1.DynaKube) {
-	addInjectionConfigVolume(pod)
 	addOneAgentVolumes(pod, dynakube)
 	if dynakube.FeatureReadOnlyCsiVolume() {
 		addVolumesForReadOnlyCSI(pod)
@@ -86,25 +85,6 @@ func addCurlOptionsVolumeMount(container *corev1.Container) {
 		MountPath: filepath.Join(oneAgentCustomKeysPath, consts.AgentCurlOptionsFileName),
 		SubPath:   consts.AgentCurlOptionsFileName,
 	})
-}
-
-func addInjectionConfigVolume(pod *corev1.Pod) {
-	pod.Spec.Volumes = append(pod.Spec.Volumes,
-		corev1.Volume{
-			Name: injectionConfigVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: consts.AgentInitSecretName,
-				},
-			},
-		},
-	)
-}
-
-func addInjectionConfigVolumeMount(container *corev1.Container) {
-	container.VolumeMounts = append(container.VolumeMounts,
-		corev1.VolumeMount{Name: injectionConfigVolumeName, MountPath: consts.AgentConfigDirMount},
-	)
 }
 
 func addOneAgentVolumes(pod *corev1.Pod, dynakube dynatracev1beta1.DynaKube) {

--- a/pkg/webhook/mutation/pod_mutator/pod_mutator.go
+++ b/pkg/webhook/mutation/pod_mutator/pod_mutator.go
@@ -171,7 +171,6 @@ func (webhook *podMutatorWebhook) handlePodMutation(ctx context.Context, mutatio
 	addInitContainerToPod(mutationRequest.Pod, mutationRequest.InstallContainer)
 	webhook.recorder.sendPodInjectEvent()
 	setDynatraceInjectedAnnotation(mutationRequest)
-
 	return nil
 }
 

--- a/pkg/webhook/mutation/pod_mutator/pod_mutator.go
+++ b/pkg/webhook/mutation/pod_mutator/pod_mutator.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"net/http/httptrace"
 	"os"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtotel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	k8spod "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/pod"


### PR DESCRIPTION
## Description

Since we are reading multiple values from the initConfig instead of envVars, we also have to make sure that the init config is always added(also when only one mutator is enabled)

## How can this be tested?

Create a Dynakube with application Monitoring -> disable injection of oneAgent and just enable data ingest -> everything should work

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
