### PR TITLE
Destroy FLC cluster after E2E execution

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -55,6 +55,7 @@ jobs:
       run: ref/.github/scripts/run-e2e-tests.sh
     - name: Destroy cluster
       run: ref/.github/scripts/destroy-cluster.sh
+      if: always()
   run-in-ocp:
     name: Run in OpenShift latest (${{ github.event.inputs.target || 'main' }})
     environment: E2E


### PR DESCRIPTION
## Description

Missing step to be triggered always on K8s.

Follow-up user story will handle smart destroyment of clusters (not destroying them always, keeping them alive and doing the cleanup on the next execution if so).

## How can this be tested?

---

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
