### PR TITLE
Validate EdgeConnect Automation to Require Provision Mode

### DIFF
--- a/pkg/webhook/validation/edgeconnect/automation_validation.go
+++ b/pkg/webhook/validation/edgeconnect/automation_validation.go
@@ -1,0 +1,20 @@
+package edgeconnect
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+)
+
+const (
+	errorAutomationRequiresProvisioner = `When enabling Kubernetes automation using provisioner mode is mandatory! Please enable spec.oauth.provisioner and provide a resp. OAuth client configuration.
+	`
+)
+
+func automationRequiresProvisionerValidation(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
+	if edgeConnect.Spec.KubernetesAutomation != nil && edgeConnect.Spec.KubernetesAutomation.Enabled && !edgeConnect.Spec.OAuth.Provisioner {
+		return errorAutomationRequiresProvisioner
+	}
+
+	return ""
+}

--- a/pkg/webhook/validation/edgeconnect/automation_validation.go
+++ b/pkg/webhook/validation/edgeconnect/automation_validation.go
@@ -7,8 +7,7 @@ import (
 )
 
 const (
-	errorAutomationRequiresProvisioner = `When enabling Kubernetes automation using provisioner mode is mandatory! Please enable spec.oauth.provisioner and provide a resp. OAuth client configuration.
-	`
+	errorAutomationRequiresProvisioner = `When enabling Kubernetes automation using provisioner mode is mandatory! Please enable spec.oauth.provisioner and provide a resp. OAuth client configuration.`
 )
 
 func automationRequiresProvisionerValidation(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {

--- a/pkg/webhook/validation/edgeconnect/automation_validation_test.go
+++ b/pkg/webhook/validation/edgeconnect/automation_validation_test.go
@@ -1,0 +1,53 @@
+package edgeconnect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestAutomationValidator(t *testing.T) {
+	t.Run("accept edgeconnect config without automation of oauth configs set", func(t *testing.T) {
+		edgeConnect := &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{},
+		}
+		require.Empty(t, automationRequiresProvisionerValidation(context.Background(), nil, edgeConnect))
+	})
+	t.Run("reject automation without provisioning", func(t *testing.T) {
+		edgeConnect := &edgeconnect.EdgeConnect{
+
+			Spec: edgeconnect.EdgeConnectSpec{
+				KubernetesAutomation: &edgeconnect.KubernetesAutomationSpec{Enabled: true},
+				OAuth: edgeconnect.OAuthSpec{
+					Provisioner: false,
+				},
+				Resources: corev1.ResourceRequirements{},
+			},
+		}
+		require.Equal(t, errorAutomationRequiresProvisioner, automationRequiresProvisionerValidation(context.Background(), nil, edgeConnect))
+	})
+	t.Run("accept automation with provisioning enabled", func(t *testing.T) {
+		edgeConnect := &edgeconnect.EdgeConnect{
+
+			Spec: edgeconnect.EdgeConnectSpec{
+				KubernetesAutomation: &edgeconnect.KubernetesAutomationSpec{Enabled: true},
+				OAuth: edgeconnect.OAuthSpec{
+					Provisioner: true,
+				},
+			},
+		}
+		require.Empty(t, automationRequiresProvisionerValidation(context.Background(), nil, edgeConnect))
+	})
+	t.Run("reject automation with no oauth config", func(t *testing.T) {
+		edgeConnect := &edgeconnect.EdgeConnect{
+
+			Spec: edgeconnect.EdgeConnectSpec{
+				KubernetesAutomation: &edgeconnect.KubernetesAutomationSpec{Enabled: true},
+			},
+		}
+		require.Equal(t, errorAutomationRequiresProvisioner, automationRequiresProvisionerValidation(context.Background(), nil, edgeConnect))
+	})
+}

--- a/pkg/webhook/validation/edgeconnect/automation_validation_test.go
+++ b/pkg/webhook/validation/edgeconnect/automation_validation_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAutomationValidator(t *testing.T) {
-	t.Run("accept edgeconnect config without automation of oauth configs set", func(t *testing.T) {
+	t.Run("accept edgeconnect config without automation or oauth configs set", func(t *testing.T) {
 		edgeConnect := &edgeconnect.EdgeConnect{
 			Spec: edgeconnect.EdgeConnectSpec{},
 		}

--- a/pkg/webhook/validation/edgeconnect/config.go
+++ b/pkg/webhook/validation/edgeconnect/config.go
@@ -20,4 +20,5 @@ var validators = []validator{
 	nameTooLong,
 	checkHostPatternsValue,
 	isInvalidServiceName,
+	automationRequiresProvisionerValidation,
 }


### PR DESCRIPTION
## Description

see [K8S-10211](https://dt-rnd.atlassian.net/browse/)

Add validation of EdgeConnect configuration to require Provisioner Mode when enabling K8s Automation.

## How can this be tested?

deploy EdgeConnect with
```
...
spec:
  ...
  oauth:
    ...
    provisioner: false
  ...
  kubernetesAutomation:
     enabled: true 
```
must be rejected