### PR TITLE
Fix OLM release workflow

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -184,6 +184,9 @@ linters-settings:
       - '1234'
   dupl:
     threshold: 150
+  godot:
+    exclude:
+      - '^\ \+'
 
 linters:
   disable-all: true

--- a/pkg/api/v1alpha1/dynakube/dynakube_types.go
+++ b/pkg/api/v1alpha1/dynakube/dynakube_types.go
@@ -323,7 +323,7 @@ func (dk *DynaKubeStatus) SetPhase(phase status.DeploymentPhase) bool {
 // +kubebuilder:printcolumn:name="Tokens",type=string,JSONPath=`.status.tokens`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +operator-sdk:csv:customresourcedefinitions:displayName="Dynatrace DynaKube"
-// +operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,},{DaemonSet,v1,},{Pod,v1,}}.
+// +operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,},{DaemonSet,v1,},{Pod,v1,}}
 type DynaKube struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/dynakube/dynakube_types.go
+++ b/pkg/api/v1alpha1/dynakube/dynakube_types.go
@@ -314,7 +314,7 @@ func (dk *DynaKubeStatus) SetPhase(phase status.DeploymentPhase) bool {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// DynaKube is the Schema for the DynaKube API
+// DynaKube is the Schema for the DynaKube API.
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/pkg/api/v1beta1/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta1/dynakube/dynakube_types.go
@@ -58,7 +58,7 @@ type DynaKubeValueSource struct { // nolint:revive
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
 
-// DynaKube is the Schema for the DynaKube API
+// DynaKube is the Schema for the DynaKube API.
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/pkg/api/v1beta1/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta1/dynakube/dynakube_types.go
@@ -67,7 +67,7 @@ type DynaKubeValueSource struct { // nolint:revive
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +operator-sdk:csv:customresourcedefinitions:displayName="Dynatrace DynaKube"
-// +operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,},{DaemonSet,v1,},{Pod,v1,}}.
+// +operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,},{DaemonSet,v1,},{Pod,v1,}}
 type DynaKube struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
## Description

Currently our OLM make bundle script fails with: 

`/tmp/build/58f3eac1/dynatrace-operator/pkg/api/v1alpha1/dynakube/dynakube_types.go:326:1: expected comma, got "." (at <input>:1:56)
/tmp/build/58f3eac1/dynatrace-operator/pkg/api/v1alpha1/dynakube/dynakube_types.go:326:1: expected comma, got "." (at <input>:1:56)
/tmp/build/58f3eac1/dynatrace-operator/pkg/api/v1beta1/dynakube/dynakube_types.go:70:1: expected comma, got "." (at <input>:1:56)
/tmp/build/58f3eac1/dynatrace-operator/pkg/api/v1beta1/dynakube/dynakube_types.go:70:1: expected comma, got "." (at <input>:1:56)
FATA[0000] Error generating kustomize files: error getting ClusterServiceVersion base: error generating ClusterServiceVersion definitions metadata: one or more API packages had type errors 
 `

## How can this be tested?

make bundle

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
