### PR TITLE
Move startup-probe from csi-server to csi-provisioner

### DIFF
--- a/cmd/csi/server/builder.go
+++ b/cmd/csi/server/builder.go
@@ -136,7 +136,7 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 			return err
 		}
 
-		err = csidriver.NewServer(csiManager.GetClient(), builder.getCsiOptions(), access).SetupWithManager(csiManager)
+		err = csidriver.NewServer(builder.getCsiOptions(), access).SetupWithManager(csiManager)
 		if err != nil {
 			return err
 		}

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -102,7 +102,6 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
-        {{- include "dynatrace-operator.startupProbe" . | nindent 8 }}
         ports:
         - containerPort: 10080
           name: livez
@@ -142,6 +141,7 @@ spec:
           - name: MAX_UNMOUNTED_VOLUME_AGE
             value: "{{ .Values.csidriver.maxUnmountedVolumeAge}}"
           {{- end }}
+        {{- include "dynatrace-operator.startupProbe" . | nindent 8 }}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -170,14 +170,6 @@ tests:
                   periodSeconds: 5
                   successThreshold: 1
                   timeoutSeconds: 1
-                startupProbe:
-                  exec:
-                    command:
-                      - /usr/local/bin/dynatrace-operator
-                      - startup-probe
-                  periodSeconds: 10
-                  timeoutSeconds: 5
-                  failureThreshold: 1
                 name: server
                 ports:
                   - containerPort: 10080
@@ -224,6 +216,14 @@ tests:
                         fieldPath: metadata.namespace
                 image: image-name
                 imagePullPolicy: Always
+                startupProbe:
+                  exec:
+                    command:
+                      - /usr/local/bin/dynatrace-operator
+                      - startup-probe
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 1
                 livenessProbe:
                   failureThreshold: 3
                   httpGet:

--- a/pkg/controllers/csi/driver/server.go
+++ b/pkg/controllers/csi/driver/server.go
@@ -38,11 +38,9 @@ import (
 	"google.golang.org/grpc/status"
 	"k8s.io/utils/mount"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Server struct {
-	client  client.Client
 	fs      afero.Afero
 	mounter mount.Interface
 	db      metadata.Access
@@ -55,9 +53,8 @@ type Server struct {
 var _ csi.IdentityServer = &Server{}
 var _ csi.NodeServer = &Server{}
 
-func NewServer(client client.Client, opts dtcsi.CSIOptions, db metadata.Access) *Server {
+func NewServer(opts dtcsi.CSIOptions, db metadata.Access) *Server {
 	return &Server{
-		client:  client,
 		opts:    opts,
 		fs:      afero.Afero{Fs: afero.NewOsFs()},
 		mounter: mount.New(""),
@@ -85,8 +82,8 @@ func (svr *Server) Start(ctx context.Context) error {
 	}
 
 	svr.publishers = map[string]csivolumes.Publisher{
-		appvolumes.Mode:  appvolumes.NewAppVolumePublisher(svr.client, svr.fs, svr.mounter, svr.db, svr.path),
-		hostvolumes.Mode: hostvolumes.NewHostVolumePublisher(svr.client, svr.fs, svr.mounter, svr.db, svr.path),
+		appvolumes.Mode:  appvolumes.NewAppVolumePublisher(svr.fs, svr.mounter, svr.db, svr.path),
+		hostvolumes.Mode: hostvolumes.NewHostVolumePublisher(svr.fs, svr.mounter, svr.db, svr.path),
 	}
 
 	log.Info("starting listener", "protocol", proto, "address", addr)

--- a/pkg/controllers/csi/driver/volumes/app/publisher.go
+++ b/pkg/controllers/csi/driver/volumes/app/publisher.go
@@ -34,12 +34,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/utils/mount"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewAppVolumePublisher(client client.Client, fs afero.Afero, mounter mount.Interface, db metadata.Access, path metadata.PathResolver) csivolumes.Publisher {
+func NewAppVolumePublisher(fs afero.Afero, mounter mount.Interface, db metadata.Access, path metadata.PathResolver) csivolumes.Publisher {
 	return &AppVolumePublisher{
-		client:  client,
 		fs:      fs,
 		mounter: mounter,
 		db:      db,
@@ -48,7 +46,6 @@ func NewAppVolumePublisher(client client.Client, fs afero.Afero, mounter mount.I
 }
 
 type AppVolumePublisher struct {
-	client  client.Client
 	fs      afero.Afero
 	mounter mount.Interface
 	db      metadata.Access

--- a/pkg/controllers/csi/driver/volumes/host/publisher.go
+++ b/pkg/controllers/csi/driver/volumes/host/publisher.go
@@ -29,14 +29,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/utils/mount"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const failedToGetOsAgentVolumePrefix = "failed to get osagent volume info from database: "
 
-func NewHostVolumePublisher(client client.Client, fs afero.Afero, mounter mount.Interface, db metadata.Access, path metadata.PathResolver) csivolumes.Publisher {
+func NewHostVolumePublisher(fs afero.Afero, mounter mount.Interface, db metadata.Access, path metadata.PathResolver) csivolumes.Publisher {
 	return &HostVolumePublisher{
-		client:  client,
 		fs:      fs,
 		mounter: mounter,
 		db:      db,
@@ -45,7 +43,6 @@ func NewHostVolumePublisher(client client.Client, fs afero.Afero, mounter mount.
 }
 
 type HostVolumePublisher struct {
-	client  client.Client
 	fs      afero.Afero
 	mounter mount.Interface
 	db      metadata.Access


### PR DESCRIPTION
## Description

The csi-server does not do requests that care about DNS while the csi-provisioner does, so the startup-probe fits there better.

(also removes some deadcode)

## How can this be tested?

Deploy operator, startup-probe is on the csi-provisioner and not the server
(otherwise everything should work as expected)

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
