### PR TITLE
 Update dynamic app name label to constant "dynatrace-operator" value

### DIFF
--- a/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
@@ -16,7 +16,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}
+  name: dynatrace-operator
   labels:
     {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
 rules:
@@ -106,15 +106,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}
+  name: dynatrace-operator
   labels:
     {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}
+    name: dynatrace-operator
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}
+  name: dynatrace-operator
   apiGroup: rbac.authorization.k8s.io
 {{ end }}

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -16,7 +16,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: dynatrace-operator
   namespace: {{ .Release.Namespace }}
   labels:
       {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
@@ -36,7 +36,7 @@ spec:
       annotations:
         dynatrace.com/inject: "false"
       {{- if (.Values.operator).apparmor}}
-        container.apparmor.security.beta.kubernetes.io/{{ .Release.Name }}: runtime/default
+        container.apparmor.security.beta.kubernetes.io/operator: runtime/default
       {{- end }}
       {{- if .Values.operator.annotations }}
         {{- toYaml .Values.operator.annotations | nindent 8 }}
@@ -49,7 +49,7 @@ spec:
         {{- end }}
     spec:
       containers:
-        - name: {{ .Release.Name }}
+        - name: operator
           args:
             - operator
           # Replace this with the built image name
@@ -105,7 +105,7 @@ spec:
       volumes:
         - emptyDir: { }
           name: tmp-cert-dir
-      serviceAccountName: {{ .Release.Name }}
+      serviceAccountName: dynatrace-operator
       securityContext:
         {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
       {{- if .Values.customPullSecret }}

--- a/config/helm/chart/default/templates/Common/operator/role-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/role-operator.yaml
@@ -16,7 +16,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}
+  name: dynatrace-operator
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
@@ -172,15 +172,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}
+  name: dynatrace-operator
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}
+    name: dynatrace-operator
 roleRef:
   kind: Role
-  name: {{ .Release.Name }}
+  name: dynatrace-operator
   apiGroup: rbac.authorization.k8s.io
 {{ end }}

--- a/config/helm/chart/default/templates/Common/operator/serviceaccount-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/serviceaccount-operator.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}
+  name: dynatrace-operator
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}

--- a/config/helm/chart/default/templates/NOTES.txt
+++ b/config/helm/chart/default/templates/NOTES.txt
@@ -7,4 +7,4 @@ https://github.com/Dynatrace/dynatrace-operator
 
 To verify the current state of the deployments, try:
   $ kubectl get pods -n {{ .Release.Namespace }}
-  $ kubectl logs -f deployment/{{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ kubectl logs -f deployment/dynatrace-operator -n {{ .Release.Namespace }}

--- a/config/helm/chart/default/templates/_labels.tpl
+++ b/config/helm/chart/default/templates/_labels.tpl
@@ -16,7 +16,7 @@
 Selector labels
 */}}
 {{- define "dynatrace-operator.futureSelectorLabels" -}}
-app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/name: dynatrace-operator
 {{- if not (.Values).manifests }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/config/helm/chart/default/templates/application.yaml
+++ b/config/helm/chart/default/templates/application.yaml
@@ -61,7 +61,7 @@ spec:
         url: https://www.dynatrace.com/technologies/kubernetes-monitoring
   selector:
     matchLabels:
-      app.kubernetes.io/name: "{{ .Release.Name }}"
+      app.kubernetes.io/name: dynatrace-operator
   componentKinds:
     - group: apps/v1
       kind: DaemonSet

--- a/config/helm/chart/default/tests/Common/operator/clusterrole-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/clusterrole-operator_test.yaml
@@ -9,20 +9,20 @@ tests:
           of: ClusterRoleBinding
       - equal:
           path: metadata.name
-          value: RELEASE-NAME
+          value: dynatrace-operator
       - isNotEmpty:
           path: metadata.labels
       - contains:
           path: subjects
           content:
             kind: ServiceAccount
-            name: RELEASE-NAME
+            name: dynatrace-operator
             namespace: NAMESPACE
       - equal:
           path: roleRef
           value:
             kind: ClusterRole
-            name: RELEASE-NAME
+            name: dynatrace-operator
             apiGroup: rbac.authorization.k8s.io
   - it: ClusterRole should exist with extra permissions for openshift
     documentIndex: 0
@@ -33,7 +33,7 @@ tests:
           of: ClusterRole
       - equal:
           path: metadata.name
-          value: RELEASE-NAME
+          value: dynatrace-operator
       - isNotEmpty:
           path: metadata.labels
       - contains:

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -42,12 +42,24 @@ tests:
           of: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME
+          value: dynatrace-operator
       - equal:
           path: metadata.namespace
           value: NAMESPACE
       - isNotEmpty:
           path: metadata.labels
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: dynatrace-operator
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: operator
+      - equal:
+          path: metadata.labels["helm.sh/chart"]
+          value: dynatrace-operator-1.0.0
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: 1.0.1
       - equal:
           path: spec.replicas
           value: 1
@@ -66,7 +78,7 @@ tests:
           path: spec.template.spec
           value:
             containers:
-              - name: RELEASE-NAME
+              - name: operator
                 args:
                   - operator
                 # Replace this with the built image name
@@ -142,7 +154,7 @@ tests:
             securityContext:
               seccompProfile:
                 type: RuntimeDefault
-            serviceAccountName: RELEASE-NAME
+            serviceAccountName: dynatrace-operator
             tolerations:
               - effect: NoSchedule
                 key: kubernetes.io/arch
@@ -208,7 +220,7 @@ tests:
           of: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME
+          value: dynatrace-operator
       - equal:
           path: metadata.namespace
           value: NAMESPACE
@@ -232,7 +244,7 @@ tests:
           path: spec.template.spec
           value:
             containers:
-              - name: RELEASE-NAME
+              - name: operator
                 args:
                   - operator
                 # Replace this with the built image name
@@ -308,7 +320,7 @@ tests:
             securityContext:
               seccompProfile:
                 type: RuntimeDefault
-            serviceAccountName: RELEASE-NAME
+            serviceAccountName: dynatrace-operator
             tolerations:
               - effect: NoSchedule
                 key: kubernetes.io/arch

--- a/config/helm/chart/default/tests/Common/operator/role-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/role-operator_test.yaml
@@ -7,7 +7,7 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: RELEASE-NAME
+          value: dynatrace-operator
       - equal:
           path: metadata.namespace
           value: NAMESPACE
@@ -169,7 +169,7 @@ tests:
           of: RoleBinding
       - equal:
           path: metadata.name
-          value: RELEASE-NAME
+          value: dynatrace-operator
       - equal:
           path: metadata.namespace
           value: NAMESPACE
@@ -179,10 +179,10 @@ tests:
           path: subjects
           content:
             kind: ServiceAccount
-            name: RELEASE-NAME
+            name: dynatrace-operator
       - equal:
           path: roleRef
           value:
             kind: Role
-            name: RELEASE-NAME
+            name: dynatrace-operator
             apiGroup: rbac.authorization.k8s.io

--- a/config/helm/chart/default/tests/Common/operator/serviceaccount-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/serviceaccount-operator_test.yaml
@@ -10,7 +10,7 @@ tests:
           of: ServiceAccount
       - equal:
           path: metadata.name
-          value: RELEASE-NAME
+          value: dynatrace-operator
       - equal:
           path: metadata.namespace
           value: NAMESPACE
@@ -25,7 +25,7 @@ tests:
           of: ServiceAccount
       - equal:
           path: metadata.name
-          value: RELEASE-NAME
+          value: dynatrace-operator
       - equal:
           path: metadata.namespace
           value: NAMESPACE

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -21,7 +21,7 @@ tests:
           value: NAMESPACE
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
-          value: RELEASE-NAME
+          value: dynatrace-operator
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
           value: webhook
@@ -209,7 +209,7 @@ tests:
           value: NAMESPACE
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
-          value: RELEASE-NAME
+          value: dynatrace-operator
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
           value: webhook


### PR DESCRIPTION
## Description
Resources connected to the Operator deployment should not have deployment/pod/container/... names that change when a different helm chart name than the default is chosen.


## How can this be tested?

Run the following commands to verify that there is a seamless upgrade:
```sh
helm install nondefaultname oci://docker.io/dynatrace/dynatrace-operator --version 0.15.0 -n dynatrace --atomic
helm upgrade nondefaultname config/helm/chart/default --set "imageRef.repository=quay.io/dynatrace/dynatrace-operator" --set "imageRef.tag=snapshot" --atomic --create-namespace -n dynatrace
```

The following should change during migration:
- `nondefaultname` deployment name and prefix for pod is changed to `dynatrace-operator`
- `nondefaultname` container name for operator pod is changed to `operator`
- RBAC resources connected to Operator deployment have their names updated to `dynatrace-operator`

No change in label selector.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
