### PR TITLE
Fix activeGate replica conversion

### DIFF
--- a/pkg/api/v1beta1/dynakube/convert_from.go
+++ b/pkg/api/v1beta1/dynakube/convert_from.go
@@ -74,6 +74,7 @@ func (dst *DynaKube) fromActiveGateSpec(src *v1beta2.DynaKube) {
 	dst.Spec.ActiveGate.DNSPolicy = src.Spec.ActiveGate.DNSPolicy
 	dst.Spec.ActiveGate.TopologySpreadConstraints = src.Spec.ActiveGate.TopologySpreadConstraints
 	dst.Spec.ActiveGate.Resources = src.Spec.ActiveGate.Resources
+	dst.Spec.ActiveGate.Replicas = address.Of(src.Spec.ActiveGate.Replicas)
 
 	for _, capability := range src.Spec.ActiveGate.Capabilities {
 		dst.Spec.ActiveGate.Capabilities = append(dst.Spec.ActiveGate.Capabilities, CapabilityDisplayName(capability))

--- a/pkg/api/v1beta1/dynakube/convert_from_test.go
+++ b/pkg/api/v1beta1/dynakube/convert_from_test.go
@@ -185,6 +185,7 @@ func compareActiveGateSpec(t *testing.T, oldSpec ActiveGateSpec, newSpec v1beta2
 	assert.Equal(t, oldSpec.TlsSecretName, newSpec.TlsSecretName)
 	assert.Equal(t, oldSpec.TopologySpreadConstraints, newSpec.TopologySpreadConstraints)
 	assert.Equal(t, oldSpec.Group, newSpec.Group)
+	assert.Equal(t, *oldSpec.Replicas, newSpec.Replicas)
 
 	if oldSpec.CustomProperties != nil || newSpec.CustomProperties != nil { // necessary so we don't explode with nil pointer when not set
 		require.NotNil(t, oldSpec.CustomProperties)

--- a/pkg/api/v1beta1/dynakube/convert_to.go
+++ b/pkg/api/v1beta1/dynakube/convert_to.go
@@ -89,6 +89,10 @@ func (src *DynaKube) toActiveGateSpec(dst *v1beta2.DynaKube) {
 			ValueFrom: src.Spec.ActiveGate.CustomProperties.ValueFrom,
 		}
 	}
+
+	if src.Spec.ActiveGate.Replicas != nil {
+		dst.Spec.ActiveGate.Replicas = *src.Spec.ActiveGate.Replicas
+	}
 }
 
 func (src *DynaKube) toMovedFields(dst *v1beta2.DynaKube) error {


### PR DESCRIPTION
## Description

Currently the conversion of the replicas field of the activeGate is broken -> it is always converted to 1 (default value)

## How can this be tested?

Apply a Dynakube in v1beta1 and replicas of activeGate set to > 1 -> check if the replicas are kept after conversion to v1beta2 happened