### PR TITLE
Disable data migration and fix linting issues

### DIFF
--- a/cmd/csi/init/builder.go
+++ b/cmd/csi/init/builder.go
@@ -74,16 +74,17 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 			return err
 		}
 
-		// new schema
-		conn, err := metadata.NewDBAccess(dtcsi.MetadataAccessPath)
-		if err != nil {
-			return err
-		}
-		// new migrations
-		err = conn.SchemaMigration(signalHandler)
-		if err != nil {
-			return err
-		}
+		// DISABLED UNTIL RELEASE 1.2
+		// // new schema
+		// conn, err := metadata.NewDBAccess(dtcsi.MetadataAccessPath)
+		// if err != nil {
+		// 	return err
+		// }
+		// // new migrations
+		// err = conn.SchemaMigration(signalHandler)
+		// if err != nil {
+		// 	return err
+		// }
 
 		csiOptions := dtcsi.CSIOptions{
 			NodeId:   nodeId,

--- a/pkg/api/v1alpha1/dynakube/dynakube_types.go
+++ b/pkg/api/v1alpha1/dynakube/dynakube_types.go
@@ -1,6 +1,8 @@
 // +kubebuilder:object:generate=true
 // +groupName=dynatrace.com
 // +versionName=v1alpha1
+//
+//nolint:revive
 package dynakube
 
 import (

--- a/pkg/api/v1alpha1/dynakube/helpers.go
+++ b/pkg/api/v1alpha1/dynakube/helpers.go
@@ -56,7 +56,7 @@ func (dk *DynaKube) ActiveGateImage() string {
 
 	registry := buildImageRegistry(dk.Spec.APIURL)
 
-	return fmt.Sprintf("%s/linux/activegate:latest", registry)
+	return registry + "/linux/activegate:latest"
 }
 
 // ImmutableOneAgentImage returns the immutable OneAgent image to be used with the dk DynaKube instance.


### PR DESCRIPTION
## Description

Disable CSI Driver data migration until release 1.2

Fix linting issues

## How can this be tested?

Unit tests

## Checklist

~~- [ ] Unit tests have been updated/added~~
- [X] PR is labeled accordingly with a single label
- [X] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
