### PR TITLE
Remove schemaVersion from EdgeConnect Settings object

### DIFF
--- a/pkg/clients/edgeconnect/environment_settings.go
+++ b/pkg/clients/edgeconnect/environment_settings.go
@@ -12,16 +12,14 @@ import (
 
 const (
 	KubernetesConnectionSchemaID = "app:dynatrace.kubernetes.connector:connection"
-	KubernetesConnectionVersion  = "0.1.6"
 	KubernetesConnectionScope    = "environment"
 )
 
 type EnvironmentSetting struct {
-	ObjectId      *string                 `json:"objectId"`
-	SchemaId      string                  `json:"schemaId"`
-	SchemaVersion string                  `json:"schemaVersion"`
-	Scope         string                  `json:"scope"`
-	Value         EnvironmentSettingValue `json:"value"`
+	ObjectId *string                 `json:"objectId"`
+	SchemaId string                  `json:"schemaId"`
+	Scope    string                  `json:"scope"`
+	Value    EnvironmentSettingValue `json:"value"`
 }
 
 type EnvironmentSettingValue struct {
@@ -110,8 +108,6 @@ func (c *client) CreateConnectionSetting(es EnvironmentSetting) error {
 }
 
 func (c *client) UpdateConnectionSetting(es EnvironmentSetting) error {
-	es.SchemaVersion = KubernetesConnectionVersion
-
 	jsonStr, err := json.Marshal(es)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/clients/edgeconnect/environment_settings_test.go
+++ b/pkg/clients/edgeconnect/environment_settings_test.go
@@ -14,10 +14,9 @@ import (
 var testObjectId = "test-objectId"
 
 var testEnvironmentSetting = EnvironmentSetting{
-	ObjectId:      &testObjectId,
-	SchemaId:      KubernetesConnectionSchemaID,
-	SchemaVersion: KubernetesConnectionVersion,
-	Scope:         KubernetesConnectionScope,
+	ObjectId: &testObjectId,
+	SchemaId: KubernetesConnectionSchemaID,
+	Scope:    KubernetesConnectionScope,
 	Value: EnvironmentSettingValue{
 		Name:      "test-name",
 		UID:       "test-uid",

--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -750,9 +750,8 @@ func (controller *Controller) createOrUpdateConnectionSetting(edgeConnectClient 
 
 		err = edgeConnectClient.CreateConnectionSetting(
 			edgeconnect.EnvironmentSetting{
-				SchemaId:      edgeconnect.KubernetesConnectionSchemaID,
-				SchemaVersion: edgeconnect.KubernetesConnectionVersion,
-				Scope:         edgeconnect.KubernetesConnectionScope,
+				SchemaId: edgeconnect.KubernetesConnectionSchemaID,
+				Scope:    edgeconnect.KubernetesConnectionScope,
 				Value: edgeconnect.EnvironmentSettingValue{
 					Name:      edgeConnect.Name,
 					UID:       edgeConnect.Status.KubeSystemUID,

--- a/pkg/controllers/edgeconnect/controller_test.go
+++ b/pkg/controllers/edgeconnect/controller_test.go
@@ -51,11 +51,10 @@ var (
 	testObjectId      = "my:default"
 
 	testEnvironmentSetting = edgeconnect.EnvironmentSetting{
-		ObjectId:      &testObjectId,
-		SchemaId:      edgeconnect.KubernetesConnectionSchemaID,
-		SchemaVersion: edgeconnect.KubernetesConnectionVersion,
-		Scope:         edgeconnect.KubernetesConnectionScope,
-		Value:         edgeconnect.EnvironmentSettingValue{},
+		ObjectId: &testObjectId,
+		SchemaId: edgeconnect.KubernetesConnectionSchemaID,
+		Scope:    edgeconnect.KubernetesConnectionScope,
+		Value:    edgeconnect.EnvironmentSettingValue{},
 	}
 )
 


### PR DESCRIPTION
## Description

Remove `schemaVersion` from EdgeConnect settings object. It's not necessary.

## How can this be tested?

- Deploy EdgeConnect with `provisioner: true` and `kubernetesAutomation.enabled: true`
- Settings object (located here https://dib18963.dev.apps.dynatracelabs.com/ui/apps/dynatrace.classic.settings/ui/settings/app:dynatrace.kubernetes.connector:connection?gf=all) should be created and deleted after CR deletion