### PR TITLE
Set E2E execution at 0AM and tweak dispatchable workfow

### DIFF
--- a/.github/scripts/create-cluster.sh
+++ b/.github/scripts/create-cluster.sh
@@ -2,8 +2,6 @@
 
 set -x
 
-pwd
-
 DEFAULT_TIMEOUT="60m" # K8s takes <10min, Openshift >40min
 
 kubectl version

--- a/.github/scripts/create-cluster.sh
+++ b/.github/scripts/create-cluster.sh
@@ -2,16 +2,18 @@
 
 set -x
 
+pwd
+
 DEFAULT_TIMEOUT="60m" # K8s takes <10min, Openshift >40min
 
 kubectl version
 
-echo "Creating environment '$ENVIRONMENT' in namespace '$NAMESPACE'"
+echo "Creating environment '$FLC_ENVIRONMENT' in namespace '$FLC_NAMESPACE'"
 
-kubectl get flcenvironments --namespace $NAMESPACE
+kubectl get flcenvironments --namespace $FLC_NAMESPACE
 
-echo "Patching environment '$ENVIRONMENT' to 'deployed'"
-kubectl patch --namespace $NAMESPACE --type merge --patch '{"spec": {"desiredState": "environment-deployed"}}' flcenvironment $ENVIRONMENT
+echo "Patching environment '$FLC_ENVIRONMENT' to 'deployed'"
+kubectl patch --namespace $FLC_NAMESPACE --type merge --patch '{"spec": {"desiredState": "environment-deployed"}}' flcenvironment $FLC_ENVIRONMENT
 
-echo "Waiting up to '$DEFAULT_TIMEOUT' for successful deployment of environment '$ENVIRONMENT'"
-kubectl wait --namespace $NAMESPACE --timeout="$DEFAULT_TIMEOUT" --for=condition=InTransition=false flcenvironment $ENVIRONMENT
+echo "Waiting up to '$DEFAULT_TIMEOUT' for successful deployment of environment '$FLC_ENVIRONMENT'"
+kubectl wait --namespace $FLC_NAMESPACE --timeout="$DEFAULT_TIMEOUT" --for=condition=InTransition=false flcenvironment $FLC_ENVIRONMENT

--- a/.github/scripts/destroy-cluster.sh
+++ b/.github/scripts/destroy-cluster.sh
@@ -2,9 +2,9 @@
 
 set -x
 
-echo "Destroying environment '$ENVIRONMENT' in namespace '$NAMESPACE'"
+echo "Destroying environment '$FLC_ENVIRONMENT' in namespace '$FLC_NAMESPACE'"
 
-kubectl get flcenvironments --namespace $NAMESPACE
+kubectl get flcenvironments --namespace "$FLC_NAMESPACE"
 
-echo "Patching environment '$ENVIRONMENT' to 'not-deployed'"
-kubectl patch --namespace $NAMESPACE --type merge --patch '{"spec": {"desiredState": "environment-not-deployed"}}' flcenvironment $ENVIRONMENT
+echo "Patching environment '$FLC_ENVIRONMENT' to 'not-deployed'"
+kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch '{"spec": {"desiredState": "environment-not-deployed"}}' flcenvironment "$FLC_ENVIRONMENT"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,4 +1,4 @@
-name: Run E2E tests
+name: E2E tests
 
 on:
   schedule:
@@ -13,7 +13,7 @@ on:
 
 jobs:
   run-in-k8s:
-    name: Run in Kubernetes (${{ github.event.inputs.target }})
+    name: Run in Kubernetes 1.26 (${{ github.event.inputs.target }})
     environment: E2E
     env:
       FLC_NAMESPACE: dto-k8s-ondemand
@@ -56,7 +56,7 @@ jobs:
     - name: Destroy cluster
       run: ref/.github/scripts/destroy-cluster.sh
   run-in-ocp:
-    name: Run in Openshift (${{ github.event.inputs.target }})
+    name: Run in OpenShift 4.14 (${{ github.event.inputs.target }})
     environment: E2E
     env:
       FLC_NAMESPACE: dto-ocp-ondemand

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -3,16 +3,22 @@ name: Run E2E tests
 on:
   schedule:
     # every work day at 5:00 AM
-    - cron: 5 0 * * 1-5
+    - cron: 0 0 * * 1-5
   workflow_dispatch:
+    inputs:
+      target:
+        description: 'Target branch to run E2E tests over'
+        required: true
+        default: 'main'
 
 jobs:
   run-in-k8s:
-    name: Run in Kubernetes
+    name: Run in Kubernetes (${{ github.event.inputs.target }})
     environment: E2E
     env:
-      NAMESPACE: dto-k8s-ondemand
-      ENVIRONMENT: dto-k8s-1-26
+      FLC_NAMESPACE: dto-k8s-ondemand
+      FLC_ENVIRONMENT: dto-k8s-1-26
+      TARGET_BRANCH: ${{ github.event.inputs.target }}
       TENANT1_NAME: ${{ secrets.TENANT1_NAME }}
       TENANT1_APITOKEN: ${{ secrets.TENANT1_APITOKEN }}
       TENANT1_OTELTOKEN: ${{ secrets.TENANT1_OTELTOKEN }}
@@ -24,30 +30,38 @@ jobs:
     - self-hosted
     - operator-e2e
     steps:
-    - name: Checkout
+    - name: Checkout workflow scripts from ref branch
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        path: ref
+    - name: Checkout target branch
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: ${{ github.event.inputs.target }}
+        path: target
     - name: Set up kubectl
       uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0
     - name: Set up go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version-file: "${{ github.workspace }}/go.mod"
+        go-version-file: "${{ github.workspace }}/target/go.mod"
     - name: Set up helm
       uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Create cluster
-      run: .github/scripts/create-cluster.sh
+      run: ref/.github/scripts/create-cluster.sh
     - name: Run tests
-      run: .github/scripts/run-test.sh
+      run: ref/.github/scripts/run-e2e-tests.sh
     - name: Destroy cluster
-      run: .github/scripts/destroy-cluster.sh
+      run: ref/.github/scripts/destroy-cluster.sh
   run-in-ocp:
-    name: Run in Openshift
+    name: Run in Openshift (${{ github.event.inputs.target }})
     environment: E2E
     env:
-      NAMESPACE: dto-ocp-ondemand
-      ENVIRONMENT: dto-ocp-4-14
+      FLC_NAMESPACE: dto-ocp-ondemand
+      FLC_ENVIRONMENT: dto-ocp-4-14
+      TARGET_BRANCH: ${{ github.event.inputs.target }}
       TENANT1_NAME: ${{ secrets.TENANT1_NAME }}
       TENANT1_APITOKEN: ${{ secrets.TENANT1_APITOKEN }}
       TENANT1_OTELTOKEN: ${{ secrets.TENANT1_OTELTOKEN }}
@@ -59,21 +73,28 @@ jobs:
     - self-hosted
     - operator-e2e
     steps:
-    - name: Checkout
+    - name: Checkout workflow scripts from ref branch
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        path: ref
+    - name: Checkout target branch
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: ${{ github.event.inputs.target }}
+        path: target
     - name: Set up kubectl
       uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0
     - name: Set up go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version-file: "${{ github.workspace }}/go.mod"
+        go-version-file: "${{ github.workspace }}/target/go.mod"
     - name: Set up helm
       uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Create cluster
-      run: .github/scripts/create-cluster.sh
+      run: ref/.github/scripts/create-cluster.sh
     - name: Run tests
-      run: .github/scripts/run-test.sh
+      run: ref/.github/scripts/run-e2e-tests.sh
     - name: Destroy cluster
-      run: .github/scripts/destroy-cluster.sh
+      run: ref/.github/scripts/destroy-cluster.sh


### PR DESCRIPTION
## Description

Now that we turned off Concourse pipeline, we can set the execution time to 00:00 AM.

Now, the E2E tests dispatchable workflow can be executed targeting any branch. The way it works:
- Checkout GH action reference branch
- Checkout target branch
- Use reference branch scripts to run `make test/e2e` on the checked-out target branch (this is necessary in order to not have to cherry-pick the scripts in all branches)
- Profit

## How can this be tested?

[Check previous execution targeting release-1.0](https://github.com/Dynatrace/dynatrace-operator/actions/runs/8114068207)

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
