### PR TITLE
Add prerequisites installation to all python commands

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install python requirements
-        run: pip install -r hack/requirements.txt
+        run: make prerequisites/python
       - name: Find last 3 release branches
         run: |
           git fetch --prune --tags
@@ -29,6 +29,7 @@ jobs:
           cat release-branches.txt
       - name: Update renovate file
         run: |
+          source local/.venv/bin/activate
           python3 hack/build/ci/update-renovate-json5.py release-branches.txt .github/renovate.json5
       - name: Create pull request for adding new release branches to renovate.json5
         uses: peter-evans/create-pull-request@v6

--- a/hack/make/doc.mk
+++ b/hack/make/doc.mk
@@ -3,14 +3,14 @@
 doc: doc/api-ref doc/gen-gomarkdoc
 
 ## Generate API docs for custom resources
-doc/api-ref: manifests
-	python3 ./hack/doc/custom_resource_params_to_md.py ./config/crd/bases/dynatrace.com_activegates.yaml > ./doc/api/activegate-api-ref.md
-	python3 ./hack/doc/custom_resource_params_to_md.py ./config/crd/bases/dynatrace.com_dynakubes.yaml > ./doc/api/dynakube-api-ref.md
-	python3 ./hack/doc/custom_resource_params_to_md.py ./config/crd/bases/dynatrace.com_edgeconnects.yaml > ./doc/api/edgeconnect-api-ref.md
+doc/api-ref: manifests prerequisites/python
+	source local/.venv/bin/activate && python3 ./hack/doc/custom_resource_params_to_md.py ./config/crd/bases/dynatrace.com_activegates.yaml > ./doc/api/activegate-api-ref.md
+	source local/.venv/bin/activate && python3 ./hack/doc/custom_resource_params_to_md.py ./config/crd/bases/dynatrace.com_dynakubes.yaml > ./doc/api/dynakube-api-ref.md
+	source local/.venv/bin/activate && python3 ./hack/doc/custom_resource_params_to_md.py ./config/crd/bases/dynatrace.com_edgeconnects.yaml > ./doc/api/edgeconnect-api-ref.md
 
 ## Create a table containing permissions needed by Operator components
-doc/permissions: manifests
-	python3 ./hack/doc/role-permissions2md.py ./config/deploy/openshift/openshift-all.yaml > permissions.md
+doc/permissions: manifests prerequisites/python
+	source local/.venv/bin/activate && python3 ./hack/doc/role-permissions2md.py ./config/deploy/openshift/openshift-all.yaml > permissions.md
 
 ## Run scripts that generate markdown documentation using gomarkdoc (./hack/doc)
 doc/gen-gomarkdoc: prerequisites/gomarkdoc prerequisites/markdownlint

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -70,3 +70,7 @@ prerequisites/setup-pre-commit:
 ## Install 'gomarkdoc' if it is missing
 prerequisites/gomarkdoc:
 	go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@$(gomarkdoc_version)
+
+## Install python dependencies
+prerequisites/python:
+	python3 -m venv local/.venv && source local/.venv/bin/activate && pip3 install -r hack/requirements.txt


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[Issue Link](https://dt-rnd.atlassian.net/browse/K8S-9236)

Prerequisites should be automatically installed when a command that requires python is used

## How can this be tested?

Run `make doc/api-ref` and check if it is working