### PR TITLE
Update renovate config to automate OTEL go-monorepo update to include bump for "go.opentelemetry.io/otel/semconv/v<version>"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,9 +53,9 @@
         "(^|/|\\.)otel.go$",
       ],
       matchStrings: [
-        "depName=(?<depName>.*?)\\s.*go.opentelemetry.io\\/otel\\/semconv\\/v(?<currentValue>.*)\\\"",
+        "packageName=(?<packageName>.*?) depName=(?<depName>.*?)\\s.*go.opentelemetry.io\\/otel\\/semconv\\/v(?<currentValue>.*)\"",
       ],
-      datasourceTemplate: "go",
+      datasourceTemplate: "github-releases",
     },
   ],
   packageRules: [
@@ -118,6 +118,13 @@
       enabled: true,
       automerge: true,
       allowedVersions: "/^v?[0-9]+[\\.\\-][0-9]+([\\-\\.][0-9]+)*$/",
+    },
+    {
+      matchPackagePatterns: [
+        "go.opentelemetry.io\\/otel*",
+      ],
+      groupName: "opentelemetry-go monorepo",
+      groupSlug: "opentelemetry-go-monorepo",
     },
     {
       matchManagers: [

--- a/pkg/util/dtotel/otel.go
+++ b/pkg/util/dtotel/otel.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/resource"
-	// renovate depName=go.opentelemetry.io/otel/semconv
+	// renovate packageName=open-telemetry/semantic-conventions depName=go.opentelemetry.io/otel/semconv
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/types"


### PR DESCRIPTION
## Description

This PR resolves problem of updating manually each go-monorepo update of go.opentelemetry.io/otel/semconv/v<version>. 

It's confusing I know, but this package has different repo and different RELEASE version, thats why solution includes:
1. Upgrade main monorepo packages (go based)
2. Find and update otel.go (import version using github-release)
3. Group 2 set of changes into one
😅 😅 😅 😅 😅 

## How can this be tested?

Validated in my fork https://github.com/andriisoldatenko/dynatrace-operator/pull/50/files