### PR TITLE
Adds workflow to move dev-latest tag on the most recent release branch

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1,0 +1,51 @@
+name: dev-release
+
+on:
+  push:
+    branches:
+      - release-*
+
+permissions:
+  contents: write
+
+jobs:
+  run:
+    name: Run script
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Run script
+        id: run
+        run: |
+          echo "--- latestReleaseBranch"
+          latestReleaseBranch="$(git branch -r --list 'origin/release-*' | sort --version-sort | tail -n 1 | tr -d ' ')"
+          echo "$latestReleaseBranch"
+          echo "---"
+
+          echo "--- current branch"
+          echo "origin/${{ github.ref_name }}"
+          echo "---"
+
+          if [ "$latestReleaseBranch" != "origin/${{ github.ref_name }}" ]; then
+            echo "older branch - nothing to do"
+            exit 0
+          fi
+
+          if [ "${{ github.event.ref }}" != "refs/heads/${{ github.ref_name }}" ]; then
+            echo "push tag - nothing to do"
+            exit 0
+          fi
+
+          echo "--- dev-latest tag before"
+          if [ -e .git/refs/tags/dev-latest ]; then cat .git/refs/tags/dev-latest ; fi
+          echo "---"
+
+          git tag -f dev-latest ${{ github.event.after }}
+          git push -f origin dev-latest
+
+          echo "--- dev-latest tag after"
+          if [ -e .git/refs/tags/dev-latest ]; then cat .git/refs/tags/dev-latest ; fi
+          echo "---"


### PR DESCRIPTION
## Description
Adds workflow to automatically create `dev-latest` tag which points to the most recent commit on the most recent release branch.

## How can this be tested?
Use forked repo. Push commits to `release-0.1.3` and `release-0.2.1` branches.  `dev-latest` tag should always point to the most recent commit on the `release-0.2.1` branch.

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
