### PR TITLE
Use dynamic codeModulesVersion in cloudNative codeModules e2e test

### DIFF
--- a/test/features/publicregistry/publicregistry.go
+++ b/test/features/publicregistry/publicregistry.go
@@ -3,30 +3,17 @@
 package publicregistry
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/activegate"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/registry"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
-	"golang.org/x/mod/semver"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-)
-
-const (
-	agPublicECR = "public.ecr.aws/dynatrace/dynatrace-activegate"
-	oaPublicECR = "public.ecr.aws/dynatrace/dynatrace-oneagent"
-	cmPublicECR = "public.ecr.aws/dynatrace/dynatrace-codemodules"
 )
 
 // Feature defines the e2e test to verify that public-registry images can be deployed by the operator and that they function
@@ -43,14 +30,14 @@ func Feature(t *testing.T) features.Feature {
 	secretConfig := tenant.GetSingleTenantSecret(t)
 
 	oaSpec := cloudnative.DefaultCloudNativeSpec()
-	oaSpec.Image = getLatestImageURI(t, oaPublicECR)
-	oaSpec.CodeModulesImage = getLatestImageURI(t, cmPublicECR)
+	oaSpec.Image = registry.GetLatestOneAgentImageURI(t)
+	oaSpec.CodeModulesImage = registry.GetLatestCodeModulesImageURI(t)
 
 	options := []dynakube.Option{
 		dynakube.WithApiUrl(secretConfig.ApiUrl),
 		dynakube.WithCloudNativeSpec(oaSpec),
 		dynakube.WithActiveGate(),
-		dynakube.WithCustomActiveGateImage(getLatestImageURI(t, agPublicECR)),
+		dynakube.WithCustomActiveGateImage(registry.GetLatestActiveGateImageURI(t)),
 	}
 	testDynakube := *dynakube.New(options...)
 
@@ -75,26 +62,4 @@ func Feature(t *testing.T) features.Feature {
 	dynakube.Delete(builder, helpers.LevelTeardown, testDynakube)
 
 	return builder.Feature()
-}
-
-func getLatestImageURI(t *testing.T, repoURI string) string {
-	repo, err := name.NewRepository(repoURI)
-	require.NoError(t, err)
-
-	tags, err := remote.List(repo)
-	slices.SortFunc(tags, func(a, b string) int {
-		if strings.HasPrefix(a, "sha") {
-			return -1
-		}
-		if strings.HasPrefix(b, "sha") {
-			return 1
-		}
-		semverA, _ := dtversion.ToSemver(a)
-		semverB, _ := dtversion.ToSemver(b)
-
-		return semver.Compare(semverA, semverB)
-	})
-	require.NoError(t, err)
-
-	return fmt.Sprintf("%s:%s", repoURI, tags[len(tags)-1])
 }

--- a/test/helpers/registry/registry.go
+++ b/test/helpers/registry/registry.go
@@ -1,0 +1,54 @@
+package registry
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	agPublicECR = "public.ecr.aws/dynatrace/dynatrace-activegate"
+	oaPublicECR = "public.ecr.aws/dynatrace/dynatrace-oneagent"
+	cmPublicECR = "public.ecr.aws/dynatrace/dynatrace-codemodules"
+)
+
+func GetLatestActiveGateImageURI(t *testing.T) string {
+	return getLatestImageURI(t, agPublicECR)
+}
+
+func GetLatestOneAgentImageURI(t *testing.T) string {
+	return getLatestImageURI(t, oaPublicECR)
+}
+
+func GetLatestCodeModulesImageURI(t *testing.T) string {
+	return getLatestImageURI(t, cmPublicECR)
+}
+
+func getLatestImageURI(t *testing.T, repoURI string) string {
+	repo, err := name.NewRepository(repoURI)
+	require.NoError(t, err)
+
+	tags, err := remote.List(repo)
+	slices.SortFunc(tags, func(a, b string) int {
+		if strings.HasPrefix(a, "sha") {
+			return -1
+		}
+		if strings.HasPrefix(b, "sha") {
+			return 1
+		}
+		semverA, _ := dtversion.ToSemver(a)
+		semverB, _ := dtversion.ToSemver(b)
+
+		return semver.Compare(semverA, semverB)
+	})
+	require.NoError(t, err)
+
+	return fmt.Sprintf("%s:%s", repoURI, tags[len(tags)-1])
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->



## Description

Currently the cloudNative codeModules test is using a hardcoded codeModulesImage from quay. 
This PR updates the logic to dynamically fetch the code modules version from ECR.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->


[Jira](https://dt-rnd.atlassian.net/browse/K8S-9649)

## How can this be tested?

Run `make test/e2e/cloudnative/codemodules` and check if newest codeModules are used. 
(Check `Spec.OneAgent.CloudNativeFullStack.CodeModulesImage` field)

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->