### PR TITLE
Mount trustedCAs configmap to the ActiveGate pod

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -3452,7 +3452,7 @@ spec:
               trustedCAs:
                 description: |-
                   Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
-                  Note: Applies only to Dynatrace Operator and OneAgent, not to ActiveGate.
+                  Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.
                 type: string
             required:
             - apiUrl

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -4117,7 +4117,7 @@ spec:
               trustedCAs:
                 description: |-
                   Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
-                  Note: Applies only to Dynatrace Operator and OneAgent, not to ActiveGate.
+                  Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.
                 type: string
             required:
             - apiUrl

--- a/doc/api/dynakube-api-ref.md
+++ b/doc/api/dynakube-api-ref.md
@@ -12,7 +12,7 @@
 |proxy|Set custom proxy settings either directly or from a secret with the field proxy. Note: Applies to Dynatrace Operator, ActiveGate, and OneAgents.|-|object|
 |skipCertCheck|Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster. Set to true if you want to skip certification validation checks.|-|boolean|
 |tokens|Name of the secret holding the tokens used for connecting to Dynatrace.|-|string|
-|trustedCAs|Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap. Note: Applies only to Dynatrace Operator and OneAgent, not to ActiveGate.|-|string|
+|trustedCAs|Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap. Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.|-|string|
 
 ### .spec.oneAgent
 

--- a/pkg/api/v1beta1/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta1/dynakube/dynakube_types.go
@@ -106,7 +106,7 @@ type DynaKubeSpec struct { //nolint:revive
 	Tokens string `json:"tokens,omitempty"`
 
 	// Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
-	// Note: Applies only to Dynatrace Operator and OneAgent, not to ActiveGate.
+	// Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Trusted CAs",order=6,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:ConfigMap"}
 	TrustedCAs string `json:"trustedCAs,omitempty"`

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
@@ -29,7 +29,9 @@ type initContainerModifier interface {
 func GenerateAllModifiers(dynakube dynatracev1beta1.DynaKube, capability capability.Capability, agBaseContainerEnvMap *prioritymap.Map) []builder.Modifier {
 	return []builder.Modifier{
 		NewAuthTokenModifier(dynakube),
+		NewSSLVolumeModifier(dynakube),
 		NewCertificatesModifier(dynakube),
+		NewTrustedCAsVolumeModifier(dynakube),
 		NewCustomPropertiesModifier(dynakube, capability),
 		NewProxyModifier(dynakube),
 		NewRawImageModifier(dynakube, agBaseContainerEnvMap),

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/ssl_volume.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/ssl_volume.go
@@ -1,8 +1,6 @@
 package modifiers
 
 import (
-	"path/filepath"
-
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
@@ -11,30 +9,25 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ volumeModifier = CertificatesModifier{}
-var _ volumeMountModifier = CertificatesModifier{}
-var _ builder.Modifier = CertificatesModifier{}
+var _ volumeModifier = SSLVolumeModifier{}
+var _ volumeMountModifier = SSLVolumeModifier{}
+var _ builder.Modifier = SSLVolumeModifier{}
 
-const (
-	jettyCerts     = "server-certs"
-	secretsRootDir = "/var/lib/dynatrace/secrets/"
-)
-
-func NewCertificatesModifier(dynakube dynatracev1beta1.DynaKube) CertificatesModifier {
-	return CertificatesModifier{
+func NewSSLVolumeModifier(dynakube dynatracev1beta1.DynaKube) SSLVolumeModifier {
+	return SSLVolumeModifier{
 		dynakube: dynakube,
 	}
 }
 
-type CertificatesModifier struct {
+type SSLVolumeModifier struct {
 	dynakube dynatracev1beta1.DynaKube
 }
 
-func (mod CertificatesModifier) Enabled() bool {
-	return mod.dynakube.HasActiveGateCaCert()
+func (mod SSLVolumeModifier) Enabled() bool {
+	return mod.dynakube.HasActiveGateCaCert() || mod.dynakube.Spec.TrustedCAs != ""
 }
 
-func (mod CertificatesModifier) Modify(sts *appsv1.StatefulSet) error {
+func (mod SSLVolumeModifier) Modify(sts *appsv1.StatefulSet) error {
 	baseContainer := container.FindContainerInPodSpec(&sts.Spec.Template.Spec, consts.ActiveGateContainerName)
 	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, mod.getVolumes()...)
 	baseContainer.VolumeMounts = append(baseContainer.VolumeMounts, mod.getVolumeMounts()...)
@@ -42,25 +35,23 @@ func (mod CertificatesModifier) Modify(sts *appsv1.StatefulSet) error {
 	return nil
 }
 
-func (mod CertificatesModifier) getVolumes() []corev1.Volume {
+func (mod SSLVolumeModifier) getVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{
-			Name: jettyCerts,
+			Name: consts.GatewaySslVolumeName,
 			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: mod.dynakube.Spec.ActiveGate.TlsSecretName,
-				},
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
 	}
 }
 
-func (mod CertificatesModifier) getVolumeMounts() []corev1.VolumeMount {
+func (mod SSLVolumeModifier) getVolumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
-			ReadOnly:  true,
-			Name:      jettyCerts,
-			MountPath: filepath.Join(secretsRootDir, "tls"),
+			ReadOnly:  false,
+			Name:      consts.GatewaySslVolumeName,
+			MountPath: consts.GatewaySslMountPoint,
 		},
 	}
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/ssl_volume_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/ssl_volume_test.go
@@ -1,0 +1,56 @@
+package modifiers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSLVolumeEnabled(t *testing.T) {
+	t.Run("true - TlsSecretName", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		enableKubeMonCapability(&dynakube)
+		dynakube.Spec.ActiveGate.TlsSecretName = testTlsSecretName
+
+		mod := NewSSLVolumeModifier(dynakube)
+
+		assert.True(t, mod.Enabled())
+	})
+
+	t.Run("true - TrustedCAs", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		enableKubeMonCapability(&dynakube)
+		dynakube.Spec.TrustedCAs = testTlsSecretName
+
+		mod := NewSSLVolumeModifier(dynakube)
+
+		assert.True(t, mod.Enabled())
+	})
+
+	t.Run("false", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		enableKubeMonCapability(&dynakube)
+
+		mod := NewSSLVolumeModifier(dynakube)
+
+		assert.False(t, mod.Enabled())
+	})
+}
+
+func TestSSLVolumeModify(t *testing.T) {
+	t.Run("successfully modified", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		enableKubeMonCapability(&dynakube)
+		dynakube.Spec.ActiveGate.TlsSecretName = testTlsSecretName
+
+		mod := NewSSLVolumeModifier(dynakube)
+		builder := createBuilderForTesting()
+
+		sts, _ := builder.AddModifier(mod).Build()
+
+		require.NotEmpty(t, sts)
+		isSubset(t, mod.getVolumes(), sts.Spec.Template.Spec.Volumes)
+		isSubset(t, mod.getVolumeMounts(), sts.Spec.Template.Spec.Containers[0].VolumeMounts)
+	})
+}

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume.go
@@ -1,0 +1,73 @@
+package modifiers
+
+import (
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/container"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ volumeModifier = TrustedCAsModifier{}
+var _ volumeMountModifier = TrustedCAsModifier{}
+var _ builder.Modifier = TrustedCAsModifier{}
+
+const (
+	volumeName     = "trustedcas"
+	trustedCAsDir  = "/var/lib/dynatrace/secrets/rootca"
+	trustedCAsFile = "rootca.pem"
+)
+
+func NewTrustedCAsVolumeModifier(dynakube dynatracev1beta1.DynaKube) TrustedCAsModifier {
+	return TrustedCAsModifier{
+		dynakube: dynakube,
+	}
+}
+
+type TrustedCAsModifier struct {
+	dynakube dynatracev1beta1.DynaKube
+}
+
+func (mod TrustedCAsModifier) Enabled() bool {
+	return mod.dynakube.Spec.TrustedCAs != ""
+}
+
+func (mod TrustedCAsModifier) Modify(sts *appsv1.StatefulSet) error {
+	baseContainer := container.FindContainerInPodSpec(&sts.Spec.Template.Spec, consts.ActiveGateContainerName)
+	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, mod.getVolumes()...)
+	baseContainer.VolumeMounts = append(baseContainer.VolumeMounts, mod.getVolumeMounts()...)
+
+	return nil
+}
+
+func (mod TrustedCAsModifier) getVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: mod.dynakube.Spec.TrustedCAs,
+					},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "certs",
+							Path: trustedCAsFile,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (mod TrustedCAsModifier) getVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			ReadOnly:  true,
+			Name:      volumeName,
+			MountPath: trustedCAsDir,
+		},
+	}
+}

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume_test.go
@@ -1,0 +1,56 @@
+package modifiers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrustedCAsVolumeEnabled(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		enableKubeMonCapability(&dynakube)
+		dynakube.Spec.TrustedCAs = testTlsSecretName
+
+		mod := NewTrustedCAsVolumeModifier(dynakube)
+
+		assert.True(t, mod.Enabled())
+	})
+
+	t.Run("false - TlsSecretName", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		enableKubeMonCapability(&dynakube)
+		dynakube.Spec.ActiveGate.TlsSecretName = testTlsSecretName
+
+		mod := NewTrustedCAsVolumeModifier(dynakube)
+
+		assert.False(t, mod.Enabled())
+	})
+
+	t.Run("false", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		enableKubeMonCapability(&dynakube)
+
+		mod := NewTrustedCAsVolumeModifier(dynakube)
+
+		assert.False(t, mod.Enabled())
+	})
+}
+
+func TestTrustedCAsVolumeModify(t *testing.T) {
+	t.Run("successfully modified", func(t *testing.T) {
+		dynakube := getBaseDynakube()
+		enableKubeMonCapability(&dynakube)
+		dynakube.Spec.TrustedCAs = testTlsSecretName
+
+		mod := NewTrustedCAsVolumeModifier(dynakube)
+		builder := createBuilderForTesting()
+
+		sts, _ := builder.AddModifier(mod).Build()
+
+		require.NotEmpty(t, sts)
+		isSubset(t, mod.getVolumes(), sts.Spec.Template.Spec.Volumes)
+		isSubset(t, mod.getVolumeMounts(), sts.Spec.Template.Spec.Containers[0].VolumeMounts)
+	})
+}


### PR DESCRIPTION
## Description

We want ActiveGate to be able to communicate with other HTTPS servers (proxy, dynatrace server) using custom TLS certificates.

`dynakube.spec.trustedCAs` configmap is automatically mounted to the ActiveGate pod. `entrypoint.sh` script of the AG image imports all certificates and configures AG accordingly.

## How can this be tested?

Unittests:
```
make go/test
```

Using a HTTPS proxy with custom certificate:
```
  activeGate:                                                                                                                                                                                                                                                                                                                                                                                 
    capabilities:                                                                                                                                                                                                                                                                                                                                                                             
      - routing                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  proxy:                                                                                                                                                                                                                                                                                                                                                                                      
      value: https://squid.proxy:3128                                                                                                                                                                                                                                                                                                                                                         
  trustedCAs: proxycert  
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
