### PR TITLE
Copy ruxitagentproc.conf config into upper-dir

### DIFF
--- a/pkg/controllers/csi/driver/volumes/app/publisher.go
+++ b/pkg/controllers/csi/driver/volumes/app/publisher.go
@@ -19,6 +19,7 @@ package appvolumes
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	csivolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver/volumes"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/spf13/afero"
 	"google.golang.org/grpc/codes"
@@ -147,18 +149,57 @@ func (publisher *AppVolumePublisher) buildLowerDir(bindCfg *csivolumes.BindConfi
 		binFolderName = bindCfg.ImageDigest
 	}
 	directories := []string{
-		publisher.path.AgentConfigDir(bindCfg.TenantUUID, bindCfg.DynakubeName),
 		publisher.path.AgentSharedBinaryDirForAgent(binFolderName),
 	}
 	return strings.Join(directories, ":")
+}
+
+func (publisher *AppVolumePublisher) prepareUpperDir(bindCfg *csivolumes.BindConfig, volumeCfg *csivolumes.VolumeConfig) (string, error) {
+	upperDir := publisher.path.OverlayVarDir(bindCfg.TenantUUID, volumeCfg.VolumeID)
+	err := publisher.fs.MkdirAll(upperDir, os.ModePerm)
+	if err != nil {
+		return "", errors.WithMessagef(err, "failed create overlay upper directory structure, path: %s", upperDir)
+	}
+
+	destAgentConfPath := publisher.path.OverlayVarRuxitAgentProcConf(bindCfg.TenantUUID, volumeCfg.VolumeID)
+	err = publisher.fs.MkdirAll(filepath.Dir(destAgentConfPath), os.ModePerm)
+	if err != nil {
+		return "", errors.WithMessagef(err, "failed create overlay upper directory agen config directory structure, path: %s", upperDir)
+	}
+
+	srcAgentConfPath := publisher.path.AgentSharedRuxitAgentProcConf(bindCfg.TenantUUID, volumeCfg.DynakubeName)
+	srcFile, err := publisher.fs.Open(srcAgentConfPath)
+	if err != nil {
+		return "", errors.WithMessagef(err, "failed to open source ruxitagentproc.conf file, path: %s", srcAgentConfPath)
+	}
+	defer func() { _ = srcFile.Close() }()
+	srcStat, err := srcFile.Stat()
+	if err != nil {
+		return "", errors.WithMessage(err, "failed to get source ruxitagentproc.conf file info")
+	}
+
+	destFile, err := publisher.fs.OpenFile(destAgentConfPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcStat.Mode())
+	if err != nil {
+		return "", errors.WithMessagef(err, "failed to open destination ruxitagentproc.conf file, path: %s", destAgentConfPath)
+	}
+	defer func() { _ = destFile.Close() }()
+
+	_, err = io.Copy(destFile, srcFile)
+	if err != nil {
+		return "", errors.WithMessagef(err, "failed to copy ruxitagentproc.conf file to overlay, from->to: %s -> %s", srcAgentConfPath, destAgentConfPath)
+	}
+
+	return upperDir, nil
 }
 
 func (publisher *AppVolumePublisher) mountOneAgent(bindCfg *csivolumes.BindConfig, volumeCfg *csivolumes.VolumeConfig) error {
 	mappedDir := publisher.path.OverlayMappedDir(bindCfg.TenantUUID, volumeCfg.VolumeID)
 	_ = publisher.fs.MkdirAll(mappedDir, os.ModePerm)
 
-	upperDir := publisher.path.OverlayVarDir(bindCfg.TenantUUID, volumeCfg.VolumeID)
-	_ = publisher.fs.MkdirAll(upperDir, os.ModePerm)
+	upperDir, err := publisher.prepareUpperDir(bindCfg, volumeCfg)
+	if err != nil {
+		return err
+	}
 
 	workDir := publisher.path.OverlayWorkDir(bindCfg.TenantUUID, volumeCfg.VolumeID)
 	_ = publisher.fs.MkdirAll(workDir, os.ModePerm)

--- a/pkg/controllers/csi/driver/volumes/app/publisher_test.go
+++ b/pkg/controllers/csi/driver/volumes/app/publisher_test.go
@@ -35,6 +35,7 @@ func TestPublishVolume(t *testing.T) {
 		mounter := mount.NewFakeMounter([]mount.MountPoint{})
 		publisher := newPublisherForTesting(mounter)
 		mockUrlDynakubeMetadata(t, &publisher)
+		mockSharedRuxitAgentProcConf(t, &publisher)
 
 		response, err := publisher.PublishVolume(context.TODO(), createTestVolumeConfig())
 		require.NoError(t, err)
@@ -45,7 +46,7 @@ func TestPublishVolume(t *testing.T) {
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Device)
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Type)
 		assert.Equal(t, []string{
-			"lowerdir=/a-tenant-uuid/a-dynakube/config:/codemodules/1.2-3",
+			"lowerdir=/codemodules/1.2-3",
 			"upperdir=/a-tenant-uuid/run/a-volume/var",
 			"workdir=/a-tenant-uuid/run/a-volume/work"},
 			mounter.MountPoints[0].Opts)
@@ -55,6 +56,10 @@ func TestPublishVolume(t *testing.T) {
 		assert.Equal(t, "", mounter.MountPoints[1].Type)
 		assert.Equal(t, []string{"bind"}, mounter.MountPoints[1].Opts)
 		assert.Equal(t, testTargetPath, mounter.MountPoints[1].Path)
+
+		confCopied, err := publisher.fs.Exists(publisher.path.OverlayVarRuxitAgentProcConf(testTenantUUID, testVolumeId))
+		require.NoError(t, err)
+		assert.True(t, confCopied)
 
 		assertReferencesForPublishedVolume(t, &publisher, mounter)
 	})
@@ -63,6 +68,7 @@ func TestPublishVolume(t *testing.T) {
 		mounter := mount.NewFakeMounter([]mount.MountPoint{})
 		publisher := newPublisherForTesting(mounter)
 		mockImageDynakubeMetadata(t, &publisher)
+		mockSharedRuxitAgentProcConf(t, &publisher)
 
 		response, err := publisher.PublishVolume(context.TODO(), createTestVolumeConfig())
 		require.NoError(t, err)
@@ -73,7 +79,7 @@ func TestPublishVolume(t *testing.T) {
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Device)
 		assert.Equal(t, "overlay", mounter.MountPoints[0].Type)
 		assert.Equal(t, []string{
-			"lowerdir=/a-tenant-uuid/a-dynakube/config:/codemodules/" + testImageDigest,
+			"lowerdir=/codemodules/" + testImageDigest,
 			"upperdir=/a-tenant-uuid/run/a-volume/var",
 			"workdir=/a-tenant-uuid/run/a-volume/work"},
 			mounter.MountPoints[0].Opts)
@@ -83,6 +89,10 @@ func TestPublishVolume(t *testing.T) {
 		assert.Equal(t, "", mounter.MountPoints[1].Type)
 		assert.Equal(t, []string{"bind"}, mounter.MountPoints[1].Opts)
 		assert.Equal(t, testTargetPath, mounter.MountPoints[1].Path)
+
+		confCopied, err := publisher.fs.Exists(publisher.path.OverlayVarRuxitAgentProcConf(testTenantUUID, testVolumeId))
+		require.NoError(t, err)
+		assert.True(t, confCopied)
 
 		assertReferencesForPublishedVolumeWithCodeModulesImage(t, &publisher, mounter)
 	})
@@ -98,6 +108,45 @@ func TestPublishVolume(t *testing.T) {
 
 		require.Empty(t, mounter.MountPoints)
 	})
+}
+
+func TestPrepareUpperDir(t *testing.T) {
+	testFileContent := []byte{'t', 'e', 's', 't'}
+	testBindConfig := &csivolumes.BindConfig{
+		TenantUUID: testTenantUUID,
+	}
+
+	t.Run("happy path -> file copied from shared dir to overlay dir", func(t *testing.T) {
+		mounter := mount.NewFakeMounter([]mount.MountPoint{})
+
+		publisher := newPublisherForTesting(mounter)
+		mockSharedRuxitAgentProcConf(t, &publisher, testFileContent...)
+
+		upperDir, err := publisher.prepareUpperDir(testBindConfig, createTestVolumeConfig())
+		require.NoError(t, err)
+		require.NotEmpty(t, upperDir)
+		assertUpperDirContent(t, &publisher, testFileContent)
+	})
+
+	t.Run("sad path -> source file doesn't exist -> error", func(t *testing.T) {
+		mounter := mount.NewFakeMounter([]mount.MountPoint{})
+
+		publisher := newPublisherForTesting(mounter)
+
+		upperDir, err := publisher.prepareUpperDir(testBindConfig, createTestVolumeConfig())
+		require.Error(t, err)
+		require.Empty(t, upperDir)
+
+		confCopied, err := publisher.fs.Exists(publisher.path.OverlayVarRuxitAgentProcConf(testTenantUUID, testVolumeId))
+		require.NoError(t, err)
+		assert.False(t, confCopied)
+	})
+}
+
+func assertUpperDirContent(t *testing.T, publisher *AppVolumePublisher, expected []byte) {
+	content, err := publisher.fs.ReadFile(publisher.path.OverlayVarRuxitAgentProcConf(testTenantUUID, testVolumeId))
+	require.NoError(t, err)
+	assert.Equal(t, expected, content)
 }
 
 func TestHasTooManyMountAttempts(t *testing.T) {
@@ -191,13 +240,14 @@ func TestNodePublishAndUnpublishVolume(t *testing.T) {
 	mounter := mount.NewFakeMounter([]mount.MountPoint{})
 	publisher := newPublisherForTesting(mounter)
 	mockUrlDynakubeMetadata(t, &publisher)
+	mockSharedRuxitAgentProcConf(t, &publisher)
 
 	publishResponse, err := publisher.PublishVolume(context.TODO(), createTestVolumeConfig())
 
+	require.NoError(t, err)
 	assert.Equal(t, 1, testutil.CollectAndCount(agentsVersionsMetric))
 	assert.Equal(t, float64(1), testutil.ToFloat64(agentsVersionsMetric.WithLabelValues(testAgentVersion)))
 
-	assert.NoError(t, err)
 	assert.NotNil(t, publishResponse)
 	assert.NotEmpty(t, mounter.MountPoints)
 	assertReferencesForPublishedVolume(t, &publisher, mounter)
@@ -307,6 +357,16 @@ func mockFailedPublishedVolume(t *testing.T, publisher *AppVolumePublisher) {
 func mockUrlDynakubeMetadata(t *testing.T, publisher *AppVolumePublisher) {
 	err := publisher.db.InsertDynakube(context.TODO(), metadata.NewDynakube(testDynakubeName, testTenantUUID, testAgentVersion, "", 0))
 	require.NoError(t, err)
+}
+
+func mockSharedRuxitAgentProcConf(t *testing.T, publisher *AppVolumePublisher, content ...byte) {
+	file, err := publisher.fs.Create(publisher.path.AgentSharedRuxitAgentProcConf(testTenantUUID, testDynakubeName))
+	defer func() { _ = file.Close() }()
+	require.NoError(t, err)
+	if len(content) > 0 {
+		_, err = file.Write(content)
+		require.NoError(t, err)
+	}
 }
 
 func mockImageDynakubeMetadata(t *testing.T, publisher *AppVolumePublisher) {

--- a/pkg/controllers/csi/metadata/path_resolver.go
+++ b/pkg/controllers/csi/metadata/path_resolver.go
@@ -24,20 +24,6 @@ func (pr PathResolver) AgentBinaryDir(tenantUUID string) string {
 }
 
 // Deprecated
-func (pr PathResolver) AgentProcessModuleConfigForVersion(tenantUUID string, version string) string {
-	return filepath.Join(pr.AgentBinaryDirForVersion(tenantUUID, version), "agent", "conf", "ruxitagentproc.conf")
-}
-
-// Deprecated
-func (pr PathResolver) SourceAgentProcessModuleConfigForVersion(tenantUUID string, version string) string {
-	return filepath.Join(pr.AgentBinaryDirForVersion(tenantUUID, version), "agent", "conf", "_ruxitagentproc.conf")
-}
-
-func (pr PathResolver) AgentRuxitProcResponseCache(tenantUUID string) string {
-	return filepath.Join(pr.TenantDir(tenantUUID), "revision.json")
-}
-
-// Deprecated
 func (pr PathResolver) AgentBinaryDirForVersion(tenantUUID string, version string) string {
 	return filepath.Join(pr.AgentBinaryDir(tenantUUID), version)
 }
@@ -62,9 +48,6 @@ func (pr PathResolver) AgentConfigDir(tenantUUID string, dynakubeName string) st
 	return filepath.Join(pr.TenantDir(tenantUUID), dynakubeName, dtcsi.SharedAgentConfigDir)
 }
 
-// Deprecated
-func (pr PathResolver) InnerAgentBinaryDirForSymlinkForVersion(tenantUUID string, version string) string {
-	return filepath.Join(pr.AgentBinaryDirForVersion(tenantUUID, version), "agent", "bin", "current")
 func (pr PathResolver) AgentSharedRuxitAgentProcConf(tenantUUID, dynakubeName string) string {
 	return filepath.Join(pr.AgentConfigDir(tenantUUID, dynakubeName), processmoduleconfig.RuxitAgentProcPath)
 }

--- a/pkg/controllers/csi/metadata/path_resolver.go
+++ b/pkg/controllers/csi/metadata/path_resolver.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
+	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/processmoduleconfig"
 )
 
 type PathResolver struct {
@@ -64,6 +65,12 @@ func (pr PathResolver) AgentConfigDir(tenantUUID string, dynakubeName string) st
 // Deprecated
 func (pr PathResolver) InnerAgentBinaryDirForSymlinkForVersion(tenantUUID string, version string) string {
 	return filepath.Join(pr.AgentBinaryDirForVersion(tenantUUID, version), "agent", "bin", "current")
+func (pr PathResolver) AgentSharedRuxitAgentProcConf(tenantUUID, dynakubeName string) string {
+	return filepath.Join(pr.AgentConfigDir(tenantUUID, dynakubeName), processmoduleconfig.RuxitAgentProcPath)
+}
+
+func (pr PathResolver) OverlayVarRuxitAgentProcConf(tenantUUID, volumeId string) string {
+	return filepath.Join(pr.OverlayVarDir(tenantUUID, volumeId), processmoduleconfig.RuxitAgentProcPath)
 }
 
 func (pr PathResolver) AgentRunDir(tenantUUID string) string {


### PR DESCRIPTION
## Description

Instead of having multiple lower-dirs that will be merged, the config is just copied to the upper-dir.

We do this to avoid undefined behaviour incase we change the config overtime.
- We regularly update the config, which is problematic if that is a lower dir, because:
   - "Changes to the underlying filesystems while part of a mounted overlay filesystem are not allowed." (Ref https://docs.kernel.org/filesystems/overlayfs.html#changes-to-underlying-filesystems)
   - It "works", but the behaviour is undefined and can actually cause problems.

## How can this be tested?

If you shell into the CSI driver's pod, and check the upper-dir `ruxitagentproc.conf` it should be the correct config:
Example for upper-dir: 
`data/zib50933/run/csi-82962f01ee59384a8105bf60be0fab48aa030f6c9d5eeb604e3ab88e5ff8daa6/var/agent/conf/ruxitagentproc.conf`

to check that there is no more config lower-dir look at `/proc/mounts`:
```shell
> tail -n 1 /proc/mounts
overlay /data/zib50933/run/csi-82962f01ee59384a8105bf60be0fab48aa030f6c9d5eeb604e3ab88e5ff8daa6/mapped overlay rw,relatime,lowerdir=/data/codemodules/1.286.0.20240131-150854,upperdir=/data/zib50933/run/csi-82962f01ee59384a8105bf60be0fab48aa030f6c9d5eeb604e3ab88e5ff8daa6/var,workdir=/data/zib50933/run/csi-82962f01ee59384a8105bf60be0fab48aa030f6c9d5eeb604e3ab88e5ff8daa6/work 0 0
```

For a more real life scenario, the following **should no longer happen**:
Step 1: Deploy DynaKube, builtin:networkzones is disabled and .spec.networkZone is unset
Step 2: Deploy app with agent injection
Step 3: Update DynaKube, set .spec.networkZone
- The content of the ruxitagentproc.conf changes in the container, because the content of the ruxitagentproc.conf  in the lower-dir gets updated (THIS IS WHAT DOES NOT HAPPEN ANYMORE)
Step 4: Let app container with agent crash and restart
- Agent reads updated but invalid ruxitagentproc.conf and fails to start

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
Instead of having multiple lower-dirs that will be merged, the config is just copied to the upper-dir