### PR TITLE
Fix typo in otel doc

### DIFF
--- a/doc/otel.md
+++ b/doc/otel.md
@@ -1,4 +1,4 @@
-# Open Telemetry in the operator
+# OpenTelemetry in the operator
 
 *Note:* This guide is still work-in-progress and will evolve as we learn more about OpenTelemetry instrumentation best practices.
 


### PR DESCRIPTION
## Description

It's `OpenTelemetry`, no `Open Telemetry` (otel guys reached out after checking the docs)

## How can this be tested?

https://opentelemetry.io/

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
