### PR TITLE
Only support autoUpdate for default registry in EdgeConnect

### DIFF
--- a/pkg/controllers/edgeconnect/version/updater.go
+++ b/pkg/controllers/edgeconnect/version/updater.go
@@ -59,25 +59,25 @@ func (u updater) Update(ctx context.Context) error {
 	}()
 
 	image := u.edgeConnect.Image()
-
-	imageVersion, err := u.registryClient.GetImageVersion(ctx, image)
-	if err != nil {
-		return err
-	}
-
-	imageID, err := u.combineImageWithDigest(imageVersion.Digest)
-	if err != nil {
-		return err
-	}
-
 	target := u.Target()
-	target.ImageID = imageID
 
-	if u.edgeConnect.IsCustomImage() {
-		target.Source = status.CustomImageVersionSource
-	} else {
+	if !u.edgeConnect.IsCustomImage() {
+		imageVersion, err := u.registryClient.GetImageVersion(ctx, image)
+		if err != nil {
+			return err
+		}
+
+		image, err = u.combineImageWithDigest(imageVersion.Digest)
+		if err != nil {
+			return err
+		}
+
 		target.Source = status.PublicRegistryVersionSource
+	} else {
+		target.Source = status.CustomImageVersionSource
 	}
+
+	target.ImageID = image
 
 	return nil
 }


### PR DESCRIPTION
## Description

cherry pick of (#2744)

## How can this be tested?

same as (#2744)

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
