### PR TITLE
Push Helm Chart to ECR on Release

### DIFF
--- a/.github/actions/upload-helm/action.yaml
+++ b/.github/actions/upload-helm/action.yaml
@@ -1,12 +1,6 @@
 name: Upload helm package
 description: Upload the helm package
 inputs:
-  registry-username:
-    description: Username for the OCI registry
-    required: true
-  registry-password:
-    description: Password for the OCI registry
-    required: true
   registry-url:
     description: URL for the OCI registry
     required: true
@@ -43,16 +37,9 @@ runs:
     id: push-helm-to-OCI
     shell: bash
     run: |
-      helm registry login -u "${{ inputs.registry-username }}" -p "${{ inputs.registry-password }}" "${{ inputs.registry-url }}"
-      hack/build/ci/push-helm-chart.sh \
+        hack/build/ci/push-helm-chart.sh \
         "./helm-pkg/dynatrace-operator-${{ inputs.version-without-prefix }}.tgz" \
         "oci://${{ inputs.registry-url }}/${{ inputs.registry-namespace }}"
-  - name: Login to Registry
-    uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
-    with:
-      registry: ${{ inputs.image-base-url }}
-      username: ${{ inputs.registry-username }}
-      password: ${{ inputs.registry-password }}
   - name: Sign OCI package with cosign
     uses: ./.github/actions/sign-image
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -336,6 +336,27 @@ jobs:
           version-without-prefix: ${{ needs.prepare.outputs.version_without_prefix }}
           cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           cosign-password: ${{ secrets.COSIGN_PASSWORD }}
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.ECR_IMAGEPUSH_ROLE }}
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registry-type: public
+      - name: Upload helm package to ECR
+        shell: bash
+        run: |
+          hack/build/ci/push-helm-chart.sh \
+            "./helm-pkg/dynatrace-operator-${{ inputs.version-without-prefix }}.tgz" \
+            "oci://public.ecr.aws/${{ ECR_REPOSITORY }}"
+      - name: Sign OCI package with cosign
+        uses: ./.github/actions/sign-image
+        with:
+          image: "oci://public.ecr.aws/${{ ECR_REPOSITORY }}/${{ dynatrace-operator }}:${{ needs.prepare.outputs.version }}@${{ steps.push-helm-to-OCI.outputs.digest }}"
+          signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Prepare cosign.pub artifact
         env:
           COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -363,6 +363,7 @@ jobs:
           version-without-prefix: ${{ needs.prepare.outputs.version_without_prefix }}
           cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           cosign-password: ${{ secrets.COSIGN_PASSWORD }}
+# TODO: cleanup
 #      - name: Upload helm package to ECR
 #        shell: bash
 #        run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -327,11 +327,20 @@ jobs:
           secring: ${{ secrets.HELM_SECRING }}
           passphrase: ${{ secrets.HELM_PASSPHRASE }}
           output-dir: "./helm-pkg"
+      - name: Login Helm to dockerhub
+        id: push-helm-to-OCI
+        shell: bash
+        run: |
+          helm registry login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" "registry.hub.docker.com"
+      - name: Login Docker to dockerhub
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Upload and sign helm package to dockerhub
         uses: ./.github/actions/upload-helm
         with:
-          registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
-          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
           version: ${{ needs.prepare.outputs.version }}
           version-without-prefix: ${{ needs.prepare.outputs.version_without_prefix }}
           cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
@@ -345,18 +354,27 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
           registry-type: public
-      - name: Upload helm package to ECR
-        shell: bash
-        run: |
-          hack/build/ci/push-helm-chart.sh \
-            "./helm-pkg/dynatrace-operator-${{ inputs.version-without-prefix }}.tgz" \
-            "oci://public.ecr.aws/${{ ECR_REPOSITORY }}"
-      - name: Sign OCI package with cosign
-        uses: ./.github/actions/sign-image
+      - name: Upload and sign helm package to dockerhub
+        uses: ./.github/actions/upload-helm
         with:
-          image: "oci://public.ecr.aws/${{ ECR_REPOSITORY }}/${{ dynatrace-operator }}:${{ needs.prepare.outputs.version }}@${{ steps.push-helm-to-OCI.outputs.digest }}"
-          signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          signing-password: ${{ secrets.COSIGN_PASSWORD }}
+          registry-url: public.ecr.aws
+          image-base-url: public.ecr.aws #???
+          version: ${{ needs.prepare.outputs.version }}
+          version-without-prefix: ${{ needs.prepare.outputs.version_without_prefix }}
+          cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          cosign-password: ${{ secrets.COSIGN_PASSWORD }}
+#      - name: Upload helm package to ECR
+#        shell: bash
+#        run: |
+#          hack/build/ci/push-helm-chart.sh \
+#            "./helm-pkg/dynatrace-operator-${{ inputs.version-without-prefix }}.tgz" \
+#            "oci://public.ecr.aws/${{ ECR_REPOSITORY }}"
+#      - name: Sign OCI package with cosign
+#        uses: ./.github/actions/sign-image
+#        with:
+#          image: "oci://public.ecr.aws/${{ ECR_REPOSITORY }}/${{ dynatrace-operator }}:${{ needs.prepare.outputs.version }}@${{ steps.push-helm-to-OCI.outputs.digest }}"
+#          signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
+#          signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Prepare cosign.pub artifact
         env:
           COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -328,7 +328,6 @@ jobs:
           passphrase: ${{ secrets.HELM_PASSPHRASE }}
           output-dir: "./helm-pkg"
       - name: Login Helm to dockerhub
-        id: push-helm-to-OCI
         shell: bash
         run: |
           helm registry login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" "registry.hub.docker.com"
@@ -358,24 +357,11 @@ jobs:
         uses: ./.github/actions/upload-helm
         with:
           registry-url: public.ecr.aws
-          image-base-url: public.ecr.aws #???
+          image-base-url: public.ecr.aws
           version: ${{ needs.prepare.outputs.version }}
           version-without-prefix: ${{ needs.prepare.outputs.version_without_prefix }}
           cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           cosign-password: ${{ secrets.COSIGN_PASSWORD }}
-# TODO: cleanup
-#      - name: Upload helm package to ECR
-#        shell: bash
-#        run: |
-#          hack/build/ci/push-helm-chart.sh \
-#            "./helm-pkg/dynatrace-operator-${{ inputs.version-without-prefix }}.tgz" \
-#            "oci://public.ecr.aws/${{ ECR_REPOSITORY }}"
-#      - name: Sign OCI package with cosign
-#        uses: ./.github/actions/sign-image
-#        with:
-#          image: "oci://public.ecr.aws/${{ ECR_REPOSITORY }}/${{ dynatrace-operator }}:${{ needs.prepare.outputs.version }}@${{ steps.push-helm-to-OCI.outputs.digest }}"
-#          signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
-#          signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Prepare cosign.pub artifact
         env:
           COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -353,7 +353,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
           registry-type: public
-      - name: Upload and sign helm package to dockerhub
+      - name: Upload and sign helm package to Amazon ECR
         uses: ./.github/actions/upload-helm
         with:
           registry-url: public.ecr.aws


### PR DESCRIPTION
## Description

Reworks how we do helm pushes to include Amazon ECR. Moves login logic from action to workflow as it is only called there, adds login to ECR steps to workflow and reuses helm upload action for ECR.

## How can this be tested?

Not as convenient as I would like to: when running next release 😞 

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
