### PR TITLE
Fix otel metric name duplication

### DIFF
--- a/pkg/webhook/mutation/namespace_mutator/otel.go
+++ b/pkg/webhook/mutation/namespace_mutator/otel.go
@@ -11,11 +11,12 @@ import (
 
 const (
 	// the attribute key needs to be added to the allow list on the receiving tenant
-	mutatedNamespaceNameKey = "webhook.mutationrequest.namespace.name"
+	mutatedNamespaceNameKey            = "webhook.mutationrequest.namespace.name"
+	namespaceMutationHandledMetricName = "handledNamespaceMutationRequests"
 )
 
 func countHandleMutationRequest(ctx context.Context, namespace string) {
-	dtotel.Count(ctx, webhookotel.Meter(), "handledPodMutationRequests", int64(1),
+	dtotel.Count(ctx, webhookotel.Meter(), namespaceMutationHandledMetricName, int64(1),
 		attribute.String(webhookotel.WebhookPodNameKey, webhookotel.GetWebhookPodName()),
 		attribute.String(mutatedNamespaceNameKey, namespace))
 }

--- a/pkg/webhook/mutation/pod_mutator/otel.go
+++ b/pkg/webhook/mutation/pod_mutator/otel.go
@@ -13,7 +13,8 @@ import (
 
 const (
 	// the attribute key needs to be added to the allow list on the receiving tenant.
-	mutatedPodNameKey = "webhook.mutationrequest.pod.name"
+	mutatedPodNameKey            = "webhook.mutationrequest.pod.name"
+	podMutationHandledMetricName = "handledPodMutationRequests"
 )
 
 var envPodName string
@@ -28,7 +29,7 @@ func getWebhookPodName() string {
 }
 
 func countHandleMutationRequest(ctx context.Context, mutatedPodName string) {
-	dtotel.Count(ctx, webhookotel.Meter(), "handledPodMutationRequests", int64(1),
+	dtotel.Count(ctx, webhookotel.Meter(), podMutationHandledMetricName, int64(1),
 		attribute.String(webhookotel.WebhookPodNameKey, getWebhookPodName()),
 		attribute.String(mutatedPodNameKey, mutatedPodName))
 }


### PR DESCRIPTION
## Description

Instead of having 2 different metrics we had 1. (probably copy-pasta 🍝 mistake)

## How can this be tested?

-

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
