### PR TITLE
Store ruxitagentproc file in node fs by dynakube name

### DIFF
--- a/pkg/controllers/csi/driver/volumes/app/publisher.go
+++ b/pkg/controllers/csi/driver/volumes/app/publisher.go
@@ -147,7 +147,7 @@ func (publisher *AppVolumePublisher) buildLowerDir(bindCfg *csivolumes.BindConfi
 		binFolderName = bindCfg.ImageDigest
 	}
 	directories := []string{
-		publisher.path.AgentConfigDir(bindCfg.TenantUUID),
+		publisher.path.AgentConfigDir(bindCfg.TenantUUID, bindCfg.DynakubeName),
 		publisher.path.AgentSharedBinaryDirForAgent(binFolderName),
 	}
 	return strings.Join(directories, ":")

--- a/pkg/controllers/csi/driver/volumes/app/publisher_test.go
+++ b/pkg/controllers/csi/driver/volumes/app/publisher_test.go
@@ -45,7 +45,7 @@ func TestPublishVolume(t *testing.T) {
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Device)
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Type)
 		assert.Equal(t, []string{
-			"lowerdir=/a-tenant-uuid/config:/codemodules/1.2-3",
+			"lowerdir=/a-tenant-uuid/a-dynakube/config:/codemodules/1.2-3",
 			"upperdir=/a-tenant-uuid/run/a-volume/var",
 			"workdir=/a-tenant-uuid/run/a-volume/work"},
 			mounter.MountPoints[0].Opts)
@@ -73,7 +73,7 @@ func TestPublishVolume(t *testing.T) {
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Device)
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Type)
 		assert.Equal(t, []string{
-			"lowerdir=/a-tenant-uuid/config:/codemodules/" + testImageDigest,
+			"lowerdir=/a-tenant-uuid/a-dynakube/config:/codemodules/" + testImageDigest,
 			"upperdir=/a-tenant-uuid/run/a-volume/var",
 			"workdir=/a-tenant-uuid/run/a-volume/work"},
 			mounter.MountPoints[0].Opts)

--- a/pkg/controllers/csi/driver/volumes/bind_config.go
+++ b/pkg/controllers/csi/driver/volumes/bind_config.go
@@ -13,6 +13,7 @@ type BindConfig struct {
 	TenantUUID       string
 	Version          string
 	ImageDigest      string
+	DynakubeName     string
 	MaxMountAttempts int
 }
 
@@ -28,6 +29,7 @@ func NewBindConfig(ctx context.Context, access metadata.Access, volumeCfg *Volum
 		TenantUUID:       dynakube.TenantUUID,
 		Version:          dynakube.LatestVersion,
 		ImageDigest:      dynakube.ImageDigest,
+		DynakubeName:     dynakube.Name,
 		MaxMountAttempts: dynakube.MaxFailedMountAttempts,
 	}, nil
 }

--- a/pkg/controllers/csi/driver/volumes/bind_config_test.go
+++ b/pkg/controllers/csi/driver/volumes/bind_config_test.go
@@ -37,8 +37,9 @@ func TestNewBindConfig(t *testing.T) {
 		bindCfg, err := NewBindConfig(context.TODO(), db, volumeCfg)
 
 		expected := BindConfig{
-			TenantUUID: testTenantUUID,
-			Version:    testAgentVersion,
+			TenantUUID:   testTenantUUID,
+			Version:      testAgentVersion,
+			DynakubeName: testDynakubeName,
 		}
 		assert.NoError(t, err)
 		assert.NotNil(t, bindCfg)

--- a/pkg/controllers/csi/metadata/path_resolver.go
+++ b/pkg/controllers/csi/metadata/path_resolver.go
@@ -57,8 +57,8 @@ func (pr PathResolver) AgentSharedBinaryDirForAgent(versionOrDigest string) stri
 	return filepath.Join(pr.AgentSharedBinaryDirBase(), versionOrDigest)
 }
 
-func (pr PathResolver) AgentConfigDir(tenantUUID string) string {
-	return filepath.Join(pr.TenantDir(tenantUUID), dtcsi.SharedAgentConfigDir)
+func (pr PathResolver) AgentConfigDir(tenantUUID string, dynakubeName string) string {
+	return filepath.Join(pr.TenantDir(tenantUUID), dynakubeName, dtcsi.SharedAgentConfigDir)
 }
 
 // Deprecated

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -40,7 +40,7 @@ func (provisioner *OneAgentProvisioner) installAgentImage(dynakube dynatracev1be
 	}
 
 	targetDir := provisioner.path.AgentSharedBinaryDirForAgent(imageDigest)
-	targetConfigDir := provisioner.path.AgentConfigDir(tenantUUID)
+	targetConfigDir := provisioner.path.AgentConfigDir(tenantUUID, dynakube.GetName())
 	err = provisioner.installAgent(imageInstaller, dynakube, targetDir, targetImage, tenantUUID)
 	if err != nil {
 		return "", err
@@ -62,7 +62,7 @@ func (provisioner *OneAgentProvisioner) installAgentZip(dynakube dynatracev1beta
 	urlInstaller := provisioner.urlInstallerBuilder(provisioner.fs, dtc, getUrlProperties(targetVersion, provisioner.path))
 
 	targetDir := provisioner.path.AgentSharedBinaryDirForAgent(targetVersion)
-	targetConfigDir := provisioner.path.AgentConfigDir(tenantUUID)
+	targetConfigDir := provisioner.path.AgentConfigDir(tenantUUID, dynakube.GetName())
 	err = provisioner.installAgent(urlInstaller, dynakube, targetDir, targetVersion, tenantUUID)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description

Change the file path on which the ruxitagentproc.conf file is stored in the node fs. Adding dynakube name to allow having multiple dynakubes per tenant.

Old:
`rootDir/tenantUUID/config/ruxitagentproc.conf`
New:
`rootDir/tenantUUID/dynakubeName/config/ruxitagentproc.conf`

'Old' files are left behind in the old file path and will be cleaned up when old pods are terminated.

## How can this be tested?

Unit tests + run operator locally with no errors shown.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
