### PR TITLE
Increase mutatingwebhookconfiguration timeout to 10s

### DIFF
--- a/config/helm/chart/default/tests/Common/webhook/mutatingwebhookconfiguration_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/mutatingwebhookconfiguration_test.yaml
@@ -19,7 +19,7 @@ tests:
               - name: webhook.pod.dynatrace.com
                 reinvocationPolicy: IfNeeded
                 failurePolicy: Ignore
-                timeoutSeconds: 2
+                timeoutSeconds: 10
                 rules:
                   - apiGroups: [ "" ]
                     apiVersions: [ "v1" ]
@@ -40,7 +40,7 @@ tests:
               - name: webhook.ns.dynatrace.com
                 reinvocationPolicy: IfNeeded
                 failurePolicy: Ignore
-                timeoutSeconds: 2
+                timeoutSeconds: 10
                 rules:
                   - apiGroups: [ "" ]
                     apiVersions: [ "v1" ]

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -87,7 +87,7 @@ webhook:
   validatingWebhook:
     timeoutSeconds: 10
   mutatingWebhook:
-    timeoutSeconds: 2
+    timeoutSeconds: 10
 
 csidriver:
   enabled: true


### PR DESCRIPTION
## Description

Increase mutatingwebhookconfiguration timeout to 10s

## How can this be tested?

Deploy operator -> mutatingwebhook config should have set 10s as timeout

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
