### PR TITLE
pin squid image version

### DIFF
--- a/test/testdata/network/proxy-ssl.yaml
+++ b/test/testdata/network/proxy-ssl.yaml
@@ -85,7 +85,7 @@ spec:
     spec:
       serviceAccountName: proxy
       containers:
-      - image: ghcr.io/b4tman/squid-ssl-bump
+      - image: ghcr.io/b4tman/squid-ssl-bump:6.6
         name: squid
         env:
           - name: SQUID_CONFIG_FILE


### PR DESCRIPTION
## Description

Pin squid image for proxy with SSL `test/testdata/network/proxy-ssl.yaml`, new release 6.7 has broken `run.sh`

I've created an issue in https://github.com/b4tman/docker-squid/issues/130


## How can this be tested?

`make test/e2e/cloudnative/istio`

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
