### PR TITLE
Add Github action running nightly E2E tests

### DIFF
--- a/.github/scripts/create-cluster.sh
+++ b/.github/scripts/create-cluster.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -x
+
+DEFAULT_TIMEOUT="60m" # K8s takes <10min, Openshift >40min
+
+kubectl version
+
+echo "Creating environment '$ENVIRONMENT' in namespace '$NAMESPACE'"
+
+kubectl get flcenvironments --namespace $NAMESPACE
+
+echo "Patching environment '$ENVIRONMENT' to 'deployed'"
+kubectl patch --namespace $NAMESPACE --type merge --patch '{"spec": {"desiredState": "environment-deployed"}}' flcenvironment $ENVIRONMENT
+
+echo "Waiting up to '$DEFAULT_TIMEOUT' for successful deployment of environment '$ENVIRONMENT'"
+kubectl wait --namespace $NAMESPACE --timeout="$DEFAULT_TIMEOUT" --for=condition=InTransition=false flcenvironment $ENVIRONMENT

--- a/.github/scripts/destroy-cluster.sh
+++ b/.github/scripts/destroy-cluster.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo "Destroying environment '$ENVIRONMENT' in namespace '$NAMESPACE'"
+
+kubectl get flcenvironments --namespace $NAMESPACE
+
+echo "Patching environment '$ENVIRONMENT' to 'not-deployed'"
+kubectl patch --namespace $NAMESPACE --type merge --patch '{"spec": {"desiredState": "environment-not-deployed"}}' flcenvironment $ENVIRONMENT

--- a/.github/scripts/run-test.sh
+++ b/.github/scripts/run-test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e
+
+ENVIRONMENT_KUBECONFIG="$RUNNER_TEMP/environment-kubeconfig"
+ENVIRONMENT_SECRET_NAME="$ENVIRONMENT-kubeconfig"
+
+echo "Loading kubeconfig from secret for environment '$ENVIRONMENT' from namespace '$NAMESPACE'"
+kubectl get secret --namespace "$NAMESPACE" "$ENVIRONMENT_SECRET_NAME" -o jsonpath='{.data.kubeconfig}' | base64 --decode > "$ENVIRONMENT_KUBECONFIG"
+
+echo "Switching to test cluster for environment '$ENVIRONMENT'!"
+export KUBECONFIG="$ENVIRONMENT_KUBECONFIG"
+
+kubectl version
+kubectl config view
+
+mkdir -p test/testdata/secrets/
+
+pushd test/testdata/secrets/
+
+cat << EOF > single-tenant.yaml
+tenantUid: $TENANT1_NAME
+apiUrl: https://$TENANT1_NAME.dev.dynatracelabs.com/api
+apiToken: $TENANT1_APITOKEN
+EOF
+
+cat << EOF > multi-tenant.yaml
+tenants:
+  - tenantUid: $TENANT1_NAME
+    apiUrl: https://$TENANT1_NAME.dev.dynatracelabs.com/api
+    apiToken: $TENANT1_APITOKEN
+  - tenantUid: $TENANT2_NAME
+    apiUrl: https://$TENANT2_NAME.dev.dynatracelabs.com/api
+    apiToken: $TENANT2_APITOKEN
+EOF
+
+cat << EOF > edgeconnect-tenant.yaml
+name: e2e-test
+tenantUid: $TENANT1_NAME
+apiServer: $TENANT1_NAME.dev.apps.dynatracelabs.com/api
+oAuthClientId: $TENANT1_OAUTH_CLIENT_ID
+oAuthClientSecret: $TENANT1_OAUTH_SECRET
+EOF
+
+cat << EOF > otel-tenant.yaml
+endpoint: $TENANT1_NAME.dev.dynatracelabs.com
+apiToken: $TENANT1_OTELTOKEN
+EOF
+
+popd
+
+echo "Running tests for environment '$ENVIRONMENT' ..."
+make BRANCH="${GITHUB_REF##*/}" test/e2e # use current branch image to run tests
+
+echo "Test run completed!"

--- a/.github/scripts/run-test.sh
+++ b/.github/scripts/run-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu -o pipefail
 
 ENVIRONMENT_KUBECONFIG="$RUNNER_TEMP/environment-kubeconfig"
 ENVIRONMENT_SECRET_NAME="$ENVIRONMENT-kubeconfig"

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -1,0 +1,77 @@
+name: Run E2E tests
+
+on:
+  schedule:
+    - cron: 4 0 * * 1-5 # every work day at 4:00 AM
+
+jobs:
+  run-in-k8s:
+    name: Run in Kubernetes
+    environment: E2E
+    env:
+      NAMESPACE: dto-k8s-ondemand
+      ENVIRONMENT: dto-k8s-1-26
+      TENANT1_NAME: ${{ secrets.TENANT1_NAME }}
+      TENANT1_APITOKEN: ${{ secrets.TENANT1_APITOKEN }}
+      TENANT1_OTELTOKEN: ${{ secrets.TENANT1_OTELTOKEN }}
+      TENANT1_OAUTH_CLIENT_ID: ${{ secrets.TENANT1_OAUTH_CLIENT_ID }}
+      TENANT1_OAUTH_SECRET: ${{ secrets.TENANT1_OAUTH_SECRET }}
+      TENANT2_NAME: ${{ secrets.TENANT2_NAME }}
+      TENANT2_APITOKEN: ${{ secrets.TENANT2_APITOKEN }}
+    runs-on:
+    - self-hosted
+    - operator-e2e
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Set up kubectl
+      uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0
+    - name: Set up go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version-file: "${{ github.workspace }}/go.mod"
+    - name: Set up helm
+      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create cluster
+      run: .github/scripts/create-cluster.sh
+    - name: Run tests
+      run: .github/scripts/run-test.sh
+    - name: Destroy cluster
+      run: .github/scripts/destroy-cluster.sh
+  run-in-ocp:
+    name: Run in Openshift
+    environment: E2E
+    env:
+      NAMESPACE: dto-ocp-ondemand
+      ENVIRONMENT: dto-ocp-4-14
+      TENANT1_NAME: ${{ secrets.TENANT1_NAME }}
+      TENANT1_APITOKEN: ${{ secrets.TENANT1_APITOKEN }}
+      TENANT1_OTELTOKEN: ${{ secrets.TENANT1_OTELTOKEN }}
+      TENANT1_OAUTH_CLIENT_ID: ${{ secrets.TENANT1_OAUTH_CLIENT_ID }}
+      TENANT1_OAUTH_SECRET: ${{ secrets.TENANT1_OAUTH_SECRET }}
+      TENANT2_NAME: ${{ secrets.TENANT2_NAME }}
+      TENANT2_APITOKEN: ${{ secrets.TENANT2_APITOKEN }}
+    runs-on:
+    - self-hosted
+    - operator-e2e
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Set up kubectl
+      uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0
+    - name: Set up go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version-file: "${{ github.workspace }}/go.mod"
+    - name: Set up helm
+      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create cluster
+      run: .github/scripts/create-cluster.sh
+    - name: Run tests
+      run: .github/scripts/run-test.sh
+    - name: Destroy cluster
+      run: .github/scripts/destroy-cluster.sh


### PR DESCRIPTION
## Description

New Github action running E2E tests daily at 4:00 AM (I will update this to 00:00 AM once I remove the 'old' concourse pipeline; this is just to not overlap them).

Once this action is successfully executed overnight, I will remove the concourse pipeline.

## How can this be tested?

Check previous executions (e.g. https://github.com/Dynatrace/dynatrace-operator/actions/runs/8081015061)
In that case, Openshift failed because of timeout in cluster creation, now I set the timeout to 60min.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
