### PR TITLE
Lower case kind annotation on webhook pod mutation

### DIFF
--- a/pkg/webhook/mutation/pod_mutator/dataingest_mutation/mutator.go
+++ b/pkg/webhook/mutation/pod_mutator/dataingest_mutation/mutator.go
@@ -2,6 +2,7 @@ package dataingest_mutation
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/ingestendpoint"
@@ -124,7 +125,9 @@ func setWorkloadAnnotations(pod *corev1.Pod, workload *workloadInfo) {
 		pod.Annotations = make(map[string]string)
 	}
 
-	pod.Annotations[dtwebhook.AnnotationWorkloadKind] = workload.kind
+	// workload kind annotation in lower case according to dt semantic-dictionary
+	// https://bitbucket.lab.dynatrace.org/projects/DEUS/repos/semantic-dictionary/browse/source/fields/k8s.yaml
+	pod.Annotations[dtwebhook.AnnotationWorkloadKind] = strings.ToLower(workload.kind)
 	pod.Annotations[dtwebhook.AnnotationWorkloadName] = workload.name
 }
 

--- a/pkg/webhook/mutation/pod_mutator/dataingest_mutation/mutator_test.go
+++ b/pkg/webhook/mutation/pod_mutator/dataingest_mutation/mutator_test.go
@@ -184,6 +184,12 @@ func TestWorkloadAnnotations(t *testing.T) {
 		assert.Equal(t, testWorkloadInfoName, maputils.GetField(request.Pod.Annotations, dtwebhook.AnnotationWorkloadName, "not-found"))
 		assert.Equal(t, testWorkloadInfoKind, maputils.GetField(request.Pod.Annotations, dtwebhook.AnnotationWorkloadKind, "not-found"))
 	})
+	t.Run("should lower case kind annotation", func(t *testing.T) {
+		request := createTestMutationRequest(nil, nil)
+		setWorkloadAnnotations(request.Pod, &workloadInfo{name: testWorkloadInfoName, kind: "SuperWorkload"})
+		assert.Contains(t, request.Pod.Annotations, dtwebhook.AnnotationWorkloadKind)
+		assert.Equal(t, "superworkload", request.Pod.Annotations[dtwebhook.AnnotationWorkloadKind])
+	})
 }
 
 func TestContainerIsInjected(t *testing.T) {


### PR DESCRIPTION
## Description

Set the Webhook Pod mutation kind annotation to lower case, according to DT semantic dictionary (https://bitbucket.lab.dynatrace.org/projects/DEUS/repos/semantic-dictionary/browse/source/fields/k8s.yaml)

## How can this be tested?

- Unit tests
- Deploy an app workload and check its pods annotations, should contain the workload kind in lower case

## Checklist

- [X] Unit tests have been updated/added
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
