### PR TITLE
Fix workload owner detection

### DIFF
--- a/pkg/consts/enrichment_injection.go
+++ b/pkg/consts/enrichment_injection.go
@@ -6,7 +6,6 @@ const (
 	EnrichmentInjectedEnv        = "METADATA_ENRICHMENT_INJECTED"
 	EnrichmentWorkloadKindEnv    = "DT_WORKLOAD_KIND"
 	EnrichmentWorkloadNameEnv    = "DT_WORKLOAD_NAME"
-	EnrichmentUnknownWorkload    = "UNKNOWN"
 )
 
 var (

--- a/pkg/injection/startup/env.go
+++ b/pkg/injection/startup/env.go
@@ -275,11 +275,7 @@ func (env *environment) addWorkloadKind() error {
 		return err
 	}
 
-	if workloadKind == consts.EnrichmentUnknownWorkload {
-		env.WorkloadKind = ""
-	} else {
-		env.WorkloadKind = workloadKind
-	}
+	env.WorkloadKind = workloadKind
 
 	return nil
 }
@@ -290,11 +286,7 @@ func (env *environment) addWorkloadName() error {
 		return err
 	}
 
-	if workloadName == consts.EnrichmentUnknownWorkload {
-		env.WorkloadName = ""
-	} else {
-		env.WorkloadName = workloadName
-	}
+	env.WorkloadName = workloadName
 
 	return nil
 }

--- a/pkg/injection/startup/env_test.go
+++ b/pkg/injection/startup/env_test.go
@@ -71,23 +71,6 @@ func TestNewEnv(t *testing.T) {
 		assert.False(t, env.OneAgentInjected)
 		assert.True(t, env.MetadataEnrichmentInjected)
 	})
-	t.Run(`create new env for only metadata-enrichment injection with unknown owner workload`, func(t *testing.T) {
-		resetEnv := prepMetadataEnrichmentTestEnv(t, true)
-
-		env, err := newEnv()
-
-		resetEnv()
-
-		require.NoError(t, err)
-		require.NotNil(t, env)
-
-		assert.NotEmpty(t, env.K8ClusterID)
-		assert.Empty(t, env.WorkloadKind)
-		assert.Empty(t, env.WorkloadName)
-
-		assert.False(t, env.OneAgentInjected)
-		assert.True(t, env.MetadataEnrichmentInjected)
-	})
 	t.Run(`create new env for only oneagent`, func(t *testing.T) {
 		resetEnv := prepOneAgentTestEnv(t)
 

--- a/pkg/webhook/mutation/pod/metadata/workload.go
+++ b/pkg/webhook/mutation/pod/metadata/workload.go
@@ -81,9 +81,11 @@ func findRootOwner(ctx context.Context, clt client.Client, childObjectMetadata *
 			if err != nil {
 				return childObjectMetadata, err
 			}
+
 			if isWellKnownWorkload(parentObjectMetadata) {
 				return parentObjectMetadata, nil
 			}
+
 			return childObjectMetadata, nil
 		}
 	}

--- a/pkg/webhook/mutation/pod/metadata/workload_test.go
+++ b/pkg/webhook/mutation/pod/metadata/workload_test.go
@@ -51,7 +51,8 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 
 		daemonSet := appsv1.DaemonSet{
 			TypeMeta: metav1.TypeMeta{
-				Kind: "DaemonSet",
+				Kind:       "DaemonSet",
+				APIVersion: "apps/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resourceName,
@@ -162,7 +163,8 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 
 		deployment := appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{
-				Kind: "Deployment",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				OwnerReferences: []metav1.OwnerReference{

--- a/pkg/webhook/mutation/pod/metadata/workload_test.go
+++ b/pkg/webhook/mutation/pod/metadata/workload_test.go
@@ -114,7 +114,7 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 				Namespace: namespaceName,
 			},
 		}
-		client := fake.NewClient(&pod, &namespace)
+		client := fake.NewClient(&pod, &secret)
 		workloadInfo, err := findRootOwnerOfPod(ctx, client, &pod, namespaceName)
 		require.NoError(t, err)
 		assert.Equal(t, resourceName, workloadInfo.name)

--- a/pkg/webhook/mutation/pod/metadata/workload_test.go
+++ b/pkg/webhook/mutation/pod/metadata/workload_test.go
@@ -90,7 +90,7 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 		assert.Equal(t, "Pod", workloadInfo.kind)
 	})
 
-	t.Run("should be empty if owner is not well known", func(t *testing.T) {
+	t.Run("should be pod if owner is not well known", func(t *testing.T) {
 		pod := corev1.Pod{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Pod",
@@ -98,8 +98,8 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "unknown",
-						Kind:       "unknown",
+						APIVersion: "v1",
+						Kind:       "Secret",
 						Name:       "test",
 						Controller: address.Of(true),
 					},
@@ -107,14 +107,20 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 				Name: resourceName,
 			},
 		}
-		client := fake.NewClient(&pod)
+		namespace := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: namespaceName,
+			},
+		}
+		client := fake.NewClient(&pod, &namespace)
 		workloadInfo, err := findRootOwnerOfPod(ctx, client, &pod, namespaceName)
 		require.NoError(t, err)
-		assert.Equal(t, "UNKNOWN", workloadInfo.name)
-		assert.Equal(t, "UNKNOWN", workloadInfo.kind)
+		assert.Equal(t, resourceName, workloadInfo.name)
+		assert.Equal(t, "Pod", workloadInfo.kind)
 	})
 
-	t.Run("should be unknown if no controller is the owner", func(t *testing.T) {
+	t.Run("should be pod if no controller is the owner", func(t *testing.T) {
 		pod := corev1.Pod{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Pod",
@@ -135,8 +141,65 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 		client := fake.NewClient(&pod)
 		workloadInfo, err := findRootOwnerOfPod(ctx, client, &pod, namespaceName)
 		require.NoError(t, err)
-		assert.Equal(t, "UNKNOWN", workloadInfo.name)
-		assert.Equal(t, "UNKNOWN", workloadInfo.kind)
+		assert.Equal(t, namespaceName, workloadInfo.name)
+		assert.Equal(t, "Pod", workloadInfo.kind)
+	})
+	t.Run("should find the root owner of the pod if the root owner is unknown", func(t *testing.T) {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "test",
+						Controller: address.Of(true),
+					},
+				},
+				Name:      resourceName,
+				Namespace: namespaceName,
+			},
+		}
+
+		deployment := appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Deployment",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "Secret",
+						Name:       "test",
+						Controller: address.Of(true),
+					},
+				},
+				Name:      resourceName,
+				Namespace: namespaceName,
+			},
+		}
+
+		secret := corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Secret",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: namespaceName,
+			},
+		}
+
+		namespace := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+			},
+		}
+
+		client := fake.NewClient(&pod, &deployment, &secret, &namespace)
+
+		workloadInfo, err := findRootOwnerOfPod(ctx, client, &pod, namespaceName)
+		require.NoError(t, err)
+		assert.Equal(t, resourceName, workloadInfo.name)
+		assert.Equal(t, "Deployment", workloadInfo.kind)
 	})
 }
 


### PR DESCRIPTION
## Description

Ticket: https://dt-rnd.atlassian.net/browse/K8S-10007

Fixes the current state of the workload detection, the pod itself is always the default owner of itself, if there is a well known owner in the hierarchy, then we take the highest in line as the owner. There is no more unknown, as the default should be the pod itself

## How can this be tested?

Deploy operator -> create pods with owner references and check the env vars