### PR TITLE
Increase codemodules storage size delta in E2E tests

### DIFF
--- a/test/features/cloudnative/codemodules/codemodules.go
+++ b/test/features/cloudnative/codemodules/codemodules.go
@@ -48,7 +48,7 @@ import (
 const (
 	codeModulesVersion = "1.246.0.20220627-183412"
 	codeModulesImage   = "quay.io/dynatrace/codemodules:" + codeModulesVersion
-	diskUsageKiBDelta  = 100000
+	diskUsageKiBDelta  = 1000000
 
 	dataPath                 = "/data/"
 	provisionerContainerName = "provisioner"


### PR DESCRIPTION
## Description

Agent binary got bigger, to fix the E2E test we need to increase the storage size delta.

Failed E2E -> https://github.com/Dynatrace/dynatrace-operator/actions/runs/8444596233

## How can this be tested?

We will see tonight

## Checklist

- [X] Unit tests have been updated/added
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
