### PR TITLE
fixup: replace gomnd by mnd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -160,7 +160,7 @@ linters-settings:
         deny:
           - pkg: "github.com/google/go-cmp"
             desc: Please don't use go-cmp for non-test code.
-  gomnd:
+  mnd:
     checks:
       - argument
       - case
@@ -214,7 +214,7 @@ linters:
   - godot                     # Check if comments end in a period.
   - gofmt                     # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
   - goheader                  # Checks is file header matches to pattern.
-  - gomnd                     # An analyzer to detect magic numbers.
+  - mnd                       # An analyzer to detect magic numbers.
   - gomoddirectives           # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
   - gomodguard                # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
   - goprintffuncname          # Checks that printf-like functions are named with f at the end.

--- a/cmd/support_archive/builder.go
+++ b/cmd/support_archive/builder.go
@@ -38,7 +38,7 @@ const (
 )
 
 const (
-	_ = 1 << (10 * iota) //nolint:gomnd
+	_ = 1 << (10 * iota) //nolint:mnd
 	Kibi
 	Mebi
 )

--- a/pkg/controllers/csi/metadata/sqlite_gorm_client_test.go
+++ b/pkg/controllers/csi/metadata/sqlite_gorm_client_test.go
@@ -88,6 +88,7 @@ func TestUpdateTenantConfig(t *testing.T) {
 
 func TestDeleteTenantConfig(t *testing.T) {
 	var tenantConfig *TenantConfig
+
 	var codeModules []CodeModule
 
 	t.Run("on cascade deletion true", func(t *testing.T) {
@@ -195,6 +196,7 @@ func TestIsCodeModuleOrphaned(t *testing.T) {
 		codeModule := &CodeModule{
 			Version: "1.0",
 		}
+
 		db.db.Create(tenantConfig)
 		db.db.Create(codeModule)
 

--- a/pkg/util/dttoken/token_test.go
+++ b/pkg/util/dttoken/token_test.go
@@ -20,6 +20,7 @@ func TestGenerateToken(t *testing.T) {
 	t.Run("string representation of token", func(t *testing.T) {
 		tokenA, err := New("test")
 		require.NoError(t, err)
+
 		tokenParts := strings.Split(tokenA.String(), ".")
 		assert.Len(t, tokenParts, 3)
 		assert.Equal(t, "test", tokenParts[0])


### PR DESCRIPTION
## Description

Remove depreciation warning by replacing gomnd by mnd 


## How can this be tested?

make go/lint
