### PR TITLE
Add ipv6 support to ActiveGate deployment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -302,6 +302,8 @@ service:
   golangci-lint-version: 1.55.x # use the fixed version to not introduce new linters unexpectedly
 
 issues:
+  exclude-dirs:
+    - pkg/api/v1alpha1/dynakube # legacy version, should not be changed
   exclude-rules:
     # Exclude duplicate code and function length and complexity checking in test
     # files (due to common repeats and long functions in test code)
@@ -337,7 +339,3 @@ issues:
     - path-except: 'pkg/api/(.+)\.go'
       linters:
         - godot
-
-run:
-  skip-dirs:
-    - pkg/api/v1alpha1/dynakube # legacy version, should not be changed

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1246,10 +1246,6 @@ spec:
                     description: The ActiveGate container image. Defaults to the latest
                       ActiveGate image provided by the registry on the tenant
                     type: string
-                  ipv6:
-                    description: If enabled, the ActiveGate will be configured in
-                      a way to work in a cluster that uses IPv6 instead of IPv4.
-                    type: boolean
                   labels:
                     additionalProperties:
                       type: string
@@ -3489,6 +3485,12 @@ spec:
                       performed
                     format: date-time
                     type: string
+                  serviceIPs:
+                    description: The ClusterIPs set by Kubernetes on the ActiveGate
+                      Service created by the Operator
+                    items:
+                      type: string
+                    type: array
                   source:
                     description: Source of the image (tenant-registry, public-registry,
                       ...)

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1246,6 +1246,10 @@ spec:
                     description: The ActiveGate container image. Defaults to the latest
                       ActiveGate image provided by the registry on the tenant
                     type: string
+                  ipv6:
+                    description: If enabled, the ActiveGate will be configured in
+                      a way to work in a cluster that uses IPv6 instead of IPv4.
+                    type: boolean
                   labels:
                     additionalProperties:
                       type: string

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - bases
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
-- patches/webhook_in_dynakubes.yaml
-#+kubebuilder:scaffold:crdkustomizewebhookpatch
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patches/webhook_in_dynakubes.yaml

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -1911,10 +1911,6 @@ spec:
                     description: The ActiveGate container image. Defaults to the latest
                       ActiveGate image provided by the registry on the tenant
                     type: string
-                  ipv6:
-                    description: If enabled, the ActiveGate will be configured in
-                      a way to work in a cluster that uses IPv6 instead of IPv4.
-                    type: boolean
                   labels:
                     additionalProperties:
                       type: string
@@ -4154,6 +4150,12 @@ spec:
                       performed
                     format: date-time
                     type: string
+                  serviceIPs:
+                    description: The ClusterIPs set by Kubernetes on the ActiveGate
+                      Service created by the Operator
+                    items:
+                      type: string
+                    type: array
                   source:
                     description: Source of the image (tenant-registry, public-registry,
                       ...)

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -1911,6 +1911,10 @@ spec:
                     description: The ActiveGate container image. Defaults to the latest
                       ActiveGate image provided by the registry on the tenant
                     type: string
+                  ipv6:
+                    description: If enabled, the ActiveGate will be configured in
+                      a way to work in a cluster that uses IPv6 instead of IPv4.
+                    type: boolean
                   labels:
                     additionalProperties:
                       type: string

--- a/pkg/api/v1beta1/dynakube/activegate_types.go
+++ b/pkg/api/v1beta1/dynakube/activegate_types.go
@@ -81,11 +81,6 @@ type ActiveGateSpec struct {
 	// Activegate capabilities enabled (routing, kubernetes-monitoring, metrics-ingest, dynatrace-api)
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Capabilities",order=10,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Capabilities []CapabilityDisplayName `json:"capabilities,omitempty"`
-
-	// If enabled, the ActiveGate will be configured in a way to work in a cluster that uses IPv6 instead of IPv4.
-	// +optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="IPv6",order=23,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:PriorityClass"}
-	IPv6 bool `json:"ipv6,omitempty"`
 }
 
 // CapabilityProperties is a struct which can be embedded by ActiveGate capabilities

--- a/pkg/api/v1beta1/dynakube/activegate_types.go
+++ b/pkg/api/v1beta1/dynakube/activegate_types.go
@@ -81,6 +81,11 @@ type ActiveGateSpec struct {
 	// Activegate capabilities enabled (routing, kubernetes-monitoring, metrics-ingest, dynatrace-api)
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Capabilities",order=10,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
 	Capabilities []CapabilityDisplayName `json:"capabilities,omitempty"`
+
+	// If enabled, the ActiveGate will be configured in a way to work in a cluster that uses IPv6 instead of IPv4.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="IPv6",order=23,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:PriorityClass"}
+	IPv6 bool `json:"ipv6,omitempty"`
 }
 
 // CapabilityProperties is a struct which can be embedded by ActiveGate capabilities

--- a/pkg/api/v1beta1/dynakube/dynakube_status.go
+++ b/pkg/api/v1beta1/dynakube/dynakube_status.go
@@ -103,6 +103,9 @@ type ActiveGateStatus struct {
 
 	// Information about Active Gate's connections
 	ConnectionInfoStatus ActiveGateConnectionInfoStatus `json:"connectionInfoStatus,omitempty"`
+
+	// The ClusterIPs set by Kubernetes on the ActiveGate Service created by the Operator
+	ServiceIPs []string `json:"serviceIPs,omitempty"`
 }
 
 type CodeModulesStatus struct {

--- a/pkg/controllers/dynakube/activegate/capability/capability.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability.go
@@ -68,7 +68,7 @@ type MultiCapability struct {
 	capabilityBase
 }
 
-func NewMultiCapability(dk *dynatracev1beta1.DynaKube) *MultiCapability {
+func NewMultiCapability(dk *dynatracev1beta1.DynaKube) Capability {
 	mc := MultiCapability{
 		capabilityBase{
 			shortName: consts.MultiActiveGateName,
@@ -98,7 +98,7 @@ func NewMultiCapability(dk *dynatracev1beta1.DynaKube) *MultiCapability {
 }
 
 // Deprecated
-func NewKubeMonCapability(dk *dynatracev1beta1.DynaKube) *KubeMonCapability {
+func NewKubeMonCapability(dk *dynatracev1beta1.DynaKube) Capability {
 	c := &KubeMonCapability{
 		*kubeMonBase(),
 	}
@@ -113,7 +113,7 @@ func NewKubeMonCapability(dk *dynatracev1beta1.DynaKube) *KubeMonCapability {
 }
 
 // Deprecated
-func NewRoutingCapability(dk *dynatracev1beta1.DynaKube) *RoutingCapability {
+func NewRoutingCapability(dk *dynatracev1beta1.DynaKube) Capability {
 	c := &RoutingCapability{
 		*routingBase(),
 	}

--- a/pkg/controllers/dynakube/activegate/capability/capability_test.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability_test.go
@@ -78,7 +78,7 @@ func TestNewMultiCapability(t *testing.T) {
 }
 
 func TestBuildServiceHostNameForDNSEntryPoint(t *testing.T) {
-	actual := BuildServiceHostName("test-name", "test-component-feature")
+	actual := buildServiceHostName("test-name", "test-component-feature")
 	assert.NotEmpty(t, actual)
 
 	expected := "$(TEST_NAME_TEST_COMPONENT_FEATURE_SERVICE_HOST):$(TEST_NAME_TEST_COMPONENT_FEATURE_SERVICE_PORT)"
@@ -87,12 +87,12 @@ func TestBuildServiceHostNameForDNSEntryPoint(t *testing.T) {
 	testStringName := "this---test_string"
 	testStringFeature := "SHOULD--_--PaRsEcORrEcTlY"
 	expected = "$(THIS___TEST_STRING_SHOULD_____PARSECORRECTLY_SERVICE_HOST):$(THIS___TEST_STRING_SHOULD_____PARSECORRECTLY_SERVICE_PORT)"
-	actual = BuildServiceHostName(testStringName, testStringFeature)
+	actual = buildServiceHostName(testStringName, testStringFeature)
 	assert.Equal(t, expected, actual)
 }
 
 func TestBuildServiceDomainNameForDNSEntryPoint(t *testing.T) {
-	actual := BuildServiceDomainName("test-name", "test-namespace", "test-component-feature")
+	actual := buildServiceDomainName("test-name", "test-namespace", "test-component-feature")
 	assert.NotEmpty(t, actual)
 
 	expected := "test-name-test-component-feature.test-namespace:$(TEST_NAME_TEST_COMPONENT_FEATURE_SERVICE_PORT)"
@@ -102,6 +102,6 @@ func TestBuildServiceDomainNameForDNSEntryPoint(t *testing.T) {
 	testNamespace := "this_is---namespace_string"
 	testStringFeature := "SHOULD--_--PaRsEcORrEcTlY"
 	expected = "this---dynakube_string-SHOULD--_--PaRsEcORrEcTlY.this_is---namespace_string:$(THIS___DYNAKUBE_STRING_SHOULD_____PARSECORRECTLY_SERVICE_PORT)"
-	actual = BuildServiceDomainName(testStringName, testNamespace, testStringFeature)
+	actual = buildServiceDomainName(testStringName, testNamespace, testStringFeature)
 	assert.Equal(t, expected, actual)
 }

--- a/pkg/controllers/dynakube/activegate/internal/capability/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/capability/reconciler.go
@@ -48,6 +48,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
 		err = r.setAGServiceIPs(ctx)
 		if err != nil {
 			return err
@@ -64,11 +65,14 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 func (r *Reconciler) setAGServiceIPs(ctx context.Context) error {
 	template := CreateService(r.dynakube, r.capability.ShortName())
 	present := &corev1.Service{}
+
 	err := r.client.Get(ctx, object.Key(template), present)
 	if err != nil {
 		return errors.WithStack(err)
 	}
+
 	r.dynakube.Status.ActiveGate.ServiceIPs = present.Spec.ClusterIPs
+
 	return nil
 }
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
@@ -73,5 +73,5 @@ func (mod ServicePortModifier) getEnvs() []corev1.EnvVar {
 }
 
 func (mod ServicePortModifier) buildDNSEntryPoint() string {
-	return capability.BuildDNSEntryPoint(mod.dynakube.Name, mod.dynakube.Namespace, mod.capability)
+	return capability.BuildDNSEntryPoint(mod.dynakube, mod.capability)
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/prioritymap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func setServicePortUsage(dynakube *dynatracev1beta1.DynaKube, isUsed bool) {
@@ -57,104 +56,5 @@ func TestServicePortModify(t *testing.T) {
 		isSubset(t, expectedPorts, container.Ports)
 		isSubset(t, expectedEnv, container.Env)
 		assert.Equal(t, consts.HttpsServicePortName, container.ReadinessProbe.HTTPGet.Port.StrVal)
-	})
-}
-
-func TestBuildDNSEntryPoint(t *testing.T) {
-	t.Run("DNSEntryPoint for ActiveGate routing capability", func(t *testing.T) {
-		dynakubeActiveGateCapability := dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dynakube",
-				Namespace: "dynatrace",
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				ActiveGate: dynatracev1beta1.ActiveGateSpec{
-					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-						dynatracev1beta1.RoutingCapability.DisplayName,
-					},
-				},
-			},
-		}
-		multiCapability := capability.NewMultiCapability(&dynakubeActiveGateCapability)
-		portModifier := NewServicePortModifier(dynakubeActiveGateCapability, multiCapability, prioritymap.New())
-		dnsEntryPoint := portModifier.buildDNSEntryPoint()
-		assert.Equal(t, "https://$(DYNAKUBE_ACTIVEGATE_SERVICE_HOST):$(DYNAKUBE_ACTIVEGATE_SERVICE_PORT)/communication,https://dynakube-activegate.dynatrace:$(DYNAKUBE_ACTIVEGATE_SERVICE_PORT)/communication", dnsEntryPoint)
-	})
-
-	t.Run("DNSEntryPoint for ActiveGate k8s monitoring capability", func(t *testing.T) {
-		dynakubeActiveGateCapability := dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dynakube",
-				Namespace: "dynatrace",
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				ActiveGate: dynatracev1beta1.ActiveGateSpec{
-					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-						dynatracev1beta1.KubeMonCapability.DisplayName,
-					},
-				},
-			},
-		}
-		multiCapability := capability.NewMultiCapability(&dynakubeActiveGateCapability)
-		portModifier := NewServicePortModifier(dynakubeActiveGateCapability, multiCapability, prioritymap.New())
-		dnsEntryPoint := portModifier.buildDNSEntryPoint()
-		assert.Equal(t, "https://$(DYNAKUBE_ACTIVEGATE_SERVICE_HOST):$(DYNAKUBE_ACTIVEGATE_SERVICE_PORT)/communication", dnsEntryPoint)
-	})
-
-	t.Run("DNSEntryPoint for ActiveGate routing+kubemon capabilities", func(t *testing.T) {
-		dynakubeActiveGateCapability := dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dynakube",
-				Namespace: "dynatrace",
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				ActiveGate: dynatracev1beta1.ActiveGateSpec{
-					Capabilities: []dynatracev1beta1.CapabilityDisplayName{
-						dynatracev1beta1.KubeMonCapability.DisplayName,
-						dynatracev1beta1.RoutingCapability.DisplayName,
-					},
-				},
-			},
-		}
-		multiCapability := capability.NewMultiCapability(&dynakubeActiveGateCapability)
-		portModifier := NewServicePortModifier(dynakubeActiveGateCapability, multiCapability, prioritymap.New())
-		dnsEntryPoint := portModifier.buildDNSEntryPoint()
-		assert.Equal(t, "https://$(DYNAKUBE_ACTIVEGATE_SERVICE_HOST):$(DYNAKUBE_ACTIVEGATE_SERVICE_PORT)/communication,https://dynakube-activegate.dynatrace:$(DYNAKUBE_ACTIVEGATE_SERVICE_PORT)/communication", dnsEntryPoint)
-	})
-
-	t.Run("DNSEntryPoint for deprecated routing ActiveGate", func(t *testing.T) {
-		dynakubeRoutingActiveGate := dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dynakube",
-				Namespace: "dynatrace",
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				Routing: dynatracev1beta1.RoutingSpec{
-					Enabled: true,
-				},
-			},
-		}
-		routingCapability := capability.NewRoutingCapability(&dynakubeRoutingActiveGate)
-		portModifier := NewServicePortModifier(dynakubeRoutingActiveGate, routingCapability, prioritymap.New())
-		dnsEntryPoint := portModifier.buildDNSEntryPoint()
-		assert.Equal(t, "https://$(DYNAKUBE_ROUTING_SERVICE_HOST):$(DYNAKUBE_ROUTING_SERVICE_PORT)/communication,https://dynakube-routing.dynatrace:$(DYNAKUBE_ROUTING_SERVICE_PORT)/communication", dnsEntryPoint)
-	})
-
-	t.Run("DNSEntryPoint for deprecated kubernetes monitoring ActiveGate", func(t *testing.T) {
-		dynakubeKubeMonActiveGate := dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dynakube",
-				Namespace: "dynatrace",
-			},
-			Spec: dynatracev1beta1.DynaKubeSpec{
-				KubernetesMonitoring: dynatracev1beta1.KubernetesMonitoringSpec{
-					Enabled: true,
-				},
-			},
-		}
-		kubeMonCapability := capability.NewKubeMonCapability(&dynakubeKubeMonActiveGate)
-		portModifier := NewServicePortModifier(dynakubeKubeMonActiveGate, kubeMonCapability, prioritymap.New())
-		dnsEntryPoint := portModifier.buildDNSEntryPoint()
-		assert.Equal(t, "https://$(DYNAKUBE_KUBEMON_SERVICE_HOST):$(DYNAKUBE_KUBEMON_SERVICE_PORT)/communication", dnsEntryPoint)
 	})
 }


### PR DESCRIPTION
## Description

We filled out the `DT_DNS_ENTRY_POINT` envvar based on the IP of the created `Service` to the ActiveGate `StatefulSet` using the envvars that are automatically added by kubernetes. (see in docs https://kubernetes.io/docs/concepts/services-networking/service/)

However, this is problematic when we consider that:
- the IPs of the `Service` can be IPv4 or IPv6, and the DNS entry points are actual URLs (example: `https://10.123.123.12:443/communication`).
- the contents "auto-added" Service envs are not formatted according to _RFC2732_ in the case of IPv6 (makes sense).

Due to this "limitation", we can't rely on the "auto-added" envs, instead, we look at the `Service` we create and get the IPs from it, then add each to the `DT_DNS_ENTRY_POINT` directly, formatted correctly.
- This way we can support even dual-stack setups.

Sidenote: Ignore the first commit, that was my easy/quick POC without magic.

## How can this be tested?

This is semi-difficult, because you need a dual-stack cluster (can be created on GKE) + do changes to the code, that enforces the usage of `DualStack` IPFamily, because otherwise it will always use IPv4. (if you can configure your cluster to not have to do this, then you deserve all the 🌮 )

I did this, so you don't necessarily have to:
- The service
![image](https://github.com/Dynatrace/dynatrace-operator/assets/31651557/5628aa51-05cb-400b-b336-bc59eafb5eed)
- The resulting entry points
![image](https://github.com/Dynatrace/dynatrace-operator/assets/31651557/8806f76a-35fa-4990-863a-60790ba6c5d0)

Otherwise, the unittests are straight forward.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
