### PR TITLE
Increase matrix: max-parallel and set fail-fast: false

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -21,6 +21,9 @@ jobs:
   run-matrix:
     name: Run using version/platform
     strategy:
+      # we don't want to cancel all in-progress jobs if any matrix job fails.
+      fail-fast: false
+      max-parallel: 4
       matrix:
         include:
           - version: 1-24


### PR DESCRIPTION
Currently, if the single job fails, Github will cancel all other jobs, but they are independent, so we want to run all of them.

Also running 2 parallel jobs is a bit slow, so I've increased to 4, since every job takes ~ 2hours or so.