### PR TITLE
Add Conditions for ActiveGate and CodeModules to the Istio Reconciler

### DIFF
--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -107,12 +107,10 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		return err
 	}
 
-	if r.dynakube.NeedsActiveGate() {
-		if r.istioReconciler != nil {
-			err = r.istioReconciler.ReconcileActiveGateCommunicationHosts(ctx, r.dynakube)
-			if err != nil {
-				return err
-			}
+	if r.istioReconciler != nil {
+		err = r.istioReconciler.ReconcileActiveGateCommunicationHosts(ctx, r.dynakube)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/controllers/dynakube/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/reconciler_test.go
@@ -416,7 +416,7 @@ func createIstioReconcilerMock(t *testing.T) istio.Reconciler {
 	reconciler := istiomock.NewReconciler(t)
 	reconciler.On("ReconcileActiveGateCommunicationHosts",
 		mock.AnythingOfType("context.backgroundCtx"),
-		mock.AnythingOfType("*dynakube.DynaKube")).Return(nil).Once()
+		mock.AnythingOfType("*dynakube.DynaKube")).Return(nil).Twice()
 
 	return reconciler
 }

--- a/pkg/controllers/dynakube/injection/reconciler.go
+++ b/pkg/controllers/dynakube/injection/reconciler.go
@@ -78,6 +78,14 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 	}
 
 	if !r.dynakube.NeedAppInjection() {
+		if r.istioReconciler != nil {
+			err = r.istioReconciler.ReconcileCodeModuleCommunicationHosts(ctx, r.dynakube)
+
+			if err != nil {
+				log.Info("Error reconciling Istio codemodules", "error", err)
+			}
+		}
+
 		return r.removeAppInjection(ctx)
 	}
 

--- a/pkg/controllers/dynakube/injection/reconciler.go
+++ b/pkg/controllers/dynakube/injection/reconciler.go
@@ -82,7 +82,7 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		err = r.istioReconciler.ReconcileCodeModuleCommunicationHosts(ctx, r.dynakube)
 
 		if err != nil {
-			log.Info("Error reconciling Istio configuration for CodeModules", "error", err)
+			log.Info("error reconciling istio configuration for codemodules", "error", err)
 		}
 	}
 

--- a/pkg/controllers/dynakube/injection/reconciler.go
+++ b/pkg/controllers/dynakube/injection/reconciler.go
@@ -82,7 +82,7 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		err = r.istioReconciler.ReconcileCodeModuleCommunicationHosts(ctx, r.dynakube)
 
 		if err != nil {
-			log.Info("error reconciling istio configuration for codemodules", "error", err)
+			log.Error(err, "error reconciling istio configuration for codemodules")
 		}
 	}
 

--- a/pkg/controllers/dynakube/istio/conditions.go
+++ b/pkg/controllers/dynakube/istio/conditions.go
@@ -6,14 +6,14 @@ import (
 )
 
 func getConditionTypeName(component string) string {
-	return "IstioServiceConfigurationFor" + component
+	return "IstioFor" + component
 }
 
 func setServiceEntryUpdatedConditionForComponent(conditions *[]metav1.Condition, component string) {
 	condition := metav1.Condition{
 		Type:    getConditionTypeName(component),
 		Status:  metav1.ConditionTrue,
-		Reason:  "IstioServiceConfigurationFor" + component + "Changed",
+		Reason:  "IstioFor" + component + "Changed",
 		Message: "ServiceEntries and VirtualServices for " + component + " have been configured.",
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
@@ -21,9 +21,9 @@ func setServiceEntryUpdatedConditionForComponent(conditions *[]metav1.Condition,
 
 func setServiceEntryFailedConditionForComponent(conditions *[]metav1.Condition, component string, err error) {
 	condition := metav1.Condition{
-		Type:    "IstioServiceConfigurationFor" + component,
+		Type:    getConditionTypeName(component),
 		Status:  metav1.ConditionFalse,
-		Reason:  "IstioServiceConfigurationFor" + component + "Failed",
+		Reason:  "IstioFor" + component + "Failed",
 		Message: "Failed to configure Istio ServiceEntries and VirtualServices for " + component + " with error: " + err.Error(),
 	}
 	_ = meta.SetStatusCondition(conditions, condition)

--- a/pkg/controllers/dynakube/istio/conditions.go
+++ b/pkg/controllers/dynakube/istio/conditions.go
@@ -2,32 +2,31 @@ package istio
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func createConditionTypeForComponent(component string) string {
-	return fmt.Sprintf("IstioServiceConfigurationFor%s", strings.ToTitle(component))
+func getConditionTypeName(component string) string {
+	return "IstioServiceConfigurationFor" + component
 }
 
 func setServiceEntryUpdatedConditionForComponent(conditions *[]metav1.Condition, component string) {
 	condition := metav1.Condition{
-		Type:    createConditionTypeForComponent(component),
+		Type:    getConditionTypeName(component),
 		Status:  metav1.ConditionTrue,
-		Reason:  fmt.Sprintf("IstioServiceConfigurationFor%sChanged", strings.ToTitle(component)),
-		Message: fmt.Sprintf("ServiceEntries and VirtualServices for %s have been configured.", strings.ToTitle(component)),
+		Reason:  "IstioServiceConfigurationFor" + component + "Changed",
+		Message: "ServiceEntries and VirtualServices for " + component + " have been configured.",
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }
 
 func setServiceEntryFailedConditionForComponent(conditions *[]metav1.Condition, component string, err error) {
 	condition := metav1.Condition{
-		Type:    createConditionTypeForComponent(component),
+		Type:    "IstioServiceConfigurationFor" + component,
 		Status:  metav1.ConditionFalse,
-		Reason:  fmt.Sprintf("ServiceEntryFor%sFailed", strings.ToTitle(component)),
-		Message: fmt.Sprintf("Failed to configure Istio ServiceEntries and VirtualServices for %s with error: %s", strings.ToTitle(component), err.Error()),
+		Reason:  "IstioServiceConfigurationFor" + component + "Failed",
+		Message: fmt.Sprintf("Failed to configure Istio ServiceEntries and VirtualServices for %s with error: %s", component, err.Error()),
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }

--- a/pkg/controllers/dynakube/istio/conditions.go
+++ b/pkg/controllers/dynakube/istio/conditions.go
@@ -1,8 +1,6 @@
 package istio
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -26,7 +24,7 @@ func setServiceEntryFailedConditionForComponent(conditions *[]metav1.Condition, 
 		Type:    "IstioServiceConfigurationFor" + component,
 		Status:  metav1.ConditionFalse,
 		Reason:  "IstioServiceConfigurationFor" + component + "Failed",
-		Message: fmt.Sprintf("Failed to configure Istio ServiceEntries and VirtualServices for %s with error: %s", component, err.Error()),
+		Message: "Failed to configure Istio ServiceEntries and VirtualServices for " + component + " with error: " + err.Error(),
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }

--- a/pkg/controllers/dynakube/istio/conditions.go
+++ b/pkg/controllers/dynakube/istio/conditions.go
@@ -1,0 +1,44 @@
+package istio
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createConditionTypeForComponent(component string) string {
+	return fmt.Sprintf("IstioServiceConfigurationFor%s", strings.ToTitle(component))
+}
+
+func setServiceEntryUpdatedConditionForComponent(conditions *[]metav1.Condition, component string) {
+	condition := metav1.Condition{
+		Type:    createConditionTypeForComponent(component),
+		Status:  metav1.ConditionTrue,
+		Reason:  fmt.Sprintf("IstioServiceConfigurationFor%sChanged", strings.ToTitle(component)),
+		Message: fmt.Sprintf("ServiceEntries and VirtualServices for %s have been configured.", strings.ToTitle(component)),
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
+}
+
+func setServiceEntryFailedConditionForComponent(conditions *[]metav1.Condition, component string, err error) {
+	condition := metav1.Condition{
+		Type:    createConditionTypeForComponent(component),
+		Status:  metav1.ConditionFalse,
+		Reason:  fmt.Sprintf("ServiceEntryFor%sFailed", strings.ToTitle(component)),
+		Message: fmt.Sprintf("Failed to configure Istio ServiceEntries and VirtualServices for %s with error: %s", strings.ToTitle(component), err.Error()),
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
+}
+
+//
+// func setIPServiceEntryForActiveGateFailedCondition(conditions *[]metav1.Condition, err error) {
+// 	condition := metav1.Condition{
+// 		Type:    serviceEntryForActiveGateConditionType,
+// 		Status:  metav1.ConditionFalse,
+// 		Reason:  ipServiceEntryForActiveGateFailedReason,
+// 		Message: "Failed to create an IP ServiceEntry for ActiveGate, error: " + err.Error(),
+// 	}
+// 	_ = meta.SetStatusCondition(conditions, condition)
+// }

--- a/pkg/controllers/dynakube/istio/conditions.go
+++ b/pkg/controllers/dynakube/istio/conditions.go
@@ -28,14 +28,3 @@ func setServiceEntryFailedConditionForComponent(conditions *[]metav1.Condition, 
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }
-
-//
-// func setIPServiceEntryForActiveGateFailedCondition(conditions *[]metav1.Condition, err error) {
-// 	condition := metav1.Condition{
-// 		Type:    serviceEntryForActiveGateConditionType,
-// 		Status:  metav1.ConditionFalse,
-// 		Reason:  ipServiceEntryForActiveGateFailedReason,
-// 		Message: "Failed to create an IP ServiceEntry for ActiveGate, error: " + err.Error(),
-// 	}
-// 	_ = meta.SetStatusCondition(conditions, condition)
-// }

--- a/pkg/controllers/dynakube/istio/config.go
+++ b/pkg/controllers/dynakube/istio/config.go
@@ -13,7 +13,8 @@ var (
 const (
 	OperatorComponent   = "operator"
 	OneAgentComponent   = "oneagent"
-	ActiveGateComponent = "activegate"
+	CodeModuleComponent = "CodeModule"
+	ActiveGateComponent = "ActiveGate"
 	IstioGVRName        = "networking.istio.io"
 	IstioGVRVersion     = "v1beta1"
 )

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -269,17 +269,10 @@ func (r *reconciler) reconcileFQDNServiceEntry(ctx context.Context, fqdnHosts []
 func (r *reconciler) cleanupFQDNServiceEntry(ctx context.Context, component string) error {
 	entryName := BuildNameForFQDNServiceEntry(r.client.Owner.GetName(), component)
 
-	err := r.client.DeleteServiceEntry(ctx, entryName)
-	if err != nil {
-		return err
-	}
+	errServiceEntry := r.client.DeleteServiceEntry(ctx, entryName)
+	errVirtualService := r.client.DeleteVirtualService(ctx, entryName)
 
-	err = r.client.DeleteVirtualService(ctx, entryName)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return goerrors.Join(errServiceEntry, errVirtualService)
 }
 
 func buildObjectMeta(name, namespace string, labels map[string]string) metav1.ObjectMeta {

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -224,12 +224,7 @@ func (r *reconciler) reconcileIPServiceEntry(ctx context.Context, ipHosts []dtcl
 func (r *reconciler) cleanupIPServiceEntry(ctx context.Context, component string) error {
 	entryName := BuildNameForIPServiceEntry(r.client.Owner.GetName(), component)
 
-	err := r.client.DeleteServiceEntry(ctx, entryName)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return r.client.DeleteServiceEntry(ctx, entryName)
 }
 
 func (r *reconciler) reconcileFQDNServiceEntry(ctx context.Context, fqdnHosts []dtclient.CommunicationHost, component string) error {

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -116,6 +116,8 @@ func (r *reconciler) ReconcileActiveGateCommunicationHosts(ctx context.Context, 
 	}
 
 	if !conditions.IsOutdated(r.timeProvider, dynakube, getConditionTypeName(conditionComponent)) {
+		log.Info("Condition still within time threshold...skipping further reconciliation")
+
 		return nil
 	}
 

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -70,7 +70,7 @@ func (r *reconciler) ReconcileCodeModuleCommunicationHosts(ctx context.Context, 
 
 	if !dynakube.NeedAppInjection() {
 		if isIstioConfigured(dynakube, conditionComponent) {
-			log.Info("AppInjection disabled, cleaning up")
+			log.Info("appinjection disabled, cleaning up")
 
 			return r.CleanupIstio(ctx, dynakube, conditionComponent, OneAgentComponent)
 		} else {
@@ -107,7 +107,7 @@ func (r *reconciler) ReconcileActiveGateCommunicationHosts(ctx context.Context, 
 
 	if !dynakube.NeedsActiveGate() {
 		if isIstioConfigured(dynakube, conditionComponent) {
-			log.Info("ActiveGate disabled, cleaning up")
+			log.Info("activegate disabled, cleaning up")
 
 			return r.CleanupIstio(ctx, dynakube, conditionComponent, ActiveGateComponent)
 		} else {
@@ -116,7 +116,7 @@ func (r *reconciler) ReconcileActiveGateCommunicationHosts(ctx context.Context, 
 	}
 
 	if !conditions.IsOutdated(r.timeProvider, dynakube, getConditionTypeName(conditionComponent)) {
-		log.Info("Condition still within time threshold...skipping further reconciliation")
+		log.Info("condition still within time threshold...skipping further reconciliation")
 
 		return nil
 	}

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -2,7 +2,7 @@ package istio
 
 import (
 	"context"
-	"errors"
+	goerrors "errors"
 	"net"
 
 	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
@@ -12,7 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
-	errorshelper "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -41,7 +41,7 @@ func (r *reconciler) ReconcileAPIUrl(ctx context.Context, dynakube *dynatracev1b
 	log.Info("reconciling istio components for the Dynatrace API url")
 
 	if dynakube == nil {
-		return errorshelper.New("can't reconcile api url of nil dynakube")
+		return errors.New("can't reconcile api url of nil dynakube")
 	}
 
 	apiHost, err := dtclient.ParseEndpoint(dynakube.Spec.APIURL)
@@ -51,7 +51,7 @@ func (r *reconciler) ReconcileAPIUrl(ctx context.Context, dynakube *dynatracev1b
 
 	err = r.reconcileCommunicationHosts(ctx, []dtclient.CommunicationHost{apiHost}, OperatorComponent)
 	if err != nil {
-		return errorshelper.WithMessage(err, "error reconciling config for Dynatrace API URL")
+		return errors.WithMessage(err, "error reconciling config for Dynatrace API URL")
 	}
 
 	log.Info("reconciled istio objects for API url")
@@ -65,7 +65,7 @@ func (r *reconciler) ReconcileCodeModuleCommunicationHosts(ctx context.Context, 
 	log.Info("reconciling istio components for oneagent-code-modules communication hosts")
 
 	if dynakube == nil {
-		return errorshelper.New("can't reconcile oneagent communication hosts of nil dynakube")
+		return errors.New("can't reconcile oneagent communication hosts of nil dynakube")
 	}
 
 	if !dynakube.NeedAppInjection() {
@@ -102,7 +102,7 @@ func (r *reconciler) ReconcileActiveGateCommunicationHosts(ctx context.Context, 
 	log.Info("reconciling istio components for activegate communication hosts")
 
 	if dynakube == nil {
-		return errorshelper.New("can't reconcile activegate communication hosts of nil dynakube")
+		return errors.New("can't reconcile activegate communication hosts of nil dynakube")
 	}
 
 	if !dynakube.NeedsActiveGate() {
@@ -144,7 +144,7 @@ func (r *reconciler) CleanupIstio(ctx context.Context, dynakube *dynatracev1beta
 	err2 := r.cleanupFQDNServiceEntry(ctx, component)
 
 	// try to clean up all entries even if one fails
-	return errors.Join(err1, err2)
+	return goerrors.Join(err1, err2)
 }
 
 func isIstioConfigured(dynakube *dynatracev1beta2.DynaKube, conditionComponent string) bool {
@@ -156,7 +156,7 @@ func isIstioConfigured(dynakube *dynatracev1beta2.DynaKube, conditionComponent s
 func (r *reconciler) reconcileCommunicationHostsForComponent(ctx context.Context, comHosts []dtclient.CommunicationHost, componentName string) error {
 	err := r.reconcileCommunicationHosts(ctx, comHosts, componentName)
 	if err != nil {
-		return errorshelper.WithMessage(err, "error reconciling config for Dynatrace communication hosts")
+		return errors.WithMessage(err, "error reconciling config for Dynatrace communication hosts")
 	}
 
 	log.Info("reconciled istio objects for communication hosts", "component", componentName)

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
-	errorslib "github.com/pkg/errors"
+	errorshelper "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -41,7 +41,7 @@ func (r *reconciler) ReconcileAPIUrl(ctx context.Context, dynakube *dynatracev1b
 	log.Info("reconciling istio components for the Dynatrace API url")
 
 	if dynakube == nil {
-		return errorslib.New("can't reconcile api url of nil dynakube")
+		return errorshelper.New("can't reconcile api url of nil dynakube")
 	}
 
 	apiHost, err := dtclient.ParseEndpoint(dynakube.Spec.APIURL)
@@ -51,7 +51,7 @@ func (r *reconciler) ReconcileAPIUrl(ctx context.Context, dynakube *dynatracev1b
 
 	err = r.reconcileCommunicationHosts(ctx, []dtclient.CommunicationHost{apiHost}, OperatorComponent)
 	if err != nil {
-		return errorslib.WithMessage(err, "error reconciling config for Dynatrace API URL")
+		return errorshelper.WithMessage(err, "error reconciling config for Dynatrace API URL")
 	}
 
 	log.Info("reconciled istio objects for API url")
@@ -63,7 +63,7 @@ func (r *reconciler) ReconcileCodeModuleCommunicationHosts(ctx context.Context, 
 	log.Info("reconciling istio components for oneagent-code-modules communication hosts")
 
 	if dynakube == nil {
-		return errorslib.New("can't reconcile oneagent communication hosts of nil dynakube")
+		return errorshelper.New("can't reconcile oneagent communication hosts of nil dynakube")
 	}
 
 	oneAgentCommunicationHosts := oaconnectioninfo.GetCommunicationHosts(dynakube)
@@ -92,7 +92,7 @@ func (r *reconciler) ReconcileActiveGateCommunicationHosts(ctx context.Context, 
 	log.Info("reconciling istio components for activegate communication hosts")
 
 	if dynakube == nil {
-		return errorslib.New("can't reconcile activegate communication hosts of nil dynakube")
+		return errorshelper.New("can't reconcile activegate communication hosts of nil dynakube")
 	}
 
 	if !dynakube.NeedsActiveGate() {
@@ -146,7 +146,7 @@ func isIstioConfigured(dynakube *dynatracev1beta2.DynaKube, conditionComponent s
 func (r *reconciler) reconcileCommunicationHostsForComponent(ctx context.Context, comHosts []dtclient.CommunicationHost, componentName string) error {
 	err := r.reconcileCommunicationHosts(ctx, comHosts, componentName)
 	if err != nil {
-		return errorslib.WithMessage(err, "error reconciling config for Dynatrace communication hosts")
+		return errorshelper.WithMessage(err, "error reconciling config for Dynatrace communication hosts")
 	}
 
 	log.Info("reconciled istio objects for communication hosts", "component", componentName)

--- a/pkg/controllers/dynakube/istio/reconciler_test.go
+++ b/pkg/controllers/dynakube/istio/reconciler_test.go
@@ -246,9 +246,9 @@ func TestReconcileOneAgentCommunicationHosts(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
 
-		statusCondition := meta.FindStatusCondition(*dynakube.Conditions(), "IstioServiceConfigurationForCodeModule")
+		statusCondition := meta.FindStatusCondition(*dynakube.Conditions(), "IstioForCodeModule")
 		require.NotNil(t, statusCondition)
-		require.Equal(t, "IstioServiceConfigurationForCodeModuleChanged", statusCondition.Reason)
+		require.Equal(t, "IstioForCodeModuleChanged", statusCondition.Reason)
 	})
 	t.Run("unknown k8s client error => error", func(t *testing.T) {
 		fakeClient := fakeistio.NewSimpleClientset()
@@ -260,9 +260,9 @@ func TestReconcileOneAgentCommunicationHosts(t *testing.T) {
 		err := reconciler.ReconcileCodeModuleCommunicationHosts(ctx, dynakube)
 		require.Error(t, err)
 
-		statusCondition := meta.FindStatusCondition(*dynakube.Conditions(), "IstioServiceConfigurationForCodeModule")
+		statusCondition := meta.FindStatusCondition(*dynakube.Conditions(), "IstioForCodeModule")
 		require.NotNil(t, statusCondition)
-		require.Equal(t, "IstioServiceConfigurationForCodeModuleFailed", statusCondition.Reason)
+		require.Equal(t, "IstioForCodeModuleFailed", statusCondition.Reason)
 	})
 }
 
@@ -298,9 +298,9 @@ func TestReconcileActiveGateCommunicationHosts(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
 
-		statusCondition := meta.FindStatusCondition(*dynakube.Conditions(), "IstioServiceConfigurationForActiveGate")
+		statusCondition := meta.FindStatusCondition(*dynakube.Conditions(), "IstioForActiveGate")
 		require.NotNil(t, statusCondition)
-		require.Equal(t, "IstioServiceConfigurationForActiveGateChanged", statusCondition.Reason)
+		require.Equal(t, "IstioForActiveGateChanged", statusCondition.Reason)
 	})
 	t.Run("unknown k8s client error => error", func(t *testing.T) {
 		fakeClient := fakeistio.NewSimpleClientset()
@@ -312,9 +312,9 @@ func TestReconcileActiveGateCommunicationHosts(t *testing.T) {
 		err := reconciler.ReconcileActiveGateCommunicationHosts(ctx, dynakube)
 		require.Error(t, err)
 
-		statusCondition := meta.FindStatusCondition(*dynakube.Conditions(), "IstioServiceConfigurationForActiveGate")
+		statusCondition := meta.FindStatusCondition(*dynakube.Conditions(), "IstioForActiveGate")
 		require.NotNil(t, statusCondition)
-		require.Equal(t, "IstioServiceConfigurationForActiveGateFailed", statusCondition.Reason)
+		require.Equal(t, "IstioForActiveGateFailed", statusCondition.Reason)
 	})
 	t.Run("verify removal of conditions", func(t *testing.T) {
 		fakeClient := fakeistio.NewSimpleClientset()
@@ -337,16 +337,16 @@ func TestReconcileActiveGateCommunicationHosts(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
 
-		statusCondition := meta.FindStatusCondition(*dynakube.Conditions(), "IstioServiceConfigurationForActiveGate")
+		statusCondition := meta.FindStatusCondition(*dynakube.Conditions(), "IstioForActiveGate")
 		require.NotNil(t, statusCondition)
-		require.Equal(t, "IstioServiceConfigurationForActiveGateChanged", statusCondition.Reason)
+		require.Equal(t, "IstioForActiveGateChanged", statusCondition.Reason)
 
 		kube := dynakube
 		kube.Status.ActiveGate.ConnectionInfoStatus.Endpoints = ""
 		err = reconciler.ReconcileActiveGateCommunicationHosts(ctx, kube)
 		require.NoError(t, err)
 
-		statusCondition2 := meta.FindStatusCondition(*dynakube.Conditions(), "IstioServiceConfigurationForActiveGate")
+		statusCondition2 := meta.FindStatusCondition(*dynakube.Conditions(), "IstioForActiveGate")
 		require.Nil(t, statusCondition2)
 	})
 }

--- a/pkg/controllers/dynakube/istio/reconciler_test.go
+++ b/pkg/controllers/dynakube/istio/reconciler_test.go
@@ -3,6 +3,7 @@ package istio
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
@@ -335,7 +336,7 @@ func TestReconcileActiveGateCommunicationHosts(t *testing.T) {
 		err := reconciler.ReconcileActiveGateCommunicationHosts(ctx, dynakube)
 		require.NoError(t, err)
 
-		expectedFQDNName := BuildNameForFQDNServiceEntry(dynakube.GetName(), ActiveGateComponent)
+		expectedFQDNName := BuildNameForFQDNServiceEntry(dynakube.GetName(), strings.ToLower(ActiveGateComponent))
 		serviceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedFQDNName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
@@ -378,7 +379,7 @@ func TestReconcileActiveGateCommunicationHosts(t *testing.T) {
 		err := r.ReconcileActiveGateCommunicationHosts(ctx, dynakube)
 		require.NoError(t, err)
 
-		expectedFQDNName := BuildNameForFQDNServiceEntry(dynakube.GetName(), ActiveGateComponent)
+		expectedFQDNName := BuildNameForFQDNServiceEntry(dynakube.GetName(), strings.ToLower(ActiveGateComponent))
 		serviceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedFQDNName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
@@ -423,7 +424,7 @@ func TestReconcileActiveGateCommunicationHosts(t *testing.T) {
 		err := reconciler.ReconcileActiveGateCommunicationHosts(ctx, dynakube)
 		require.NoError(t, err)
 
-		expectedFQDNName := BuildNameForFQDNServiceEntry(dynakube.GetName(), ActiveGateComponent)
+		expectedFQDNName := BuildNameForFQDNServiceEntry(dynakube.GetName(), strings.ToLower(ActiveGateComponent))
 		serviceEntry, err := fakeClient.NetworkingV1beta1().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedFQDNName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)

--- a/pkg/controllers/dynakube/istio/reconciler_test.go
+++ b/pkg/controllers/dynakube/istio/reconciler_test.go
@@ -296,7 +296,7 @@ func TestReconcileOneAgentCommunicationHosts(t *testing.T) {
 		require.Equal(t, "IstioForCodeModuleChanged", statusCondition.Reason)
 
 		dynakube.Spec.OneAgent.CloudNativeFullStack = nil
-		dynakube.Spec.OneAgent.HostMonitoring = &dynatracev1beta1.HostInjectSpec{}
+		dynakube.Spec.OneAgent.HostMonitoring = &dynatracev1beta2.HostInjectSpec{}
 
 		err = r.ReconcileCodeModuleCommunicationHosts(ctx, dynakube)
 		require.NoError(t, err)
@@ -406,9 +406,9 @@ func TestReconcileActiveGateCommunicationHosts(t *testing.T) {
 
 		// advance time to be outside api threshold
 		rec2 := r.(*reconciler)
-		time := rec.timeProvider.Now().Add(dynakube.FeatureApiRequestThreshold() * 2)
+		time := rec2.timeProvider.Now().Add(dynakube.ApiRequestThreshold() * 2)
 		rec2.timeProvider.Set(time)
-		err = r.ReconcileActiveGateCommunicationHosts(ctx, dynakube)
+		err = rec2.ReconcileActiveGateCommunicationHosts(ctx, dynakube)
 		require.NoError(t, err)
 
 		statusCondition3 := meta.FindStatusCondition(*dynakube.Conditions(), "IstioForActiveGate")
@@ -440,7 +440,7 @@ func TestReconcileActiveGateCommunicationHosts(t *testing.T) {
 		require.NotNil(t, statusCondition)
 		require.Equal(t, "IstioForActiveGateChanged", statusCondition.Reason)
 
-		dynakube.Spec.ActiveGate.Capabilities = []dynatracev1beta1.CapabilityDisplayName{}
+		dynakube.Spec.ActiveGate.Capabilities = []dynatracev1beta2.CapabilityDisplayName{}
 		err = reconciler.ReconcileActiveGateCommunicationHosts(ctx, dynakube)
 		require.NoError(t, err)
 
@@ -485,9 +485,10 @@ func createTestDynaKube() *dynatracev1beta2.DynaKube {
 					dynatracev1beta2.RoutingCapability.DisplayName,
 				},
 			},
-			OneAgent: dynatracev1beta1.OneAgentSpec{
-				CloudNativeFullStack: &dynatracev1beta1.CloudNativeFullStackSpec{},
+			OneAgent: dynatracev1beta2.OneAgentSpec{
+				CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
 			},
+			DynatraceApiRequestThreshold: 15,
 		},
 		Status: dynatracev1beta2.DynaKubeStatus{
 			OneAgent: dynatracev1beta2.OneAgentStatus{


### PR DESCRIPTION
## Description

[K8S-9578](https://dt-rnd.atlassian.net/browse/K8S-9578?atlOrigin=eyJpIjoiMzk3NmZmOGU3MDQ1NGIwYjg3MjA3MzlhZGE0MTUyMzUiLCJwIjoiaiJ9)

Have conditions for the istio reconciler, for the ActiveGate and CodeModule connection-info ServiceEntry creation logic.
Have “Reasons“ for the following scenarios:

* ServiceEntries and VirualServices created/updated

* Error due to kubernetes API problems

## How can this be tested?
 
* Run the unit-tests.
* Deploy Istio and a Dynakube with Istio enabled. Describe the DynaKube and look for the newly added conditions starting with `IstioServiceConfigurationFor*`.