### PR TITLE
Research OpenFeature API for OneAgent multi version support updated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/open-feature/go-sdk v1.9.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
 github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/open-feature/go-sdk v1.9.0 h1:1Nyj+XNHfL0rRGZgGCbZ29CHDD57PQJL7Q/2ZbW/E8c=
+github.com/open-feature/go-sdk v1.9.0/go.mod h1:n5BM4DfvIiKaWWquZnL/yVihcGM5aLsz7rNYE3BkXAM=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc4 h1:oOxKUJWnFC4YGHCCMNql1x4YaDfYBTS5Y4x/Cgeo1E0=

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
@@ -12,10 +12,20 @@ const argumentPrefix = "--"
 const customArgumentPriority = 2
 const defaultArgumentPriority = 1
 
+// OpenFeature research relevant!
 func (dsInfo *builderInfo) arguments() []string {
 	argMap := prioritymap.New(prioritymap.WithSeparator(prioritymap.DefaultSeparator), prioritymap.WithPriority(defaultArgumentPriority))
 
-	dsInfo.appendProxyArg(argMap)
+	// is this the right spot to make that request? or pass it down to config?
+	// alternatively we could hide OpenFeature behind a facade in DynaKube as we currently treat feature flags
+	passProxyAsParam, err := dsInfo.oneAgentVersionManager.ShouldUseProxyAsParam(dsInfo.dynakube.OneAgentVersion())
+	if err != nil {
+		// handle error
+	}
+	if passProxyAsParam {
+		dsInfo.appendProxyArg(argMap)
+	}
+
 	dsInfo.appendNetworkZoneArg(argMap)
 
 	appendOperatorVersionArg(argMap)

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -3,6 +3,7 @@ package daemonset
 import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
@@ -44,6 +45,7 @@ const (
 	probeDefaultSuccessThreshold = int32(1)
 )
 
+// OpenFeature research relevant!
 type HostMonitoring struct {
 	builderInfo
 }
@@ -53,45 +55,49 @@ type ClassicFullStack struct {
 }
 
 type builderInfo struct {
-	dynakube       *dynatracev1beta1.DynaKube
-	hostInjectSpec *dynatracev1beta1.HostInjectSpec
-	clusterID      string
-	deploymentType string
+	dynakube               *dynatracev1beta1.DynaKube
+	hostInjectSpec         *dynatracev1beta1.HostInjectSpec
+	oneAgentVersionManager *oneagent.VersionManager
+	clusterID              string
+	deploymentType         string
 }
 
 type Builder interface {
 	BuildDaemonSet() (*appsv1.DaemonSet, error)
 }
 
-func NewHostMonitoring(instance *dynatracev1beta1.DynaKube, clusterId string) Builder {
+func NewHostMonitoring(instance *dynatracev1beta1.DynaKube, clusterId string, oneAgentVersionManager *oneagent.VersionManager) Builder {
 	return &HostMonitoring{
 		builderInfo{
-			dynakube:       instance,
-			hostInjectSpec: instance.Spec.OneAgent.HostMonitoring,
-			clusterID:      clusterId,
-			deploymentType: deploymentmetadata.HostMonitoringDeploymentType,
+			dynakube:               instance,
+			hostInjectSpec:         instance.Spec.OneAgent.HostMonitoring,
+			oneAgentVersionManager: oneAgentVersionManager,
+			clusterID:              clusterId,
+			deploymentType:         deploymentmetadata.HostMonitoringDeploymentType,
 		},
 	}
 }
 
-func NewCloudNativeFullStack(instance *dynatracev1beta1.DynaKube, clusterId string) Builder {
+func NewCloudNativeFullStack(instance *dynatracev1beta1.DynaKube, clusterId string, oneAgentVersionManager *oneagent.VersionManager) Builder {
 	return &HostMonitoring{
 		builderInfo{
-			dynakube:       instance,
-			hostInjectSpec: &instance.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec,
-			clusterID:      clusterId,
-			deploymentType: deploymentmetadata.CloudNativeDeploymentType,
+			dynakube:               instance,
+			hostInjectSpec:         &instance.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec,
+			oneAgentVersionManager: oneAgentVersionManager,
+			clusterID:              clusterId,
+			deploymentType:         deploymentmetadata.CloudNativeDeploymentType,
 		},
 	}
 }
 
-func NewClassicFullStack(instance *dynatracev1beta1.DynaKube, clusterId string) Builder {
+func NewClassicFullStack(instance *dynatracev1beta1.DynaKube, clusterId string, oneAgentVersionManager *oneagent.VersionManager) Builder {
 	return &ClassicFullStack{
 		builderInfo{
-			dynakube:       instance,
-			hostInjectSpec: instance.Spec.OneAgent.ClassicFullStack,
-			clusterID:      clusterId,
-			deploymentType: deploymentmetadata.ClassicFullStackDeploymentType,
+			dynakube:               instance,
+			hostInjectSpec:         instance.Spec.OneAgent.ClassicFullStack,
+			oneAgentVersionManager: oneAgentVersionManager,
+			clusterID:              clusterId,
+			deploymentType:         deploymentmetadata.ClassicFullStackDeploymentType,
 		},
 	}
 }
@@ -174,6 +180,7 @@ func (dsInfo *builderInfo) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 func (dsInfo *builderInfo) podSpec() corev1.PodSpec {
 	resources := dsInfo.resources()
 	dnsPolicy := dsInfo.dnsPolicy()
+
 	arguments := dsInfo.arguments()
 	environmentVariables := dsInfo.environmentVariables()
 	volumeMounts := dsInfo.volumeMounts()

--- a/pkg/controllers/dynakube/oneagent/oneagent_version_manager.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_version_manager.go
@@ -1,0 +1,48 @@
+package oneagent
+
+import (
+	"context"
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+const (
+	MinOneAgentVersionSupported = "1.2.3" // minimum version supported by this operator installer
+	MaxOneAgentVersionSupported = "1.4.5" // maximum version supported by this operator installer
+)
+
+// OpenFeature research relevant!
+func NewOneAgentVersionManager(provider openfeature.FeatureProvider) *VersionManager {
+
+	err := openfeature.SetProvider(provider)
+	if err != nil {
+		// handle error
+	}
+	/*initialize supported version ranges */
+	client := openfeature.NewClient("dynakube-operator")
+	return &VersionManager{
+		OfClient: client,
+	}
+}
+
+// bad name, but manager is pretty generic
+type VersionManager struct {
+	OfClient *openfeature.Client
+}
+
+func (vm *VersionManager) IsOneAgentVersionSupported(oneAgentVersion string) bool {
+	// do semver version comparison of oneAgentVersion and
+	// * min/max version supported by this operator, and also get
+	// * versions supported by the ConfigMap
+	// to see if OneAgent version that should be installed is supported
+	return true
+}
+
+// we could use the EvaluationContext to map the featureflags of each version- there has to be a mapping
+// of version ranges to configurations
+func (vm *VersionManager) GetContextForVersion(versoneAgentVersion string) openfeature.EvaluationContext {
+	return openfeature.EvaluationContext{}
+}
+
+func (vm *VersionManager) ShouldUseProxyAsParam(version string) (bool, error) {
+	return vm.OfClient.BooleanValue(context.TODO(), "proxy-as-param", true, openfeature.EvaluationContext{})
+}

--- a/pkg/util/feature/OneAgnetConfigMapSample.yaml
+++ b/pkg/util/feature/OneAgnetConfigMapSample.yaml
@@ -1,0 +1,37 @@
+# OpenFeature research relevant
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-oneagent-features
+data:
+
+#EvaluationContext: per OneAgent version a file mount?
+#     |
+#<----+----->
+  oneagent-v1.properties: |
+    param1=1
+    param2=sampletext
+    proxy-as-param=true
+  oneagent-v2.properties: |
+    param1=2
+    param2=text
+    proxy-as-param=false
+
+---
+#perator pod snippet to mount ConfigMap
+volumeMounts:
+  - name: oneagent-features
+    mountPath: "/supported-oneagent-versions"
+    readOnly: true
+volumes:
+  # You set volumes at the Pod level, then mount them into containers inside that Pod
+  - name: config
+    configMap:
+      # Provide the name of the ConfigMap you want to mount.
+      name: oneagent-features
+      # An array of keys from the ConfigMap to create as files
+      items:
+        - key: "oneagent-v1.properties"
+          path: "oneagent-v1.properties"
+        - key: "oneagent-v2.properties"
+          path: "oneagent-v2.properties"

--- a/pkg/util/feature/config_map_feature_provider.go
+++ b/pkg/util/feature/config_map_feature_provider.go
@@ -1,0 +1,172 @@
+package feature
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+const (
+	ErrorFlagNotFound = "flag not found"
+
+	OneAgentVersionMappingKey = "OneAgentVersionMappingKey"
+)
+
+// OpenFeature research relevant!
+func ReadConfigMapAndCreateFeatureProvider(ctx context.Context, apiReader client.Reader) (*ConfigMapFeatureProvider, error) {
+	configMap, err := ReadConfigMap(ctx, apiReader)
+	if err != nil {
+		return nil, err
+	}
+	return NewConfigMapFeatureProvider(configMap), nil
+}
+
+func NewConfigMapFeatureProvider(configMap *corev1.ConfigMap) *ConfigMapFeatureProvider {
+	return &ConfigMapFeatureProvider{
+		configMap: configMap,
+	}
+}
+
+func ReadConfigMap(ctx context.Context, apiReader client.Reader) (*corev1.ConfigMap, error) {
+	var configMap corev1.ConfigMap
+	key := client.ObjectKey{Name: OneAgentVersionMappingKey, Namespace: "dynatrace"} // optimise key generation?
+	err := apiReader.Get(ctx, key, &configMap)
+	if err != nil {
+		return nil, err
+	}
+	return &configMap, nil
+}
+
+// ConfigMapFeatureProvider implements the OpenFeatureProvider interface
+type ConfigMapFeatureProvider struct {
+	configMap *corev1.ConfigMap
+}
+
+var _ openfeature.FeatureProvider = ConfigMapFeatureProvider{}
+
+// REQUIRED as per spec
+func (k ConfigMapFeatureProvider) Metadata() openfeature.Metadata {
+	// return information about supported OneAgent versions, release date, OneAgent ConfigMap version
+	return openfeature.Metadata{
+		Name: "OneAgentVersionConfig",
+	}
+}
+
+// REQUIRED functionality: boolean, int, string and object
+// imho nice basic provider can be found at https://github.com/open-feature/go-sdk-contrib/blob/main/providers/from-env/pkg/provider.go
+func (k ConfigMapFeatureProvider) BooleanEvaluation(ctx context.Context, flagKey string, defaultValue bool, evalCtx openfeature.FlattenedContext) openfeature.BoolResolutionDetail {
+	res := k.resolveFlag(flagKey, defaultValue, evalCtx)
+	v, ok := res.Value.(bool)
+	if !ok {
+		return openfeature.BoolResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				ResolutionError: openfeature.NewTypeMismatchResolutionError(""),
+				Reason:          openfeature.ErrorReason,
+			},
+		}
+	}
+
+	return openfeature.BoolResolutionDetail{
+		Value:                    v,
+		ProviderResolutionDetail: res.ProviderResolutionDetail,
+	}
+}
+
+// REQUIRED functionality: boolean, int, string and object
+func (k ConfigMapFeatureProvider) StringEvaluation(ctx context.Context, flagKey string, defaultValue string, evalCtx openfeature.FlattenedContext) openfeature.StringResolutionDetail {
+	res := k.resolveFlag(flagKey, defaultValue, evalCtx)
+	v, ok := res.Value.(string)
+	if !ok {
+		return openfeature.StringResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				ResolutionError: openfeature.NewTypeMismatchResolutionError(""),
+				Reason:          openfeature.ErrorReason,
+			},
+		}
+	}
+
+	return openfeature.StringResolutionDetail{
+		Value:                    v,
+		ProviderResolutionDetail: res.ProviderResolutionDetail,
+	}
+}
+
+// not 100% sure on that, as numbers are required for providers while float should be supported in the client,
+// but as I do not see much benefit in not implementing it just do it
+func (k ConfigMapFeatureProvider) FloatEvaluation(ctx context.Context, flagKey string, defaultValue float64, evalCtx openfeature.FlattenedContext) openfeature.FloatResolutionDetail {
+	res := k.resolveFlag(flagKey, defaultValue, evalCtx)
+	v, ok := res.Value.(float64)
+	if !ok {
+		return openfeature.FloatResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				ResolutionError: openfeature.NewTypeMismatchResolutionError(""),
+				Reason:          openfeature.ErrorReason,
+			},
+		}
+	}
+
+	return openfeature.FloatResolutionDetail{
+		Value:                    v,
+		ProviderResolutionDetail: res.ProviderResolutionDetail,
+	}
+}
+
+// REQUIRED functionality: boolean, int, string and object
+func (k ConfigMapFeatureProvider) IntEvaluation(ctx context.Context, flagKey string, defaultValue int64, evalCtx openfeature.FlattenedContext) openfeature.IntResolutionDetail {
+	res := k.resolveFlag(flagKey, defaultValue, evalCtx)
+	v, ok := res.Value.(float64)
+	if !ok {
+		return openfeature.IntResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				ResolutionError: openfeature.NewTypeMismatchResolutionError(""),
+				Reason:          openfeature.ErrorReason,
+			},
+		}
+	}
+
+	return openfeature.IntResolutionDetail{
+		Value:                    int64(v),
+		ProviderResolutionDetail: res.ProviderResolutionDetail,
+	}
+}
+
+// REQUIRED functionality: boolean, int, string and object
+func (k ConfigMapFeatureProvider) ObjectEvaluation(ctx context.Context, flagKey string, defaultValue any, evalCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+	return k.resolveFlag(flagKey, defaultValue, evalCtx)
+}
+
+// REQUIRED as per spec, but not the actual implementation of the hooking mechanism as I interpret it...
+// why we might want to implement it: logging and tracing...
+func (k ConfigMapFeatureProvider) Hooks() []openfeature.Hook {
+	return []openfeature.Hook{}
+}
+
+func (p *ConfigMapFeatureProvider) resolveFlag(flagKey string, defaultValue any, evalCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+	// fetch the stored flag from environment variables
+	value, found := p.configMap.Data[flagKey] // TODO: insert kube apicall here p.envFetch.fetchStoredFlag(flagKey)
+	if !found {
+		return openfeature.InterfaceResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				ResolutionError: openfeature.NewGeneralResolutionError(ErrorFlagNotFound),
+				Reason:          openfeature.ErrorReason,
+			},
+		}
+	}
+	// ignore evalContext or variants here- look for detail in the imple of
+	// https://github.com/open-feature/go-sdk-contrib/blob/main/providers/from-env/pkg/provider.go
+
+	return openfeature.InterfaceResolutionDetail{
+		Value: value,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+			Variant: "ignored for research",
+			Reason:  "ignored for research",
+		},
+	}
+}


### PR DESCRIPTION
## Description

Please include the following:

a possible solution on how to use K8s ConfigMaps to model differences in OneAgent multi version support.

a data model for mapping OneAgent versions to flag values was out-of-scope for this research.

Solution shows how the OneAgent Reconciler creates a component doing the version magic (VersionManager for lack of better name) implementing a basic OpenFeature FeatureProvider that uses the K89s API to access a ConfigMap. 
The VersionManager is then passed through the DaemonSet to the argument component to illustrate the use of the mechanism with the proxy parameter.


## How can this be tested?

not intended to run.

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
