### PR TITLE
fixup auto renovate update: we should use main branch

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          ref: main
       - name: Install Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:


### PR DESCRIPTION
## Description

tl;dr we should checkout from main because create PR against main, not a release-, but we should trigger using release.

## How can this be tested?

rerun-workflow after merging this