### PR TITLE
Version reconcile only fails if there is no version info in the status

### DIFF
--- a/pkg/controllers/dynakube/version/reconciler.go
+++ b/pkg/controllers/dynakube/version/reconciler.go
@@ -70,7 +70,13 @@ func (r *reconciler) updateVersionStatuses(ctx context.Context, updater StatusUp
 
 	err := r.run(ctx, updater)
 	if err != nil {
-		return err
+		if updater.Target().ImageID == "" && updater.Target().Version == "" {
+			log.Info("unable to set version info, no previous version to fallback to", "component", updater.Name())
+
+			return err
+		}
+
+		log.Error(err, "unable to refresh version info, moving on with version from previous run", "component", updater.Name())
 	}
 
 	_, ok := updater.(*oneAgentUpdater)

--- a/pkg/controllers/dynakube/version/reconciler_test.go
+++ b/pkg/controllers/dynakube/version/reconciler_test.go
@@ -143,6 +143,43 @@ func TestReconcile(t *testing.T) {
 	})
 }
 
+func TestUpdateVersionStatuses(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty version info + failing reconcile => return error", func(t *testing.T) {
+		mockClient := dtclientmock.NewClient(t)
+		versionReconciler := reconciler{
+			dtClient:     mockClient,
+			apiReader:    fake.NewClient(),
+			timeProvider: timeprovider.New().Freeze(),
+		}
+		err := versionReconciler.updateVersionStatuses(ctx, newFailingUpdater(t, &status.VersionStatus{}), &dynatracev1beta1.DynaKube{})
+		require.Error(t, err)
+	})
+
+	t.Run("version info (.Version) set + failing reconcile => return nil", func(t *testing.T) {
+		mockClient := dtclientmock.NewClient(t)
+		versionReconciler := reconciler{
+			dtClient:     mockClient,
+			apiReader:    fake.NewClient(),
+			timeProvider: timeprovider.New().Freeze(),
+		}
+		err := versionReconciler.updateVersionStatuses(ctx, newFailingUpdater(t, &status.VersionStatus{Version: "1.2.3"}), &dynatracev1beta1.DynaKube{})
+		require.NoError(t, err)
+	})
+
+	t.Run("version info (.ImageID) set + failing reconcile => return nil", func(t *testing.T) {
+		mockClient := dtclientmock.NewClient(t)
+		versionReconciler := reconciler{
+			dtClient:     mockClient,
+			apiReader:    fake.NewClient(),
+			timeProvider: timeprovider.New().Freeze(),
+		}
+		err := versionReconciler.updateVersionStatuses(ctx, newFailingUpdater(t, &status.VersionStatus{ImageID: "1.2.3"}), &dynatracev1beta1.DynaKube{})
+		require.NoError(t, err)
+	})
+}
+
 func TestNeedsUpdate(t *testing.T) {
 	timeProvider := timeprovider.New().Freeze()
 

--- a/pkg/controllers/dynakube/version/updater_test.go
+++ b/pkg/controllers/dynakube/version/updater_test.go
@@ -9,6 +9,7 @@ import (
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	versionmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -295,6 +296,16 @@ func newCustomVersionUpdater(t *testing.T, target *status.VersionStatus, version
 	updater.On("CustomImage").Maybe().Return("")
 	updater.On("IsPublicRegistryEnabled").Maybe().Maybe().Return(false)
 	updater.On("CustomVersion").Maybe().Return(version)
+
+	return updater
+}
+
+func newFailingUpdater(t *testing.T, target *status.VersionStatus) *versionmock.StatusUpdater {
+	updater := newBaseUpdater(t, target, true)
+	updater.On("CustomImage").Maybe().Return("")
+	updater.On("IsPublicRegistryEnabled").Maybe().Return(false)
+	updater.On("CustomVersion").Maybe().Return("")
+	updater.On("UseTenantRegistry", mock.Anything).Maybe().Return(errors.New("BOOM"))
 
 	return updater
 }


### PR DESCRIPTION
## Description

We don't want to block a reconciliation if we fail to refresh the version information for a given component.
So we only fail the version reconcile for a component if there is nothing to fall back to; otherwise, we log the error (for specific components that even have a condition `VerificationFailed`) and move on.

## How can this be tested?

The unit test is pretty straightforward, otherwise, you can:

Deploy a Dyankube that will do some "version-reconciling","" check that I didn't break the default behavior.
Then, somehow try to break the few requests we do for version reconciling. (one way would be to lower the latest oneagent in the tenant, so the downgrade check will fail)
And notice that everything is fine because we just fallback to the previous version.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
