### PR TITLE
Add Verification of OneAgent Version

### DIFF
--- a/pkg/api/v1beta2/dynakube/validation/oneagent.go
+++ b/pkg/api/v1beta2/dynakube/validation/oneagent.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
@@ -135,6 +136,21 @@ func conflictingOneAgentVolumeStorageSettings(_ context.Context, _ *Validator, d
 func conflictingHostGroupSettings(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	if dk.HostGroupAsParam() != "" {
 		return warningHostGroupConflict
+	}
+
+	return ""
+}
+
+var oneAgentSemVerVersionSpec = regexp.MustCompile(`^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$`)
+
+func validateOneAgentVersionIsSemVerCompliant(_ context.Context, _ *dynakubeValidator, dk *dynakube.DynaKube) string {
+	agentVersion := dk.CustomOneAgentVersion()
+	if agentVersion == "" {
+		return ""
+	}
+
+	if !oneAgentSemVerVersionSpec.MatchString(agentVersion) {
+		return "Only semantic versions are allowed!"
 	}
 
 	return ""

--- a/pkg/api/v1beta2/dynakube/validation/oneagent.go
+++ b/pkg/api/v1beta2/dynakube/validation/oneagent.go
@@ -3,10 +3,11 @@ package validation
 import (
 	"context"
 	"fmt"
-	"regexp"
+	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
+	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -141,15 +142,14 @@ func conflictingHostGroupSettings(_ context.Context, _ *Validator, dk *dynakube.
 	return ""
 }
 
-var oneAgentSemVerVersionSpec = regexp.MustCompile(`^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$`)
-
 func validateOneAgentVersionIsSemVerCompliant(_ context.Context, _ *dynakubeValidator, dk *dynakube.DynaKube) string {
 	agentVersion := dk.CustomOneAgentVersion()
 	if agentVersion == "" {
 		return ""
 	}
 
-	if !oneAgentSemVerVersionSpec.MatchString(agentVersion) {
+	version := "v" + agentVersion
+	if !(semver.IsValid(version) && semver.Prerelease(version) == "" && semver.Build(version) == "" && len(strings.Split(version, ".")) == 3) {
 		return "Only semantic versions in the form of major.minor.patch (e.g. 1.0.0) are allowed!"
 	}
 

--- a/pkg/api/v1beta2/dynakube/validation/oneagent.go
+++ b/pkg/api/v1beta2/dynakube/validation/oneagent.go
@@ -26,24 +26,24 @@ The conflicting Dynakube: %s
 
 func conflictingOneAgentConfiguration(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	counter := 0
-	if dk.ApplicationMonitoringMode() {
+	if dynakube.ApplicationMonitoringMode() {
 		counter += 1
 	}
 
-	if dk.CloudNativeFullstackMode() {
+	if dynakube.CloudNativeFullstackMode() {
 		counter += 1
 	}
 
-	if dk.ClassicFullStackMode() {
+	if dynakube.ClassicFullStackMode() {
 		counter += 1
 	}
 
-	if dk.HostMonitoringMode() {
+	if dynakube.HostMonitoringMode() {
 		counter += 1
 	}
 
 	if counter > 1 {
-		log.Info("requested dynakube has conflicting one agent configuration", "name", dk.Name, "namespace", dk.Namespace)
+		log.Info("requested dynakube has conflicting one agent configuration", "name", dynakube.Name, "namespace", dynakube.Namespace)
 
 		return errorConflictingOneagentMode
 	}
@@ -68,12 +68,12 @@ func conflictingNodeSelector(ctx context.Context, dv *Validator, dk *dynakube.Dy
 			continue
 		}
 
-		nodeSelectorMap := dk.NodeSelector()
+		nodeSelectorMap := dynakube.NodeSelector()
 		validNodeSelectorMap := item.NodeSelector()
 
-		if item.Name != dk.Name {
+		if item.Name != dynakube.Name {
 			if hasConflictingMatchLabels(nodeSelectorMap, validNodeSelectorMap) {
-				log.Info("requested dynakube has conflicting nodeSelector", "name", dk.Name, "namespace", dk.Namespace)
+				log.Info("requested dynakube has conflicting nodeSelector", "name", dynakube.Name, "namespace", dynakube.Namespace)
 
 				return fmt.Sprintf(errorNodeSelectorConflict, item.Name)
 			}
@@ -106,8 +106,8 @@ func hasConflictingMatchLabels(labelMap, otherLabelMap map[string]string) bool {
 	return labelSelector.Matches(otherLabelSelectorLabels) || otherLabelSelector.Matches(labelSelectorLabels)
 }
 
-func hasOneAgentVolumeStorageEnabled(dk *dynakube.DynaKube) (isEnabled bool, isSet bool) {
-	envVar := env.FindEnvVar(dk.GetOneAgentEnvironment(), oneagentEnableVolumeStorageEnvVarName)
+func hasOneAgentVolumeStorageEnabled(dynakube *dynatracev1beta2.DynaKube) (isEnabled bool, isSet bool) {
+	envVar := env.FindEnvVar(dynakube.GetOneAgentEnvironment(), oneagentEnableVolumeStorageEnvVarName)
 	isSet = envVar != nil
 	isEnabled = isSet && envVar.Value == "true"
 

--- a/pkg/api/v1beta2/dynakube/validation/oneagent.go
+++ b/pkg/api/v1beta2/dynakube/validation/oneagent.go
@@ -28,24 +28,24 @@ The conflicting Dynakube: %s
 
 func conflictingOneAgentConfiguration(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	counter := 0
-	if dynakube.ApplicationMonitoringMode() {
+	if dk.ApplicationMonitoringMode() {
 		counter += 1
 	}
 
-	if dynakube.CloudNativeFullstackMode() {
+	if dk.CloudNativeFullstackMode() {
 		counter += 1
 	}
 
-	if dynakube.ClassicFullStackMode() {
+	if dk.ClassicFullStackMode() {
 		counter += 1
 	}
 
-	if dynakube.HostMonitoringMode() {
+	if dk.HostMonitoringMode() {
 		counter += 1
 	}
 
 	if counter > 1 {
-		log.Info("requested dynakube has conflicting one agent configuration", "name", dynakube.Name, "namespace", dynakube.Namespace)
+		log.Info("requested dynakube has conflicting one agent configuration", "name", dk.Name, "namespace", dk.Namespace)
 
 		return errorConflictingOneagentMode
 	}
@@ -70,12 +70,12 @@ func conflictingNodeSelector(ctx context.Context, dv *Validator, dk *dynakube.Dy
 			continue
 		}
 
-		nodeSelectorMap := dynakube.NodeSelector()
+		nodeSelectorMap := dk.NodeSelector()
 		validNodeSelectorMap := item.NodeSelector()
 
-		if item.Name != dynakube.Name {
+		if item.Name != dk.Name {
 			if hasConflictingMatchLabels(nodeSelectorMap, validNodeSelectorMap) {
-				log.Info("requested dynakube has conflicting nodeSelector", "name", dynakube.Name, "namespace", dynakube.Namespace)
+				log.Info("requested dynakube has conflicting nodeSelector", "name", dk.Name, "namespace", dk.Namespace)
 
 				return fmt.Sprintf(errorNodeSelectorConflict, item.Name)
 			}
@@ -108,8 +108,8 @@ func hasConflictingMatchLabels(labelMap, otherLabelMap map[string]string) bool {
 	return labelSelector.Matches(otherLabelSelectorLabels) || otherLabelSelector.Matches(labelSelectorLabels)
 }
 
-func hasOneAgentVolumeStorageEnabled(dynakube *dynatracev1beta2.DynaKube) (isEnabled bool, isSet bool) {
-	envVar := env.FindEnvVar(dynakube.GetOneAgentEnvironment(), oneagentEnableVolumeStorageEnvVarName)
+func hasOneAgentVolumeStorageEnabled(dk *dynakube.DynaKube) (isEnabled bool, isSet bool) {
+	envVar := env.FindEnvVar(dk.GetOneAgentEnvironment(), oneagentEnableVolumeStorageEnvVarName)
 	isSet = envVar != nil
 	isEnabled = isSet && envVar.Value == "true"
 
@@ -142,7 +142,7 @@ func conflictingHostGroupSettings(_ context.Context, _ *Validator, dk *dynakube.
 	return ""
 }
 
-func validateOneAgentVersionIsSemVerCompliant(_ context.Context, _ *dynakubeValidator, dk *dynakube.DynaKube) string {
+func validateOneAgentVersionIsSemVerCompliant(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	agentVersion := dk.CustomOneAgentVersion()
 	if agentVersion == "" {
 		return ""

--- a/pkg/api/v1beta2/dynakube/validation/oneagent.go
+++ b/pkg/api/v1beta2/dynakube/validation/oneagent.go
@@ -150,7 +150,7 @@ func validateOneAgentVersionIsSemVerCompliant(_ context.Context, _ *dynakubeVali
 	}
 
 	if !oneAgentSemVerVersionSpec.MatchString(agentVersion) {
-		return "Only semantic versions are allowed!"
+		return "Only semantic versions in the form of major.minor.patch (e.g. 1.0.0) are allowed!"
 	}
 
 	return ""

--- a/pkg/api/v1beta2/dynakube/validation/oneagent_test.go
+++ b/pkg/api/v1beta2/dynakube/validation/oneagent_test.go
@@ -428,7 +428,7 @@ func createDynakubeWithHostGroup(args []string, hostGroup string) *dynakube.Dyna
 func TestValidateOneAgentVersionIsSemVer(t *testing.T) {
 	testCasesAcceptedVersions := []string{"", "1.0.0", "1.200.1"}
 
-	testCasesNotAcceptedVersions := []string{"latest", "raw", "1.200.1-raw"}
+	testCasesNotAcceptedVersions := []string{"latest", "raw", "1.200.1-raw", "1.200.1+build", "1.200", "1", "1.0", "v1.200.0"}
 
 	for _, tc := range testCasesAcceptedVersions {
 		t.Run("should accept version "+tc, func(t *testing.T) {

--- a/pkg/api/v1beta2/dynakube/validation/oneagent_test.go
+++ b/pkg/api/v1beta2/dynakube/validation/oneagent_test.go
@@ -448,7 +448,7 @@ func TestValidateOneAgentVersionIsSemVer(t *testing.T) {
 
 	for _, tc := range testCasesNotAcceptedVersions {
 		t.Run("should accept version "+tc, func(t *testing.T) {
-			assertDeniedResponse(t, []string{"Only semantic versions are allowed!"}, &dynatracev1beta2.DynaKube{
+			assertDeniedResponse(t, []string{"Only semantic versions in the form of major.minor.patch (e.g. 1.0.0) are allowed!"}, &dynatracev1beta2.DynaKube{
 				ObjectMeta: defaultDynakubeObjectMeta,
 				Spec: dynatracev1beta2.DynaKubeSpec{
 					APIURL: testApiUrl,

--- a/pkg/api/v1beta2/dynakube/validation/oneagent_test.go
+++ b/pkg/api/v1beta2/dynakube/validation/oneagent_test.go
@@ -424,3 +424,41 @@ func createDynakubeWithHostGroup(args []string, hostGroup string) *dynakube.Dyna
 		},
 	}
 }
+
+func TestValidateOneAgentVersionIsSemVer(t *testing.T) {
+	testCasesAcceptedVersions := []string{"", "1.0.0", "1.200.1"}
+
+	testCasesNotAcceptedVersions := []string{"latest", "raw", "1.200.1-raw"}
+
+	for _, tc := range testCasesAcceptedVersions {
+		t.Run("should accept version "+tc, func(t *testing.T) {
+			assertAllowedResponseWithoutWarnings(t, &dynatracev1beta2.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynatracev1beta2.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynatracev1beta2.OneAgentSpec{
+						ClassicFullStack: &dynatracev1beta2.HostInjectSpec{
+							Version: tc,
+						},
+					},
+				},
+			})
+		})
+	}
+
+	for _, tc := range testCasesNotAcceptedVersions {
+		t.Run("should accept version "+tc, func(t *testing.T) {
+			assertDeniedResponse(t, []string{"Only semantic versions are allowed!"}, &dynatracev1beta2.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynatracev1beta2.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynatracev1beta2.OneAgentSpec{
+						ClassicFullStack: &dynatracev1beta2.HostInjectSpec{
+							Version: tc,
+						},
+					},
+				},
+			})
+		})
+	}
+}

--- a/pkg/api/v1beta2/dynakube/validation/oneagent_test.go
+++ b/pkg/api/v1beta2/dynakube/validation/oneagent_test.go
@@ -428,16 +428,16 @@ func createDynakubeWithHostGroup(args []string, hostGroup string) *dynakube.Dyna
 func TestValidateOneAgentVersionIsSemVer(t *testing.T) {
 	testCasesAcceptedVersions := []string{"", "1.0.0", "1.200.1"}
 
-	testCasesNotAcceptedVersions := []string{"latest", "raw", "1.200.1-raw", "1.200.1+build", "1.200", "1", "1.0", "v1.200.0"}
+	testCasesNotAcceptedVersions := []string{"latest", "raw", "1.200.1-raw", "v1.200.1-raw", "1.200.1+build", "v1.200.1+build", "1.200.1-raw+build", "v1.200.1-raw+build", "1.200", "v1.200", "1", "v1", "1.0", "v1.0", "v1.200.0"}
 
 	for _, tc := range testCasesAcceptedVersions {
 		t.Run("should accept version "+tc, func(t *testing.T) {
-			assertAllowedResponseWithoutWarnings(t, &dynatracev1beta2.DynaKube{
+			assertAllowed(t, &dynakube.DynaKube{
 				ObjectMeta: defaultDynakubeObjectMeta,
-				Spec: dynatracev1beta2.DynaKubeSpec{
+				Spec: dynakube.DynaKubeSpec{
 					APIURL: testApiUrl,
-					OneAgent: dynatracev1beta2.OneAgentSpec{
-						ClassicFullStack: &dynatracev1beta2.HostInjectSpec{
+					OneAgent: dynakube.OneAgentSpec{
+						ClassicFullStack: &dynakube.HostInjectSpec{
 							Version: tc,
 						},
 					},
@@ -448,12 +448,12 @@ func TestValidateOneAgentVersionIsSemVer(t *testing.T) {
 
 	for _, tc := range testCasesNotAcceptedVersions {
 		t.Run("should accept version "+tc, func(t *testing.T) {
-			assertDeniedResponse(t, []string{"Only semantic versions in the form of major.minor.patch (e.g. 1.0.0) are allowed!"}, &dynatracev1beta2.DynaKube{
+			assertDenied(t, []string{"Only semantic versions in the form of major.minor.patch (e.g. 1.0.0) are allowed!"}, &dynakube.DynaKube{
 				ObjectMeta: defaultDynakubeObjectMeta,
-				Spec: dynatracev1beta2.DynaKubeSpec{
+				Spec: dynakube.DynaKubeSpec{
 					APIURL: testApiUrl,
-					OneAgent: dynatracev1beta2.OneAgentSpec{
-						ClassicFullStack: &dynatracev1beta2.HostInjectSpec{
+					OneAgent: dynakube.OneAgentSpec{
+						ClassicFullStack: &dynakube.HostInjectSpec{
 							Version: tc,
 						},
 					},

--- a/pkg/api/v1beta2/dynakube/validation/validation.go
+++ b/pkg/api/v1beta2/dynakube/validation/validation.go
@@ -37,6 +37,7 @@ var (
 		nameTooLong,
 		namespaceSelectorViolateLabelSpec,
 		imageFieldHasTenantImage,
+		validateOneAgentVersionIsSemVerCompliant,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,


### PR DESCRIPTION
see [K8S-10190](https://dt-rnd.atlassian.net/browse/K8S-10190)

## Description

The operator should reject OneAgent versions that are not conformant to major.minor.patch pattern subset of SemVer. e.g. 1.0.0

## How can this be tested?

Apply a DK with OneAgent version set to an invalid version such as `latest`, `raw` or `1.296.0-raw` and to a valid one such as 1.296.0