### PR TITLE
Move relevant reconciler calls inside ActiveGate reconciler

### DIFF
--- a/pkg/controllers/dynakube/activegate.go
+++ b/pkg/controllers/dynakube/activegate.go
@@ -5,35 +5,12 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/version"
 	"github.com/pkg/errors"
 )
 
-func (controller *Controller) reconcileActiveGate(ctx context.Context, dynakube *dynakube.DynaKube, dtc dynatrace.Client, istioClient *istio.Client, connectionReconciler connectioninfo.Reconciler, versionReconciler version.Reconciler) error { //nolint: revive
-	if dynakube.NeedsActiveGate() { // TODO: this is not optimal, because this check is in the activegate reconciler as well (to do the cleanup)
-		err := connectionReconciler.ReconcileActiveGate(ctx, dynakube)
-		if err != nil {
-			return err
-		}
-
-		err = versionReconciler.ReconcileActiveGate(ctx, dynakube)
-		if err != nil {
-			return err
-		}
-
-		if istioClient != nil {
-			istioReconciler := istio.NewReconciler(istioClient)
-			err = istioReconciler.ReconcileActiveGateCommunicationHosts(ctx, dynakube)
-
-			if err != nil {
-				return err
-			}
-		}
-	} // TODO: have a cleanup for things that we create above
-
-	reconciler := controller.activeGateReconcilerBuilder(controller.client, controller.apiReader, controller.scheme, dynakube, dtc)
+func (controller *Controller) reconcileActiveGate(ctx context.Context, dynakube *dynakube.DynaKube, dtc dynatrace.Client, istioClient *istio.Client) error {
+	reconciler := controller.activeGateReconcilerBuilder(controller.client, controller.apiReader, controller.scheme, dynakube, dtc, istioClient)
 	err := reconciler.Reconcile(ctx)
 
 	if err != nil {

--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -10,9 +10,13 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/version"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/configmap"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/object"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 	"golang.org/x/net/context"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +31,9 @@ type Reconciler struct {
 	apiReader                         client.Reader
 	scheme                            *runtime.Scheme
 	authTokenReconciler               controllers.Reconciler
+	istioReconciler                   istio.Reconciler
+	connectionReconciler              connectioninfo.Reconciler
+	versionReconciler                 version.Reconciler
 	newStatefulsetReconcilerFunc      statefulset.NewReconcilerFunc
 	newCapabilityReconcilerFunc       capabilityInternal.NewReconcilerFunc
 	newCustomPropertiesReconcilerFunc func(customPropertiesOwnerName string, customPropertiesSource *dynatracev1beta1.DynaKubeValueSource) controllers.Reconciler
@@ -34,10 +41,21 @@ type Reconciler struct {
 
 var _ controllers.Reconciler = (*Reconciler)(nil)
 
-type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client) controllers.Reconciler
+type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client, istioClient *istio.Client) controllers.Reconciler
 
-func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client) controllers.Reconciler {
+func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client, istioClient *istio.Client) controllers.Reconciler { //nolint: revive
+	time := timeprovider.New().Freeze()
+	fs := afero.Afero{Fs: afero.NewOsFs()}
+
+	var istioReconciler istio.Reconciler
+	if istioClient != nil {
+		istioReconciler = istio.NewReconciler(istioClient)
+	}
+
 	authTokenReconciler := authtoken.NewReconciler(clt, apiReader, scheme, dynakube, dtc)
+	versionReconciler := version.NewReconciler(apiReader, dtc, fs, time)
+	connectionInfoReconciler := connectioninfo.NewReconciler(clt, apiReader, scheme, dtc)
+
 	newCustomPropertiesReconcilerFunc := func(customPropertiesOwnerName string, customPropertiesSource *dynatracev1beta1.DynaKubeValueSource) controllers.Reconciler {
 		return customproperties.NewReconciler(clt, dynakube, customPropertiesOwnerName, scheme, customPropertiesSource)
 	}
@@ -48,6 +66,9 @@ func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.S
 		scheme:                            scheme,
 		dynakube:                          dynakube,
 		authTokenReconciler:               authTokenReconciler,
+		istioReconciler:                   istioReconciler,
+		connectionReconciler:              connectionInfoReconciler,
+		versionReconciler:                 versionReconciler,
 		newCustomPropertiesReconcilerFunc: newCustomPropertiesReconcilerFunc,
 		newStatefulsetReconcilerFunc:      statefulset.NewReconciler,
 		newCapabilityReconcilerFunc:       capabilityInternal.NewReconciler,
@@ -61,6 +82,24 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	}
 
 	if r.dynakube.NeedsActiveGate() {
+		err = r.connectionReconciler.ReconcileActiveGate(ctx, r.dynakube)
+		if err != nil {
+			return err
+		}
+
+		err = r.versionReconciler.ReconcileActiveGate(ctx, r.dynakube)
+		if err != nil {
+			return err
+		}
+
+		if r.istioReconciler != nil {
+			err = r.istioReconciler.ReconcileActiveGateCommunicationHosts(ctx, r.dynakube)
+			if err != nil {
+				return err
+			}
+		}
+		// TODO: have a cleanup for things that we create above
+
 		err := r.authTokenReconciler.Reconcile(ctx)
 		if err != nil {
 			return errors.WithMessage(err, "could not reconcile Dynatrace ActiveGateAuthToken secrets")

--- a/pkg/controllers/dynakube/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/reconciler_test.go
@@ -12,10 +12,12 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/version"
 	mocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	controllerMocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
 	connectioninfoMocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/connectioninfo"
+	istioMocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/istio"
 	versionMocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -67,6 +69,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				Name:      testName,
 			},
 			Spec: dynatracev1beta1.DynaKubeSpec{
+				EnableIstio: true,
 				ActiveGate: dynatracev1beta1.ActiveGateSpec{
 					Capabilities: []dynatracev1beta1.CapabilityDisplayName{dynatracev1beta1.RoutingCapability.DisplayName},
 				},
@@ -77,6 +80,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeClient, fakeClient, scheme.Scheme, instance, dtc, nil).(*Reconciler)
 		r.connectionReconciler = createConnectionInfoReconcilerMock(t)
 		r.versionReconciler = createVersionReconcilerMock(t)
+		r.istioReconciler = createIstioReconcilerMock(t)
 
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
@@ -371,4 +375,13 @@ func createVersionReconcilerMock(t *testing.T) version.Reconciler {
 		mock.AnythingOfType("*dynakube.DynaKube")).Return(nil).Once()
 
 	return versionReconciler
+}
+
+func createIstioReconcilerMock(t *testing.T) istio.Reconciler {
+	reconciler := istioMocks.NewReconciler(t)
+	reconciler.On("ReconcileActiveGateCommunicationHosts",
+		mock.AnythingOfType("context.backgroundCtx"),
+		mock.AnythingOfType("*dynakube.DynaKube")).Return(nil).Once()
+
+	return reconciler
 }

--- a/pkg/controllers/dynakube/activegate_test.go
+++ b/pkg/controllers/dynakube/activegate_test.go
@@ -10,8 +10,6 @@ import (
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/apimonitoring"
 	mockcontroller "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
-	mockconnectioninfo "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/connectioninfo"
-	mockversion "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +42,7 @@ func TestReconcileActiveGate(t *testing.T) {
 			activeGateReconcilerBuilder: createActivegateReconcilerBuilder(mockActiveGateReconciler),
 		}
 
-		err := controller.reconcileActiveGate(ctx, dynakube, nil, nil, nil, nil)
+		err := controller.reconcileActiveGate(ctx, dynakube, nil, nil)
 		require.NoError(t, err)
 	})
 	t.Run("no active-gate configured => active-gate reconcile returns error => returns error", func(t *testing.T) {
@@ -62,7 +60,7 @@ func TestReconcileActiveGate(t *testing.T) {
 			activeGateReconcilerBuilder: createActivegateReconcilerBuilder(mockActiveGateReconciler),
 		}
 
-		err := controller.reconcileActiveGate(ctx, dynakube, nil, nil, nil, nil)
+		err := controller.reconcileActiveGate(ctx, dynakube, nil, nil)
 		require.Error(t, err)
 		require.Equal(t, "failed to reconcile ActiveGate: BOOM", err.Error())
 	})
@@ -91,12 +89,6 @@ func TestReconcileActiveGate(t *testing.T) {
 
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{})
 
-		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
-		mockConnectionInfoReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
-
-		mockVersionReconciler := mockversion.NewReconciler(t)
-		mockVersionReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
-
 		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
 		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
 
@@ -107,7 +99,7 @@ func TestReconcileActiveGate(t *testing.T) {
 			apiMonitoringReconcilerBuilder: apimonitoring.NewReconciler, // TODO: actually mock it
 		}
 
-		err := controller.reconcileActiveGate(ctx, instance, mockClient, nil, mockConnectionInfoReconciler, mockVersionReconciler)
+		err := controller.reconcileActiveGate(ctx, instance, mockClient, nil)
 		require.NoError(t, err)
 		mockClient.AssertCalled(t, "CreateOrUpdateKubernetesSetting",
 			mock.AnythingOfType("context.backgroundCtx"),
@@ -149,12 +141,6 @@ func TestReconcileActiveGate(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string")).Return(testUID, nil)
 
-		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
-		mockConnectionInfoReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
-
-		mockVersionReconciler := mockversion.NewReconciler(t)
-		mockVersionReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
-
 		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
 		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
 
@@ -165,7 +151,7 @@ func TestReconcileActiveGate(t *testing.T) {
 			apiMonitoringReconcilerBuilder: apimonitoring.NewReconciler, // TODO: actually mock it
 		}
 
-		err := controller.reconcileActiveGate(ctx, instance, mockClient, nil, mockConnectionInfoReconciler, mockVersionReconciler)
+		err := controller.reconcileActiveGate(ctx, instance, mockClient, nil)
 		require.NoError(t, err)
 		mockClient.AssertCalled(t, "CreateOrUpdateKubernetesSetting",
 			mock.AnythingOfType("context.backgroundCtx"),

--- a/pkg/controllers/dynakube/controller.go
+++ b/pkg/controllers/dynakube/controller.go
@@ -348,7 +348,7 @@ func (controller *Controller) reconcileComponents(ctx context.Context, dynatrace
 
 	log.Info("start reconciling ActiveGate")
 
-	err := controller.reconcileActiveGate(ctx, dynakube, dynatraceClient, istioClient, connectionInfoReconciler, versionReconciler)
+	err := controller.reconcileActiveGate(ctx, dynakube, dynatraceClient, istioClient)
 	if err != nil {
 		log.Info("could not reconcile ActiveGate")
 

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -339,13 +339,13 @@ func TestReconcileComponents(t *testing.T) {
 		fakeClient := fake.NewClientWithIndex(dynakube)
 		// ReconcileCodeModuleCommunicationHosts
 		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
-		mockConnectionInfoReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
 		mockConnectionInfoReconciler.On("ReconcileOneAgent", mock.Anything, dynakube).Return(nil)
 
 		mockVersionReconciler := mockversion.NewReconciler(t)
 		mockVersionReconciler.On("ReconcileOneAgent", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
 
 		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler.On("Reconcile", mock.Anything).Return(errors.New("BOOM"))
 
 		mockInjectionReconciler := mockinjection.NewReconciler(t)
 		mockInjectionReconciler.On("Reconcile", mock.Anything).Return(errors.New("BOOM"))
@@ -375,12 +375,9 @@ func TestReconcileComponents(t *testing.T) {
 		fakeClient := fake.NewClientWithIndex(dynakube)
 
 		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
-		mockConnectionInfoReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
 		mockConnectionInfoReconciler.On("ReconcileOneAgent", mock.Anything, dynakube).Return(connectioninfo.NoOneAgentCommunicationHostsError)
 
 		mockVersionReconciler := mockversion.NewReconciler(t)
-		mockVersionReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(nil)
-
 		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
 		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
 
@@ -409,12 +406,12 @@ func TestReconcileComponents(t *testing.T) {
 		fakeClient := fake.NewClientWithIndex(dynakube)
 
 		mockConnectionInfoReconciler := mockconnectioninfo.NewReconciler(t)
-		mockConnectionInfoReconciler.On("ReconcileActiveGate", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
-
-		mockVersionReconciler := mockversion.NewReconciler(t)
-
 		mockConnectionInfoReconciler.On("ReconcileOneAgent", mock.Anything, dynakube).Return(errors.New("BOOM"))
 
+		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
+
+		mockVersionReconciler := mockversion.NewReconciler(t)
 		mockInjectionReconciler := mockinjection.NewReconciler(t)
 
 		controller := &Controller{
@@ -426,6 +423,7 @@ func TestReconcileComponents(t *testing.T) {
 			versionReconcilerBuilder:        createVersionReconcilerBuilder(mockVersionReconciler),
 			connectionInfoReconcilerBuilder: createConnectionInfoReconcilerBuilder(mockConnectionInfoReconciler),
 			injectionReconcilerBuilder:      createInjectionReconcilerBuilder(mockInjectionReconciler),
+			activeGateReconcilerBuilder:     createActivegateReconcilerBuilder(mockActiveGateReconciler),
 		}
 		mockedDtc := mockedclient.NewClient(t)
 		err := controller.reconcileComponents(ctx, mockedDtc, nil, dynakube)
@@ -437,7 +435,7 @@ func TestReconcileComponents(t *testing.T) {
 }
 
 func createActivegateReconcilerBuilder(reconciler controllers.Reconciler) activegate.ReconcilerBuilder {
-	return func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client) controllers.Reconciler {
+	return func(clt client.Client, apiReader client.Reader, scheme *runtime.Scheme, dynakube *dynatracev1beta1.DynaKube, dtc dtclient.Client, istioClient *istio.Client) controllers.Reconciler {
 		return reconciler
 	}
 }


### PR DESCRIPTION
## Description

A reconciler should call all reconciler it depends on.
In case of the active gate reconciler this was not the case and is fixed here.

## How can this be tested?

- Run dynakube with activegate and check if everything works as before

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
