### PR TITLE
Combined certificates from the init secret propagated to the injected agent

### DIFF
--- a/pkg/api/v1beta1/dynakube/certs.go
+++ b/pkg/api/v1beta1/dynakube/certs.go
@@ -46,7 +46,7 @@ func (dk *DynaKube) TrustedCAs(ctx context.Context, kubeReader client.Reader) ([
 	return nil, nil
 }
 
-func (dk *DynaKube) ActiveGateTlsCert(ctx context.Context, kubeReader client.Reader) (string, error) {
+func (dk *DynaKube) ActiveGateTlsCert(ctx context.Context, kubeReader client.Reader) ([]byte, error) {
 	if dk.HasActiveGateCaCert() {
 		secretName := dk.Spec.ActiveGate.TlsSecretName
 
@@ -54,11 +54,13 @@ func (dk *DynaKube) ActiveGateTlsCert(ctx context.Context, kubeReader client.Rea
 
 		err := kubeReader.Get(ctx, client.ObjectKey{Name: secretName, Namespace: dk.Namespace}, &tlsSecret)
 		if err != nil {
-			return "", errors.WithMessage(err, fmt.Sprintf("failed to get activeGate tlsCert from %s secret", secretName))
+			return nil, errors.WithMessage(err, fmt.Sprintf("failed to get activeGate tlsCert from %s secret", secretName))
 		}
 
-		return string(tlsSecret.Data[TlsCertKey]), nil
+		if tlsCertKey, ok := tlsSecret.Data[TlsCertKey]; ok {
+			return tlsCertKey, nil
+		}
 	}
 
-	return "", nil
+	return nil, nil
 }

--- a/pkg/consts/agent_injection.go
+++ b/pkg/consts/agent_injection.go
@@ -29,4 +29,9 @@ const (
 	AgentShareDirMount    = "/mnt/share"
 	AgentConfigDirMount   = "/mnt/config"
 	AgentConfInitDirMount = "/mnt/agent-conf"
+
+	TrustedCAsInitSecretField    = "trustedcas"
+	ActiveGateCAsInitSecretField = "agcerts"
+	CustomCertsFileName          = "custom.pem"
+	CustomProxyCertsFileName     = "custom_proxy.pem"
 )

--- a/pkg/injection/namespace/initgeneration/initgeneration.go
+++ b/pkg/injection/namespace/initgeneration/initgeneration.go
@@ -121,7 +121,17 @@ func (g *InitGenerator) generate(ctx context.Context, dk *dynatracev1beta1.DynaK
 		return nil, err
 	}
 
-	data, err := g.createSecretData(secretConfig)
+	agCerts, err := dk.ActiveGateTlsCert(ctx, g.apiReader)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	trustedCAs, err := dk.TrustedCAs(ctx, g.apiReader)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	data, err := g.createSecretData(secretConfig, agCerts, trustedCAs)
 	if err != nil {
 		return nil, err
 	}
@@ -145,16 +155,6 @@ func (g *InitGenerator) createSecretConfigForDynaKube(ctx context.Context, dynak
 		}
 	}
 
-	trustedCAs, err := dynakube.TrustedCAs(ctx, g.apiReader)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	tlsCert, err := dynakube.ActiveGateTlsCert(ctx, g.apiReader)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
 	oneAgentNoProxy := ""
 
 	if dynakube.NeedsActiveGate() {
@@ -171,11 +171,9 @@ func (g *InitGenerator) createSecretConfigForDynaKube(ctx context.Context, dynak
 		NoProxy:             dynakube.FeatureNoProxy(),
 		OneAgentNoProxy:     oneAgentNoProxy,
 		NetworkZone:         dynakube.Spec.NetworkZone,
-		TrustedCAs:          string(trustedCAs),
 		SkipCertCheck:       dynakube.Spec.SkipCertCheck,
 		HasHost:             dynakube.CloudNativeFullstackMode(),
 		MonitoringNodes:     hostMonitoringNodes,
-		TlsCert:             tlsCert,
 		HostGroup:           dynakube.HostGroup(),
 		InitialConnectRetry: dynakube.FeatureAgentInitialConnectRetry(),
 		EnforcementMode:     dynakube.FeatureEnforcementMode(),
@@ -274,14 +272,16 @@ func (g *InitGenerator) initIMNodes() (nodeInfo, error) {
 	return nodeInfo{nodes: nodeList.Items, imNodes: imNodes}, nil
 }
 
-func (g *InitGenerator) createSecretData(secretConfig *startup.SecretConfig) (map[string][]byte, error) {
+func (g *InitGenerator) createSecretData(secretConfig *startup.SecretConfig, agCerts []byte, cas []byte) (map[string][]byte, error) {
 	jsonContent, err := json.Marshal(*secretConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	return map[string][]byte{
-		consts.AgentInitSecretConfigField: jsonContent,
-		dynatracev1beta1.ProxyKey:         []byte(secretConfig.Proxy), // needed so that it can be mounted to the user's pod without directly reading the secret
+		consts.AgentInitSecretConfigField:   jsonContent,
+		dynatracev1beta1.ProxyKey:           []byte(secretConfig.Proxy), // needed so that it can be mounted to the user's pod without directly reading the secret
+		consts.ActiveGateCAsInitSecretField: agCerts,
+		consts.TrustedCAsInitSecretField:    cas,
 	}, nil
 }

--- a/pkg/injection/startup/dtclient_builder.go
+++ b/pkg/injection/startup/dtclient_builder.go
@@ -5,14 +5,16 @@ import (
 )
 
 type dtclientBuilder struct {
-	config  *SecretConfig
-	options []dtclient.Option
+	config     *SecretConfig
+	trustedCAs string
+	options    []dtclient.Option
 }
 
-func newDTClientBuilder(config *SecretConfig) *dtclientBuilder {
+func newDTClientBuilder(config *SecretConfig, trustedCAs string) *dtclientBuilder {
 	return &dtclientBuilder{
-		config:  config,
-		options: []dtclient.Option{},
+		config:     config,
+		trustedCAs: trustedCAs,
+		options:    []dtclient.Option{},
 	}
 }
 
@@ -72,9 +74,9 @@ func (builder *dtclientBuilder) addHostGroup() {
 }
 
 func (builder *dtclientBuilder) addTrustedCerts() {
-	if builder.config.TrustedCAs != "" {
+	if builder.trustedCAs != "" {
 		log.Info("using TrustedCAs, check the secret for more details")
 
-		builder.options = append(builder.options, dtclient.Certs([]byte(builder.config.TrustedCAs)))
+		builder.options = append(builder.options, dtclient.Certs([]byte(builder.trustedCAs)))
 	}
 }

--- a/pkg/injection/startup/dtclient_builder_test.go
+++ b/pkg/injection/startup/dtclient_builder_test.go
@@ -10,7 +10,7 @@ import (
 func TestCreateClient(t *testing.T) {
 	t.Run(`no options`, func(t *testing.T) {
 		config := basicTestSecretConfigForClient()
-		builder := newDTClientBuilder(config)
+		builder := newDTClientBuilder(config, "")
 
 		client, err := builder.createClient()
 
@@ -22,7 +22,7 @@ func TestCreateClient(t *testing.T) {
 
 	t.Run(`multiple options`, func(t *testing.T) {
 		config := complexTestSecretConfigForClient()
-		builder := newDTClientBuilder(config)
+		builder := newDTClientBuilder(config, testTrustedCA)
 
 		client, err := builder.createClient()
 
@@ -49,6 +49,5 @@ func complexTestSecretConfigForClient() *SecretConfig {
 		Proxy:       testProxy,
 		NoProxy:     testNoProxy,
 		NetworkZone: testNetworkZone,
-		TrustedCAs:  testTrustedCA,
 	}
 }

--- a/pkg/injection/startup/files.go
+++ b/pkg/injection/startup/files.go
@@ -96,7 +96,7 @@ func (runner *Runner) createJsonEnrichmentFile() error {
 	)
 	jsonPath := filepath.Join(consts.EnrichmentMountPath, fmt.Sprintf(consts.EnrichmentFilenameTemplate, "json"))
 
-	return runner.createConfFile(jsonPath, jsonContent)
+	return runner.createConfigFile(jsonPath, jsonContent, true)
 }
 
 func (runner *Runner) createPropsEnrichmentFile() error {
@@ -110,39 +110,32 @@ func (runner *Runner) createPropsEnrichmentFile() error {
 	)
 	propsPath := filepath.Join(consts.EnrichmentMountPath, fmt.Sprintf(consts.EnrichmentFilenameTemplate, "properties"))
 
-	return runner.createConfFile(propsPath, propsContent)
+	return runner.createConfigFile(propsPath, propsContent, true)
 }
 
 func (runner *Runner) createCurlOptionsFile() error {
 	content := runner.getCurlOptionsContent()
 	path := filepath.Join(consts.AgentShareDirMount, consts.AgentCurlOptionsFileName)
 
-	return runner.createConfFile(path, content)
+	return runner.createConfigFile(path, content, true)
 }
 
-func (runner *Runner) createConfFile(path string, content string) error {
-	err := createConfigFile(runner.fs, path, content)
+func (runner *Runner) createConfigFile(path string, content string, verbose bool) error {
+	err := createFile(runner.fs, path, content)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	log.Info("created file", "filePath", path, "content", content)
-
-	return nil
-}
-
-func (runner *Runner) createConfFileWithShortMessage(path string, content string) error {
-	err := createConfigFile(runner.fs, path, content)
-	if err != nil {
-		return errors.WithStack(err)
+	if verbose {
+		log.Info("created file", "filePath", path, "content", content)
+	} else {
+		log.Info("created file", "filePath", path)
 	}
 
-	log.Info("created file", "filePath", path)
-
 	return nil
 }
 
-func createConfigFile(fs afero.Fs, path string, content string) error {
+func createFile(fs afero.Fs, path string, content string) error {
 	err := fs.MkdirAll(filepath.Dir(path), onlyReadAllFileMode)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/injection/startup/files.go
+++ b/pkg/injection/startup/files.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 )
 
 const (
@@ -120,12 +121,34 @@ func (runner *Runner) createCurlOptionsFile() error {
 }
 
 func (runner *Runner) createConfFile(path string, content string) error {
-	err := runner.fs.MkdirAll(filepath.Dir(path), onlyReadAllFileMode)
+	err := createConfigFile(runner.fs, path, content)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	file, err := runner.fs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, onlyReadAllFileMode)
+	log.Info("created file", "filePath", path, "content", content)
+
+	return nil
+}
+
+func (runner *Runner) createConfFileWithShortMessage(path string, content string) error {
+	err := createConfigFile(runner.fs, path, content)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	log.Info("created file", "filePath", path)
+
+	return nil
+}
+
+func createConfigFile(fs afero.Fs, path string, content string) error {
+	err := fs.MkdirAll(filepath.Dir(path), onlyReadAllFileMode)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	file, err := fs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, onlyReadAllFileMode)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -134,8 +157,6 @@ func (runner *Runner) createConfFile(path string, content string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
-	log.Info("created file", "filePath", path, "content", content)
 
 	return nil
 }

--- a/pkg/injection/startup/files_test.go
+++ b/pkg/injection/startup/files_test.go
@@ -19,7 +19,7 @@ func TestCreateConfFile(t *testing.T) {
 	t.Run(`create file`, func(t *testing.T) {
 		path := "test"
 
-		err := runner.createConfFile(path, "test")
+		err := runner.createConfigFile(path, "test", true)
 
 		require.NoError(t, err)
 
@@ -32,7 +32,7 @@ func TestCreateConfFile(t *testing.T) {
 	t.Run(`create nested file`, func(t *testing.T) {
 		path := filepath.Join("dir1", "dir2", "test")
 
-		err := runner.createConfFile(path, "test")
+		err := runner.createConfigFile(path, "test", true)
 
 		require.NoError(t, err)
 

--- a/pkg/injection/startup/run.go
+++ b/pkg/injection/startup/run.go
@@ -260,7 +260,7 @@ func (runner *Runner) configureOneAgent() error {
 }
 
 func (runner *Runner) setLDPreload() error {
-	return runner.createConfFile(filepath.Join(consts.AgentShareDirMount, consts.LdPreloadFilename), filepath.Join(runner.env.InstallPath, consts.LibAgentProcPath))
+	return runner.createConfigFile(filepath.Join(consts.AgentShareDirMount, consts.LdPreloadFilename), filepath.Join(runner.env.InstallPath, consts.LibAgentProcPath), true)
 }
 
 func (runner *Runner) createContainerConfigurationFiles() error {
@@ -281,7 +281,7 @@ func (runner *Runner) createContainerConfigurationFiles() error {
 			}
 		}
 
-		if err := runner.createConfFile(confFilePath, content); err != nil {
+		if err := runner.createConfigFile(confFilePath, content, true); err != nil {
 			return err
 		}
 	}
@@ -305,7 +305,7 @@ func (runner *Runner) propagateTLSCert() error {
 	if runner.agCerts != "" || runner.trustedCAs != "" {
 		log.Info("propagating tls certificates to agent")
 
-		if err := runner.createConfFileWithShortMessage(filepath.Join(consts.AgentShareDirMount, consts.CustomCertsFileName), runner.agCerts+"\n"+runner.trustedCAs); err != nil {
+		if err := runner.createConfigFile(filepath.Join(consts.AgentShareDirMount, consts.CustomCertsFileName), runner.agCerts+"\n"+runner.trustedCAs, false); err != nil {
 			return err
 		}
 	}
@@ -313,7 +313,7 @@ func (runner *Runner) propagateTLSCert() error {
 	if runner.trustedCAs != "" {
 		log.Info("propagating tls certificates to agent proxy configuration")
 
-		if err := runner.createConfFileWithShortMessage(filepath.Join(consts.AgentShareDirMount, consts.CustomProxyCertsFileName), runner.trustedCAs); err != nil {
+		if err := runner.createConfigFile(filepath.Join(consts.AgentShareDirMount, consts.CustomProxyCertsFileName), runner.trustedCAs, false); err != nil {
 			return err
 		}
 	}

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/config.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/config.go
@@ -22,8 +22,9 @@ const (
 	oneAgentShareVolumeName   = "oneagent-share"
 	injectionConfigVolumeName = "injection-config"
 
-	oneAgentCustomKeysPath = "/var/lib/dynatrace/oneagent/agent/customkeys"
-	customCertFileName     = "custom.pem"
+	oneAgentCustomKeysPath  = "/var/lib/dynatrace/oneagent/agent/customkeys"
+	customCertFileName      = "custom.pem"
+	customProxyCertFileName = "custom_proxy.pem"
 
 	preloadPath       = "/etc/ld.so.preload"
 	containerConfPath = "/var/lib/dynatrace/oneagent/agent/config/container.conf"

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/config.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/config.go
@@ -22,9 +22,7 @@ const (
 	oneAgentShareVolumeName   = "oneagent-share"
 	injectionConfigVolumeName = "injection-config"
 
-	oneAgentCustomKeysPath  = "/var/lib/dynatrace/oneagent/agent/customkeys"
-	customCertFileName      = "custom.pem"
-	customProxyCertFileName = "custom_proxy.pem"
+	oneAgentCustomKeysPath = "/var/lib/dynatrace/oneagent/agent/customkeys"
 
 	preloadPath       = "/etc/ld.so.preload"
 	containerConfPath = "/var/lib/dynatrace/oneagent/agent/config/container.conf"

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/containers.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/containers.go
@@ -95,9 +95,7 @@ func (mutator *OneAgentPodMutator) addOneAgentToContainer(request *dtwebhook.Rei
 	addDeploymentMetadataEnv(container, dynakube, mutator.clusterID)
 	addPreloadEnv(container, installPath)
 
-	if dynakube.HasActiveGateCaCert() {
-		addCertVolumeMounts(container)
-	}
+	addCertVolumeMounts(container, dynakube)
 
 	if dynakube.FeatureAgentInitialConnectRetry() > 0 {
 		addCurlOptionsVolumeMount(container)

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/volumes.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/volumes.go
@@ -67,8 +67,8 @@ func addCertVolumeMounts(container *corev1.Container, dynakube dynatracev1beta1.
 		container.VolumeMounts = append(container.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      oneAgentShareVolumeName,
-				MountPath: filepath.Join(oneAgentCustomKeysPath, customCertFileName),
-				SubPath:   customCertFileName,
+				MountPath: filepath.Join(oneAgentCustomKeysPath, consts.CustomCertsFileName),
+				SubPath:   consts.CustomCertsFileName,
 			})
 	}
 
@@ -76,8 +76,8 @@ func addCertVolumeMounts(container *corev1.Container, dynakube dynatracev1beta1.
 		container.VolumeMounts = append(container.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      oneAgentShareVolumeName,
-				MountPath: filepath.Join(oneAgentCustomKeysPath, customProxyCertFileName),
-				SubPath:   customProxyCertFileName,
+				MountPath: filepath.Join(oneAgentCustomKeysPath, consts.CustomProxyCertsFileName),
+				SubPath:   consts.CustomProxyCertsFileName,
 			})
 	}
 }

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/volumes_test.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/volumes_test.go
@@ -63,8 +63,8 @@ func TestAddCertVolumeMounts(t *testing.T) {
 
 		addCertVolumeMounts(container, dynakube)
 		require.Len(t, container.VolumeMounts, 2) // custom.pem, custom_proxy.pem
-		assert.Equal(t, customCertFileName, container.VolumeMounts[0].SubPath)
-		assert.Equal(t, customProxyCertFileName, container.VolumeMounts[1].SubPath)
+		assert.Equal(t, consts.CustomCertsFileName, container.VolumeMounts[0].SubPath)
+		assert.Equal(t, consts.CustomProxyCertsFileName, container.VolumeMounts[1].SubPath)
 	})
 	t.Run("shouldn't add proxy cert volume mounts", func(t *testing.T) {
 		dynakube := dynatracev1beta1.DynaKube{
@@ -81,7 +81,7 @@ func TestAddCertVolumeMounts(t *testing.T) {
 
 		addCertVolumeMounts(container, dynakube)
 		require.Len(t, container.VolumeMounts, 1)
-		assert.Equal(t, customCertFileName, container.VolumeMounts[0].SubPath)
+		assert.Equal(t, consts.CustomCertsFileName, container.VolumeMounts[0].SubPath)
 	})
 }
 

--- a/pkg/webhook/mutation/pod_mutator/oneagent_mutation/volumes_test.go
+++ b/pkg/webhook/mutation/pod_mutator/oneagent_mutation/volumes_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/volumes"
 	"github.com/pkg/errors"
@@ -45,10 +46,40 @@ func TestAddReadOnlyCSIVolumeMounts(t *testing.T) {
 }
 
 func TestAddCertVolumeMounts(t *testing.T) {
-	t.Run("should add cert volume mounts", func(t *testing.T) {
+	t.Run("shouldn't add any cert volume mounts", func(t *testing.T) {
+		dynakube := dynatracev1beta1.DynaKube{}
 		container := &corev1.Container{}
 
-		addCertVolumeMounts(container)
+		addCertVolumeMounts(container, dynakube)
+		require.Empty(t, container.VolumeMounts)
+	})
+	t.Run("should add both cert volume mounts", func(t *testing.T) {
+		dynakube := dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				TrustedCAs: "test",
+			},
+		}
+		container := &corev1.Container{}
+
+		addCertVolumeMounts(container, dynakube)
+		require.Len(t, container.VolumeMounts, 2) // custom.pem, custom_proxy.pem
+		assert.Equal(t, customCertFileName, container.VolumeMounts[0].SubPath)
+		assert.Equal(t, customProxyCertFileName, container.VolumeMounts[1].SubPath)
+	})
+	t.Run("shouldn't add proxy cert volume mounts", func(t *testing.T) {
+		dynakube := dynatracev1beta1.DynaKube{
+			Spec: dynatracev1beta1.DynaKubeSpec{
+				ActiveGate: dynatracev1beta1.ActiveGateSpec{
+					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
+						"routing",
+					},
+					TlsSecretName: "test",
+				},
+			},
+		}
+		container := &corev1.Container{}
+
+		addCertVolumeMounts(container, dynakube)
 		require.Len(t, container.VolumeMounts, 1)
 		assert.Equal(t, customCertFileName, container.VolumeMounts[0].SubPath)
 	})


### PR DESCRIPTION
## Description

ActiveGate certificates and trustedCAs certificates should be used by the injected agent on application pods. There is a single file only read by the agent (`custom.pem`) which can be used for that purpose so combined certificates from the init secret are stored the file. 

The following properties have been moved to separate fields:
- data.config.trustedCAs -> data.trustedcas
- data.config.tlsCert -> data.agcerts

These fields are mounted directly to the initContainer of the app pod. 

Based on their content, the `Runner` creates `/mnt/share/custom.pem` and `/mnt/share/custom_proxy.pem` files mounted to the application container. The `/mnt/share/custom_proxy.pem` contains `trustedCAs` certificates only because AG is never an HTTP(s) proxy,

AG certs and TrustedCAs can't be combined into single set of certificates by the Operator because of the Dynatrace Client which is used by the `Runner`. DC would use AG certificate to verify Dynatrace Server if AG certificate was provided without any trustedCAs.

## How can this be tested?

Unittests.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
