### PR TITLE
Fix CRD generation for releases

### DIFF
--- a/hack/make/manifests/crd.mk
+++ b/hack/make/manifests/crd.mk
@@ -19,5 +19,6 @@ manifests/crd/release: manifests/crd/helm
 	helm template dynatrace-operator config/helm/chart/default \
 			--namespace dynatrace \
 			--set installCRD=true \
+			--set csidriver.enabled=false \
 			--set partial="crd" > $(RELEASE_CRD_YAML)
 


### PR DESCRIPTION
## Description

Currently the CRD generation is broken, since the CSI driver was enabled by default in v1.0.0, this leads to the fact that the CRD generated with `make manifests/crd/release` also has other CSI resources in it (daemonset, Roles,...)

## How can this be tested?

`make manifests/crd/release` should only generate the CRD and no other resource should be in the file