### PR TITLE
Add short names for dynakube

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -13,6 +13,9 @@ spec:
     kind: DynaKube
     listKind: DynaKubeList
     plural: dynakubes
+    shortNames:
+    - dk
+    - dks
     singular: dynakube
   scope: Namespaced
   versions:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -677,6 +677,9 @@ spec:
     kind: DynaKube
     listKind: DynaKubeList
     plural: dynakubes
+    shortNames:
+    - dk
+    - dks
     singular: dynakube
   preserveUnknownFields: false
   scope: Namespaced

--- a/pkg/api/v1alpha1/dynakube/dynakube_types.go
+++ b/pkg/api/v1alpha1/dynakube/dynakube_types.go
@@ -323,7 +323,7 @@ func (dk *DynaKubeStatus) SetPhase(phase status.DeploymentPhase) bool {
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=dynakubes,scope=Namespaced,categories=dynatrace
+// +kubebuilder:resource:path=dynakubes,scope=Namespaced,categories=dynatrace,shortName={dk,dks}
 // +kubebuilder:printcolumn:name="ApiUrl",type=string,JSONPath=`.spec.apiUrl`
 // +kubebuilder:printcolumn:name="Tokens",type=string,JSONPath=`.status.tokens`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`


### PR DESCRIPTION
## Description
With this the short names `dk` and `dks` are added to the dynakube CRD. They can then be used with the `kubectl get` command like for example: `kubectl get ds` for daemonset.

## How can this be tested?
Deploy operator with this CRD and try out these commands:
- `kubectl get dk`
- `kubectl get dks`

## Checklist

- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
