### PR TITLE
Add Slack notification when E2E fails

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -109,7 +109,7 @@ jobs:
     steps:
     - name: Notify failure in Slack
       id: slack
-      uses: slackapi/slack-github-action@v1.25.0
+      uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
       with:
         channel-id: 'int-cp-operator'
         slack-message: ":warning: E2E tests failed on ${{ github.event.inputs.target || 'main' }} branch: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -98,3 +98,20 @@ jobs:
       run: ref/.github/scripts/run-e2e-tests.sh
     - name: Destroy cluster
       run: ref/.github/scripts/destroy-cluster.sh
+  notify-failure:
+    name: Notify failure in Slack
+    environment: E2E
+    needs: ["run-in-k8s", "run-in-ocp"]
+    runs-on:
+    - self-hosted
+    - operator-e2e
+    if: failure()
+    steps:
+    - name: Notify failure in Slack
+      id: slack
+      uses: slackapi/slack-github-action@v1.25.0
+      with:
+        channel-id: 'int-cp-operator'
+        slack-message: ":warning: E2E tests failed on ${{ github.event.inputs.target || 'main' }} branch: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Description

Whenever the E2E tests workflow fails, send a notification to the `int-cp-operator` channel.

## How can this be tested?

Tested in sandbox workspace

![image](https://github.com/Dynatrace/dynatrace-operator/assets/61692514/9b15b697-4b87-473b-a79f-6ca3e76aed3f)

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
