### PR TITLE
Remove gke-autopilot as platform from helm chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -310,6 +310,7 @@ jobs:
           make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
           make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
           make manifests/openshift IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
+          cp config/deploy/kubernetes/kubernetes.yaml config/deploy/kubernetes/gke-autopilot.yaml
       - name: Build helm packages
         uses: ./.github/actions/build-helm
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -258,7 +258,7 @@ jobs:
           registry-type: public
       - name: Create sbom for ${{matrix.registry}}
         id: sbom
-        uses: aquasecurity/trivy-action@595be6a0f6560a0a8fc419ddf630567fc623531d # 0.22.0
+        uses: aquasecurity/trivy-action@7c2007bcb556501da015201bcba5aa14069b74e2 # 0.23.0
         with:
           image-ref: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ needs.manifest.outputs.digest }}
           format: 'cyclonedx'

--- a/config/helm/chart/default/templates/_platform.tpl
+++ b/config/helm/chart/default/templates/_platform.tpl
@@ -38,7 +38,7 @@ Exclude Kubernetes manifest not running on OLM
 Check if platform is set to a valid one
 */}}
 {{- define "dynatrace-operator.platformIsValid" -}}
-{{- $validPlatforms := list "kubernetes" "openshift" "google-marketplace" "azure-marketplace" -}}
+{{- $validPlatforms := list "kubernetes" "openshift" "gke-autopilot" "google-marketplace" "azure-marketplace" -}}
 {{- if has (include "dynatrace-operator.platform" .) $validPlatforms -}}
     {{ default "set" }}
 {{- end -}}
@@ -48,7 +48,7 @@ Check if platform is set to a valid one
 Enforces that platform is set to a valid one
 */}}
 {{- define "dynatrace-operator.platformRequired" -}}
-{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift or google-marketplace" (include "dynatrace-operator.platformIsValid" .))}}
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift, gke-autopilot or google-marketplace" (include "dynatrace-operator.platformIsValid" .))}}
 {{- end -}}
 
 {{- define "dynatrace-operator.nodeAffinity" -}}

--- a/config/helm/chart/default/templates/_platform.tpl
+++ b/config/helm/chart/default/templates/_platform.tpl
@@ -38,7 +38,7 @@ Exclude Kubernetes manifest not running on OLM
 Check if platform is set to a valid one
 */}}
 {{- define "dynatrace-operator.platformIsValid" -}}
-{{- $validPlatforms := list "kubernetes" "openshift" "gke-autopilot" "google-marketplace" "azure-marketplace" -}}
+{{- $validPlatforms := list "kubernetes" "openshift" "google-marketplace" "gke-autopilot" "azure-marketplace" -}}
 {{- if has (include "dynatrace-operator.platform" .) $validPlatforms -}}
     {{ default "set" }}
 {{- end -}}
@@ -48,7 +48,7 @@ Check if platform is set to a valid one
 Enforces that platform is set to a valid one
 */}}
 {{- define "dynatrace-operator.platformRequired" -}}
-{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift, gke-autopilot or google-marketplace" (include "dynatrace-operator.platformIsValid" .))}}
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift, google-marketplace, or gke-autopilot" (include "dynatrace-operator.platformIsValid" .))}}
 {{- end -}}
 
 {{- define "dynatrace-operator.nodeAffinity" -}}

--- a/config/helm/chart/default/templates/_platform.tpl
+++ b/config/helm/chart/default/templates/_platform.tpl
@@ -20,8 +20,6 @@ Auto-detect the platform (if not set), according to the available APIVersions
         {{- printf .Values.platform -}}
     {{- else if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
         {{- printf "openshift" -}}
-    {{- else if .Capabilities.APIVersions.Has "auto.gke.io/v1" }}
-        {{- printf "gke-autopilot" -}}
     {{- else }}
         {{- printf "kubernetes" -}}
     {{- end -}}
@@ -40,7 +38,7 @@ Exclude Kubernetes manifest not running on OLM
 Check if platform is set to a valid one
 */}}
 {{- define "dynatrace-operator.platformIsValid" -}}
-{{- $validPlatforms := list "kubernetes" "openshift" "google-marketplace" "gke-autopilot" "azure-marketplace" -}}
+{{- $validPlatforms := list "kubernetes" "openshift" "google-marketplace" "azure-marketplace" -}}
 {{- if has (include "dynatrace-operator.platform" .) $validPlatforms -}}
     {{ default "set" }}
 {{- end -}}
@@ -50,7 +48,7 @@ Check if platform is set to a valid one
 Enforces that platform is set to a valid one
 */}}
 {{- define "dynatrace-operator.platformRequired" -}}
-{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift, google-marketplace, or gke-autopilot" (include "dynatrace-operator.platformIsValid" .))}}
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift or google-marketplace" (include "dynatrace-operator.platformIsValid" .))}}
 {{- end -}}
 
 {{- define "dynatrace-operator.nodeAffinity" -}}
@@ -59,7 +57,6 @@ affinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
         - matchExpressions:
-              {{- if ne (include "dynatrace-operator.platform" .) "gke-autopilot"}}
             - key: kubernetes.io/arch
               operator: In
               values:
@@ -67,7 +64,6 @@ affinity:
                 - arm64
                 - ppc64le
                 - s390x
-              {{- end }}
             - key: kubernetes.io/os
               operator: In
               values:

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -26,13 +26,6 @@ tests:
       - hasDocuments:
           count: 1
 
-  - it: should exist if platform is set to gke-autopilot
-    set:
-      platform: gke-autopilot
-    asserts:
-      - hasDocuments:
-          count: 1
-
   - it: should exist on kubernetes
     set:
       platform: kubernetes
@@ -398,22 +391,6 @@ tests:
     asserts:
       - isNull:
           path: spec.template.spec.imagePullSecrets
-
-  - it: should have only OS node affinity on GKE Autopilot
-    set:
-      platform: gke-autopilot
-    asserts:
-      - equal:
-          path: spec.template.spec.affinity
-          value:
-              nodeAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  nodeSelectorTerms:
-                    - matchExpressions:
-                        - key: kubernetes.io/os
-                          operator: In
-                          values:
-                            - linux
 
   - it: should take custom labels
     set:

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -479,22 +479,6 @@ tests:
                 type: RuntimeDefault
             serviceAccountName: dynatrace-webhook
 
-  - it: should have only OS node affinity on GKE Autopilot
-    set:
-      platform: gke-autopilot
-    asserts:
-      - equal:
-          path: spec.template.spec.affinity
-          value:
-              nodeAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  nodeSelectorTerms:
-                    - matchExpressions:
-                        - key: kubernetes.io/os
-                          operator: In
-                          values:
-                            - linux
-
   - it: should have imagePullSecrets defined in spec
     set:
       customPullSecret: pull-secret

--- a/config/helm/chart/default/tests/Google/application_test.yaml
+++ b/config/helm/chart/default/tests/Google/application_test.yaml
@@ -22,10 +22,3 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-
-  - it: should not exist if platform is set to gke-autopilot
-    set:
-      platform: gke-autopilot
-    asserts:
-      - hasDocuments:
-          count: 0

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# may be set to "kubernetes", "openshift"
+# may be set to "kubernetes", "openshift", "gke-autopilot" (deprecated)
 platform: ""
 
 #image qualifier; OBSOLETE -> use imageref instead!

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# may be set to "kubernetes", "openshift", or "gke-autopilot"
+# may be set to "kubernetes", "openshift"
 platform: ""
 
 #image qualifier; OBSOLETE -> use imageref instead!

--- a/hack/make/deploy/gke.mk
+++ b/hack/make/deploy/gke.mk
@@ -1,12 +1,3 @@
-## Deploy the operator in the Google Autopilot cluster configured in ~/.kube/config
-deploy/gke-autopilot:
-	@make ENABLE_CSI=false PLATFORM="gke-autopilot" deploy
-
-## Undeploy the operator in the Google Autopilot cluster configured in ~/.kube/config
-undeploy/gke-autopilot:
-	@make ENABLE_CSI=false PLATFORM="gke-autopilot" undeploy
-
-
 ## Deploys the operator using a snapshot deployer image for a standard GKE cluster
 deploy/gke/deployer:
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/application/master/deploy/kube-app-manager-aio.yaml

--- a/hack/make/manifests/config.mk
+++ b/hack/make/manifests/config.mk
@@ -9,7 +9,6 @@ MANIFESTS_DIR=config/deploy/
 RELEASE_CRD_YAML=config/deploy/dynatrace-operator-crd.yaml
 
 KUBERNETES_CORE_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes.yaml
-KUBERNETES_AUTOPILOT_YAML=$(MANIFESTS_DIR)kubernetes/gke-autopilot.yaml
 KUBERNETES_CSIDRIVER_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-csi.yaml
 KUBERNETES_OLM_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-olm.yaml
 KUBERNETES_ALL_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-all.yaml

--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -20,18 +20,8 @@ manifests/kubernetes/core: manifests/crd/helm
 		  --set olm="${OLM}" \
 		  --set image="$(IMAGE_URI)" > "$(KUBERNETES_CORE_YAML)"
 
-## Generates a Kubernetes manifest with a CRD for gke-autopilot
-manifests/kubernetes/gke-autopilot: manifests/crd/helm
-	helm template dynatrace-operator config/helm/chart/default \
-			--namespace dynatrace \
-			--set installCRD=true \
-			--set platform="gke-autopilot" \
-			--set manifests=true \
-			--set olm="${OLM}" \
-			--set image="$(IMAGE_URI)" > "$(KUBERNETES_AUTOPILOT_YAML)"
-
 ## Generates a manifest for Kubernetes including a CRD, a CSI driver deployment
-manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi manifests/kubernetes/gke-autopilot
+manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi manifests/kubernetes/core
 	cat "$(KUBERNETES_CORE_YAML)" "$(KUBERNETES_CSIDRIVER_YAML)" > "$(KUBERNETES_ALL_YAML)"
 
 ## Generates a manifest for Kubernetes including OLM version

--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -21,7 +21,7 @@ manifests/kubernetes/core: manifests/crd/helm
 		  --set image="$(IMAGE_URI)" > "$(KUBERNETES_CORE_YAML)"
 
 ## Generates a manifest for Kubernetes including a CRD, a CSI driver deployment
-manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi manifests/kubernetes/core
+manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi
 	cat "$(KUBERNETES_CORE_YAML)" "$(KUBERNETES_CSIDRIVER_YAML)" > "$(KUBERNETES_ALL_YAML)"
 
 ## Generates a manifest for Kubernetes including OLM version

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -132,21 +132,5 @@ test/e2e/edgeconnect: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=edgeconnect-install" $(SKIPCLEANUP)
 
 ## Runs e2e tests on gke-autopilot
-test/e2e/gke-autopilot: manifests/kubernetes/gke-autopilot
+test/e2e/gke-autopilot: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=app-metadata-enrichment,name=app-read-only-csi-volume,name=app-read-only-csi-volume,name=app-without-csi,name=activegate-default" $(SKIPCLEANUP)
-
-## Runs Application Monitoring metadata-enrichment e2e test only on gke-autopilot
-test/e2e/gke-autopilot/applicationmonitoring/metadataenrichment: manifests/kubernetes/gke-autopilot
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=app-metadata-enrichment"  $(SKIPCLEANUP)
-
-## Runs Application Monitoring label versio detection e2e test only on gke-autopilot
-test/e2e/gke-autopilot/applicationmonitoring/labelversion: manifests/kubernetes/gke-autopilot
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=app-label-version"  $(SKIPCLEANUP)
-
-## Runs Application Monitoring readonly csi-volume e2e test only on gke-autopilot
-test/e2e/gke-autopilot/applicationmonitoring/readonlycsivolume: manifests/kubernetes/gke-autopilot
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=app-read-only-csi-volume" $(SKIPCLEANUP)
-
-## Runs Application Monitoring without CSI e2e test only on gke-autopilot
-test/e2e/gke-autopilot/applicationmonitoring/withoutcsi: manifests/kubernetes/gke-autopilot
-	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -args --labels "name=app-without-csi" $(SKIPCLEANUP)


### PR DESCRIPTION
## Description

Ticket: https://dt-rnd.atlassian.net/browse/K8S-10194

Formerly we introduced gke-autopilot as a platform to the helm chart in order remove nodeAffinity from the templates, as this caused the deployments to be rejected by warden (policy engine). Since this requierment got removed we can also remove gke-autopilot as platform.

## How can this be tested?

`make manifests`
`k apply -f ~/workspace/dynatrace-operator/config/deploy/kubernetes/kubernetes.yaml`

or 

```
helm install dynatrace-operator config/helm/chart/default \
                        --namespace dynatrace \
                        --create-namespace \
                        --atomic \
                        --set installCRD=true \
                        --set csidriver.enabled=false \
                        --set image="quay.io/dynatrace/dynatrace-operator:snapshot"
```


Check if the operator components are deployed correctly on an gke-autopilot cluster