### PR TITLE
Make log lines more consistent

### DIFF
--- a/pkg/logd/pretty_log_writer_test.go
+++ b/pkg/logd/pretty_log_writer_test.go
@@ -9,12 +9,8 @@ import (
 )
 
 func TestErrorPrettify_Write(t *testing.T) {
-	t.Run(`Write unescapes newlines and tabs`, func(t *testing.T) {
-		// backticks ` interpret newlines and tabs as their escaped version
-		// I.e., `\n` = "\\n"
-		// Which is why backslashes remain in the result text
-		testString := `{"newlines" : "some\\n text to \n\\n escape newlines", "tabs": "some\t text\t to \\t\t escape tabs", "mixed": "some\n\\n text \n\t to escape \\n\\t tabs \t\\n\n\\t"}`
-		expectedString := "{\"mixed\":\"some\n\\\n text \n\t to escape \\\n\\\t tabs \t\\\n\n\\\t\",\"newlines\":\"some\\\n text to \n\\\n escape newlines\",\"tabs\":\"some\t text\t to \\\t\t escape tabs\"}\n"
+	t.Run("Don't touch input without stacktrace, to keep the order intact", func(t *testing.T) {
+		testString := `{"level":"info","ts":"2024-05-28T14:00:03.031Z","logger":"csi-driver","msg":"starting listener","protocol":"unix","address":"csi/csi.sock"}`
 
 		bufferString := bytes.NewBufferString("")
 		errPrettify := NewPrettyLogWriter(WithWriter(bufferString))
@@ -22,9 +18,9 @@ func TestErrorPrettify_Write(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Positive(t, written)
-		assert.Equal(t, expectedString, bufferString.String())
+		assert.Equal(t, testString, bufferString.String())
 	})
-	t.Run(`Write replaces "stacktrace" with "errorVerbose"`, func(t *testing.T) {
+	t.Run("Write replaces 'stacktrace' with 'errorVerbose'", func(t *testing.T) {
 		testString := `{"stacktrace":"stacktrace","errorVerbose":"errorVerbose"}`
 		expectedString := "{\"stacktrace\":\"errorVerbose\"}\n"
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->
The https://github.com/Dynatrace/dynatrace-operator/pull/2659 PR introduced a bit of a problem in the logs.

Example:
- Before the change: (there is a predefined order in the keys)
```
{"level":"info","ts":"2024-05-28T14:00:03.031Z","logger":"main.controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
{"level":"info","ts":"2024-05-28T14:00:03.031Z","logger":"main","msg":"starting server","kind":"health probe","addr":":10080"}
```
- After the change: (keys are ordered alphanumerically)
```
{"bindAddress":":8080","level":"info","logger":"main.controller-runtime.metrics","msg":"Serving metrics server","secure":false,"ts":"2024-05-28T14:05:53.774Z"}
{"addr":":10080","level":"info","logger":"main","msg":"starting server","name":"health probe","ts":"2024-05-28T14:05:53.774Z"}
``` 

The source of the problem is that we used to send error to `stderr` and everything else to `stdout`, and we had a different `io.Writer` for each.
- We didn't use to touch `stdout`
- We only prettified the `stderr` input, to have nicer stacktraces
   - these logs probably always had this problem, but because of the messiness of the stacktrace it wasn't noticed  

But now we send everything through the "prettifier", so every log line is out of order.

The ordering mess-up happens because we unmarshal the log line, do some changes, then just marshal it again.

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

Look at the log lines produced by the operator:
- "keys" in info logs should have a predefined order
- stacktraces show up in a "pretty" way still