### PR TITLE
Add OTelC `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding` to Helm chart

### DIFF
--- a/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
@@ -1,5 +1,5 @@
 {{- include "dynatrace-operator.platformRequired" . }}
-{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{ if eq (include "dynatrace-operator.partial" .) "false" }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,31 +13,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: dynatrace-extensions-controller
+  name: prometheus-service-detector
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "dynatrace-operator.extensionsControllerLabels" . | nindent 4 }}
+    {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
 rules:
-  - apiGroups: ["security.openshift.io"]
-    resources: ["securitycontextconstraints"]
-    resourceNames: ["privileged"]
-    verbs: ["use"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
 ---
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  name: dynatrace-extensions-controller
+  name: prometheus-service-detector
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "dynatrace-operator.extensionsControllerLabels" . | nindent 4 }}
+    {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-service-detector
 subjects:
   - kind: ServiceAccount
-    name: dynatrace-extensions-controller
-roleRef:
-  kind: Role
-  name: dynatrace-extensions-controller
-  apiGroup: rbac.authorization.k8s.io
+    name: dynatrace-extensions-collector
 {{ end }}

--- a/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector.yaml
@@ -1,0 +1,24 @@
+{{- include "dynatrace-operator.platformRequired" . }}
+{{ if eq (include "dynatrace-operator.partial" .) "false" }}
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-extensions-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
+{{ end }}
+

--- a/config/helm/chart/default/templates/_labels.tpl
+++ b/config/helm/chart/default/templates/_labels.tpl
@@ -108,3 +108,11 @@ Extensions Controller (EEC) labels
 {{ include "dynatrace-operator.commonLabels" . }}
 app.kubernetes.io/component: dynatrace-extensions-controller
 {{- end -}}
+
+{{/*
+Extensions OpenTelemetry Collector (OTelC) labels
+*/}}
+{{- define "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" -}}
+{{ include "dynatrace-operator.commonLabels" . }}
+app.kubernetes.io/component: dynatrace-extensions-collector
+{{- end -}}

--- a/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector_test.yaml
@@ -1,0 +1,8 @@
+suite: test clusterrole for the extensions OpenTelemetry collector
+templates:
+  - Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
+tests:
+  - it: should exist
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector_test.yaml
@@ -1,0 +1,18 @@
+suite: test service account for extensions OpenTelemetry collector
+templates:
+  - Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector.yaml
+tests:
+  - it: should exist
+    set:
+      platform: kubernetes
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: dynatrace-extensions-collector
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - isNotEmpty:
+          path: metadata.labels


### PR DESCRIPTION
## Description

[K8S-10310](https://dt-rnd.atlassian.net/browse/K8S-10310)

Add Extensions OpenTelemetry Collector (OTelC) `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding` to Helm chart.

## How can this be tested?

- `make helm/test`
- `make deploy/helm`