### PR TITLE
fixup ondemand env

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -71,7 +71,7 @@ jobs:
 
   notify-failure:
     name: Notify failure in Slack
-    environment: E2E ondemand
+    environment: E2E
     needs: [ "run-matrix" ]
     if: ${{ failure() || cancelled() }}
     runs-on: ubuntu-latest
@@ -80,6 +80,6 @@ jobs:
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           channel-id: 'int-cp-operator'
-          slack-message: ":x: E2E ondemand tests failed `${{ matrix.platform }}-${{ matrix.version }}` on ${{ github.event.inputs.target }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          slack-message: ":x: E2E ondemand tests failed on ${{ github.event.inputs.target }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION

## Description

Because there is a configured github environment with all the secrets, and its called E2E

