### PR TITLE
Add conditions and proper cleanup to injection reconciler

### DIFF
--- a/pkg/controllers/dynakube/injection/conditions.go
+++ b/pkg/controllers/dynakube/injection/conditions.go
@@ -9,7 +9,7 @@ const (
 	metaDataEnrichmentConditionType   = "MetadataEnrichment"
 	codeModulesInjectionConditionType = "CodeModulesInjection"
 
-	nsAndSecretsCreatedReason  = "NamespaceAndSecretsCreated"
+	nsAndSecretsCreatedReason  = "SecretsCreated"
 	nsAndSecretsCreatedMessage = "Namespaces mapped and secrets created"
 )
 

--- a/pkg/controllers/dynakube/injection/conditions.go
+++ b/pkg/controllers/dynakube/injection/conditions.go
@@ -1,0 +1,34 @@
+package injection
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	metaDataEnrichmentConditionType   = "MetadataEnrichment"
+	codeModulesInjectionConditionType = "CodeModulesInjection"
+
+	nsAndSecretsCreatedReason  = "NamespaceAndSecretsCreated"
+	nsAndSecretsCreatedMessage = "Namespaces mapped and secrets created"
+)
+
+func setMetadataEnrichmentCreatedCondition(conditions *[]metav1.Condition) {
+	condition := metav1.Condition{
+		Type:    metaDataEnrichmentConditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  nsAndSecretsCreatedReason,
+		Message: nsAndSecretsCreatedMessage,
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
+}
+
+func setCodeModulesInjectionCreatedCondition(conditions *[]metav1.Condition) {
+	condition := metav1.Condition{
+		Type:    codeModulesInjectionConditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  nsAndSecretsCreatedReason,
+		Message: nsAndSecretsCreatedMessage,
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
+}

--- a/pkg/controllers/dynakube/injection/conditions.go
+++ b/pkg/controllers/dynakube/injection/conditions.go
@@ -9,16 +9,16 @@ const (
 	metaDataEnrichmentConditionType   = "MetadataEnrichment"
 	codeModulesInjectionConditionType = "CodeModulesInjection"
 
-	nsAndSecretsCreatedReason  = "SecretsCreated"
-	nsAndSecretsCreatedMessage = "Namespaces mapped and secrets created"
+	secretsCreatedReason  = "SecretsCreated"
+	secretsCreatedMessage = "Namespaces mapped and secrets created"
 )
 
 func setMetadataEnrichmentCreatedCondition(conditions *[]metav1.Condition) {
 	condition := metav1.Condition{
 		Type:    metaDataEnrichmentConditionType,
 		Status:  metav1.ConditionTrue,
-		Reason:  nsAndSecretsCreatedReason,
-		Message: nsAndSecretsCreatedMessage,
+		Reason:  secretsCreatedReason,
+		Message: secretsCreatedMessage,
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }
@@ -27,8 +27,8 @@ func setCodeModulesInjectionCreatedCondition(conditions *[]metav1.Condition) {
 	condition := metav1.Condition{
 		Type:    codeModulesInjectionConditionType,
 		Status:  metav1.ConditionTrue,
-		Reason:  nsAndSecretsCreatedReason,
-		Message: nsAndSecretsCreatedMessage,
+		Reason:  secretsCreatedReason,
+		Message: secretsCreatedMessage,
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }

--- a/pkg/controllers/dynakube/injection/reconciler.go
+++ b/pkg/controllers/dynakube/injection/reconciler.go
@@ -15,8 +15,11 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/ingestendpoint"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/initgeneration"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/mapper"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -134,15 +137,8 @@ func (r *reconciler) removeAppInjection(ctx context.Context) (err error) {
 		return err
 	}
 
-	endpointSecretGenerator := ingestendpoint.NewSecretGenerator(r.client, r.apiReader, r.dynakube.Namespace)
-
-	err = endpointSecretGenerator.RemoveEndpointSecrets(ctx, namespaces)
-	if err != nil {
-		log.Info("could not remove metadata-enrichment secret")
-
-		return err
-	}
-	// TODO: remove initgeneration secret as well + handle errors jointly
+	r.cleanupEnrichmentInjection(ctx, namespaces)
+	r.cleanupOneAgentInjection(ctx, namespaces)
 
 	return nil
 }
@@ -154,7 +150,7 @@ func (r *reconciler) setupOneAgentInjection(ctx context.Context) error {
 
 	err := initgeneration.NewInitGenerator(r.client, r.apiReader, r.dynakube.Namespace).GenerateForDynakube(ctx, r.dynakube)
 	if err != nil {
-		log.Info("failed to generate init secret")
+		conditions.SetError(r.dynakube.Conditions(), codeModulesInjectionConditionType, err)
 
 		return err
 	}
@@ -163,7 +159,24 @@ func (r *reconciler) setupOneAgentInjection(ctx context.Context) error {
 		r.dynakube.Status.SetPhase(status.Running)
 	}
 
+	setCodeModulesInjectionCreatedCondition(r.dynakube.Conditions())
+
 	return nil
+}
+
+func (r *reconciler) cleanupOneAgentInjection(ctx context.Context, namespaces []corev1.Namespace) {
+	errs := make([]error, 0)
+
+	if meta.FindStatusCondition(*r.dynakube.Conditions(), codeModulesInjectionConditionType) != nil {
+		err := initgeneration.NewInitGenerator(r.client, r.apiReader, r.dynakube.Namespace).Cleanup(ctx, namespaces)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		meta.RemoveStatusCondition(r.dynakube.Conditions(), codeModulesInjectionConditionType)
+	}
+
+	log.Error(goerrors.Join(errs...), "failed to clean-up code module injection")
 }
 
 func (r *reconciler) setupEnrichmentInjection(ctx context.Context) error {
@@ -176,11 +189,25 @@ func (r *reconciler) setupEnrichmentInjection(ctx context.Context) error {
 	err := endpointSecretGenerator.GenerateForDynakube(ctx, r.dynakube)
 	if err != nil {
 		log.Info("failed to generate the metadata-enrichment secret")
+		conditions.SetError(r.dynakube.Conditions(), metaDataEnrichmentConditionType, err)
 
 		return err
 	}
 
+	setMetadataEnrichmentCreatedCondition(r.dynakube.Conditions())
+
 	return nil
+}
+
+func (r *reconciler) cleanupEnrichmentInjection(ctx context.Context, namespaces []corev1.Namespace) {
+	if meta.FindStatusCondition(*r.dynakube.Conditions(), metaDataEnrichmentConditionType) != nil {
+		err := ingestendpoint.NewSecretGenerator(r.client, r.apiReader, r.dynakube.Namespace).RemoveEndpointSecrets(ctx, namespaces)
+		if err != nil {
+			log.Error(err, "failed to clean-up metadata-enrichment secrets")
+		}
+
+		meta.RemoveStatusCondition(r.dynakube.Conditions(), metaDataEnrichmentConditionType)
+	}
 }
 
 func (r *reconciler) createDynakubeMapper(ctx context.Context) *mapper.DynakubeMapper {

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -9,7 +9,7 @@ import (
 	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/activegate"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
+	oaconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"

--- a/pkg/injection/namespace/initgeneration/initgeneration.go
+++ b/pkg/injection/namespace/initgeneration/initgeneration.go
@@ -109,6 +109,17 @@ func (g *InitGenerator) GenerateForDynakube(ctx context.Context, dk *dynatracev1
 	return nil
 }
 
+func (g *InitGenerator) Cleanup(ctx context.Context, namespaces []corev1.Namespace) error {
+	nsList := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		nsList = append(nsList, ns.Name)
+	}
+
+	secretQuery := k8ssecret.NewQuery(ctx, g.client, g.apiReader, log)
+
+	return secretQuery.DeleteForNamespaces(consts.AgentInitSecretName, nsList)
+}
+
 // generate gets the necessary info the create the init secret data
 func (g *InitGenerator) generate(ctx context.Context, dk *dynatracev1beta2.DynaKube) (map[string][]byte, error) {
 	hostMonitoringNodes, err := g.getHostMonitoringNodes(dk)

--- a/pkg/util/conditions/error.go
+++ b/pkg/util/conditions/error.go
@@ -8,6 +8,7 @@ import (
 const (
 	KubeApiErrorReason      = "KubeApiError"
 	DynatraceApiErrorReason = "DynatraceApiError"
+	ErrorReason             = "Error"
 )
 
 func SetKubeApiError(conditions *[]metav1.Condition, conditionType string, err error) {
@@ -34,6 +35,20 @@ func SetDynatraceApiError(conditions *[]metav1.Condition, conditionType string, 
 		Status:  metav1.ConditionFalse,
 		Reason:  DynatraceApiErrorReason,
 		Message: "A problem occurred when using the Dynatrace API: " + err.Error(),
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
+}
+
+func SetError(conditions *[]metav1.Condition, conditionType string, err error) {
+	if err == nil {
+		return
+	}
+
+	condition := metav1.Condition{
+		Type:    conditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  ErrorReason,
+		Message: "A problem occurred: " + err.Error(),
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }

--- a/pkg/util/conditions/error.go
+++ b/pkg/util/conditions/error.go
@@ -1,6 +1,9 @@
 package conditions
 
 import (
+	"errors"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -8,7 +11,6 @@ import (
 const (
 	KubeApiErrorReason      = "KubeApiError"
 	DynatraceApiErrorReason = "DynatraceApiError"
-	ErrorReason             = "Error"
 )
 
 func SetKubeApiError(conditions *[]metav1.Condition, conditionType string, err error) {
@@ -39,16 +41,8 @@ func SetDynatraceApiError(conditions *[]metav1.Condition, conditionType string, 
 	_ = meta.SetStatusCondition(conditions, condition)
 }
 
-func SetError(conditions *[]metav1.Condition, conditionType string, err error) {
-	if err == nil {
-		return
-	}
+func IsKubeApiError(err error) bool {
+	status, ok := err.(k8serrors.APIStatus)
 
-	condition := metav1.Condition{
-		Type:    conditionType,
-		Status:  metav1.ConditionFalse,
-		Reason:  ErrorReason,
-		Message: "A problem occurred: " + err.Error(),
-	}
-	_ = meta.SetStatusCondition(conditions, condition)
+	return ok || errors.As(err, &status)
 }

--- a/pkg/util/conditions/error_test.go
+++ b/pkg/util/conditions/error_test.go
@@ -1,0 +1,23 @@
+package conditions
+
+import (
+	"errors"
+	"testing"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func TestIsKubeApiError(t *testing.T) {
+	assert.False(t, IsKubeApiError(nil), "Nil error should not be a Kube API error")
+	assert.False(t, IsKubeApiError(errors.New("Some error")), "Non-Kube API error should not be a Kube API error")
+	assert.True(t, IsKubeApiError(k8serrors.NewBadRequest("Bad request")), "Kube API error should be a Kube API error")
+
+	t.Run("wrapped error", func(t *testing.T) {
+		var err error
+		err = k8serrors.NewBadRequest("Bad request")
+		err = pkgerrors.WithStack(err)
+		assert.True(t, IsKubeApiError(err), "Kube API error should be a Kube API error even if wrapped")
+	})
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

The dynakube conditions should show what happend in our operator.
We want to extend the conditions by the result of the injection reconciler. 

In addition we can cleanup the created secrets when needed.

[Jira Ticket](https://dt-rnd.atlassian.net/browse/K8S-9579)

## How can this be tested?

- Run a dynakube with cloudnative and metrics ingest enabled => check if the 2 created conditions are there
- Remove everathing from the dynakube => check if secrets in monitored namespaces are deleted