### PR TITLE
Fix wrong hostname used for Kubernetes API in EdgeConnect configuration.

### DIFF
--- a/pkg/api/v1alpha1/edgeconnect/edgeconnect_types.go
+++ b/pkg/api/v1alpha1/edgeconnect/edgeconnect_types.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/edgeconnect"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -188,7 +187,7 @@ type EdgeConnectList struct { //nolint:revive
 }
 
 const (
-	kubernetesDefaultDNS     = "kubernetes.default.svc.cluster.local"
+	KubernetesDefaultDNS     = "kubernetes.default.svc.cluster.local"
 	kubernetesHostnameSuffix = "kubernetes-automation"
 )
 
@@ -214,9 +213,14 @@ func (e *EdgeConnect) HostPatterns() []string {
 	return hostPatterns
 }
 
-func (e *EdgeConnect) HostMappings() []edgeconnect.HostMapping {
-	hostMappings := make([]edgeconnect.HostMapping, 0)
-	hostMappings = append(hostMappings, edgeconnect.HostMapping{From: e.K8sAutomationHostPattern(), To: kubernetesDefaultDNS})
+type HostMapping struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+func (e *EdgeConnect) HostMappings() []HostMapping {
+	hostMappings := make([]HostMapping, 0)
+	hostMappings = append(hostMappings, HostMapping{From: e.K8sAutomationHostPattern(), To: KubernetesDefaultDNS})
 
 	return hostMappings
 }

--- a/pkg/api/v1alpha1/edgeconnect/edgeconnect_types_test.go
+++ b/pkg/api/v1alpha1/edgeconnect/edgeconnect_types_test.go
@@ -3,7 +3,6 @@ package edgeconnect
 import (
 	"testing"
 
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/edgeconnect"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,10 +19,10 @@ func TestHostMappings(t *testing.T) {
 			},
 		}
 		got := e.HostMappings()
-		expected := []edgeconnect.HostMapping{
+		expected := []HostMapping{
 			{
 				From: "test-edgeconnect.test-namespace.test-kube-system-uid." + kubernetesHostnameSuffix,
-				To:   kubernetesDefaultDNS,
+				To:   KubernetesDefaultDNS,
 			},
 		}
 		require.EqualValues(t, expected, got)

--- a/pkg/clients/edgeconnect/client.go
+++ b/pkg/clients/edgeconnect/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 
+	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/utils"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2/clientcredentials"
@@ -214,7 +215,7 @@ func (c *client) GetEdgeConnect(edgeConnectId string) (GetResponse, error) {
 }
 
 // UpdateEdgeConnect updates existing edge connect hostPatterns and oauthClientId
-func (c *client) UpdateEdgeConnect(edgeConnectId, name string, hostPatterns []string, hostMappings []HostMapping, oauthClientId string) error {
+func (c *client) UpdateEdgeConnect(edgeConnectId, name string, hostPatterns []string, hostMappings []edgeconnectv1alpha1.HostMapping, oauthClientId string) error {
 	edgeConnectUrl := c.getEdgeConnectUrl(edgeConnectId)
 
 	body := NewRequest(name, hostPatterns, hostMappings, oauthClientId)
@@ -284,7 +285,7 @@ func (c *client) DeleteEdgeConnect(edgeConnectId string) error {
 }
 
 // CreateEdgeConnect creates new edge connect
-func (c *client) CreateEdgeConnect(name string, hostPatterns []string, hostMappings []HostMapping, oauthClientId string) (CreateResponse, error) {
+func (c *client) CreateEdgeConnect(name string, hostPatterns []string, hostMappings []edgeconnectv1alpha1.HostMapping, oauthClientId string) (CreateResponse, error) {
 	edgeConnectsUrl := c.getEdgeConnectsUrl()
 
 	body := NewRequest(name, hostPatterns, hostMappings, oauthClientId)

--- a/pkg/clients/edgeconnect/client_test.go
+++ b/pkg/clients/edgeconnect/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -36,7 +37,7 @@ func TestCreateEdgeConnect(t *testing.T) {
 		edgeConnectServer, edgeConnectClient := createTestEdgeConnectServer(t, edgeConnectCreateServerHandler(false))
 		defer edgeConnectServer.Close()
 
-		resp, err := edgeConnectClient.CreateEdgeConnect("InternalServices", []string{"*.internal.org"}, []HostMapping{}, "dt0s02.AIOUP56P")
+		resp, err := edgeConnectClient.CreateEdgeConnect("InternalServices", []string{"*.internal.org"}, []edgeconnect.HostMapping{}, "dt0s02.AIOUP56P")
 		require.NoError(t, err)
 		assert.Equal(t, "InternalServices", resp.Name)
 	})
@@ -44,17 +45,17 @@ func TestCreateEdgeConnect(t *testing.T) {
 		edgeConnectServer, edgeConnectClient := createTestEdgeConnectServer(t, edgeConnectCreateServerHandler(true))
 		defer edgeConnectServer.Close()
 
-		_, err := edgeConnectClient.CreateEdgeConnect("", []string{"*.internal.org"}, []HostMapping{}, "dt0s02.AIOUP56P")
+		_, err := edgeConnectClient.CreateEdgeConnect("", []string{"*.internal.org"}, []edgeconnect.HostMapping{}, "dt0s02.AIOUP56P")
 		require.Error(t, err, "edgeconnect server error 400: Constraints violated.")
 	})
 	t.Run("create edge connect with hostMappings", func(t *testing.T) {
 		edgeConnectServer, edgeConnectClient := createTestEdgeConnectServer(t, edgeConnectCreateServerHandler(false))
 		defer edgeConnectServer.Close()
 
-		hostMappings := []HostMapping{
+		hostMappings := []edgeconnect.HostMapping{
 			{
 				From: "test-edgeconnect.test-namespace.test-kube-system-uid.kubernetes-automation",
-				To:   "kubernetes.default.svc.cluster.local",
+				To:   edgeconnect.KubernetesDefaultDNS,
 			},
 		}
 
@@ -105,7 +106,7 @@ func TestUpdateEdgeConnect(t *testing.T) {
 		edgeConnectServer, edgeConnectClient := createTestEdgeConnectServer(t, edgeConnectUpdateServerHandler())
 		defer edgeConnectServer.Close()
 
-		err := edgeConnectClient.UpdateEdgeConnect(EdgeConnectID, "test_name", []string{""}, []HostMapping{}, "")
+		err := edgeConnectClient.UpdateEdgeConnect(EdgeConnectID, "test_name", []string{""}, []edgeconnect.HostMapping{}, "")
 		require.NoError(t, err)
 	})
 
@@ -113,7 +114,7 @@ func TestUpdateEdgeConnect(t *testing.T) {
 		edgeConnectServer, edgeConnectClient := createTestEdgeConnectServer(t, edgeConnectUpdateServerHandler())
 		defer edgeConnectServer.Close()
 
-		err := edgeConnectClient.UpdateEdgeConnect("", "test_name", []string{""}, []HostMapping{}, "")
+		err := edgeConnectClient.UpdateEdgeConnect("", "test_name", []string{""}, []edgeconnect.HostMapping{}, "")
 		require.Error(t, err, http.StatusBadRequest)
 	})
 }

--- a/pkg/clients/edgeconnect/edgeconnect.go
+++ b/pkg/clients/edgeconnect/edgeconnect.go
@@ -1,6 +1,10 @@
 package edgeconnect
 
-import "time"
+import (
+	"time"
+
+	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+)
 
 type OauthClientStatus int
 
@@ -35,32 +39,27 @@ type ListResponse struct {
 }
 
 type CreateResponse struct {
-	ModificationInfo           ModificationInfo `json:"modificationInfo"`
-	Metadata                   Metadata         `json:"metadata"`
-	ID                         string           `json:"id,omitempty"`
-	Name                       string           `json:"name"`
-	OauthClientId              string           `json:"oauthClientId"`
-	OauthClientSecret          string           `json:"oauthClientSecret"`
-	OauthClientResource        string           `json:"oauthClientResource"`
-	HostPatterns               []string         `json:"hostPatterns"`
-	HostMappings               []HostMapping    `json:"hostMappings"`
-	ManagedByDynatraceOperator bool             `json:"managedByDynatraceOperator,omitempty"`
+	ModificationInfo           ModificationInfo                  `json:"modificationInfo"`
+	Metadata                   Metadata                          `json:"metadata"`
+	ID                         string                            `json:"id,omitempty"`
+	Name                       string                            `json:"name"`
+	OauthClientId              string                            `json:"oauthClientId"`
+	OauthClientSecret          string                            `json:"oauthClientSecret"`
+	OauthClientResource        string                            `json:"oauthClientResource"`
+	HostPatterns               []string                          `json:"hostPatterns"`
+	HostMappings               []edgeconnectv1alpha1.HostMapping `json:"hostMappings"`
+	ManagedByDynatraceOperator bool                              `json:"managedByDynatraceOperator,omitempty"`
 }
 
 type Request struct {
-	Name                       string        `json:"name"`
-	OauthClientId              string        `json:"oauthClientId,omitempty"`
-	HostPatterns               []string      `json:"hostPatterns"`
-	HostMappings               []HostMapping `json:"hostMappings"`
-	ManagedByDynatraceOperator bool          `json:"managedByDynatraceOperator,omitempty"`
+	Name                       string                            `json:"name"`
+	OauthClientId              string                            `json:"oauthClientId,omitempty"`
+	HostPatterns               []string                          `json:"hostPatterns"`
+	HostMappings               []edgeconnectv1alpha1.HostMapping `json:"hostMappings"`
+	ManagedByDynatraceOperator bool                              `json:"managedByDynatraceOperator,omitempty"`
 }
 
-type HostMapping struct {
-	From string `json:"from"`
-	To   string `json:"to"`
-}
-
-func NewRequest(name string, hostPatterns []string, hostMappings []HostMapping, oauthClientId string) *Request {
+func NewRequest(name string, hostPatterns []string, hostMappings []edgeconnectv1alpha1.HostMapping, oauthClientId string) *Request {
 	return &Request{
 		Name:                       name,
 		HostPatterns:               hostPatterns,

--- a/pkg/clients/edgeconnect/iface.go
+++ b/pkg/clients/edgeconnect/iface.go
@@ -1,15 +1,17 @@
 package edgeconnect
 
+import edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+
 // Client is the interface for the Dynatrace EdgeConnect REST API client.
 type Client interface {
 	// GetEdgeConnect return details of single edge connect
 	GetEdgeConnect(edgeConnectId string) (GetResponse, error)
 
 	// CreateEdgeConnect creates edge connect
-	CreateEdgeConnect(name string, hostPatterns []string, hostMappings []HostMapping, oauthClientId string) (CreateResponse, error)
+	CreateEdgeConnect(name string, hostPatterns []string, hostMappings []edgeconnectv1alpha1.HostMapping, oauthClientId string) (CreateResponse, error)
 
 	// UpdateEdgeConnect updates edge connect
-	UpdateEdgeConnect(edgeConnectId, name string, hostPatterns []string, hostMappings []HostMapping, oauthClientId string) error
+	UpdateEdgeConnect(edgeConnectId, name string, hostPatterns []string, hostMappings []edgeconnectv1alpha1.HostMapping, oauthClientId string) error
 
 	// DeleteEdgeConnect deletes edge connect
 	DeleteEdgeConnect(edgeConnectId string) error

--- a/pkg/controllers/edgeconnect/controller_test.go
+++ b/pkg/controllers/edgeconnect/controller_test.go
@@ -49,10 +49,10 @@ const (
 var (
 	testHostPatterns  = []string{"*.internal.org", testK8sAutomationHostPattern}
 	testHostPatterns2 = []string{"*.external.org", testK8sAutomationHostPattern}
-	testHostMappings  = []edgeconnect.HostMapping{
+	testHostMappings  = []edgeconnectv1alpha1.HostMapping{
 		{
 			From: testK8sAutomationHostPattern,
-			To:   "kubernetes.default.svc.cluster.local",
+			To:   edgeconnectv1alpha1.KubernetesDefaultDNS,
 		},
 	}
 	testObjectId = "my:default"

--- a/pkg/controllers/edgeconnect/secret/secret.go
+++ b/pkg/controllers/edgeconnect/secret/secret.go
@@ -93,6 +93,6 @@ func createKubernetesApiSecret(token string) config.Secret {
 		Name:            "K8S_SERVICE_ACCOUNT_TOKEN",
 		Token:           token,
 		FromFile:        "/var/run/secrets/kubernetes.io/serviceaccount/token",
-		RestrictHostsTo: []string{"kubernetes.default.svc"},
+		RestrictHostsTo: []string{edgeconnectv1alpha1.KubernetesDefaultDNS},
 	}
 }

--- a/pkg/controllers/edgeconnect/secret/secret_test.go
+++ b/pkg/controllers/edgeconnect/secret/secret_test.go
@@ -156,7 +156,7 @@ secrets:
       token: dummy-token
       from_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       restrict_hosts_to:
-        - kubernetes.default.svc
+        - kubernetes.default.svc.cluster.local
 `
 		assert.Equal(t, expected, string(cfg))
 	})

--- a/test/mocks/pkg/clients/edgeconnect/client.go
+++ b/test/mocks/pkg/clients/edgeconnect/client.go
@@ -3,7 +3,8 @@
 package mocks
 
 import (
-	edgeconnect "github.com/Dynatrace/dynatrace-operator/pkg/clients/edgeconnect"
+	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/edgeconnect"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -67,7 +68,7 @@ func (_c *Client_CreateConnectionSetting_Call) RunAndReturn(run func(edgeconnect
 }
 
 // CreateEdgeConnect provides a mock function with given fields: name, hostPatterns, hostMappings, oauthClientId
-func (_m *Client) CreateEdgeConnect(name string, hostPatterns []string, hostMappings []edgeconnect.HostMapping, oauthClientId string) (edgeconnect.CreateResponse, error) {
+func (_m *Client) CreateEdgeConnect(name string, hostPatterns []string, hostMappings []edgeconnectv1alpha1.HostMapping, oauthClientId string) (edgeconnect.CreateResponse, error) {
 	ret := _m.Called(name, hostPatterns, hostMappings, oauthClientId)
 
 	if len(ret) == 0 {
@@ -76,16 +77,16 @@ func (_m *Client) CreateEdgeConnect(name string, hostPatterns []string, hostMapp
 
 	var r0 edgeconnect.CreateResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, []string, []edgeconnect.HostMapping, string) (edgeconnect.CreateResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(string, []string, []edgeconnectv1alpha1.HostMapping, string) (edgeconnect.CreateResponse, error)); ok {
 		return rf(name, hostPatterns, hostMappings, oauthClientId)
 	}
-	if rf, ok := ret.Get(0).(func(string, []string, []edgeconnect.HostMapping, string) edgeconnect.CreateResponse); ok {
+	if rf, ok := ret.Get(0).(func(string, []string, []edgeconnectv1alpha1.HostMapping, string) edgeconnect.CreateResponse); ok {
 		r0 = rf(name, hostPatterns, hostMappings, oauthClientId)
 	} else {
 		r0 = ret.Get(0).(edgeconnect.CreateResponse)
 	}
 
-	if rf, ok := ret.Get(1).(func(string, []string, []edgeconnect.HostMapping, string) error); ok {
+	if rf, ok := ret.Get(1).(func(string, []string, []edgeconnectv1alpha1.HostMapping, string) error); ok {
 		r1 = rf(name, hostPatterns, hostMappings, oauthClientId)
 	} else {
 		r1 = ret.Error(1)
@@ -108,9 +109,9 @@ func (_e *Client_Expecter) CreateEdgeConnect(name interface{}, hostPatterns inte
 	return &Client_CreateEdgeConnect_Call{Call: _e.mock.On("CreateEdgeConnect", name, hostPatterns, hostMappings, oauthClientId)}
 }
 
-func (_c *Client_CreateEdgeConnect_Call) Run(run func(name string, hostPatterns []string, hostMappings []edgeconnect.HostMapping, oauthClientId string)) *Client_CreateEdgeConnect_Call {
+func (_c *Client_CreateEdgeConnect_Call) Run(run func(name string, hostPatterns []string, hostMappings []edgeconnectv1alpha1.HostMapping, oauthClientId string)) *Client_CreateEdgeConnect_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].([]string), args[2].([]edgeconnect.HostMapping), args[3].(string))
+		run(args[0].(string), args[1].([]string), args[2].([]edgeconnectv1alpha1.HostMapping), args[3].(string))
 	})
 	return _c
 }
@@ -120,7 +121,7 @@ func (_c *Client_CreateEdgeConnect_Call) Return(_a0 edgeconnect.CreateResponse, 
 	return _c
 }
 
-func (_c *Client_CreateEdgeConnect_Call) RunAndReturn(run func(string, []string, []edgeconnect.HostMapping, string) (edgeconnect.CreateResponse, error)) *Client_CreateEdgeConnect_Call {
+func (_c *Client_CreateEdgeConnect_Call) RunAndReturn(run func(string, []string, []edgeconnectv1alpha1.HostMapping, string) (edgeconnect.CreateResponse, error)) *Client_CreateEdgeConnect_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -432,7 +433,7 @@ func (_c *Client_UpdateConnectionSetting_Call) RunAndReturn(run func(edgeconnect
 }
 
 // UpdateEdgeConnect provides a mock function with given fields: edgeConnectId, name, hostPatterns, hostMappings, oauthClientId
-func (_m *Client) UpdateEdgeConnect(edgeConnectId string, name string, hostPatterns []string, hostMappings []edgeconnect.HostMapping, oauthClientId string) error {
+func (_m *Client) UpdateEdgeConnect(edgeConnectId string, name string, hostPatterns []string, hostMappings []edgeconnectv1alpha1.HostMapping, oauthClientId string) error {
 	ret := _m.Called(edgeConnectId, name, hostPatterns, hostMappings, oauthClientId)
 
 	if len(ret) == 0 {
@@ -440,7 +441,7 @@ func (_m *Client) UpdateEdgeConnect(edgeConnectId string, name string, hostPatte
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, []string, []edgeconnect.HostMapping, string) error); ok {
+	if rf, ok := ret.Get(0).(func(string, string, []string, []edgeconnectv1alpha1.HostMapping, string) error); ok {
 		r0 = rf(edgeConnectId, name, hostPatterns, hostMappings, oauthClientId)
 	} else {
 		r0 = ret.Error(0)
@@ -464,9 +465,9 @@ func (_e *Client_Expecter) UpdateEdgeConnect(edgeConnectId interface{}, name int
 	return &Client_UpdateEdgeConnect_Call{Call: _e.mock.On("UpdateEdgeConnect", edgeConnectId, name, hostPatterns, hostMappings, oauthClientId)}
 }
 
-func (_c *Client_UpdateEdgeConnect_Call) Run(run func(edgeConnectId string, name string, hostPatterns []string, hostMappings []edgeconnect.HostMapping, oauthClientId string)) *Client_UpdateEdgeConnect_Call {
+func (_c *Client_UpdateEdgeConnect_Call) Run(run func(edgeConnectId string, name string, hostPatterns []string, hostMappings []edgeconnectv1alpha1.HostMapping, oauthClientId string)) *Client_UpdateEdgeConnect_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].([]string), args[3].([]edgeconnect.HostMapping), args[4].(string))
+		run(args[0].(string), args[1].(string), args[2].([]string), args[3].([]edgeconnectv1alpha1.HostMapping), args[4].(string))
 	})
 	return _c
 }
@@ -476,7 +477,7 @@ func (_c *Client_UpdateEdgeConnect_Call) Return(_a0 error) *Client_UpdateEdgeCon
 	return _c
 }
 
-func (_c *Client_UpdateEdgeConnect_Call) RunAndReturn(run func(string, string, []string, []edgeconnect.HostMapping, string) error) *Client_UpdateEdgeConnect_Call {
+func (_c *Client_UpdateEdgeConnect_Call) RunAndReturn(run func(string, string, []string, []edgeconnectv1alpha1.HostMapping, string) error) *Client_UpdateEdgeConnect_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Description

The wrong (incomplete) hostname was used for host restrictions in the EdgeConnect config file. This has been fixed. Additonally, `HostMappings` was moved to keep dependencies cleaner.

## How can this be tested?

Deploy EdgeConnect wtih enabled `kuberneteAutomation` and check the EdgeConnec configuration.