### PR TITLE
Check `name` and `namespace` when filtering EdgeConnect connection settings object

### DIFF
--- a/pkg/clients/edgeconnect/environment_settings.go
+++ b/pkg/clients/edgeconnect/environment_settings.go
@@ -35,7 +35,7 @@ type EnvironmentSettingsResponse struct {
 	PageSize   int                  `json:"pageSize"`
 }
 
-func (c *client) GetConnectionSetting(uid string) (EnvironmentSetting, error) {
+func (c *client) GetConnectionSetting(name, namespace, uid string) (EnvironmentSetting, error) {
 	settingsObjectsUrl := c.getSettingsObjectsUrl()
 
 	req, err := http.NewRequestWithContext(c.ctx, http.MethodGet, settingsObjectsUrl, nil)
@@ -69,7 +69,7 @@ func (c *client) GetConnectionSetting(uid string) (EnvironmentSetting, error) {
 	}
 
 	for _, item := range resDataJson.Items {
-		if item.Value.UID == uid {
+		if item.Value.Name == name && item.Value.Namespace == namespace && item.Value.UID == uid {
 			return item, nil
 		}
 	}

--- a/pkg/clients/edgeconnect/environment_settings_test.go
+++ b/pkg/clients/edgeconnect/environment_settings_test.go
@@ -28,13 +28,13 @@ var testEnvironmentSetting = EnvironmentSetting{
 func TestGetConnectionSetting(t *testing.T) {
 	t.Run("Server response OK", func(t *testing.T) {
 		client := MockEdgeConnectClient(http.StatusOK)
-		es, err := client.GetConnectionSetting("test-uid")
+		es, err := client.GetConnectionSetting("test-name", "test-namespace", "test-uid")
 		require.NoError(t, err)
 		require.NotNil(t, es)
 	})
 	t.Run("Server response NOK", func(t *testing.T) {
 		client := MockEdgeConnectClient(http.StatusBadRequest)
-		es, err := client.GetConnectionSetting("test-uid")
+		es, err := client.GetConnectionSetting("test-name", "test-namespace", "test-uid")
 		require.Error(t, err)
 		require.Equal(t, EnvironmentSetting{}, es)
 	})

--- a/pkg/clients/edgeconnect/iface.go
+++ b/pkg/clients/edgeconnect/iface.go
@@ -17,8 +17,8 @@ type Client interface {
 	// GetEdgeConnects returns list of edge connects
 	GetEdgeConnects(name string) (ListResponse, error)
 
-	// GetConnectionSetting returns a connection setting object by value uid
-	GetConnectionSetting(uid string) (EnvironmentSetting, error)
+	// GetConnectionSetting returns a connection setting object by value name, namespace and kube-system namespace UID
+	GetConnectionSetting(name, namespace, uid string) (EnvironmentSetting, error)
 
 	// CreateConnectionSetting creates a connection setting object
 	CreateConnectionSetting(es EnvironmentSetting) error

--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -167,7 +167,7 @@ func (controller *Controller) reconcileEdgeConnectDeletion(ctx context.Context, 
 	}
 
 	if edgeConnect.IsK8SAutomationEnabled() && edgeConnect.IsProvisionerModeEnabled() {
-		err = controller.deleteConnectionSetting(edgeConnectClient, edgeConnect.Status.KubeSystemUID)
+		err = controller.deleteConnectionSetting(edgeConnectClient, edgeConnect)
 		if err != nil {
 			_log.Info("reconcile deletion: Deleting connection setting failed")
 
@@ -178,8 +178,8 @@ func (controller *Controller) reconcileEdgeConnectDeletion(ctx context.Context, 
 	return edgeConnectClient.DeleteEdgeConnect(tenantEdgeConnect.ID)
 }
 
-func (controller *Controller) deleteConnectionSetting(edgeConnectClient edgeconnect.Client, kubeSystemUID string) error {
-	envSetting, err := edgeConnectClient.GetConnectionSetting(kubeSystemUID)
+func (controller *Controller) deleteConnectionSetting(edgeConnectClient edgeconnect.Client, edgeConnect *edgeconnectv1alpha1.EdgeConnect) error {
+	envSetting, err := edgeConnectClient.GetConnectionSetting(edgeConnect.Name, edgeConnect.Namespace, edgeConnect.Status.KubeSystemUID)
 	if err != nil {
 		return err
 	}
@@ -731,7 +731,7 @@ func (controller *Controller) createOrUpdateEdgeConnectDeploymentAndSettings(ctx
 func (controller *Controller) createOrUpdateConnectionSetting(edgeConnectClient edgeconnect.Client, edgeConnect *edgeconnectv1alpha1.EdgeConnect, latestToken string) error {
 	_log := log.WithValues("namespace", edgeConnect.Namespace, "name", edgeConnect.Name)
 
-	envSetting, err := edgeConnectClient.GetConnectionSetting(edgeConnect.Status.KubeSystemUID)
+	envSetting, err := edgeConnectClient.GetConnectionSetting(edgeConnect.Name, edgeConnect.Namespace, edgeConnect.Status.KubeSystemUID)
 	if err != nil {
 		_log.Info("Failed getting EdgeConnect connection setting object")
 

--- a/pkg/controllers/edgeconnect/controller_test.go
+++ b/pkg/controllers/edgeconnect/controller_test.go
@@ -222,7 +222,7 @@ func TestReconcileProvisionerCreate(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSetting", mock.Anything).Return(testEnvironmentSetting, nil)
+		edgeConnectClient.On("GetConnectionSetting", mock.Anything, mock.Anything, mock.Anything).Return(testEnvironmentSetting, nil)
 		edgeConnectClient.On("UpdateConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -283,7 +283,7 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSetting", mock.Anything).Return(testEnvironmentSetting, nil)
+		edgeConnectClient.On("GetConnectionSetting", mock.Anything, mock.Anything, mock.Anything).Return(testEnvironmentSetting, nil)
 		edgeConnectClient.On("UpdateConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -343,7 +343,7 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSetting", mock.Anything).Return(testEnvironmentSetting, nil)
+		edgeConnectClient.On("GetConnectionSetting", mock.Anything, mock.Anything, mock.Anything).Return(testEnvironmentSetting, nil)
 		edgeConnectClient.On("UpdateConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -406,7 +406,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSetting", mock.Anything).Return(testEnvironmentSetting, nil)
+		edgeConnectClient.On("GetConnectionSetting", mock.Anything, mock.Anything, mock.Anything).Return(testEnvironmentSetting, nil)
 		edgeConnectClient.On("DeleteConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -436,7 +436,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSetting", mock.Anything).Return(testEnvironmentSetting, nil)
+		edgeConnectClient.On("GetConnectionSetting", mock.Anything, mock.Anything, mock.Anything).Return(testEnvironmentSetting, nil)
 		edgeConnectClient.On("DeleteConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -526,7 +526,7 @@ func TestReconcileProvisionerWithK8sAutomationsCreate(t *testing.T) {
 		}
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSetting", mock.Anything).Return(testEnvironmentSetting, nil)
+		edgeConnectClient.On("GetConnectionSetting", mock.Anything, mock.Anything, mock.Anything).Return(testEnvironmentSetting, nil)
 		edgeConnectClient.On("UpdateConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -854,7 +854,7 @@ func mockNewEdgeConnectClientUpdate(edgeConnectClient *edgeconnectmock.Client, f
 		// CreateEdgeConnect creates edge connect
 		edgeConnectClient.On("UpdateEdgeConnect", testCreatedId, testName, toHostPatterns, testHostMappings, testCreatedOauthClientId).Return(nil)
 
-		edgeConnectClient.On("GetConnectionSetting", mock.Anything).Return(testEnvironmentSetting, nil)
+		edgeConnectClient.On("GetConnectionSetting", mock.Anything, mock.Anything, mock.Anything).Return(testEnvironmentSetting, nil)
 		edgeConnectClient.On("UpdateConnectionSetting", mock.Anything).Return(nil)
 
 		return edgeConnectClient, nil
@@ -914,7 +914,7 @@ func TestController_createOrUpdateConnectionSetting(t *testing.T) {
 			edgeConnectClientBuilder: newEdgeConnectClient(),
 		}
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSetting", mock.Anything).Return(edgeconnect.EnvironmentSetting{}, nil)
+		edgeConnectClient.On("GetConnectionSetting", mock.Anything, mock.Anything, mock.Anything).Return(edgeconnect.EnvironmentSetting{}, nil)
 		edgeConnectClient.On("CreateConnectionSetting", mock.Anything).Return(nil)
 		err := controller.createOrUpdateConnectionSetting(edgeConnectClient, createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns), "")
 		require.NoError(t, err)
@@ -929,7 +929,7 @@ func TestController_createOrUpdateConnectionSetting(t *testing.T) {
 			edgeConnectClientBuilder: newEdgeConnectClient(),
 		}
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSetting", mock.Anything).Return(testEnvironmentSetting, nil)
+		edgeConnectClient.On("GetConnectionSetting", mock.Anything, mock.Anything, mock.Anything).Return(testEnvironmentSetting, nil)
 		err := controller.createOrUpdateConnectionSetting(edgeConnectClient, createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns), "")
 		require.NoError(t, err)
 	})

--- a/test/mocks/pkg/clients/edgeconnect/client.go
+++ b/test/mocks/pkg/clients/edgeconnect/client.go
@@ -217,9 +217,9 @@ func (_c *Client_DeleteEdgeConnect_Call) RunAndReturn(run func(string) error) *C
 	return _c
 }
 
-// GetConnectionSetting provides a mock function with given fields: uid
-func (_m *Client) GetConnectionSetting(uid string) (edgeconnect.EnvironmentSetting, error) {
-	ret := _m.Called(uid)
+// GetConnectionSetting provides a mock function with given fields: name, namespace, uid
+func (_m *Client) GetConnectionSetting(name string, namespace string, uid string) (edgeconnect.EnvironmentSetting, error) {
+	ret := _m.Called(name, namespace, uid)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetConnectionSetting")
@@ -227,17 +227,17 @@ func (_m *Client) GetConnectionSetting(uid string) (edgeconnect.EnvironmentSetti
 
 	var r0 edgeconnect.EnvironmentSetting
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (edgeconnect.EnvironmentSetting, error)); ok {
-		return rf(uid)
+	if rf, ok := ret.Get(0).(func(string, string, string) (edgeconnect.EnvironmentSetting, error)); ok {
+		return rf(name, namespace, uid)
 	}
-	if rf, ok := ret.Get(0).(func(string) edgeconnect.EnvironmentSetting); ok {
-		r0 = rf(uid)
+	if rf, ok := ret.Get(0).(func(string, string, string) edgeconnect.EnvironmentSetting); ok {
+		r0 = rf(name, namespace, uid)
 	} else {
 		r0 = ret.Get(0).(edgeconnect.EnvironmentSetting)
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(uid)
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(name, namespace, uid)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -251,14 +251,16 @@ type Client_GetConnectionSetting_Call struct {
 }
 
 // GetConnectionSetting is a helper method to define mock.On call
+//   - name string
+//   - namespace string
 //   - uid string
-func (_e *Client_Expecter) GetConnectionSetting(uid interface{}) *Client_GetConnectionSetting_Call {
-	return &Client_GetConnectionSetting_Call{Call: _e.mock.On("GetConnectionSetting", uid)}
+func (_e *Client_Expecter) GetConnectionSetting(name interface{}, namespace interface{}, uid interface{}) *Client_GetConnectionSetting_Call {
+	return &Client_GetConnectionSetting_Call{Call: _e.mock.On("GetConnectionSetting", name, namespace, uid)}
 }
 
-func (_c *Client_GetConnectionSetting_Call) Run(run func(uid string)) *Client_GetConnectionSetting_Call {
+func (_c *Client_GetConnectionSetting_Call) Run(run func(name string, namespace string, uid string)) *Client_GetConnectionSetting_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(string), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -268,7 +270,7 @@ func (_c *Client_GetConnectionSetting_Call) Return(_a0 edgeconnect.EnvironmentSe
 	return _c
 }
 
-func (_c *Client_GetConnectionSetting_Call) RunAndReturn(run func(string) (edgeconnect.EnvironmentSetting, error)) *Client_GetConnectionSetting_Call {
+func (_c *Client_GetConnectionSetting_Call) RunAndReturn(run func(string, string, string) (edgeconnect.EnvironmentSetting, error)) *Client_GetConnectionSetting_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Description

[K8S-10407](https://dt-rnd.atlassian.net/browse/K8S-10407)

Add name and namespace when getting the EdgeConnect settings object

## How can this be tested?

Deploy EdgeConnect on provisioner: true and kubernetesAutomation.enabled: true. Check that object gets created/updated/deleted