### PR TITLE
Reintroduce split manifests in release note generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -315,10 +315,6 @@ jobs:
           make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
           make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
           make manifests/openshift IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
-      - name: Rename manifests
-        run: |
-          mv config/deploy/kubernetes/kubernetes-all.yaml config/deploy/kubernetes/kubernetes.yaml
-          mv config/deploy/openshift/openshift-all.yaml config/deploy/openshift/openshift.yaml
       - name: Build helm packages
         uses: ./.github/actions/build-helm
         with:
@@ -378,6 +374,8 @@ jobs:
             config/deploy/dynatrace-operator-crd.yaml
             config/deploy/kubernetes/kubernetes.yaml
             config/deploy/openshift/openshift.yaml
+            config/deploy/kubernetes/kubernetes-csi.yaml
+            config/deploy/openshift/openshift-csi.yaml
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
           draft: true
@@ -393,6 +391,8 @@ jobs:
             config/deploy/kubernetes/kubernetes.yaml
             config/deploy/kubernetes/gke-autopilot.yaml
             config/deploy/openshift/openshift.yaml
+            config/deploy/kubernetes/kubernetes-csi.yaml
+            config/deploy/openshift/openshift-csi.yaml
             helm-pkg/dynatrace-operator-${{ needs.prepare.outputs.version_without_prefix }}.tgz
             helm-pkg/dynatrace-operator-${{ needs.prepare.outputs.version_without_prefix }}.tgz.prov
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/hack/build/ci/generate-release-notes.sh
+++ b/hack/build/ci/generate-release-notes.sh
@@ -21,10 +21,22 @@ _Full changelog will be published with the final release, including bugfixes and
 release_footer="### What's Changed
 Release Notes can be found in our [official Documentation](https://docs.dynatrace.com/docs/whats-new/release-notes/dynatrace-operator)."
 
-footer=""
-
 kubernetes_manifests="kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/download/${tag}/kubernetes.yaml"
 openshift_manifests="oc apply -f https://github.com/Dynatrace/dynatrace-operator/releases/download/${tag}/openshift.yaml"
+
+kubernetes_manifests="${kubernetes_manifests}
+kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/download/${tag}/kubernetes-csi.yaml"
+
+openshift_manifests="${openshift_manifests}
+oc apply -f https://github.com/Dynatrace/dynatrace-operator/releases/download/${tag}/openshift-csi.yaml"
+
+if [ "${pre_release}" = false ] ; then
+  footer="${release_footer}"
+else
+  footer="${pre_release_footer}"
+fi
+
+footer=""
 
 if [ "${pre_release}" = false ] ; then
   footer="${release_footer}"


### PR DESCRIPTION
## Description

Partial revert of #2948 + update to the `release` action step to make the revert actually work properly.
It was decided that the split manifests (for csi and non-csi) was more versatile. 

## How can this be tested?

Running  ./hack/build/ci/generate-release-notes.sh locally should give you an idea how it looks. (the script update)
Checking the `release` action should be done in a fork.

## Checklist

- ~[ ] Unit tests have been updated/added~
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
