### PR TITLE
Fix failing e2e release test

### DIFF
--- a/test/features/cloudnative/upgrade/upgrade.go
+++ b/test/features/cloudnative/upgrade/upgrade.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-func Feature(t *testing.T) features.Feature {
+func Feature(t *testing.T, usesOldVersion bool) features.Feature {
 	builder := features.New("upgrade a cloudnative installation")
 	builder.WithLabel("name", "cloudnative-upgrade")
 	secretConfig := tenant.GetSingleTenantSecret(t)
@@ -31,7 +31,7 @@ func Feature(t *testing.T) features.Feature {
 	)
 	builder.Assess("create sample namespace", sampleApp.InstallNamespace())
 
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube, usesOldVersion)
 
 	// Register sample app install
 	builder.Assess("install sample app", sampleApp.Install())

--- a/test/helpers/components/oneagent/daemonset.go
+++ b/test/helpers/components/oneagent/daemonset.go
@@ -5,6 +5,7 @@ package oneagent
 import (
 	"context"
 
+	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
@@ -16,6 +17,10 @@ import (
 )
 
 func WaitForDaemonset(dynakube dynatracev1beta2.DynaKube) features.Func {
+	return helpers.ToFeatureFunc(daemonset.WaitFor(dynakube.OneAgentDaemonsetName(), dynakube.Namespace), true)
+}
+
+func WaitForDaemonsetV1Beta1(dynakube dynatracev1beta1.DynaKube) features.Func {
 	return helpers.ToFeatureFunc(daemonset.WaitFor(dynakube.OneAgentDaemonsetName(), dynakube.Namespace), true)
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

With the introduction of `v1beta2` this e2e test failed. This was because the operator was installed with using the `0.15.0` tag. This version of the operator does not know `v1beta2`, thus it failed. I fixed this by simply checking if the used version for the helm command does know `v1beta2` or not.

related ticket: https://dt-rnd.atlassian.net/browse/K8S-10110

## How can this be tested?

run `make test/e2e/release`

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->