### PR TITLE
Consider namespaceSelector of metadataEnrichment in mapper

### DIFF
--- a/pkg/api/v1beta1/dynakube/convert_from_test.go
+++ b/pkg/api/v1beta1/dynakube/convert_from_test.go
@@ -132,7 +132,7 @@ func compareBase(t *testing.T, oldDk DynaKube, newDk v1beta2.DynaKube) {
 func compareMovedFields(t *testing.T, oldDk DynaKube, newDk v1beta2.DynaKube) {
 	assert.Equal(t, oldDk.FeatureApiRequestThreshold(), newDk.ApiRequestThreshold())
 	assert.Equal(t, oldDk.FeatureOneAgentSecCompProfile(), newDk.OneAgentSecCompProfile())
-	assert.Equal(t, !oldDk.FeatureDisableMetadataEnrichment(), newDk.MetaDataEnrichmentEnabled())
+	assert.Equal(t, !oldDk.FeatureDisableMetadataEnrichment(), newDk.MetadataEnrichmentEnabled())
 	assert.Equal(t, *oldDk.NamespaceSelector(), newDk.Spec.MetadataEnrichment.NamespaceSelector)
 
 	if newDk.NeedAppInjection() {

--- a/pkg/api/v1beta2/dynakube/properties.go
+++ b/pkg/api/v1beta2/dynakube/properties.go
@@ -432,7 +432,7 @@ func (dk *DynaKube) ApiRequestThreshold() time.Duration {
 	return time.Duration(dk.Spec.DynatraceApiRequestThreshold) * time.Minute
 }
 
-func (dk *DynaKube) MetaDataEnrichmentEnabled() bool {
+func (dk *DynaKube) MetadataEnrichmentEnabled() bool {
 	return dk.Spec.MetadataEnrichment.Enabled
 }
 

--- a/pkg/api/v1beta2/dynakube/properties.go
+++ b/pkg/api/v1beta2/dynakube/properties.go
@@ -257,6 +257,10 @@ func (dk *DynaKube) OneAgentNamespaceSelector() *metav1.LabelSelector {
 	return nil
 }
 
+func (dk *DynaKube) MetadataEnrichmentNamespaceSelector() *metav1.LabelSelector {
+	return &dk.Spec.MetadataEnrichment.NamespaceSelector
+}
+
 func (dk *DynaKube) OneAgentSecCompProfile() string {
 	switch {
 	case dk.CloudNativeFullstackMode():

--- a/pkg/controllers/dynakube/injection/reconciler.go
+++ b/pkg/controllers/dynakube/injection/reconciler.go
@@ -165,7 +165,7 @@ func (r *reconciler) setupOneAgentInjection(ctx context.Context) error {
 }
 
 func (r *reconciler) setupEnrichmentInjection(ctx context.Context) error {
-	if !r.dynakube.MetaDataEnrichmentEnabled() {
+	if !r.dynakube.MetadataEnrichmentEnabled() {
 		return nil
 	}
 

--- a/pkg/controllers/dynakube/injection/reconciler_test.go
+++ b/pkg/controllers/dynakube/injection/reconciler_test.go
@@ -88,6 +88,11 @@ func TestReconciler(t *testing.T) {
 				},
 				MetadataEnrichment: dynatracev1beta2.MetadataEnrichment{
 					Enabled: true,
+					NamespaceSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							testNamespaceSelectorLabel: testDynakube,
+						},
+					},
 				},
 			},
 		}

--- a/pkg/injection/namespace/ingestendpoint/secret.go
+++ b/pkg/injection/namespace/ingestendpoint/secret.go
@@ -137,7 +137,7 @@ func (g *SecretGenerator) prepare(ctx context.Context, dk *dynatracev1beta2.Dyna
 
 	endpointPropertiesBuilder := strings.Builder{}
 
-	if dk.MetaDataEnrichmentEnabled() { // TODO: why check here and not at the very beginning?
+	if dk.MetadataEnrichmentEnabled() { // TODO: why check here and not at the very beginning?
 		if _, err := endpointPropertiesBuilder.WriteString(fmt.Sprintf("%s=%s\n", MetricsUrlSecretField, fields[MetricsUrlSecretField])); err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -162,7 +162,7 @@ func (g *SecretGenerator) PrepareFields(ctx context.Context, dk *dynatracev1beta
 		return nil, errors.WithMessage(err, "failed to query tokens")
 	}
 
-	if dk.MetaDataEnrichmentEnabled() { // TODO: why check here and not at the very beginning?
+	if dk.MetadataEnrichmentEnabled() { // TODO: why check here and not at the very beginning?
 		if token, ok := tokens.Data[dtclient.DataIngestToken]; ok {
 			fields[MetricsTokenSecretField] = string(token)
 		}

--- a/pkg/injection/namespace/mapper/mapper.go
+++ b/pkg/injection/namespace/mapper/mapper.go
@@ -18,7 +18,7 @@ type ConflictChecker struct {
 }
 
 func (c *ConflictChecker) check(dk *dynatracev1beta2.DynaKube) error {
-	if !dk.NeedAppInjection() && !dk.MetaDataEnrichmentEnabled() {
+	if !dk.NeedAppInjection() && !dk.MetadataEnrichmentEnabled() {
 		return nil
 	}
 
@@ -67,7 +67,7 @@ func matchDynakubeToNamespace(dk *dynatracev1beta2.DynaKube, namespace *corev1.N
 		return false, err
 	}
 
-	matchesMetadataEnrichment, err := matchMetaDataEnrichment(dk, namespace)
+	matchesMetadataEnrichment, err := matchMetadataEnrichment(dk, namespace)
 	if err != nil {
 		return false, err
 	}
@@ -92,8 +92,8 @@ func matchOneAgent(dk *dynatracev1beta2.DynaKube, namespace *corev1.Namespace) (
 	return selector.Matches(labels.Set(namespace.Labels)), nil
 }
 
-func matchMetaDataEnrichment(dk *dynatracev1beta2.DynaKube, namespace *corev1.Namespace) (bool, error) {
-	if !dk.MetaDataEnrichmentEnabled() {
+func matchMetadataEnrichment(dk *dynatracev1beta2.DynaKube, namespace *corev1.Namespace) (bool, error) {
+	if !dk.MetadataEnrichmentEnabled() {
 		return false, nil
 	} else if dk.MetadataEnrichmentNamespaceSelector() == nil {
 		return true, nil

--- a/pkg/webhook/mutation/pod/metadata/mutator.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator.go
@@ -34,7 +34,7 @@ func NewMutator(webhookNamespace string, client client.Client, apiReader client.
 func (mut *Mutator) Enabled(request *dtwebhook.BaseRequest) bool {
 	enabledOnPod := maputils.GetFieldBool(request.Pod.Annotations, dtwebhook.AnnotationMetadataEnrichmentInject,
 		request.DynaKube.FeatureAutomaticInjection())
-	enabledOnDynakube := request.DynaKube.MetaDataEnrichmentEnabled()
+	enabledOnDynakube := request.DynaKube.MetadataEnrichmentEnabled()
 
 	return enabledOnPod && enabledOnDynakube
 }


### PR DESCRIPTION
## Description

Related Ticket: https://dt-rnd.atlassian.net/browse/K8S-9334

Since we introduced a seperate metadataEnrichment section in the v1beta2 Dynakube, which has a seperate namespace Selector, we need to update the mapper, that labels the matching namespaces. 

With this PR, both namespaceSelectors are considered by the mapper. If one of those match or are empty the namespace is considered a match.
Also the validationWebhook should deny a Dynakube that has any conflicting namespaceSelector with any other Dynakube, since a namespace can only be mapped to one Dynakube at a time

## How can this be tested?

Deploy Operator -> Test a v1beta2 Dynakube with appOnly or cloudNative and metadataEnrichment and namespaceSelectors
Deploy Operator -> Test a v1beta2 Dynakube with only appOnly or cloudNative and a namespaceSelector
Deploy Operator -> Test two Dynakubes with conflicting metadataEnrichment namespaceSelectors

