### PR TITLE
hostmonitoring args update

### DIFF
--- a/assets/samples/dynakube/hostMonitoring.yaml
+++ b/assets/samples/dynakube/hostMonitoring.yaml
@@ -133,7 +133,7 @@ spec:
       # For a list of the limitations for OneAgents in Docker, see https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
       #
       args:
-        - --set-monitoring-mode=infra
+        - --set-monitoring-mode=infra-only
 
   # Configuration for ActiveGate instances.
   #


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
Updating the **oneagent hostmonitoring args** from infra to infra-only.

**Example from Dyantrace Documentation**
oneagent:
  hostMonitoring:
     args:
       - --set-monitoring-mode=infra-only

https://docs.dynatrace.com/docs/setup-and-configuration/setup-on-k8s/installation/other/host-monitoring

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->