### PR TITLE
Fix proxy url parsing function

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/proxy/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/proxy/reconciler.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"net/url"
+	"strings"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
@@ -116,6 +117,11 @@ func (r *Reconciler) createProxyMap(ctx context.Context, dynakube *dynatracev1be
 }
 
 func parseProxyUrl(proxy string) (host, port, username, password string, err error) { //nolint:revive // maximum number of return results per function exceeded; max 3 but got 5
+	if !strings.HasPrefix(strings.ToLower(proxy), "http://") && !strings.HasPrefix(strings.ToLower(proxy), "https://") {
+		log.Info("proxy url has no scheme. The default 'http://' scheme used")
+		proxy = "http://" + proxy
+	}
+
 	proxyUrl, err := url.Parse(proxy)
 	if err != nil {
 		return "", "", "", "", errors.New("could not parse proxy URL")

--- a/pkg/controllers/dynakube/activegate/internal/proxy/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/proxy/reconciler_test.go
@@ -78,8 +78,83 @@ func TestReconcileWithoutProxy(t *testing.T) {
 }
 
 func TestReconcileProxyValue(t *testing.T) {
-	t.Run(`reconcile proxy Value`, func(t *testing.T) {
-		var proxyValue = buildProxyUrl(proxyUsername, proxyPassword, proxyHost, proxyPort)
+	t.Run(`reconcile proxy Value - no scheme, no username`, func(t *testing.T) {
+		var proxyValue = buildProxyUrl("", "", "", proxyHost, proxyPort)
+		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
+		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: proxyValue}
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var proxySecret corev1.Secret
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+
+		assert.Empty(t, proxySecret.Data[proxyPasswordField])
+		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
+		assert.Equal(t, []byte(proxyHost), proxySecret.Data[proxyHostField])
+		assert.Empty(t, proxySecret.Data[proxyUsernameField])
+	})
+	t.Run(`reconcile proxy Value - no scheme, with username`, func(t *testing.T) {
+		var proxyValue = buildProxyUrl("", proxyUsername, proxyPassword, proxyHost, proxyPort)
+		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
+		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: proxyValue}
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var proxySecret corev1.Secret
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+
+		assert.Equal(t, []byte(proxyPassword), proxySecret.Data[proxyPasswordField])
+		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
+		assert.Equal(t, []byte(proxyHost), proxySecret.Data[proxyHostField])
+		assert.Equal(t, []byte(proxyUsername), proxySecret.Data[proxyUsernameField])
+	})
+	t.Run(`reconcile proxy Value - http scheme, no username`, func(t *testing.T) {
+		var proxyValue = buildProxyUrl("http", "", "", proxyHost, proxyPort)
+		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
+		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: proxyValue}
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var proxySecret corev1.Secret
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+
+		assert.Empty(t, proxySecret.Data[proxyPasswordField])
+		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
+		assert.Equal(t, []byte(proxyHost), proxySecret.Data[proxyHostField])
+		assert.Empty(t, proxySecret.Data[proxyUsernameField])
+	})
+	t.Run(`reconcile proxy Value - https scheme, no username`, func(t *testing.T) {
+		var proxyValue = buildProxyUrl("https", "", "", proxyHost, proxyPort)
+		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
+		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: proxyValue}
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var proxySecret corev1.Secret
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+
+		assert.Empty(t, proxySecret.Data[proxyPasswordField])
+		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
+		assert.Equal(t, []byte(proxyHost), proxySecret.Data[proxyHostField])
+		assert.Empty(t, proxySecret.Data[proxyUsernameField])
+	})
+	t.Run(`reconcile proxy Value - http scheme`, func(t *testing.T) {
+		var proxyValue = buildProxyUrl("http", proxyUsername, proxyPassword, proxyHost, proxyPort)
+		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
+		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: proxyValue}
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var proxySecret corev1.Secret
+		_ = r.client.Get(context.Background(), client.ObjectKey{Name: capability.BuildProxySecretName(testDynakubeName), Namespace: testNamespace}, &proxySecret)
+
+		assert.Equal(t, []byte(proxyPassword), proxySecret.Data[proxyPasswordField])
+		assert.Equal(t, []byte(proxyPort), proxySecret.Data[proxyPortField])
+		assert.Equal(t, []byte(proxyHost), proxySecret.Data[proxyHostField])
+		assert.Equal(t, []byte(proxyUsername), proxySecret.Data[proxyUsernameField])
+	})
+	t.Run(`reconcile proxy Value - https scheme`, func(t *testing.T) {
+		var proxyValue = buildProxyUrl("https", proxyUsername, proxyPassword, proxyHost, proxyPort)
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
 		r.dynakube.Spec.Proxy = &dynatracev1beta1.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
@@ -110,7 +185,7 @@ func TestReconcileProxyValue(t *testing.T) {
 }
 
 func TestReconcileProxyValueFrom(t *testing.T) {
-	var proxyUrl = buildProxyUrl(proxyUsername, proxyPassword, proxyHost, proxyPort)
+	var proxyUrl = buildProxyUrl("http", proxyUsername, proxyPassword, proxyHost, proxyPort)
 	var testClient = fake.NewClientBuilder().WithObjects(createProxySecret(proxyUrl)).Build()
 	r := newTestReconcilerWithInstance(testClient)
 
@@ -141,7 +216,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		assert.Equal(t, []byte(proxyUsername), proxySecret.Data[proxyUsernameField])
 
 		r.dynakube.Spec.Proxy.ValueFrom = ""
-		r.dynakube.Spec.Proxy.Value = buildProxyUrl(proxyDifferentUsername, proxyPassword, proxyHost, proxyPort)
+		r.dynakube.Spec.Proxy.Value = buildProxyUrl("http", proxyDifferentUsername, proxyPassword, proxyHost, proxyPort)
 		err = r.Reconcile(context.Background())
 
 		require.NoError(t, err)
@@ -171,6 +246,13 @@ func createProxySecret(proxyUrl string) *corev1.Secret {
 	}
 }
 
-func buildProxyUrl(username string, password string, host string, port string) string {
-	return "http://" + username + ":" + password + "@" + host + ":" + port
+func buildProxyUrl(scheme string, username string, password string, host string, port string) string {
+	url := ""
+	if scheme != "" {
+		url = scheme + "://"
+	}
+	if username != "" {
+		url = url + username + ":" + password + "@"
+	}
+	return url + host + ":" + port
 }


### PR DESCRIPTION
## Description

Adds the default HTTP scheme to the proxy url if it's missing because otherwise `url.Parse` function fails. It returns empty `url.Host` part if there is no scheme.

## How can this be tested?

Unittests.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
