### PR TITLE
Make csi-gc less aggressive

### DIFF
--- a/pkg/controllers/csi/gc/binaries.go
+++ b/pkg/controllers/csi/gc/binaries.go
@@ -20,6 +20,12 @@ func (gc *CSIGarbageCollector) runBinaryGarbageCollection() {
 	}
 
 	for _, codeModule := range codeModules {
+		if !gc.time.Now().Time.After(codeModule.DeletedAt.Time.Add(safeRemovalThreshold)) {
+			log.Info("skipping recently orphaned codemodule", "version", codeModule.Version, "location", codeModule.Location)
+
+			continue
+		}
+
 		log.Info("cleaning up orphaned codemodule binary", "version", codeModule.Version, "location", codeModule.Location)
 		removeUnusedVersion(fs, codeModule.Location)
 

--- a/pkg/controllers/csi/gc/reconciler.go
+++ b/pkg/controllers/csi/gc/reconciler.go
@@ -8,6 +8,7 @@ import (
 
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/spf13/afero"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -18,12 +19,18 @@ type CSIGarbageCollector struct {
 	apiReader client.Reader
 	fs        afero.Fs
 	db        metadata.Cleaner
-	path      metadata.PathResolver
+	time      *timeprovider.Provider
+
+	path metadata.PathResolver
 
 	maxUnmountedVolumeAge time.Duration
 }
 
 var _ reconcile.Reconciler = (*CSIGarbageCollector)(nil)
+
+const (
+	safeRemovalThreshold = 5 * time.Minute
+)
 
 // NewCSIGarbageCollector returns a new CSIGarbageCollector
 func NewCSIGarbageCollector(apiReader client.Reader, opts dtcsi.CSIOptions, db metadata.Cleaner) *CSIGarbageCollector {
@@ -32,6 +39,7 @@ func NewCSIGarbageCollector(apiReader client.Reader, opts dtcsi.CSIOptions, db m
 		fs:                    afero.NewOsFs(),
 		db:                    db,
 		path:                  metadata.PathResolver{RootDir: opts.RootDir},
+		time:                  timeprovider.New(),
 		maxUnmountedVolumeAge: determineMaxUnmountedVolumeAge(os.Getenv(maxUnmountedCsiVolumeAgeEnv)),
 	}
 }
@@ -65,6 +73,12 @@ func (gc *CSIGarbageCollector) Reconcile(ctx context.Context, request reconcile.
 		}
 
 		for _, osm := range osMounts {
+			if !gc.time.Now().Time.After(osm.DeletedAt.Time.Add(safeRemovalThreshold)) {
+				log.Info("skipping recently removed os-mount", "location", osm.Location)
+
+				continue
+			}
+
 			if osm.TenantConfigUID == tenantConfig.UID {
 				dir, _ := afero.ReadDir(gc.fs, osm.Location)
 				for _, d := range dir {

--- a/pkg/controllers/csi/gc/reconciler.go
+++ b/pkg/controllers/csi/gc/reconciler.go
@@ -3,6 +3,7 @@ package csigc
 import (
 	"context"
 	"os"
+	"path"
 	"time"
 
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
@@ -65,7 +66,11 @@ func (gc *CSIGarbageCollector) Reconcile(ctx context.Context, request reconcile.
 
 		for _, osm := range osMounts {
 			if osm.TenantConfigUID == tenantConfig.UID {
-				gc.fs.RemoveAll(osm.Location)
+				dir, _ := afero.ReadDir(gc.fs, osm.Location)
+				for _, d := range dir {
+					gc.fs.RemoveAll(path.Join([]string{osm.Location, d.Name()}...))
+				}
+
 				gc.db.PurgeOSMount(&osm)
 			}
 		}

--- a/pkg/controllers/dynakube/istio/reconciler_test.go
+++ b/pkg/controllers/dynakube/istio/reconciler_test.go
@@ -301,6 +301,7 @@ func TestReconcileOneAgentCommunicationHosts(t *testing.T) {
 
 		err = r.ReconcileCodeModuleCommunicationHosts(ctx, dynakube)
 		require.NoError(t, err)
+
 		statusCondition = meta.FindStatusCondition(*dynakube.Conditions(), "IstioForCodeModule")
 		require.Nil(t, statusCondition)
 


### PR DESCRIPTION
## Description
https://dt-rnd.atlassian.net/browse/K8S-10338 ~(part of the fix, not all)~

Removing the whole folder may cause problems in a quick/messy uninstall.

The idea behind the change is that the `BidirectionalMountPropagation` might not be "fast enough" if we remove the whole folder that was mounted very close (ie.: almost at the same time) to the unmount then it might not get propagated properly, causing the pod with the mount to be stuck forever, and requiring manual.


## How can this be tested?

1. Deploy operator + cloud-native
2. remove operator (cloud-native oneagents should get stuck `Terminating`)
3. reinstall operator (cloud-native oneagents should get unstuck)
