### PR TITLE
Fix s390x image

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -275,6 +275,9 @@ spec:
         - key: kubernetes.io/arch
           value: ppc64le
           effect: NoSchedule
+        - key: kubernetes.io/arch
+          value: s390x
+          effect: NoSchedule
         - key: ToBeDeletedByClusterAutoscaler
           operator: Exists
           effect: NoSchedule

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -97,6 +97,7 @@ spec:
                       - amd64
                       - arm64
                       - ppc64le
+                      - s390x
                   {{- end }}
                   - key: kubernetes.io/os
                     operator: In
@@ -127,5 +128,8 @@ spec:
           effect: NoSchedule
         - key: kubernetes.io/arch
           value: ppc64le
+          effect: NoSchedule
+        - key: kubernetes.io/arch
+          value: s390x
           effect: NoSchedule
 {{ end }}

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -79,6 +79,7 @@ spec:
                       - amd64
                       - arm64
                       - ppc64le
+                      - s390x
                    {{- end }}
                   - key: kubernetes.io/os
                     operator: In
@@ -155,5 +156,8 @@ spec:
           effect: NoSchedule
         - key: kubernetes.io/arch
           value: ppc64le
+          effect: NoSchedule
+        - key: kubernetes.io/arch
+          value: s390x
           effect: NoSchedule
 {{ end }}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -36,6 +36,9 @@ tests:
             key: kubernetes.io/arch
             value: ppc64le
           - effect: NoSchedule
+            key: kubernetes.io/arch
+            value: s390x
+          - effect: NoSchedule
             key: ToBeDeletedByClusterAutoscaler
             operator: Exists
 
@@ -138,6 +141,9 @@ tests:
                 - effect: NoSchedule
                   key: kubernetes.io/arch
                   value: ppc64le
+                - effect: NoSchedule
+                  key: kubernetes.io/arch
+                  value: s390x
                 - effect: NoSchedule
                   key: ToBeDeletedByClusterAutoscaler
                   operator: Exists

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -144,6 +144,7 @@ tests:
                             - amd64
                             - arm64
                             - ppc64le
+                            - s390x
                         - key: kubernetes.io/os
                           operator: In
                           values:
@@ -165,6 +166,9 @@ tests:
               - effect: NoSchedule
                 key: kubernetes.io/arch
                 value: ppc64le
+              - effect: NoSchedule
+                key: kubernetes.io/arch
+                value: s390x
       - isNull:
           path: spec.template.spec.nodeSelector
 
@@ -192,6 +196,9 @@ tests:
             - effect: NoSchedule
               key: kubernetes.io/arch
               value: ppc64le
+            - effect: NoSchedule
+              key: kubernetes.io/arch
+              value: s390x
 
   - it: should have nodeSelectors if set in kubernetes
     set:
@@ -310,6 +317,7 @@ tests:
                             - amd64
                             - arm64
                             - ppc64le
+                            - s390x
                         - key: kubernetes.io/os
                           operator: In
                           values:
@@ -331,6 +339,9 @@ tests:
               - effect: NoSchedule
                 key: kubernetes.io/arch
                 value: ppc64le
+              - effect: NoSchedule
+                key: kubernetes.io/arch
+                value: s390x
       - isNull:
           path: spec.template.spec.nodeSelector
 
@@ -357,6 +368,9 @@ tests:
             - effect: NoSchedule
               key: kubernetes.io/arch
               value: ppc64le
+            - effect: NoSchedule
+              key: kubernetes.io/arch
+              value: s390x
 
   - it: should have nodeSelectors if set in openshift
     set:

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -82,6 +82,7 @@ tests:
                             - amd64
                             - arm64
                             - ppc64le
+                            - s390x
                         - key: kubernetes.io/os
                           operator: In
                           values:
@@ -96,6 +97,9 @@ tests:
               - effect: NoSchedule
                 key: kubernetes.io/arch
                 value: ppc64le
+              - effect: NoSchedule
+                key: kubernetes.io/arch
+                value: s390x
             containers:
               - name: webhook
                 args:
@@ -181,6 +185,9 @@ tests:
           - effect: NoSchedule
             key: kubernetes.io/arch
             value: ppc64le
+          - effect: NoSchedule
+            key: kubernetes.io/arch
+            value: s390x
 
   - it: should have nodeSelectors if set
     set:
@@ -251,6 +258,7 @@ tests:
                             - amd64
                             - arm64
                             - ppc64le
+                            - s390x
                         - key: kubernetes.io/os
                           operator: In
                           values:
@@ -265,6 +273,9 @@ tests:
               - effect: NoSchedule
                 key: kubernetes.io/arch
                 value: ppc64le
+              - effect: NoSchedule
+                key: kubernetes.io/arch
+                value: s390x
             containers:
               - name: webhook
                 args:
@@ -387,6 +398,7 @@ tests:
                             - amd64
                             - arm64
                             - ppc64le
+                            - s390x
                         - key: kubernetes.io/os
                           operator: In
                           values:
@@ -401,6 +413,10 @@ tests:
               - effect: NoSchedule
                 key: kubernetes.io/arch
                 value: ppc64le
+              - effect: NoSchedule
+                key: kubernetes.io/arch
+                value: s390x
+
             containers:
               - name: webhook
                 args:


### PR DESCRIPTION
## Description
Operator components can be scheduled properly on `s390x` nodes:
- Added missing nodeAffinity/tolerations
- Added missing `s390x` tag to image manifest

## How can this be tested?

Try to pull `s390x` image via manifest.
