### PR TITLE
Add a wait timeout to E2E Test Setup for OCP Environments and Check Result of Deployments for all Environments

### DIFF
--- a/.github/scripts/create-cluster.sh
+++ b/.github/scripts/create-cluster.sh
@@ -3,6 +3,7 @@
 set -x
 
 DEFAULT_TIMEOUT="60m" # K8s takes <10min, Openshift >40min
+desired_state="environment-deployed"
 
 kubectl version
 
@@ -15,3 +16,19 @@ kubectl patch --namespace $FLC_NAMESPACE --type merge --patch '{"spec": {"desire
 
 echo "Waiting up to '$DEFAULT_TIMEOUT' for successful deployment of environment '$FLC_ENVIRONMENT'"
 kubectl wait --namespace $FLC_NAMESPACE --timeout="$DEFAULT_TIMEOUT" --for=condition=InTransition=false flcenvironment $FLC_ENVIRONMENT
+
+if [[ "$FLC_ENVIRONMENT" == *"ocp"* ]]; then
+  echo "PLATFORM is set to 'ocp'. Waiting for 5 minutes..."
+  sleep 300  # Wait for 5 minutes (300 seconds)
+  echo "done"
+fi
+
+echo "Checking currentState='$desired_state' for '$FLC_ENVIRONMENT'..."
+flc_state=$(kubectl get flcenvironment "$FLC_ENVIRONMENT" --namespace "$FLC_NAMESPACE" -ojsonpath="{.status.currentState}")
+if [[ "$flc_state" != "$desired_state" ]]; then
+  echo "Pipeline deployment did not reach expected state '$desired_state', currentState: ${flc_state}..."
+  exit 1
+  else
+    echo "successful..."
+fi
+echo "done"

--- a/.github/scripts/create-cluster.sh
+++ b/.github/scripts/create-cluster.sh
@@ -3,19 +3,19 @@
 set -x
 
 DEFAULT_TIMEOUT="60m" # K8s takes <10min, Openshift >40min
-desired_state="environment-deployed"
+DESIRED_STATE="environment-deployed"
 
 kubectl version
 
 echo "Creating environment '$FLC_ENVIRONMENT' in namespace '$FLC_NAMESPACE'"
 
-kubectl get flcenvironments --namespace $FLC_NAMESPACE
+kubectl get flcenvironments --namespace "$FLC_NAMESPACE"
 
 echo "Patching environment '$FLC_ENVIRONMENT' to 'deployed'"
-kubectl patch --namespace $FLC_NAMESPACE --type merge --patch '{"spec": {"desiredState": "environment-deployed"}}' flcenvironment $FLC_ENVIRONMENT
+kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch '{"spec": {"desiredState": "environment-deployed"}}' flcenvironment "$FLC_ENVIRONMENT"
 
 echo "Waiting up to '$DEFAULT_TIMEOUT' for successful deployment of environment '$FLC_ENVIRONMENT'"
-kubectl wait --namespace $FLC_NAMESPACE --timeout="$DEFAULT_TIMEOUT" --for=condition=InTransition=false flcenvironment $FLC_ENVIRONMENT
+kubectl wait --namespace "$FLC_NAMESPACE" --timeout="$DEFAULT_TIMEOUT" --for=condition=InTransition=false flcenvironment "$FLC_ENVIRONMENT"
 
 if [[ "$FLC_ENVIRONMENT" == *"ocp"* ]]; then
   echo "PLATFORM is set to 'ocp'. Waiting for 5 minutes..."
@@ -23,10 +23,10 @@ if [[ "$FLC_ENVIRONMENT" == *"ocp"* ]]; then
   echo "done"
 fi
 
-echo "Checking currentState='$desired_state' for '$FLC_ENVIRONMENT'..."
+echo "Checking currentState='$DESIRED_STATE' for '$FLC_ENVIRONMENT'..."
 flc_state=$(kubectl get flcenvironment "$FLC_ENVIRONMENT" --namespace "$FLC_NAMESPACE" -ojsonpath="{.status.currentState}")
-if [[ "$flc_state" != "$desired_state" ]]; then
-  echo "Pipeline deployment did not reach expected state '$desired_state', currentState: ${flc_state}..."
+if [[ "$flc_state" != "$DESIRED_STATE" ]]; then
+  echo "Pipeline deployment did not reach expected state '$DESIRED_STATE', currentState: ${flc_state}..."
   exit 1
   else
     echo "successful..."


### PR DESCRIPTION
## Description

* Check the deployment status of FLC deployments and only continue if deployment was successful.
* Wait for proper OCP setup so teardown can clean up properly.

## How can this be tested?

Run E2E tests with workflow from this branch while using a release branch to run tests against.