### PR TITLE
Remove deprecated alpha.operator.dynatrace.com/feature- feature-flag prefix (main)

### DIFF
--- a/pkg/api/v1beta1/dynakube/feature_flags.go
+++ b/pkg/api/v1beta1/dynakube/feature_flags.go
@@ -20,15 +20,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/logger"
 )
 
 const (
-	DeprecatedFeatureFlagPrefix = "alpha.operator.dynatrace.com/feature-"
-
 	AnnotationFeaturePrefix = "feature.dynatrace.com/"
 
 	// General.
@@ -103,13 +100,6 @@ func (dk *DynaKube) getDisableFlagWithDeprecatedAnnotation(annotation string, de
 
 func (dk *DynaKube) getFeatureFlagRaw(annotation string) string {
 	if raw, ok := dk.Annotations[annotation]; ok {
-		return raw
-	}
-
-	split := strings.Split(annotation, "/")
-
-	postFix := split[1]
-	if raw, ok := dk.Annotations[DeprecatedFeatureFlagPrefix+postFix]; ok {
 		return raw
 	}
 

--- a/pkg/webhook/validation/dynakube/config.go
+++ b/pkg/webhook/validation/dynakube/config.go
@@ -38,7 +38,6 @@ var validators = []validator{
 }
 
 var warnings = []validator{
-	deprecatedFeatureFlagFormat,
 	missingActiveGateMemoryLimit,
 	deprecatedFeatureFlagDisableActiveGateUpdates,
 	deprecatedFeatureFlagDisableMetadataEnrichment,

--- a/pkg/webhook/validation/dynakube/deprecation.go
+++ b/pkg/webhook/validation/dynakube/deprecation.go
@@ -8,10 +8,6 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 )
 
-const (
-	featureDeprecatedWarningMessage = `DEPRECATED: %s`
-)
-
 func getDeprecatedFeatureFlagsWillBeRemoved() []string {
 	return []string{
 		dynatracev1beta1.AnnotationInjectionFailurePolicy,
@@ -26,19 +22,6 @@ func getDeprecatedFeatureFlagsWillBeMovedCRD() []string {
 		dynatracev1beta1.AnnotationFeatureActiveGateUpdates,
 		dynatracev1beta1.AnnotationFeatureLabelVersionDetection,
 	}
-}
-
-func deprecatedFeatureFlagFormat(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {
-	if dynakube.Annotations == nil {
-		return ""
-	}
-
-	deprecatedPrefix := dynatracev1beta1.DeprecatedFeatureFlagPrefix
-	if len(dynatracev1beta1.FlagsWithPrefix(dynakube, deprecatedPrefix)) > 0 {
-		return fmt.Sprintf(featureDeprecatedWarningMessage, "'alpha.operator.dynatrace.com/feature-' prefix will be replaced with the 'feature.dynatrace.com/' prefix for dynakube feature-flags")
-	}
-
-	return ""
 }
 
 func deprecatedFeatureFlagDisableActiveGateUpdates(_ context.Context, _ *dynakubeValidator, dynakube *dynatracev1beta1.DynaKube) string {

--- a/pkg/webhook/validation/dynakube/deprecation_test.go
+++ b/pkg/webhook/validation/dynakube/deprecation_test.go
@@ -3,7 +3,6 @@ package dynakube
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
@@ -16,23 +15,6 @@ func TestDeprecationWarning(t *testing.T) {
 		dynakubeMeta := defaultDynakubeObjectMeta
 		dynakubeMeta.Annotations = map[string]string{
 			dynatracev1beta1.AnnotationFeatureAutomaticInjection: "true",
-		}
-		dynakube := &dynatracev1beta1.DynaKube{
-			ObjectMeta: dynakubeMeta,
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				APIURL: testApiUrl,
-			},
-		}
-		assertAllowedResponseWithWarnings(t, 1, dynakube)
-		assert.True(t, dynakube.FeatureAutomaticInjection())
-	})
-
-	t.Run(`warning present`, func(t *testing.T) {
-		dynakubeMeta := defaultDynakubeObjectMeta
-		split := strings.Split(dynatracev1beta1.AnnotationFeatureAutomaticInjection, "/")
-		postFix := split[1]
-		dynakubeMeta.Annotations = map[string]string{
-			dynatracev1beta1.DeprecatedFeatureFlagPrefix + postFix: "true",
 		}
 		dynakube := &dynatracev1beta1.DynaKube{
 			ObjectMeta: dynakubeMeta,


### PR DESCRIPTION
## Description

Same as #2752 

## How can this be tested?

Same as #2752 

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
