### PR TITLE
Add the missing ns in the service-detector CRB

### DIFF
--- a/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
@@ -39,4 +39,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: dynatrace-extensions-collector
+    namespace: {{ .Release.Namespace }}
 {{ end }}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

The namespace for the ServiceAccount we are binding the ClusterRole is missing.

## How can this be tested?
Run `make deploy/helm`, and it shouldn't fail 