### PR TITLE
Add integration test to check build variables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,10 +61,11 @@ jobs:
         id: depdownload
         run: |
           hack/build/ci/install-cgo-dependencies.sh
-      - name: Run Unit tests
+      - name: Run Unit tests and Integration tests
         id: unittest
         run: |
           make go/test
+          make go/integration_test
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/cmd/integration/integration_test.go
+++ b/cmd/integration/integration_test.go
@@ -15,7 +15,10 @@ func TestBuildVariables(t *testing.T) {
 		t.Fatalf("Failed to run 'git branch': %v", err)
 	}
 
-	currentBranch := getCurrentBranch(string(output))
+	currentBranch, err := getCurrentBranch(string(output))
+	if err != nil {
+		t.Fatalf("Failed to get current branch: %v", err)
+	}
 
 	// get the current git commit
 	currentGitCommit := exec.Command("git", "log", "-n", "1", currentBranch)
@@ -40,14 +43,14 @@ func TestBuildVariables(t *testing.T) {
 	}
 }
 
-func getCurrentBranch(output string) string {
+func getCurrentBranch(output string) (string, error) {
 	lines := strings.Split(output, "\n")
 	for _, line := range lines {
 		if strings.HasPrefix(line, "*") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "*"))
+			return strings.TrimSpace(strings.TrimPrefix(line, "*")), nil
 		}
 	}
-	return ""
+	return "", fmt.Errorf("could not find current branch")
 }
 
 func extractCommitHash(input string) (string, error) {

--- a/cmd/integration/integration_test.go
+++ b/cmd/integration/integration_test.go
@@ -1,0 +1,64 @@
+package integration
+
+import (
+	"fmt"
+	"github.com/Dynatrace/dynatrace-operator/pkg/version"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestBuildVariables(t *testing.T) {
+	cmd := exec.Command("git", "branch")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to run 'git branch': %v", err)
+	}
+
+	currentBranch := getCurrentBranch(string(output))
+
+	// get the current git commit
+	currentGitCommit := exec.Command("git", "log", "-n", "1", currentBranch)
+	gitCommitOutput, err := currentGitCommit.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to run 'git log': %v", err)
+	}
+
+	commitHash, err := extractCommitHash(string(gitCommitOutput))
+	if err != nil {
+		t.Fatalf("Failed to run 'git branch': %v", err)
+	}
+
+	expectedGitCommitHash := version.Commit
+	if commitHash != expectedGitCommitHash {
+		t.Errorf("Git commits not equal. Expected: %s, Actual: %s", expectedGitCommitHash, commitHash)
+	}
+
+	expectedVersion := version.Version
+	if !strings.Contains(expectedVersion, currentBranch) {
+		t.Errorf("Versions not equal. Expected: %s, Actual: %s", expectedVersion, currentBranch)
+	}
+}
+
+func getCurrentBranch(output string) string {
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "*") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "*"))
+		}
+	}
+	return ""
+}
+
+func extractCommitHash(input string) (string, error) {
+	lines := strings.Split(input, "\n")
+
+	for _, line := range lines {
+		if strings.Contains(line, "commit") {
+			commitHash := strings.Split(line, " ")
+			return strings.TrimSpace(commitHash[1]), nil
+		}
+	}
+
+	return "", fmt.Errorf("commit hash not found in input")
+}

--- a/cmd/integration/integration_test.go
+++ b/cmd/integration/integration_test.go
@@ -1,67 +1,35 @@
+//go:build integration
+
 package integration
 
 import (
-	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/pkg/version"
+	"github.com/stretchr/testify/assert"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 )
 
 func TestBuildVariables(t *testing.T) {
-	cmd := exec.Command("git", "branch")
-	output, err := cmd.CombinedOutput()
+	cmd := exec.Command("git", "branch", "--show-current")
+	currentBranch, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to run 'git branch': %v", err)
 	}
 
-	currentBranch, err := getCurrentBranch(string(output))
-	if err != nil {
-		t.Fatalf("Failed to get current branch: %v", err)
-	}
-
 	// get the current git commit
-	currentGitCommit := exec.Command("git", "log", "-n", "1", currentBranch)
+	currentGitCommit := exec.Command("git", "rev-parse", "HEAD")
 	gitCommitOutput, err := currentGitCommit.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to run 'git log': %v", err)
 	}
 
-	commitHash, err := extractCommitHash(string(gitCommitOutput))
-	if err != nil {
-		t.Fatalf("Failed to run 'git branch': %v", err)
-	}
-
+	commitHash := strings.TrimSpace(string(gitCommitOutput))
 	expectedGitCommitHash := version.Commit
-	if commitHash != expectedGitCommitHash {
-		t.Errorf("Git commits not equal. Expected: %s, Actual: %s", expectedGitCommitHash, commitHash)
-	}
+	assert.Equal(t, expectedGitCommitHash, commitHash)
 
 	expectedVersion := version.Version
-	if !strings.Contains(expectedVersion, currentBranch) {
-		t.Errorf("Versions not equal. Expected: %s, Actual: %s", expectedVersion, currentBranch)
-	}
-}
-
-func getCurrentBranch(output string) (string, error) {
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		if strings.HasPrefix(line, "*") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "*")), nil
-		}
-	}
-	return "", fmt.Errorf("could not find current branch")
-}
-
-func extractCommitHash(input string) (string, error) {
-	lines := strings.Split(input, "\n")
-
-	for _, line := range lines {
-		if strings.Contains(line, "commit") {
-			commitHash := strings.Split(line, " ")
-			return strings.TrimSpace(commitHash[1]), nil
-		}
-	}
-
-	return "", fmt.Errorf("commit hash not found in input")
+	curBranch := strings.TrimSpace(string(currentBranch))
+	assert.Equal(t, expectedVersion, curBranch)
 }

--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -32,6 +32,9 @@ go/lint: go/format go/vet go/golangci
 go/test:
 	go test ./... -coverprofile=coverage.txt -covermode=atomic -tags "$(shell ./hack/build/create_go_build_tags.sh false)"
 
+go/integration_test:
+	go test -ldflags="-X 'github.com/Dynatrace/dynatrace-operator/pkg/version.Commit=$(shell git rev-parse HEAD)' -X 'github.com/Dynatrace/dynatrace-operator/pkg/version.Version=$(shell git branch --show-current)'" ./cmd/integration/*
+
 ## creates mocks from .mockery.yaml
 go/gen_mocks:
 	mockery


### PR DESCRIPTION
## Description

With this a new integration (no e2e) test is added to check if the build variables (commitHash, version) are set correctly, as we had issues in the past with the corresponding log line.

## How can this be tested?

run the test but do not forget the necessary flags.
example: `go test -ldflags="-X 'github.com/Dynatrace/dynatrace-operator/pkg/version.Commit=$(git rev-parse HEAD)' -X 'github.com/Dynatrace/dynatrace-operator/pkg/version.Version=$(git branch)'" **./cmd/integration/*`

## Checklist

- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
