### PR TITLE
Only support autoUpdate for default registry in EdgeConnect

### DIFF
--- a/pkg/controllers/edgeconnect/version/updater_test.go
+++ b/pkg/controllers/edgeconnect/version/updater_test.go
@@ -20,31 +20,65 @@ import (
 
 const fakeDigest = "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc"
 
-func TestReconcile(t *testing.T) {
-	edgeConnect := createBasicEdgeConnect()
-	fakeRegistryClient := mocks.NewMockImageGetter(t)
-	fakeImageVersion := registry.ImageVersion{Digest: fakeDigest}
-	fakeRegistryClient.On("GetImageVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fakeImageVersion, nil)
+func TestUpdate(t *testing.T) {
+	ctx := context.Background()
+	t.Run("default image => registry used", func(t *testing.T) {
+		edgeConnect := createBasicEdgeConnect()
+		fakeRegistryClient := mocks.NewMockImageGetter(t)
+		fakeImageVersion := registry.ImageVersion{Digest: fakeDigest}
+		fakeRegistryClient.On("GetImageVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fakeImageVersion, nil)
 
-	updater := newUpdater(fake.NewClient(), timeprovider.New(), fakeRegistryClient, edgeConnect)
+		updater := newUpdater(fake.NewClient(), timeprovider.New(), fakeRegistryClient, edgeConnect)
 
-	err := updater.Update(context.TODO())
-	require.NoError(t, err)
+		err := updater.Update(ctx)
+		require.NoError(t, err)
 
-	require.Equal(t, fmt.Sprintf("docker.io/dynatrace/edgeconnect:latest@%s", fakeDigest), edgeConnect.Status.Version.ImageID)
-	require.NotNil(t, edgeConnect.Status.Version.LastProbeTimestamp)
+		require.Equal(t, "docker.io/dynatrace/edgeconnect:latest@"+fakeDigest, edgeConnect.Status.Version.ImageID)
+		require.NotNil(t, edgeConnect.Status.Version.LastProbeTimestamp)
 
-	// check invalid digest
-	invalidImageVersion := registry.ImageVersion{Digest: "invaliddigest"}
-	fakeRegistryClient.On("GetImageVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(invalidImageVersion, nil)
+		// check invalid digest
+		invalidImageVersion := registry.ImageVersion{Digest: "invaliddigest"}
+		fakeRegistryClient.On("GetImageVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(invalidImageVersion, nil)
 
-	updater = newUpdater(fake.NewClient(), timeprovider.New(), fakeRegistryClient, edgeConnect)
+		updater = newUpdater(fake.NewClient(), timeprovider.New(), fakeRegistryClient, edgeConnect)
 
-	err = updater.Update(context.TODO())
-	require.NoError(t, err)
+		err = updater.Update(ctx)
+		require.NoError(t, err)
 
-	// digest should not have been updated due to probe timestamp
-	require.True(t, strings.Contains(edgeConnect.Status.Version.ImageID, fakeDigest))
+		// digest should not have been updated due to probe timestamp
+		require.True(t, strings.Contains(edgeConnect.Status.Version.ImageID, fakeDigest))
+	})
+
+	t.Run("custom tag used => registry still used", func(t *testing.T) {
+		edgeConnect := createBasicEdgeConnect()
+		customTag := "1.2.3"
+		edgeConnect.Spec.ImageRef.Tag = customTag
+		fakeRegistryClient := mocks.NewMockImageGetter(t)
+		fakeImageVersion := registry.ImageVersion{Digest: fakeDigest}
+		fakeRegistryClient.On("GetImageVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fakeImageVersion, nil)
+
+		updater := newUpdater(fake.NewClient(), timeprovider.New(), fakeRegistryClient, edgeConnect)
+
+		err := updater.Update(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, fmt.Sprintf("docker.io/dynatrace/edgeconnect:%s@%s", customTag, fakeDigest), edgeConnect.Status.Version.ImageID)
+		require.NotNil(t, edgeConnect.Status.Version.LastProbeTimestamp)
+	})
+
+	t.Run("custom registry used => registry NOT used", func(t *testing.T) {
+		edgeConnect := createBasicEdgeConnect()
+		customRegistry := "best.registry.io/dynatrace/edgeconnect"
+		edgeConnect.Spec.ImageRef.Repository = customRegistry
+
+		updater := newUpdater(fake.NewClient(), timeprovider.New(), nil, edgeConnect)
+
+		err := updater.Update(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, fmt.Sprintf("%s:latest", customRegistry), edgeConnect.Status.Version.ImageID)
+		require.NotNil(t, edgeConnect.Status.Version.LastProbeTimestamp)
+	})
 }
 
 func TestCombineImagesWithDigest(t *testing.T) {
@@ -57,7 +91,7 @@ func TestCombineImagesWithDigest(t *testing.T) {
 		combined, err := updater.combineImageWithDigest(fakeDigest)
 
 		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf("docker.io/dynatrace/edgeconnect:latest@%s", fakeDigest), combined)
+		require.Equal(t, "docker.io/dynatrace/edgeconnect:latest@%s"+fakeDigest, combined)
 	})
 
 	t.Run("malformed image should fail", func(t *testing.T) {

--- a/pkg/controllers/edgeconnect/version/updater_test.go
+++ b/pkg/controllers/edgeconnect/version/updater_test.go
@@ -76,7 +76,7 @@ func TestUpdate(t *testing.T) {
 		err := updater.Update(ctx)
 		require.NoError(t, err)
 
-		require.Equal(t, fmt.Sprintf("%s:latest", customRegistry), edgeConnect.Status.Version.ImageID)
+		require.Equal(t, customRegistry+":latest", edgeConnect.Status.Version.ImageID)
 		require.NotNil(t, edgeConnect.Status.Version.LastProbeTimestamp)
 	})
 }
@@ -91,7 +91,7 @@ func TestCombineImagesWithDigest(t *testing.T) {
 		combined, err := updater.combineImageWithDigest(fakeDigest)
 
 		require.NoError(t, err)
-		require.Equal(t, "docker.io/dynatrace/edgeconnect:latest@%s"+fakeDigest, combined)
+		require.Equal(t, "docker.io/dynatrace/edgeconnect:latest@"+fakeDigest, combined)
 	})
 
 	t.Run("malformed image should fail", func(t *testing.T) {


### PR DESCRIPTION
Please include the following:
To remain consistent with the DynaKube and avoid confusion, we will not support `autoUpdate` for custom image repositories.

This is so we can avoid requiring the `customPullSecret` for custom image registries.

We will still use the registry to get the version(digest) that allows `autoUpdate` to function.
- This is because we don't have an endpoint in the Dyntrace API to check which is the latest EdgeConnect version.
- The default registry is `docker.io`, so no `customPullSecret` is needed

I left in that if only the `imageRef.Tag` is not default we still get the digest, this is mainly an implementation detail, also its security best practice to use to digest, which is a plus.

## How can this be tested?

The unit-tests are pretty straight forward.

But you can get an edgeconnect image from a non-default registry and then you should still be able to use it even if the operator it self wouldn't be able to pull. (also no digest will be in the imageID of the EdgeConnect CR Status)

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
