### PR TITLE
Use mockery mock constructor in version/updater_test.go files

### DIFF
--- a/pkg/controllers/edgeconnect/version/updater_test.go
+++ b/pkg/controllers/edgeconnect/version/updater_test.go
@@ -22,7 +22,7 @@ const fakeDigest = "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac
 
 func TestReconcile(t *testing.T) {
 	edgeConnect := createBasicEdgeConnect()
-	fakeRegistryClient := &mocks.MockImageGetter{}
+	fakeRegistryClient := mocks.NewMockImageGetter(t)
 	fakeImageVersion := registry.ImageVersion{Digest: fakeDigest}
 	fakeRegistryClient.On("GetImageVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fakeImageVersion, nil)
 
@@ -49,9 +49,7 @@ func TestReconcile(t *testing.T) {
 
 func TestCombineImagesWithDigest(t *testing.T) {
 	edgeConnect := createBasicEdgeConnect()
-	fakeRegistryClient := &mocks.MockImageGetter{}
-	fakeImageVersion := registry.ImageVersion{Digest: fakeDigest}
-	fakeRegistryClient.On("GetImageVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fakeImageVersion, nil)
+	fakeRegistryClient := mocks.NewMockImageGetter(t)
 
 	updater := newUpdater(fake.NewClient(), nil, fakeRegistryClient, edgeConnect)
 
@@ -72,8 +70,7 @@ func TestCombineImagesWithDigest(t *testing.T) {
 
 func TestReconcileRequired(t *testing.T) {
 	currentTime := timeprovider.New().Freeze()
-	mockImageGetter := &mocks.MockImageGetter{}
-	mockImageGetter.On("GetImageVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(registry.ImageVersion{}, nil)
+	mockImageGetter := mocks.NewMockImageGetter(t)
 
 	t.Run("initial reconcile always required", func(t *testing.T) {
 		edgeConnect := createBasicEdgeConnect()


### PR DESCRIPTION
## Description

Use `mocks.NewMockImageGetter(t)` and `mocks.NewStatusUpdater(t)` in unit tests.

This showed that some tests have unnecessary mocked functions, which I deleted.

## How can this be tested?

Unit tests

## Checklist

- [X] Unit tests have been updated/added
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
