### PR TITLE
Fallback E2E success notification

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -104,20 +104,12 @@ jobs:
     name: Notify failure in Slack
     environment: E2E
     needs: ["run-in-k8s", "run-in-ocp"]
+    if: ${{ failure() || cancelled() }}
     runs-on:
     - self-hosted
     - operator-e2e
     steps:
-    - name: Notify success in Slack
-      if: ${{ success() }}
-      uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
-      with:
-        channel-id: 'int-cp-operator'
-        slack-message: ":check: E2E tests passed on ${{ github.event.inputs.target || 'main' }} branch :peepobeer: (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     - name: Notify failure in Slack
-      if: ${{ failure() || cancelled() }}
       uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
       with:
         channel-id: 'int-cp-operator'


### PR DESCRIPTION
## Description

Turns out is not as easy as I thought to have both FAIL and PASS notifications after E2E tests. This steps failed last night.

Falling back to only having FAIL notification, and will create a story to improve on this as it's taking more time.

## How can this be tested?

Tested on previous workflow runs

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
