### PR TITLE
Use oneAgent.hostGroup in ApplicationMonitoring mode (release-1.0)

### DIFF
--- a/pkg/api/v1beta1/dynakube/properties.go
+++ b/pkg/api/v1beta1/dynakube/properties.go
@@ -480,13 +480,22 @@ func (dk *DynaKube) HostGroup() string {
 
 func (dk *DynaKube) HostGroupAsParam() string {
 	var hostGroup string
-	if dk.CloudNativeFullstackMode() && dk.Spec.OneAgent.CloudNativeFullStack.Args != nil {
-		for _, arg := range dk.Spec.OneAgent.CloudNativeFullStack.Args {
-			key, value := splitArg(arg)
-			if key == "--set-host-group" {
-				hostGroup = value
-				break
-			}
+	var args []string
+
+	switch {
+	case dk.CloudNativeFullstackMode() && dk.Spec.OneAgent.CloudNativeFullStack.Args != nil:
+		args = dk.Spec.OneAgent.CloudNativeFullStack.Args
+	case dk.ClassicFullStackMode() && dk.Spec.OneAgent.ClassicFullStack.Args != nil:
+		args = dk.Spec.OneAgent.ClassicFullStack.Args
+	case dk.HostMonitoringMode() && dk.Spec.OneAgent.HostMonitoring.Args != nil:
+		args = dk.Spec.OneAgent.HostMonitoring.Args
+	}
+
+	for _, arg := range args {
+		key, value := splitArg(arg)
+		if key == "--set-host-group" {
+			hostGroup = value
+			break
 		}
 	}
 	return hostGroup

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
@@ -37,9 +37,7 @@ func (dsInfo *builderInfo) arguments() ([]string, error) {
 
 	dsInfo.appendHostInjectArgs(argMap)
 
-	if dsInfo.dynakube.CloudNativeFullstackMode() {
-		dsInfo.appendHostGroupArg(argMap)
-	}
+	dsInfo.appendHostGroupArg(argMap)
 
 	return argMap.AsKeyValueStrings(), nil
 }

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -19,6 +19,10 @@ const (
 	testClusterID = "test-cluster-id"
 	testURL       = "https://testing.dev.dynatracelabs.com/api"
 	testName      = "test-name"
+
+	testNewHostGroupName     = "newhostgroup"
+	testOldHostGroupArgument = "--set-host-group=oldhostgroup"
+	testNewHostGroupArgument = "--set-host-group=newhostgroup"
 )
 
 func TestArguments(t *testing.T) {
@@ -230,5 +234,71 @@ func TestPodSpec_Arguments(t *testing.T) {
 		daemonset, _ := dsInfo.BuildDaemonSet()
 		podSpecs := daemonset.Spec.Template.Spec
 		assert.Contains(t, podSpecs.Containers[0].Args, "--set-host-id-source=k8s-node-name")
+	})
+	t.Run(`has host-group for classicFullstack`, func(t *testing.T) {
+		classicInstance := &dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					HostGroup: testNewHostGroupName,
+					ClassicFullStack: &dynatracev1beta1.HostInjectSpec{
+						Args: []string{testOldHostGroupArgument},
+					},
+				},
+			},
+		}
+
+		dsInfo := HostMonitoring{
+			builderInfo{
+				dynakube:       classicInstance,
+				hostInjectSpec: classicInstance.Spec.OneAgent.ClassicFullStack,
+			},
+		}
+		arguments, err := dsInfo.arguments()
+		require.NoError(t, err)
+		assert.Contains(t, arguments, testNewHostGroupArgument)
+	})
+	t.Run(`has host-group for cloudNativeFullstack`, func(t *testing.T) {
+		cloudNativeInstance := &dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					HostGroup: testNewHostGroupName,
+					CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{
+						HostInjectSpec: dynatracev1beta1.HostInjectSpec{Args: []string{testOldHostGroupArgument}},
+					},
+				},
+			},
+		}
+
+		dsInfo := HostMonitoring{
+			builderInfo{
+				dynakube:       cloudNativeInstance,
+				hostInjectSpec: &cloudNativeInstance.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec,
+			},
+		}
+		arguments, err := dsInfo.arguments()
+		require.NoError(t, err)
+		assert.Contains(t, arguments, testNewHostGroupArgument)
+	})
+	t.Run(`has host-group for HostMonitoring`, func(t *testing.T) {
+		hostMonitoringInstance := &dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				OneAgent: dynatracev1beta1.OneAgentSpec{
+					HostGroup: testNewHostGroupName,
+					HostMonitoring: &dynatracev1beta1.HostInjectSpec{
+						Args: []string{testOldHostGroupArgument},
+					},
+				},
+			},
+		}
+
+		dsInfo := HostMonitoring{
+			builderInfo{
+				dynakube:       hostMonitoringInstance,
+				hostInjectSpec: hostMonitoringInstance.Spec.OneAgent.HostMonitoring,
+			},
+		}
+		arguments, err := dsInfo.arguments()
+		require.NoError(t, err)
+		assert.Contains(t, arguments, testNewHostGroupArgument)
 	})
 }

--- a/pkg/injection/startup/dtclient_builder.go
+++ b/pkg/injection/startup/dtclient_builder.go
@@ -36,6 +36,7 @@ func (builder *dtclientBuilder) setOptions() {
 	builder.addCertCheck()
 	builder.addProxy()
 	builder.addNetworkZone()
+	builder.addHostGroup()
 	builder.addTrustedCerts()
 }
 
@@ -56,6 +57,12 @@ func (builder *dtclientBuilder) addProxy() {
 func (builder *dtclientBuilder) addNetworkZone() {
 	if builder.config.NetworkZone != "" {
 		builder.options = append(builder.options, dtclient.NetworkZone(builder.config.NetworkZone))
+	}
+}
+
+func (builder *dtclientBuilder) addHostGroup() {
+	if builder.config.HostGroup != "" {
+		builder.options = append(builder.options, dtclient.HostGroup(builder.config.HostGroup))
 	}
 }
 

--- a/pkg/injection/startup/run.go
+++ b/pkg/injection/startup/run.go
@@ -155,6 +155,11 @@ func (runner *Runner) getProcessModuleConfig() (*dtclient.ProcessModuleConfig, e
 	if runner.config.OneAgentNoProxy != "" {
 		processModuleConfig = processModuleConfig.AddNoProxy(runner.config.OneAgentNoProxy)
 	}
+
+	if runner.config.HostGroup != "" {
+		processModuleConfig.AddHostGroup(runner.config.HostGroup)
+	}
+
 	return processModuleConfig, nil
 }
 

--- a/pkg/webhook/validation/dynakube/oneagent_test.go
+++ b/pkg/webhook/validation/dynakube/oneagent_test.go
@@ -371,6 +371,38 @@ func TestOneAgentHostGroup(t *testing.T) {
 			1,
 			createDynakubeWithHostGroup([]string{"--set-host-group=arg"}, "field"),
 			&defaultCSIDaemonSet)
+
+		assertAllowedResponseWithWarnings(t,
+			1,
+			&dynatracev1beta1.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynatracev1beta1.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynatracev1beta1.OneAgentSpec{
+						ClassicFullStack: &dynatracev1beta1.HostInjectSpec{
+							Args: []string{"--set-host-group=arg"},
+						},
+						HostGroup: "",
+					},
+				},
+			},
+			&defaultCSIDaemonSet)
+
+		assertAllowedResponseWithWarnings(t,
+			1,
+			&dynatracev1beta1.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynatracev1beta1.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynatracev1beta1.OneAgentSpec{
+						HostMonitoring: &dynatracev1beta1.HostInjectSpec{
+							Args: []string{"--set-host-group=arg"},
+						},
+						HostGroup: "",
+					},
+				},
+			},
+			&defaultCSIDaemonSet)
 	})
 }
 


### PR DESCRIPTION
[PR main branch](https://github.com/Dynatrace/dynatrace-operator/pull/2772)

## Description

`oneAgent.hostGroup` parameter is passed to code modules in case of application monitoring mode. In such a case standalone logic adds `hostGroup` field to the ProcessModuleConfig configuration and additionally standalone dynatrace client applies `hostGroup` to requests which can use it (getProcessModuleConfig).

`oneAgent.hostGroup` parameter has higher priority then `--set-host-group` argument for all related deployment modes (having `args` field). Validation webhook print a warning every time the argument is used.


## How can this be tested?
`hostGroup` is used:
1) Deploy ApplicationMonitoring dynakube
```
  oneAgent:
    hostGroup: appmongroup
    applicationMonitoring:
      useCSIDriver: false/true
```
- check init secret in a monitored namespace
`kubectl -n <namespace>  get -o json secret/dynatrace-dynakube-config|jq -r '.data.config'|base64 -d|jq -r '.hostGroup'`
- check `ruxitagentproc.conf` on the app pod
`kubectl -n <namespace> exec -t deployment.apps/<appname>l -- /bin/sh -c "cat /opt/dynatrace/oneagent-paas/agent/conf/ruxitagentproc.conf | grep hostGroup"`


No changes in other modes:
1) Deploy ClassicFullStack dynakube
```
  oneAgent:
    hostGroup: cngroupnew
    cloudNativeFullStack:
      args:
      - "--set-host-group=cngroupold"
```
- check `--set-host-group` value used in `oneagent` pods 
`kubectl -n dynatrace  get -o json daemonset.apps/dynakube-oneagent | jq -r '.spec.template.spec.containers[0].args | grep set-host-group'`
- check init secret in a monitored namespace
`kubectl -n <namespace>  get -o json secret/dynatrace-dynakube-config|jq -r '.data.config'|base64 -d|jq -r '.hostGroup'`
- check `ruxitagentproc.conf` on the app pod
`kubectl -n <namespace> exec -t deployment.apps/<appname>l -- /bin/sh -c "cat /opt/dynatrace/oneagent-paas/agent/conf/ruxitagentproc.conf | grep hostGroup"`

2) Deploy CloudNativeFullStack dynakube
```
  oneAgent:
    hostGroup: cfsgroupnew
    classicFullStack:
      args:
      - "--set-host-group=cfsgroupold"
```      
- check `--set-host-group` value used in `oneagent` pods 
`kubectl -n dynatrace  get -o json daemonset.apps/dynakube-oneagent | jq -r '.spec.template.spec.containers[0].args | grep set-host-group'`
- check init secret in a monitored namespace
`kubectl -n <namespace>  get -o json secret/dynatrace-dynakube-config|jq -r '.data.config'|base64 -d|jq -r '.hostGroup'`
- check `ruxitagentproc.conf` on the app pod
`kubectl -n <namespace> exec -t deployment.apps/<appname>l -- /bin/sh -c "cat /opt/dynatrace/oneagent-paas/agent/conf/ruxitagentproc.conf | grep hostGroup"`


## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
