### PR TITLE
Bump version for kubernetes settings objects to 0.1.6

### DIFF
--- a/pkg/clients/edgeconnect/environment_settings.go
+++ b/pkg/clients/edgeconnect/environment_settings.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	KubernetesConnectionSchemaID = "app:dynatrace.kubernetes.connector:connection"
-	KubernetesConnectionVersion  = "0.1.5"
+	KubernetesConnectionVersion  = "0.1.6"
 	KubernetesConnectionScope    = "environment"
 )
 


### PR DESCRIPTION
## Description
Bump version for settings objects.

## How can this be tested?

Deploy edgeconnect with automation enabled.
