### PR TITLE
Fix missing ConnectionInfo secret in case of no app monitoring

### DIFF
--- a/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
@@ -45,7 +45,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader, scheme *runtime.S
 var NoOneAgentCommunicationHostsError = errors.New("no communication hosts for OneAgent are available")
 
 func (r *reconciler) Reconcile(ctx context.Context) error {
-	if !r.dynakube.NeedAppInjection() || !r.dynakube.NeedsOneAgent() {
+	if !r.dynakube.NeedAppInjection() && !r.dynakube.NeedsOneAgent() {
 		meta.RemoveStatusCondition(r.dynakube.Conditions(), oaConnectionInfoConditionType)
 		r.dynakube.Status.OneAgent.ConnectionInfoStatus = dynatracev1beta1.OneAgentConnectionInfoStatus{}
 		// TODO: Delete secret if there


### PR DESCRIPTION
## Description

It's just a fix for a little logic mess up.

In case of `ClassicFullStack` or `HostMonitroing` the oneagent-connection-info creation was skipped, because the initial "is-needed" check was incorrect. (used `||` instead of `&&`). Added an extra test to make sure this doesn't happen again. 

## How can this be tested?

Deploy a dynakube with `ClassicFullStack` or `HostMonitroing`. 

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
