### PR TITLE
Add EEC ServiceAccount, Role and RoleBinding to Helm chart

### DIFF
--- a/config/helm/chart/default/templates/Common/extensions-controller/role-extensions-controller.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-controller/role-extensions-controller.yaml
@@ -1,0 +1,41 @@
+{{- include "dynatrace-operator.platformRequired" . }}
+{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dynatrace-extensions-controller
+  labels:
+    {{- include "dynatrace-operator.extensionsControllerLabels" . | nindent 4 }}
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["privileged"]
+    verbs: ["use"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dynatrace-extensions-controller
+  labels:
+    {{- include "dynatrace-operator.extensionsControllerLabels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: dynatrace-extensions-controller
+roleRef:
+  kind: Role
+  name: dynatrace-extensions-controller
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/config/helm/chart/default/templates/Common/extensions-controller/serviceaccount-extensions-controller.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-controller/serviceaccount-extensions-controller.yaml
@@ -1,0 +1,24 @@
+{{- include "dynatrace-operator.platformRequired" . }}
+{{ if eq (include "dynatrace-operator.partial" .) "false" }}
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-extensions-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dynatrace-operator.extensionsControllerLabels" . | nindent 4 }}
+{{ end }}
+

--- a/config/helm/chart/default/templates/_labels.tpl
+++ b/config/helm/chart/default/templates/_labels.tpl
@@ -100,3 +100,11 @@ OneAgent labels
 {{ include "dynatrace-operator.commonLabels" . }}
 app.kubernetes.io/component: oneagent
 {{- end -}}
+
+{{/*
+Extensions Controller (EEC) labels
+*/}}
+{{- define "dynatrace-operator.extensionsControllerLabels" -}}
+{{ include "dynatrace-operator.commonLabels" . }}
+app.kubernetes.io/component: dynatrace-extensions-controller
+{{- end -}}

--- a/config/helm/chart/default/tests/Common/extensions-controller/role-extensions-controller_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-controller/role-extensions-controller_test.yaml
@@ -1,0 +1,51 @@
+suite: test role for the extensions controller
+templates:
+  - Common/extensions-controller/role-extensions-controller.yaml
+tests:
+  - it: should not exist by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Role should exist with for openshift
+    documentIndex: 0
+    set:
+      platform: openshift
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: dynatrace-extensions-controller
+      - isNotEmpty:
+          path: metadata.labels
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - security.openshift.io
+            resourceNames:
+              - privileged
+            resources:
+              - securitycontextconstraints
+            verbs:
+              - use
+  - it: RoleBinding should exist with for openshift
+    documentIndex: 1
+    set:
+      platform: openshift
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: dynatrace-extensions-controller
+      - isNotEmpty:
+          path: metadata.labels
+  - it: Role and RoleBinding are not rendered for csi
+    set:
+      platform: openshift
+      partial: csi
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/config/helm/chart/default/tests/Common/extensions-controller/serviceaccount-extensions-controller_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-controller/serviceaccount-extensions-controller_test.yaml
@@ -1,0 +1,18 @@
+suite: test service account for extensions controller
+templates:
+  - Common/extensions-controller/serviceaccount-extensions-controller.yaml
+tests:
+  - it: should exist
+    set:
+      platform: kubernetes
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: dynatrace-extensions-controller
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - isNotEmpty:
+          path: metadata.labels


### PR DESCRIPTION
## Description

[K8S-10119](https://dt-rnd.atlassian.net/browse/K8S-10119)

Add EEC `ServiceAccount` and Openshift's `Role` and `RoleBinding` to Helm chart.

## How can this be tested?

- `make test/helm`
- `make deploy/helm`, check that `ServiceAccount` exists. 
- `Role` and `RoleBinding` should only exist when deploying on Openshift.