### PR TITLE
Improve error handling for dt token generator

### DIFF
--- a/pkg/util/dttoken/token.go
+++ b/pkg/util/dttoken/token.go
@@ -22,18 +22,28 @@ func (t Token) String() string {
 	return fmt.Sprintf("%s.%s.%s", t.prefix, t.public, t.private)
 }
 
-func New(prefix string) *Token {
-	return &Token{prefix: prefix, public: generateRandom(publicPortionSize), private: generateRandom(privatePortionSize)}
+func New(prefix string) (*Token, error) {
+	public, err := generateRandom(publicPortionSize)
+	if err != nil {
+		return nil, err
+	}
+
+	private, err := generateRandom(privatePortionSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Token{prefix: prefix, public: public, private: private}, nil
 }
 
 // generate base32 encoded random string using base32.StdEncoding
-func generateRandom(size int) string {
+func generateRandom(size int) (string, error) {
 	b := make([]byte, size)
 	_, err := rand.Read(b)
 
 	if err != nil {
-		return ""
+		return "", err
 	}
 
-	return base32.StdEncoding.EncodeToString(b)[:size]
+	return base32.StdEncoding.EncodeToString(b)[:size], nil
 }

--- a/pkg/util/dttoken/token_test.go
+++ b/pkg/util/dttoken/token_test.go
@@ -5,17 +5,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateToken(t *testing.T) {
 	t.Run("generate token but always new one", func(t *testing.T) {
-		tokenA := New("test")
-		tokenB := New("test")
+		tokenA, err := New("test")
+		require.NoError(t, err)
+		tokenB, err := New("test")
+		require.NoError(t, err)
 
 		assert.NotEqual(t, tokenA, tokenB)
 	})
 	t.Run("string representation of token", func(t *testing.T) {
-		tokenA := New("test")
+		tokenA, err := New("test")
+		require.NoError(t, err)
 		tokenParts := strings.Split(tokenA.String(), ".")
 		assert.Len(t, tokenParts, 3)
 		assert.Equal(t, "test", tokenParts[0])
@@ -26,7 +30,13 @@ func TestGenerateToken(t *testing.T) {
 
 func Test_generateRandom(t *testing.T) {
 	t.Run("check random length", func(t *testing.T) {
-		assert.Len(t, generateRandom(10), 10)
-		assert.Len(t, generateRandom(32), 32)
+		ten, err := generateRandom(10)
+		require.NoError(t, err)
+		assert.Len(t, ten, 10)
+	})
+	t.Run("error", func(t *testing.T) {
+		r, err := generateRandom(32)
+		require.NoError(t, err)
+		require.Len(t, r, 32)
 	})
 }


### PR DESCRIPTION
## Description

This PR covers: if an error occurs, propagate it to the caller

[resolves issue](https://dt-rnd.atlassian.net/browse/K8S-9890)

## How can this be tested?

unit-tests

