### PR TITLE
Make csidriver updateStrategy configurable

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -272,7 +272,5 @@ spec:
           operator: Exists
           effect: NoSchedule
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 1
-    type: RollingUpdate
+    {{- toYaml .Values.csidriver.updateStrategy | nindent 4 }}
 {{- end -}}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -373,6 +373,37 @@ tests:
               - emptyDir: { }
                 name: tmp-dir
 
+  - it: should have default updateStrategy
+    set:
+      platform: kubernetes
+      image: image-name
+      csidriver.enabled: true
+    asserts:
+      - isNotEmpty:
+          path: spec.updateStrategy
+      - equal:
+          path: spec.updateStrategy
+          value:
+            rollingUpdate:
+              maxUnavailable: 1
+            type: RollingUpdate
+
+  - it: updateStrategy should be configurable
+    set:
+      platform: kubernetes
+      image: image-name
+      csidriver.enabled: true
+      csidriver.updateStrategy.rollingUpdate.maxUnavailable: 3
+    asserts:
+      - isNotEmpty:
+          path: spec.updateStrategy
+      - equal:
+          path: spec.updateStrategy
+          value:
+            rollingUpdate:
+              maxUnavailable: 3
+            type: RollingUpdate
+
   - it: should have imagePullSecrets defined in spec
     set:
       platform: kubernetes

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -105,6 +105,10 @@ csidriver:
       operator: Exists
   labels: []
   annotations: []
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   csiInit:
     securityContext:
       runAsUser: 0


### PR DESCRIPTION
## Description
https://dt-rnd.atlassian.net/browse/K8S-9601

Make the `updateStrategy` part of the csi DaemonSet configurable via Helm.

## How can this be tested?

`make deploy/helm` should use the defaults set in the values.yaml
- play around with your own values.yaml