### PR TITLE
Fix pull secret not found error preventing codeModulesImage download

### DIFF
--- a/pkg/oci/dockerkeychain/docker_keychain.go
+++ b/pkg/oci/dockerkeychain/docker_keychain.go
@@ -33,9 +33,9 @@ func (keychain *DockerKeychain) loadDockerConfigFromSecret(ctx context.Context, 
 	}
 
 	if err := apiReader.Get(ctx, client.ObjectKey{Namespace: pullSecret.Namespace, Name: pullSecret.Name}, &pullSecret); err != nil {
-		log.Info("failed to load registry pull secret", "name", pullSecret.Name, "namespace", pullSecret.Namespace)
+		log.Info("No registry pull secret loaded", "name", pullSecret.Name, "namespace", pullSecret.Namespace, "err", err)
 
-		return errors.WithStack(err)
+		return nil
 	}
 
 	dockerAuths, err := extractDockerAuthsFromSecret(&pullSecret)

--- a/pkg/oci/dockerkeychain/docker_keychain_test.go
+++ b/pkg/oci/dockerkeychain/docker_keychain_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -24,7 +23,7 @@ const (
 )
 
 func TestNewDockerKeychain(t *testing.T) {
-	t.Run("secret not found", func(t *testing.T) {
+	t.Run("secret not found, try without secret", func(t *testing.T) {
 		pullSecret := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-secret",
@@ -34,8 +33,7 @@ func TestNewDockerKeychain(t *testing.T) {
 		client := fake.NewClient()
 
 		_, err := NewDockerKeychain(context.TODO(), client, pullSecret)
-		require.Error(t, err)
-		require.True(t, k8sErrors.IsNotFound(err))
+		require.NoError(t, err)
 	})
 
 	t.Run("invalid format of docker secret dockerconfigjson", func(t *testing.T) {


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/K8S-10501

The image pulling logic in the operator always expects a pull-secret to be present. Even if it doesn’t make sense. (public images) Since recently we stopped generating the default pull-secret for appmon (reasoning was that in the default scenario appmon doesn’t pull an image, but gets a zip file.)

Fixed version: 
`{"level":"info","ts":"2024-07-03T16:07:03.426Z","logger":"csi-provisioner","msg":"csi directories exist","path":"/data/asj34817"}
{"level":"info","ts":"2024-07-03T16:07:03.449Z","logger":"docker-keychain","msg":"No registry pull secret loaded","name":"dynakube-luhi-v2-pull-secret","namespace":"dynatrace","err":"secrets \"dynakube-luhi-v2-pull-secret\" not found"}
{"level":"info","ts":"2024-07-03T16:07:03.449Z","logger":"oneagent-image","msg":"installing agent from image"}
{"level":"info","ts":"2024-07-03T16:07:03.449Z","logger":"oneagent-image","msg":"installing agent","target dir":"/data/codemodules/ZG9ja2VyLmlvL2R5bmF0cmFjZS9keW5hdHJhY2UtY29kZW1vZHVsZXM6MS4yODkuMTU1LjIwMjQwNjA0LTEzMzgzMA=="}
{"level":"info","ts":"2024-07-03T16:07:03.872Z","logger":"oneagent-image","msg":"pullOciImage","ref_identifier":"1.289.155.20240604-133830","ref.Name":"index.docker.io/dynatrace/dynatrace-codemodules:1.289.155.20240604-133830","ref.String":"docker.io/dynatrace/dynatrace-codemodules:1.289.155.20240604-133830"}
{"level":"info","ts":"2024-07-03T16:07:08.429Z","logger":"oneagent-image","msg":"unpackOciImage","sourcePath":"/data/cache/ZG9ja2VyLmlvL2R5bmF0cmFjZS9keW5hdHJhY2UtY29kZW1vZHVsZXM6MS4yODkuMTU1LjIwMjQwNjA0LTEzMzgzMA==/blobs/sha256/370b610f89c02b41ce15f1a6b941d9b44fa1ff4ce0ba99d36c8f53585d1164b5"}
{"level":"info","ts":"2024-07-03T16:07:08.429Z","logger":"oneagent-zip","msg":"extracting tar gzip","source":"/data/cache/ZG9ja2VyLmlvL2R5bmF0cmFjZS9keW5hdHJhY2UtY29kZW1vZHVsZXM6MS4yODkuMTU1LjIwMjQwNjA0LTEzMzgzMA==/blobs/sha256/370b610f89c02b41ce15f1a6b941d9b44fa1ff4ce0ba99d36c8f53585d1164b5","destinationDir":"/data/codemodules/ZG9ja2VyLmlvL2R5bmF0cmFjZS9keW5hdHJhY2UtY29kZW1vZHVsZXM6MS4yODkuMTU1LjIwMjQwNjA0LTEzMzgzMA=="}
{"level":"info","ts":"2024-07-03T16:07:18.866Z","logger":"oneagent-zip","msg":"moving unpacked archive to target","targetDir":"/data/codemodules/ZG9ja2VyLmlvL2R5bmF0cmFjZS9keW5hdHJhY2UtY29kZW1vZHVsZXM6MS4yODkuMTU1LjIwMjQwNjA0LTEzMzgzMA=="}
{"level":"info","ts":"2024-07-03T16:07:18.867Z","logger":"oneagent-image","msg":"unpackOciImage","targetDir":"/data/codemodules/ZG9ja2VyLmlvL2R5bmF0cmFjZS9keW5hdHJhY2UtY29kZW1vZHVsZXM6MS4yODkuMTU1LjIwMjQwNjA0LTEzMzgzMA=="}
{"level":"info","ts":"2024-07-03T16:07:18.927Z","logger":"oneagent-symlink","msg":"found version","version":"1.289.155.20240604-133830"}
{"level":"info","ts":"2024-07-03T16:07:18.928Z","logger":"oneagent-symlink","msg":"creating symlink","points-to(relative)":"1.289.155.20240604-133830","location":"/data/codemodules/ZG9ja2VyLmlvL2R5bmF0cmFjZS9keW5hdHJhY2UtY29kZW1vZHVsZXM6MS4yODkuMTU1LjIwMjQwNjA0LTEzMzgzMA==/agent/bin/current"}`


## How can this be tested?

Apply a Dynakube with only AppMonitoring (no activeGate!) and useCSIDriver: true aswell as a codeModulesImage from a publicly available registry e.g https://hub.docker.com/r/dynatrace/dynatrace-codemodules/tags