### PR TITLE
Move startup-probe from csi-server to csi-provisioner #2823

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -102,7 +102,6 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
-        {{- include "dynatrace-operator.startupProbe" . | nindent 8 }}
         ports:
         - containerPort: 10080
           name: livez
@@ -142,6 +141,7 @@ spec:
           - name: MAX_UNMOUNTED_VOLUME_AGE
             value: "{{ .Values.csidriver.maxUnmountedVolumeAge}}"
           {{- end }}
+        {{- include "dynatrace-operator.startupProbe" . | nindent 8 }}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -170,14 +170,6 @@ tests:
                   periodSeconds: 5
                   successThreshold: 1
                   timeoutSeconds: 1
-                startupProbe:
-                  exec:
-                    command:
-                      - /usr/local/bin/dynatrace-operator
-                      - startup-probe
-                  periodSeconds: 10
-                  timeoutSeconds: 5
-                  failureThreshold: 1
                 name: server
                 ports:
                   - containerPort: 10080
@@ -224,6 +216,14 @@ tests:
                         fieldPath: metadata.namespace
                 image: image-name
                 imagePullPolicy: Always
+                startupProbe:
+                  exec:
+                    command:
+                      - /usr/local/bin/dynatrace-operator
+                      - startup-probe
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 1
                 livenessProbe:
                   failureThreshold: 3
                   httpGet:


### PR DESCRIPTION
## Description

Please include the following:

cherry pick of #2823 (without the deadcode removal, due to conflicts)

## How can this be tested?

same as #2823 

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
