### PR TITLE
Fix edgeconnect url in E2E tests

### DIFF
--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -38,7 +38,7 @@ EOF
 cat << EOF > edgeconnect-tenant.yaml
 name: e2e-test
 tenantUid: $TENANT1_NAME
-apiServer: $TENANT1_NAME.dev.apps.dynatracelabs.com/api
+apiServer: $TENANT1_NAME.dev.apps.dynatracelabs.com
 oAuthClientId: $TENANT1_OAUTH_CLIENT_ID
 oAuthClientSecret: $TENANT1_OAUTH_SECRET
 EOF


### PR DESCRIPTION
## Description

Fix API URL on Edgeconnect test secret file

## How can this be tested?

///

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
