### PR TITLE
Remove builder tags from v1beta2 to make conversion webhook work

### DIFF
--- a/pkg/api/v1beta2/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta2/dynakube/dynakube_types.go
@@ -1,6 +1,4 @@
-// +kubebuilder:object:generate=true
-// +groupName=dynatrace.com
-// +versionName=v1beta2
+// TODO: Add kubebuilder tags
 package dynakube
 
 import (

--- a/pkg/api/v1beta2/dynakube/dynakube_webhook.go
+++ b/pkg/api/v1beta2/dynakube/dynakube_webhook.go
@@ -1,9 +1,0 @@
-package dynakube
-
-import ctrl "sigs.k8s.io/controller-runtime"
-
-func (r *DynaKube) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
-		Complete()
-}

--- a/pkg/api/v1beta2/groupversion_info.go
+++ b/pkg/api/v1beta2/groupversion_info.go
@@ -12,9 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1beta2 contains API Schema definitions for the dynatrace v1beta2 API group
-// +kubebuilder:object:generate=true
-// +groupName=dynatrace.com
+// TODO: Add kubebuilder tags
 package v1beta2
 
 import (


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

Because a new dynakube version was introduced but no logic whatsoever for conversion, the conversion webhook was confused and could not list dynakubes when running kubectl get dynakube.

This is a quick fix for it. [Ticket](https://dt-rnd.atlassian.net/browse/K8S-9805)

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

At first please remove your cache where api calls are cached:

- <home-dir>/.kube/cache/discovery/<some-ip>
- deploy operator
- query dynakube, maybe also test basic functionality