### PR TITLE
Add hostgroup parameter to process module config request URL

### DIFF
--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -216,3 +216,9 @@ func NetworkZone(networkZone string) Option {
 		c.networkZone = networkZone
 	}
 }
+
+func HostGroup(hostGroup string) Option {
+	return func(c *dynatraceClient) {
+		c.hostGroup = hostGroup
+	}
+}

--- a/pkg/clients/dynatrace/dynatrace_client.go
+++ b/pkg/clients/dynatrace/dynatrace_client.go
@@ -35,6 +35,8 @@ type dynatraceClient struct {
 
 	networkZone string
 
+	hostGroup string
+
 	httpClient *http.Client
 
 	hostCache map[string]hostInfo

--- a/pkg/clients/dynatrace/processmoduleconfig.go
+++ b/pkg/clients/dynatrace/processmoduleconfig.go
@@ -11,7 +11,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const generalSectionName = "general"
+const (
+	generalSectionName = "general"
+	hostGroupParamName = "hostgroup"
+)
 
 type ProcessModuleConfig struct {
 	Revision   uint                    `json:"revision"`
@@ -171,6 +174,9 @@ func (dtc *dynatraceClient) createProcessModuleConfigRequest(prevRevision uint) 
 	}
 	query := req.URL.Query()
 	query.Add("revision", strconv.FormatUint(uint64(prevRevision), 10))
+	if dtc.hostGroup != "" {
+		query.Add(hostGroupParamName, dtc.hostGroup)
+	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Api-Token %s", dtc.paasToken))

--- a/pkg/clients/dynatrace/processmoduleconfig_test.go
+++ b/pkg/clients/dynatrace/processmoduleconfig_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const goodProcessModuleConfigResponse = `
+const (
+	goodProcessModuleConfigResponse = `
 {
 	"revision": 1,
 	"properties": [{
@@ -26,17 +27,35 @@ const goodProcessModuleConfigResponse = `
 	]
 }
 `
+	hostGroup = "hg"
+)
 
 func TestCreateProcessModuleConfigRequest(t *testing.T) {
-	dc := &dynatraceClient{
-		paasToken: "token123",
-	}
-	require.NotNil(t, dc)
+	t.Run("hostGroup undefined", func(t *testing.T) {
+		dc := &dynatraceClient{
+			paasToken: "token123",
+		}
+		require.NotNil(t, dc)
 
-	req, err := dc.createProcessModuleConfigRequest(0)
-	require.Nil(t, err)
-	assert.Equal(t, "0", req.URL.Query().Get("revision"))
-	assert.Contains(t, req.Header.Get("Authorization"), dc.paasToken)
+		req, err := dc.createProcessModuleConfigRequest(0)
+		require.Nil(t, err)
+		assert.Equal(t, "0", req.URL.Query().Get("revision"))
+		assert.Empty(t, req.URL.Query().Get(hostGroupParamName))
+		assert.Contains(t, req.Header.Get("Authorization"), dc.paasToken)
+	})
+	t.Run("hostGroup defined", func(t *testing.T) {
+		dc := &dynatraceClient{
+			paasToken: "token123",
+			hostGroup: hostGroup,
+		}
+		require.NotNil(t, dc)
+
+		req, err := dc.createProcessModuleConfigRequest(0)
+		require.Nil(t, err)
+		assert.Equal(t, "0", req.URL.Query().Get("revision"))
+		assert.Equal(t, hostGroup, req.URL.Query().Get(hostGroupParamName))
+		assert.Contains(t, req.Header.Get("Authorization"), dc.paasToken)
+	})
 }
 
 func TestSpecialProcessModuleConfigRequestStatus(t *testing.T) {

--- a/pkg/controllers/dynakube/dynatraceclient/builder.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder.go
@@ -73,6 +73,7 @@ func (dynatraceClientBuilder builder) Build() (dtclient.Client, error) {
 	opts := newOptions(dynatraceClientBuilder.context())
 	opts.appendCertCheck(dynatraceClientBuilder.dynakube.Spec.SkipCertCheck)
 	opts.appendNetworkZone(dynatraceClientBuilder.dynakube.Spec.NetworkZone)
+	opts.appendHostGroup(dynatraceClientBuilder.dynakube.HostGroup())
 
 	err := opts.appendProxySettings(apiReader, &dynatraceClientBuilder.dynakube)
 	if err != nil {

--- a/pkg/controllers/dynakube/dynatraceclient/options.go
+++ b/pkg/controllers/dynakube/dynatraceclient/options.go
@@ -28,6 +28,12 @@ func (opts *options) appendNetworkZone(networkZone string) {
 	}
 }
 
+func (opts *options) appendHostGroup(hostGroup string) {
+	if hostGroup != "" {
+		opts.Opts = append(opts.Opts, dtclient.HostGroup(hostGroup))
+	}
+}
+
 func (opts *options) appendCertCheck(skipCertCheck bool) {
 	opts.Opts = append(opts.Opts, dtclient.SkipCertificateValidation(skipCertCheck))
 }


### PR DESCRIPTION
## Description

Use `hostgroup` parameter for process module config request.

## How can this be tested?

1) "Create" a hostgroup  
Deploy dynakube:
```
spec:
  activeGate:
    capabilities:
      - kubernetes-monitoring
  oneAgent:
    cloudNativeFullStack:
      args:
      - "--set-host-group=host-group-test"
```
UI: 
- go to `Deployment status`/`OneAgents` page
- click `Host group: host-group-test` link below host name
- from the menu on the left choose `Container technologies`
- enable `Docker for Windows Server containers` and save changes.

2) Check value of `dockerWindowsInjection` property. It's set to `on` (after few minutes).
```
watch -n 10 /bin/bash -c "date ; kubectl -n dynatrace exec -t pod/dynatrace-oneagent-csi-driver-<HASH> -- /bin/bash -c \"cat /data/<TENANT>>/config/agent/conf/ruxitagentproc.conf\" | grep \"^.*Injection o\" | sort | grep dockerWindowsInjection"
```

3) Update dynakube:
```
spec:
  activeGate:
    capabilities:
      - kubernetes-monitoring
  oneAgent:
    cloudNativeFullStack: {}
```

4) Check value of `dockerWindowsInjection` property. It's set to `off`.

5) Switch to the `main` branch. Deploy operator from scratch. 

6) Repeat steps 1-4 (without UI part). Value of `dockerWindowsInjection` property is always `off`.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
