### PR TITLE
Re-add simpler public-registry e2e test

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -73,10 +73,6 @@ test/e2e/cloudnative/network-zone: manifests/crd/helm
 test/e2e/cloudnative/proxy: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -args --labels "name=cloudnative-proxy" $(SKIPCLEANUP)
 
-## Runs CloudNative public registry e2e test only
-test/e2e/cloudnative/publicregistry: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=cloudnative-public-registry" $(SKIPCLEANUP)
-
 ## Runs Classic/CloudNative mode switching tests
 test/e2e/cloudnative/switchmodes: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=cloudnative-to-classic" $(SKIPCLEANUP)
@@ -100,6 +96,10 @@ test/e2e/applicationmonitoring/readonlycsivolume: manifests/crd/helm
 ## Runs Application Monitoring without CSI e2e test only
 test/e2e/applicationmonitoring/withoutcsi: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=app-without-csi" $(SKIPCLEANUP)
+
+## Runs public registry images e2e test only
+test/e2e/publicregistry: manifests/crd/helm
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=public-registry-images" $(SKIPCLEANUP)
 
 ## Runs SupportArchive e2e test only
 test/e2e/supportarchive: manifests/crd/helm

--- a/pkg/util/dtversion/dtversion.go
+++ b/pkg/util/dtversion/dtversion.go
@@ -1,0 +1,50 @@
+// Package dtversion's purpose is to convert the component/image versions used by Dynatrace into semver
+// - Example version used by Dynatrace:
+//   - 1.283.132.20240205-143805 (this translates to [version-number].[sprint-number].[quick-fix].[build-date]-[build-timestamp])
+//   - The operator does not care about the [build-date] and [build-timestamp] parts, so we can ignore those, and after that converting it to semver is trivial
+//   - As semver: v1.283.132
+package dtversion
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	semverPrefix = "v"
+	semverSep    = "."
+
+	// relevantVersionLength defines how many segments of the semver we care about, for-example:
+	// in case of 3, we only care about major.minor.patch and the rest is ignored.
+	relevantSemverLength = 3
+)
+
+func ToSemver(version string) (string, error) {
+	if version == "" {
+		return "", nil
+	}
+
+	split := strings.Split(version, semverSep)
+
+	var semantic string
+
+	if len(split) > relevantSemverLength {
+		semantic = strings.Join(split[:relevantSemverLength], semverSep)
+	} else {
+		semantic = strings.Join(split, semverSep)
+	}
+
+	if !strings.HasPrefix(semantic, semverPrefix) {
+		semantic = semverPrefix + semantic
+	}
+
+	result := semver.Canonical(semantic)
+
+	if !semver.IsValid(result) {
+		return "", errors.New(version + " is not possible to convert to a semver format.")
+	}
+
+	return result, nil
+}

--- a/pkg/util/dtversion/dtversion_test.go
+++ b/pkg/util/dtversion/dtversion_test.go
@@ -1,0 +1,91 @@
+package dtversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToSemver(t *testing.T) {
+	type test struct {
+		title         string
+		inputVersion  string
+		outputVersion string
+		expectError   bool
+	}
+
+	testCases := []test{
+		{
+			title:         "full version",
+			inputVersion:  "1.267.209.20231204-134602",
+			outputVersion: "v1.267.209",
+			expectError:   false,
+		},
+		{
+			title:         "partial version works - no dash part at the end",
+			inputVersion:  "1.277.209.20231204",
+			outputVersion: "v1.277.209",
+			expectError:   false,
+		},
+		{
+			title:         "partial version works - only till patch version",
+			inputVersion:  "1.277.209",
+			outputVersion: "v1.277.209",
+			expectError:   false,
+		},
+		{
+			title:         "partial version works - only till minor version",
+			inputVersion:  "1.277",
+			outputVersion: "v1.277.0",
+			expectError:   false,
+		},
+		{
+			title:         "partial version works - only till mayor version",
+			inputVersion:  "1",
+			outputVersion: "v1.0.0",
+			expectError:   false,
+		},
+		{
+			title:         "empty version works",
+			inputVersion:  "",
+			outputVersion: "",
+			expectError:   false,
+		},
+		{
+			title:         "works with 'v' prefix",
+			inputVersion:  "v1.277",
+			outputVersion: "v1.277.0",
+			expectError:   false,
+		},
+		{
+			title:         "works without 'v' prefix",
+			inputVersion:  "1.275.0",
+			outputVersion: "v1.275.0",
+			expectError:   false,
+		},
+		{
+			title:         "malformed version - returns error",
+			inputVersion:  ".4.malformed-",
+			outputVersion: "",
+			expectError:   true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.title, func(t *testing.T) {
+			actual, err := ToSemver(testCase.inputVersion)
+
+			if testCase.expectError {
+				require.Error(t, err)
+				require.Empty(t, actual)
+				assert.Contains(t, err.Error(), testCase.inputVersion)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.outputVersion, actual)
+		})
+	}
+}

--- a/test/features/publicregistry/publicregistry.go
+++ b/test/features/publicregistry/publicregistry.go
@@ -1,0 +1,1 @@
+package publicregistry

--- a/test/features/publicregistry/publicregistry.go
+++ b/test/features/publicregistry/publicregistry.go
@@ -1,1 +1,100 @@
+//go:build e2e
+
 package publicregistry
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
+	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/activegate"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+	"golang.org/x/mod/semver"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	agPublicECR = "public.ecr.aws/dynatrace/dynatrace-activegate"
+	oaPublicECR = "public.ecr.aws/dynatrace/dynatrace-oneagent"
+	cmPublicECR = "public.ecr.aws/dynatrace/dynatrace-codemodules"
+)
+
+// Feature defines the e2e test to verify that public-registry images can be deployed by the operator and that they function
+// This includes:
+//   - ActiveGate StatefulSet gets ready
+//   - CodeModules can be downloaded and mounted
+//   - OneAgent DaemonSet gets ready
+//
+// It determines the latest version of each image using the registry.
+func Feature(t *testing.T) features.Feature {
+	builder := features.New("Public registry images")
+	// Register operator install
+	builder.WithLabel("name", "public-registry-images")
+	secretConfig := tenant.GetSingleTenantSecret(t)
+
+	oaSpec := cloudnative.DefaultCloudNativeSpec()
+	oaSpec.Image = getLatestImageURI(t, oaPublicECR)
+	oaSpec.CodeModulesImage = getLatestImageURI(t, cmPublicECR)
+
+	options := []dynakube.Option{
+		dynakube.WithApiUrl(secretConfig.ApiUrl),
+		dynakube.WithCloudNativeSpec(oaSpec),
+		dynakube.WithActiveGate(),
+		dynakube.WithCustomActiveGateImage(getLatestImageURI(t, agPublicECR)),
+	}
+	testDynakube := *dynakube.New(options...)
+
+	// Register sample app install
+	sampleNamespace := *namespace.New("public-registry-sample")
+	sampleApp := sample.NewApp(t, &testDynakube, sample.WithNamespace(sampleNamespace), sample.AsDeployment())
+
+	builder.Assess("create sample namespace", sampleApp.InstallNamespace())
+
+	// Register dynakube install - will verify OneAgent DaemonSet startup
+	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+
+	// Install Sample apps - will check if CodeModule could be downloaded and mounted
+	builder.Assess("install sample app", sampleApp.Install())
+	cloudnative.AssessSampleInitContainers(builder, sampleApp)
+
+	// Check if the ActiveGate could start up
+	builder.Assess("ActiveGate started", activegate.WaitForStatefulSet(&testDynakube, "activegate"))
+
+	// Register sample, dynakube and operator uninstall
+	builder.Teardown(sampleApp.Uninstall())
+	dynakube.Delete(builder, helpers.LevelTeardown, testDynakube)
+
+	return builder.Feature()
+}
+
+func getLatestImageURI(t *testing.T, repoURI string) string {
+	repo, err := name.NewRepository(repoURI)
+	require.NoError(t, err)
+
+	tags, err := remote.List(repo)
+	slices.SortFunc(tags, func(a, b string) int {
+		if strings.HasPrefix(a, "sha") {
+			return -1
+		}
+		if strings.HasPrefix(b, "sha") {
+			return 1
+		}
+		semverA, _ := dtversion.ToSemver(a)
+		semverB, _ := dtversion.ToSemver(b)
+
+		return semver.Compare(semverA, semverB)
+	})
+	require.NoError(t, err)
+
+	return fmt.Sprintf("%s:%s", repoURI, tags[len(tags)-1])
+}

--- a/test/helpers/components/dynakube/options.go
+++ b/test/helpers/components/dynakube/options.go
@@ -71,6 +71,12 @@ func WithActiveGate() Option {
 	}
 }
 
+func WithCustomActiveGateImage(imageURI string) Option {
+	return func(dynakube *dynakubev1beta1.DynaKube) {
+		dynakube.Spec.ActiveGate.Image = imageURI
+	}
+}
+
 func WithNameBasedNamespaceSelector() Option {
 	return func(dynakube *dynakubev1beta1.DynaKube) {
 		dynakube.Spec.NamespaceSelector = metav1.LabelSelector{

--- a/test/scenarios/standard/standard_test.go
+++ b/test/scenarios/standard/standard_test.go
@@ -3,7 +3,6 @@
 package standard
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/test/features/publicregistry"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/test/features/activegate"
@@ -16,6 +15,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative/network_zones"
 	cloudToClassic "github.com/Dynatrace/dynatrace-operator/test/features/cloudnative/switch_modes"
 	"github.com/Dynatrace/dynatrace-operator/test/features/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/test/features/publicregistry"
 	supportArchive "github.com/Dynatrace/dynatrace-operator/test/features/support_archive"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"

--- a/test/scenarios/standard/standard_test.go
+++ b/test/scenarios/standard/standard_test.go
@@ -3,6 +3,7 @@
 package standard
 
 import (
+	"github.com/Dynatrace/dynatrace-operator/test/features/publicregistry"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/test/features/activegate"
@@ -49,6 +50,7 @@ func TestStandard(t *testing.T) {
 		applicationmonitoring.ReadOnlyCSIVolume(t),
 		applicationmonitoring.WithoutCSI(t),
 		codemodules.InstallFromImage(t),
+		publicregistry.Feature(t),
 		disabledAutoInjection.Feature(t),
 		supportArchive.Feature(t),
 		edgeconnect.Feature(t),


### PR DESCRIPTION
## Description
Adds a e2e test for public-registry images, just to verify that the operator configures them correctly, so they start up.
- Uses the ECR public-registry
- Always uses the latest versions available on said registry

Has also a bit of a refactor for semver conversion.

## How can this be tested?

run `make test/e2e/publicregistry`

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
