### PR TITLE
Create ruxitagentproc.conf secret on dynakube reconcile

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -3589,6 +3589,9 @@ spec:
               dynatraceApi:
                 description: Observed state of Dynatrace API
                 properties:
+                  lastProcessModuleConfigUpdate:
+                    format: date-time
+                    type: string
                   lastTokenScopeRequest:
                     description: Time of the last token request
                     format: date-time

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -3589,9 +3589,6 @@ spec:
               dynatraceApi:
                 description: Observed state of Dynatrace API
                 properties:
-                  lastProcessModuleConfigUpdate:
-                    format: date-time
-                    type: string
                   lastTokenScopeRequest:
                     description: Time of the last token request
                     format: date-time
@@ -3665,6 +3662,10 @@ spec:
                   lastProbeTimestamp:
                     description: Indicates when the last check for a new version was
                       performed
+                    format: date-time
+                    type: string
+                  lastProcessModuleConfigUpdate:
+                    description: Time of the last process module config update
                     format: date-time
                     type: string
                   source:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -3601,9 +3601,6 @@ spec:
               dynatraceApi:
                 description: Observed state of Dynatrace API
                 properties:
-                  lastProcessModuleConfigUpdate:
-                    format: date-time
-                    type: string
                   lastTokenScopeRequest:
                     description: Time of the last token request
                     format: date-time
@@ -3677,6 +3674,10 @@ spec:
                   lastProbeTimestamp:
                     description: Indicates when the last check for a new version was
                       performed
+                    format: date-time
+                    type: string
+                  lastProcessModuleConfigUpdate:
+                    description: Time of the last process module config update
                     format: date-time
                     type: string
                   source:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -3601,6 +3601,9 @@ spec:
               dynatraceApi:
                 description: Observed state of Dynatrace API
                 properties:
+                  lastProcessModuleConfigUpdate:
+                    format: date-time
+                    type: string
                   lastTokenScopeRequest:
                     description: Time of the last token request
                     format: date-time

--- a/pkg/api/v1beta1/dynakube/dynakube_status.go
+++ b/pkg/api/v1beta1/dynakube/dynakube_status.go
@@ -50,8 +50,6 @@ type DynaKubeStatus struct { // nolint:revive
 type DynatraceApiStatus struct {
 	// Time of the last token request
 	LastTokenScopeRequest metav1.Time `json:"lastTokenScopeRequest,omitempty"`
-
-	LastProcessModuleConfigUpdate metav1.Time `json:"lastProcessModuleConfigUpdate,omitempty"`
 }
 
 func GetCacheValidMessage(functionName string, lastRequestTimestamp metav1.Time, timeout time.Duration) string {
@@ -116,6 +114,9 @@ type OneAgentStatus struct {
 
 	// Time of the last instance status update
 	LastInstanceStatusUpdate *metav1.Time `json:"lastInstanceStatusUpdate,omitempty"`
+
+	// Time of the last process module config update
+	LastProcessModuleConfigUpdate *metav1.Time `json:"lastProcessModuleConfigUpdate,omitempty"`
 
 	// Information about OneAgent's connections
 	ConnectionInfoStatus OneAgentConnectionInfoStatus `json:"connectionInfoStatus,omitempty"`

--- a/pkg/api/v1beta1/dynakube/dynakube_status.go
+++ b/pkg/api/v1beta1/dynakube/dynakube_status.go
@@ -50,6 +50,8 @@ type DynaKubeStatus struct { // nolint:revive
 type DynatraceApiStatus struct {
 	// Time of the last token request
 	LastTokenScopeRequest metav1.Time `json:"lastTokenScopeRequest,omitempty"`
+
+	LastProcessModuleConfigUpdate metav1.Time `json:"lastProcessModuleConfigUpdate,omitempty"`
 }
 
 func GetCacheValidMessage(functionName string, lastRequestTimestamp metav1.Time, timeout time.Duration) string {

--- a/pkg/controllers/dynakube/controller.go
+++ b/pkg/controllers/dynakube/controller.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceapi"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceclient"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/processmoduleconfigsecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/status"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/version"
@@ -210,7 +211,17 @@ func (controller *Controller) reconcileDynaKube(ctx context.Context, dynakube *d
 	}
 
 	log.Info("start reconciling deployment meta data")
-	err = deploymentmetadata.NewReconciler(controller.client, controller.apiReader, controller.scheme, *dynakube, controller.clusterID).Reconcile(ctx)
+	err = deploymentmetadata.NewReconciler(
+		controller.client, controller.apiReader, controller.scheme, *dynakube, controller.clusterID).
+		Reconcile(ctx)
+	if err != nil {
+		return err
+	}
+
+	log.Info("start reconciling process module config")
+	err = processmoduleconfigsecret.NewReconciler(
+		controller.client, controller.apiReader, dynatraceClient, dynakube, controller.scheme, timeprovider.New()).
+		Reconcile(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -983,6 +983,8 @@ func createDTMockClient(t *testing.T, paasTokenScopes, apiTokenScopes dtclient.T
 	mockClient.On("CreateOrUpdateKubernetesSetting", testName, testUID, mock.AnythingOfType("string")).
 		Return(testObjectID, nil).Maybe()
 	mockClient.On("GetActiveGateConnectionInfo").Return(dtclient.ActiveGateConnectionInfo{}, nil).Maybe()
+	mockClient.On("GetProcessModuleConfig", mock.AnythingOfType("uint")).
+		Return(&dtclient.ProcessModuleConfig{}, nil).Maybe()
 
 	return mockClient
 }

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/config.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/config.go
@@ -1,0 +1,9 @@
+package processmoduleconfigsecret
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/logger"
+)
+
+var (
+	log = logger.Factory.GetLogger("dynakube-processmoduleconfigsecret")
+)

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
@@ -19,7 +19,7 @@ import (
 const (
 	PullSecretSuffix             = "-pmc-secret"
 	DefaultMinRequestThreshold   = 15 * time.Minute
-	SecretKeyProcessModuleConfig = "processmoduleconfig"
+	SecretKeyProcessModuleConfig = "ruxitagentproc.conf"
 )
 
 type Reconciler struct {

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
@@ -87,7 +87,7 @@ func (r *Reconciler) getOrCreateSecretIfNotExists(ctx context.Context) (*corev1.
 			return nil, err
 		}
 
-		r.dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate = *r.timeProvider.Now()
+		r.dynakube.Status.OneAgent.LastProcessModuleConfigUpdate = r.timeProvider.Now()
 		return newSecret, nil
 	}
 	return &config, nil
@@ -103,13 +103,15 @@ func (r *Reconciler) updateSecret(ctx context.Context, oldSecret *corev1.Secret)
 		return err
 	}
 
-	r.dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate = *r.timeProvider.Now()
+	r.dynakube.Status.OneAgent.LastProcessModuleConfigUpdate = r.timeProvider.Now()
 	return nil
 }
 
 func (r *Reconciler) updateSecretIfOutdated(ctx context.Context, oldSecret *corev1.Secret) error {
-	if r.timeProvider.IsOutdated(&r.dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate, DefaultMinRequestThreshold) {
+	if r.timeProvider.IsOutdated(r.dynakube.Status.OneAgent.LastProcessModuleConfigUpdate, DefaultMinRequestThreshold) {
 		return r.updateSecret(ctx, oldSecret)
+	} else {
+		log.Info("skipping updating process module config due to min request threshold")
 	}
 	return nil
 }

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
@@ -3,7 +3,6 @@ package processmoduleconfigsecret
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
@@ -18,7 +17,6 @@ import (
 
 const (
 	PullSecretSuffix             = "-pmc-secret"
-	DefaultMinRequestThreshold   = 15 * time.Minute
 	SecretKeyProcessModuleConfig = "ruxitagentproc.conf"
 )
 
@@ -108,7 +106,7 @@ func (r *Reconciler) updateSecret(ctx context.Context, oldSecret *corev1.Secret)
 }
 
 func (r *Reconciler) updateSecretIfOutdated(ctx context.Context, oldSecret *corev1.Secret) error {
-	if r.timeProvider.IsOutdated(r.dynakube.Status.OneAgent.LastProcessModuleConfigUpdate, DefaultMinRequestThreshold) {
+	if r.timeProvider.IsOutdated(r.dynakube.Status.OneAgent.LastProcessModuleConfigUpdate, r.dynakube.FeatureApiRequestThreshold()) {
 		return r.updateSecret(ctx, oldSecret)
 	} else {
 		log.Info("skipping updating process module config due to min request threshold")

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
@@ -1,0 +1,140 @@
+package processmoduleconfigsecret
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	PullSecretSuffix             = "-pmc-secret"
+	DefaultMinRequestThreshold   = 15 * time.Minute
+	SecretKeyProcessModuleConfig = "processmoduleconfig"
+)
+
+type Reconciler struct {
+	client       client.Client
+	apiReader    client.Reader
+	dtClient     dtclient.Client
+	dynakube     *dynatracev1beta1.DynaKube
+	scheme       *runtime.Scheme
+	timeProvider *timeprovider.Provider
+}
+
+func NewReconciler(clt client.Client, //nolint:revive
+	apiReader client.Reader,
+	dtClient dtclient.Client,
+	dynakube *dynatracev1beta1.DynaKube,
+	scheme *runtime.Scheme,
+	timeProvider *timeprovider.Provider) *Reconciler {
+	return &Reconciler{
+		client:       clt,
+		apiReader:    apiReader,
+		dtClient:     dtClient,
+		dynakube:     dynakube,
+		scheme:       scheme,
+		timeProvider: timeProvider,
+	}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context) error {
+	if r.dynakube.CloudNativeFullstackMode() || r.dynakube.ApplicationMonitoringMode() {
+		err := r.reconcileSecret(ctx)
+		if err != nil {
+			log.Info("could not reconcile pull secret")
+			return errors.WithStack(err)
+		}
+	} else {
+		log.Info("skipping process module secret reconciler")
+	}
+
+	return nil
+}
+
+func (r *Reconciler) reconcileSecret(ctx context.Context) error {
+	secret, err := r.getOrCreateSecretIfNotExists(ctx)
+	if err != nil {
+		return errors.WithMessage(err, "could not get or create secret")
+	}
+
+	if err := r.updateSecretIfOutdated(ctx, secret); err != nil {
+		return errors.WithMessage(err, "could not update secret")
+	}
+	return nil
+}
+
+func (r *Reconciler) getOrCreateSecretIfNotExists(ctx context.Context) (*corev1.Secret, error) { // created, error
+	var config corev1.Secret
+	err := r.apiReader.Get(ctx, client.ObjectKey{Name: extendWithSuffix(r.dynakube.Name), Namespace: r.dynakube.Namespace}, &config)
+	if k8serrors.IsNotFound(err) {
+		log.Info("creating pull secret")
+		newSecret, err := r.prepareSecret()
+		if err != nil {
+			return nil, err
+		}
+
+		if err = r.client.Create(ctx, newSecret); err != nil {
+			return nil, err
+		}
+
+		r.dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate = *r.timeProvider.Now()
+		return newSecret, nil
+	}
+	return &config, nil
+}
+
+func (r *Reconciler) updateSecret(ctx context.Context, oldSecret *corev1.Secret) error {
+	newSecret, err := r.prepareSecret()
+	if err != nil {
+		return err
+	}
+	oldSecret.Data = newSecret.Data
+	if err = r.client.Update(ctx, oldSecret); err != nil {
+		return err
+	}
+
+	r.dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate = *r.timeProvider.Now()
+	return nil
+}
+
+func (r *Reconciler) updateSecretIfOutdated(ctx context.Context, oldSecret *corev1.Secret) error {
+	if r.timeProvider.IsOutdated(&r.dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate, DefaultMinRequestThreshold) {
+		return r.updateSecret(ctx, oldSecret)
+	}
+	return nil
+}
+
+func (r *Reconciler) prepareSecret() (*corev1.Secret, error) {
+	pmc, err := r.dtClient.GetProcessModuleConfig(0)
+	if err != nil {
+		return nil, err
+	}
+
+	marshaled, err := json.Marshal(pmc)
+	if err != nil {
+		log.Info("could not marshal process module config")
+		return nil, err
+	}
+
+	newSecret, err := secret.Create(r.scheme, r.dynakube,
+		secret.NewNameModifier(extendWithSuffix(r.dynakube.Name)),
+		secret.NewNamespaceModifier(r.dynakube.Namespace),
+		secret.NewTypeModifier(corev1.SecretTypeOpaque),
+		secret.NewDataModifier(map[string][]byte{SecretKeyProcessModuleConfig: marshaled}))
+
+	return newSecret, err
+}
+
+func extendWithSuffix(name string) string {
+	return name + PullSecretSuffix
+}

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
@@ -53,7 +53,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 			return errors.WithStack(err)
 		}
 	} else {
-		log.Info("skipping process module secret reconciler")
+		log.Info("skipping process module config secret reconciler")
 	}
 
 	return nil
@@ -75,7 +75,7 @@ func (r *Reconciler) getOrCreateSecretIfNotExists(ctx context.Context) (*corev1.
 	var config corev1.Secret
 	err := r.apiReader.Get(ctx, client.ObjectKey{Name: extendWithSuffix(r.dynakube.Name), Namespace: r.dynakube.Namespace}, &config)
 	if k8serrors.IsNotFound(err) {
-		log.Info("creating pull secret")
+		log.Info("creating process module config secret")
 		newSecret, err := r.prepareSecret()
 		if err != nil {
 			return nil, err

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler_test.go
@@ -1,0 +1,100 @@
+package processmoduleconfigsecret
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
+	clientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	testName      = "test-name"
+	testNamespace = "test-namespace"
+)
+
+func TestReconciler_Reconcile(t *testing.T) {
+	t.Run("Create and update works with minimal setup", func(t *testing.T) {
+		dynakube := createDynakube(dynatracev1beta1.OneAgentSpec{
+			CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{}})
+
+		mockK8sClient := fake.NewClient(dynakube)
+		mockTime := timeprovider.New().Freeze()
+
+		reconciler := NewReconciler(mockK8sClient,
+			mockK8sClient, createMockDtClient(t, 0), dynakube, scheme.Scheme, mockTime)
+		err := reconciler.Reconcile(context.TODO())
+		require.NoError(t, err)
+
+		checkSecretForValue(t, mockK8sClient, "\"revision\":0")
+		require.True(t, dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate.Time == mockTime.Now().Time)
+
+		// update should be blocked by timeout
+		mockTime.Set(timeprovider.Now())
+		reconciler.dtClient = createMockDtClient(t, 1)
+		err = reconciler.Reconcile(context.TODO())
+		require.NoError(t, err)
+		checkSecretForValue(t, mockK8sClient, "\"revision\":0")
+		require.True(t, dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate.Time != mockTime.Now().Time)
+
+		// go forward in time => should update again
+		futureTime := metav1.NewTime(time.Now().Add(time.Hour))
+		mockTime.Set(&futureTime)
+
+		err = reconciler.Reconcile(context.TODO())
+		require.NoError(t, err)
+		checkSecretForValue(t, mockK8sClient, "\"revision\":1")
+		require.True(t, dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate.Time == futureTime.Time)
+	})
+	t.Run("Only runs when required", func(t *testing.T) {
+		dynakube := createDynakube(dynatracev1beta1.OneAgentSpec{
+			ClassicFullStack: &dynatracev1beta1.HostInjectSpec{}})
+
+		reconciler := NewReconciler(nil, nil, nil, dynakube, scheme.Scheme, timeprovider.New())
+		err := reconciler.Reconcile(context.TODO())
+
+		require.NoError(t, err)
+	})
+}
+
+func checkSecretForValue(t *testing.T, k8sClient client.Client, shouldContain string) {
+	var secret corev1.Secret
+	err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: extendWithSuffix(testName), Namespace: testNamespace}, &secret)
+	require.NoError(t, err)
+
+	processModuleConfig, ok := secret.Data[SecretKeyProcessModuleConfig]
+	require.True(t, ok)
+	require.True(t, strings.Contains(string(processModuleConfig), shouldContain))
+}
+
+func createDynakube(oneAgentSpec dynatracev1beta1.OneAgentSpec) *dynatracev1beta1.DynaKube {
+	return &dynatracev1beta1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testName,
+		},
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			OneAgent: oneAgentSpec,
+		},
+	}
+}
+
+func createMockDtClient(t *testing.T, revision uint) *clientmock.Client {
+	mockClient := clientmock.NewClient(t)
+	mockClient.On("GetProcessModuleConfig", mock.AnythingOfType("uint")).Return(&dtclient.ProcessModuleConfig{
+		Revision:   revision,
+		Properties: nil,
+	}, nil)
+	return mockClient
+}

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler_test.go
@@ -38,7 +38,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		checkSecretForValue(t, mockK8sClient, "\"revision\":0")
-		require.True(t, dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate.Time == mockTime.Now().Time)
+		require.True(t, dynakube.Status.OneAgent.LastProcessModuleConfigUpdate.Time == mockTime.Now().Time)
 
 		// update should be blocked by timeout
 		mockTime.Set(timeprovider.Now())
@@ -46,7 +46,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		err = reconciler.Reconcile(context.TODO())
 		require.NoError(t, err)
 		checkSecretForValue(t, mockK8sClient, "\"revision\":0")
-		require.True(t, dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate.Time != mockTime.Now().Time)
+		require.True(t, dynakube.Status.OneAgent.LastProcessModuleConfigUpdate.Time != mockTime.Now().Time)
 
 		// go forward in time => should update again
 		futureTime := metav1.NewTime(time.Now().Add(time.Hour))
@@ -55,7 +55,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		err = reconciler.Reconcile(context.TODO())
 		require.NoError(t, err)
 		checkSecretForValue(t, mockK8sClient, "\"revision\":1")
-		require.True(t, dynakube.Status.DynatraceApi.LastProcessModuleConfigUpdate.Time == futureTime.Time)
+		require.True(t, dynakube.Status.OneAgent.LastProcessModuleConfigUpdate.Time == futureTime.Time)
 	})
 	t.Run("Only runs when required", func(t *testing.T) {
 		dynakube := createDynakube(dynatracev1beta1.OneAgentSpec{


### PR DESCRIPTION
## Description

To reduce the number of requests to the tenant, the file ruxitagentproc.conf should be saved into a secret.
This will be the future source of truth for that file.

## How can this be tested?

Create a cloudnative or application monitoring dynakube and check if the secret was created.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
