### PR TITLE
fixup! TestStandard/read_only_csi_volume

### DIFF
--- a/pkg/consts/agent_injection.go
+++ b/pkg/consts/agent_injection.go
@@ -24,7 +24,6 @@ const (
 	AgentContainerImageEnvTemplate = "CONTAINER_%d_IMAGE"
 
 	AgentInjectedEnv = "ONEAGENT_INJECTED"
-	AgentReadonlyCSI = "CSI_VOLUME_READONLY"
 
 	AgentBinDirMount      = "/mnt/bin"
 	AgentShareDirMount    = "/mnt/share"


### PR DESCRIPTION
## Description

This PR fixup e2e test check for env var TestStandard/read_only_csi_volume 

The logic was removed in prev PR, so here we remove check from test.

## How can this be tested?


`make test/e2e/standard`


## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
