### PR TITLE
Add E2E tests slack notification when PASSED tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -107,13 +107,20 @@ jobs:
     runs-on:
     - self-hosted
     - operator-e2e
-    if: failure()
     steps:
-    - name: Notify failure in Slack
-      id: slack
+    - name: Notify success in Slack
+      if: ${{ success() }}
       uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
       with:
         channel-id: 'int-cp-operator'
-        slack-message: ":warning: E2E tests failed on ${{ github.event.inputs.target || 'main' }} branch: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        slack-message: ":check: E2E tests passed on ${{ github.event.inputs.target || 'main' }} branch :peepobeer: (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    - name: Notify failure in Slack
+      if: ${{ failure() || cancelled() }}
+      uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+      with:
+        channel-id: 'int-cp-operator'
+        slack-message: ":x: E2E tests failed on ${{ github.event.inputs.target || 'main' }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Description

Now we also get a SUCCESS message in Slack if the E2E tests pass :smile: 

## How can this be tested?

Tonight will happen

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
