### PR TITLE
Ignore terminating namespace during mapping (#2877)

### DIFF
--- a/pkg/util/kubeobjects/secret/secret.go
+++ b/pkg/util/kubeobjects/secret/secret.go
@@ -119,6 +119,12 @@ func (query Query) createOrUpdateForNamespaces(newSecret corev1.Secret, namespac
 	creationCount := 0
 	var errs []error
 	for _, namespace := range namespaces {
+		if namespace.Status.Phase == corev1.NamespaceTerminating {
+			query.Log.Info("skipping terminating namespace", "namespace", namespace.Name)
+
+			continue
+		}
+
 		newSecret.Namespace = namespace.Name
 		if oldSecret, ok := namespacesContainingSecret[namespace.Name]; ok {
 			if !AreSecretsEqual(oldSecret, newSecret) {

--- a/pkg/util/kubeobjects/secret/secret_test.go
+++ b/pkg/util/kubeobjects/secret/secret_test.go
@@ -147,6 +147,14 @@ func TestMultipleSecrets(t *testing.T) {
 					Name: "nsNotYetExisting",
 				},
 			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nsTerminating",
+				},
+				Status: corev1.NamespaceStatus{
+					Phase: corev1.NamespaceTerminating,
+				},
+			},
 		}
 
 		secret := corev1.Secret{

--- a/pkg/webhook/mutation/namespace_mutator/mutator.go
+++ b/pkg/webhook/mutation/namespace_mutator/mutator.go
@@ -48,8 +48,8 @@ func (nm *namespaceMutator) Handle(ctx context.Context, request admission.Reques
 	}
 
 	log.Info("namespace request", "namespace", request.Name, "operation", request.Operation)
+
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: request.Namespace}}
-	nsMapper := mapper.NewNamespaceMapper(nm.client, nm.apiReader, nm.namespace, &ns)
 	if err := decodeRequestToNamespace(request, &ns); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
@@ -61,6 +61,8 @@ func (nm *namespaceMutator) Handle(ctx context.Context, request admission.Reques
 	}
 
 	log.Info("checking namespace labels", "namespace", request.Name)
+
+	nsMapper := mapper.NewNamespaceMapper(nm.client, nm.apiReader, nm.namespace, &ns)
 	updatedNamespace, err := nsMapper.MapFromNamespace(ctx)
 	if err != nil {
 		span.RecordError(err)


### PR DESCRIPTION
## Description

same as #2877

## How can this be tested?

same as #2877

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
