### PR TITLE
Adopt EdgeConnect provisioning for K8S API access

### DIFF
--- a/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
@@ -60,14 +60,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - services
-    resourceNames:
-      - kubernetes
-    verbs:
-      - get
-  - apiGroups:
-      - ""
-    resources:
       - events
     verbs:
       - create

--- a/pkg/api/v1alpha1/edgeconnect/properties.go
+++ b/pkg/api/v1alpha1/edgeconnect/properties.go
@@ -35,6 +35,14 @@ func (edgeConnect *EdgeConnect) IsCustomImage() bool {
 	return edgeConnect.Spec.ImageRef.Repository != ""
 }
 
+func (edgeConnect *EdgeConnect) IsProvisionerModeEnabled() bool {
+	return edgeConnect.Spec.OAuth.Provisioner
+}
+
+func (edgeConnect *EdgeConnect) IsK8SAutomationEnabled() bool {
+	return edgeConnect.Spec.KubernetesAutomation != nil && edgeConnect.Spec.KubernetesAutomation.Enabled
+}
+
 func (edgeConnect *EdgeConnect) EmptyPullSecret() corev1.Secret {
 	return corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/api/v1alpha1/edgeconnect/secret.go
+++ b/pkg/api/v1alpha1/edgeconnect/secret.go
@@ -46,7 +46,7 @@ func (ec *EdgeConnect) GetOAuthClientFromSecret(ctx context.Context, kubeReader 
 
 	resource := ec.Spec.OAuth.Resource
 
-	if ec.Spec.OAuth.Provisioner {
+	if ec.IsProvisionerModeEnabled() {
 		resourceBytes, hasKey := clientSecret.Data[consts.KeyEdgeConnectOauthResource]
 		if !hasKey {
 			return oAuth, errors.Errorf("missing %s in %s", consts.KeyEdgeConnectOauthResource, secretName)

--- a/pkg/clients/edgeconnect/client.go
+++ b/pkg/clients/edgeconnect/client.go
@@ -87,8 +87,8 @@ type ServerError struct {
 
 // DetailsError represents details of errors
 type DetailsError struct {
-	ConstraintViolations ConstraintViolations `json:"constraintViolations"`
-	MissingScopes        []string             `json:"missingScopes,omitempty"`
+	ConstraintViolations []ConstraintViolations `json:"constraintViolations"`
+	MissingScopes        []string               `json:"missingScopes,omitempty"`
 }
 
 // ConstraintViolations represents constraint violation errors

--- a/pkg/clients/edgeconnect/client_test.go
+++ b/pkg/clients/edgeconnect/client_test.go
@@ -173,10 +173,12 @@ func edgeConnectCreateServerHandler(errorBadRequest bool) http.HandlerFunc {
 						Code:    400,
 						Message: "Constraints violated.",
 						Details: DetailsError{
-							ConstraintViolations: ConstraintViolations{
-								Message:           "must not be null",
-								Path:              "path",
-								ParameterLocation: "PAYLOAD_BODY",
+							ConstraintViolations: []ConstraintViolations{
+								{
+									Message:           "must not be null",
+									Path:              "path",
+									ParameterLocation: "PAYLOAD_BODY",
+								},
 							},
 						},
 					},

--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -706,6 +706,7 @@ func (controller *Controller) createOrUpdateEdgeConnectConfigSecret(ctx context.
 	return hasher.GenerateHash(secretConfig.Data)
 }
 
+// indicator of the cluster the EC configuration is related to
 func (controller *Controller) k8sHostname(ctx context.Context, ecName string, ecNamespace string) (string, error) {
 	var kubeSystemNamespace corev1.Namespace
 

--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -403,7 +403,7 @@ func (controller *Controller) reconcileEdgeConnectProvisioner(ctx context.Contex
 		}
 	}
 
-	k8sHostname, err := controller.k8sHostname(ctx, edgeConnect.Name, edgeConnect.Namespace)
+	k8sHostname, err := controller.k8sAutomationHostPattern(ctx, edgeConnect.Name, edgeConnect.Namespace)
 	if err != nil {
 		return err
 	}
@@ -706,8 +706,7 @@ func (controller *Controller) createOrUpdateEdgeConnectConfigSecret(ctx context.
 	return hasher.GenerateHash(secretConfig.Data)
 }
 
-// indicator of the cluster the EC configuration is related to
-func (controller *Controller) k8sHostname(ctx context.Context, ecName string, ecNamespace string) (string, error) {
+func (controller *Controller) k8sAutomationHostPattern(ctx context.Context, ecName string, ecNamespace string) (string, error) {
 	var kubeSystemNamespace corev1.Namespace
 
 	err := controller.apiReader.Get(ctx, client.ObjectKey{Name: kubeSystemNamespaceName}, &kubeSystemNamespace)

--- a/pkg/controllers/edgeconnect/deployment/deployment.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment.go
@@ -59,7 +59,6 @@ func create(instance *edgeconnectv1alpha1.EdgeConnect) *appsv1.Deployment {
 					Volumes:                       prepareVolumes(instance),
 					NodeSelector:                  instance.Spec.NodeSelector,
 					Tolerations:                   instance.Spec.Tolerations,
-					HostAliases:                   []corev1.HostAlias{},
 					TopologySpreadConstraints:     instance.Spec.TopologySpreadConstraints,
 				},
 			},

--- a/pkg/controllers/edgeconnect/secret/secret.go
+++ b/pkg/controllers/edgeconnect/secret/secret.go
@@ -22,7 +22,7 @@ func PrepareConfigFile(ctx context.Context, instance *edgeconnectv1alpha1.EdgeCo
 	}
 
 	// For provisioned we need to read another secret, which later we mount to EdgeConnect pod
-	if instance.Spec.OAuth.Provisioner {
+	if instance.IsProvisionerModeEnabled() {
 		oAuth, err := instance.GetOAuthClientFromSecret(ctx, apiReader, instance.ClientSecretName())
 		if err != nil {
 			return []byte{}, err

--- a/pkg/webhook/validation/edgeconnect/host_patterns.go
+++ b/pkg/webhook/validation/edgeconnect/host_patterns.go
@@ -11,7 +11,7 @@ const (
 )
 
 func checkHostPatternsValue(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
-	if edgeConnect.Spec.OAuth.Provisioner && len(edgeConnect.Spec.HostPatterns) == 0 {
+	if !edgeConnect.IsK8SAutomationEnabled() && edgeConnect.IsProvisionerModeEnabled() && len(edgeConnect.Spec.HostPatterns) == 0 {
 		return errorHostPattersIsRequired
 	}
 

--- a/pkg/webhook/validation/edgeconnect/host_patterns.go
+++ b/pkg/webhook/validation/edgeconnect/host_patterns.go
@@ -11,7 +11,7 @@ const (
 )
 
 func checkHostPatternsValue(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
-	if !edgeConnect.IsK8SAutomationEnabled() && edgeConnect.IsProvisionerModeEnabled() && len(edgeConnect.Spec.HostPatterns) == 0 {
+	if edgeConnect.IsProvisionerModeEnabled() && len(edgeConnect.Spec.HostPatterns) == 0 && !edgeConnect.IsK8SAutomationEnabled() {
 		return errorHostPattersIsRequired
 	}
 


### PR DESCRIPTION
## Description

1) Removes HostAlias from the EC pod.
2) Adds K8S _hostname_ as alias for accessing the K8S API in EdgeConnect provisioning mode with k8sAutomation enabled.

The hostname is constructed following this pattern
```
 <edgeconnect-CR-name>.<edgeconnect-CR-namespace>.<cluster-ID>.kubernetes-automation
 ```
 
## How can this be tested?

Unittests.

Install EC with `provisioner` mode and K8SAutomation enabled :
```
  oauth:
    provisioner: true
  hostPatterns:
  - '*.d.internal.org'
  kubernetesAutomation:
    enabled: true
```
K8S `hostname` is present on the `ShowDetails/Host Patterns` list on the UI :
```
*.d.internal.org
<CR name>.dynatrace.273ec656-603d-46c8-b5f5-5c47a6903dff.kubernetes-automation
```
Disable K8SAutomation. `Host Patterns` on the UI should contain just 1 entry now :
```
*.d.internal.org
```