### PR TITLE
Add all pull secrets to all components

### DIFF
--- a/pkg/api/v1beta2/dynakube/properties.go
+++ b/pkg/api/v1beta2/dynakube/properties.go
@@ -211,14 +211,16 @@ func (dk *DynaKube) PullSecretName() string {
 	return dk.Name + PullSecretSuffix
 }
 
-// PullSecretWithoutData returns a secret which can be used to query the actual secrets data from the cluster.
-func (dk *DynaKube) PullSecretWithoutData() corev1.Secret {
-	return corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      dk.PullSecretName(),
-			Namespace: dk.Namespace,
-		},
+// PullSecretsNames returns the names of the pull secrets to be used for immutable images.
+func (dk *DynaKube) PullSecretsNames() []string {
+	names := []string{
+		dk.Name + PullSecretSuffix,
 	}
+	if dk.Spec.CustomPullSecret != "" {
+		names = append(names, dk.Spec.CustomPullSecret)
+	}
+
+	return names
 }
 
 func (dk *DynaKube) NeedsReadOnlyOneAgents() bool {

--- a/pkg/api/v1beta2/dynakube/properties.go
+++ b/pkg/api/v1beta2/dynakube/properties.go
@@ -223,6 +223,17 @@ func (dk *DynaKube) PullSecretsNames() []string {
 	return names
 }
 
+func (dk *DynaKube) ImagePullSecretReferences() []corev1.LocalObjectReference {
+	imagePullSecrets := make([]corev1.LocalObjectReference, 0)
+	for _, pullSecretName := range dk.PullSecretsNames() {
+		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{
+			Name: pullSecretName,
+		})
+	}
+
+	return imagePullSecrets
+}
+
 func (dk *DynaKube) NeedsReadOnlyOneAgents() bool {
 	return dk.HostMonitoringMode() || dk.CloudNativeFullstackMode()
 }

--- a/pkg/api/v1beta2/dynakube/properties.go
+++ b/pkg/api/v1beta2/dynakube/properties.go
@@ -211,8 +211,8 @@ func (dk *DynaKube) PullSecretName() string {
 	return dk.Name + PullSecretSuffix
 }
 
-// PullSecretsNames returns the names of the pull secrets to be used for immutable images.
-func (dk *DynaKube) PullSecretsNames() []string {
+// PullSecretNames returns the names of the pull secrets to be used for immutable images.
+func (dk *DynaKube) PullSecretNames() []string {
 	names := []string{
 		dk.Name + PullSecretSuffix,
 	}
@@ -225,7 +225,7 @@ func (dk *DynaKube) PullSecretsNames() []string {
 
 func (dk *DynaKube) ImagePullSecretReferences() []corev1.LocalObjectReference {
 	imagePullSecrets := make([]corev1.LocalObjectReference, 0)
-	for _, pullSecretName := range dk.PullSecretsNames() {
+	for _, pullSecretName := range dk.PullSecretNames() {
 		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{
 			Name: pullSecretName,
 		})

--- a/pkg/api/v1beta3/dynakube/properties.go
+++ b/pkg/api/v1beta3/dynakube/properties.go
@@ -212,7 +212,7 @@ func (dk *DynaKube) PullSecretName() string {
 }
 
 // PullSecretsNames returns the names of the pull secrets to be used for immutable images.
-func (dk *DynaKube) PullSecretsNames() []string {
+func (dk *DynaKube) PullSecretNames() []string {
 	names := []string{
 		dk.Name + PullSecretSuffix,
 	}
@@ -225,7 +225,7 @@ func (dk *DynaKube) PullSecretsNames() []string {
 
 func (dk *DynaKube) ImagePullSecretReferences() []corev1.LocalObjectReference {
 	imagePullSecrets := make([]corev1.LocalObjectReference, 0)
-	for _, pullSecretName := range dk.PullSecretsNames() {
+	for _, pullSecretName := range dk.PullSecretNames() {
 		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{
 			Name: pullSecretName,
 		})

--- a/pkg/api/v1beta3/dynakube/properties.go
+++ b/pkg/api/v1beta3/dynakube/properties.go
@@ -211,14 +211,27 @@ func (dk *DynaKube) PullSecretName() string {
 	return dk.Name + PullSecretSuffix
 }
 
-// PullSecretWithoutData returns a secret which can be used to query the actual secrets data from the cluster.
-func (dk *DynaKube) PullSecretWithoutData() corev1.Secret {
-	return corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      dk.PullSecretName(),
-			Namespace: dk.Namespace,
-		},
+// PullSecretsNames returns the names of the pull secrets to be used for immutable images.
+func (dk *DynaKube) PullSecretsNames() []string {
+	names := []string{
+		dk.Name + PullSecretSuffix,
 	}
+	if dk.Spec.CustomPullSecret != "" {
+		names = append(names, dk.Spec.CustomPullSecret)
+	}
+
+	return names
+}
+
+func (dk *DynaKube) ImagePullSecretReferences() []corev1.LocalObjectReference {
+	imagePullSecrets := make([]corev1.LocalObjectReference, 0)
+	for _, pullSecretName := range dk.PullSecretsNames() {
+		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{
+			Name: pullSecretName,
+		})
+	}
+
+	return imagePullSecrets
 }
 
 func (dk *DynaKube) NeedsReadOnlyOneAgents() bool {

--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -32,7 +32,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/url"
-	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtotel"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -61,7 +60,6 @@ type OneAgentProvisioner struct {
 	dynatraceClientBuilder dynatraceclient.Builder
 	urlInstallerBuilder    urlInstallerBuilder
 	imageInstallerBuilder  imageInstallerBuilder
-	registryClientBuilder  registry.ClientBuilder
 	opts                   dtcsi.CSIOptions
 	path                   metadata.PathResolver
 }
@@ -80,7 +78,6 @@ func NewOneAgentProvisioner(mgr manager.Manager, opts dtcsi.CSIOptions, db metad
 		dynatraceClientBuilder: dynatraceclient.NewBuilder(mgr.GetAPIReader()),
 		urlInstallerBuilder:    url.NewUrlInstaller,
 		imageInstallerBuilder:  image.NewImageInstaller,
-		registryClientBuilder:  registry.NewClient,
 	}
 }
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -118,6 +118,13 @@ func (statefulSetBuilder Builder) addUserAnnotations(sts *appsv1.StatefulSet) {
 }
 
 func (statefulSetBuilder Builder) addTemplateSpec(sts *appsv1.StatefulSet) {
+	imagePullSecrets := make([]corev1.LocalObjectReference, 0)
+	for _, pullSecretName := range statefulSetBuilder.dynakube.PullSecretsNames() {
+		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{
+			Name: pullSecretName,
+		})
+	}
+
 	podSpec := corev1.PodSpec{
 		Containers:         statefulSetBuilder.buildBaseContainer(),
 		NodeSelector:       statefulSetBuilder.capability.Properties().NodeSelector,
@@ -129,9 +136,7 @@ func (statefulSetBuilder Builder) addTemplateSpec(sts *appsv1.StatefulSet) {
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
 		},
-		ImagePullSecrets: []corev1.LocalObjectReference{
-			{Name: statefulSetBuilder.dynakube.PullSecretName()},
-		},
+		ImagePullSecrets:  imagePullSecrets,
 		PriorityClassName: statefulSetBuilder.dynakube.Spec.ActiveGate.PriorityClassName,
 		DNSPolicy:         statefulSetBuilder.dynakube.Spec.ActiveGate.DNSPolicy,
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -3,7 +3,7 @@ package statefulset
 import (
 	"strconv"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
@@ -31,14 +31,14 @@ type Builder struct {
 	envMap     *prioritymap.Map
 	kubeUID    types.UID
 	configHash string
-	dynakube   dynatracev1beta2.DynaKube
+	dynakube   dynakube.DynaKube
 }
 
-func NewStatefulSetBuilder(kubeUID types.UID, configHash string, dynakube dynatracev1beta2.DynaKube, capability capability.Capability) Builder {
+func NewStatefulSetBuilder(kubeUID types.UID, configHash string, dk dynakube.DynaKube, capability capability.Capability) Builder {
 	return Builder{
 		kubeUID:    kubeUID,
 		configHash: configHash,
-		dynakube:   dynakube,
+		dynakube:   dk,
 		capability: capability,
 		envMap:     prioritymap.New(prioritymap.WithPriority(defaultEnvPriority)),
 	}
@@ -118,13 +118,6 @@ func (statefulSetBuilder Builder) addUserAnnotations(sts *appsv1.StatefulSet) {
 }
 
 func (statefulSetBuilder Builder) addTemplateSpec(sts *appsv1.StatefulSet) {
-	imagePullSecrets := make([]corev1.LocalObjectReference, 0)
-	for _, pullSecretName := range statefulSetBuilder.dynakube.PullSecretsNames() {
-		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{
-			Name: pullSecretName,
-		})
-	}
-
 	podSpec := corev1.PodSpec{
 		Containers:         statefulSetBuilder.buildBaseContainer(),
 		NodeSelector:       statefulSetBuilder.capability.Properties().NodeSelector,
@@ -136,7 +129,7 @@ func (statefulSetBuilder Builder) addTemplateSpec(sts *appsv1.StatefulSet) {
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
 		},
-		ImagePullSecrets:  imagePullSecrets,
+		ImagePullSecrets:  statefulSetBuilder.dynakube.ImagePullSecretReferences(),
 		PriorityClassName: statefulSetBuilder.dynakube.Spec.ActiveGate.PriorityClassName,
 		DNSPolicy:         statefulSetBuilder.dynakube.Spec.ActiveGate.DNSPolicy,
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
@@ -189,7 +189,8 @@ func TestAddTemplateSpec(t *testing.T) {
 
 		assert.NotEmpty(t, spec.Containers)
 		assert.NotEmpty(t, spec.Affinity)
-		assert.Equal(t, dynakube.PullSecretName(), spec.ImagePullSecrets[0].Name)
+		assert.Equal(t, len(dynakube.PullSecretsNames()), len(spec.ImagePullSecrets))
+		assert.Equal(t, dynakube.PullSecretsNames()[0], spec.ImagePullSecrets[0].Name)
 	})
 
 	t.Run("adds capability specific stuff", func(t *testing.T) {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
@@ -189,8 +189,8 @@ func TestAddTemplateSpec(t *testing.T) {
 
 		assert.NotEmpty(t, spec.Containers)
 		assert.NotEmpty(t, spec.Affinity)
-		assert.Equal(t, len(dynakube.PullSecretsNames()), len(spec.ImagePullSecrets))
-		assert.Equal(t, dynakube.PullSecretsNames()[0], spec.ImagePullSecrets[0].Name)
+		assert.Equal(t, len(dynakube.PullSecretNames()), len(spec.ImagePullSecrets))
+		assert.Equal(t, dynakube.PullSecretNames()[0], spec.ImagePullSecrets[0].Name)
 	})
 
 	t.Run("adds capability specific stuff", func(t *testing.T) {

--- a/pkg/controllers/dynakube/controller.go
+++ b/pkg/controllers/dynakube/controller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/mapper"
-	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
@@ -69,7 +68,6 @@ func NewDynaKubeController(kubeClient client.Client, apiReader client.Reader, co
 		clusterID:              clusterID,
 		dynatraceClientBuilder: dynatraceclient.NewBuilder(apiReader),
 		istioClientBuilder:     istio.NewClient,
-		registryClientBuilder:  registry.NewClient,
 
 		deploymentMetadataReconcilerBuilder: deploymentmetadata.NewReconciler,
 		activeGateReconcilerBuilder:         activegate.NewReconciler,
@@ -102,7 +100,6 @@ type Controller struct {
 	dynatraceClientBuilder dynatraceclient.Builder
 	config                 *rest.Config
 	istioClientBuilder     istio.ClientBuilder
-	registryClientBuilder  registry.ClientBuilder
 
 	deploymentMetadataReconcilerBuilder deploymentmetadata.ReconcilerBuilder
 	activeGateReconcilerBuilder         activegate.ReconcilerBuilder

--- a/pkg/controllers/dynakube/controller_system_test.go
+++ b/pkg/controllers/dynakube/controller_system_test.go
@@ -408,7 +408,6 @@ func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, ins
 	controller := &Controller{
 		client:                              fakeClient,
 		apiReader:                           fakeClient,
-		registryClientBuilder:               createFakeRegistryClientBuilder(t),
 		dynatraceClientBuilder:              mockDtcBuilder,
 		fs:                                  afero.Afero{Fs: afero.NewMemMapFs()},
 		deploymentMetadataReconcilerBuilder: deploymentmetadata.NewReconciler,

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -39,10 +39,6 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dynakube *dynatra
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	if r.dynakube.Spec.CustomPullSecret != "" {
-		return nil
-	}
-
 	if !(r.dynakube.NeedsOneAgent() || r.dynakube.NeedsActiveGate()) {
 		if meta.FindStatusCondition(*r.dynakube.Conditions(), PullSecretConditionType) == nil {
 			return nil // no condition == nothing is there to clean up

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -16,9 +16,10 @@ const (
 	testKey   = "test-key"
 	testValue = "test-value"
 
-	testClusterID = "test-cluster-id"
-	testURL       = "https://testing.dev.dynatracelabs.com/api"
-	testName      = "test-name"
+	testClusterID    = "test-cluster-id"
+	testURL          = "https://testing.dev.dynatracelabs.com/api"
+	testDynakubeName = "test-dynakube-name"
+	testName         = "test-name"
 
 	testNewHostGroupName     = "newhostgroup"
 	testOldHostGroupArgument = "--set-host-group=oldhostgroup"

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -307,14 +307,7 @@ func (b *builder) imagePullSecrets() []corev1.LocalObjectReference {
 		return []corev1.LocalObjectReference{}
 	}
 
-	imagePullSecrets := make([]corev1.LocalObjectReference, 0)
-	for _, pullSecretName := range b.dk.PullSecretsNames() {
-		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{
-			Name: pullSecretName,
-		})
-	}
-
-	return imagePullSecrets
+	return b.dk.ImagePullSecretReferences()
 }
 
 func (b *builder) securityContext() *corev1.SecurityContext {

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -307,7 +307,14 @@ func (b *builder) imagePullSecrets() []corev1.LocalObjectReference {
 		return []corev1.LocalObjectReference{}
 	}
 
-	return []corev1.LocalObjectReference{{Name: b.dk.PullSecretName()}}
+	imagePullSecrets := make([]corev1.LocalObjectReference, 0)
+	for _, pullSecretName := range b.dk.PullSecretsNames() {
+		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{
+			Name: pullSecretName,
+		})
+	}
+
+	return imagePullSecrets
 }
 
 func (b *builder) securityContext() *corev1.SecurityContext {

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -130,6 +130,9 @@ func TestLabels(t *testing.T) {
 
 func TestCustomPullSecret(t *testing.T) {
 	instance := dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testDynakubeName,
+		},
 		Spec: dynakube.DynaKubeSpec{
 			APIURL: testURL,
 			OneAgent: dynakube.OneAgentSpec{
@@ -144,8 +147,9 @@ func TestCustomPullSecret(t *testing.T) {
 
 	podSpecs := ds.Spec.Template.Spec
 	assert.NotNil(t, podSpecs)
-	assert.NotEmpty(t, podSpecs.ImagePullSecrets)
-	assert.Equal(t, testName, podSpecs.ImagePullSecrets[0].Name)
+	assert.Len(t, podSpecs.ImagePullSecrets, 2)
+	assert.Equal(t, testDynakubeName+dynakube.PullSecretSuffix, podSpecs.ImagePullSecrets[0].Name)
+	assert.Equal(t, testName, podSpecs.ImagePullSecrets[1].Name)
 }
 
 func TestResources(t *testing.T) {

--- a/pkg/injection/codemodule/installer/image/installer.go
+++ b/pkg/injection/codemodule/installer/image/installer.go
@@ -30,7 +30,6 @@ type Properties struct {
 }
 
 func NewImageInstaller(ctx context.Context, fs afero.Fs, props *Properties) (installer.Installer, error) {
-	pullSecret := props.Dynakube.PullSecretWithoutData()
 	defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	transport, err := registry.PrepareTransportForDynaKube(ctx, props.ApiReader, defaultTransport, props.Dynakube)
@@ -38,7 +37,7 @@ func NewImageInstaller(ctx context.Context, fs afero.Fs, props *Properties) (ins
 		return nil, err
 	}
 
-	keychain, err := dockerkeychain.NewDockerKeychain(ctx, props.ApiReader, pullSecret)
+	keychain, err := dockerkeychain.NewDockerKeychains(ctx, props.ApiReader, props.Dynakube.Namespace, props.Dynakube.PullSecretsNames())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/injection/codemodule/installer/image/installer.go
+++ b/pkg/injection/codemodule/installer/image/installer.go
@@ -37,7 +37,7 @@ func NewImageInstaller(ctx context.Context, fs afero.Fs, props *Properties) (ins
 		return nil, err
 	}
 
-	keychain, err := dockerkeychain.NewDockerKeychains(ctx, props.ApiReader, props.Dynakube.Namespace, props.Dynakube.PullSecretsNames())
+	keychain, err := dockerkeychain.NewDockerKeychains(ctx, props.ApiReader, props.Dynakube.Namespace, props.Dynakube.PullSecretNames())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/injection/codemodule/installer/image/installer_test.go
+++ b/pkg/injection/codemodule/installer/image/installer_test.go
@@ -69,7 +69,12 @@ func TestNewImageInstaller(t *testing.T) {
 		},
 		Spec: dynatracev1beta2.DynaKubeSpec{},
 	}
-	pullSecret := dynakube.PullSecretWithoutData()
+	pullSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dynakube.PullSecretName(),
+			Namespace: dynakube.Namespace,
+		},
+	}
 	pullSecret.Data = map[string][]byte{
 		corev1.DockerConfigJsonKey: []byte(emptyDockerConfig),
 	}

--- a/pkg/oci/dockerkeychain/docker_keychain.go
+++ b/pkg/oci/dockerkeychain/docker_keychain.go
@@ -41,9 +41,9 @@ func (keychain *DockerKeychain) loadDockerConfigFromSecrets(ctx context.Context,
 		pullSecret := corev1.Secret{}
 
 		if err := apiReader.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: pullSecretName}, &pullSecret); err != nil {
-			log.Info("failed to load registry pull secret", "name", pullSecretName, "namespace", namespaceName)
+			log.Info("registry pull secret not loaded", "name", pullSecretName, "namespace", namespaceName)
 
-			return errors.WithStack(err)
+			continue
 		}
 
 		dockerAuths, err := extractDockerAuthsFromSecret(&pullSecret)
@@ -59,9 +59,12 @@ func (keychain *DockerKeychain) loadDockerConfigFromSecrets(ctx context.Context,
 		}
 	}
 
-	keychain.dockerConfig = &configFile
-
-	log.Debug("loaded docker configs", "registries", maps.Keys(configFile.AuthConfigs))
+	if len(configFile.AuthConfigs) > 0 {
+		keychain.dockerConfig = &configFile
+		log.Debug("loaded docker configs", "registries", maps.Keys(configFile.AuthConfigs))
+	} else {
+		log.Debug("no docker configs found")
+	}
 
 	return nil
 }

--- a/pkg/oci/dockerkeychain/docker_keychain_test.go
+++ b/pkg/oci/dockerkeychain/docker_keychain_test.go
@@ -15,11 +15,25 @@ import (
 )
 
 const (
-	registryName = "docker.test.com"
-	testToken    = "test-token"
-	testPassword = "test-password"
-	testAuth     = "dGVzdC10b2tlbjp0ZXN0LXBhc3N3b3Jk" // echo -n "test-token:test-password" | base64
-	dockerConfig = "{\"auths\":{\"" + registryName + "\":{\"username\":\"" + testToken + "\",\"password\":\"" + testPassword + "\",\"auth\":\"" + testAuth + "\"}}}"
+	registryName         = "docker.test.com"
+	registryTestToken    = "test-token"
+	registryTestPassword = "test-password"
+	registryTestAuth     = "dGVzdC10b2tlbjp0ZXN0LXBhc3N3b3Jk" // echo -n "test-token:test-password" | base64
+	registryDockerConfig = "{\"auths\":{\"" + registryName + "\":{\"username\":\"" + registryTestToken + "\",\"password\":\"" + registryTestPassword + "\",\"auth\":\"" + registryTestAuth + "\"}}}"
+
+	registryCustomTestToken    = "custom-test-token"
+	registryCustomTestPassword = "custom-test-password"
+	registryCustomTestAuth     = "Y3VzdG9tLXRlc3QtdG9rZW46Y3VzdG9tLXRlc3QtcGFzc3dvcmQ=" // echo -n "custom-test-token:custom-test-password" | base64
+	registryCustomDockerConfig = "{\"auths\":{\"" + registryName + "\":{\"username\":\"" + registryCustomTestToken + "\",\"password\":\"" + registryCustomTestPassword + "\",\"auth\":\"" + registryCustomTestAuth + "\"}}}"
+
+	e2eRegistryName         = "e2e.test.com"
+	e2eRegistryTestToken    = "e2e-test-token"
+	e2eRegistryTestPassword = "e2e-test-password"
+	e2eRegistryTestAuth     = "ZTJlLXRlc3QtdG9rZW46ZTJlLXRlc3QtcGFzc3dvcmQ=" // echo -n "e2e-test-token:e2e-test-password" | base64
+	e2eRegistryDockerConfig = "{\"auths\":{\"" + e2eRegistryName + "\":{\"username\":\"" + e2eRegistryTestToken + "\",\"password\":\"" + e2eRegistryTestPassword + "\",\"auth\":\"" + e2eRegistryTestAuth + "\"}}}"
+
+	tenantPullSecretName = "dynakube-pull-secret"
+	customPullSecretName = "custom-pull-secret"
 )
 
 func TestNewDockerKeychain(t *testing.T) {
@@ -64,7 +78,7 @@ func TestNewDockerKeychain(t *testing.T) {
 				Namespace: "dynatrace",
 			},
 			Data: map[string][]byte{
-				corev1.DockerConfigJsonKey: []byte(dockerConfig),
+				corev1.DockerConfigJsonKey: []byte(registryDockerConfig),
 			},
 			Type: corev1.SecretTypeDockerConfigJson,
 		}
@@ -81,8 +95,8 @@ func TestNewDockerKeychain(t *testing.T) {
 		assert.NotNil(t, authenticator)
 		auth, err := authenticator.Authorization()
 		require.NoError(t, err)
-		assert.Equal(t, testToken, auth.Username)
-		assert.Equal(t, testPassword, auth.Password)
+		assert.Equal(t, registryTestToken, auth.Username)
+		assert.Equal(t, registryTestPassword, auth.Password)
 	})
 }
 
@@ -92,5 +106,90 @@ func TestNewDockerKeychains(t *testing.T) {
 
 		_, err := NewDockerKeychains(context.TODO(), client, "dynatrace", []string{"dynakube-pull-secret"})
 		require.NoError(t, err)
+	})
+
+	t.Run("the same registry", func(t *testing.T) {
+		tenantPullSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tenantPullSecretName,
+				Namespace: "dynatrace",
+			},
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(registryDockerConfig),
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+		}
+		customPullSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      customPullSecretName,
+				Namespace: "dynatrace",
+			},
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(registryCustomDockerConfig),
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+		}
+		client := fake.NewClientWithIndex(&tenantPullSecret, &customPullSecret)
+
+		keychain, err := NewDockerKeychains(context.TODO(), client, "dynatrace", []string{tenantPullSecretName, customPullSecretName})
+		require.NoError(t, err)
+		registry, err := name.NewRegistry(registryName, name.StrictValidation)
+		require.NoError(t, err)
+
+		authenticator, err := keychain.Resolve(registry)
+
+		require.NoError(t, err)
+		assert.NotNil(t, authenticator)
+		auth, err := authenticator.Authorization()
+		require.NoError(t, err)
+		assert.Equal(t, registryCustomTestToken, auth.Username)
+		assert.Equal(t, registryCustomTestPassword, auth.Password)
+	})
+
+	t.Run("different registries", func(t *testing.T) {
+		tenantPullSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tenantPullSecretName,
+				Namespace: "dynatrace",
+			},
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(registryDockerConfig),
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+		}
+		customPullSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      customPullSecretName,
+				Namespace: "dynatrace",
+			},
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(e2eRegistryDockerConfig),
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+		}
+		client := fake.NewClientWithIndex(&tenantPullSecret, &customPullSecret)
+
+		keychain, err := NewDockerKeychains(context.TODO(), client, "dynatrace", []string{tenantPullSecretName, customPullSecretName})
+		require.NoError(t, err)
+
+		registry, err := name.NewRegistry(registryName, name.StrictValidation)
+		require.NoError(t, err)
+		authenticator, err := keychain.Resolve(registry)
+		require.NoError(t, err)
+		assert.NotNil(t, authenticator)
+		auth, err := authenticator.Authorization()
+		require.NoError(t, err)
+		assert.Equal(t, registryTestToken, auth.Username)
+		assert.Equal(t, registryTestPassword, auth.Password)
+
+		registry, err = name.NewRegistry(e2eRegistryName, name.StrictValidation)
+		require.NoError(t, err)
+		authenticator, err = keychain.Resolve(registry)
+		require.NoError(t, err)
+		assert.NotNil(t, authenticator)
+		auth, err = authenticator.Authorization()
+		require.NoError(t, err)
+		assert.Equal(t, e2eRegistryTestToken, auth.Username)
+		assert.Equal(t, e2eRegistryTestPassword, auth.Password)
 	})
 }

--- a/pkg/oci/dockerkeychain/docker_keychain_test.go
+++ b/pkg/oci/dockerkeychain/docker_keychain_test.go
@@ -85,3 +85,12 @@ func TestNewDockerKeychain(t *testing.T) {
 		assert.Equal(t, testPassword, auth.Password)
 	})
 }
+
+func TestNewDockerKeychains(t *testing.T) {
+	t.Run("tenant secret not found", func(t *testing.T) {
+		client := fake.NewClient()
+
+		_, err := NewDockerKeychains(context.TODO(), client, "dynatrace", []string{"dynakube-pull-secret"})
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description

[K8S-10395](https://dt-rnd.atlassian.net/browse/K8S-10395)

All dynakube image pull secrets added to OneAgent, ActiveGate specs.

All dynakube image pull secrets used by csi.ImageInstaller.

EdgeConnect controller uses registry.Client but depends on EdgeConnect.Spec.CustomPullSecret.

dynakube.controller.registryClientBuilder is not used (~registry.Client~).

csiprovisioner.OneAgentProvisioner.registryClientBuilder is not used (~registry.Client~).

How it works:

dockerAuth(s) loaded by `configFile.LoadFromReader(...)` from different secrets are stored in a single instance of `configFile.AuthConfigs` map. `configFile.LoadFromReader(...)` basically does `map[k] = v` so it works for many secrets.

See:
- https://github.com/docker/cli/blob/master/cli/config/config.go#L106
- https://github.com/docker/cli/blob/master/cli/config/configfile/file.go#L83


## How can this be tested?

Copy codemodules image to a private registry:
```
podman pull public.ecr.aws/dynatrace/dynatrace-codemodules:1.293.133.20240618-095559 
podman tag public.ecr.aws/dynatrace/dynatrace-codemodules:1.293.133.20240618-095559 <registry>/codemodules:1.293.133.20240618-095559 
podman push <registry>/codemodules:1.293.133.20240618-095559 
```
Create pull image secret:
```
kubectl -n dynatrace create secret docker-registry <secretname>  --docker-server=<registry> --docker-username=<username>  --docker-password=<password>
```
Enable DEBUG log level:
```
kubectl -n dynatrace set env daemonset.apps/dynatrace-oneagent-csi-driver -c provisioner --env=LOG_LEVEL=debug
```
Apply dynakube:
```
spec:
  customPullSecret: <secretname>                                                                                                                                                                                                                                                                                                                                                                      
  oneAgent:                                                                                                                                                                                                                                                                                                                                                                                   
    cloudNativeFullStack:                                                                                                                                                                                                                                                                                                                                                                     
      codeModulesImage: "<registry>/codemodules:1.293.133.20240618-095559" 
```
Check csi logs:
```
[]$ kubectl -n dynatrace logs -f pod/dynatrace-oneagent-csi-driver-<svbwp>

{"level":"debug","ts":"2024-07-04T11:52:56.889Z","logger":"docker-keychain","msg":"loaded docker configs","registries":["<registry>","<tenant>"]}
{"level":"info","ts":"2024-07-04T11:52:56.889Z","logger":"oneagent-image","msg":"installing agent from image"}
{"level":"info","ts":"2024-07-04T11:52:56.889Z","logger":"oneagent-image","msg":"installing agent","target dir":"/data/codemodules/cXVheS5pby9hZGFtX29yY2hvbHNraS9keW5vcDoxLjI5My4xMzMuMjAyNDA2MTgtMDk1NTU5"}
{"level":"info","ts":"2024-07-04T11:52:57.298Z","logger":"oneagent-image","msg":"pullOciImage","ref_identifier":"1.293.133.20240618-095559","ref.Name":"<registry>/codemodules:1.293.133.20240618-095559","ref.String":"<registry>/codemodules:1.293.133.20240618-095559"}
{"level":"info","ts":"2024-07-04T11:53:00.736Z","logger":"oneagent-image","msg":"unpackOciImage","sourcePath":"/data/cache/cXVheS5pby9hZGFtX29yY2hvbHNraS9keW5vcDoxLjI5My4xMzMuMjAyNDA2MTgtMDk1NTU5/blobs/sha256/9592808cd833be900caf7c72a18a97cc8c6c0f54077ddcca84a1030d8fec18b6"}
```
Check OneAgent image pull secrets:
```
kubectl -n dynatrace get daemonset.apps/dynakube-oneagent -o jsonpath="{.spec.template.spec.imagePullSecrets}"
```
there should be two secrets:
```
[{"name":"dynakube-pull-secret"},{"name":"<secretname>"}]
```