### PR TITLE
Pass in the platform during CodeModulesImage pull

### DIFF
--- a/cmd/troubleshoot/image.go
+++ b/cmd/troubleshoot/image.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
 	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -89,7 +90,13 @@ func tryImagePull(ctx context.Context, keychain authn.Keychain, transport *http.
 		return err
 	}
 
-	_, err = remote.Get(imageReference, remote.WithContext(ctx), remote.WithAuthFromKeychain(keychain), remote.WithTransport(transport))
+	_, err = remote.Get(
+		imageReference,
+		remote.WithContext(ctx),
+		remote.WithAuthFromKeychain(keychain),
+		remote.WithTransport(transport),
+		remote.WithPlatform(arch.ImagePlatform),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/arch/amd64.go
+++ b/pkg/arch/amd64.go
@@ -3,4 +3,5 @@
 package arch
 
 const Arch = ArchX86
+const ImageArch = AMDImageArch
 const Flavor = FlavorMultidistro

--- a/pkg/arch/arm64.go
+++ b/pkg/arch/arm64.go
@@ -3,4 +3,5 @@
 package arch
 
 const Arch = ArchARM
+const ImageArch = ARMImageArch
 const Flavor = FlavorDefault

--- a/pkg/arch/consts.go
+++ b/pkg/arch/consts.go
@@ -15,8 +15,9 @@ const (
 
 	// These architectures are for the Image Registry
 
-	AMDImageArch = "amd64"
-	ARMImageArch = "arm64"
+	AMDImageArch   = "amd64"
+	ARMImageArch   = "arm64"
+	PPCLEImageArch = "ppc64le"
 
 	DefaultImageOS = "linux"
 )

--- a/pkg/arch/consts.go
+++ b/pkg/arch/consts.go
@@ -1,16 +1,29 @@
 package arch
 
+import containerv1 "github.com/google/go-containerregistry/pkg/v1"
+
 const (
 	FlavorDefault     = "default"
 	FlavorMultidistro = "multidistro"
 
 	// These architectures are for the DynatraceAPI
+
 	ArchX86   = "x86"
 	ArchARM   = "arm"
 	ArchPPCLE = "ppcle"
 	ArchS390  = "s390"
 
 	// These architectures are for the Image Registry
+
 	AMDImageArch = "amd64"
 	ARMImageArch = "arm64"
+
+	DefaultImageOS = "linux"
+)
+
+var (
+	ImagePlatform = containerv1.Platform{
+		OS:           DefaultImageOS,
+		Architecture: ImageArch,
+	}
 )

--- a/pkg/arch/consts.go
+++ b/pkg/arch/consts.go
@@ -4,8 +4,13 @@ const (
 	FlavorDefault     = "default"
 	FlavorMultidistro = "multidistro"
 
+	// These architectures are for the DynatraceAPI
 	ArchX86   = "x86"
 	ArchARM   = "arm"
 	ArchPPCLE = "ppcle"
 	ArchS390  = "s390"
+
+	// These architectures are for the Image Registry
+	AMDImageArch = "amd64"
+	ARMImageArch = "arm64"
 )

--- a/pkg/arch/ppc64le.go
+++ b/pkg/arch/ppc64le.go
@@ -4,3 +4,4 @@ package arch
 
 const Arch = ArchPPCLE
 const Flavor = FlavorDefault
+const ImageArch = PPCLEImageArch

--- a/pkg/injection/codemodule/installer/image/unpack.go
+++ b/pkg/injection/codemodule/installer/image/unpack.go
@@ -16,10 +16,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	defaultOS = "linux"
-)
-
 type imagePullInfo struct {
 	imageCacheDir string
 	targetDir     string
@@ -52,10 +48,7 @@ func (installer *Installer) pullImageInfo(imageName string) (*containerv1.Image,
 	image, err := remote.Image(ref, remote.WithContext(context.TODO()),
 		remote.WithAuthFromKeychain(installer.keychain),
 		remote.WithTransport(installer.transport),
-		remote.WithPlatform(containerv1.Platform{
-			OS:           defaultOS,
-			Architecture: arch.ImageArch,
-		}),
+		remote.WithPlatform(arch.ImagePlatform),
 	)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "getting image %q", imageName)

--- a/pkg/injection/codemodule/installer/image/unpack.go
+++ b/pkg/injection/codemodule/installer/image/unpack.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/common"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -13,6 +14,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
+)
+
+const (
+	defaultOS = "linux"
 )
 
 type imagePullInfo struct {
@@ -44,7 +49,14 @@ func (installer *Installer) pullImageInfo(imageName string) (*containerv1.Image,
 		return nil, errors.WithMessagef(err, "parsing reference %q:", imageName)
 	}
 
-	image, err := remote.Image(ref, remote.WithContext(context.TODO()), remote.WithAuthFromKeychain(installer.keychain), remote.WithTransport(installer.transport))
+	image, err := remote.Image(ref, remote.WithContext(context.TODO()),
+		remote.WithAuthFromKeychain(installer.keychain),
+		remote.WithTransport(installer.transport),
+		remote.WithPlatform(containerv1.Platform{
+			OS:           defaultOS,
+			Architecture: arch.ImageArch,
+		}),
+	)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "getting image %q", imageName)
 	}

--- a/pkg/oci/registry/client.go
+++ b/pkg/oci/registry/client.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/dockerkeychain"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -109,6 +110,7 @@ func (c *Client) GetImageVersion(ctx context.Context, imageName string) (ImageVe
 	options := []remote.Option{
 		remote.WithContext(ctx),
 		remote.WithTransport(c.transport),
+		remote.WithPlatform(arch.ImagePlatform),
 	}
 	if c.keychain != nil {
 		options = append(options, remote.WithAuthFromKeychain(c.keychain))
@@ -157,7 +159,12 @@ func (c *Client) PullImageInfo(ctx context.Context, imageName string) (*containe
 		return nil, errors.WithMessagef(err, "parsing reference %q:", imageName)
 	}
 
-	image, err := remote.Image(ref, remote.WithContext(ctx), remote.WithAuthFromKeychain(c.keychain), remote.WithTransport(c.transport))
+	image, err := remote.Image(ref,
+		remote.WithContext(ctx),
+		remote.WithAuthFromKeychain(c.keychain),
+		remote.WithTransport(c.transport),
+		remote.WithPlatform(arch.ImagePlatform),
+	)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "getting image %q", imageName)
 	}


### PR DESCRIPTION
## Description

cherry pick of 3 PRs that are related to the same problem:
- [Pass in the platform during CodeModulesImage pull (](https://github.com/Dynatrace/dynatrace-operator/commit/f541bf8835a21a3a65c223d8f8c872b69569bfef)https://github.com/Dynatrace/dynatrace-operator/pull/2755[)](https://github.com/Dynatrace/dynatrace-operator/commit/f541bf8835a21a3a65c223d8f8c872b69569bfef)
- [Use the platform for all image related operations (](https://github.com/Dynatrace/dynatrace-operator/commit/df292cee309f01cf3a8bdbd91534f1d2e50d1462)https://github.com/Dynatrace/dynatrace-operator/pull/2759[)](https://github.com/Dynatrace/dynatrace-operator/commit/df292cee309f01cf3a8bdbd91534f1d2e50d1462)
- [add image arch for ppcle (](https://github.com/Dynatrace/dynatrace-operator/commit/2e433c0af18ad8179c8cee124eb6d2b648ee97e0)https://github.com/Dynatrace/dynatrace-operator/pull/2771[)](https://github.com/Dynatrace/dynatrace-operator/commit/2e433c0af18ad8179c8cee124eb6d2b648ee97e0)

(wont result in a true cherry-pick, because of the 3 PRs becoming 1, but history would be incorrect even if we cherry-picked 1-by-1 because of the squash we do during merge)

## How can this be tested?

same as the cherry picked PRs

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
