### PR TITLE
Remove log line from support archive zip.

### DIFF
--- a/cmd/csi/init/builder.go
+++ b/cmd/csi/init/builder.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/cmd/config"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -51,6 +52,7 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(dtcsi.UnixUmask)
 		version.LogVersion()
+		logd.LogBaseLoggerSettings()
 
 		kubeConfig, err := builder.configProvider.GetConfig()
 		if err != nil {

--- a/cmd/csi/provisioner/builder.go
+++ b/cmd/csi/provisioner/builder.go
@@ -6,6 +6,7 @@ import (
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	csiprovisioner "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/provisioner"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtotel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/pkg/errors"
@@ -106,6 +107,7 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(dtcsi.UnixUmask)
 		version.LogVersion()
+		logd.LogBaseLoggerSettings()
 
 		kubeConfig, err := builder.configProvider.GetConfig()
 		if err != nil {

--- a/cmd/csi/server/builder.go
+++ b/cmd/csi/server/builder.go
@@ -6,6 +6,7 @@ import (
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	csidriver "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtotel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/pkg/errors"
@@ -110,6 +111,7 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(dtcsi.UnixUmask)
 		version.LogVersion()
+		logd.LogBaseLoggerSettings()
 
 		kubeConfig, err := builder.configProvider.GetConfig()
 		if err != nil {

--- a/cmd/operator/builder.go
+++ b/cmd/operator/builder.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/cmd/config"
 	cmdManager "github.com/Dynatrace/dynatrace-operator/cmd/manager"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/certificates"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtotel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
@@ -125,6 +126,7 @@ func (builder CommandBuilder) setClientFromConfig(kubeCfg *rest.Config) (Command
 func (builder CommandBuilder) buildRun() func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		version.LogVersion()
+		logd.LogBaseLoggerSettings()
 
 		kubeCfg, err := builder.configProvider.GetConfig()
 		if err != nil {

--- a/cmd/troubleshoot/builder.go
+++ b/cmd/troubleshoot/builder.go
@@ -71,6 +71,7 @@ func clusterOptions(opts *cluster.Options) {
 func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		version.LogVersion()
+		logd.LogBaseLoggerSettings()
 
 		kubeConfig, err := builder.configProvider.GetConfig()
 		if err != nil {

--- a/cmd/webhook/builder.go
+++ b/cmd/webhook/builder.go
@@ -8,6 +8,7 @@ import (
 	cmdManager "github.com/Dynatrace/dynatrace-operator/cmd/manager"
 	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtotel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
@@ -119,6 +120,7 @@ func startCertificateWatcher(webhookManager manager.Manager, namespace string, p
 func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		version.LogVersion()
+		logd.LogBaseLoggerSettings()
 
 		kubeConfig, err := builder.configProvider.GetConfig()
 		if err != nil {

--- a/pkg/logd/logger.go
+++ b/pkg/logd/logger.go
@@ -27,10 +27,14 @@ func Get() Logger {
 	baseLoggerOnce.Do(func() {
 		logLevel := readLogLevelFromEnv()
 		baseLogger = createLogger(NewPrettyLogWriter(), logLevel)
-		baseLogger.Info("logging level", "logLevel", logLevel.String())
 	})
 
 	return baseLogger
+}
+
+func LogBaseLoggerSettings() {
+	logLevel := readLogLevelFromEnv()
+	baseLogger.Info("logging level", "logLevel", logLevel.String())
 }
 
 func createLogger(out io.Writer, logLevel zapcore.Level) Logger {


### PR DESCRIPTION
## Description

A rogue log line logging loglevels corrupts the support archive zip if written directly to stdout. Moved logging of loglevel analogous to logging of version string.

## How can this be tested?

Deploy the operator and create a support archive using `--stdout`. Check if resulting zip file can be unpacked. Linux `unzip` was able to handle the corrupted zip file, so try to use other unzippers (e.g. Windows built in zip, 7Zip).