### PR TITLE
Fix reconcile interval incase of an error when updating the agent in the provisioner

### DIFF
--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -233,14 +233,14 @@ func (provisioner *OneAgentProvisioner) collectGarbage(ctx context.Context, requ
 	return result, nil
 }
 
-func (provisioner *OneAgentProvisioner) provisionCodeModules(ctx context.Context, dk *dynatracev1beta2.DynaKube, tenantConfig *metadata.TenantConfig) (bool, error) {
+func (provisioner *OneAgentProvisioner) provisionCodeModules(ctx context.Context, dk *dynatracev1beta2.DynaKube, tenantConfig *metadata.TenantConfig) (requeue bool, err error) {
 	// creates a dt client and checks tokens exist for the given dynakube
 	dtc, err := buildDtc(provisioner, ctx, dk)
 	if err != nil {
 		return true, err
 	}
 
-	requeue, err := provisioner.updateAgentInstallation(ctx, dtc, tenantConfig, dk)
+	requeue, err = provisioner.updateAgentInstallation(ctx, dtc, tenantConfig, dk)
 	if err != nil {
 		return requeue, err
 	}

--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -130,8 +130,12 @@ func (provisioner *OneAgentProvisioner) Reconcile(ctx context.Context, request r
 	}
 
 	requeue, err := provisioner.provisionCodeModules(ctx, dk, tenantConfig)
-	if err != nil && requeue {
-		return reconcile.Result{RequeueAfter: dtcsi.ShortRequeueDuration}, err
+	if err != nil {
+		if requeue {
+			return reconcile.Result{RequeueAfter: dtcsi.ShortRequeueDuration}, err
+		}
+
+		return reconcile.Result{}, err
 	}
 
 	return provisioner.collectGarbage(ctx, request)

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -212,7 +212,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 
 		require.EqualError(t, err, `secrets "`+dkName+`" not found`)
 		require.NotNil(t, result)
-		require.Equal(t, reconcile.Result{}, result)
+		require.Equal(t, reconcile.Result{RequeueAfter: dtcsi.ShortRequeueDuration}, result)
 	})
 	t.Run("error when creating dynatrace client", func(t *testing.T) {
 		gc := reconcilermock.NewReconciler(t)
@@ -262,7 +262,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 
 		require.EqualError(t, err, "failed to create Dynatrace client: "+errorMsg)
 		require.NotNil(t, result)
-		require.Equal(t, reconcile.Result{}, result)
+		require.Equal(t, reconcile.Result{RequeueAfter: dtcsi.ShortRequeueDuration}, result)
 	})
 	t.Run("error creating directories", func(t *testing.T) {
 		gc := reconcilermock.NewReconciler(t)


### PR DESCRIPTION
## Description

Ticket: https://dt-rnd.atlassian.net/browse/K8S-10521

If the download of the codemodule fails, the csi-driver will not do a faster requeue (ie.: retry) to try to download the codemodule again. We should do a faster reconcile in such scenarios

## How can this be tested?

Deploy a Dynakube -> set a wrong image in the codeModulesImage field