### PR TITLE
Unify the mock package import naming

### DIFF
--- a/cmd/support_archive/logs_test.go
+++ b/cmd/support_archive/logs_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
-	corev1mocks "github.com/Dynatrace/dynatrace-operator/pkg/util/testing/mocks/k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1mock "github.com/Dynatrace/dynatrace-operator/pkg/util/testing/mocks/k8s.io/client-go/kubernetes/typed/core/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -106,7 +106,7 @@ func TestLogCollectorPodListError(t *testing.T) {
 	supportArchive := newZipArchive(bufio.NewWriter(&buffer))
 	defer assertNoErrorOnClose(t, supportArchive)
 
-	mockedPods := corev1mocks.NewPodInterface(t)
+	mockedPods := corev1mock.NewPodInterface(t)
 	mockedPods.EXPECT().
 		List(ctx, createPodListOptions(labels.AppNameLabel)).
 		Return(nil, assert.AnError)
@@ -139,7 +139,7 @@ func TestLogCollectorGetPodFail(t *testing.T) {
 	supportArchive := newZipArchive(bufio.NewWriter(&buffer))
 	defer assertNoErrorOnClose(t, supportArchive)
 
-	mockedPods := corev1mocks.NewPodInterface(t)
+	mockedPods := corev1mock.NewPodInterface(t)
 	listOptionsAppName := createPodListOptions(labels.AppNameLabel)
 	listOptionsManagedByOperator := createPodListOptions(labels.AppManagedByLabel)
 
@@ -177,7 +177,7 @@ func TestLogCollectorGetLogsFail(t *testing.T) {
 	supportArchive := newZipArchive(bufio.NewWriter(&buffer))
 	defer assertNoErrorOnClose(t, supportArchive)
 
-	mockedPods := corev1mocks.NewPodInterface(t)
+	mockedPods := corev1mock.NewPodInterface(t)
 	listOptionsAppName := createPodListOptions(labels.AppNameLabel)
 	listOptionsManagedByOperator := createPodListOptions(labels.AppManagedByLabel)
 
@@ -253,7 +253,7 @@ func TestLogCollectorNoAbortOnError(t *testing.T) {
 	buffer := bytes.Buffer{}
 	supportArchive := newZipArchive(bufio.NewWriter(&buffer))
 
-	mockedPods := corev1mocks.NewPodInterface(t)
+	mockedPods := corev1mock.NewPodInterface(t)
 	listOptionsAppName := createPodListOptions(labels.AppNameLabel)
 	listOptionsManagedByOperator := createPodListOptions(labels.AppManagedByLabel)
 	getOptions := metav1.GetOptions{}

--- a/doc/coding-style-guide.md
+++ b/doc/coding-style-guide.md
@@ -181,6 +181,8 @@ runtime.goexit
 - Abstract the setup/assert phase as much as possible so it can be reused in other tests in the package.
 - Use `t.Run` and give a title that describes what you are testing in that run.
 - Use `context.Background` when a context is needed, use `context.TODO` ONLY for actual TODOs. (example: you want to create a special context here later to test something specific)
+- Use `<...>mock` as package import alias, in all cases, even if no alias would strictly be necessary.
+  - Examples: `dtclientmock`, `controllermock`, `dtbuildermock`, `injectionmock`, `registrymock`
 - Use this structure: (or table-tests)
 
 ```go

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/processmoduleconfigsecret"
-	dtClientMock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/dynatraceclient"
+	dtbuildermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/dynatraceclient"
 	installermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/injection/codemodule/installer"
 	reconcilermock "github.com/Dynatrace/dynatrace-operator/test/mocks/sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"github.com/spf13/afero"
@@ -193,7 +193,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 				},
 			},
 		)
-		mockDtcBuilder := dtClientMock.NewBuilder(t)
+		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 
 		gc := reconcilermock.NewReconciler(t)
 		db := metadata.FakeMemoryDB()
@@ -252,7 +252,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 	})
 	t.Run("error when creating dynatrace client", func(t *testing.T) {
 		gc := reconcilermock.NewReconciler(t)
-		mockDtcBuilder := dtClientMock.NewBuilder(t)
+		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 		mockDtcBuilder.On("SetContext", mock.Anything).Return(mockDtcBuilder)
 		mockDtcBuilder.On("SetDynakube", mock.Anything).Return(mockDtcBuilder)
 		mockDtcBuilder.On("SetTokens", mock.Anything).Return(mockDtcBuilder)
@@ -303,7 +303,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		errorfs := &mkDirAllErrorFs{
 			Fs: afero.NewMemMapFs(),
 		}
-		mockDtcBuilder := dtClientMock.NewBuilder(t)
+		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 		provisioner := &OneAgentProvisioner{
 			apiReader: fake.NewClient(
 				&dynatracev1beta1.DynaKube{
@@ -343,7 +343,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 	t.Run("error getting latest agent version", func(t *testing.T) {
 		gc := reconcilermock.NewReconciler(t)
 		memFs := afero.NewMemMapFs()
-		mockDtcBuilder := dtClientMock.NewBuilder(t)
+		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 		dynakube := &dynatracev1beta1.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: dkName,
@@ -402,7 +402,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 	t.Run("error getting dynakube from db", func(t *testing.T) {
 		gc := reconcilermock.NewReconciler(t)
 		memFs := afero.NewMemMapFs()
-		mockDtcBuilder := dtClientMock.NewBuilder(t)
+		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 
 		provisioner := &OneAgentProvisioner{
 			apiReader: fake.NewClient(
@@ -618,7 +618,7 @@ func TestUpdateAgentInstallation(t *testing.T) {
 		dynakube := getDynakube()
 		enableCodeModules(dynakube)
 
-		mockDtcBuilder := dtClientMock.NewBuilder(t)
+		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 
 		var dtc dtclient.Client
 
@@ -662,7 +662,7 @@ func TestUpdateAgentInstallation(t *testing.T) {
 		dynakube := getDynakube()
 		enableCodeModules(dynakube)
 
-		mockDtcBuilder := dtClientMock.NewBuilder(t)
+		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 
 		var dtc dtclient.Client
 
@@ -700,7 +700,7 @@ func TestUpdateAgentInstallation(t *testing.T) {
 	t.Run("updateAgentInstallation without codeModules", func(t *testing.T) {
 		dynakube := getDynakube()
 
-		mockDtcBuilder := dtClientMock.NewBuilder(t)
+		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 
 		var dtc dtclient.Client
 
@@ -742,7 +742,7 @@ func TestUpdateAgentInstallation(t *testing.T) {
 	t.Run("updateAgentInstallation without codeModules errors and requeues", func(t *testing.T) {
 		dynakube := getDynakube()
 
-		mockDtcBuilder := dtClientMock.NewBuilder(t)
+		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 
 		var dtc dtclient.Client
 

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	"github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -42,7 +42,7 @@ func newTestReconcilerWithInstance(t *testing.T, client client.Client) *Reconcil
 			APIURL: "https://testing.dev.dynatracelabs.com/api",
 		},
 	}
-	dtc := mocks.NewClient(t)
+	dtc := dtclientmock.NewClient(t)
 	dtc.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testAgAuthTokenResponse, nil).Maybe()
 
 	r := NewReconciler(client, client, scheme.Scheme, instance, dtc)

--- a/pkg/controllers/dynakube/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/reconciler_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/version"
-	mocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
-	controllerMocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
-	istioMocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/istio"
-	versionMocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	controllermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
+	istiomock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/istio"
+	versionmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -47,7 +47,7 @@ var (
 )
 
 func TestReconciler_Reconcile(t *testing.T) {
-	dtc := mocks.NewClient(t)
+	dtc := dtclientmock.NewClient(t)
 	dtc.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
 
 	t.Run(`Create works with minimal setup`, func(t *testing.T) {
@@ -117,7 +117,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		fakeClient := fake.NewClient()
-		fakeReconciler := controllerMocks.NewReconciler(t)
+		fakeReconciler := controllermock.NewReconciler(t)
 		fakeReconciler.On("Reconcile", mock.Anything).Return(nil)
 		proxyReconciler := Reconciler{
 			client:              fakeClient,
@@ -197,7 +197,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 }
 
 func TestServiceCreation(t *testing.T) {
-	dynatraceClient := mocks.NewClient(t)
+	dynatraceClient := dtclientmock.NewClient(t)
 	dynatraceClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
 
 	dynakube := &dynatracev1beta1.DynaKube{
@@ -325,7 +325,7 @@ func TestReconcile_ActivegateConfigMap(t *testing.T) {
 	}
 
 	t.Run(`create activegate ConfigMap`, func(t *testing.T) {
-		fakeReconciler := controllerMocks.NewReconciler(t)
+		fakeReconciler := controllermock.NewReconciler(t)
 		fakeReconciler.On("Reconcile", mock.Anything).Return(nil)
 
 		fakeClient := fake.NewClient(testKubeSystemNamespace)
@@ -359,7 +359,7 @@ func TestReconcile_ActivegateConfigMap(t *testing.T) {
 }
 
 func createConnectionInfoReconcilerMock(t *testing.T) controllers.Reconciler {
-	connectionInfoReconciler := controllerMocks.NewReconciler(t)
+	connectionInfoReconciler := controllermock.NewReconciler(t)
 	connectionInfoReconciler.On("Reconcile",
 		mock.AnythingOfType("context.backgroundCtx")).Return(nil).Once()
 
@@ -367,7 +367,7 @@ func createConnectionInfoReconcilerMock(t *testing.T) controllers.Reconciler {
 }
 
 func createVersionReconcilerMock(t *testing.T) version.Reconciler {
-	versionReconciler := versionMocks.NewReconciler(t)
+	versionReconciler := versionmock.NewReconciler(t)
 	versionReconciler.On("ReconcileActiveGate",
 		mock.AnythingOfType("context.backgroundCtx"),
 		mock.AnythingOfType("*dynakube.DynaKube")).Return(nil).Once()
@@ -376,7 +376,7 @@ func createVersionReconcilerMock(t *testing.T) version.Reconciler {
 }
 
 func createIstioReconcilerMock(t *testing.T) istio.Reconciler {
-	reconciler := istioMocks.NewReconciler(t)
+	reconciler := istiomock.NewReconciler(t)
 	reconciler.On("ReconcileActiveGateCommunicationHosts",
 		mock.AnythingOfType("context.backgroundCtx"),
 		mock.AnythingOfType("*dynakube.DynaKube")).Return(nil).Once()

--- a/pkg/controllers/dynakube/activegate_test.go
+++ b/pkg/controllers/dynakube/activegate_test.go
@@ -9,7 +9,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/apimonitoring"
-	mockcontroller "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
+	controllermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +33,7 @@ func TestReconcileActiveGate(t *testing.T) {
 
 		fakeClient := fake.NewClientWithIndex(dynakube)
 
-		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler := controllermock.NewReconciler(t)
 		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
 
 		controller := &Controller{
@@ -51,7 +51,7 @@ func TestReconcileActiveGate(t *testing.T) {
 
 		fakeClient := fake.NewClientWithIndex(dynakube)
 
-		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler := controllermock.NewReconciler(t)
 		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
 
 		controller := &Controller{
@@ -89,7 +89,7 @@ func TestReconcileActiveGate(t *testing.T) {
 
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{})
 
-		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler := controllermock.NewReconciler(t)
 		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
 
 		controller := &Controller{
@@ -141,7 +141,7 @@ func TestReconcileActiveGate(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string")).Return(testUID, nil)
 
-		mockActiveGateReconciler := mockcontroller.NewReconciler(t)
+		mockActiveGateReconciler := controllermock.NewReconciler(t)
 		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
 
 		controller := &Controller{

--- a/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
@@ -6,7 +6,7 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	"github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -29,7 +29,7 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 }
 
 func createReconciler(t *testing.T, dynakube *dynatracev1beta1.DynaKube, uid string, monitoredEntities []dtclient.MonitoredEntity, getSettingsResponse dtclient.GetSettingsResponse, objectID string, meID interface{}) *Reconciler { //nolint:revive // argument-limit doesn't apply to constructors
-	mockClient := mocks.NewClient(t)
+	mockClient := dtclientmock.NewClient(t)
 	mockClient.On("GetMonitoredEntitiesForKubeSystemUUID", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
 		Return(monitoredEntities, nil)
 	mockClient.On("GetSettingsForMonitoredEntities", mock.AnythingOfType("context.backgroundCtx"), monitoredEntities, mock.AnythingOfType("string")).
@@ -51,7 +51,7 @@ func createReconciler(t *testing.T, dynakube *dynatracev1beta1.DynaKube, uid str
 }
 
 func createReconcilerWithError(t *testing.T, dynakube *dynatracev1beta1.DynaKube, monitoredEntitiesError error, getSettingsResponseError error, createSettingsResponseError error, createAppSettingsResponseError error) *Reconciler { //nolint:revive
-	mockClient := mocks.NewClient(t)
+	mockClient := dtclientmock.NewClient(t)
 	mockClient.On("GetMonitoredEntitiesForKubeSystemUUID", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
 		Return([]dtclient.MonitoredEntity{}, monitoredEntitiesError)
 	mockClient.On("GetSettingsForMonitoredEntities",

--- a/pkg/controllers/dynakube/connectioninfo/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/activegate/reconciler_test.go
@@ -10,7 +10,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
-	"github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -36,7 +36,7 @@ func TestReconcile(t *testing.T) {
 			Name:      testName,
 		}}
 
-	dtc := mocks.NewClient(t)
+	dtc := dtclientmock.NewClient(t)
 	dtc.On("GetActiveGateConnectionInfo", mock.AnythingOfType("context.backgroundCtx")).Return(getTestActiveGateConnectionInfo(), nil).Maybe()
 
 	t.Run(`store ActiveGate connection info to DynaKube status`, func(t *testing.T) {
@@ -107,7 +107,7 @@ func TestReconcile_TenantSecret(t *testing.T) {
 			Namespace: testNamespace,
 			Name:      testName,
 		}}
-	dtc := mocks.NewClient(t)
+	dtc := dtclientmock.NewClient(t)
 	dtc.On("GetActiveGateConnectionInfo", mock.AnythingOfType("context.backgroundCtx")).Return(getTestActiveGateConnectionInfo(), nil)
 
 	t.Run(`create activegate secret`, func(t *testing.T) {

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler_test.go
@@ -10,7 +10,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
-	"github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -49,7 +49,7 @@ func TestReconcile(t *testing.T) {
 			Name:      testName,
 		}}
 
-	dtc := mocks.NewClient(t)
+	dtc := dtclientmock.NewClient(t)
 	dtc.On("GetOneAgentConnectionInfo", mock.AnythingOfType("context.backgroundCtx")).Return(getTestOneAgentConnectionInfo(), nil).Maybe()
 
 	t.Run(`store OneAgent connection info to DynaKube status`, func(t *testing.T) {
@@ -124,7 +124,7 @@ func TestReconcile_NoOneAgentCommunicationHosts(t *testing.T) {
 			Name:      testName,
 		}}
 
-	dtc := mocks.NewClient(t)
+	dtc := dtclientmock.NewClient(t)
 	dtc.On("GetOneAgentConnectionInfo", mock.AnythingOfType("context.backgroundCtx")).Return(dtclient.OneAgentConnectionInfo{
 		ConnectionInfo: dtclient.ConnectionInfo{
 			TenantUUID:  testTenantUUID,
@@ -180,7 +180,7 @@ func TestReconcile_TenantSecret(t *testing.T) {
 			Name:      testName,
 		}}
 
-	dtc := mocks.NewClient(t)
+	dtc := dtclientmock.NewClient(t)
 	dtc.On("GetOneAgentConnectionInfo", mock.AnythingOfType("context.backgroundCtx")).Return(getTestOneAgentConnectionInfo(), nil)
 
 	t.Run(`create oneagent secret`, func(t *testing.T) {

--- a/pkg/controllers/dynakube/controller_system_test.go
+++ b/pkg/controllers/dynakube/controller_system_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
 	semVersion "github.com/Dynatrace/dynatrace-operator/pkg/version"
-	mockedclient "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
-	dtClientMock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/dynatraceclient"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtbuildermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/dynatraceclient"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -384,8 +384,8 @@ func TestAPIError(t *testing.T) {
 	})
 }
 
-func createDTMockClient(t *testing.T, paasTokenScopes, apiTokenScopes dtclient.TokenScopes) *mockedclient.Client {
-	mockClient := mockedclient.NewClient(t)
+func createDTMockClient(t *testing.T, paasTokenScopes, apiTokenScopes dtclient.TokenScopes) *dtclientmock.Client {
+	mockClient := dtclientmock.NewClient(t)
 
 	mockClient.On("GetCommunicationHostForClient").Return(dtclient.CommunicationHost{
 		Protocol: testProtocol,
@@ -466,7 +466,7 @@ func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, ins
 
 	fakeClient := fake.NewClientWithIndex(objects...)
 
-	mockDtcBuilder := dtClientMock.NewBuilder(t)
+	mockDtcBuilder := dtbuildermock.NewBuilder(t)
 	mockDtcBuilder.On("SetContext", mock.Anything).Return(mockDtcBuilder)
 	mockDtcBuilder.On("SetDynakube", mock.Anything).Return(mockDtcBuilder)
 	mockDtcBuilder.On("SetTokens", mock.Anything).Return(mockDtcBuilder)

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
-	mocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
-	controllerMocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
-	versionMocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	controllermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
+	versionmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -88,7 +88,7 @@ func TestReconcile(t *testing.T) {
 			},
 		}
 
-		connectionInfoReconciler := controllerMocks.NewReconciler(t)
+		connectionInfoReconciler := controllermock.NewReconciler(t)
 		connectionInfoReconciler.On("Reconcile",
 			mock.AnythingOfType("context.backgroundCtx")).Return(oaconnectioninfo.NoOneAgentCommunicationHostsError).Once()
 
@@ -117,7 +117,7 @@ func TestReconcile(t *testing.T) {
 			},
 		}
 
-		versionReconciler := versionMocks.NewReconciler(t)
+		versionReconciler := versionmock.NewReconciler(t)
 		versionReconciler.On("ReconcileOneAgent",
 			mock.AnythingOfType("context.backgroundCtx"),
 			mock.AnythingOfType("*dynakube.DynaKube")).Return(errors.New("BOOM")).Once()
@@ -128,7 +128,7 @@ func TestReconcile(t *testing.T) {
 			apiReader:                fakeClient,
 			scheme:                   scheme.Scheme,
 			dynakube:                 &dynaKube,
-			connectionInfoReconciler: controllerMocks.NewReconciler(t),
+			connectionInfoReconciler: controllermock.NewReconciler(t),
 			versionReconciler:        versionReconciler,
 		}
 
@@ -169,7 +169,7 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironmentAndDNSPolicy(t *testing.T)
 	}
 
 	fakeClient := fake.NewClient()
-	dtClient := mocks.NewClient(t)
+	dtClient := dtclientmock.NewClient(t)
 
 	reconciler := &Reconciler{
 		client:                   fakeClient,
@@ -720,7 +720,7 @@ func TestReconcile_OneAgentConfigMap(t *testing.T) {
 }
 
 func createConnectionInfoReconcilerMock(t *testing.T) controllers.Reconciler {
-	connectionInfoReconciler := controllerMocks.NewReconciler(t)
+	connectionInfoReconciler := controllermock.NewReconciler(t)
 	connectionInfoReconciler.On("Reconcile",
 		mock.AnythingOfType("context.backgroundCtx")).Return(nil).Once()
 
@@ -728,7 +728,7 @@ func createConnectionInfoReconcilerMock(t *testing.T) controllers.Reconciler {
 }
 
 func createVersionReconcilerMock(t *testing.T) versions.Reconciler {
-	versionReconciler := versionMocks.NewReconciler(t)
+	versionReconciler := versionmock.NewReconciler(t)
 	versionReconciler.On("ReconcileOneAgent",
 		mock.AnythingOfType("context.backgroundCtx"),
 		mock.AnythingOfType("*dynakube.DynaKube")).Return(nil).Once()

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -7,7 +7,7 @@ import (
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	"github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -115,7 +115,7 @@ func testVerifyTokenScopes(t *testing.T) {
 			RequiredScopes: []string{"a", "c"},
 		},
 	}
-	fakeDynatraceClient := mocks.NewClient(t)
+	fakeDynatraceClient := dtclientmock.NewClient(t)
 
 	fakeDynatraceClient.
 		On("GetTokenScopes", mock.AnythingOfType("context.backgroundCtx"), "empty-scopes").

--- a/pkg/controllers/dynakube/version/activegate_test.go
+++ b/pkg/controllers/dynakube/version/activegate_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	mockedclient "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -38,7 +38,7 @@ func TestActiveGateUpdater(t *testing.T) {
 				},
 			},
 		}
-		mockClient := mockedclient.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 		mockActiveGateImageInfo(mockClient, testImage)
 
 		updater := newActiveGateUpdater(dynakube, fake.NewClient(), mockClient)
@@ -73,7 +73,7 @@ func TestActiveGateUseDefault(t *testing.T) {
 		}
 		expectedImage := dynakube.DefaultActiveGateImage()
 		expectedVersion := "1.2.3.4-5"
-		mockClient := mockedclient.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 
 		mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(expectedVersion, nil)
 

--- a/pkg/controllers/dynakube/version/codemodules_test.go
+++ b/pkg/controllers/dynakube/version/codemodules_test.go
@@ -8,7 +8,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
-	mocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +34,7 @@ func TestCodeModulesUpdater(t *testing.T) {
 				},
 			},
 		}
-		mockClient := mocks.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 		mockCodeModulesImageInfo(mockClient, testImage)
 		updater := newCodeModulesUpdater(dynakube, mockClient)
 
@@ -66,7 +66,7 @@ func TestCodeModulesUseDefault(t *testing.T) {
 				CodeModules: oldCodeModulesStatus(),
 			},
 		}
-		mockClient := mocks.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 		updater := newCodeModulesUpdater(dynakube, mockClient)
 
 		err := updater.UseTenantRegistry(ctx)
@@ -84,7 +84,7 @@ func TestCodeModulesUseDefault(t *testing.T) {
 				CodeModules: oldCodeModulesStatus(),
 			},
 		}
-		mockClient := mocks.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 		mockLatestAgentVersion(mockClient, testVersion)
 		updater := newCodeModulesUpdater(dynakube, mockClient)
 

--- a/pkg/controllers/dynakube/version/oneagent_test.go
+++ b/pkg/controllers/dynakube/version/oneagent_test.go
@@ -9,7 +9,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
-	mockedclient "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +33,7 @@ func TestOneAgentUpdater(t *testing.T) {
 				},
 			},
 		}
-		mockClient := mockedclient.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 		mockOneAgentImageInfo(mockClient, testImage)
 
 		updater := newOneAgentUpdater(dynakube, fake.NewClient(), mockClient)
@@ -65,7 +65,7 @@ func TestOneAgentUseDefault(t *testing.T) {
 		}
 		expectedImage := dynakube.DefaultOneAgentImage()
 
-		mockClient := mockedclient.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 
 		updater := newOneAgentUpdater(dynakube, fake.NewClient(), mockClient)
 
@@ -85,7 +85,7 @@ func TestOneAgentUseDefault(t *testing.T) {
 		}
 		expectedImage := dynakube.DefaultOneAgentImage()
 
-		mockClient := mockedclient.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 		mockLatestAgentVersion(mockClient, testVersion)
 
 		updater := newOneAgentUpdater(dynakube, fake.NewClient(), mockClient)
@@ -115,7 +115,7 @@ func TestOneAgentUseDefault(t *testing.T) {
 			},
 		}
 
-		mockClient := mockedclient.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 		mockLatestAgentVersion(mockClient, testVersion)
 
 		updater := newOneAgentUpdater(dynakube, fake.NewClient(), mockClient)

--- a/pkg/controllers/dynakube/version/reconciler_test.go
+++ b/pkg/controllers/dynakube/version/reconciler_test.go
@@ -12,7 +12,7 @@ import (
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dtpullsecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
-	mockedclient "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -48,7 +48,7 @@ func TestReconcile(t *testing.T) {
 	}
 
 	t.Run("no update if hash provider returns error", func(t *testing.T) {
-		mockClient := mockedclient.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 		mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return("", errors.New("Something wrong happened"))
 
 		versionReconciler := reconciler{
@@ -70,7 +70,7 @@ func TestReconcile(t *testing.T) {
 		setupPullSecret(t, fakeClient, *dynakube)
 
 		dkStatus := &dynakube.Status
-		mockClient := mockedclient.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 		mockLatestAgentVersion(mockClient, latestAgentVersion)
 		mockLatestActiveGateVersion(mockClient, latestActiveGateVersion)
 
@@ -116,7 +116,7 @@ func TestReconcile(t *testing.T) {
 
 		dkStatus := &dynakube.Status
 
-		mockClient := mockedclient.NewClient(t)
+		mockClient := dtclientmock.NewClient(t)
 		mockActiveGateImageInfo(mockClient, testActiveGateImage)
 		mockCodeModulesImageInfo(mockClient, testCodeModulesImage)
 		mockOneAgentImageInfo(mockClient, testOneAgentImage)
@@ -322,22 +322,22 @@ func createTestPullSecret(fakeClient client.Client, dynakube dynatracev1beta1.Dy
 	})
 }
 
-func mockActiveGateImageInfo(mockClient *mockedclient.Client, imageInfo dtclient.LatestImageInfo) {
+func mockActiveGateImageInfo(mockClient *dtclientmock.Client, imageInfo dtclient.LatestImageInfo) {
 	mockClient.On("GetLatestActiveGateImage", mock.AnythingOfType("context.backgroundCtx")).Return(&imageInfo, nil)
 }
 
-func mockCodeModulesImageInfo(mockClient *mockedclient.Client, imageInfo dtclient.LatestImageInfo) {
+func mockCodeModulesImageInfo(mockClient *dtclientmock.Client, imageInfo dtclient.LatestImageInfo) {
 	mockClient.On("GetLatestCodeModulesImage", mock.AnythingOfType("context.backgroundCtx")).Return(&imageInfo, nil)
 }
 
-func mockOneAgentImageInfo(mockClient *mockedclient.Client, imageInfo dtclient.LatestImageInfo) {
+func mockOneAgentImageInfo(mockClient *dtclientmock.Client, imageInfo dtclient.LatestImageInfo) {
 	mockClient.On("GetLatestOneAgentImage", mock.AnythingOfType("context.backgroundCtx")).Return(&imageInfo, nil)
 }
 
-func mockLatestAgentVersion(mockClient *mockedclient.Client, latestVersion string) {
+func mockLatestAgentVersion(mockClient *dtclientmock.Client, latestVersion string) {
 	mockClient.On("GetLatestAgentVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything, mock.Anything).Return(latestVersion, nil)
 }
 
-func mockLatestActiveGateVersion(mockClient *mockedclient.Client, latestVersion string) {
+func mockLatestActiveGateVersion(mockClient *dtclientmock.Client, latestVersion string) {
 	mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(latestVersion, nil)
 }

--- a/pkg/controllers/dynakube/version/updater_test.go
+++ b/pkg/controllers/dynakube/version/updater_test.go
@@ -8,7 +8,7 @@ import (
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
-	mocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
+	versionmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -283,14 +283,14 @@ func enablePublicRegistry(dynakube *dynatracev1beta1.DynaKube) *dynatracev1beta1
 	return dynakube
 }
 
-func newCustomImageUpdater(t *testing.T, target *status.VersionStatus, image string) *mocks.StatusUpdater {
+func newCustomImageUpdater(t *testing.T, target *status.VersionStatus, image string) *versionmock.StatusUpdater {
 	updater := newBaseUpdater(t, target, true)
 	updater.On("CustomImage").Maybe().Return(image)
 
 	return updater
 }
 
-func newCustomVersionUpdater(t *testing.T, target *status.VersionStatus, version string, autoUpdate bool) *mocks.StatusUpdater {
+func newCustomVersionUpdater(t *testing.T, target *status.VersionStatus, version string, autoUpdate bool) *versionmock.StatusUpdater {
 	updater := newBaseUpdater(t, target, autoUpdate)
 	updater.On("CustomImage").Maybe().Return("")
 	updater.On("IsPublicRegistryEnabled").Maybe().Maybe().Return(false)
@@ -299,7 +299,7 @@ func newCustomVersionUpdater(t *testing.T, target *status.VersionStatus, version
 	return updater
 }
 
-func newDefaultUpdater(t *testing.T, target *status.VersionStatus, autoUpdate bool) *mocks.StatusUpdater {
+func newDefaultUpdater(t *testing.T, target *status.VersionStatus, autoUpdate bool) *versionmock.StatusUpdater {
 	updater := newBaseUpdater(t, target, autoUpdate)
 	updater.On("CustomImage").Maybe().Return("")
 	updater.On("IsPublicRegistryEnabled").Maybe().Return(false)
@@ -309,7 +309,7 @@ func newDefaultUpdater(t *testing.T, target *status.VersionStatus, autoUpdate bo
 	return updater
 }
 
-func newPublicRegistryUpdater(t *testing.T, target *status.VersionStatus, imageInfo *dtclient.LatestImageInfo, autoUpdate bool) *mocks.StatusUpdater {
+func newPublicRegistryUpdater(t *testing.T, target *status.VersionStatus, imageInfo *dtclient.LatestImageInfo, autoUpdate bool) *versionmock.StatusUpdater {
 	updater := newBaseUpdater(t, target, autoUpdate)
 	updater.On("CustomImage").Maybe().Return("")
 	updater.On("IsPublicRegistryEnabled").Maybe().Return(true)
@@ -318,15 +318,15 @@ func newPublicRegistryUpdater(t *testing.T, target *status.VersionStatus, imageI
 	return updater
 }
 
-func newClassicFullStackUpdater(t *testing.T, target *status.VersionStatus, autoUpdate bool) *mocks.StatusUpdater {
+func newClassicFullStackUpdater(t *testing.T, target *status.VersionStatus, autoUpdate bool) *versionmock.StatusUpdater {
 	updater := newBaseUpdater(t, target, autoUpdate)
 	updater.On("IsPublicRegistryEnabled").Maybe().Return(false)
 
 	return updater
 }
 
-func newBaseUpdater(t *testing.T, target *status.VersionStatus, autoUpdate bool) *mocks.StatusUpdater {
-	updater := mocks.NewStatusUpdater(t)
+func newBaseUpdater(t *testing.T, target *status.VersionStatus, autoUpdate bool) *versionmock.StatusUpdater {
+	updater := versionmock.NewStatusUpdater(t)
 	updater.On("Name").Maybe().Return("mock")
 	updater.On("Target").Maybe().Return(target)
 	updater.On("IsEnabled").Maybe().Return(true)

--- a/pkg/controllers/edgeconnect/controller_test.go
+++ b/pkg/controllers/edgeconnect/controller_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
 	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
-	mocksedgeconnect "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/edgeconnect"
+	edgeconnectmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/edgeconnect"
 	registrymock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/oci/registry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -141,7 +141,7 @@ func TestReconcileProvisionerCreate(t *testing.T) {
 	t.Run("create EdgeConnect", func(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
-		edgeConnectClient := mocksedgeconnect.NewClient(t)
+		edgeConnectClient := edgeconnectmock.NewClient(t)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
@@ -198,7 +198,7 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 	t.Run("recreate EdgeConnect due to missing client secret", func(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
-		edgeConnectClient := mocksedgeconnect.NewClient(t)
+		edgeConnectClient := edgeconnectmock.NewClient(t)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
@@ -254,7 +254,7 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 	t.Run("recreate EdgeConnect due to invalid id", func(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
-		edgeConnectClient := mocksedgeconnect.NewClient(t)
+		edgeConnectClient := edgeconnectmock.NewClient(t)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
@@ -313,7 +313,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 	t.Run("delete EdgeConnect", func(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
 
-		edgeConnectClient := mocksedgeconnect.NewClient(t)
+		edgeConnectClient := edgeconnectmock.NewClient(t)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
@@ -340,7 +340,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 	t.Run("delete EdgeConnect - missing client secret", func(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
 
-		edgeConnectClient := mocksedgeconnect.NewClient(t)
+		edgeConnectClient := edgeconnectmock.NewClient(t)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
@@ -366,7 +366,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 	t.Run("delete EdgeConnect - missing EdgeConnect on the tenant", func(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
 
-		edgeConnectClient := mocksedgeconnect.NewClient(t)
+		edgeConnectClient := edgeconnectmock.NewClient(t)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
@@ -395,7 +395,7 @@ func TestReconcileProvisionerUpdate(t *testing.T) {
 	t.Run("update EdgeConnect", func(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns2)
 
-		edgeConnectClient := mocksedgeconnect.NewClient(t)
+		edgeConnectClient := edgeconnectmock.NewClient(t)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
@@ -516,7 +516,7 @@ func createFakeClientAndReconcilerForProvisioner(t *testing.T, instance *edgecon
 	return controller
 }
 
-func mockNewEdgeConnectClientCreate(edgeConnectClient *mocksedgeconnect.Client) func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
+func mockNewEdgeConnectClientCreate(edgeConnectClient *edgeconnectmock.Client) func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
 	return func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
 		edgeConnectClient.On("GetEdgeConnects", testName).Return(
 			edgeconnect.ListResponse{
@@ -542,7 +542,7 @@ func mockNewEdgeConnectClientCreate(edgeConnectClient *mocksedgeconnect.Client) 
 	}
 }
 
-func mockNewEdgeConnectClientRecreate(edgeConnectClient *mocksedgeconnect.Client, id string) func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
+func mockNewEdgeConnectClientRecreate(edgeConnectClient *edgeconnectmock.Client, id string) func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
 	return func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
 		edgeConnectClient.On("GetEdgeConnects", testName).Return(
 			edgeconnect.ListResponse{
@@ -578,7 +578,7 @@ func mockNewEdgeConnectClientRecreate(edgeConnectClient *mocksedgeconnect.Client
 	}
 }
 
-func mockNewEdgeConnectClientDelete(edgeConnectClient *mocksedgeconnect.Client) func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
+func mockNewEdgeConnectClientDelete(edgeConnectClient *edgeconnectmock.Client) func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
 	return func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
 		edgeConnectClient.On("GetEdgeConnects", testName).Return(
 			edgeconnect.ListResponse{
@@ -601,7 +601,7 @@ func mockNewEdgeConnectClientDelete(edgeConnectClient *mocksedgeconnect.Client) 
 	}
 }
 
-func mockNewEdgeConnectClientDeleteNotFoundOnTenant(edgeConnectClient *mocksedgeconnect.Client) func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
+func mockNewEdgeConnectClientDeleteNotFoundOnTenant(edgeConnectClient *edgeconnectmock.Client) func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
 	return func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
 		edgeConnectClient.On("GetEdgeConnects", testName).Return(
 			edgeconnect.ListResponse{
@@ -615,7 +615,7 @@ func mockNewEdgeConnectClientDeleteNotFoundOnTenant(edgeConnectClient *mocksedge
 	}
 }
 
-func mockNewEdgeConnectClientUpdate(edgeConnectClient *mocksedgeconnect.Client) func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
+func mockNewEdgeConnectClientUpdate(edgeConnectClient *edgeconnectmock.Client) func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
 	return func(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnect.Client, error) {
 		edgeConnectClient.On("GetEdgeConnects", testName).Return(
 			edgeconnect.ListResponse{

--- a/pkg/controllers/nodes/nodes_controller_test.go
+++ b/pkg/controllers/nodes/nodes_controller_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceclient"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
-	"github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -153,7 +153,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("Server error when removing node", func(t *testing.T) {
 		fakeClient := createDefaultFakeClient()
 
-		dtClient := mocks.NewClient(t)
+		dtClient := dtclientmock.NewClient(t)
 		dtClient.On("GetEntityIDForIP", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return("", ErrNotFound)
 
 		ctrl := createDefaultReconciler(fakeClient, dtClient)
@@ -166,7 +166,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("Remove host from cache even if server error: host not found", func(t *testing.T) {
 		fakeClient := createDefaultFakeClient()
 
-		dtClient := mocks.NewClient(t)
+		dtClient := dtclientmock.NewClient(t)
 		dtClient.On("GetEntityIDForIP", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return("", dtclient.HostNotFoundErr{IP: "1.2.3.4"})
 
 		ctrl := createDefaultReconciler(fakeClient, dtClient)
@@ -245,7 +245,7 @@ func (builder mockDynatraceClientBuilder) BuildWithTokenVerification(*dynatracev
 	return builder.dynatraceClient, nil
 }
 
-func createDefaultReconciler(fakeClient client.Client, dtClient *mocks.Client) *Controller {
+func createDefaultReconciler(fakeClient client.Client, dtClient *dtclientmock.Client) *Controller {
 	return &Controller{
 		client:    fakeClient,
 		apiReader: fakeClient,
@@ -259,8 +259,8 @@ func createDefaultReconciler(fakeClient client.Client, dtClient *mocks.Client) *
 	}
 }
 
-func createDTMockClient(t *testing.T, ip, host string) *mocks.Client {
-	dtClient := mocks.NewClient(t)
+func createDTMockClient(t *testing.T, ip, host string) *dtclientmock.Client {
+	dtClient := dtclientmock.NewClient(t)
 	dtClient.On("GetEntityIDForIP", mock.AnythingOfType("context.backgroundCtx"), ip).Return(host, nil)
 	dtClient.On("SendEvent", mock.AnythingOfType("context.backgroundCtx"), mock.MatchedBy(func(e *dtclient.EventData) bool {
 		return e.EventType == "MARKED_FOR_TERMINATION"

--- a/pkg/injection/codemodule/installer/url/installer_test.go
+++ b/pkg/injection/codemodule/installer/url/installer_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/zip"
-	"github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -51,7 +51,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 	})
 	t.Run(`error when downloading latest agent`, func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		dtc := mocks.NewClient(t)
+		dtc := dtclientmock.NewClient(t)
 		dtc.
 			On("GetAgent", mock.AnythingOfType("context.backgroundCtx"), dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"),
@@ -77,7 +77,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 	t.Run(`error unzipping file`, func(t *testing.T) {
 		fs := afero.NewMemMapFs()
 
-		dtc := mocks.NewClient(t)
+		dtc := dtclientmock.NewClient(t)
 		dtc.
 			On("GetAgent", mock.AnythingOfType("context.backgroundCtx"), dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"),
@@ -109,7 +109,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 	})
 	t.Run(`downloading and unzipping agent via version`, func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		dtc := mocks.NewClient(t)
+		dtc := dtclientmock.NewClient(t)
 		dtc.On("GetAgent",
 			mock.AnythingOfType("context.backgroundCtx"),
 			dtclient.OsUnix,
@@ -150,7 +150,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 	})
 	t.Run(`downloading and unzipping latest agent`, func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		dtc := mocks.NewClient(t)
+		dtc := dtclientmock.NewClient(t)
 		dtc.
 			On("GetLatestAgent", mock.AnythingOfType("context.backgroundCtx"), dtclient.OsUnix, dtclient.InstallerTypePaaS, arch.FlavorMultidistro,
 				mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), mock.AnythingOfType("bool"),
@@ -184,7 +184,7 @@ func TestInstallAgentFromUrl(t *testing.T) {
 	})
 	t.Run(`downloading and unzipping agent via url`, func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		dtc := mocks.NewClient(t)
+		dtc := dtclientmock.NewClient(t)
 		dtc.
 			On("GetAgentViaInstallerUrl", mock.AnythingOfType("context.backgroundCtx"), testUrl, mock.AnythingOfType("*mem.File")).
 			Run(func(args mock.Arguments) {

--- a/pkg/injection/startup/run_test.go
+++ b/pkg/injection/startup/run_test.go
@@ -8,8 +8,8 @@ import (
 
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
-	mockedclient "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
-	mockedinstaller "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/injection/codemodule/installer"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	installermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/injection/codemodule/installer"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -143,10 +143,10 @@ func TestInstallOneAgent(t *testing.T) {
 		runner := createMockedRunner(t)
 		_, err := runner.fs.Create(filepath.Join(consts.AgentBinDirMount, "agent/conf/ruxitagentproc.conf"))
 		require.NoError(t, err)
-		runner.dtclient.(*mockedclient.Client).
+		runner.dtclient.(*dtclientmock.Client).
 			On("GetProcessModuleConfig", mock.AnythingOfType("context.backgroundCtx"), uint(0)).
 			Return(getTestProcessModuleConfig(), nil)
-		runner.installer.(*mockedinstaller.Installer).
+		runner.installer.(*installermock.Installer).
 			On("InstallAgent", mock.AnythingOfType("context.backgroundCtx"), consts.AgentBinDirMount).
 			Return(true, nil)
 
@@ -156,7 +156,7 @@ func TestInstallOneAgent(t *testing.T) {
 	})
 	t.Run("sad install -> install fail", func(t *testing.T) {
 		runner := createMockedRunner(t)
-		runner.installer.(*mockedinstaller.Installer).
+		runner.installer.(*installermock.Installer).
 			On("InstallAgent", mock.AnythingOfType("context.backgroundCtx"), consts.AgentBinDirMount).
 			Return(false, fmt.Errorf("BOOM"))
 
@@ -166,10 +166,10 @@ func TestInstallOneAgent(t *testing.T) {
 	})
 	t.Run("sad install -> ruxitagent update fail", func(t *testing.T) {
 		runner := createMockedRunner(t)
-		runner.dtclient.(*mockedclient.Client).
+		runner.dtclient.(*dtclientmock.Client).
 			On("GetProcessModuleConfig", mock.AnythingOfType("context.backgroundCtx"), uint(0)).
 			Return(getTestProcessModuleConfig(), nil)
-		runner.installer.(*mockedinstaller.Installer).
+		runner.installer.(*installermock.Installer).
 			On("InstallAgent", mock.AnythingOfType("context.backgroundCtx"), consts.AgentBinDirMount).
 			Return(true, nil)
 
@@ -179,10 +179,10 @@ func TestInstallOneAgent(t *testing.T) {
 	})
 	t.Run("sad install -> ruxitagent endpoint fail", func(t *testing.T) {
 		runner := createMockedRunner(t)
-		runner.dtclient.(*mockedclient.Client).
+		runner.dtclient.(*dtclientmock.Client).
 			On("GetProcessModuleConfig", mock.AnythingOfType("context.backgroundCtx"), uint(0)).
 			Return(&dtclient.ProcessModuleConfig{}, fmt.Errorf("BOOM"))
-		runner.installer.(*mockedinstaller.Installer).
+		runner.installer.(*installermock.Installer).
 			On("InstallAgent", mock.AnythingOfType("context.backgroundCtx"), consts.AgentBinDirMount).
 			Return(true, nil)
 
@@ -197,7 +197,7 @@ func TestRun(t *testing.T) {
 	runner.config.HasHost = false
 	runner.env.OneAgentInjected = true
 	runner.env.DataIngestInjected = true
-	runner.dtclient.(*mockedclient.Client).
+	runner.dtclient.(*dtclientmock.Client).
 		On("GetProcessModuleConfig", mock.AnythingOfType("context.backgroundCtx"), uint(0)).
 		Return(getTestProcessModuleConfig(), nil)
 
@@ -214,7 +214,7 @@ func TestRun(t *testing.T) {
 		assertIfReadOnlyCSIFilesExists(t, *runner)
 	})
 	t.Run("install + config generation", func(t *testing.T) {
-		runner.installer.(*mockedinstaller.Installer).
+		runner.installer.(*installermock.Installer).
 			On("InstallAgent", mock.AnythingOfType("context.backgroundCtx"), consts.AgentBinDirMount).
 			Return(true, nil)
 
@@ -294,7 +294,7 @@ func TestGetProcessModuleConfig(t *testing.T) {
 
 	t.Run("error if api call fails", func(t *testing.T) {
 		runner := createMockedRunner(t)
-		runner.dtclient.(*mockedclient.Client).
+		runner.dtclient.(*dtclientmock.Client).
 			On("GetProcessModuleConfig", mock.AnythingOfType("context.backgroundCtx"), uint(0)).
 			Return(&dtclient.ProcessModuleConfig{}, fmt.Errorf("BOOM"))
 
@@ -308,7 +308,7 @@ func TestGetProcessModuleConfig(t *testing.T) {
 
 		runner := createMockedRunner(t)
 		runner.config.Proxy = proxy
-		runner.dtclient.(*mockedclient.Client).
+		runner.dtclient.(*dtclientmock.Client).
 			On("GetProcessModuleConfig", mock.AnythingOfType("context.backgroundCtx"), uint(0)).
 			Return(getTestProcessModuleConfig(), nil)
 
@@ -328,7 +328,7 @@ func TestGetProcessModuleConfig(t *testing.T) {
 
 		runner := createMockedRunner(t)
 		runner.config.OneAgentNoProxy = oneAgentNoProxy
-		runner.dtclient.(*mockedclient.Client).
+		runner.dtclient.(*dtclientmock.Client).
 			On("GetProcessModuleConfig", mock.AnythingOfType("context.backgroundCtx"), uint(0)).
 			Return(getTestProcessModuleConfig(), nil)
 
@@ -506,8 +506,8 @@ func createTestRunner(t *testing.T) *Runner {
 
 func createMockedRunner(t *testing.T) *Runner {
 	runner := createTestRunner(t)
-	runner.installer = mockedinstaller.NewInstaller(t)
-	runner.dtclient = mockedclient.NewClient(t)
+	runner.installer = installermock.NewInstaller(t)
+	runner.dtclient = dtclientmock.NewClient(t)
 
 	return runner
 }

--- a/pkg/util/builder/builder_test.go
+++ b/pkg/util/builder/builder_test.go
@@ -3,7 +3,7 @@ package builder
 import (
 	"testing"
 
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/builder/mocks"
+	buildermock "github.com/Dynatrace/dynatrace-operator/pkg/util/builder/mocks"
 	modifiermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/util/builder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -12,17 +12,17 @@ import (
 
 func TestBuilder(t *testing.T) {
 	t.Run("Simple, no modifiers", func(t *testing.T) {
-		b := GenericBuilder[mocks.DataMock]{}
+		b := GenericBuilder[buildermock.DataMock]{}
 		actual, err := b.Build()
 		require.NoError(t, err)
 
-		expected := mocks.DataMock{}
+		expected := buildermock.DataMock{}
 		assert.Equal(t, expected, actual)
 	})
 	t.Run("One modifier", func(t *testing.T) {
-		b := GenericBuilder[mocks.DataMock]{}
+		b := GenericBuilder[buildermock.DataMock]{}
 
-		modifierMock := modifiermock.NewModifier[mocks.DataMock](t)
+		modifierMock := modifiermock.NewModifier[buildermock.DataMock](t)
 		modifierMock.On("Modify", mock.Anything).Return(nil)
 		modifierMock.On("Enabled").Return(true)
 
@@ -31,13 +31,13 @@ func TestBuilder(t *testing.T) {
 
 		modifierMock.AssertNumberOfCalls(t, "Modify", 1)
 
-		expected := mocks.DataMock{}
+		expected := buildermock.DataMock{}
 		assert.Equal(t, expected, actual)
 	})
 	t.Run("One modifier, not enabled", func(t *testing.T) {
-		b := GenericBuilder[mocks.DataMock]{}
+		b := GenericBuilder[buildermock.DataMock]{}
 
-		modifierMock := modifiermock.NewModifier[mocks.DataMock](t)
+		modifierMock := modifiermock.NewModifier[buildermock.DataMock](t)
 		modifierMock.On("Modify", mock.Anything).Return(nil).Maybe()
 		modifierMock.On("Enabled").Return(false)
 
@@ -46,17 +46,17 @@ func TestBuilder(t *testing.T) {
 
 		modifierMock.AssertNumberOfCalls(t, "Modify", 0)
 
-		expected := mocks.DataMock{}
+		expected := buildermock.DataMock{}
 		assert.Equal(t, expected, actual)
 	})
 	t.Run("Two modifiers, one used twice", func(t *testing.T) {
-		b := GenericBuilder[mocks.DataMock]{}
+		b := GenericBuilder[buildermock.DataMock]{}
 
-		modifierMock0 := modifiermock.NewModifier[mocks.DataMock](t)
+		modifierMock0 := modifiermock.NewModifier[buildermock.DataMock](t)
 		modifierMock0.On("Modify", mock.Anything).Return(nil)
 		modifierMock0.On("Enabled").Return(true)
 
-		modifierMock1 := modifiermock.NewModifier[mocks.DataMock](t)
+		modifierMock1 := modifiermock.NewModifier[buildermock.DataMock](t)
 		modifierMock1.On("Modify", mock.Anything).Return(nil)
 		modifierMock1.On("Enabled").Return(true)
 
@@ -66,17 +66,17 @@ func TestBuilder(t *testing.T) {
 		modifierMock0.AssertNumberOfCalls(t, "Modify", 2)
 		modifierMock1.AssertNumberOfCalls(t, "Modify", 1)
 
-		expected := mocks.DataMock{}
+		expected := buildermock.DataMock{}
 		assert.Equal(t, expected, actual)
 	})
 	t.Run("Chain of modifiers", func(t *testing.T) {
-		b := GenericBuilder[mocks.DataMock]{}
+		b := GenericBuilder[buildermock.DataMock]{}
 
-		modifierMock0 := modifiermock.NewModifier[mocks.DataMock](t)
+		modifierMock0 := modifiermock.NewModifier[buildermock.DataMock](t)
 		modifierMock0.On("Modify", mock.Anything).Return(nil)
 		modifierMock0.On("Enabled").Return(true)
 
-		modifierMock1 := modifiermock.NewModifier[mocks.DataMock](t)
+		modifierMock1 := modifiermock.NewModifier[buildermock.DataMock](t)
 		modifierMock1.On("Modify", mock.Anything).Return(nil)
 		modifierMock1.On("Enabled").Return(true)
 

--- a/pkg/webhook/mutation/pod_mutator/pod_mutator_test.go
+++ b/pkg/webhook/mutation/pod_mutator/pod_mutator_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
-	mocks "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/webhook"
+	webhookmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/webhook"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -230,7 +230,7 @@ func TestHandlePodReinvocation(t *testing.T) {
 }
 
 func assertPodMutatorCalls(t *testing.T, mutator dtwebhook.PodMutator, expectedCalls int) {
-	mock, ok := mutator.(*mocks.PodMutator)
+	mock, ok := mutator.(*webhookmock.PodMutator)
 	if !ok {
 		t.Fatalf("assertPodMutatorCalls: mutator is not a mock")
 	}
@@ -273,8 +273,8 @@ func createTestWebhook(mutators []dtwebhook.PodMutator, objects []client.Object)
 	}
 }
 
-func createSimplePodMutatorMock(t *testing.T) *mocks.PodMutator {
-	mutator := mocks.NewPodMutator(t)
+func createSimplePodMutatorMock(t *testing.T) *webhookmock.PodMutator {
+	mutator := webhookmock.NewPodMutator(t)
 	mutator.On("Enabled", mock.Anything).Return(true).Maybe()
 	mutator.On("Injected", mock.Anything).Return(false).Maybe()
 	mutator.On("Mutate", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -283,8 +283,8 @@ func createSimplePodMutatorMock(t *testing.T) *mocks.PodMutator {
 	return mutator
 }
 
-func createAlreadyInjectedPodMutatorMock(t *testing.T) *mocks.PodMutator {
-	mutator := mocks.NewPodMutator(t)
+func createAlreadyInjectedPodMutatorMock(t *testing.T) *webhookmock.PodMutator {
+	mutator := webhookmock.NewPodMutator(t)
 	mutator.On("Enabled", mock.Anything).Return(true).Maybe()
 	mutator.On("Injected", mock.Anything).Return(true).Maybe()
 	mutator.On("Mutate", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -293,8 +293,8 @@ func createAlreadyInjectedPodMutatorMock(t *testing.T) *mocks.PodMutator {
 	return mutator
 }
 
-func createFailPodMutatorMock(t *testing.T) *mocks.PodMutator {
-	mutator := mocks.NewPodMutator(t)
+func createFailPodMutatorMock(t *testing.T) *webhookmock.PodMutator {
+	mutator := webhookmock.NewPodMutator(t)
 	mutator.On("Enabled", mock.Anything).Return(true).Maybe()
 	mutator.On("Injected", mock.Anything).Return(false).Maybe()
 	mutator.On("Mutate", mock.Anything, mock.Anything).Return(fmt.Errorf("BOOM")).Maybe()


### PR DESCRIPTION
## Description

Just a simple unification of how we import mock packages around the codebase.

## How can this be tested?

Search the codebase for imports I left out, and still break the update stye-guide.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
