### PR TITLE
Add Dynakube status condition for the AG dynakube-activegate-authtoken-secret secret

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/authtoken/conditions.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/conditions.go
@@ -8,7 +8,7 @@ import (
 
 const ActiveGateAuthTokenSecretConditionType string = "ActiveGateAuthTokenSecret"
 
-func SetAuthSecretCreated(conditions *[]metav1.Condition, conditionType string, msg string) {
+func setAuthSecretCreated(conditions *[]metav1.Condition, conditionType string, msg string) {
 	condition := metav1.Condition{
 		Type:    conditionType,
 		Status:  metav1.ConditionTrue,

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/conditions.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/conditions.go
@@ -1,0 +1,3 @@
+package authtoken
+
+const ActiveGateAuthTokenSecretConditionType string = "ActiveGateAuthTokenSecret"

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/conditions.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/conditions.go
@@ -1,3 +1,19 @@
 package authtoken
 
+import (
+	cond "github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 const ActiveGateAuthTokenSecretConditionType string = "ActiveGateAuthTokenSecret"
+
+func SetAuthSecretCreated(conditions *[]metav1.Condition, conditionType string, msg string) {
+	condition := metav1.Condition{
+		Type:    conditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  cond.SecretCreatedReason,
+		Message: msg,
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
+}

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -161,5 +161,5 @@ func (r *Reconciler) conditionSetSecretCreated(secret *corev1.Secret) {
 	tokenAllParts := strings.Split(string(secret.Data[ActiveGateAuthTokenName]), ".")
 	tokenPublicPart := strings.Join(tokenAllParts[:2], ".")
 
-	SetAuthSecretCreated(r.dynakube.Conditions(), ActiveGateAuthTokenSecretConditionType, "secret created "+days+" day(s) ago, token:"+tokenPublicPart)
+	setAuthSecretCreated(r.dynakube.Conditions(), ActiveGateAuthTokenSecretConditionType, "secret created "+days+" day(s) ago, token:"+tokenPublicPart)
 }

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -161,5 +161,5 @@ func (r *Reconciler) conditionSetSecretCreated(secret *corev1.Secret) {
 	tokenAllParts := strings.Split(string(secret.Data[ActiveGateAuthTokenName]), ".")
 	tokenPublicPart := strings.Join(tokenAllParts[:2], ".")
 
-	conditions.SetAuthSecretCreated(r.dynakube.Conditions(), ActiveGateAuthTokenSecretConditionType, "secret created "+days+" day(s) ago, token:"+tokenPublicPart)
+	SetAuthSecretCreated(r.dynakube.Conditions(), ActiveGateAuthTokenSecretConditionType, "secret created "+days+" day(s) ago, token:"+tokenPublicPart)
 }

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
@@ -118,6 +118,7 @@ func TestReconcile(t *testing.T) {
 		authToken.CreationTimestamp = metav1.Time{Time: time.Now().Round(1 * time.Second).Add(-AuthTokenRotationInterval).Add(-5 * time.Second)}
 		err = r.client.Update(context.Background(), &authToken)
 		require.NoError(t, err)
+
 		firstCreationTimestamp := authToken.CreationTimestamp
 
 		// let's "wait", small difference needed to compare LastTransitionTime
@@ -160,6 +161,7 @@ func TestReconcile(t *testing.T) {
 
 		var authToken corev1.Secret
 		_ = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
+
 		require.NoError(t, err)
 		assert.NotEmpty(t, authToken.Data[ActiveGateAuthTokenName])
 
@@ -169,6 +171,7 @@ func TestReconcile(t *testing.T) {
 		authToken.CreationTimestamp = metav1.Time{Time: time.Now().Round(1 * time.Second).Add(-AuthTokenRotationInterval).Add(1 * time.Minute)}
 		err = r.client.Update(context.Background(), &authToken)
 		require.NoError(t, err)
+
 		firstCreationTimestamp := authToken.CreationTimestamp
 
 		// let's "wait", small difference needed to compare LastTransitionTime

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
@@ -5,17 +5,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
 	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 const (
@@ -32,8 +34,8 @@ var (
 	}
 )
 
-func newTestReconcilerWithInstance(t *testing.T, client client.Client) *Reconciler {
-	instance := &dynatracev1beta2.DynaKube{
+func newInstance() *dynatracev1beta2.DynaKube {
+	return &dynatracev1beta2.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testDynakubeName,
@@ -47,17 +49,36 @@ func newTestReconcilerWithInstance(t *testing.T, client client.Client) *Reconcil
 			},
 		},
 	}
+}
+
+func newTestReconciler(t *testing.T, client client.Client, instance *dynatracev1beta2.DynaKube) *Reconciler {
 	dtc := dtclientmock.NewClient(t)
-	dtc.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testAgAuthTokenResponse, nil).Maybe()
+	dtc.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testAgAuthTokenResponse, nil)
 
 	r := NewReconciler(client, client, instance, dtc)
 
 	return r
 }
 
+func clientCreateWithTimestamp() func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+	return func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+		obj.SetCreationTimestamp(metav1.Time{Time: time.Now()})
+
+		return client.Create(ctx, obj, opts...)
+	}
+}
+
 func TestReconcile(t *testing.T) {
+	interceptorFuncs := interceptor.Funcs{
+		Create: clientCreateWithTimestamp(),
+	}
+
 	t.Run(`reconcile auth token for first time`, func(t *testing.T) {
-		r := newTestReconcilerWithInstance(t, fake.NewClientBuilder().Build())
+		instance := newInstance()
+
+		clt := fake.NewClientBuilder().Build()
+
+		r := newTestReconciler(t, clt, instance)
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -65,49 +86,111 @@ func TestReconcile(t *testing.T) {
 		_ = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
 
 		assert.NotEmpty(t, authToken.Data[ActiveGateAuthTokenName])
+
+		condition := meta.FindStatusCondition(*instance.Conditions(), ActiveGateAuthTokenSecretConditionType)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
 	})
 	t.Run(`reconcile outdated auth token`, func(t *testing.T) {
-		clt := fake.NewClientBuilder().
-			WithScheme(scheme.Scheme).
-			WithObjects(&corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              secretName,
-					Namespace:         testNamespace,
-					CreationTimestamp: metav1.Time{Time: time.Now().Add(-AuthTokenRotationInterval).Add(-5 * time.Second)},
-				},
-				Data: map[string][]byte{ActiveGateAuthTokenName: []byte(testToken)},
-			}).
-			Build()
+		instance := newInstance()
 
-		r := newTestReconcilerWithInstance(t, clt)
+		clt := interceptor.NewClient(fake.NewClientBuilder().Build(), interceptorFuncs)
+
+		r := newTestReconciler(t, clt, instance)
+
+		// create secret
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
-		var authToken corev1.Secret
-		_ = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
+		condition := meta.FindStatusCondition(*instance.Conditions(), ActiveGateAuthTokenSecretConditionType)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
+		firstTransition := condition.LastTransitionTime
 
+		var authToken corev1.Secret
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
+		require.NoError(t, err)
+		assert.NotEmpty(t, authToken.Data[ActiveGateAuthTokenName])
+
+		// "initialize" the secret as if it was created a month ago
+		authToken.Data = map[string][]byte{ActiveGateAuthTokenName: []byte(testToken)}
+		// time.Round is called because client.Update(secret)->json.Marshall(secret) rounds CreationTimestamp to seconds
+		authToken.CreationTimestamp = metav1.Time{Time: time.Now().Round(1 * time.Second).Add(-AuthTokenRotationInterval).Add(-5 * time.Second)}
+		err = r.client.Update(context.Background(), &authToken)
+		require.NoError(t, err)
+		firstCreationTimestamp := authToken.CreationTimestamp
+
+		// let's "wait", small difference needed to compare LastTransitionTime
+		time.Sleep(1 * time.Second)
+
+		// update secret
+		err = r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		condition = meta.FindStatusCondition(*instance.Conditions(), ActiveGateAuthTokenSecretConditionType)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
+		secondTransition := condition.LastTransitionTime
+
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
+		require.NoError(t, err)
+		assert.NotEmpty(t, authToken.Data[ActiveGateAuthTokenName])
+		secondCreationTimestamp := authToken.CreationTimestamp
+
+		// token has been changed
 		assert.NotEqual(t, authToken.Data[ActiveGateAuthTokenName], []byte(testToken))
+		assert.NotEqual(t, firstCreationTimestamp, secondCreationTimestamp)
+		assert.NotEqual(t, secondTransition, firstTransition)
 	})
 	t.Run(`reconcile valid auth token`, func(t *testing.T) {
-		clt := fake.NewClientBuilder().
-			WithScheme(scheme.Scheme).
-			WithObjects(&corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              secretName,
-					Namespace:         testNamespace,
-					CreationTimestamp: metav1.Time{Time: time.Now().Add(-AuthTokenRotationInterval).Add(1 * time.Minute)},
-				},
-				Data: map[string][]byte{ActiveGateAuthTokenName: []byte(testToken)},
-			}).
-			Build()
-		r := newTestReconcilerWithInstance(t, clt)
+		instance := newInstance()
 
+		clt := interceptor.NewClient(fake.NewClientBuilder().Build(), interceptorFuncs)
+
+		r := newTestReconciler(t, clt, instance)
+
+		// create secret
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
+		condition := meta.FindStatusCondition(*instance.Conditions(), ActiveGateAuthTokenSecretConditionType)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
+		firstTransition := condition.LastTransitionTime
+
 		var authToken corev1.Secret
 		_ = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
+		require.NoError(t, err)
+		assert.NotEmpty(t, authToken.Data[ActiveGateAuthTokenName])
 
+		// "initialize" the secret as if it was created a month ago
+		authToken.Data = map[string][]byte{ActiveGateAuthTokenName: []byte(testToken)}
+		// time.Round is called because client.Update(secret)->json.Marshall(secret) rounds CreationTimestamp to seconds
+		authToken.CreationTimestamp = metav1.Time{Time: time.Now().Round(1 * time.Second).Add(-AuthTokenRotationInterval).Add(1 * time.Minute)}
+		err = r.client.Update(context.Background(), &authToken)
+		require.NoError(t, err)
+		firstCreationTimestamp := authToken.CreationTimestamp
+
+		// let's "wait", small difference needed to compare LastTransitionTime
+		time.Sleep(1 * time.Second)
+
+		// do not update secret
+		err = r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		condition = meta.FindStatusCondition(*instance.Conditions(), ActiveGateAuthTokenSecretConditionType)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
+		secondTransition := condition.LastTransitionTime
+
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.ActiveGateAuthTokenSecret(), Namespace: testNamespace}, &authToken)
+		require.NoError(t, err)
+		assert.NotEmpty(t, authToken.Data[ActiveGateAuthTokenName])
+		secondCreationTimestamp := authToken.CreationTimestamp
+
+		// token hasn't been changed
 		assert.Equal(t, authToken.Data[ActiveGateAuthTokenName], []byte(testToken))
+		assert.Equal(t, firstCreationTimestamp, secondCreationTimestamp)
+		assert.Equal(t, secondTransition, firstTransition)
 	})
 }

--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -112,6 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 
 	// TODO: move cleanup to ActiveGate reconciler
 	meta.RemoveStatusCondition(r.dynakube.Conditions(), statefulset.ActiveGateStatefulSetConditionType)
+	meta.RemoveStatusCondition(r.dynakube.Conditions(), authtoken.ActiveGateAuthTokenSecretConditionType)
 
 	return nil
 }

--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -93,11 +93,11 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 				return err
 			}
 		}
+	}
 
-		err = r.authTokenReconciler.Reconcile(ctx)
-		if err != nil {
-			return errors.WithMessage(err, "could not reconcile Dynatrace ActiveGateAuthToken secrets")
-		}
+	err = r.authTokenReconciler.Reconcile(ctx)
+	if err != nil {
+		return errors.WithMessage(err, "could not reconcile Dynatrace ActiveGateAuthToken secrets")
 	}
 
 	for _, agCapability := range capability.GenerateActiveGateCapabilities(r.dynakube) {
@@ -112,7 +112,6 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 
 	// TODO: move cleanup to ActiveGate reconciler
 	meta.RemoveStatusCondition(r.dynakube.Conditions(), statefulset.ActiveGateStatefulSetConditionType)
-	meta.RemoveStatusCondition(r.dynakube.Conditions(), authtoken.ActiveGateAuthTokenSecretConditionType)
 
 	return nil
 }

--- a/pkg/controllers/dynakube/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/reconciler_test.go
@@ -46,7 +46,7 @@ var (
 
 func TestReconciler_Reconcile(t *testing.T) {
 	dtc := dtclientmock.NewClient(t)
-	dtc.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+	dtc.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 
 	t.Run(`Create works with minimal setup`, func(t *testing.T) {
 		instance := &dynatracev1beta2.DynaKube{
@@ -199,7 +199,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 func TestServiceCreation(t *testing.T) {
 	dynatraceClient := dtclientmock.NewClient(t)
-	dynatraceClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+	dynatraceClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 
 	dynakube := &dynatracev1beta2.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/dynakube/controller_system_test.go
+++ b/pkg/controllers/dynakube/controller_system_test.go
@@ -69,7 +69,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 	})
 	t.Run(`Create reconciles proxy secret`, func(t *testing.T) {
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
-		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 		mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
 		instance := &dynatracev1beta2.DynaKube{
@@ -108,7 +108,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 	t.Run(`reconciles phase change correctly`, func(t *testing.T) {
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeSettingsRead, dtclient.TokenScopeSettingsWrite, dtclient.TokenScopeActiveGateTokenCreate})
 
-		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 		mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
 		instance := &dynatracev1beta2.DynaKube{
@@ -192,7 +192,7 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 		dtclient.TokenScopeActiveGateTokenCreate,
 	})
 
-	mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, nil)
+	mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 	mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
 	instance := &dynatracev1beta2.DynaKube{

--- a/pkg/util/conditions/secret.go
+++ b/pkg/util/conditions/secret.go
@@ -40,3 +40,13 @@ func SetSecretOutdated(conditions *[]metav1.Condition, conditionType, message st
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }
+
+func SetAuthSecretCreated(conditions *[]metav1.Condition, conditionType string, msg string) {
+	condition := metav1.Condition{
+		Type:    conditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  SecretCreatedReason,
+		Message: msg,
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
+}

--- a/pkg/util/conditions/secret.go
+++ b/pkg/util/conditions/secret.go
@@ -40,13 +40,3 @@ func SetSecretOutdated(conditions *[]metav1.Condition, conditionType, message st
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }
-
-func SetAuthSecretCreated(conditions *[]metav1.Condition, conditionType string, msg string) {
-	condition := metav1.Condition{
-		Type:    conditionType,
-		Status:  metav1.ConditionTrue,
-		Reason:  SecretCreatedReason,
-		Message: msg,
-	}
-	_ = meta.SetStatusCondition(conditions, condition)
-}


### PR DESCRIPTION
## Description

Adds new `ActiveGateAuthTokenSecret` condition :
```
  - lastTransitionTime: "2024-05-24T10:57:12Z"
    message: secret created 0 day(s) ago, token:dt0g02.ABCDEFGH
    reason: SecretCreated
    status: "True"
    type: ActiveGateAuthTokenSecret
```    

`lastTransitionTime` field is updated if:
- token expired and new instance of the secret is created
- k8s client error occurred
- Dynatrace server error occurred

In case of an error the `message` field contains description of the error. Otherwise the message informs about token's lifetime and public part of the token. The field is updated once a day counting down the token's lifetime (it doesn't affect `lastTransitionTime` field).

For example the secret was created on Friday:
```
  - lastTransitionTime: "2024-05-24T10:57:12Z"                                                                                                                                                                                                                                                                                                                                                
    message: secret created 0 day(s) ago, token:dt0g02.LVBZLERV                                                                                                                                                                                                                                                                                                                               
    reason: SecretCreated                                                                                                                                                                                                                                                                                                                                                                     
    status: "True"                                                                                                                                                                                                                                                                                                                                                                            
    type: ActiveGateAuthTokenSecret
```
after weekend:
```
  - lastTransitionTime: "2024-05-24T10:57:12Z"
    message: secret created 2 day(s) ago, token:dt0g02.LVBZLERV
    reason: SecretCreated
    status: "True"
    type: ActiveGateAuthTokenSecret
```


## How can this be tested?

Unittests.

Deploy CN with ActiveGate. 

Check AG status after 1 day :
- `lastTransitionTime` - shoud be the same
- `message` - token should be the same, lifetime should be set to `1 day(s) ago`

Remove AG from the dynakube :
- the condition shoud be removed from the dynakube status