### PR TITLE
Remove resources limit field from csi provisioner

### DIFF
--- a/config/helm/chart/default/questions.yml
+++ b/config/helm/chart/default/questions.yml
@@ -179,20 +179,6 @@ questions:
     type: string
     group: "CSI Driver Deployment Configuration"
 
-  - variable: csidriver.provisioner.limits.cpu
-    label: "CPU resource limits settings for Dynatrace CSI Driver's provisioner container"
-    description: "The maximum amount of CPU resources that the Dynatrace CSI Driver's provisioner container can use. Default: 300m"
-    default: "300m"
-    type: string
-    group: "CSI Driver Deployment Configuration"
-
-  - variable: csidriver.provisioner.limits.memory
-    label: "Memory resource limits settings for Dynatrace CSI Driver's provisioner container"
-    description: "The maximum amount of memory that the Dynatrace CSI Driver's provisioner container can use. Pod restarted if exceeded. Default: 100Mi"
-    default: "100Mi"
-    type: string
-    group: "CSI Driver Deployment Configuration"
-
   - variable: csidriver.registrar.requests.cpu
     label: "CPU resource requests settings for Dynatrace CSI Driver's registrar container"
     description: "The minimum amount of CPU resources that the Dynatrace CSI Driver's registrar container should request. Affects scheduling. Default: 20m"

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -246,9 +246,6 @@ tests:
                     name: livez
                     protocol: TCP
                 resources:
-                  limits:
-                    cpu: 300m
-                    memory: 100Mi
                   requests:
                     cpu: 300m
                     memory: 100Mi
@@ -439,8 +436,6 @@ tests:
       csidriver.enabled: true
       csidriver.provisioner.resources.requests.cpu: 600m
       csidriver.provisioner.resources.requests.memory: 200Mi
-      csidriver.provisioner.resources.limits.cpu: 900m
-      csidriver.provisioner.resources.limits.memory: 300Mi
     asserts:
       - equal:
           path: spec.template.spec.containers[1].name
@@ -451,12 +446,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.memory
           value: 200Mi
-      - equal:
-          path: spec.template.spec.containers[1].resources.limits.cpu
-          value: 900m
-      - equal:
-          path: spec.template.spec.containers[1].resources.limits.memory
-          value: 300Mi
   - it: should take resource limits from values file for server
     set:
       csidriver.enabled: true

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -156,9 +156,6 @@ csidriver:
       requests:
         cpu: 300m
         memory: 100Mi
-      limits:
-        cpu: 300m
-        memory: 100Mi
   registrar:
     securityContext:
       runAsUser: 0

--- a/config/helm/schema.yaml
+++ b/config/helm/schema.yaml
@@ -298,20 +298,6 @@ properties:
       The amount of memory allocation the CSI driver requests from the cluster.
       It is recommended for the memory requests to be the same as the memory limits.
     default: 100Mi
-  csidriver.provisioner.resources.limits.cpu:
-    type: string
-    title: CSI driver CPU limit - provisioner
-    description: |
-      The amount of CPU allocation to which the cluster may limit the CSI driver.
-      It is recommended for the CPU limits to be the same as the CPU requests.
-    default: 300m
-  csidriver.provisioner.resources.limits.memory:
-    type: string
-    title: CSI driver Memory limit - provisioner
-    description: |
-      The amount of memory allocation to which the cluster may limit the CSI driver.
-      It is recommended for the memory limits to be the same as the memory requests.
-    default: 100Mi
   csidriver.server.resources.requests.cpu:
     type: string
     title: CSI driver CPU request - server


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

After some discussions the decision was made that the limit field in the resources of the csi provisioner is not needed due to it not being used frequently enough. So it was decided to remove it.

Ticket: https://dt-rnd.atlassian.net/browse/K8S-9743

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

- run helm unittests
- deploy operator via helm and check resources of the csi provisioner