### PR TITLE
Avoid using skopeo in release pipeline

### DIFF
--- a/.github/actions/upload-image/action.yaml
+++ b/.github/actions/upload-image/action.yaml
@@ -20,6 +20,10 @@ inputs:
     description: Set if platform suffix should be skipped for image
     required: false
     default: ""
+outputs:
+  digest:
+    description: The digest of the pushed image
+    value: ${{ steps.push-image.outputs.digest }}
 
 runs:
   using: "composite"
@@ -30,6 +34,7 @@ runs:
         name: operator-${{ inputs.platform }}
         path: /tmp
     - name: Upload image to Registry
+      id: push-image
       shell: bash
       env:
         IMAGE: "${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,6 +98,7 @@ jobs:
         with:
           registry-type: public
       - name: Push ${{matrix.platform}} to ${{matrix.registry}}
+        id: push-image
         uses: ./.github/actions/upload-image
         with:
           platform: ${{ matrix.platform }}
@@ -105,16 +106,10 @@ jobs:
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{ matrix.url }}
           repository: ${{ secrets[matrix.repository] }}
-      - name: Get image digest
-        id: digest
-        env:
-          IMAGE: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}-${{ matrix.platform }}
-        run: |
-          hack/build/ci/get-image-digest.sh
       - name: Sign image for ${{matrix.registry}}
         uses: ./.github/actions/sign-image
         with:
-          image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}-${{ matrix.platform }}@${{steps.digest.outputs.digest}}
+          image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}-${{ matrix.platform }}@${{steps.push-image.outputs.digest}}
           signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
 

--- a/hack/build/ci/get-image-digest.sh
+++ b/hack/build/ci/get-image-digest.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-digest=$(skopeo inspect docker-daemon:"${IMAGE}" --format "{{.Digest}}")
-echo "digest=${digest}">> "$GITHUB_OUTPUT"

--- a/hack/build/ci/upload-docker-image.sh
+++ b/hack/build/ci/upload-docker-image.sh
@@ -23,4 +23,8 @@ srcImage=$(docker load -i "${imageTarPath}" | cut -d' ' -f3)
 
 docker load --input "${imageTarPath}"
 docker tag "${srcImage}" "${targetImage}"
-docker push "${targetImage}"
+imageinfo=$(docker push "${targetImage}")
+
+# filtering by image-tag directly does not work currently see: https://github.com/moby/moby/issues/29901
+digest=$(echo "$imageinfo" | tail -n 1 | cut -d " " -f 3)
+echo "digest=${digest}">> "$GITHUB_OUTPUT"

--- a/hack/build/ci/upload-docker-image.sh
+++ b/hack/build/ci/upload-docker-image.sh
@@ -23,8 +23,8 @@ srcImage=$(docker load -i "${imageTarPath}" | cut -d' ' -f3)
 
 docker load --input "${imageTarPath}"
 docker tag "${srcImage}" "${targetImage}"
-imageinfo=$(docker push "${targetImage}")
+pushinfo=$(docker push "${targetImage}")
 
 # filtering by image-tag directly does not work currently see: https://github.com/moby/moby/issues/29901
-digest=$(echo "$imageinfo" | tail -n 1 | cut -d " " -f 3)
+digest=$(echo "$pushinfo" | tail -n 1 | cut -d " " -f 3)
 echo "digest=${digest}">> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

The last run of the release pipeline failed, as skopeo has incompatible version with docker. Therefore we should try to avoid using skopeo

## How can this be tested?

Fork operator repo and simulate release (or wait for the next release)