### PR TITLE
Add s390x build support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,7 +182,7 @@ jobs:
     needs: [prepare, tests, linting]
     strategy:
       matrix:
-        platform: [amd64, arm64, ppc64le]
+        platform: [amd64, arm64, ppc64le, s390x]
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -200,7 +200,7 @@ jobs:
     needs: [prepare, build]
     strategy:
       matrix:
-        platform: [amd64, arm64, ppc64le]
+        platform: [amd64, arm64, ppc64le, s390x]
     if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
     needs: [prepare]
     strategy:
       matrix:
-        platform: [amd64, arm64, ppc64le]
+        platform: [amd64, arm64, ppc64le, s390x]
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -60,7 +60,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        platform: [amd64, arm64, ppc64le]
+        platform: [amd64, arm64, ppc64le, s390x]
         registry: [gcr, dockerhub, amazon-ecr]
         include:
         - registry: gcr

--- a/pkg/arch/amd64.go
+++ b/pkg/arch/amd64.go
@@ -3,5 +3,5 @@
 package arch
 
 const Arch = ArchX86
-const ImageArch = AMDImageArch
+const ImageArch = AMDImage
 const Flavor = FlavorMultidistro

--- a/pkg/arch/arm64.go
+++ b/pkg/arch/arm64.go
@@ -3,5 +3,5 @@
 package arch
 
 const Arch = ArchARM
-const ImageArch = ARMImageArch
+const ImageArch = ARMImage
 const Flavor = FlavorDefault

--- a/pkg/arch/consts.go
+++ b/pkg/arch/consts.go
@@ -15,10 +15,10 @@ const (
 
 	// These architectures are for the Image Registry
 
-	AMDImageArch   = "amd64"
-	ARMImageArch   = "arm64"
-	PPCLEImageArch = "ppc64le"
-	S390ImageArch  = "s390x"
+	AMDImage   = "amd64"
+	ARMImage   = "arm64"
+	PPCLEImage = "ppc64le"
+	S390Image  = "s390x"
 
 	DefaultImageOS = "linux"
 )

--- a/pkg/arch/consts.go
+++ b/pkg/arch/consts.go
@@ -18,6 +18,7 @@ const (
 	AMDImageArch   = "amd64"
 	ARMImageArch   = "arm64"
 	PPCLEImageArch = "ppc64le"
+	S390ImageArch  = "s390x"
 
 	DefaultImageOS = "linux"
 )

--- a/pkg/arch/ppc64le.go
+++ b/pkg/arch/ppc64le.go
@@ -4,4 +4,4 @@ package arch
 
 const Arch = ArchPPCLE
 const Flavor = FlavorDefault
-const ImageArch = PPCLEImageArch
+const ImageArch = PPCLEImage

--- a/pkg/arch/s390x.go
+++ b/pkg/arch/s390x.go
@@ -3,4 +3,5 @@
 package arch
 
 const Arch = ArchS390
+const ImageArch = S390ImageArch
 const Flavor = FlavorDefault

--- a/pkg/arch/s390x.go
+++ b/pkg/arch/s390x.go
@@ -3,5 +3,5 @@
 package arch
 
 const Arch = ArchS390
-const ImageArch = S390ImageArch
+const ImageArch = S390Image
 const Flavor = FlavorDefault

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
@@ -94,7 +94,7 @@ func TestGetBaseObjectMeta(t *testing.T) {
 					{
 						Key:      "kubernetes.io/arch",
 						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{"amd64", "arm64", "ppc64le"},
+						Values:   []string{"amd64", "arm64", "ppc64le", "s390x"},
 					},
 					{
 						Key:      "kubernetes.io/os",

--- a/pkg/controllers/dynakube/oneagent/daemonset/affinity_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/affinity_test.go
@@ -15,7 +15,7 @@ func TestAffinity(t *testing.T) {
 			{
 				Key:      "beta.kubernetes.io/arch",
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"amd64", "arm64", "ppc64le"},
+				Values:   []string{"amd64", "arm64", "ppc64le", "s390x"},
 			},
 			{
 				Key:      "beta.kubernetes.io/os",
@@ -29,7 +29,7 @@ func TestAffinity(t *testing.T) {
 			{
 				Key:      "kubernetes.io/arch",
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"amd64", "arm64", "ppc64le"},
+				Values:   []string{"amd64", "arm64", "ppc64le", "s390x"},
 			},
 			{
 				Key:      "kubernetes.io/os",

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -516,7 +516,7 @@ func TestNewDaemonset_Affinity(t *testing.T) {
 				{
 					Key:      "beta.kubernetes.io/arch",
 					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"amd64", "arm64", "ppc64le"},
+					Values:   []string{"amd64", "arm64", "ppc64le", "s390x"},
 				},
 				{
 					Key:      "beta.kubernetes.io/os",
@@ -530,7 +530,7 @@ func TestNewDaemonset_Affinity(t *testing.T) {
 				{
 					Key:      "kubernetes.io/arch",
 					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"amd64", "arm64", "ppc64le"},
+					Values:   []string{"amd64", "arm64", "ppc64le", "s390x"},
 				},
 				{
 					Key:      "kubernetes.io/os",

--- a/pkg/util/kubeobjects/node/affinity.go
+++ b/pkg/util/kubeobjects/node/affinity.go
@@ -11,7 +11,7 @@ const (
 )
 
 func AffinityNodeRequirementForSupportedArches() []corev1.NodeSelectorRequirement {
-	return affinityNodeRequirementsForArches(arch.AMDImageArch, arch.ARMImageArch, arch.PPCLEImageArch, arch.S390ImageArch)
+	return affinityNodeRequirementsForArches(arch.AMDImage, arch.ARMImage, arch.PPCLEImage, arch.S390Image)
 }
 
 func affinityNodeRequirementsForArches(arches ...string) []corev1.NodeSelectorRequirement {

--- a/pkg/util/kubeobjects/node/affinity.go
+++ b/pkg/util/kubeobjects/node/affinity.go
@@ -1,21 +1,17 @@
 package node
 
 import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	kubernetesArch = "kubernetes.io/arch"
 	kubernetesOS   = "kubernetes.io/os"
-
-	amd64   = "amd64"
-	arm64   = "arm64"
-	ppc64le = "ppc64le"
-	linux   = "linux"
 )
 
 func AffinityNodeRequirementForSupportedArches() []corev1.NodeSelectorRequirement {
-	return affinityNodeRequirementsForArches(amd64, arm64, ppc64le)
+	return affinityNodeRequirementsForArches(arch.AMDImageArch, arch.ARMImageArch, arch.PPCLEImageArch, arch.S390ImageArch)
 }
 
 func affinityNodeRequirementsForArches(arches ...string) []corev1.NodeSelectorRequirement {
@@ -28,7 +24,7 @@ func affinityNodeRequirementsForArches(arches ...string) []corev1.NodeSelectorRe
 		{
 			Key:      kubernetesOS,
 			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{linux},
+			Values:   []string{arch.DefaultImageOS},
 		},
 	}
 }

--- a/pkg/util/kubeobjects/node/affinity_test.go
+++ b/pkg/util/kubeobjects/node/affinity_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAffinityNodeRequirement(t *testing.T) {
-	assert.Equal(t, AffinityNodeRequirementForSupportedArches(), affinityNodeRequirementsForArches(arch.AMDImageArch, arch.ARMImageArch, arch.PPCLEImageArch, arch.S390ImageArch))
+	assert.Equal(t, AffinityNodeRequirementForSupportedArches(), affinityNodeRequirementsForArches(arch.AMDImage, arch.ARMImage, arch.PPCLEImage, arch.S390Image))
 	assert.Contains(t, AffinityNodeRequirementForSupportedArches(), linuxRequirement())
 }
 

--- a/pkg/util/kubeobjects/node/affinity_test.go
+++ b/pkg/util/kubeobjects/node/affinity_test.go
@@ -3,12 +3,13 @@ package node
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func TestAffinityNodeRequirement(t *testing.T) {
-	assert.Equal(t, AffinityNodeRequirementForSupportedArches(), affinityNodeRequirementsForArches(amd64, arm64, ppc64le))
+	assert.Equal(t, AffinityNodeRequirementForSupportedArches(), affinityNodeRequirementsForArches(arch.AMDImageArch, arch.ARMImageArch, arch.PPCLEImageArch, arch.S390ImageArch))
 	assert.Contains(t, AffinityNodeRequirementForSupportedArches(), linuxRequirement())
 }
 
@@ -16,6 +17,6 @@ func linuxRequirement() corev1.NodeSelectorRequirement {
 	return corev1.NodeSelectorRequirement{
 		Key:      kubernetesOS,
 		Operator: corev1.NodeSelectorOpIn,
-		Values:   []string{linux},
+		Values:   []string{arch.DefaultImageOS},
 	}
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->
Adds the possibility to deploy OneAgents and ActiveGates on clusters that run on s390x nodes.
Updates the CI steps to build the Operator's image for s390x.

_Related Jira issue_: [K8S-9512](https://dt-rnd.atlassian.net/browse/K8S-9512)

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->
If the CI passes, and manages to build the image, then that is the most we can do now. 
(otherwise you would need a a390x cluster, those are hard to come by, and another internal team are tasked to test it)