### PR TITLE
Handle custom-image in case of version checks

### DIFF
--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
@@ -15,11 +15,11 @@ const defaultArgumentPriority = 1
 func (dsInfo *builderInfo) arguments() ([]string, error) {
 	argMap := prioritymap.New(prioritymap.WithSeparator(prioritymap.DefaultSeparator), prioritymap.WithPriority(defaultArgumentPriority))
 
-	isProxyAsEnvVarDeprecated, err := IsProxyAsEnvVarDeprecated(dsInfo.dynakube.OneAgentVersion())
+	isProxyAsEnvDeprecated, err := isProxyAsEnvVarDeprecated(dsInfo.dynakube.OneAgentVersion())
 	if err != nil {
 		return []string{}, err
 	}
-	if !isProxyAsEnvVarDeprecated {
+	if !isProxyAsEnvDeprecated {
 		// deprecated
 		dsInfo.appendProxyArg(argMap)
 	}

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -30,7 +30,6 @@ func TestArguments(t *testing.T) {
 
 		expectedDefaultArguments := []string{
 			"--set-host-property=OperatorVersion=$(DT_OPERATOR_VERSION)",
-			"--set-proxy=",
 			"--set-server={$(DT_SERVER)}",
 			"--set-tenant=$(DT_TENANT)",
 		}
@@ -70,7 +69,6 @@ func TestArguments(t *testing.T) {
 
 		expectedDefaultArguments := []string{
 			"--set-host-property=OperatorVersion=$(DT_OPERATOR_VERSION)",
-			"--set-proxy=",
 			"--set-server={$(DT_SERVER)}",
 			"--set-tenant=$(DT_TENANT)",
 			"test-value",
@@ -96,7 +94,6 @@ func TestArguments(t *testing.T) {
 			"--set-host-group=APP_LUSTIG_PETER",
 			"--set-host-id-source=lustiglustig",
 			"--set-host-property=OperatorVersion=$(DT_OPERATOR_VERSION)",
-			"--set-proxy=",
 			"--set-server=https://hyper.super.com:9999",
 			"--set-tenant=$(DT_TENANT)",
 		}
@@ -157,11 +154,13 @@ func TestPodSpec_Arguments(t *testing.T) {
 
 	// deprecated
 	t.Run(`has proxy arg`, func(t *testing.T) {
+		instance.Status.OneAgent.Version = "1.272.0.0-0"
 		instance.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: testValue}
 		podSpecs, _ = dsInfo.podSpec()
 		assert.Contains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
 
 		instance.Spec.Proxy = nil
+		instance.Status.OneAgent.Version = ""
 		podSpecs, _ = dsInfo.podSpec()
 		assert.NotContains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
 	})

--- a/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
@@ -1,6 +1,7 @@
 package daemonset
 
 import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
@@ -20,6 +21,10 @@ const (
 	oneagentReadOnlyMode              = "ONEAGENT_READ_ONLY_MODE"
 
 	proxyEnv = "https_proxy"
+
+	// ProxyAsEnvVarDeprecatedVersion holds the version after which OneAgent allows mounting proxy as file, therefore
+	// enabling us to deprecate the env var/arg approach (which is non security compliant)
+	ProxyAsEnvVarDeprecatedVersion = "1.273.0.0-0"
 )
 
 const customEnvPriority = prioritymap.HighPriority
@@ -39,11 +44,11 @@ func (dsInfo *builderInfo) environmentVariables() ([]corev1.EnvVar, error) {
 	dsInfo.addConnectionInfoEnvs(envMap)
 	dsInfo.addReadOnlyEnv(envMap)
 
-	isProxyAsEnvVarDeprecated, err := IsProxyAsEnvVarDeprecated(dsInfo.dynakube.OneAgentVersion())
+	isProxyAsEnvDeprecated, err := isProxyAsEnvVarDeprecated(dsInfo.dynakube.OneAgentVersion())
 	if err != nil {
 		return []corev1.EnvVar{}, err
 	}
-	if !isProxyAsEnvVarDeprecated {
+	if !isProxyAsEnvDeprecated {
 		// deprecated
 		dsInfo.addProxyEnv(envMap)
 	}
@@ -140,15 +145,10 @@ func addDefaultValueSource(envVarMap *prioritymap.Map, name string, value *corev
 	})
 }
 
-const (
-	// starting with this version, OneAgent allows mounting proxy as file, therefore
-	// enabling us to deprecate the env var/arg approach (which is non security compliant)
-	ProxyAsEnvVarDeprecatedVersion = "1.273.0.0-0"
-)
-
-func IsProxyAsEnvVarDeprecated(oneAgentVersion string) (bool, error) {
-	if oneAgentVersion == "" {
-		return false, nil
+func isProxyAsEnvVarDeprecated(oneAgentVersion string) (bool, error) {
+	if oneAgentVersion == "" || oneAgentVersion == string(status.CustomImageVersionSource) {
+		// If the version is unknown or from a custom image, then we don't care about deprecation.
+		return true, nil
 	}
 	runningVersion, err := version.ExtractSemanticVersion(oneAgentVersion)
 	if err != nil {
@@ -161,7 +161,7 @@ func IsProxyAsEnvVarDeprecated(oneAgentVersion string) (bool, error) {
 
 	result := version.CompareSemanticVersions(runningVersion, versionConstraint)
 
-	// if current OneAgent version is older than fix version
+	// if a current OneAgent version is older than fix version
 	if result < 0 {
 		return false, nil
 	}

--- a/pkg/controllers/dynakube/oneagent/daemonset/env_vars_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/env_vars_test.go
@@ -3,6 +3,7 @@ package daemonset
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
@@ -49,8 +50,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		assertNodeNameEnv(t, envVars)
 		assertConnectionInfoEnv(t, envVars, dynakube)
 		assertDeploymentMetadataEnv(t, envVars, dynakube.Name)
-		// deprecated
-		assertProxyEnv(t, envVars, dynakube)
+
 		assertReadOnlyEnv(t, envVars)
 	})
 	t.Run("when injected envvars are provided then they will not be overridden", func(t *testing.T) {
@@ -298,7 +298,7 @@ func TestIsProxyAsEnvVarDeprecated(t *testing.T) {
 		{
 			name:            "empty version",
 			oneAgentVersion: "",
-			want:            false,
+			want:            true,
 			wantErr:         false,
 		},
 		{
@@ -319,16 +319,22 @@ func TestIsProxyAsEnvVarDeprecated(t *testing.T) {
 			want:            true,
 			wantErr:         false,
 		},
+		{
+			name:            "custom-image -> hard-coded version placeholder",
+			oneAgentVersion: string(status.CustomImageVersionSource),
+			want:            true,
+			wantErr:         false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := IsProxyAsEnvVarDeprecated(tt.oneAgentVersion)
+			got, err := isProxyAsEnvVarDeprecated(tt.oneAgentVersion)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("IsProxyAsEnvVarDeprecated() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("isProxyAsEnvVarDeprecated() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("IsProxyAsEnvVarDeprecated() = %v, want %v", got, tt.want)
+				t.Errorf("isProxyAsEnvVarDeprecated() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -286,7 +286,6 @@ func TestReconcile_InstancesSet(t *testing.T) {
 			"--set-host-group=APP_LUSTIG_PETER",
 			"--set-host-id-source=fqdn",
 			"--set-host-property=OperatorVersion=$(DT_OPERATOR_VERSION)",
-			"--set-proxy=",
 			"--set-server=https://hyper.super.com:9999",
 			"--set-tenant=$(DT_TENANT)",
 		}
@@ -310,7 +309,6 @@ func TestReconcile_InstancesSet(t *testing.T) {
 			"--set-host-group=APP_LUSTIG_PETER",
 			"--set-host-id-source=auto",
 			"--set-host-property=OperatorVersion=$(DT_OPERATOR_VERSION)",
-			"--set-proxy=",
 			"--set-server=https://hyper.super.com:9999",
 			"--set-tenant=$(DT_TENANT)",
 		}

--- a/pkg/controllers/dynakube/version/healthconfig.go
+++ b/pkg/controllers/dynakube/version/healthconfig.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	containerv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
@@ -44,7 +45,7 @@ func newHealthConfig(command []string) *containerv1.HealthConfig {
 
 func getOneAgentHealthConfig(agentVersion string) (*containerv1.HealthConfig, error) {
 	var testCommand []string
-	if agentVersion != "" {
+	if agentVersion != "" && agentVersion != string(status.CustomImageVersionSource) {
 		agentSemver := agentVersionToSemver(agentVersion)
 		if !semver.IsValid(agentSemver) {
 			return nil, errors.Errorf("provided oneagent version %s is not a valid semver", agentVersion)

--- a/pkg/controllers/dynakube/version/healthconfig_test.go
+++ b/pkg/controllers/dynakube/version/healthconfig_test.go
@@ -3,6 +3,7 @@ package version
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,6 +82,12 @@ func TestGetOneAgentHealthConfig(t *testing.T) {
 			inputVersion:    ".4.malformed-",
 			expectedCommand: nil,
 			expectError:     true,
+		},
+		{
+			title:           "incase of custom-image",
+			inputVersion:    string(status.CustomImageVersionSource),
+			expectedCommand: currentHealthCheck,
+			expectError:     false,
 		},
 	}
 


### PR DESCRIPTION
## Description

Incase a custom image is used for the OneAgent DaemonSet, then we set the `Version` and `Source` in the Dynakube's `Status` to the `custom-image` constant. 

Our version checks didn't handle this, now they do.

Also flipped the proxy env version check, so if we **don't** know the version then we **don't** use the deprecated proxy envvar.
- This was decided to be consistent with the HealthConfig logic.
   - Furthermore the HealthConfig version check is checking for a newer version.
- If we don't want to do this, then IMO we need to make the HealthConfig logic consistent with it as well. 

## How can this be tested?

In case the `oneAgent.image` field is set to something, everything works

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
