### PR TITLE
Adds spec.oneAgent.hostGroup field (release-1.0)

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -2723,6 +2723,9 @@ spec:
                         description: The OneAgent version to be used.
                         type: string
                     type: object
+                  hostGroup:
+                    description: Sets a host group for OneAgent.
+                    type: string
                   hostMonitoring:
                     description: |-
                       Has a single OneAgent per node via DaemonSet.

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -2735,6 +2735,9 @@ spec:
                         description: The OneAgent version to be used.
                         type: string
                     type: object
+                  hostGroup:
+                    description: Sets a host group for OneAgent.
+                    type: string
                   hostMonitoring:
                     description: |-
                       Has a single OneAgent per node via DaemonSet.

--- a/doc/api/dynakube-api-ref.md
+++ b/doc/api/dynakube-api-ref.md
@@ -14,6 +14,12 @@
 |tokens|Name of the secret holding the tokens used for connecting to Dynatrace.|-|string|
 |trustedCAs|Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap. Note: Applies only to Dynatrace Operator and OneAgent, not to ActiveGate.|-|string|
 
+### .spec.oneAgent
+
+|Parameter|Description|Default value|Data type|
+|:-|:-|:-|:-|
+|hostGroup|Sets a host group for OneAgent.|-|string|
+
 ### .spec.activeGate
 
 |Parameter|Description|Default value|Data type|

--- a/pkg/api/v1beta1/dynakube/oneagent_types.go
+++ b/pkg/api/v1beta1/dynakube/oneagent_types.go
@@ -27,6 +27,11 @@ type OneAgentSpec struct {
 	// Doesn't inject into application pods.
 	// +nullable
 	HostMonitoring *HostInjectSpec `json:"hostMonitoring,omitempty"`
+
+	// Sets a host group for OneAgent.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Host Group",order=5,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	HostGroup string `json:"hostGroup,omitempty"`
 }
 
 type CloudNativeFullStackSpec struct {

--- a/pkg/api/v1beta1/dynakube/properties.go
+++ b/pkg/api/v1beta1/dynakube/properties.go
@@ -471,6 +471,14 @@ func tenantUUID(apiUrl string) (string, error) {
 }
 
 func (dk *DynaKube) HostGroup() string {
+	if dk.Spec.OneAgent.HostGroup != "" {
+		return dk.Spec.OneAgent.HostGroup
+	}
+
+	return dk.HostGroupAsParam()
+}
+
+func (dk *DynaKube) HostGroupAsParam() string {
 	var hostGroup string
 	if dk.CloudNativeFullstackMode() && dk.Spec.OneAgent.CloudNativeFullStack.Args != nil {
 		for _, arg := range dk.Spec.OneAgent.CloudNativeFullStack.Args {

--- a/pkg/api/v1beta1/dynakube/properties_test.go
+++ b/pkg/api/v1beta1/dynakube/properties_test.go
@@ -512,3 +512,54 @@ func TestDynaKube_ShallUpdateActiveGateConnectionInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestOneAgentHostGroup(t *testing.T) {
+	t.Run("get host group from cloudNativeFullstack.args", func(t *testing.T) {
+		dk := DynaKube{
+			Spec: DynaKubeSpec{
+				OneAgent: OneAgentSpec{
+					CloudNativeFullStack: &CloudNativeFullStackSpec{
+						HostInjectSpec: HostInjectSpec{
+							Args: []string{
+								"--set-host-group=arg",
+							},
+						},
+					},
+				},
+			},
+		}
+		hostGroup := dk.HostGroup()
+		assert.Equal(t, "arg", hostGroup)
+	})
+
+	t.Run("get host group from oneagent.hostGroup", func(t *testing.T) {
+		dk := DynaKube{
+			Spec: DynaKubeSpec{
+				OneAgent: OneAgentSpec{
+					HostGroup: "field",
+				},
+			},
+		}
+		hostGroup := dk.HostGroup()
+		assert.Equal(t, "field", hostGroup)
+	})
+
+	t.Run("get host group if both methods used", func(t *testing.T) {
+		dk := DynaKube{
+			Spec: DynaKubeSpec{
+				OneAgent: OneAgentSpec{
+					CloudNativeFullStack: &CloudNativeFullStackSpec{
+						HostInjectSpec: HostInjectSpec{
+							Args: []string{
+								"--set-host-group=arg",
+							},
+						},
+					},
+					HostGroup: "field",
+				},
+			},
+		}
+		hostGroup := dk.HostGroup()
+		assert.Equal(t, "field", hostGroup)
+	})
+}

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
@@ -37,6 +37,10 @@ func (dsInfo *builderInfo) arguments() ([]string, error) {
 
 	dsInfo.appendHostInjectArgs(argMap)
 
+	if dsInfo.dynakube.CloudNativeFullstackMode() {
+		dsInfo.appendHostGroupArg(argMap)
+	}
+
 	return argMap.AsKeyValueStrings(), nil
 }
 
@@ -58,6 +62,12 @@ func appendOperatorVersionArg(argMap *prioritymap.Map) {
 func (dsInfo *builderInfo) appendNetworkZoneArg(argMap *prioritymap.Map) {
 	if dsInfo.dynakube != nil && dsInfo.dynakube.Spec.NetworkZone != "" {
 		argMap.Append(argumentPrefix+"set-network-zone", dsInfo.dynakube.Spec.NetworkZone)
+	}
+}
+
+func (dsInfo *builderInfo) appendHostGroupArg(argMap *prioritymap.Map) {
+	if dsInfo.dynakube != nil && dsInfo.dynakube.Spec.OneAgent.HostGroup != "" {
+		argMap.Append(argumentPrefix+"set-host-group", dsInfo.dynakube.Spec.OneAgent.HostGroup, prioritymap.WithPriority(prioritymap.HighPriority))
 	}
 }
 

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -814,3 +814,29 @@ func TestAnnotations(t *testing.T) {
 		assert.Equal(t, expectedAnnotations, daemonset.Spec.Template.Annotations)
 	})
 }
+
+func TestOneAgentHostGroup(t *testing.T) {
+	t.Run("cloud native - host group settings", func(t *testing.T) {
+		dynakube := dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
+						HostInjectSpec: dynatracev1beta1.HostInjectSpec{
+							Args: []string{
+								"--set-host-group=oldgroup",
+							},
+						},
+					},
+					HostGroup: "newgroup",
+				},
+			},
+		}
+
+		builder := NewCloudNativeFullStack(&dynakube, testClusterID)
+		daemonset, err := builder.BuildDaemonSet()
+
+		require.NoError(t, err)
+		assert.NotNil(t, daemonset)
+		assert.Equal(t, "--set-host-group=newgroup", daemonset.Spec.Template.Spec.Containers[0].Args[0])
+	})
+}

--- a/pkg/webhook/validation/dynakube/config.go
+++ b/pkg/webhook/validation/dynakube/config.go
@@ -48,6 +48,7 @@ var warnings = []validator{
 	deprecatedFeatureFlagWillBeDeleted,
 	deprecatedFeatureFlagMovedCRDField,
 	unsupportedOneAgentImage,
+	conflictingHostGroupSettings,
 }
 
 func SetLogger(logger logr.Logger) {

--- a/pkg/webhook/validation/dynakube/oneagent.go
+++ b/pkg/webhook/validation/dynakube/oneagent.go
@@ -20,6 +20,8 @@ The conflicting Dynakube: %s
 	errorVolumeStorageReadOnlyModeConflict = `The DynaKube's specification specifies a read-only host file system and OneAgent has volume storage enabled.`
 
 	warningOneAgentInstallerEnvVars = `Environment variables ONEAGENT_INSTALLER_SCRIPT_URL and ONEAGENT_INSTALLER_TOKEN are only relevant for an unsupported image type. Please make sure you are using a supported image.`
+
+	warningHostGroupConflict = `DynaKube's specification sets the host group using --set-host-group parameter. Instead, specify the new spec.oneagent.hostGroup field. If you use both settings, the new field precedes the parameter.`
 )
 
 func conflictingOneAgentConfiguration(_ context.Context, dv *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
@@ -108,5 +110,13 @@ func conflictingOneAgentVolumeStorageSettings(_ context.Context, dv *dynakubeVal
 	if dynakube.NeedsReadOnlyOneAgents() && volumeStorageSet && !volumeStorageEnabled {
 		return errorVolumeStorageReadOnlyModeConflict
 	}
+	return ""
+}
+
+func conflictingHostGroupSettings(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
+	if dynakube.HostGroupAsParam() != "" {
+		return warningHostGroupConflict
+	}
+
 	return ""
 }

--- a/pkg/webhook/validation/dynakube/oneagent_test.go
+++ b/pkg/webhook/validation/dynakube/oneagent_test.go
@@ -345,3 +345,48 @@ func TestUnsupportedOneAgentImage(t *testing.T) {
 		})
 	}
 }
+
+func TestOneAgentHostGroup(t *testing.T) {
+	t.Run(`valid dynakube specs`, func(t *testing.T) {
+		assertAllowedResponseWithoutWarnings(t,
+			createDynakubeWithHostGroup([]string{}, ""),
+			&defaultCSIDaemonSet)
+
+		assertAllowedResponseWithoutWarnings(t,
+			createDynakubeWithHostGroup([]string{"--other-param=1"}, ""),
+			&defaultCSIDaemonSet)
+
+		assertAllowedResponseWithoutWarnings(t,
+			createDynakubeWithHostGroup([]string{}, "field"),
+			&defaultCSIDaemonSet)
+	})
+
+	t.Run(`obsolete settings`, func(t *testing.T) {
+		assertAllowedResponseWithWarnings(t,
+			1,
+			createDynakubeWithHostGroup([]string{"--set-host-group=arg"}, ""),
+			&defaultCSIDaemonSet)
+
+		assertAllowedResponseWithWarnings(t,
+			1,
+			createDynakubeWithHostGroup([]string{"--set-host-group=arg"}, "field"),
+			&defaultCSIDaemonSet)
+	})
+}
+
+func createDynakubeWithHostGroup(args []string, hostGroup string) *dynatracev1beta1.DynaKube {
+	return &dynatracev1beta1.DynaKube{
+		ObjectMeta: defaultDynakubeObjectMeta,
+		Spec: dynatracev1beta1.DynaKubeSpec{
+			APIURL: testApiUrl,
+			OneAgent: dynatracev1beta1.OneAgentSpec{
+				CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
+					HostInjectSpec: dynatracev1beta1.HostInjectSpec{
+						Args: args,
+					},
+				},
+				HostGroup: hostGroup,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Description
[PR for main branch](https://github.com/Dynatrace/dynatrace-operator/pull/2748)

Adds `spec.oneAgent.hostGroup` field to the Dynakube.
Prints warning when `spec.oneAgent.cloudNativeFullStack.args` is used to set host group.

`--set-host-group` argument of `daemonset.OneAgent.Containers[dynatrace-oneagent]` container is set to `oneAgent.hostGroup` value if new field is specified.

## How can this be tested?

Deploy CN dynakube with `--set-host-group=oldgroup` argument and `oneagent.hostGroup=newgroup`:
```
spec:
  oneAgent:
    hostGroup: newgroup
    cloudNativeFullStack:
      args:
      - "--set-host-group=oldgroup"
```
- you should see validation warning
- `Deployment status`/`OneAgents`/\<host\> `Host group:` link is set to `newgroup`
- OneAgent pods - `kctl describe daemonset.apps/dynakube-oneagent`
```
Containers:
   dynatrace-oneagent:
    Args:
      --set-host-group=newgroup
```
- init secret in a monitored namespace `kubectl -n <namespace> get -o json secret/dynatrace-dynakube-config | jq -r '.data.config' | base64 -d | jq -r '.hostGroup'`
```
newgroup
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
