### PR TITLE
Adapt the local linting command to new linters

### DIFF
--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -29,7 +29,7 @@ go/golangci:
 	golangci-lint run --build-tags "$(shell ./hack/build/create_go_build_tags.sh true)" --timeout 300s
 
 ## Runs all the linting tools
-go/lint: prerequisites/go-linting go/format go/vet go/golangci
+go/lint: prerequisites/go-linting go/format go/vet go/wsl go/golangci
 
 ## Runs all go unit tests and writes the coverprofile to coverage.txt
 go/test:

--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -21,12 +21,15 @@ go/format: go/fmt go/gci
 go/vet:
 	go vet -copylocks=false $(LINT_TARGET)
 
+go/wsl:
+	wsl -fix ./pkg/...
+
 ## Runs golangci-lint
 go/golangci:
 	golangci-lint run --build-tags "$(shell ./hack/build/create_go_build_tags.sh true)" --timeout 300s
 
 ## Runs all the linting tools
-go/lint: go/format go/vet go/golangci
+go/lint: prerequisites/go-linting go/format go/vet go/golangci
 
 ## Runs all go unit tests and writes the coverprofile to coverage.txt
 go/test:

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -38,6 +38,7 @@ prerequisites/go-linting:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golang_ci_cmd_version)
 	go install github.com/daixiang0/gci@$(gci_version)
 	go install golang.org/x/tools/cmd/goimports@$(golang_tools_version)
+	go install github.com/bombsimon/wsl/v4/cmd...@master
 	go install golang.org/x/tools/cmd/deadcode@$(golang_tools_version)
 
 ## Install 'helm' if it is missing


### PR DESCRIPTION
## Description

Several linters were introduced recently, one in particular `wsl` has its own fixer command, that we should use in the `make go/lint` command.

Also added the linting tools install/update make target as a prerequisite to the `make go/lint` command, so we don't have to think about locally updating the linters.  (it slows the command down a bit, but the golangci-lint is already dog slow, so it doesn't really matter)

## How can this be tested?

run `make go/lint`

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
