### PR TITLE
Add EC validator to reject CR with Kubernetes Automation feature enabled

### DIFF
--- a/pkg/webhook/validation/edgeconnect/api_server_test.go
+++ b/pkg/webhook/validation/edgeconnect/api_server_test.go
@@ -37,10 +37,10 @@ func TestApiServer(t *testing.T) {
 						Endpoint:     "endpoint",
 						Resource:     "resource",
 					},
-					ServiceAccountName: testServiceAccountName,
+					ServiceAccountName: defaultServiceAccountName,
 				},
 			}
-			assertAllowedResponse(t, edgeConnect, prepareTestServiceAccount(testServiceAccountName, testNamespace))
+			assertAllowedResponse(t, edgeConnect, prepareTestServiceAccount(defaultServiceAccountName, testNamespace))
 		}
 	})
 

--- a/pkg/webhook/validation/edgeconnect/config.go
+++ b/pkg/webhook/validation/edgeconnect/config.go
@@ -20,4 +20,5 @@ var validators = []validator{
 	nameTooLong,
 	checkHostPatternsValue,
 	isInvalidServiceName,
+	isKubernetesAutomationEnabled,
 }

--- a/pkg/webhook/validation/edgeconnect/host_patterns_test.go
+++ b/pkg/webhook/validation/edgeconnect/host_patterns_test.go
@@ -22,10 +22,10 @@ func TestHostPatternsRequired(t *testing.T) {
 					Endpoint:     "endpoint",
 					Resource:     "resource",
 				},
-				ServiceAccountName: testServiceAccountName,
+				ServiceAccountName: defaultServiceAccountName,
 			},
 		}
-		response := handleRequest(t, edgeConnect, prepareTestServiceAccount(testServiceAccountName, testNamespace))
+		response := handleRequest(t, edgeConnect, prepareTestServiceAccount(defaultServiceAccountName, testNamespace))
 		assert.True(t, response.Allowed)
 		assert.Empty(t, response.Warnings)
 	})

--- a/pkg/webhook/validation/edgeconnect/kubernetes_automation.go
+++ b/pkg/webhook/validation/edgeconnect/kubernetes_automation.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	defaultServiceAccountName               = "dynatrace-edgeconnect"
-	errorKubernetesAutomationNotImplemented = `you tried to enable the EdgeConnect Kubernetes Automation feature and/or manually set a service account. This feature is still a work in progress and is not supported yet.`
+	errorKubernetesAutomationNotImplemented = `You tried to enable the EdgeConnect Kubernetes Automation feature and/or manually set a service account. This feature is still a work in progress and is not supported yet.`
 )
 
 func isKubernetesAutomationEnabled(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {

--- a/pkg/webhook/validation/edgeconnect/kubernetes_automation.go
+++ b/pkg/webhook/validation/edgeconnect/kubernetes_automation.go
@@ -11,7 +11,7 @@ const (
 )
 
 func isKubernetesAutomationEnabled(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
-	if edgeConnect.Spec.ServiceAccountName != defaultServiceAccountName || edgeConnect.Spec.KubernetesAutomation != nil && edgeConnect.Spec.KubernetesAutomation.Enabled {
+	if edgeConnect.Spec.ServiceAccountName != defaultServiceAccountName || (edgeConnect.Spec.KubernetesAutomation != nil && edgeConnect.Spec.KubernetesAutomation.Enabled) {
 		return errorKubernetesAutomationNotImplemented
 	}
 

--- a/pkg/webhook/validation/edgeconnect/kubernetes_automation.go
+++ b/pkg/webhook/validation/edgeconnect/kubernetes_automation.go
@@ -1,0 +1,19 @@
+package edgeconnect
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"golang.org/x/net/context"
+)
+
+const (
+	defaultServiceAccountName               = "dynatrace-edgeconnect"
+	errorKubernetesAutomationNotImplemented = `you tried to enable the EdgeConnect Kubernetes Automation feature and/or manually set a service account. This feature is still a work in progress and is not supported yet.`
+)
+
+func isKubernetesAutomationEnabled(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
+	if edgeConnect.Spec.ServiceAccountName != defaultServiceAccountName || edgeConnect.Spec.KubernetesAutomation != nil && edgeConnect.Spec.KubernetesAutomation.Enabled {
+		return errorKubernetesAutomationNotImplemented
+	}
+
+	return ""
+}

--- a/pkg/webhook/validation/edgeconnect/kubernetes_automation_test.go
+++ b/pkg/webhook/validation/edgeconnect/kubernetes_automation_test.go
@@ -1,0 +1,43 @@
+package edgeconnect
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+)
+
+func TestKubernetesAutomation(t *testing.T) {
+	t.Run("service account defined", func(t *testing.T) {
+		edgeConnect := &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				ServiceAccountName: testServiceAccountName,
+			},
+		}
+		assertDeniedResponse(t, []string{errorKubernetesAutomationNotImplemented}, edgeConnect)
+	})
+
+	t.Run("kubernetes automation enabled", func(t *testing.T) {
+		edgeConnect := &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				ServiceAccountName: defaultServiceAccountName,
+				KubernetesAutomation: &edgeconnect.KubernetesAutomationSpec{
+					Enabled: true,
+				},
+			},
+		}
+		assertDeniedResponse(t, []string{errorKubernetesAutomationNotImplemented}, edgeConnect)
+	})
+
+	t.Run("kubernetes automation disabled", func(t *testing.T) {
+		edgeConnect := &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				ApiServer:          "id." + allowedSuffix[0],
+				ServiceAccountName: defaultServiceAccountName,
+				KubernetesAutomation: &edgeconnect.KubernetesAutomationSpec{
+					Enabled: false,
+				},
+			},
+		}
+		assertAllowedResponse(t, edgeConnect)
+	})
+}

--- a/pkg/webhook/validation/edgeconnect/name_test.go
+++ b/pkg/webhook/validation/edgeconnect/name_test.go
@@ -48,11 +48,11 @@ func TestNameTooLong(t *testing.T) {
 				},
 				Spec: edgeconnect.EdgeConnectSpec{
 					ApiServer:          "id." + allowedSuffix[0],
-					ServiceAccountName: testServiceAccountName,
+					ServiceAccountName: defaultServiceAccountName,
 				},
 			}
 			if test.allow {
-				assertAllowedResponse(t, ec, prepareTestServiceAccount(testServiceAccountName, testNamespace))
+				assertAllowedResponse(t, ec, prepareTestServiceAccount(defaultServiceAccountName, testNamespace))
 			} else {
 				errorMessage := fmt.Sprintf(errorNameTooLong, edgeconnect.MaxNameLength)
 				assertDeniedResponse(t, []string{errorMessage}, ec)


### PR DESCRIPTION
## Description

New validator rejects EdgeConnect CR with KubernetesAutomation enabled or customized ServiceAccountName.

ServiceAccountName is set to the default value on the CRD level so it's never empty. 


## How can this be tested?

1) Unittests.

2) Try to apply EC with KubernetesAutomation enabled and/or customized serviceAccountName :
```
spec:
  kubernetesAutomation:
    enabled: false / true
  serviceAccountName: dynatrace-edgeconnect / test-dynatrace-edgeconnect
```
3) Apply valid EdgeConnect then change value of `enabled` and/or `serviceAccountName` and try to save changes. 
