### PR TITLE
Publish e2e test results on github

### DIFF
--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -51,6 +51,6 @@ EOF
 popd
 
 echo "Running tests for environment '$FLC_ENVIRONMENT'..."
-make BRANCH="$TARGET_BRANCH" test/e2e
+make BRANCH="$TARGET_BRANCH" test/e2e-publish
 
 echo "Success!"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -53,8 +53,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install gotestsum
-      run: |
-        go install gotest.tools/gotestsum@latest
+      run: go install gotest.tools/gotestsum@latest
     - name: Create cluster
       run: ref/.github/scripts/create-cluster.sh
     - name: Run tests
@@ -65,8 +64,7 @@ jobs:
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
-        files: |
-          target/results/*.xml
+        files: target/results/*.xml
       if: always()
   run-in-ocp:
     name: Run in OpenShift latest (${{ github.event.inputs.target || 'main' }})
@@ -106,8 +104,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install gotestsum
-      run: |
-        go install gotest.tools/gotestsum@latest
+      run: go install gotest.tools/gotestsum@latest
     - name: Create cluster
       run: ref/.github/scripts/create-cluster.sh
     - name: Run tests
@@ -118,8 +115,7 @@ jobs:
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
-        files: |
-          target/results/*.xml
+        files: target/results/*.xml
       if: always()
   notify-failure:
     name: Notify failure in Slack

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -11,6 +11,9 @@ on:
         required: true
         default: 'main'
 
+permissions:
+  checks: write
+
 jobs:
   run-in-k8s:
     name: Run in Kubernetes latest (${{ github.event.inputs.target || 'main' }})
@@ -49,12 +52,21 @@ jobs:
       uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install gotestsum
+      run: |
+        go install gotest.tools/gotestsum@latest
     - name: Create cluster
       run: ref/.github/scripts/create-cluster.sh
     - name: Run tests
       run: ref/.github/scripts/run-e2e-tests.sh
     - name: Destroy cluster
       run: ref/.github/scripts/destroy-cluster.sh
+      if: always()
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        files: |
+          target/results/*.xml
       if: always()
   run-in-ocp:
     name: Run in OpenShift latest (${{ github.event.inputs.target || 'main' }})
@@ -93,12 +105,21 @@ jobs:
       uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install gotestsum
+      run: |
+        go install gotest.tools/gotestsum@latest
     - name: Create cluster
       run: ref/.github/scripts/create-cluster.sh
     - name: Run tests
       run: ref/.github/scripts/run-e2e-tests.sh
     - name: Destroy cluster
       run: ref/.github/scripts/destroy-cluster.sh
+      if: always()
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        files: |
+          target/results/*.xml
       if: always()
   notify-failure:
     name: Notify failure in Slack

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -1,3 +1,9 @@
+GOTESTCMD:=go test
+
+## Start a test and save the result to an xml file
+test/e2e/%/publish:
+	@make GOTESTCMD='gotestsum --junitfile results/$(notdir $(@D)).xml --' $(@D)
+
 ## Start a test and skip TEARDOWN steps if it fails
 test/e2e/%/debug:
 	@make SKIPCLEANUP="--fail-fast" $(@D)
@@ -10,17 +16,25 @@ test/e2e:
 	make test/e2e/release || RC=1; \
 	exit $$RC
 
+## Run standard, istio and release e2e tests
+test/e2e-publish:
+	RC=0; \
+	make test/e2e/standard/publish || RC=1; \
+	make test/e2e/istio/publish || RC=1; \
+	make test/e2e/release/publish || RC=1; \
+	exit $$RC
+
 ## Run standard e2e test only
 test/e2e/standard: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 200m -count=1 ./test/scenarios/standard -args --skip-labels "name=cloudnative-network-zone" $(SKIPCLEANUP)
+	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 200m -count=1 ./test/scenarios/standard -args --skip-labels "name=cloudnative-network-zone" $(SKIPCLEANUP)
 
 ## Run istio e2e test only
 test/e2e/istio: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 200m -count=1 ./test/scenarios/istio -args $(SKIPCLEANUP)
+	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 200m -count=1 ./test/scenarios/istio -args $(SKIPCLEANUP)
 
 ## Run release e2e test only
 test/e2e/release: manifests/crd/helm
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/release -args $(SKIPCLEANUP)
+	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/release -args $(SKIPCLEANUP)
 
 ## Runs ActiveGate e2e test only
 test/e2e/activegate: manifests/crd/helm


### PR DESCRIPTION
## Description

e2e test results are published on the `E2E tests` workflow page.

![image](https://github.com/Dynatrace/dynatrace-operator/assets/84514340/4598d56a-1a5a-4fe1-83db-781b98af60e1)

The main e2e tests can be executed in two ways:
1. to see output on the console:
- test/e2e/standard
- test/e2e/istio
- test/e2e/release
2. to save test results to the `results/` directory:
- test/e2e/standard/publish
- test/e2e/istio/publish
- test/e2e/release/publish

Each `target` creates one file so the following files are created when tests are run by the `e2e-tests` workflow:
- standard.xml
- istio.xml
- release.xml

The workflow then collect data from all files and adds `Test Results` part to the `Summary` page.

## How can this be tested?
Execute e2e tests from github actions.

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
