### PR TITLE
Run wsl linter and fix leftover problems

### DIFF
--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -22,7 +22,7 @@ go/vet:
 	go vet -copylocks=false $(LINT_TARGET)
 
 go/wsl:
-	wsl -fix ./pkg/...
+	wsl -fix -allow-trailing-comment ./pkg/...
 
 ## Runs golangci-lint
 go/golangci:

--- a/pkg/clients/dynatrace/communication_hosts_test.go
+++ b/pkg/clients/dynatrace/communication_hosts_test.go
@@ -45,6 +45,7 @@ func TestReadCommunicationHosts(t *testing.T) {
 	{
 		m, err := readFromString(goodCommunicationEndpointsResponse)
 		require.NoError(t, err)
+
 		expected := []CommunicationHost{
 			{Protocol: "https", Host: "10.0.0.1", Port: 8000},
 			{Protocol: "https", Host: "example.live.dynatrace.com", Port: 443},
@@ -60,6 +61,7 @@ func TestReadCommunicationHosts(t *testing.T) {
 	{
 		m, err := readFromString(mixedCommunicationEndpointsResponse)
 		require.NoError(t, err)
+
 		expected := []CommunicationHost{
 			{Protocol: "https", Host: "example.live.dynatrace.com", Port: 443},
 		}

--- a/pkg/injection/codemodule/installer/image/installer_test.go
+++ b/pkg/injection/codemodule/installer/image/installer_test.go
@@ -95,6 +95,7 @@ func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func TestInstaller_InstallAgent(t *testing.T) {
 	ctx := context.Background()
+
 	type fields struct {
 		fs        afero.Fs
 		extractor zip.Extractor

--- a/pkg/injection/codemodule/installer/url/installer_test.go
+++ b/pkg/injection/codemodule/installer/url/installer_test.go
@@ -144,9 +144,9 @@ func TestInstallAgentFromUrl(t *testing.T) {
 			},
 		}
 
+		// afero can't rename directories properly: https://github.com/spf13/afero/issues/141
 		err := installer.installAgent(ctx, testDir)
 		require.NoError(t, err)
-		// afero can't rename directories properly: https://github.com/spf13/afero/issues/141
 	})
 	t.Run(`downloading and unzipping latest agent`, func(t *testing.T) {
 		fs := afero.NewMemMapFs()
@@ -178,9 +178,9 @@ func TestInstallAgentFromUrl(t *testing.T) {
 			},
 		}
 
+		// afero can't rename directories properly: https://github.com/spf13/afero/issues/141
 		err := installer.installAgent(ctx, testDir)
 		require.NoError(t, err)
-		// afero can't rename directories properly: https://github.com/spf13/afero/issues/141
 	})
 	t.Run(`downloading and unzipping agent via url`, func(t *testing.T) {
 		fs := afero.NewMemMapFs()
@@ -207,9 +207,9 @@ func TestInstallAgentFromUrl(t *testing.T) {
 			},
 		}
 
+		// afero can't rename directories properly: https://github.com/spf13/afero/issues/141
 		err := installer.installAgent(ctx, testDir)
 		require.NoError(t, err)
-		// afero can't rename directories properly: https://github.com/spf13/afero/issues/141
 	})
 }
 

--- a/pkg/injection/startup/run_test.go
+++ b/pkg/injection/startup/run_test.go
@@ -138,6 +138,7 @@ func TestSetHostTenant(t *testing.T) {
 
 func TestInstallOneAgent(t *testing.T) {
 	ctx := context.Background()
+
 	t.Run("happy install", func(t *testing.T) {
 		runner := createMockedRunner(t)
 		_, err := runner.fs.Create(filepath.Join(consts.AgentBinDirMount, "agent/conf/ruxitagentproc.conf"))
@@ -290,6 +291,7 @@ func TestConfigureInstallation(t *testing.T) {
 
 func TestGetProcessModuleConfig(t *testing.T) {
 	ctx := context.Background()
+
 	t.Run("error if api call fails", func(t *testing.T) {
 		runner := createMockedRunner(t)
 		runner.dtclient.(*mockedclient.Client).
@@ -438,8 +440,7 @@ func TestSetLDPreload(t *testing.T) {
 			filepath.Join(
 				consts.AgentShareDirMount,
 				consts.LdPreloadFilename))
-		// TODO: Check content ?
-	})
+	}) // TODO: Check content ?
 }
 
 func TestEnrichMetadata(t *testing.T) {
@@ -453,8 +454,7 @@ func TestEnrichMetadata(t *testing.T) {
 
 		require.NoError(t, err)
 		assertIfEnrichmentFilesExists(t, *runner)
-		// TODO: Check content ?
-	})
+	}) // TODO: Check content ?
 }
 
 func TestPropagateTLSCert(t *testing.T) {

--- a/pkg/oci/registry/mocks/client.go
+++ b/pkg/oci/registry/mocks/client.go
@@ -33,10 +33,13 @@ func (_m *MockImageGetter) GetImageVersion(ctx context.Context, imageName string
 	}
 
 	var r0 registry.ImageVersion
+
 	var r1 error
+
 	if rf, ok := ret.Get(0).(func(context.Context, string) (registry.ImageVersion, error)); ok {
 		return rf(ctx, imageName)
 	}
+
 	if rf, ok := ret.Get(0).(func(context.Context, string) registry.ImageVersion); ok {
 		r0 = rf(ctx, imageName)
 	} else {
@@ -68,6 +71,7 @@ func (_c *MockImageGetter_GetImageVersion_Call) Run(run func(ctx context.Context
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string))
 	})
+
 	return _c
 }
 
@@ -90,10 +94,13 @@ func (_m *MockImageGetter) PullImageInfo(ctx context.Context, imageName string) 
 	}
 
 	var r0 *v1.Image
+
 	var r1 error
+
 	if rf, ok := ret.Get(0).(func(context.Context, string) (*v1.Image, error)); ok {
 		return rf(ctx, imageName)
 	}
+
 	if rf, ok := ret.Get(0).(func(context.Context, string) *v1.Image); ok {
 		r0 = rf(ctx, imageName)
 	} else {
@@ -127,6 +134,7 @@ func (_c *MockImageGetter_PullImageInfo_Call) Run(run func(ctx context.Context, 
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string))
 	})
+
 	return _c
 }
 


### PR DESCRIPTION
## Description

There are some problems that `wsl` command still finds, when run with `-fix` but can't actually fix themself.
Also it does not respect `nolint` (unlike `golangci-lint`), so I made the command less aggressive.

## How can this be tested?

`make go/lint` => passes and no file changes

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
