### PR TITLE
Fix proxy url parsing function - v1.0

### DIFF
--- a/pkg/controllers/dynakube/proxy/reconciler.go
+++ b/pkg/controllers/dynakube/proxy/reconciler.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"net/url"
+	"strings"
 
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
@@ -106,6 +107,11 @@ func (r *Reconciler) createProxyMap(ctx context.Context, dynakube *dynatracev1be
 }
 
 func parseProxyUrl(proxy string) (host, port, username, password string, err error) { //nolint:revive // maximum number of return results per function exceeded; max 3 but got 5
+	if !strings.HasPrefix(strings.ToLower(proxy), "http://") && !strings.HasPrefix(strings.ToLower(proxy), "https://") {
+		log.Info("proxy url has no scheme. The default 'http://' scheme used")
+		proxy = "http://" + proxy
+	}
+
 	proxyUrl, err := url.Parse(proxy)
 	if err != nil {
 		return "", "", "", "", errors.New("could not parse proxy URL")


### PR DESCRIPTION
## Description

Adds the default HTTP scheme to the proxy url if it's missing because otherwise url.Parse function fails. It returns empty url.Host part if there is no scheme.

cherry-pick from [v0.15](https://github.com/Dynatrace/dynatrace-operator/pull/2952)

## How can this be tested?

Unittests.

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
