### PR TITLE
Fix csv generation

### DIFF
--- a/pkg/api/v1beta2/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta2/dynakube/dynakube_types.go
@@ -68,7 +68,7 @@ type DynaKubeValueSource struct { //nolint:revive
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +operator-sdk:csv:customresourcedefinitions:displayName="Dynatrace DynaKube"
-// +operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,},{DaemonSet,v1,},{Pod,v1,}}.
+// +operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,},{DaemonSet,v1,},{Pod,v1,}}
 type DynaKube struct {
 	metav1.TypeMeta `json:",inline"`
 


### PR DESCRIPTION
## Description

Currently the release pipeline fails to generate a csv with following error:

`/tmp/build/58f3eac1/dynatrace-operator/pkg/api/v1beta2/dynakube/dynakube_types.go:71:1: expected comma, got "." (at <input>:1:56)
FATA[0000] Error generating kustomize files: error getting ClusterServiceVersion base: error generating ClusterServiceVersion definitions`

this is due to the comment ends with dot enforcement, which has already been fixed -> seems like a leftover on the release branch

## How can this be tested?

Not at all