### PR TITLE
Revert "Adapt the local linting command to new linters"

### DIFF
--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -21,15 +21,12 @@ go/format: go/fmt go/gci
 go/vet:
 	go vet -copylocks=false $(LINT_TARGET)
 
-go/wsl:
-	wsl -fix ./pkg/...
-
 ## Runs golangci-lint
 go/golangci:
 	golangci-lint run --build-tags "$(shell ./hack/build/create_go_build_tags.sh true)" --timeout 300s
 
 ## Runs all the linting tools
-go/lint: prerequisites/go-linting go/format go/vet go/wsl go/golangci
+go/lint: go/format go/vet go/golangci
 
 ## Runs all go unit tests and writes the coverprofile to coverage.txt
 go/test:

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -38,7 +38,6 @@ prerequisites/go-linting:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golang_ci_cmd_version)
 	go install github.com/daixiang0/gci@$(gci_version)
 	go install golang.org/x/tools/cmd/goimports@$(golang_tools_version)
-	go install github.com/bombsimon/wsl/v4/cmd...@master
 	go install golang.org/x/tools/cmd/deadcode@$(golang_tools_version)
 
 ## Install 'helm' if it is missing


### PR DESCRIPTION
The original PR breaks `make go/lint` as `wsl -fix` doesn't respect `//nollnt` directives corretly and thus reports errors.