### PR TITLE
Add missing comments to make commands

### DIFF
--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -21,6 +21,7 @@ go/format: go/fmt go/gci
 go/vet:
 	go vet -copylocks=false $(LINT_TARGET)
 
+## Runs go wsl linter
 go/wsl:
 	wsl -fix -allow-trailing-comment ./pkg/...
 
@@ -35,6 +36,7 @@ go/lint: prerequisites/go-linting go/format go/vet go/wsl go/golangci
 go/test:
 	go test ./... -coverprofile=coverage.txt -covermode=atomic -tags "$(shell ./hack/build/create_go_build_tags.sh false)"
 
+## Runs go integration test
 go/integration_test:
 	go test -ldflags="-X 'github.com/Dynatrace/dynatrace-operator/pkg/version.Commit=$(shell git rev-parse HEAD)' -X 'github.com/Dynatrace/dynatrace-operator/pkg/version.Version=$(shell git branch --show-current)'" ./cmd/integration/*
 

--- a/hack/make/images.mk
+++ b/hack/make/images.mk
@@ -30,6 +30,7 @@ images/build: ensure-tag-not-snapshot
 images/push: ensure-tag-not-snapshot
 	./hack/build/push_image.sh "${IMAGE}" "${TAG}"
 
+## Builds an Operator image and pushes it
 images/build/push: images/build images/push
 
 ## Builds and pushes the deployer image for the Google marketplace to the development environment on GCR

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -27,6 +27,7 @@ endif
 ## Install all prerequisites
 prerequisites: prerequisites/setup-go-dev-dependencies prerequisites/helm-unittest prerequisites/markdownlint prerequisites/gomarkdoc
 
+## Setup go development dependencies
 prerequisites/setup-go-dev-dependencies: prerequisites/kustomize prerequisites/controller-gen prerequisites/go-linting prerequisites/mockery
 
 ## Install 'controller-gen' if it is missing
@@ -34,6 +35,7 @@ prerequisites/controller-gen:
 	go install "sigs.k8s.io/controller-tools/cmd/controller-gen@$(controller_gen_version)"
 CONTROLLER_GEN=$(shell hack/build/command.sh controller-gen)
 
+## Install go linters
 prerequisites/go-linting:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golang_ci_cmd_version)
 	go install github.com/daixiang0/gci@$(gci_version)

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -2,6 +2,7 @@
 test/e2e/%/debug:
 	@make SKIPCLEANUP="--fail-fast" $(@D)
 
+## Run standard, istio and release e2e tests
 test/e2e:
 	RC=0; \
 	make test/e2e/standard  || RC=1; \
@@ -9,12 +10,15 @@ test/e2e:
 	make test/e2e/release || RC=1; \
 	exit $$RC
 
+## Run standard e2e test only
 test/e2e/standard: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 200m -count=1 ./test/scenarios/standard -args --skip-labels "name=cloudnative-network-zone" $(SKIPCLEANUP)
 
+## Run istio e2e test only
 test/e2e/istio: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 200m -count=1 ./test/scenarios/istio -args $(SKIPCLEANUP)
 
+## Run release e2e test only
 test/e2e/release: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/release -args $(SKIPCLEANUP)
 
@@ -69,6 +73,7 @@ test/e2e/cloudnative/network-zone: manifests/crd/helm
 test/e2e/cloudnative/proxy: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -args --labels "name=cloudnative-proxy" $(SKIPCLEANUP)
 
+## Runs CloudNative public registry e2e test only
 test/e2e/cloudnative/publicregistry: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=cloudnative-public-registry" $(SKIPCLEANUP)
 
@@ -100,6 +105,7 @@ test/e2e/applicationmonitoring/withoutcsi: manifests/crd/helm
 test/e2e/supportarchive: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=support-archive" $(SKIPCLEANUP)
 
+## Runs Edgeconnect e2e test only
 test/e2e/edgeconnect: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=edgeconnect-install" $(SKIPCLEANUP)
 


### PR DESCRIPTION
## Description

Add missing comments in make commands

## Why?

If there is no comment on the make command, `$ make` doesn't show it.

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
