### PR TITLE
Remove proxy value from init log

### DIFF
--- a/pkg/injection/startup/dtclient_builder.go
+++ b/pkg/injection/startup/dtclient_builder.go
@@ -49,7 +49,7 @@ func (builder *dtclientBuilder) addCertCheck() {
 
 func (builder *dtclientBuilder) addProxy() {
 	if builder.config.Proxy != "" {
-		log.Info("using the following proxy", "proxy", builder.config.Proxy)
+		log.Info("dtclient started using a proxy")
 		builder.options = append(builder.options, dtclient.Proxy(builder.config.Proxy, builder.config.NoProxy))
 	}
 }


### PR DESCRIPTION
## Description

Remove proxy value from init log, as it could result in leaking credentials

## How can this be tested?

Set a proxy in the Dynakube -> look at the initContainer logs

## Checklist

- [ ] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
