### PR TITLE
Set E2E execution at 5AM and make the workflow dispatchable

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -2,7 +2,9 @@ name: Run E2E tests
 
 on:
   schedule:
-    - cron: 4 0 * * 1-5 # every work day at 4:00 AM
+    # every work day at 5:00 AM
+    - cron: 5 0 * * 1-5
+  workflow_dispatch:
 
 jobs:
   run-in-k8s:


### PR DESCRIPTION
## Description

Tonight E2E github action failed because the cluster was still in destroying state (because of concourse E2E tests). Im setting this to 5 AM so the cluster has more time to be ready.

Also, I set `workflow_dispatch` as an event trigger, so we can trigger the E2E tests manually on any branch.

## How can this be tested?

Workflow dispatch can only be tested when the changes are on the main branch.

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
