### PR TITLE
Fix ignore-proxy feature flag for oneAgent daemonset

### DIFF
--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -30,7 +30,7 @@ func prepareVolumeMounts(instance *dynatracev1beta1.DynaKube) []corev1.VolumeMou
 		volumeMounts = append(volumeMounts, getActiveGateCaCertVolumeMount())
 	}
 
-	if instance != nil && instance.HasProxy() {
+	if instance != nil && instance.NeedsOneAgentProxy() {
 		volumeMounts = append(volumeMounts, getHttpProxyMount())
 	}
 
@@ -106,7 +106,7 @@ func prepareVolumes(instance *dynatracev1beta1.DynaKube) []corev1.Volume {
 		volumes = append(volumes, getActiveGateCaCertVolume(instance))
 	}
 
-	if instance.HasProxy() {
+	if instance.NeedsOneAgentProxy() {
 		volumes = append(volumes, buildHttpProxyVolume(instance))
 	}
 

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -227,7 +227,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		assert.Contains(t, volumeMounts, getClusterCaCertVolumeMount())
 		assert.Contains(t, volumeMounts, getCSIStorageMount())
 	})
-	t.Run(`has no volume if no proxy is set`, func(t *testing.T) {
+	t.Run(`has no volume if proxy is set and proxy ignore feature-flags is used`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
 			ObjectMeta: corev1.ObjectMeta{
 				Name:      "Dynakube",

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPrepareVolumes(t *testing.T) {
@@ -230,7 +229,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 	})
 	t.Run(`has no volume if no proxy is set`, func(t *testing.T) {
 		instance := &dynatracev1beta1.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: corev1.ObjectMeta{
 				Name:      "Dynakube",
 				Namespace: "dynatrace",
 				Annotations: map[string]string{
@@ -244,7 +243,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 				},
 			},
 		}
-		
+
 		volumes := prepareVolumes(instance)
 		mounts := prepareVolumeMounts(instance)
 

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -249,6 +249,5 @@ func TestPrepareVolumeMounts(t *testing.T) {
 
 		assert.NotContains(t, volumes, buildHttpProxyVolume(instance))
 		assert.NotContains(t, mounts, getHttpProxyMount())
-
 	})
 }


### PR DESCRIPTION
## Description

[Ticket](https://dt-rnd.atlassian.net/browse/K8S-9893)

Currently the oneagent-ignore-proxy feature flag is not considered, when the new way to mount the proxy to the agent via volume is used.

## How can this be tested?

Create a dynakube with a proxy and the annotation oneagent-ignore-proxy, check if the daemonset of the agent does not have a proxy volume and volume mount