### PR TITLE
Align requests/limits of init resources in cloud native fullstack sample

### DIFF
--- a/assets/samples/dynakube/cloudNativeFullStack.yaml
+++ b/assets/samples/dynakube/cloudNativeFullStack.yaml
@@ -152,11 +152,11 @@ spec:
       #
       # initResources:
       #   requests:
-      #     cpu: 60m
-      #     memory: 60Mi
+      #     cpu: 30m
+      #     memory: 30Mi
       #   limits:
       #     cpu: 100m
-      #     memory: 100Mi
+      #     memory: 60Mi
 
       # Optional: The URI of the image that contains the codemodules specific OneAgent that will be injected into pods and applications.
       # For an example of a Dockerfile creating such an image, see https://dt-url.net/operator-docker-samples

--- a/assets/samples/dynakube/cloudNativeFullStack.yaml
+++ b/assets/samples/dynakube/cloudNativeFullStack.yaml
@@ -152,11 +152,11 @@ spec:
       #
       # initResources:
       #   requests:
-      #     cpu: 100m
-      #     memory: 512Mi
+      #     cpu: 60m
+      #     memory: 60Mi
       #   limits:
-      #     cpu: 300m
-      #     memory: 1.5Gi
+      #     cpu: 100m
+      #     memory: 100Mi
 
       # Optional: The URI of the image that contains the codemodules specific OneAgent that will be injected into pods and applications.
       # For an example of a Dockerfile creating such an image, see https://dt-url.net/operator-docker-samples


### PR DESCRIPTION
## Description

Defaults should be the same as used for the init container when the CSI driver is used and no additional configuration is set: https://github.com/Dynatrace/dynatrace-operator/blob/137ff5b206fad284627425e50ce24ecb874f1b6a/pkg/webhook/mutation/pod_mutator/init_container.go#L52-L53

## How can this be tested?
Documentation changes

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
