### PR TITLE
Add additional linters: usestdlibvars and wastedassign

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -237,6 +237,8 @@ linters:
   - unconvert                 # Remove unnecessary type conversions
   - unparam                   # Reports unused function parameters
   - unused                    # Checks Go code for unused constants, variables, functions and types
+  - usestdlibvars             # A linter that detect the possibility to use variables/constants from the Go standard library.
+  - wastedassign              # wastedassign finds wasted assignment statements.
   - whitespace                # Tool for detection of leading and trailing whitespace.
   - zerologlint               # Detects the wrong usage of zerolog that a user forgets to dispatch with Send or Msg.
 
@@ -280,8 +282,6 @@ linters:
 # - tenv              # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
 # - testifylint       # Checks usage of github.com/stretchr/testify.
 # - thelper           # Thelper detects tests helpers which is not start with t.Helper() method.
-# - usestdlibvars     # A linter that detect the possibility to use variables/constants from the Go standard library.
-# - wastedassign      # wastedassign finds wasted assignment statements.
 # - wrapcheck         # Checks that errors returned from external packages are wrapped.
 # - wsl               # Add or remove empty lines.
 # TODO: Need to discuss/decide/remove

--- a/pkg/clients/dynatrace/send_event_test.go
+++ b/pkg/clients/dynatrace/send_event_test.go
@@ -156,7 +156,7 @@ func handleSendEvent(request *http.Request, writer http.ResponseWriter) {
 		"storedCorrelationIds": ["string"]}`)
 
 	switch request.Method {
-	case "POST":
+	case http.MethodPost:
 		writer.WriteHeader(http.StatusOK)
 		_, _ = writer.Write(eventPostResponse)
 	default:

--- a/pkg/clients/dynatrace/token_test.go
+++ b/pkg/clients/dynatrace/token_test.go
@@ -50,7 +50,7 @@ func handleTokenScopes(request *http.Request, writer http.ResponseWriter) {
 		return
 	}
 
-	if request.Method != "POST" {
+	if request.Method != http.MethodPost {
 		writeError(writer, http.StatusMethodNotAllowed)
 		return
 	}

--- a/pkg/injection/codemodule/installer/url/installer.go
+++ b/pkg/injection/codemodule/installer/url/installer.go
@@ -82,7 +82,7 @@ func (installer Installer) InstallAgent(targetDir string) (bool, error) {
 
 func (installer Installer) installAgent(targetDir string) error {
 	fs := installer.fs
-	path := ""
+	var path string
 	if installer.isInitContainerMode() {
 		path = targetDir
 	} else {


### PR DESCRIPTION
## Description

Please include the following:

Add new linters:
- wastedassign - finds wasted assignment statements.
- usestdlibvars - A linter that detect the possibility to use variables/constants from the Go standard library.

## How can this be tested?

unit-tests

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
