### PR TITLE
Fix default value in E2E action

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     env:
       FLC_NAMESPACE: dto-k8s-ondemand
       FLC_ENVIRONMENT: dto-k8s-1-26
-      TARGET_BRANCH: ${{ github.event.inputs.target }}
+      TARGET_BRANCH: ${{ github.event.inputs.target || 'main' }}
       TENANT1_NAME: ${{ secrets.TENANT1_NAME }}
       TENANT1_APITOKEN: ${{ secrets.TENANT1_APITOKEN }}
       TENANT1_OTELTOKEN: ${{ secrets.TENANT1_OTELTOKEN }}
@@ -61,7 +61,7 @@ jobs:
     env:
       FLC_NAMESPACE: dto-ocp-ondemand
       FLC_ENVIRONMENT: dto-ocp-4-14
-      TARGET_BRANCH: ${{ github.event.inputs.target }}
+      TARGET_BRANCH: ${{ github.event.inputs.target || 'main' }}
       TENANT1_NAME: ${{ secrets.TENANT1_NAME }}
       TENANT1_APITOKEN: ${{ secrets.TENANT1_APITOKEN }}
       TENANT1_OTELTOKEN: ${{ secrets.TENANT1_OTELTOKEN }}


### PR DESCRIPTION
## Description

I noticed that on `scheduled` event trigger, the default value from workflow_dispatch is not used. This fixes it.

## How can this be tested?

Wait for tomorrow

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
