### PR TITLE
Make otel error log less scary

### DIFF
--- a/pkg/util/dtotel/otel.go
+++ b/pkg/util/dtotel/otel.go
@@ -22,7 +22,7 @@ type shutdownFn func(ctx context.Context) error
 func Start(ctx context.Context, otelServiceName string, apiReader client.Reader, webhookNamespace string) func() {
 	endpoint, apiToken, err := getOtelConfig(ctx, apiReader, webhookNamespace)
 	if err != nil {
-		log.Info("failed to read OpenTelementry config secret", "err", err.Error())
+		log.Info("Otel was not configured, add the secret if you want to enable this functionality.")
 
 		return setupNoopOTel()
 	}

--- a/pkg/util/dtotel/otel.go
+++ b/pkg/util/dtotel/otel.go
@@ -22,7 +22,7 @@ type shutdownFn func(ctx context.Context) error
 func Start(ctx context.Context, otelServiceName string, apiReader client.Reader, webhookNamespace string) func() {
 	endpoint, apiToken, err := getOtelConfig(ctx, apiReader, webhookNamespace)
 	if err != nil {
-		log.Info("Otel was not configured, add the secret if you want to enable this functionality.")
+		log.Info("Opentelemetry instrumentation was not configured")
 
 		return setupNoopOTel()
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->
Setting up OTel requires a specific secret to be created.
This is totally optional, so most of the time this secret won't be there, so logging the error is a bit excessive.

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->
Deploy the operator without having the Otel secret setup,and check the log of the operator is less scary