### PR TITLE
Make conversion nil safe in case of empty annotations

### DIFF
--- a/pkg/api/v1beta1/dynakube/convert_from.go
+++ b/pkg/api/v1beta1/dynakube/convert_from.go
@@ -25,6 +25,9 @@ func (dst *DynaKube) ConvertFrom(srcRaw conversion.Hub) error {
 }
 
 func (dst *DynaKube) fromBase(src *v1beta2.DynaKube) {
+	if src.Annotations == nil {
+		src.Annotations = map[string]string{}
+	}
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy() // DeepCopy mainly relevant for testing
 
 	dst.Spec.APIURL = src.Spec.APIURL

--- a/pkg/api/v1beta1/dynakube/convert_from.go
+++ b/pkg/api/v1beta1/dynakube/convert_from.go
@@ -28,6 +28,7 @@ func (dst *DynaKube) fromBase(src *v1beta2.DynaKube) {
 	if src.Annotations == nil {
 		src.Annotations = map[string]string{}
 	}
+
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy() // DeepCopy mainly relevant for testing
 
 	dst.Spec.APIURL = src.Spec.APIURL

--- a/pkg/api/v1beta1/dynakube/convert_to.go
+++ b/pkg/api/v1beta1/dynakube/convert_to.go
@@ -27,6 +27,7 @@ func (src *DynaKube) toBase(dst *v1beta2.DynaKube) {
 	if src.Annotations == nil {
 		src.Annotations = map[string]string{}
 	}
+
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy() // DeepCopy mainly relevant for testing
 
 	dst.Spec.APIURL = src.Spec.APIURL

--- a/pkg/api/v1beta1/dynakube/convert_to.go
+++ b/pkg/api/v1beta1/dynakube/convert_to.go
@@ -24,6 +24,9 @@ func (src *DynaKube) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 func (src *DynaKube) toBase(dst *v1beta2.DynaKube) {
+	if src.Annotations == nil {
+		src.Annotations = map[string]string{}
+	}
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy() // DeepCopy mainly relevant for testing
 
 	dst.Spec.APIURL = src.Spec.APIURL


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->
We didn't handle the `Annotations` map safely during conversion, which can cause a panic.

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->
Deploy a v1beta2 DynaKube, with no-annotation and `metadataEnrichment.Enabled = true`. (or any new field that would be converted from an annotation)