### PR TITLE
Version status uses endpoints instead of image manifest

### DIFF
--- a/pkg/clients/dynatrace/dynatrace_client_test.go
+++ b/pkg/clients/dynatrace/dynatrace_client_test.go
@@ -152,7 +152,7 @@ func dynatraceServerHandler() http.HandlerFunc {
 
 func handleRequest(request *http.Request, writer http.ResponseWriter) {
 	latestAgentVersion := fmt.Sprintf("/v1/deployment/installer/agent/%s/%s/latest/metainfo", OsUnix, InstallerTypePaaS)
-	latestActiveGateVersion := fmt.Sprintf("/api/v1/deployment/installer/gateway/%s/latest/metainfo", OsUnix)
+	latestActiveGateVersion := fmt.Sprintf("/v1/deployment/installer/gateway/%s/latest/metainfo", OsUnix)
 	agentVersions := fmt.Sprintf("/v1/deployment/installer/agent/versions/%s/%s", OsUnix, InstallerTypePaaS)
 
 	switch request.URL.Path {

--- a/pkg/clients/dynatrace/endpoints.go
+++ b/pkg/clients/dynatrace/endpoints.go
@@ -20,7 +20,7 @@ func (dtc *dynatraceClient) getLatestAgentVersionUrl(os, installerType, flavor, 
 }
 
 func (dtc *dynatraceClient) getLatestActiveGateVersionUrl(os, arch string) string {
-	return fmt.Sprintf("%s/api/v1/deployment/installer/gateway/%s/latest/metainfo?&arch=%s",
+	return fmt.Sprintf("%s/v1/deployment/installer/gateway/%s/latest/metainfo?arch=%s",
 		dtc.url, os, arch)
 }
 

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -52,7 +52,7 @@ const (
 	testUID              = "test-uid"
 	testPaasToken        = "test-paas-token"
 	testAPIToken         = "test-api-token"
-	testVersion          = "1.217-12345-678910"
+	testVersion          = "1.217.1.12345-678910"
 	testComponentVersion = "test-component-version"
 
 	testUUID     = "test-uuid"
@@ -464,8 +464,8 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 	})
 	t.Run(`Create reconciles Kubernetes Monitoring if enabled`, func(t *testing.T) {
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
-
 		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
 
 		instance := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -502,6 +502,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 			dtclient.TokenScopeActiveGateTokenCreate})
 
 		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
 
 		instance := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -544,6 +545,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string")).Return(testUID, nil)
 		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
 
 		instance := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -581,6 +583,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 	t.Run(`Create reconciles proxy secret`, func(t *testing.T) {
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
 		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
 
 		instance := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -652,6 +655,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeSettingsRead, dtclient.TokenScopeSettingsWrite, dtclient.TokenScopeActiveGateTokenCreate})
 
 		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
 
 		instance := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -806,6 +810,7 @@ func TestReconcile_RemoveRoutingIfDisabled(t *testing.T) {
 	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
 
 	mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+	mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
 
 	instance := &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
@@ -881,6 +886,7 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 	})
 
 	mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+	mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
 
 	instance := &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1340,6 +1346,8 @@ func TestTokenConditions(t *testing.T) {
 
 func TestAPIError(t *testing.T) {
 	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
+	mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
+
 	instance := &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
@@ -1359,6 +1367,7 @@ func TestAPIError(t *testing.T) {
 
 	t.Run("should return error result on 503", func(t *testing.T) {
 		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, dtclient.ServerError{Code: http.StatusServiceUnavailable, Message: "Service unavailable"})
+
 		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
 
 		result, err := controller.Reconcile(context.Background(), reconcile.Request{
@@ -1370,6 +1379,7 @@ func TestAPIError(t *testing.T) {
 	})
 	t.Run("should return error result on 429", func(t *testing.T) {
 		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, dtclient.ServerError{Code: http.StatusTooManyRequests, Message: "Too many requests"})
+
 		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
 
 		result, err := controller.Reconcile(context.Background(), reconcile.Request{

--- a/pkg/controllers/dynakube/version/activegate_test.go
+++ b/pkg/controllers/dynakube/version/activegate_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
-	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry/mocks"
 	mockedclient "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -40,9 +38,8 @@ func TestActiveGateUpdater(t *testing.T) {
 		}
 		mockClient := mockedclient.NewClient(t)
 		mockActiveGateImageInfo(mockClient, testImage)
-		mockImageGetter := mocks.MockImageGetter{}
 
-		updater := newActiveGateUpdater(dynakube, fake.NewClient(), mockClient, &mockImageGetter)
+		updater := newActiveGateUpdater(dynakube, fake.NewClient(), mockClient)
 
 		assert.Equal(t, "activegate", updater.Name())
 		assert.True(t, updater.IsEnabled())
@@ -75,11 +72,10 @@ func TestActiveGateUseDefault(t *testing.T) {
 		expectedImage := dynakube.DefaultActiveGateImage()
 		expectedVersion := "1.2.3.4-5"
 		mockClient := mockedclient.NewClient(t)
-		mockImageGetter := mocks.MockImageGetter{}
 
-		mockImageGetter.On("GetImageVersion", mock.Anything, mock.Anything).Return(registry.ImageVersion{Version: expectedVersion}, nil)
+		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(expectedVersion, nil)
 
-		updater := newActiveGateUpdater(dynakube, fake.NewClient(), mockClient, &mockImageGetter)
+		updater := newActiveGateUpdater(dynakube, fake.NewClient(), mockClient)
 
 		err := updater.UseTenantRegistry(context.TODO())
 		require.NoError(t, err)

--- a/pkg/controllers/dynakube/version/codemodules_test.go
+++ b/pkg/controllers/dynakube/version/codemodules_test.go
@@ -8,7 +8,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
-	"github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	mocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/controllers/dynakube/version/reconciler.go
+++ b/pkg/controllers/dynakube/version/reconciler.go
@@ -57,7 +57,7 @@ func (r *reconciler) ReconcileOneAgent(ctx context.Context, dynakube *dynatracev
 func (r *reconciler) ReconcileActiveGate(ctx context.Context, dynakube *dynatracev1beta1.DynaKube) error {
 	updaters := []StatusUpdater{
 		newActiveGateUpdater(dynakube, r.apiReader, r.dtClient),
-		newSyntheticUpdater(dynakube, r.apiReader, r.dtClient, r.registryClient),
+		newSyntheticUpdater(dynakube, r.apiReader, r.dtClient),
 	}
 	for _, updater := range updaters {
 		if r.needsUpdate(updater, dynakube) {

--- a/pkg/controllers/dynakube/version/reconciler.go
+++ b/pkg/controllers/dynakube/version/reconciler.go
@@ -47,7 +47,7 @@ func (r *reconciler) ReconcileCodeModules(ctx context.Context, dynakube *dynatra
 }
 
 func (r *reconciler) ReconcileOneAgent(ctx context.Context, dynakube *dynatracev1beta1.DynaKube) error {
-	updater := newOneAgentUpdater(dynakube, r.apiReader, r.dtClient, r.registryClient)
+	updater := newOneAgentUpdater(dynakube, r.apiReader, r.dtClient)
 	if r.needsUpdate(updater, dynakube) {
 		return r.updateVersionStatuses(ctx, updater, dynakube)
 	}
@@ -56,7 +56,7 @@ func (r *reconciler) ReconcileOneAgent(ctx context.Context, dynakube *dynatracev
 
 func (r *reconciler) ReconcileActiveGate(ctx context.Context, dynakube *dynatracev1beta1.DynaKube) error {
 	updaters := []StatusUpdater{
-		newActiveGateUpdater(dynakube, r.apiReader, r.dtClient, r.registryClient),
+		newActiveGateUpdater(dynakube, r.apiReader, r.dtClient),
 		newSyntheticUpdater(dynakube, r.apiReader, r.dtClient, r.registryClient),
 	}
 	for _, updater := range updaters {

--- a/pkg/controllers/dynakube/version/synthetic.go
+++ b/pkg/controllers/dynakube/version/synthetic.go
@@ -6,29 +6,29 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	versionUnknown = "latest"
+)
+
 type syntheticUpdater struct {
-	dynakube       *dynatracev1beta1.DynaKube
-	apiReader      client.Reader
-	dtClient       dtclient.Client
-	registryClient registry.ImageGetter
+	dynakube  *dynatracev1beta1.DynaKube
+	apiReader client.Reader
+	dtClient  dtclient.Client
 }
 
 func newSyntheticUpdater(
 	dynakube *dynatracev1beta1.DynaKube,
 	apiReader client.Reader,
 	dtClient dtclient.Client,
-	registryClient registry.ImageGetter,
 ) *syntheticUpdater {
 	return &syntheticUpdater{
-		dynakube:       dynakube,
-		apiReader:      apiReader,
-		dtClient:       dtClient,
-		registryClient: registryClient,
+		dynakube:  dynakube,
+		apiReader: apiReader,
+		dtClient:  dtClient,
 	}
 }
 
@@ -70,7 +70,7 @@ func (updater syntheticUpdater) CheckForDowngrade(latestVersion string) (bool, e
 
 func (updater *syntheticUpdater) UseTenantRegistry(ctx context.Context) error {
 	defaultImage := updater.dynakube.DefaultSyntheticImage()
-	return updateSyntheticVersionStatusForTenantRegistry(ctx, updater.Target(), updater.registryClient, defaultImage)
+	return updateVersionStatusForTenantRegistry(updater.Target(), defaultImage, versionUnknown)
 }
 
 func (updater syntheticUpdater) ValidateStatus() error {

--- a/pkg/controllers/dynakube/version/synthetic.go
+++ b/pkg/controllers/dynakube/version/synthetic.go
@@ -70,7 +70,7 @@ func (updater syntheticUpdater) CheckForDowngrade(latestVersion string) (bool, e
 
 func (updater *syntheticUpdater) UseTenantRegistry(ctx context.Context) error {
 	defaultImage := updater.dynakube.DefaultSyntheticImage()
-	return updateVersionStatusForTenantRegistry(ctx, updater.Target(), updater.registryClient, defaultImage)
+	return updateSyntheticVersionStatusForTenantRegistry(ctx, updater.Target(), updater.registryClient, defaultImage)
 }
 
 func (updater syntheticUpdater) ValidateStatus() error {

--- a/pkg/controllers/dynakube/version/synthetic_test.go
+++ b/pkg/controllers/dynakube/version/synthetic_test.go
@@ -7,17 +7,12 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
-	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry/mocks"
 	mockedclient "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSyntheticUseTenantRegistry(t *testing.T) {
-	testVersion := "1.2.3.4-5"
-	testHash := getTestDigest()
 	t.Run("default image specified", func(t *testing.T) {
 		dynakube := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -39,13 +34,10 @@ func TestSyntheticUseTenantRegistry(t *testing.T) {
 		expectedImage := dynakube.DefaultSyntheticImage()
 		mockClient := mockedclient.NewClient(t)
 
-		mockImageGetter := mocks.MockImageGetter{}
-		mockImageGetter.On("GetImageVersion", mock.Anything, mock.Anything).Return(registry.ImageVersion{Version: testVersion, Digest: testHash}, nil)
-
-		updater := newSyntheticUpdater(dynakube, fake.NewClient(), mockClient, &mockImageGetter)
+		updater := newSyntheticUpdater(dynakube, fake.NewClient(), mockClient)
 
 		err := updater.UseTenantRegistry(context.TODO())
 		require.NoError(t, err, "default image set")
-		assertStatusBasedOnTenantRegistry(t, expectedImage, testVersion, dynakube.Status.Synthetic.VersionStatus)
+		assertStatusBasedOnTenantRegistry(t, expectedImage, versionUnknown, dynakube.Status.Synthetic.VersionStatus)
 	})
 }

--- a/pkg/controllers/dynakube/version/updater.go
+++ b/pkg/controllers/dynakube/version/updater.go
@@ -41,11 +41,8 @@ func (r *reconciler) run(ctx context.Context, updater StatusUpdater) error {
 	customImage := updater.CustomImage()
 	if customImage != "" {
 		log.Info("updating version status according to custom image", "updater", updater.Name())
-		err = setImageIDWithDigest(ctx, updater.Target(), r.registryClient, customImage)
-		if err != nil {
-			return err
-		}
-		return updater.ValidateStatus()
+		setImageIDToCustomImage(updater.Target(), customImage)
+		return nil
 	}
 
 	if !updater.IsAutoUpdateEnabled() {
@@ -110,6 +107,21 @@ func determineSource(updater StatusUpdater) status.VersionSource {
 	return status.TenantRegistryVersionSource
 }
 
+func setImageIDToCustomImage(
+	target *status.VersionStatus,
+	imageUri string,
+) {
+	log.Info("updating image version info",
+		"image", imageUri,
+		"oldImageID", target.ImageID)
+
+	target.ImageID = imageUri
+	target.Version = string(status.CustomImageVersionSource)
+
+	log.Info("updated image version info",
+		"newImageID", target.ImageID)
+}
+
 func setImageIDWithDigest(
 	ctx context.Context,
 	target *status.VersionStatus,
@@ -148,7 +160,7 @@ func setImageIDWithDigest(
 	return nil
 }
 
-func updateVersionStatusForTenantRegistry(
+func updateSyntheticVersionStatusForTenantRegistry(
 	ctx context.Context,
 	target *status.VersionStatus,
 	registryClient registry.ImageGetter,
@@ -172,6 +184,33 @@ func updateVersionStatusForTenantRegistry(
 		}
 		target.ImageID = taggedRef.String()
 		target.Version = imageVersion.Version
+	}
+
+	log.Info("updated image version info for tenant registry image",
+		"newImageID", target.ImageID,
+		"newVersion", target.Version)
+
+	return nil
+}
+
+func updateVersionStatusForTenantRegistry(
+	target *status.VersionStatus,
+	imageUri string,
+	latestVersion string,
+) error {
+	ref, err := name.ParseReference(imageUri)
+	if err != nil {
+		return errors.WithMessage(err, "failed to parse image uri")
+	}
+
+	log.Info("updating image version info for tenant registry image",
+		"image", imageUri,
+		"oldImageID", target.ImageID,
+		"oldVersion", target.Version)
+
+	if taggedRef, ok := ref.(name.Tag); ok {
+		target.ImageID = taggedRef.String()
+		target.Version = latestVersion
 	}
 
 	log.Info("updated image version info for tenant registry image",

--- a/pkg/controllers/dynakube/version/updater.go
+++ b/pkg/controllers/dynakube/version/updater.go
@@ -160,39 +160,6 @@ func setImageIDWithDigest(
 	return nil
 }
 
-func updateSyntheticVersionStatusForTenantRegistry(
-	ctx context.Context,
-	target *status.VersionStatus,
-	registryClient registry.ImageGetter,
-	imageUri string,
-) error {
-	ref, err := name.ParseReference(imageUri)
-	if err != nil {
-		return errors.WithMessage(err, "failed to parse image uri")
-	}
-
-	log.Info("updating image version info for tenant registry image",
-		"image", imageUri,
-		"oldImageID", target.ImageID,
-		"oldVersion", target.Version)
-
-	if taggedRef, ok := ref.(name.Tag); ok {
-		imageVersion, err := registryClient.GetImageVersion(ctx, imageUri)
-		if err != nil {
-			log.Info("failed to determine image version")
-			return err
-		}
-		target.ImageID = taggedRef.String()
-		target.Version = imageVersion.Version
-	}
-
-	log.Info("updated image version info for tenant registry image",
-		"newImageID", target.ImageID,
-		"newVersion", target.Version)
-
-	return nil
-}
-
 func updateVersionStatusForTenantRegistry(
 	target *status.VersionStatus,
 	imageUri string,

--- a/pkg/controllers/dynakube/version/updater_test.go
+++ b/pkg/controllers/dynakube/version/updater_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	mocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -495,8 +494,4 @@ func getTaggedReference(t *testing.T, image string) name.Tag {
 func assertStatusBasedOnTenantRegistry(t *testing.T, expectedImage, expectedVersion string, versionStatus status.VersionStatus) { //nolint:revive // argument-limit
 	assert.Equal(t, expectedImage, versionStatus.ImageID)
 	assert.Equal(t, expectedVersion, versionStatus.Version)
-}
-
-func getTestDigest() digest.Digest {
-	return digest.FromString("sha256:7ece13a07a20c77a31cc36906a10ebc90bd47970905ee61e8ed491b7f4c5d62f")
 }


### PR DESCRIPTION
## Description

Version status (OA,CodeModule,AG) doesn't use image manifest to get version of the image. The logic depends on the registry:
- for Tenant registry -> the response of the two endpoints (`.../latest/metainfo`) are used
- for Public registry -> no changes
- for custom image -> we do not detect the version for custom image anymore. For this reason downgrade check is also removed for custom image case. Additionally no verification of provided URI is performed,

`registry.GetImageVersion` call has been also removed from the Synthetic updater. Temporarily `Version` set to `latest`.

## How can this be tested?
1) Use unit tests `make go/test` to verify if tenant endpoints are used to get image version. 

2) Check if `*.Status.Version` field is set properly.

tenant registry - latest version on your tenant will be reported:
```
spec:
  activeGate:
    capabilities:
      - kubernetes-monitoring
  oneAgent:
    cloudNativeFullStack: {}
---
Status:
  Active Gate:
    Image ID:              <tenant>.dev.dynatracelabs.com/linux/activegate:latest
    Source:                tenant-registry
    Version:               1.285.0.20240123-020204
  Code Modules:
    Source:                tenant-registry
    Version:               1.285.0.20240122-141707
  One Agent:
    Image ID:              <tenant>.dev.dynatracelabs.com/linux/oneagent:latest
    Source:                tenant-registry
    Version:               1.285.0.20240122-141707
```
custom version - use version from the `tenant-registry` step and then do downgrade to a previous version, it should be allowed
```
spec:
  activeGate:
    capabilities:
      - kubernetes-monitoring
  oneAgent:
    cloudNativeFullStack:
      version: "1.285.0.20240122-141707"
---
Status:
  Active Gate:
    Image ID:              <tenant>.dev.dynatracelabs.com/linux/activegate:latest
    Source:                tenant-registry
    Version:               1.285.0.20240123-020204
  Code Modules:
    Source:                tenant-registry
    Version:               1.285.0.20240122-141707
  One Agent:
    Image ID:              <tenant>.dev.dynatracelabs.com/linux/oneagent:1.285.0
    Source:                custom-version
    Version:               1.285.0.20240122-141707
```
custom image -  use latest versions from the `public.ecr.aws` repo and then do downgrade to a previous versions, it should be allowed. Reported `Version` is always set to `custom-image`.
```
spec:
  activeGate:
    capabilities:
      - kubernetes-monitoring
    image: "public.ecr.aws/dynatrace/dynatrace-activegate:1.279.110.20231121-222817"
  oneAgent:
    cloudNativeFullStack:
      image: "public.ecr.aws/dynatrace/dynatrace-oneagent:1.281.150.20240122-144834"
---
Status:
  Active Gate:
    Image ID:              public.ecr.aws/dynatrace/dynatrace-activegate:1.279.110.20231121-222817
    Source:                custom-image
    Version:               custom-image
  Code Modules:
    Source:                tenant-registry
    Version:               1.285.0.20240122-141707
  One Agent:
    Image ID:              public.ecr.aws/dynatrace/dynatrace-oneagent:1.281.150.20240122-144834
    Source:                custom-image
    Version:               custom-image
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
