### PR TITLE
Changes the default registry in the helm chart from docker.io to public.ecr.aws - main

### DIFF
--- a/config/helm/chart/default/README.md
+++ b/config/helm/chart/default/README.md
@@ -34,7 +34,7 @@ helm install dynatrace-operator dynatrace/dynatrace-operator -n dynatrace --crea
 Install `dynatrace-operator` helm chart using the OCI repository and create the corresponding `dynatrace` namespace:
 
 ```console
-helm install dynatrace-operator oci://docker.io/dynatrace/dynatrace-operator  -n dynatrace --create-namespace --atomic
+helm install dynatrace-operator oci://public.ecr.aws/dynatrace/dynatrace-operator  -n dynatrace --create-namespace --atomic
 ```
 
 ## Uninstall chart

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -34,7 +34,7 @@ Check if default image or imageref is used
     {{- else if eq (include "dynatrace-operator.platform" .) "azure-marketplace" -}}
         {{- printf "%s/%s@%s" .Values.global.azure.images.operator.registry .Values.global.azure.images.operator.image .Values.global.azure.images.operator.digest }}
 	{{- else -}}
-		{{- printf "%s:v%s" "docker.io/dynatrace/dynatrace-operator" .Chart.AppVersion }}
+		{{- printf "%s:v%s" "public.ecr.aws/dynatrace/dynatrace-operator" .Chart.AppVersion }}
 	{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -503,7 +503,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/dynatrace/dynatrace-operator:v1.0.1"
+          value: "public.ecr.aws/dynatrace/dynatrace-operator:v1.0.1"
 
   - it: not setting image or imageref but platform to google-marketplace defaults to correct repo and version
     set:


### PR DESCRIPTION
## Description

cherry-pick from [release-1.0](https://github.com/Dynatrace/dynatrace-operator/pull/2738) to `main`

## How can this be tested?


## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
