### PR TITLE
Add scheme field in proxy secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/go-logr/logr v1.4.1
 	github.com/google/go-containerregistry v0.19.0
+	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.17.7
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/opencontainers/go-digest v1.0.0
@@ -76,7 +77,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect

--- a/pkg/controllers/dynakube/proxy/consts.go
+++ b/pkg/controllers/dynakube/proxy/consts.go
@@ -5,6 +5,7 @@ const (
 	portField     = "port"
 	usernameField = "username"
 	passwordField = "password"
+	schemeField   = "scheme"
 
 	SecretMountPath  = "/var/lib/dynatrace/secrets/internal-proxy"
 	SecretVolumeName = "internal-proxy-secret-volume"

--- a/pkg/controllers/dynakube/proxy/reconciler.go
+++ b/pkg/controllers/dynakube/proxy/reconciler.go
@@ -87,6 +87,7 @@ func (r *Reconciler) createProxyMap(ctx context.Context, dynakube *dynatracev1be
 			portField:     []byte(""),
 			usernameField: []byte(""),
 			passwordField: []byte(""),
+			schemeField:   []byte(""),
 		}, nil
 	}
 
@@ -95,7 +96,7 @@ func (r *Reconciler) createProxyMap(ctx context.Context, dynakube *dynatracev1be
 		return nil, err
 	}
 
-	host, port, username, password, err := parseProxyUrl(proxyUrl)
+	scheme, host, port, username, password, err := parseProxyUrl(proxyUrl)
 	if err != nil {
 		return nil, err
 	}
@@ -105,18 +106,19 @@ func (r *Reconciler) createProxyMap(ctx context.Context, dynakube *dynatracev1be
 		portField:     []byte(port),
 		usernameField: []byte(username),
 		passwordField: []byte(password),
+		schemeField:   []byte(scheme),
 	}, nil
 }
 
-func parseProxyUrl(proxy string) (host, port, username, password string, err error) { //nolint:revive // maximum number of return results per function exceeded; max 3 but got 5
+func parseProxyUrl(proxy string) (scheme, host, port, username, password string, err error) { //nolint:revive // maximum number of return results per function exceeded; max 3 but got 6
 	proxyUrl, err := url.Parse(proxy)
 	if err != nil {
-		return "", "", "", "", errors.New("could not parse proxy URL")
+		return "", "", "", "", "", errors.New("could not parse proxy URL")
 	}
 
 	passwd, _ := proxyUrl.User.Password()
 
-	return proxyUrl.Hostname(), proxyUrl.Port(), proxyUrl.User.Username(), passwd, nil
+	return proxyUrl.Scheme, proxyUrl.Hostname(), proxyUrl.Port(), proxyUrl.User.Username(), passwd, nil
 }
 
 func BuildSecretName(dynakubeName string) string {

--- a/pkg/controllers/dynakube/proxy/reconciler_test.go
+++ b/pkg/controllers/dynakube/proxy/reconciler_test.go
@@ -23,6 +23,7 @@ const (
 	proxyPassword          = "secretValue"
 	proxyPort              = "1020"
 	proxyHost              = "proxyserver.net"
+	proxyScheme            = "http"
 	proxyDifferentUsername = "differentUsername"
 )
 
@@ -118,7 +119,7 @@ func TestReconcileWithoutProxy(t *testing.T) {
 
 func TestReconcileProxyValue(t *testing.T) {
 	t.Run(`reconcile proxy Value`, func(t *testing.T) {
-		var proxyValue = buildProxyUrl(proxyUsername, proxyPassword, proxyHost, proxyPort)
+		var proxyValue = buildProxyUrl(proxyScheme, proxyUsername, proxyPassword, proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: proxyValue}
@@ -132,6 +133,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[portField])
 		assert.Equal(t, []byte(proxyHost), proxySecret.Data[hostField])
 		assert.Equal(t, []byte(proxyUsername), proxySecret.Data[usernameField])
+		assert.Equal(t, []byte(proxyScheme), proxySecret.Data[schemeField])
 	})
 	t.Run(`reconcile empty proxy Value`, func(t *testing.T) {
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
@@ -146,11 +148,12 @@ func TestReconcileProxyValue(t *testing.T) {
 		assert.Equal(t, []byte(nil), proxySecret.Data[portField])
 		assert.Equal(t, []byte(nil), proxySecret.Data[hostField])
 		assert.Equal(t, []byte(nil), proxySecret.Data[usernameField])
+		assert.Equal(t, []byte(nil), proxySecret.Data[schemeField])
 	})
 }
 
 func TestReconcileProxyValueFrom(t *testing.T) {
-	var proxyUrl = buildProxyUrl(proxyUsername, proxyPassword, proxyHost, proxyPort)
+	var proxyUrl = buildProxyUrl(proxyScheme, proxyUsername, proxyPassword, proxyHost, proxyPort)
 
 	var testClient = fake.NewClientBuilder().WithObjects(createProxySecret(proxyUrl)).Build()
 	r := newTestReconcilerWithInstance(testClient)
@@ -167,6 +170,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[portField])
 		assert.Equal(t, []byte(proxyHost), proxySecret.Data[hostField])
 		assert.Equal(t, []byte(proxyUsername), proxySecret.Data[usernameField])
+		assert.Equal(t, []byte(proxyScheme), proxySecret.Data[schemeField])
 	})
 	t.Run(`Change of Proxy ValueFrom to Value`, func(t *testing.T) {
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{ValueFrom: customProxySecret}
@@ -181,9 +185,10 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[portField])
 		assert.Equal(t, []byte(proxyHost), proxySecret.Data[hostField])
 		assert.Equal(t, []byte(proxyUsername), proxySecret.Data[usernameField])
+		assert.Equal(t, []byte(proxyScheme), proxySecret.Data[schemeField])
 
 		r.dynakube.Spec.Proxy.ValueFrom = ""
-		r.dynakube.Spec.Proxy.Value = buildProxyUrl(proxyDifferentUsername, proxyPassword, proxyHost, proxyPort)
+		r.dynakube.Spec.Proxy.Value = buildProxyUrl(proxyScheme, proxyDifferentUsername, proxyPassword, proxyHost, proxyPort)
 		err = r.Reconcile(context.Background())
 
 		require.NoError(t, err)
@@ -194,6 +199,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		assert.Equal(t, []byte(proxyPort), proxySecret.Data[portField])
 		assert.Equal(t, []byte(proxyHost), proxySecret.Data[hostField])
 		assert.Equal(t, []byte(proxyDifferentUsername), proxySecret.Data[usernameField])
+		assert.Equal(t, []byte(proxyScheme), proxySecret.Data[schemeField])
 	})
 	t.Run(`reconcile proxy ValueFrom with non existing secret`, func(t *testing.T) {
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{ValueFrom: "secret"}
@@ -213,6 +219,6 @@ func createProxySecret(proxyUrl string) *corev1.Secret {
 	}
 }
 
-func buildProxyUrl(username string, password string, host string, port string) string {
-	return "http://" + username + ":" + password + "@" + host + ":" + port
+func buildProxyUrl(scheme string, username string, password string, host string, port string) string {
+	return scheme + "://" + username + ":" + password + "@" + host + ":" + port
 }


### PR DESCRIPTION
## Description

Add scheme field in Proxy secret

## How can this be tested?

- Unit tests
- Check `<dynakube>-internal-proxy` secret data -> new field "scheme"

## Checklist

- [X] Unit tests have been updated/added
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
