### PR TITLE
Add missing hostIdSource incase of cloudNativeFullStack

### DIFF
--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
@@ -23,7 +23,7 @@ func (dsInfo *builderInfo) arguments() []string {
 
 	if dsInfo.dynakube.ClassicFullStackMode() {
 		argMap.Append(argumentPrefix+"set-host-id-source", classicHostIdSource)
-	} else if dsInfo.dynakube.HostMonitoringMode() {
+	} else if dsInfo.dynakube.HostMonitoringMode() || dsInfo.dynakube.CloudNativeFullstackMode() {
 		argMap.Append(argumentPrefix+"set-host-id-source", inframonHostIdSource)
 	}
 

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -157,12 +157,12 @@ func TestPodSpec_Arguments(t *testing.T) {
 		podSpecs = dsInfo.podSpec()
 		assert.NotContains(t, podSpecs.Containers[0].Args, "--set-network-zone="+testValue)
 	})
-	t.Run(`has webhook injection arg classic fullstack`, func(t *testing.T) {
+	t.Run(`has host-id-source arg for classic fullstack`, func(t *testing.T) {
 		daemonset, _ := dsInfo.BuildDaemonSet()
 		podSpecs = daemonset.Spec.Template.Spec
 		assert.Contains(t, podSpecs.Containers[0].Args, "--set-host-id-source=auto")
 	})
-	t.Run(`has webhook injection arg host monitoring`, func(t *testing.T) {
+	t.Run(`has host-id-source arg for hostMonitoring`, func(t *testing.T) {
 		hostMonInstance := &dynatracev1beta1.DynaKube{
 			Spec: dynatracev1beta1.DynaKubeSpec{
 				OneAgent: dynatracev1beta1.OneAgentSpec{
@@ -179,6 +179,28 @@ func TestPodSpec_Arguments(t *testing.T) {
 			builderInfo{
 				dynakube:       hostMonInstance,
 				hostInjectSpec: hostMonInjectSpec,
+				clusterID:      testClusterID,
+			},
+		}
+		daemonset, _ := dsInfo.BuildDaemonSet()
+		podSpecs := daemonset.Spec.Template.Spec
+		assert.Contains(t, podSpecs.Containers[0].Args, "--set-host-id-source=k8s-node-name")
+	})
+	t.Run(`has host-id-source arg for cloudNativeFullstack`, func(t *testing.T) {
+		cloudNativeInstance := &dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
+						HostInjectSpec: dynatracev1beta1.HostInjectSpec{Args: []string{testKey, testValue, testUID}},
+					},
+				},
+			},
+		}
+
+		dsInfo := HostMonitoring{
+			builderInfo{
+				dynakube:       cloudNativeInstance,
+				hostInjectSpec: &cloudNativeInstance.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec,
 				clusterID:      testClusterID,
 			},
 		}


### PR DESCRIPTION
## Description

Currently the hostIDSource is not set if cloudNativeFullStack is used.

## How can this be tested?

Deploy a Dynakube with cloudNativeFullStack and check if the daemonset has an arg set -> `--set-host-id-source=k8s-node-name`

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
