### PR TITLE
Refactor Dynakube Controller Unit-Tests

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -37,6 +37,9 @@ packages:
   github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo:
     interfaces:
       Reconciler:
+  github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata:
+    interfaces:
+      Reconciler:
   github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer:
     interfaces:
       Installer:

--- a/pkg/controllers/dynakube/activegate.go
+++ b/pkg/controllers/dynakube/activegate.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/apimonitoring"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
@@ -30,7 +29,7 @@ func (controller *Controller) reconcileActiveGate(ctx context.Context, dynakube 
 			}
 		}
 	} // TODO: have a cleanup for things that we create above
-	reconciler := activegate.NewReconciler(controller.client, controller.apiReader, controller.scheme, dynakube, dtc)
+	reconciler := controller.activeGateReconcilerBuilder(controller.client, controller.apiReader, controller.scheme, dynakube, dtc)
 	err := reconciler.Reconcile(ctx)
 
 	if err != nil {

--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -34,6 +34,8 @@ type Reconciler struct {
 
 var _ controllers.Reconciler = (*Reconciler)(nil)
 
+type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client) controllers.Reconciler
+
 func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client) controllers.Reconciler { //nolint:revive // argument-limit doesn't apply to constructors
 	authTokenReconciler := authtoken.NewReconciler(clt, apiReader, scheme, dynakube, dtc)
 	newCustomPropertiesReconcilerFunc := func(customPropertiesOwnerName string, customPropertiesSource *dynatracev1beta1.DynaKubeValueSource) controllers.Reconciler {

--- a/pkg/controllers/dynakube/activegate_test.go
+++ b/pkg/controllers/dynakube/activegate_test.go
@@ -2,10 +2,17 @@ package dynakube
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	mockcontroller "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
+	mockconnectioninfo "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/connectioninfo"
+	mockversion "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,17 +28,144 @@ func TestReconcileActiveGate(t *testing.T) {
 			ActiveGate: dynatracev1beta1.ActiveGateSpec{Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.KubeMonCapability.DisplayName}},
 		},
 	}
-
 	t.Run("no active-gate configured => nothing happens (only call active-gate reconciler)", func(t *testing.T) {
 		dynakube := dynakubeBase.DeepCopy()
 		dynakube.Spec.ActiveGate = dynatracev1beta1.ActiveGateSpec{}
+
 		fakeClient := fake.NewClientWithIndex(dynakube)
+
+		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
+
 		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
+			client:                      fakeClient,
+			apiReader:                   fakeClient,
+			activeGateReconcilerBuilder: createActivegateReconcilerBuilder(mockActiveGateReconciler),
 		}
 
 		err := controller.reconcileActiveGate(ctx, dynakube, nil, nil, nil, nil)
 		require.NoError(t, err)
+	})
+	t.Run("no active-gate configured => active-gate reconcile returns error => returns error", func(t *testing.T) {
+		dynakube := dynakubeBase.DeepCopy()
+		dynakube.Spec.ActiveGate = dynatracev1beta1.ActiveGateSpec{}
+
+		fakeClient := fake.NewClientWithIndex(dynakube)
+
+		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
+
+		controller := &Controller{
+			client:                      fakeClient,
+			apiReader:                   fakeClient,
+			activeGateReconcilerBuilder: createActivegateReconcilerBuilder(mockActiveGateReconciler),
+		}
+
+		err := controller.reconcileActiveGate(ctx, dynakube, nil, nil, nil, nil)
+		require.Error(t, err)
+		require.Equal(t, "failed to reconcile ActiveGate: BOOM", err.Error())
+	})
+	t.Run(`reconcile automatic kubernetes api monitoring`, func(t *testing.T) {
+		instance := &dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+				Annotations: map[string]string{
+					dynatracev1beta1.AnnotationFeatureAutomaticK8sApiMonitoring: "true",
+				},
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testApiUrl,
+				ActiveGate: dynatracev1beta1.ActiveGateSpec{
+					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+						dynatracev1beta1.KubeMonCapability.DisplayName,
+					},
+				},
+			},
+			Status: dynatracev1beta1.DynaKubeStatus{
+				KubeSystemUUID: testUID,
+			},
+		}
+		fakeClient := fake.NewClientWithIndex(instance)
+
+		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{})
+
+		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
+		mockConnectionInfoReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
+
+		mockVersionReconciler := mockversion.NewReconciler(t)
+		mockVersionReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
+
+		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
+
+		controller := &Controller{
+			client:                      fakeClient,
+			apiReader:                   fakeClient,
+			activeGateReconcilerBuilder: createActivegateReconcilerBuilder(mockActiveGateReconciler),
+		}
+
+		err := controller.reconcileActiveGate(ctx, instance, mockClient, nil, mockConnectionInfoReconciler, mockVersionReconciler)
+		assert.NoError(t, err)
+		mockClient.AssertCalled(t, "CreateOrUpdateKubernetesSetting",
+			testName,
+			testUID,
+			mock.AnythingOfType("string"))
+		assert.NoError(t, err)
+	})
+	t.Run(`reconcile automatic kubernetes api monitoring with custom cluster name`, func(t *testing.T) {
+		const clusterLabel = "..blabla..;.🙃"
+
+		instance := &dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+				Annotations: map[string]string{
+					dynatracev1beta1.AnnotationFeatureAutomaticK8sApiMonitoring:            "true",
+					dynatracev1beta1.AnnotationFeatureAutomaticK8sApiMonitoringClusterName: clusterLabel,
+				},
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testApiUrl,
+				ActiveGate: dynatracev1beta1.ActiveGateSpec{
+					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+						dynatracev1beta1.KubeMonCapability.DisplayName,
+					},
+				},
+			},
+			Status: dynatracev1beta1.DynaKubeStatus{
+				KubeSystemUUID: testUID,
+			},
+		}
+		fakeClient := fake.NewClientWithIndex(instance)
+
+		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{})
+		mockClient.On("CreateOrUpdateKubernetesSetting",
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("string")).Return(testUID, nil)
+
+		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
+		mockConnectionInfoReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
+
+		mockVersionReconciler := mockversion.NewReconciler(t)
+		mockVersionReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
+
+		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
+
+		controller := &Controller{
+			client:                      fakeClient,
+			apiReader:                   fakeClient,
+			activeGateReconcilerBuilder: createActivegateReconcilerBuilder(mockActiveGateReconciler),
+		}
+
+		err := controller.reconcileActiveGate(ctx, instance, mockClient, nil, mockConnectionInfoReconciler, mockVersionReconciler)
+		assert.NoError(t, err)
+		mockClient.AssertCalled(t, "CreateOrUpdateKubernetesSetting",
+			clusterLabel,
+			testUID,
+			mock.AnythingOfType("string"))
+		assert.NoError(t, err)
 	})
 }

--- a/pkg/controllers/dynakube/apimonitoring/reconciler.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler.go
@@ -12,6 +12,8 @@ type Reconciler struct {
 	kubeSystemUUID string
 }
 
+type ReconcilerBuilder func(dtc dtclient.Client, clusterLabel, kubeSystemUUID string) *Reconciler
+
 func NewReconciler(dtc dtclient.Client, clusterLabel, kubeSystemUUID string) *Reconciler {
 	return &Reconciler{
 		dtc,

--- a/pkg/controllers/dynakube/connectioninfo/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/reconciler.go
@@ -27,6 +27,7 @@ type reconciler struct {
 	scheme       *runtime.Scheme
 	timeProvider *timeprovider.Provider
 }
+type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dtc dtclient.Client) Reconciler
 
 func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dtc dtclient.Client) Reconciler { //nolint:revive // argument-limit doesn't apply to constructors
 	return &reconciler{

--- a/pkg/controllers/dynakube/controller_system_test.go
+++ b/pkg/controllers/dynakube/controller_system_test.go
@@ -1,0 +1,625 @@
+package dynakube
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/version"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
+	semVersion "github.com/Dynatrace/dynatrace-operator/pkg/version"
+	mockedclient "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtClientMock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/dynatraceclient"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcileActiveGate_Reconcile(t *testing.T) {
+	t.Run(`Create works with minimal setup`, func(t *testing.T) {
+		controller := &Controller{
+			client:    fake.NewClient(),
+			apiReader: fake.NewClient(),
+		}
+		result, err := controller.Reconcile(context.Background(), reconcile.Request{})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+	})
+	t.Run(`Create works with minimal setup and interface`, func(t *testing.T) { // keep as integration test?
+		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
+
+		instance := &dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testApiUrl,
+			},
+		}
+		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+
+		result, err := controller.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+	})
+	t.Run(`Create reconciles proxy secret`, func(t *testing.T) {
+		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
+		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+
+		instance := &dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testApiUrl,
+				Proxy: &dynatracev1beta1.DynaKubeProxy{
+					Value:     "https://proxy:1234",
+					ValueFrom: "",
+				},
+				ActiveGate: dynatracev1beta1.ActiveGateSpec{Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.KubeMonCapability.DisplayName}},
+			},
+
+			Status: *getTestDynkubeStatus(),
+		}
+		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+
+		result, err := controller.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+
+		var proxySecret corev1.Secret
+		name := proxy.BuildSecretName(testName)
+		err = controller.client.Get(context.Background(), client.ObjectKey{Name: name, Namespace: testNamespace}, &proxySecret)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, proxySecret)
+	})
+	t.Run(`reconciles phase change correctly`, func(t *testing.T) {
+		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeSettingsRead, dtclient.TokenScopeSettingsWrite, dtclient.TokenScopeActiveGateTokenCreate})
+
+		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+
+		instance := &dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+				Annotations: map[string]string{
+					dynatracev1beta1.AnnotationFeatureAutomaticK8sApiMonitoring: "true",
+				},
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testApiUrl,
+				ActiveGate: dynatracev1beta1.ActiveGateSpec{
+					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+						dynatracev1beta1.KubeMonCapability.DisplayName,
+					},
+				},
+			},
+			Status: *getTestDynkubeStatus(),
+		}
+		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+		// Remove existing StatefulSet created by createFakeClientAndReconciler
+		require.NoError(t, controller.client.Delete(context.Background(), &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: testName + "-activegate", Namespace: testNamespace}}))
+
+		result, err := controller.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+		})
+
+		mockClient.AssertCalled(t, "CreateOrUpdateKubernetesSetting",
+			testName,
+			testUID,
+			mock.AnythingOfType("string"))
+
+		assert.NoError(t, err)
+		assert.Equal(t, false, result.Requeue)
+
+		var activeGateStatefulSet appsv1.StatefulSet
+		assert.NoError(t,
+			controller.client.Get(context.Background(), client.ObjectKey{Name: testName + "-activegate", Namespace: testNamespace}, &activeGateStatefulSet))
+		assert.NoError(t, controller.client.Get(context.Background(), client.ObjectKey{Name: testName, Namespace: testNamespace}, instance))
+		assert.Equal(t, status.Running, instance.Status.Phase)
+	})
+}
+
+func TestReconcileOnlyOneTokenProvided_Reconcile(t *testing.T) {
+	t.Run(`Create validates apiToken correctly if apiToken with "InstallerDownload"-scope is provided`, func(t *testing.T) {
+		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeInstallerDownload, dtclient.TokenScopeActiveGateTokenCreate})
+
+		instance := &dynatracev1beta1.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				APIURL: testApiUrl,
+			}}
+		controller := createFakeClientAndReconciler(t, mockClient, instance, "", testAPIToken)
+
+		result, err := controller.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+
+		var secret corev1.Secret
+
+		err = controller.client.Get(context.Background(), client.ObjectKey{Name: testName, Namespace: testNamespace}, &secret)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, secret)
+		assert.Equal(t, string(secret.Data[dtclient.DynatraceApiToken]), testAPIToken)
+	})
+}
+func TestReconcile_RemoveRoutingIfDisabled(t *testing.T) {
+	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
+
+	mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+
+	instance := &dynatracev1beta1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			APIURL: testApiUrl,
+			Routing: dynatracev1beta1.RoutingSpec{
+				Enabled: true,
+			}}}
+	controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+	}
+
+	_, err := controller.Reconcile(context.Background(), request)
+	assert.NoError(t, err)
+
+	// Reconcile twice since routing service is created before the stateful set
+	_, err = controller.Reconcile(context.Background(), request)
+	assert.NoError(t, err)
+
+	routingCapability := capability.NewRoutingCapability(instance)
+	stsName := capability.CalculateStatefulSetName(routingCapability, testName)
+
+	routingSts := &appsv1.StatefulSet{}
+	err = controller.client.Get(context.Background(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      stsName,
+	}, routingSts)
+	assert.NoError(t, err)
+	assert.NotNil(t, routingSts)
+
+	routingSvc := &corev1.Service{}
+	err = controller.client.Get(context.Background(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      testName + "-" + routingCapability.ShortName(),
+	}, routingSvc)
+	assert.NoError(t, err)
+	assert.NotNil(t, routingSvc)
+
+	err = controller.client.Get(context.Background(), client.ObjectKey{Name: instance.Name, Namespace: instance.Namespace}, instance)
+	require.NoError(t, err)
+
+	instance.Spec.Routing.Enabled = false
+	err = controller.client.Update(context.Background(), instance)
+	require.NoError(t, err)
+
+	_, err = controller.Reconcile(context.Background(), request)
+	assert.NoError(t, err)
+
+	err = controller.client.Get(context.Background(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      stsName,
+	}, routingSts)
+	assert.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
+
+	err = controller.client.Get(context.Background(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      testName + "-" + routingCapability.ShortName(),
+	}, routingSvc)
+	assert.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
+}
+func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
+	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{
+		dtclient.TokenScopeDataExport,
+		dtclient.TokenScopeMetricsIngest,
+		dtclient.TokenScopeActiveGateTokenCreate,
+	})
+
+	mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+	mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
+
+	instance := &dynatracev1beta1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			APIURL: testApiUrl,
+			ActiveGate: dynatracev1beta1.ActiveGateSpec{
+				Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+					dynatracev1beta1.MetricsIngestCapability.DisplayName,
+					dynatracev1beta1.KubeMonCapability.DisplayName,
+					dynatracev1beta1.RoutingCapability.DisplayName,
+				},
+			}},
+	}
+
+	r := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+	}
+
+	_, err := r.Reconcile(context.Background(), request)
+	assert.NoError(t, err)
+
+	// Reconcile twice since routing service is created before the stateful set
+	_, err = r.Reconcile(context.Background(), request)
+	assert.NoError(t, err)
+
+	multiCapability := capability.NewMultiCapability(instance)
+	stsName := capability.CalculateStatefulSetName(multiCapability, testName)
+
+	routingSts := &appsv1.StatefulSet{}
+	err = r.client.Get(context.Background(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      stsName,
+	}, routingSts)
+	assert.NoError(t, err)
+	assert.NotNil(t, routingSts)
+
+	routingSvc := &corev1.Service{}
+	err = r.client.Get(context.Background(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      testName + "-" + multiCapability.ShortName(),
+	}, routingSvc)
+	assert.NoError(t, err)
+	assert.NotNil(t, routingSvc)
+
+	err = r.client.Get(context.Background(), client.ObjectKey{Name: instance.Name, Namespace: instance.Namespace}, instance)
+	require.NoError(t, err)
+
+	instance.Spec.ActiveGate.Capabilities = []dynatracev1beta1.CapabilityDisplayName{}
+	err = r.client.Update(context.Background(), instance)
+	require.NoError(t, err)
+
+	_, err = r.Reconcile(context.Background(), request)
+	assert.NoError(t, err)
+
+	err = r.client.Get(context.Background(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      stsName,
+	}, routingSts)
+	assert.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
+
+	err = r.client.Get(context.Background(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      testName + "-" + multiCapability.ShortName(),
+	}, routingSvc)
+	assert.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
+}
+
+func TestAPIError(t *testing.T) {
+	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
+	instance := &dynatracev1beta1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			APIURL:   testApiUrl,
+			OneAgent: dynatracev1beta1.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{HostInjectSpec: dynatracev1beta1.HostInjectSpec{}}},
+			ActiveGate: dynatracev1beta1.ActiveGateSpec{
+				Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+					dynatracev1beta1.KubeMonCapability.DisplayName,
+				},
+			},
+		},
+		Status: *getTestDynkubeStatus(),
+	}
+
+	t.Run("should return error result on 503", func(t *testing.T) {
+		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, dtclient.ServerError{Code: http.StatusServiceUnavailable, Message: "Service unavailable"})
+		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+
+		result, err := controller.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, fastUpdateInterval, result.RequeueAfter)
+	})
+	t.Run("should return error result on 429", func(t *testing.T) {
+		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, dtclient.ServerError{Code: http.StatusTooManyRequests, Message: "Too many requests"})
+		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+
+		result, err := controller.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, fastUpdateInterval, result.RequeueAfter)
+	})
+}
+
+func createDTMockClient(t *testing.T, paasTokenScopes, apiTokenScopes dtclient.TokenScopes) *mockedclient.Client {
+	mockClient := mockedclient.NewClient(t)
+
+	mockClient.On("GetCommunicationHostForClient").Return(dtclient.CommunicationHost{
+		Protocol: testProtocol,
+		Host:     testHost,
+		Port:     testPort,
+	}, nil).Maybe()
+	mockClient.On("GetOneAgentConnectionInfo").Return(dtclient.OneAgentConnectionInfo{
+		CommunicationHosts: []dtclient.CommunicationHost{
+			{
+				Protocol: testProtocol,
+				Host:     testHost,
+				Port:     testPort,
+			},
+			{
+				Protocol: testAnotherProtocol,
+				Host:     testAnotherHost,
+				Port:     testAnotherPort,
+			},
+		},
+		ConnectionInfo: dtclient.ConnectionInfo{
+			TenantUUID: testUUID,
+		},
+	}, nil).Maybe()
+	mockClient.On("GetTokenScopes", testPaasToken).Return(paasTokenScopes, nil).Maybe()
+	mockClient.On("GetTokenScopes", testAPIToken).Return(apiTokenScopes, nil).Maybe()
+	mockClient.On("GetOneAgentConnectionInfo").Return(
+		dtclient.OneAgentConnectionInfo{
+			ConnectionInfo: dtclient.ConnectionInfo{
+				TenantUUID: "abc123456",
+			},
+		}, nil).Maybe()
+	mockClient.On("GetLatestAgentVersion", mock.Anything, mock.Anything).Return(testVersion, nil).Maybe()
+	mockClient.On("GetMonitoredEntitiesForKubeSystemUUID", mock.AnythingOfType("string")).
+		Return([]dtclient.MonitoredEntity{}, nil).Maybe()
+	mockClient.On("GetSettingsForMonitoredEntities", []dtclient.MonitoredEntity{}, mock.AnythingOfType("string")).
+		Return(dtclient.GetSettingsResponse{}, nil).Maybe()
+	mockClient.On("CreateOrUpdateKubernetesSetting", testName, testUID, mock.AnythingOfType("string")).
+		Return(testObjectID, nil).Maybe()
+	mockClient.On("GetActiveGateConnectionInfo").Return(dtclient.ActiveGateConnectionInfo{}, nil).Maybe()
+	mockClient.On("GetProcessModuleConfig", mock.AnythingOfType("uint")).
+		Return(&dtclient.ProcessModuleConfig{}, nil).Maybe()
+
+	return mockClient
+}
+
+func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, instance *dynatracev1beta1.DynaKube, paasToken, apiToken string) *Controller {
+	data := map[string][]byte{
+		dtclient.DynatraceApiToken: []byte(apiToken),
+	}
+	if paasToken != "" {
+		data[dtclient.DynatracePaasToken] = []byte(paasToken)
+	}
+
+	objects := []client.Object{
+		instance,
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Data: data},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: kubesystem.Namespace,
+				UID:  testUID,
+			},
+		},
+	}
+
+	objects = append(objects, generateStatefulSetForTesting(testName, testNamespace, "activegate", testUID))
+	objects = append(objects, createTenantSecrets(instance)...)
+
+	fakeClient := fake.NewClientWithIndex(objects...)
+
+	mockDtcBuilder := dtClientMock.NewBuilder(t)
+	mockDtcBuilder.On("SetContext", mock.Anything).Return(mockDtcBuilder)
+	mockDtcBuilder.On("SetDynakube", mock.Anything).Return(mockDtcBuilder)
+	mockDtcBuilder.On("SetTokens", mock.Anything).Return(mockDtcBuilder)
+	mockDtcBuilder.On("BuildWithTokenVerification", mock.Anything).Return(mockClient, nil)
+
+	controller := &Controller{
+		client:                              fakeClient,
+		apiReader:                           fakeClient,
+		registryClientBuilder:               createFakeRegistryClientBuilder(),
+		scheme:                              scheme.Scheme,
+		dynatraceClientBuilder:              mockDtcBuilder,
+		fs:                                  afero.Afero{Fs: afero.NewMemMapFs()},
+		deploymentMetadataReconcilerBuilder: deploymentmetadata.NewReconciler,
+		versionReconcilerBuilder:            version.NewReconciler,
+		connectionInfoReconcilerBuilder:     connectioninfo.NewReconciler,
+		activeGateReconcilerBuilder:         activegate.NewReconciler,
+	}
+
+	return controller
+}
+
+// generateStatefulSetForTesting prepares an ActiveGate StatefulSet after a Reconciliation of the Dynakube with a specific feature enabled
+func generateStatefulSetForTesting(name, namespace, feature, kubeSystemUUID string) *appsv1.StatefulSet {
+	expectedLabels := map[string]string{
+		labels.AppNameLabel:      labels.ActiveGateComponentLabel,
+		labels.AppVersionLabel:   testComponentVersion,
+		labels.AppComponentLabel: feature,
+		labels.AppCreatedByLabel: name,
+		labels.AppManagedByLabel: semVersion.AppName,
+	}
+	expectedMatchLabels := map[string]string{
+		labels.AppNameLabel:      labels.ActiveGateComponentLabel,
+		labels.AppManagedByLabel: semVersion.AppName,
+		labels.AppCreatedByLabel: name,
+	}
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-" + feature,
+			Namespace: namespace,
+			Labels:    expectedLabels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "dynatrace.com/v1beta1",
+					Kind:       "DynaKube",
+					Name:       name,
+				},
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: expectedMatchLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: expectedLabels,
+					Annotations: map[string]string{
+						"internal.operator.dynatrace.com/custom-properties-hash": "",
+						"internal.operator.dynatrace.com/version":                "",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "truststore-volume",
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name: "certificate-loader",
+							Command: []string{
+								"/bin/bash",
+							},
+							Args: []string{
+								"-c",
+								"/opt/dynatrace/gateway/k8scrt2jks.sh",
+							},
+							WorkingDir: "/var/lib/dynatrace/gateway",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:             "truststore-volume",
+									MountPath:        "/var/lib/dynatrace/gateway/ssl",
+									MountPropagation: (*corev1.MountPropagationMode)(nil),
+								},
+							},
+							ImagePullPolicy: "Always",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: feature,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "DT_CAPABILITIES",
+									Value: "kubernetes_monitoring",
+								},
+								{
+									Name:  "DT_ID_SEED_NAMESPACE",
+									Value: namespace,
+								},
+								{
+									Name:  "DT_ID_SEED_K8S_CLUSTER_ID",
+									Value: kubeSystemUUID,
+								},
+								{
+									Name:  "DT_DEPLOYMENT_METADATA",
+									Value: "orchestration_tech=Operator-active_gate;script_version=snapshot;orchestrator_id=" + kubeSystemUUID,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "truststore-volume",
+									ReadOnly:  true,
+									MountPath: "/opt/dynatrace/gateway/jre/lib/security/cacerts",
+									SubPath:   "k8s-local.jks",
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/rest/health",
+										Port: intstr.IntOrString{
+											IntVal: 9999,
+										},
+										Scheme: "HTTPS",
+									},
+								},
+								InitialDelaySeconds: 90,
+								PeriodSeconds:       15,
+								FailureThreshold:    3,
+							},
+							ImagePullPolicy: "Always",
+						},
+					},
+					ServiceAccountName: "dynatrace-kubernetes-monitoring",
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: name + "-pull-secret",
+						},
+					},
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "kubernetes.io/arch",
+												Operator: "In",
+												Values: []string{
+													"amd64",
+												},
+											},
+											{
+												Key:      "kubernetes.io/os",
+												Operator: "In",
+												Values: []string{
+													"linux",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			PodManagementPolicy: "Parallel",
+		},
+	}
+}

--- a/pkg/controllers/dynakube/controller_system_test.go
+++ b/pkg/controllers/dynakube/controller_system_test.go
@@ -70,6 +70,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 	t.Run(`Create reconciles proxy secret`, func(t *testing.T) {
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
 		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
 
 		instance := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -107,6 +108,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeSettingsRead, dtclient.TokenScopeSettingsWrite, dtclient.TokenScopeActiveGateTokenCreate})
 
 		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
 
 		instance := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
@@ -184,6 +186,7 @@ func TestReconcile_RemoveRoutingIfDisabled(t *testing.T) {
 	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
 
 	mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+	mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
 
 	instance := &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
@@ -334,6 +337,8 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 
 func TestAPIError(t *testing.T) {
 	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
+	mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
+
 	instance := &dynatracev1beta1.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -2,7 +2,6 @@ package dynakube
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -13,19 +12,21 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/version"
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
-	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry/mocks"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
+	mockregistry "github.com/Dynatrace/dynatrace-operator/pkg/oci/registry/mocks"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
-	"github.com/Dynatrace/dynatrace-operator/pkg/version"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	mockedclient "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	mockcontroller "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
+	mockconnectioninfo "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/connectioninfo"
 	dtClientMock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/dynatraceclient"
+	mockversion "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
 	containerv1 "github.com/google/go-containerregistry/pkg/v1"
 	fakecontainer "github.com/google/go-containerregistry/pkg/v1/fake"
 	"github.com/pkg/errors"
@@ -36,12 +37,10 @@ import (
 	fakeistio "istio.io/client-go/pkg/clientset/versioned/fake"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -120,6 +119,18 @@ func TestGetDynakubeOrCleanup(t *testing.T) {
 		assert.Equal(t, expectedDynakube.Name, dk.Name)
 		assert.Equal(t, expectedDynakube.Namespace, dk.Namespace)
 		assert.Equal(t, expectedDynakube.ApiUrl(), dk.ApiUrl())
+	})
+}
+func TestMinimalRequest(t *testing.T) {
+	t.Run(`Create works with minimal setup`, func(t *testing.T) {
+		controller := &Controller{
+			client:    fake.NewClient(),
+			apiReader: fake.NewClient(),
+		}
+		result, err := controller.Reconcile(context.Background(), reconcile.Request{})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
 	})
 }
 
@@ -318,17 +329,29 @@ func TestReconcileComponents(t *testing.T) {
 	t.Run("all components reconciled, even in case of errors", func(t *testing.T) {
 		dynakube := dynakubeBase.DeepCopy()
 		fakeClient := fake.NewClientWithIndex(dynakube)
+		// ReconcileCodeModuleCommunicationHosts
+		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
+		mockConnectionInfoReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
+		mockConnectionInfoReconciler.On("ReconcileOneAgent", mock.Anything, dynakube).Return(nil)
+
+		mockVersionReconciler := mockversion.NewReconciler(t)
+		mockVersionReconciler.On("ReconcileCodeModules", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
+		mockVersionReconciler.On("ReconcileOneAgent", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
+
+		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+
 		controller := &Controller{
 			client:                fakeClient,
 			apiReader:             fakeClient,
 			scheme:                scheme.Scheme,
 			fs:                    afero.Afero{Fs: afero.NewMemMapFs()},
 			registryClientBuilder: createFakeRegistryClientBuilder(),
+
+			versionReconcilerBuilder:        createVersionReconcilerBuilder(mockVersionReconciler),
+			connectionInfoReconcilerBuilder: createConnectionInfoReconcilerBuilder(mockConnectionInfoReconciler),
+			activeGateReconcilerBuilder:     createActivegateReconcilerBuilder(mockActiveGateReconciler),
 		}
 		mockedDtc := mockedclient.NewClient(t)
-		mockedDtc.On("GetActiveGateConnectionInfo").Return(dtclient.ActiveGateConnectionInfo{}, errors.New("BOOM"))
-		mockedDtc.On("GetOneAgentConnectionInfo").Return(createTestOneAgentConnectionInfo(), nil)
-		mockedDtc.On("GetLatestAgentVersion", mock.Anything, mock.Anything).Return("", errors.New("BOOM"))
 		err := controller.reconcileComponents(ctx, mockedDtc, nil, dynakube)
 
 		require.Error(t, err)
@@ -339,16 +362,28 @@ func TestReconcileComponents(t *testing.T) {
 	t.Run("exit early in case of no oneagent conncection info", func(t *testing.T) {
 		dynakube := dynakubeBase.DeepCopy()
 		fakeClient := fake.NewClientWithIndex(dynakube)
+
+		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
+		mockConnectionInfoReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
+		mockConnectionInfoReconciler.On("ReconcileOneAgent", mock.Anything, dynakube).Return(connectioninfo.NoOneAgentCommunicationHostsError)
+
+		mockVersionReconciler := mockversion.NewReconciler(t)
+		mockVersionReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
+
+		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
+
 		controller := &Controller{
-			client:                fakeClient,
-			apiReader:             fakeClient,
-			scheme:                scheme.Scheme,
-			fs:                    afero.Afero{Fs: afero.NewMemMapFs()},
-			registryClientBuilder: createFakeRegistryClientBuilder(),
+			client:                          fakeClient,
+			apiReader:                       fakeClient,
+			scheme:                          scheme.Scheme,
+			fs:                              afero.Afero{Fs: afero.NewMemMapFs()},
+			registryClientBuilder:           createFakeRegistryClientBuilder(),
+			versionReconcilerBuilder:        createVersionReconcilerBuilder(mockVersionReconciler),
+			connectionInfoReconcilerBuilder: createConnectionInfoReconcilerBuilder(mockConnectionInfoReconciler),
+			activeGateReconcilerBuilder:     createActivegateReconcilerBuilder(mockActiveGateReconciler),
 		}
 		mockedDtc := mockedclient.NewClient(t)
-		mockedDtc.On("GetActiveGateConnectionInfo").Return(dtclient.ActiveGateConnectionInfo{}, errors.New("BOOM"))
-		mockedDtc.On("GetOneAgentConnectionInfo").Return(dtclient.OneAgentConnectionInfo{}, nil)
 		err := controller.reconcileComponents(ctx, mockedDtc, nil, dynakube)
 
 		require.Error(t, err)
@@ -358,16 +393,24 @@ func TestReconcileComponents(t *testing.T) {
 	t.Run("exit early in case of error for oneagent conncection info", func(t *testing.T) {
 		dynakube := dynakubeBase.DeepCopy()
 		fakeClient := fake.NewClientWithIndex(dynakube)
+
+		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
+		mockConnectionInfoReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
+
+		mockVersionReconciler := mockversion.NewReconciler(t)
+
+		mockConnectionInfoReconciler.On("ReconcileOneAgent", mock.Anything, dynakube).Return(errors.New("BOOM"))
+
 		controller := &Controller{
-			client:                fakeClient,
-			apiReader:             fakeClient,
-			scheme:                scheme.Scheme,
-			fs:                    afero.Afero{Fs: afero.NewMemMapFs()},
-			registryClientBuilder: createFakeRegistryClientBuilder(),
+			client:                          fakeClient,
+			apiReader:                       fakeClient,
+			scheme:                          scheme.Scheme,
+			fs:                              afero.Afero{Fs: afero.NewMemMapFs()},
+			registryClientBuilder:           createFakeRegistryClientBuilder(),
+			versionReconcilerBuilder:        createVersionReconcilerBuilder(mockVersionReconciler),
+			connectionInfoReconcilerBuilder: createConnectionInfoReconcilerBuilder(mockConnectionInfoReconciler),
 		}
 		mockedDtc := mockedclient.NewClient(t)
-		mockedDtc.On("GetActiveGateConnectionInfo").Return(dtclient.ActiveGateConnectionInfo{}, errors.New("BOOM"))
-		mockedDtc.On("GetOneAgentConnectionInfo").Return(dtclient.OneAgentConnectionInfo{}, errors.New("BOOM"))
 		err := controller.reconcileComponents(ctx, mockedDtc, nil, dynakube)
 
 		require.Error(t, err)
@@ -376,358 +419,22 @@ func TestReconcileComponents(t *testing.T) {
 	})
 }
 
-func createTestOneAgentConnectionInfo() dtclient.OneAgentConnectionInfo {
-	return dtclient.OneAgentConnectionInfo{
-		CommunicationHosts: []dtclient.CommunicationHost{
-			{
-				Protocol: "beep-boop",
-				Host:     "a-host",
-				Port:     123,
-			},
-		},
-		ConnectionInfo: dtclient.ConnectionInfo{
-			TenantUUID: "a-tenant-uuid",
-		},
+func createActivegateReconcilerBuilder(reconciler controllers.Reconciler) activegate.ReconcilerBuilder {
+	return func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client) controllers.Reconciler {
+		return reconciler
 	}
 }
 
-func TestMonitoringModesDynakube_Reconcile(t *testing.T) {
-	deploymentModes := map[string]dynatracev1beta1.OneAgentSpec{
-		"hostMonitoring":        {HostMonitoring: &dynatracev1beta1.HostInjectSpec{AutoUpdate: address.Of(false)}},
-		"classicFullStack":      {ClassicFullStack: &dynatracev1beta1.HostInjectSpec{AutoUpdate: address.Of(false)}},
-		"cloudNativeFullStack":  {CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{HostInjectSpec: dynatracev1beta1.HostInjectSpec{AutoUpdate: address.Of(false)}}},
-		"applicationMonitoring": {ApplicationMonitoring: &dynatracev1beta1.ApplicationMonitoringSpec{}},
-	}
-
-	for mode := range deploymentModes {
-		t.Run(fmt.Sprintf(`Create dynakube with %s mode`, mode), func(t *testing.T) {
-			mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
-
-			instance := &dynatracev1beta1.DynaKube{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testName,
-					Namespace: testNamespace,
-				},
-				Spec: dynatracev1beta1.DynaKubeSpec{
-					APIURL:   testApiUrl,
-					OneAgent: deploymentModes[mode],
-				},
-				Status: *getTestDynkubeStatus(),
-			}
-			controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-
-			result, err := controller.Reconcile(context.Background(), reconcile.Request{
-				NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-			})
-
-			assert.NoError(t, err)
-			assert.NotNil(t, result)
-
-			err = controller.client.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testName}, instance)
-			require.NoError(t, err)
-			assert.Equal(t, status.Running, instance.Status.Phase)
-		})
+func createConnectionInfoReconcilerBuilder(reconciler *mockconnectioninfo.Reconciler) connectioninfo.ReconcilerBuilder {
+	return func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dtc dtclient.Client) connectioninfo.Reconciler {
+		return reconciler
 	}
 }
 
-func TestReconcileActiveGate_Reconcile(t *testing.T) {
-	t.Run(`Create works with minimal setup`, func(t *testing.T) {
-		controller := &Controller{
-			client:    fake.NewClient(),
-			apiReader: fake.NewClient(),
-		}
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{})
-
-		assert.NoError(t, err)
-		assert.NotNil(t, result)
-	})
-	t.Run(`Create works with minimal setup and interface`, func(t *testing.T) {
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
-
-		instance := &dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testName,
-				Namespace: testNamespace,
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-			},
-		}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-		})
-
-		assert.NoError(t, err)
-		assert.NotNil(t, result)
-	})
-	t.Run(`Create reconciles Kubernetes Monitoring if enabled`, func(t *testing.T) {
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
-		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
-		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
-
-		instance := &dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testName,
-				Namespace: testNamespace,
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-				KubernetesMonitoring: dynatracev1beta1.KubernetesMonitoringSpec{
-					Enabled: true,
-				}},
-			Status: *getTestDynkubeStatus(),
-		}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-		})
-
-		assert.NoError(t, err)
-		assert.NotNil(t, result)
-
-		var statefulSet appsv1.StatefulSet
-
-		kubeMonCapability := capability.NewKubeMonCapability(instance)
-		name := capability.CalculateStatefulSetName(kubeMonCapability, instance.Name)
-		err = controller.client.Get(context.Background(), client.ObjectKey{Name: name, Namespace: testNamespace}, &statefulSet)
-
-		assert.NoError(t, err)
-		assert.NotNil(t, statefulSet)
-	})
-	t.Run(`Create reconciles automatic kubernetes api monitoring`, func(t *testing.T) {
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeSettingsRead, dtclient.TokenScopeSettingsWrite,
-			dtclient.TokenScopeActiveGateTokenCreate})
-
-		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
-		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
-
-		instance := &dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testName,
-				Namespace: testNamespace,
-				Annotations: map[string]string{
-					dynatracev1beta1.AnnotationFeatureAutomaticK8sApiMonitoring: "true",
-				},
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-				ActiveGate: dynatracev1beta1.ActiveGateSpec{
-					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-						dynatracev1beta1.KubeMonCapability.DisplayName,
-					},
-				},
-			},
-			Status: *getTestDynkubeStatus(),
-		}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-		})
-
-		mockClient.AssertCalled(t, "CreateOrUpdateKubernetesSetting",
-			testName,
-			testUID,
-			mock.AnythingOfType("string"))
-		assert.NoError(t, err)
-		assert.Equal(t, false, result.Requeue)
-	})
-	t.Run(`Create reconciles automatic kubernetes api monitoring with custom cluster name`, func(t *testing.T) {
-		const clusterLabel = "..blabla..;.🙃"
-
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeSettingsRead, dtclient.TokenScopeSettingsWrite,
-			dtclient.TokenScopeActiveGateTokenCreate})
-		mockClient.On("CreateOrUpdateKubernetesSetting",
-			mock.AnythingOfType("string"),
-			mock.AnythingOfType("string"),
-			mock.AnythingOfType("string")).Return(testUID, nil)
-		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
-		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
-
-		instance := &dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testName,
-				Namespace: testNamespace,
-				Annotations: map[string]string{
-					dynatracev1beta1.AnnotationFeatureAutomaticK8sApiMonitoring:            "true",
-					dynatracev1beta1.AnnotationFeatureAutomaticK8sApiMonitoringClusterName: clusterLabel,
-				},
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-				ActiveGate: dynatracev1beta1.ActiveGateSpec{
-					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-						dynatracev1beta1.KubeMonCapability.DisplayName,
-					},
-				},
-			},
-			Status: *getTestDynkubeStatus(),
-		}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-		})
-
-		mockClient.AssertCalled(t, "CreateOrUpdateKubernetesSetting",
-			clusterLabel,
-			testUID,
-			mock.AnythingOfType("string"))
-
-		assert.NoError(t, err)
-		assert.Equal(t, false, result.Requeue)
-	})
-	t.Run(`Create reconciles proxy secret`, func(t *testing.T) {
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
-		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
-		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
-
-		instance := &dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testName,
-				Namespace: testNamespace,
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-				Proxy: &dynatracev1beta1.DynaKubeProxy{
-					Value:     "https://proxy:1234",
-					ValueFrom: "",
-				},
-				ActiveGate: dynatracev1beta1.ActiveGateSpec{Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.KubeMonCapability.DisplayName}},
-			},
-
-			Status: *getTestDynkubeStatus(),
-		}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-		})
-
-		assert.NoError(t, err)
-		assert.NotNil(t, result)
-
-		var proxySecret corev1.Secret
-		name := proxy.BuildSecretName(testName)
-		err = controller.client.Get(context.Background(), client.ObjectKey{Name: name, Namespace: testNamespace}, &proxySecret)
-
-		assert.NoError(t, err)
-		assert.NotNil(t, proxySecret)
-	})
-	t.Run(`has proxy secret but feature flag disables proxy`, func(t *testing.T) {
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
-
-		instance := &dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testName,
-				Namespace: testNamespace,
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-				Proxy: &dynatracev1beta1.DynaKubeProxy{
-					Value:     "https://proxy:1234",
-					ValueFrom: "",
-				}}}
-		instance.Annotations = map[string]string{
-			dynatracev1beta1.AnnotationFeatureActiveGateIgnoreProxy: "true",
-			dynatracev1beta1.AnnotationFeatureOneAgentIgnoreProxy:   "true",
-		}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-		})
-
-		assert.NoError(t, err)
-		assert.NotNil(t, result)
-
-		var proxySecret corev1.Secret
-		name := proxy.BuildSecretName(testName)
-		err = controller.client.Get(context.Background(), client.ObjectKey{Name: name, Namespace: testNamespace}, &proxySecret)
-
-		assert.Error(t, err)
-		assert.True(t, k8serrors.IsNotFound(err))
-	})
-	t.Run(`reconciles phase change correctly`, func(t *testing.T) {
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeSettingsRead, dtclient.TokenScopeSettingsWrite, dtclient.TokenScopeActiveGateTokenCreate})
-
-		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
-		mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
-
-		instance := &dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testName,
-				Namespace: testNamespace,
-				Annotations: map[string]string{
-					dynatracev1beta1.AnnotationFeatureAutomaticK8sApiMonitoring: "true",
-				},
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-				ActiveGate: dynatracev1beta1.ActiveGateSpec{
-					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-						dynatracev1beta1.KubeMonCapability.DisplayName,
-					},
-				},
-			},
-			Status: *getTestDynkubeStatus(),
-		}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-		// Remove existing StatefulSet created by createFakeClientAndReconciler
-		require.NoError(t, controller.client.Delete(context.Background(), &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: testName + "-activegate", Namespace: testNamespace}}))
-
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-		})
-
-		mockClient.AssertCalled(t, "CreateOrUpdateKubernetesSetting",
-			testName,
-			testUID,
-			mock.AnythingOfType("string"))
-
-		assert.NoError(t, err)
-		assert.Equal(t, false, result.Requeue)
-
-		var activeGateStatefulSet appsv1.StatefulSet
-		assert.NoError(t,
-			controller.client.Get(context.Background(), client.ObjectKey{Name: testName + "-activegate", Namespace: testNamespace}, &activeGateStatefulSet))
-		assert.NoError(t, controller.client.Get(context.Background(), client.ObjectKey{Name: testName, Namespace: testNamespace}, instance))
-		assert.Equal(t, status.Running, instance.Status.Phase)
-	})
-}
-
-func TestReconcileOnlyOneTokenProvided_Reconcile(t *testing.T) {
-	t.Run(`Create validates apiToken correctly if apiToken with "InstallerDownload"-scope is provided`, func(t *testing.T) {
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeInstallerDownload, dtclient.TokenScopeActiveGateTokenCreate})
-
-		instance := &dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testName,
-				Namespace: testNamespace,
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-			}}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, "", testAPIToken)
-
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-		})
-
-		assert.NoError(t, err)
-		assert.NotNil(t, result)
-
-		var secret corev1.Secret
-
-		err = controller.client.Get(context.Background(), client.ObjectKey{Name: testName, Namespace: testNamespace}, &secret)
-
-		assert.NoError(t, err)
-		assert.NotNil(t, secret)
-		assert.Equal(t, string(secret.Data[dtclient.DynatraceApiToken]), testAPIToken)
-	})
+func createVersionReconcilerBuilder(reconciler *mockversion.Reconciler) version.ReconcilerBuilder {
+	return func(apiReader client.Reader, dtClient dtclient.Client, registryClient registry.ImageGetter, fs afero.Afero, timeProvider *timeprovider.Provider) version.Reconciler {
+		return reconciler
+	}
 }
 
 func TestRemoveOneAgentDaemonset(t *testing.T) {
@@ -737,7 +444,7 @@ func TestRemoveOneAgentDaemonset(t *testing.T) {
 			dtclient.TokenScopeInstallerDownload,
 			dtclient.TokenScopeActiveGateTokenCreate})
 
-		instance := &dynatracev1beta1.DynaKube{
+		dynakube := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -752,7 +459,7 @@ func TestRemoveOneAgentDaemonset(t *testing.T) {
 		}
 
 		objects := []client.Object{
-			instance,
+			dynakube,
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testName,
@@ -767,13 +474,12 @@ func TestRemoveOneAgentDaemonset(t *testing.T) {
 			},
 			&appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      instance.OneAgentDaemonsetName(),
+					Name:      dynakube.OneAgentDaemonsetName(),
 					Namespace: testNamespace,
 				},
 			},
 		}
-
-		objects = append(objects, createTenantSecrets(instance)...)
+		objects = append(objects, createTenantSecrets(dynakube)...)
 
 		fakeClient := fake.NewClient(objects...)
 
@@ -783,12 +489,26 @@ func TestRemoveOneAgentDaemonset(t *testing.T) {
 		mockDtcBuilder.On("SetTokens", mock.Anything).Return(mockDtcBuilder)
 		mockDtcBuilder.On("BuildWithTokenVerification", mock.Anything).Return(mockClient, nil)
 
+		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
+
+		mockVersionReconciler := mockversion.NewReconciler(t)
+
+		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
+
+		mockReconciler := mockcontroller.NewReconciler(t)
+		mockReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
+
 		controller := &Controller{
-			client:                 fakeClient,
-			apiReader:              fakeClient,
-			scheme:                 scheme.Scheme,
-			dynatraceClientBuilder: mockDtcBuilder,
-			registryClientBuilder:  createFakeRegistryClientBuilder(),
+			client:                              fakeClient,
+			apiReader:                           fakeClient,
+			scheme:                              scheme.Scheme,
+			dynatraceClientBuilder:              mockDtcBuilder,
+			registryClientBuilder:               createFakeRegistryClientBuilder(),
+			deploymentMetadataReconcilerBuilder: createDeploymentMetadataReconcilerBuilder(mockReconciler),
+			versionReconcilerBuilder:            createVersionReconcilerBuilder(mockVersionReconciler),
+			connectionInfoReconcilerBuilder:     createConnectionInfoReconcilerBuilder(mockConnectionInfoReconciler),
+			activeGateReconcilerBuilder:         createActivegateReconcilerBuilder(mockActiveGateReconciler),
 		}
 
 		result, err := controller.Reconcile(context.Background(), reconcile.Request{
@@ -800,215 +520,20 @@ func TestRemoveOneAgentDaemonset(t *testing.T) {
 
 		var daemonSet appsv1.DaemonSet
 
-		err = controller.client.Get(context.Background(), client.ObjectKey{Name: instance.OneAgentDaemonsetName(), Namespace: testNamespace}, &daemonSet)
+		err = controller.client.Get(context.Background(), client.ObjectKey{Name: dynakube.OneAgentDaemonsetName(), Namespace: testNamespace}, &daemonSet)
 
 		assert.Error(t, err)
 	})
 }
 
-func TestReconcile_RemoveRoutingIfDisabled(t *testing.T) {
-	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
-
-	mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
-	mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
-
-	instance := &dynatracev1beta1.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testName,
-			Namespace: testNamespace,
-		},
-		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL: testApiUrl,
-			Routing: dynatracev1beta1.RoutingSpec{
-				Enabled: true,
-			}}}
-	controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-	request := reconcile.Request{
-		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+func createDeploymentMetadataReconcilerBuilder(mockReconciler *mockcontroller.Reconciler) func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube dynatracev1beta1.DynaKube, clusterID string) controllers.Reconciler {
+	return func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube dynatracev1beta1.DynaKube, clusterID string) controllers.Reconciler {
+		return mockReconciler
 	}
-
-	_, err := controller.Reconcile(context.Background(), request)
-	assert.NoError(t, err)
-
-	// Reconcile twice since routing service is created before the stateful set
-	_, err = controller.Reconcile(context.Background(), request)
-	assert.NoError(t, err)
-
-	routingCapability := capability.NewRoutingCapability(instance)
-	stsName := capability.CalculateStatefulSetName(routingCapability, testName)
-
-	routingSts := &appsv1.StatefulSet{}
-	err = controller.client.Get(context.Background(), client.ObjectKey{
-		Namespace: testNamespace,
-		Name:      stsName,
-	}, routingSts)
-	assert.NoError(t, err)
-	assert.NotNil(t, routingSts)
-
-	routingSvc := &corev1.Service{}
-	err = controller.client.Get(context.Background(), client.ObjectKey{
-		Namespace: testNamespace,
-		Name:      testName + "-" + routingCapability.ShortName(),
-	}, routingSvc)
-	assert.NoError(t, err)
-	assert.NotNil(t, routingSvc)
-
-	err = controller.client.Get(context.Background(), client.ObjectKey{Name: instance.Name, Namespace: instance.Namespace}, instance)
-	require.NoError(t, err)
-
-	instance.Spec.Routing.Enabled = false
-	err = controller.client.Update(context.Background(), instance)
-	require.NoError(t, err)
-
-	_, err = controller.Reconcile(context.Background(), request)
-	assert.NoError(t, err)
-
-	err = controller.client.Get(context.Background(), client.ObjectKey{
-		Namespace: testNamespace,
-		Name:      stsName,
-	}, routingSts)
-	assert.Error(t, err)
-	assert.True(t, k8serrors.IsNotFound(err))
-
-	err = controller.client.Get(context.Background(), client.ObjectKey{
-		Namespace: testNamespace,
-		Name:      testName + "-" + routingCapability.ShortName(),
-	}, routingSvc)
-	assert.Error(t, err)
-	assert.True(t, k8serrors.IsNotFound(err))
-}
-
-func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
-	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{
-		dtclient.TokenScopeDataExport,
-		dtclient.TokenScopeMetricsIngest,
-		dtclient.TokenScopeActiveGateTokenCreate,
-	})
-
-	mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
-	mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
-
-	instance := &dynatracev1beta1.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testName,
-			Namespace: testNamespace,
-		},
-		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL: testApiUrl,
-			ActiveGate: dynatracev1beta1.ActiveGateSpec{
-				Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-					dynatracev1beta1.MetricsIngestCapability.DisplayName,
-					dynatracev1beta1.KubeMonCapability.DisplayName,
-					dynatracev1beta1.RoutingCapability.DisplayName,
-				},
-			}},
-	}
-
-	r := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-	request := reconcile.Request{
-		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-	}
-
-	_, err := r.Reconcile(context.Background(), request)
-	assert.NoError(t, err)
-
-	// Reconcile twice since routing service is created before the stateful set
-	_, err = r.Reconcile(context.Background(), request)
-	assert.NoError(t, err)
-
-	multiCapability := capability.NewMultiCapability(instance)
-	stsName := capability.CalculateStatefulSetName(multiCapability, testName)
-
-	routingSts := &appsv1.StatefulSet{}
-	err = r.client.Get(context.Background(), client.ObjectKey{
-		Namespace: testNamespace,
-		Name:      stsName,
-	}, routingSts)
-	assert.NoError(t, err)
-	assert.NotNil(t, routingSts)
-
-	routingSvc := &corev1.Service{}
-	err = r.client.Get(context.Background(), client.ObjectKey{
-		Namespace: testNamespace,
-		Name:      testName + "-" + multiCapability.ShortName(),
-	}, routingSvc)
-	assert.NoError(t, err)
-	assert.NotNil(t, routingSvc)
-
-	err = r.client.Get(context.Background(), client.ObjectKey{Name: instance.Name, Namespace: instance.Namespace}, instance)
-	require.NoError(t, err)
-
-	instance.Spec.ActiveGate.Capabilities = []dynatracev1beta1.CapabilityDisplayName{}
-	err = r.client.Update(context.Background(), instance)
-	require.NoError(t, err)
-
-	_, err = r.Reconcile(context.Background(), request)
-	assert.NoError(t, err)
-
-	err = r.client.Get(context.Background(), client.ObjectKey{
-		Namespace: testNamespace,
-		Name:      stsName,
-	}, routingSts)
-	assert.Error(t, err)
-	assert.True(t, k8serrors.IsNotFound(err))
-
-	err = r.client.Get(context.Background(), client.ObjectKey{
-		Namespace: testNamespace,
-		Name:      testName + "-" + multiCapability.ShortName(),
-	}, routingSvc)
-	assert.Error(t, err)
-	assert.True(t, k8serrors.IsNotFound(err))
-}
-
-func createDTMockClient(t *testing.T, paasTokenScopes, apiTokenScopes dtclient.TokenScopes) *mockedclient.Client {
-	mockClient := mockedclient.NewClient(t)
-
-	mockClient.On("GetCommunicationHostForClient").Return(dtclient.CommunicationHost{
-		Protocol: testProtocol,
-		Host:     testHost,
-		Port:     testPort,
-	}, nil).Maybe()
-	mockClient.On("GetOneAgentConnectionInfo").Return(dtclient.OneAgentConnectionInfo{
-		CommunicationHosts: []dtclient.CommunicationHost{
-			{
-				Protocol: testProtocol,
-				Host:     testHost,
-				Port:     testPort,
-			},
-			{
-				Protocol: testAnotherProtocol,
-				Host:     testAnotherHost,
-				Port:     testAnotherPort,
-			},
-		},
-		ConnectionInfo: dtclient.ConnectionInfo{
-			TenantUUID: testUUID,
-		},
-	}, nil).Maybe()
-	mockClient.On("GetTokenScopes", testPaasToken).Return(paasTokenScopes, nil).Maybe()
-	mockClient.On("GetTokenScopes", testAPIToken).Return(apiTokenScopes, nil).Maybe()
-	mockClient.On("GetOneAgentConnectionInfo").Return(
-		dtclient.OneAgentConnectionInfo{
-			ConnectionInfo: dtclient.ConnectionInfo{
-				TenantUUID: "abc123456",
-			},
-		}, nil).Maybe()
-	mockClient.On("GetLatestAgentVersion", mock.Anything, mock.Anything).Return(testVersion, nil).Maybe()
-	mockClient.On("GetMonitoredEntitiesForKubeSystemUUID", mock.AnythingOfType("string")).
-		Return([]dtclient.MonitoredEntity{}, nil).Maybe()
-	mockClient.On("GetSettingsForMonitoredEntities", []dtclient.MonitoredEntity{}, mock.AnythingOfType("string")).
-		Return(dtclient.GetSettingsResponse{}, nil).Maybe()
-	mockClient.On("CreateOrUpdateKubernetesSetting", testName, testUID, mock.AnythingOfType("string")).
-		Return(testObjectID, nil).Maybe()
-	mockClient.On("GetActiveGateConnectionInfo").Return(dtclient.ActiveGateConnectionInfo{}, nil).Maybe()
-	mockClient.On("GetProcessModuleConfig", mock.AnythingOfType("uint")).
-		Return(&dtclient.ProcessModuleConfig{}, nil).Maybe()
-
-	return mockClient
 }
 
 func createFakeRegistryClientBuilder() func(options ...func(*registry.Client)) (registry.ImageGetter, error) {
-	fakeRegistryClient := &mocks.MockImageGetter{}
+	fakeRegistryClient := &mockregistry.MockImageGetter{}
 	fakeImage := &fakecontainer.FakeImage{}
 	fakeImage.ConfigFileStub = func() (*containerv1.ConfigFile, error) {
 		return &containerv1.ConfigFile{}, nil
@@ -1020,204 +545,6 @@ func createFakeRegistryClientBuilder() func(options ...func(*registry.Client)) (
 
 	return func(options ...func(*registry.Client)) (registry.ImageGetter, error) {
 		return fakeRegistryClient, nil
-	}
-}
-
-func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, instance *dynatracev1beta1.DynaKube, paasToken, apiToken string) *Controller {
-	data := map[string][]byte{
-		dtclient.DynatraceApiToken: []byte(apiToken),
-	}
-	if paasToken != "" {
-		data[dtclient.DynatracePaasToken] = []byte(paasToken)
-	}
-
-	objects := []client.Object{
-		instance,
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testName,
-				Namespace: testNamespace,
-			},
-			Data: data},
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: kubesystem.Namespace,
-				UID:  testUID,
-			},
-		},
-	}
-
-	objects = append(objects, generateStatefulSetForTesting(testName, testNamespace, "activegate", testUID))
-	objects = append(objects, createTenantSecrets(instance)...)
-
-	fakeClient := fake.NewClientWithIndex(objects...)
-
-	mockDtcBuilder := dtClientMock.NewBuilder(t)
-	mockDtcBuilder.On("SetContext", mock.Anything).Return(mockDtcBuilder)
-	mockDtcBuilder.On("SetDynakube", mock.Anything).Return(mockDtcBuilder)
-	mockDtcBuilder.On("SetTokens", mock.Anything).Return(mockDtcBuilder)
-	mockDtcBuilder.On("BuildWithTokenVerification", mock.Anything).Return(mockClient, nil)
-
-	controller := &Controller{
-		client:                 fakeClient,
-		apiReader:              fakeClient,
-		registryClientBuilder:  createFakeRegistryClientBuilder(),
-		scheme:                 scheme.Scheme,
-		dynatraceClientBuilder: mockDtcBuilder,
-		fs:                     afero.Afero{Fs: afero.NewMemMapFs()},
-	}
-
-	return controller
-}
-
-// generateStatefulSetForTesting prepares an ActiveGate StatefulSet after a Reconciliation of the Dynakube with a specific feature enabled
-func generateStatefulSetForTesting(name, namespace, feature, kubeSystemUUID string) *appsv1.StatefulSet {
-	expectedLabels := map[string]string{
-		labels.AppNameLabel:      labels.ActiveGateComponentLabel,
-		labels.AppVersionLabel:   testComponentVersion,
-		labels.AppComponentLabel: feature,
-		labels.AppCreatedByLabel: name,
-		labels.AppManagedByLabel: version.AppName,
-	}
-	expectedMatchLabels := map[string]string{
-		labels.AppNameLabel:      labels.ActiveGateComponentLabel,
-		labels.AppManagedByLabel: version.AppName,
-		labels.AppCreatedByLabel: name,
-	}
-	return &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name + "-" + feature,
-			Namespace: namespace,
-			Labels:    expectedLabels,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "dynatrace.com/v1beta1",
-					Kind:       "DynaKube",
-					Name:       name,
-				},
-			},
-		},
-		Spec: appsv1.StatefulSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: expectedMatchLabels,
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"internal.operator.dynatrace.com/custom-properties-hash": "",
-						"internal.operator.dynatrace.com/version":                "",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "truststore-volume",
-						},
-					},
-					InitContainers: []corev1.Container{
-						{
-							Name: "certificate-loader",
-							Command: []string{
-								"/bin/bash",
-							},
-							Args: []string{
-								"-c",
-								"/opt/dynatrace/gateway/k8scrt2jks.sh",
-							},
-							WorkingDir: "/var/lib/dynatrace/gateway",
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:             "truststore-volume",
-									MountPath:        "/var/lib/dynatrace/gateway/ssl",
-									MountPropagation: (*corev1.MountPropagationMode)(nil),
-								},
-							},
-							ImagePullPolicy: "Always",
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name: feature,
-							Env: []corev1.EnvVar{
-								{
-									Name:  "DT_CAPABILITIES",
-									Value: "kubernetes_monitoring",
-								},
-								{
-									Name:  "DT_ID_SEED_NAMESPACE",
-									Value: namespace,
-								},
-								{
-									Name:  "DT_ID_SEED_K8S_CLUSTER_ID",
-									Value: kubeSystemUUID,
-								},
-								{
-									Name:  "DT_DEPLOYMENT_METADATA",
-									Value: "orchestration_tech=Operator-active_gate;script_version=snapshot;orchestrator_id=" + kubeSystemUUID,
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "truststore-volume",
-									ReadOnly:  true,
-									MountPath: "/opt/dynatrace/gateway/jre/lib/security/cacerts",
-									SubPath:   "k8s-local.jks",
-								},
-							},
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/rest/health",
-										Port: intstr.IntOrString{
-											IntVal: 9999,
-										},
-										Scheme: "HTTPS",
-									},
-								},
-								InitialDelaySeconds: 90,
-								PeriodSeconds:       15,
-								FailureThreshold:    3,
-							},
-							ImagePullPolicy: "Always",
-						},
-					},
-					ServiceAccountName: "dynatrace-kubernetes-monitoring",
-					ImagePullSecrets: []corev1.LocalObjectReference{
-						{
-							Name: name + "-pull-secret",
-						},
-					},
-					Affinity: &corev1.Affinity{
-						NodeAffinity: &corev1.NodeAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-								NodeSelectorTerms: []corev1.NodeSelectorTerm{
-									{
-										MatchExpressions: []corev1.NodeSelectorRequirement{
-											{
-												Key:      "kubernetes.io/arch",
-												Operator: "In",
-												Values: []string{
-													"amd64",
-												},
-											},
-											{
-												Key:      "kubernetes.io/os",
-												Operator: "In",
-												Values: []string{
-													"linux",
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			PodManagementPolicy: "Parallel",
-		},
 	}
 }
 
@@ -1341,53 +668,6 @@ func TestTokenConditions(t *testing.T) {
 
 		assert.Error(t, err, "status update will fail")
 		assertCondition(t, dynakube, dynatracev1beta1.TokenConditionType, metav1.ConditionTrue, dynatracev1beta1.ReasonTokenReady, "")
-	})
-}
-
-func TestAPIError(t *testing.T) {
-	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
-	mockClient.On("GetLatestActiveGateVersion", mock.Anything).Return(testVersion, nil)
-
-	instance := &dynatracev1beta1.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testName,
-			Namespace: testNamespace,
-		},
-		Spec: dynatracev1beta1.DynaKubeSpec{
-			APIURL:   testApiUrl,
-			OneAgent: dynatracev1beta1.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{HostInjectSpec: dynatracev1beta1.HostInjectSpec{}}},
-			ActiveGate: dynatracev1beta1.ActiveGateSpec{
-				Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-					dynatracev1beta1.KubeMonCapability.DisplayName,
-				},
-			},
-		},
-		Status: *getTestDynkubeStatus(),
-	}
-
-	t.Run("should return error result on 503", func(t *testing.T) {
-		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, dtclient.ServerError{Code: http.StatusServiceUnavailable, Message: "Service unavailable"})
-
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-		})
-
-		assert.NoError(t, err)
-		assert.Equal(t, fastUpdateInterval, result.RequeueAfter)
-	})
-	t.Run("should return error result on 429", func(t *testing.T) {
-		mockClient.On("GetActiveGateAuthToken", testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, dtclient.ServerError{Code: http.StatusTooManyRequests, Message: "Too many requests"})
-
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
-
-		result, err := controller.Reconcile(context.Background(), reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
-		})
-
-		assert.NoError(t, err)
-		assert.Equal(t, fastUpdateInterval, result.RequeueAfter)
 	})
 }
 

--- a/pkg/controllers/dynakube/deploymentmetadata/deploymentmetadata_test.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/deploymentmetadata_test.go
@@ -3,6 +3,7 @@ package deploymentmetadata
 import (
 	"testing"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,4 +42,26 @@ func TestDeploymentMetadata_asString_empty_agent(t *testing.T) {
 func TestFormatKeyValue(t *testing.T) {
 	formattedArgument := formatKeyValue(testKey, testValue)
 	assert.Equal(t, testKey+`=`+testValue, formattedArgument)
+}
+
+func TestGetOneAgentDeploymentType(t *testing.T) {
+	tests := []struct {
+		oneAgentSpec           dynatracev1beta1.OneAgentSpec
+		expectedDeploymentType string
+	}{
+		{dynatracev1beta1.OneAgentSpec{HostMonitoring: &dynatracev1beta1.HostInjectSpec{}}, HostMonitoringDeploymentType},
+		{dynatracev1beta1.OneAgentSpec{ClassicFullStack: &dynatracev1beta1.HostInjectSpec{}}, ClassicFullStackDeploymentType},
+		{dynatracev1beta1.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{}}, CloudNativeDeploymentType},
+		{dynatracev1beta1.OneAgentSpec{ApplicationMonitoring: &dynatracev1beta1.ApplicationMonitoringSpec{}}, ApplicationMonitoringDeploymentType},
+	}
+
+	for _, test := range tests {
+		dynakube := &dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				OneAgent: test.oneAgentSpec,
+			},
+		}
+		deploymentType := GetOneAgentDeploymentType(*dynakube)
+		assert.Equal(t, test.expectedDeploymentType, deploymentType)
+	}
 }

--- a/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/configmap"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/pkg/errors"
@@ -20,7 +21,9 @@ type Reconciler struct {
 	scheme    *runtime.Scheme
 }
 
-func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube dynatracev1beta1.DynaKube, clusterID string) *Reconciler { //nolint:revive // argument-limit doesn't apply to constructors
+type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube dynatracev1beta1.DynaKube, clusterID string) controllers.Reconciler
+
+func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube dynatracev1beta1.DynaKube, clusterID string) controllers.Reconciler { //nolint:revive // argument-limit doesn't apply to constructors
 	return &Reconciler{
 		client:    clt,
 		apiReader: apiReader,

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -22,6 +22,8 @@ type reconciler struct {
 	client *Client
 }
 
+type ReconcilerBuilder func(istio *Client) Reconciler
+
 func NewReconciler(istio *Client) Reconciler {
 	return &reconciler{
 		client: istio,

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler.go
@@ -33,6 +33,12 @@ const (
 	oldDsName             = "classic"
 )
 
+type ReconcilerBuilder func( //nolint:revive // maximum number of return results per function exceeded; max 3 but got 4
+	client client.Client,
+	apiReader client.Reader,
+	scheme *runtime.Scheme,
+	clusterID string) *Reconciler
+
 // NewOneAgentReconciler initializes a new ReconcileOneAgent instance
 func NewOneAgentReconciler( //nolint:revive // maximum number of return results per function exceeded; max 3 but got 4
 	client client.Client,

--- a/pkg/controllers/dynakube/phase_test.go
+++ b/pkg/controllers/dynakube/phase_test.go
@@ -1,0 +1,167 @@
+package dynakube
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestActiveGatePhaseChanges(t *testing.T) {
+	dynakube := &dynatracev1beta1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			ActiveGate: dynatracev1beta1.ActiveGateSpec{Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.KubeMonCapability.DisplayName}},
+		},
+	}
+	t.Run("no activegate statefulsets in cluster -> deploying", func(t *testing.T) {
+		fakeClient := fake.NewClient()
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineDynaKubePhase(dynakube)
+		assert.Equal(t, status.Deploying, phase)
+	})
+	t.Run("error accessing k8s api -> error", func(t *testing.T) {
+		fakeClient := errorClient{}
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineDynaKubePhase(dynakube)
+		assert.Equal(t, status.Error, phase)
+	})
+	t.Run("activegate pods not ready -> deploying", func(t *testing.T) {
+		objects := []client.Object{
+			createStatefulset(testNamespace, "test-name-kubemon", 3, 2),
+			createStatefulset(testNamespace, "test-name-routing", 3, 2),
+			createStatefulset(testNamespace, "test-name-activegate", 3, 2),
+			createStatefulset(testNamespace, "test-name-synthetic", 3, 2),
+		}
+
+		fakeClient := fake.NewClient(objects...)
+
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineDynaKubePhase(dynakube)
+		assert.Equal(t, status.Deploying, phase)
+	})
+	t.Run("activegate deployed -> running", func(t *testing.T) {
+		objects := []client.Object{
+			createStatefulset(testNamespace, "test-name-kubemon", 3, 3),
+			createStatefulset(testNamespace, "test-name-routing", 3, 3),
+			createStatefulset(testNamespace, "test-name-activegate", 3, 3),
+			createStatefulset(testNamespace, "test-name-synthetic", 3, 3),
+		}
+
+		fakeClient := fake.NewClient(objects...)
+
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineDynaKubePhase(dynakube)
+		assert.Equal(t, status.Running, phase)
+	})
+}
+
+func createStatefulset(namespace, name string, replicas, readyReplicas int32) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:      replicas,
+			ReadyReplicas: readyReplicas,
+		},
+	}
+}
+
+func TestOneAgentPhaseChanges(t *testing.T) {
+	dynakube := &dynatracev1beta1.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			OneAgent: dynatracev1beta1.OneAgentSpec{
+				ClassicFullStack: &dynatracev1beta1.HostInjectSpec{},
+			},
+		},
+	}
+	t.Run("no OneAgent pods in cluster -> deploying", func(t *testing.T) {
+		fakeClient := fake.NewClient()
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineDynaKubePhase(dynakube)
+		assert.Equal(t, status.Deploying, phase)
+	})
+	t.Run("Error accessing k8s api", func(t *testing.T) {
+		fakeClient := errorClient{}
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineDynaKubePhase(dynakube)
+		assert.Equal(t, status.Error, phase)
+	})
+	t.Run("OneAgent daemonsets in cluster not all ready -> deploying", func(t *testing.T) {
+		objects := []client.Object{
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-name-oneagent",
+					Namespace: testNamespace,
+				},
+				Status: appsv1.DaemonSetStatus{
+					CurrentNumberScheduled: 3,
+					NumberReady:            2,
+				},
+			},
+		}
+		fakeClient := fake.NewClient(objects...)
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineDynaKubePhase(dynakube)
+		assert.Equal(t, status.Deploying, phase)
+	})
+	t.Run("OneAgent daemonsets in cluster all ready -> running", func(t *testing.T) {
+		objects := []client.Object{
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-name-oneagent",
+					Namespace: testNamespace,
+				},
+				Status: appsv1.DaemonSetStatus{
+					CurrentNumberScheduled: 3,
+					NumberReady:            3,
+				},
+			},
+		}
+		fakeClient := fake.NewClient(objects...)
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineDynaKubePhase(dynakube)
+		assert.Equal(t, status.Running, phase)
+	})
+}

--- a/pkg/controllers/dynakube/version/reconciler.go
+++ b/pkg/controllers/dynakube/version/reconciler.go
@@ -28,6 +28,8 @@ type reconciler struct {
 	apiReader client.Reader
 }
 
+type ReconcilerBuilder func(apiReader client.Reader, dtClient dtclient.Client, registryClient registry.ImageGetter, fs afero.Afero, timeProvider *timeprovider.Provider) Reconciler
+
 func NewReconciler(apiReader client.Reader, dtClient dtclient.Client, registryClient registry.ImageGetter, fs afero.Afero, timeProvider *timeprovider.Provider) Reconciler { //nolint:revive
 	return &reconciler{
 		apiReader:      apiReader,

--- a/test/mocks/pkg/controllers/dynakube/istio/reconciler.go
+++ b/test/mocks/pkg/controllers/dynakube/istio/reconciler.go
@@ -6,7 +6,6 @@ import (
 	context "context"
 
 	dynakube "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
-
 	mock "github.com/stretchr/testify/mock"
 )
 


### PR DESCRIPTION
## Description

according to the goal of the ticket we should separate the dynakube controller tests more from all the component reconcilers we are currently using in the controllers' reconcile. To not loose code coverage I introduced a system test file to test all components in concert.
I also added some unit-tests where we had little coverage.

## How can this be tested?

run the unit-tests

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)