### PR TITLE
Add new rules to permission script and remove outdated permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ kind-logs-*
 test/testdata/secrets/*
 
 local/
+
+permissions.md

--- a/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
@@ -88,7 +88,6 @@ rules:
     resourceNames:
       - dynakubes.dynatrace.com
       - edgeconnects.dynatrace.com
-      - activegates.dynatrace.com
     verbs:
       - get
       - update

--- a/hack/doc/role-permissions2md.py
+++ b/hack/doc/role-permissions2md.py
@@ -39,15 +39,21 @@ resourceTerms = {
     "virtualservices": "VirtualServices",
     "leases": "Leases",
     "endpoints": "EndPoints",
-    "securitycontextconstraints": "SecurityContextConstraints"
+    "securitycontextconstraints": "SecurityContextConstraints",
+    "edgeconnects": "EdgeConnects",
+    "edgeconnects/finalizers": "EdgeConnects/Finalizers",
+    "edgeconnects/status": "EdgeConnects/Status",
+    "activegates": "ActiveGates",
+    "activegates/finalizers": "ActiveGates/Finalizers",
+    "activegates/status": "ActiveGates/Status",
 }
 
 sectionTitles = {
     "dynatrace-operator": "Dynatrace Operator",
-    "dynatrace-kubernetes-monitoring": "Dynatrace Kubernetes Monitoring (ActiveGate)",
+    "dynatrace-kubernetes-monitoring": "Dynatrace Activegate (Kubernetes Monitoring)",
     "dynatrace-webhook": "Dynatrace webhook server",
     "dynatrace-oneagent-csi-driver": "Dynatrace CSI driver",
-    "dynatrace-activegate": "Dynatrace Kubernetes Monitoring (ActiveGate)",
+    "dynatrace-activegate": "Dynatrace ActiveGate (Default)",
     "dynatrace-dynakube-oneagent": "Dynatrace OneAgent"
 }
 
@@ -70,7 +76,7 @@ def multiline_codestyle_block(entries):
         if len(entry) > 0:
             result_string += f"`{entry}`"
         else:
-            result_string += f"`-`"
+            result_string += f"`\"\"`"
     return result_string
 
 def get_resource_names(rule):
@@ -95,8 +101,8 @@ def create_role_table(role):
             for resource in resources:
                 apis = get_apis(rule)
                 resource_names = get_resource_names(rule)
-                api_gropus = get_api_groups(rule)
-                print(f"|`{resourceTerms[resource]}` |{api_gropus} |{apis} |{resource_names} |")
+                api_groups = get_api_groups(rule)
+                print(f"|`{resourceTerms[resource]}` |{api_groups} |{apis} |{resource_names} |")
 
 def convert_cluster_roles_to_markdown(role):
     print(f"\n## {sectionTitles[role['metadata']['name']]} (cluster-wide)\n")


### PR DESCRIPTION
## Description

Updated script that generates the permission table for our components to be compatible with newly added rules:
* Add mapping for Activegate and Edgeconnect

⚠️  Remove Activegate CR permission from Operator cluster role (not used).


## How can this be tested?

Verify markdown permission table is correctly generated:
1. Run `make doc/permission`
2. Verify that `permissions.md` created in project directory is there and correct

If there are missing python packages run the following command (thanks @gkrenn )
```
pip3 install -r hack/requirements.txt
```

## Checklist

- [x] Unit tests have been updated/added
- [x] PR is labeled accordingly with a single label
- [x] I have read and understood the [contribution guidelines](https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md)
