### PR TITLE
Change all imports of the CRs we use

### DIFF
--- a/cmd/support_archive/resource_query.go
+++ b/cmd/support_archive/resource_query.go
@@ -3,10 +3,10 @@ package support_archive
 import (
 	"reflect"
 
-	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2"
-	dynakubev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	appsv1 "k8s.io/api/apps/v1"
@@ -86,8 +86,8 @@ func getComponentsQueryGroup(namespace string, appName string, labelKey string) 
 func getCustomResourcesQueryGroup(namespace string) resourceQueryGroup {
 	return resourceQueryGroup{
 		resources: []schema.GroupVersionKind{
-			toGroupVersionKind(dynatracev1beta2.GroupVersion, dynakubev1beta2.DynaKube{}),
-			toGroupVersionKind(dynatracev1alpha1.GroupVersion, edgeconnect.EdgeConnect{}),
+			toGroupVersionKind(v1beta2.GroupVersion, dynakube.DynaKube{}),
+			toGroupVersionKind(v1alpha1.GroupVersion, edgeconnect.EdgeConnect{}),
 		},
 		filters: []client.ListOption{
 			client.InNamespace(namespace),

--- a/cmd/support_archive/troubleshoot_test.go
+++ b/cmd/support_archive/troubleshoot_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,7 +37,7 @@ func TestTroubleshootCollector(t *testing.T) {
 				Name: "random",
 			},
 		},
-		&dynatracev1beta2.DynaKube{
+		&dynakube.DynaKube{
 			TypeMeta:   typeMeta("DynaKube"),
 			ObjectMeta: objectMeta("dynakube1"),
 		},

--- a/cmd/troubleshoot/builder.go
+++ b/cmd/troubleshoot/builder.go
@@ -134,36 +134,36 @@ func runChecksForAllDynakubes(ctx context.Context, baseLog logd.Logger, apiReade
 	}
 }
 
-func runChecksForDynakube(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, httpClient *http.Client, dynakube dynakube.DynaKube) error {
+func runChecksForDynakube(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, httpClient *http.Client, dk dynakube.DynaKube) error {
 	log := baseLog.WithName(dynakubeCheckLoggerName)
 
-	logNewCheckf(log, "checking if '%s:%s' Dynakube is configured correctly", dynakube.Namespace, dynakube.Name)
-	logInfof(log, "using '%s:%s' Dynakube", dynakube.Namespace, dynakube.Name)
+	logNewCheckf(log, "checking if '%s:%s' Dynakube is configured correctly", dk.Namespace, dk.Name)
+	logInfof(log, "using '%s:%s' Dynakube", dk.Namespace, dk.Name)
 
-	pullSecret, err := checkDynakube(ctx, baseLog, apiReader, &dynakube)
+	pullSecret, err := checkDynakube(ctx, baseLog, apiReader, &dk)
 	if err != nil {
 		return errors.Wrapf(err, "'%s:%s' Dynakube isn't valid. %s",
-			dynakube.Namespace, dynakube.Name, dynakubeNotValidMessage())
+			dk.Namespace, dk.Name, dynakubeNotValidMessage())
 	}
 
-	logOkf(log, "'%s:%s' Dynakube is valid", dynakube.Namespace, dynakube.Name)
+	logOkf(log, "'%s:%s' Dynakube is valid", dk.Namespace, dk.Name)
 
 	keychain, err := dockerkeychain.NewDockerKeychain(ctx, apiReader, pullSecret)
 	if err != nil {
 		return err
 	}
 
-	transport, err := createTransport(ctx, apiReader, &dynakube, httpClient)
+	transport, err := createTransport(ctx, apiReader, &dk, httpClient)
 	if err != nil {
 		return err
 	}
 
-	err = verifyAllImagesAvailable(ctx, log, keychain, transport, &dynakube)
+	err = verifyAllImagesAvailable(ctx, log, keychain, transport, &dk)
 	if err != nil {
 		return err
 	}
 
-	return checkProxySettings(ctx, log, apiReader, &dynakube)
+	return checkProxySettings(ctx, log, apiReader, &dk)
 }
 
 func createTransport(ctx context.Context, apiReader client.Reader, dynakube *dynakube.DynaKube, httpClient *http.Client) (*http.Transport, error) {

--- a/cmd/troubleshoot/builder.go
+++ b/cmd/troubleshoot/builder.go
@@ -166,7 +166,7 @@ func runChecksForDynakube(ctx context.Context, baseLog logd.Logger, apiReader cl
 	return checkProxySettings(ctx, log, apiReader, &dk)
 }
 
-func createTransport(ctx context.Context, apiReader client.Reader, dynakube *dynakube.DynaKube, httpClient *http.Client) (*http.Transport, error) {
+func createTransport(ctx context.Context, apiReader client.Reader, dk *dynakube.DynaKube, httpClient *http.Client) (*http.Transport, error) {
 	var transport *http.Transport
 	if httpClient != nil && httpClient.Transport != nil {
 		transport = httpClient.Transport.(*http.Transport).Clone()
@@ -174,7 +174,7 @@ func createTransport(ctx context.Context, apiReader client.Reader, dynakube *dyn
 		transport = http.DefaultTransport.(*http.Transport).Clone()
 	}
 
-	return registry.PrepareTransportForDynaKube(ctx, apiReader, transport, dynakube)
+	return registry.PrepareTransportForDynaKube(ctx, apiReader, transport, dk)
 }
 
 func getDynakubes(ctx context.Context, log logd.Logger, apiReader client.Reader, namespaceName string, dynakubeName string) ([]dynakube.DynaKube, error) {

--- a/cmd/troubleshoot/builder.go
+++ b/cmd/troubleshoot/builder.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/cmd/config"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/dockerkeychain"
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
@@ -106,7 +106,7 @@ func RunTroubleshootCmd(ctx context.Context, log logd.Logger, namespaceName stri
 		return
 	}
 
-	dynakubes := &dynatracev1beta2.DynaKubeList{}
+	dynakubes := &dynakube.DynaKubeList{}
 
 	err = apiReader.List(ctx, dynakubes, &client.ListOptions{Namespace: namespaceName})
 	if checkCRD(log, err) != nil {
@@ -125,16 +125,16 @@ func GetK8SClusterAPIReader(kubeConfig *rest.Config) (client.Reader, error) {
 	return k8scluster.GetAPIReader(), nil
 }
 
-func runChecksForAllDynakubes(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, httpClient *http.Client, dynakubes []dynatracev1beta2.DynaKube) {
-	for _, dynakube := range dynakubes {
-		err := runChecksForDynakube(ctx, baseLog, apiReader, httpClient, dynakube)
+func runChecksForAllDynakubes(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, httpClient *http.Client, dynakubes []dynakube.DynaKube) {
+	for _, dk := range dynakubes {
+		err := runChecksForDynakube(ctx, baseLog, apiReader, httpClient, dk)
 		if err != nil {
-			logErrorf(baseLog, "Error in DynaKube %s/%s", dynakube.Namespace, dynakube.Name)
+			logErrorf(baseLog, "Error in DynaKube %s/%s", dk.Namespace, dk.Name)
 		}
 	}
 }
 
-func runChecksForDynakube(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, httpClient *http.Client, dynakube dynatracev1beta2.DynaKube) error {
+func runChecksForDynakube(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, httpClient *http.Client, dynakube dynakube.DynaKube) error {
 	log := baseLog.WithName(dynakubeCheckLoggerName)
 
 	logNewCheckf(log, "checking if '%s:%s' Dynakube is configured correctly", dynakube.Namespace, dynakube.Name)
@@ -166,7 +166,7 @@ func runChecksForDynakube(ctx context.Context, baseLog logd.Logger, apiReader cl
 	return checkProxySettings(ctx, log, apiReader, &dynakube)
 }
 
-func createTransport(ctx context.Context, apiReader client.Reader, dynakube *dynatracev1beta2.DynaKube, httpClient *http.Client) (*http.Transport, error) {
+func createTransport(ctx context.Context, apiReader client.Reader, dynakube *dynakube.DynaKube, httpClient *http.Client) (*http.Transport, error) {
 	var transport *http.Transport
 	if httpClient != nil && httpClient.Transport != nil {
 		transport = httpClient.Transport.(*http.Transport).Clone()
@@ -177,10 +177,10 @@ func createTransport(ctx context.Context, apiReader client.Reader, dynakube *dyn
 	return registry.PrepareTransportForDynaKube(ctx, apiReader, transport, dynakube)
 }
 
-func getDynakubes(ctx context.Context, log logd.Logger, apiReader client.Reader, namespaceName string, dynakubeName string) ([]dynatracev1beta2.DynaKube, error) {
+func getDynakubes(ctx context.Context, log logd.Logger, apiReader client.Reader, namespaceName string, dynakubeName string) ([]dynakube.DynaKube, error) {
 	var err error
 
-	var dynakubes []dynatracev1beta2.DynaKube
+	var dynakubes []dynakube.DynaKube
 
 	if dynakubeName == "" {
 		logNewDynakubef(log, "no Dynakube specified - checking all Dynakubes in namespace '%s'", namespaceName)
@@ -190,19 +190,19 @@ func getDynakubes(ctx context.Context, log logd.Logger, apiReader client.Reader,
 			return nil, err
 		}
 	} else {
-		dynakube, err := getSelectedDynakube(ctx, apiReader, namespaceName, dynakubeName)
+		dk, err := getSelectedDynakube(ctx, apiReader, namespaceName, dynakubeName)
 		if err != nil {
 			return nil, err
 		}
 
-		dynakubes = append(dynakubes, dynakube)
+		dynakubes = append(dynakubes, dk)
 	}
 
 	return dynakubes, nil
 }
 
-func getAllDynakubesInNamespace(ctx context.Context, log logd.Logger, apiReader client.Reader, namespaceName string) ([]dynatracev1beta2.DynaKube, error) {
-	var dynakubes dynatracev1beta2.DynaKubeList
+func getAllDynakubesInNamespace(ctx context.Context, log logd.Logger, apiReader client.Reader, namespaceName string) ([]dynakube.DynaKube, error) {
+	var dynakubes dynakube.DynaKubeList
 
 	err := apiReader.List(ctx, &dynakubes, client.InNamespace(namespaceName))
 	if err != nil {

--- a/cmd/troubleshoot/builder_test.go
+++ b/cmd/troubleshoot/builder_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,18 +22,18 @@ func TestTroubleshootCommandBuilder(t *testing.T) {
 	})
 
 	t.Run("getAllDynakubesInNamespace", func(t *testing.T) {
-		dynakube := buildTestDynakube()
-		clt := fake.NewClient(&dynakube)
+		dk := buildTestDynakube()
+		clt := fake.NewClient(&dk)
 
 		dynakubes, err := getAllDynakubesInNamespace(context.Background(), getNullLogger(t), clt, testNamespace)
 		require.NoError(t, err)
 		assert.Len(t, dynakubes, 1)
-		assert.Equal(t, dynakube.Name, dynakubes[0].Name)
+		assert.Equal(t, dk.Name, dynakubes[0].Name)
 	})
 
 	t.Run("getDynakube - only check one dynakube if set", func(t *testing.T) {
-		dynakube := buildTestDynakube()
-		clt := fake.NewClient(&dynakube)
+		dk := buildTestDynakube()
+		clt := fake.NewClient(&dk)
 		dynakubes, err := getDynakubes(context.Background(), getNullLogger(t), clt, testNamespace, testDynakube)
 		require.NoError(t, err)
 		assert.Len(t, dynakubes, 1)
@@ -41,8 +41,8 @@ func TestTroubleshootCommandBuilder(t *testing.T) {
 	})
 }
 
-func buildTestDynakube() dynatracev1beta2.DynaKube {
-	return dynatracev1beta2.DynaKube{
+func buildTestDynakube() dynakube.DynaKube {
+	return dynakube.DynaKube{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testDynakube,

--- a/cmd/troubleshoot/component.go
+++ b/cmd/troubleshoot/component.go
@@ -1,7 +1,7 @@
 package troubleshoot
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 )
 
 type component string
@@ -30,26 +30,26 @@ func (c component) SkipImageCheck(image string) bool {
 	return image == "" && c != componentCodeModules
 }
 
-func (c component) getImage(dynakube *dynatracev1beta2.DynaKube) (string, bool) {
-	if dynakube == nil {
+func (c component) getImage(dk *dynakube.DynaKube) (string, bool) {
+	if dk == nil {
 		return "", false
 	}
 
 	switch c {
 	case componentOneAgent:
-		if dynakube.CustomOneAgentImage() != "" {
-			return dynakube.CustomOneAgentImage(), true
+		if dk.CustomOneAgentImage() != "" {
+			return dk.CustomOneAgentImage(), true
 		}
 
-		return dynakube.OneAgentImage(), false
+		return dk.OneAgentImage(), false
 	case componentCodeModules:
-		return dynakube.CustomCodeModulesImage(), true
+		return dk.CustomCodeModulesImage(), true
 	case componentActiveGate:
-		if dynakube.CustomActiveGateImage() != "" {
-			return dynakube.CustomActiveGateImage(), true
+		if dk.CustomActiveGateImage() != "" {
+			return dk.CustomActiveGateImage(), true
 		}
 
-		return dynakube.ActiveGateImage(), false
+		return dk.ActiveGateImage(), false
 	}
 
 	return "", false

--- a/cmd/troubleshoot/dynakube.go
+++ b/cmd/troubleshoot/dynakube.go
@@ -54,21 +54,21 @@ func checkDynakube(ctx context.Context, baseLog logd.Logger, apiReader client.Re
 }
 
 func getSelectedDynakube(ctx context.Context, apiReader client.Reader, namespaceName, dynakubeName string) (dynakube.DynaKube, error) {
-	var dynaKube dynakube.DynaKube
+	var dk dynakube.DynaKube
 	err := apiReader.Get(
 		ctx,
 		client.ObjectKey{
 			Name:      dynakubeName,
 			Namespace: namespaceName,
 		},
-		&dynaKube,
+		&dk,
 	)
 
 	if err != nil {
 		return dynakube.DynaKube{}, determineSelectedDynakubeError(namespaceName, dynakubeName, err)
 	}
 
-	return dynaKube, nil
+	return dk, nil
 }
 
 func dynakubeNotValidMessage() string {

--- a/cmd/troubleshoot/dynakube_test.go
+++ b/cmd/troubleshoot/dynakube_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -169,27 +169,27 @@ func TestPullSecret(t *testing.T) {
 		require.NoErrorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), nil, *testNewSecretBuilder(testNamespace, testSecretName).dataAppend(".dockerconfigjson", testCustomPullSecretToken).build()), "custom pull secret does not have required tokens")
 	})
 	t.Run("custom pull secret does not have required tokens", func(t *testing.T) {
-		require.Errorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), &dynatracev1beta2.DynaKube{}, *testNewSecretBuilder(testNamespace, testSecretName).build()), "custom pull secret has required tokens")
+		require.Errorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), &dynakube.DynaKube{}, *testNewSecretBuilder(testNamespace, testSecretName).build()), "custom pull secret has required tokens")
 	})
 }
 
 func TestProxySecret(t *testing.T) {
 	t.Run("proxy secret exists", func(t *testing.T) {
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynatracev1beta2.ProxyKey).build()
+		dk := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynakube.ProxyKey).build()
 		clt := fake.NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(
-				dynakube,
+				dk,
 				testBuildNamespace(testNamespace),
-				testNewSecretBuilder(testNamespace, dynatracev1beta2.ProxyKey).build(),
+				testNewSecretBuilder(testNamespace, dynakube.ProxyKey).build(),
 			).
 			Build()
 
-		_, err := getProxyURL(context.Background(), clt, dynakube)
+		_, err := getProxyURL(context.Background(), clt, dk)
 		require.NoErrorf(t, err, "proxy secret not found")
 	})
 	t.Run("proxy secret does not exist", func(t *testing.T) {
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynatracev1beta2.ProxyKey).build()
+		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynakube.ProxyKey).build()
 		clt := fake.NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(
@@ -202,10 +202,10 @@ func TestProxySecret(t *testing.T) {
 		require.Errorf(t, err, "proxy secret found, should not exist")
 	})
 	t.Run("proxy secret has required tokens", func(t *testing.T) {
-		proxySecret := *testNewSecretBuilder(testNamespace, dynatracev1beta2.ProxyKey).
-			dataAppend(dynatracev1beta2.ProxyKey, testCustomPullSecretToken).
+		proxySecret := *testNewSecretBuilder(testNamespace, dynakube.ProxyKey).
+			dataAppend(dynakube.ProxyKey, testCustomPullSecretToken).
 			build()
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynatracev1beta2.ProxyKey).build()
+		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynakube.ProxyKey).build()
 		clt := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
 			dynakube,
 			&proxySecret).
@@ -215,7 +215,7 @@ func TestProxySecret(t *testing.T) {
 	})
 	t.Run("proxy secret does not have required tokens", func(t *testing.T) {
 		secret := *testNewSecretBuilder(testNamespace, testSecretName).build()
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynatracev1beta2.ProxyKey).build()
+		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynakube.ProxyKey).build()
 		clt := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
 			dynakube,
 			&secret).
@@ -226,15 +226,15 @@ func TestProxySecret(t *testing.T) {
 }
 
 type testDynaKubeBuilder struct {
-	dynakube *dynatracev1beta2.DynaKube
+	dynakube *dynakube.DynaKube
 }
 
-func testNewDynakubeBuilder(namespace string, dynakube string) *testDynaKubeBuilder {
+func testNewDynakubeBuilder(namespace string, dynakubeName string) *testDynaKubeBuilder {
 	return &testDynaKubeBuilder{
-		dynakube: &dynatracev1beta2.DynaKube{
+		dynakube: &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      dynakube,
+				Name:      dynakubeName,
 			},
 		},
 	}
@@ -259,7 +259,7 @@ func (builder *testDynaKubeBuilder) withCustomPullSecret(secretName string) *tes
 }
 
 func (builder *testDynaKubeBuilder) withProxy(proxyURL string) *testDynaKubeBuilder {
-	builder.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{
+	builder.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{
 		Value: proxyURL,
 	}
 
@@ -267,16 +267,16 @@ func (builder *testDynaKubeBuilder) withProxy(proxyURL string) *testDynaKubeBuil
 }
 
 func (builder *testDynaKubeBuilder) withProxySecret(secretName string) *testDynaKubeBuilder {
-	builder.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{
+	builder.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{
 		ValueFrom: secretName,
 	}
 
 	return builder
 }
 
-func (builder *testDynaKubeBuilder) withActiveGateCapability(capability dynatracev1beta2.CapabilityDisplayName) *testDynaKubeBuilder {
+func (builder *testDynaKubeBuilder) withActiveGateCapability(capability dynakube.CapabilityDisplayName) *testDynaKubeBuilder {
 	if builder.dynakube.Spec.ActiveGate.Capabilities == nil {
-		builder.dynakube.Spec.ActiveGate.Capabilities = make([]dynatracev1beta2.CapabilityDisplayName, 0)
+		builder.dynakube.Spec.ActiveGate.Capabilities = make([]dynakube.CapabilityDisplayName, 0)
 	}
 
 	builder.dynakube.Spec.ActiveGate.Capabilities = append(builder.dynakube.Spec.ActiveGate.Capabilities, capability)
@@ -293,8 +293,8 @@ func (builder *testDynaKubeBuilder) withActiveGateCustomImage(image string) *tes
 }
 
 func (builder *testDynaKubeBuilder) withCloudNativeFullStack() *testDynaKubeBuilder {
-	builder.dynakube.Spec.OneAgent.CloudNativeFullStack = &dynatracev1beta2.CloudNativeFullStackSpec{
-		HostInjectSpec: dynatracev1beta2.HostInjectSpec{},
+	builder.dynakube.Spec.OneAgent.CloudNativeFullStack = &dynakube.CloudNativeFullStackSpec{
+		HostInjectSpec: dynakube.HostInjectSpec{},
 	}
 	builder.dynakube.Status.OneAgent.ImageID = builder.dynakube.DefaultOneAgentImage(testVersion)
 
@@ -302,14 +302,14 @@ func (builder *testDynaKubeBuilder) withCloudNativeFullStack() *testDynaKubeBuil
 }
 
 func (builder *testDynaKubeBuilder) withClassicFullStack() *testDynaKubeBuilder {
-	builder.dynakube.Spec.OneAgent.ClassicFullStack = &dynatracev1beta2.HostInjectSpec{}
+	builder.dynakube.Spec.OneAgent.ClassicFullStack = &dynakube.HostInjectSpec{}
 	builder.dynakube.Status.OneAgent.ImageID = builder.dynakube.DefaultOneAgentImage(testVersion)
 
 	return builder
 }
 
 func (builder *testDynaKubeBuilder) withHostMonitoring() *testDynaKubeBuilder {
-	builder.dynakube.Spec.OneAgent.HostMonitoring = &dynatracev1beta2.HostInjectSpec{}
+	builder.dynakube.Spec.OneAgent.HostMonitoring = &dynakube.HostInjectSpec{}
 	builder.dynakube.Status.OneAgent.ImageID = builder.dynakube.DefaultOneAgentImage(testVersion)
 
 	return builder
@@ -319,7 +319,7 @@ func (builder *testDynaKubeBuilder) withClassicFullStackCustomImage(image string
 	if builder.dynakube.Spec.OneAgent.ClassicFullStack != nil {
 		builder.dynakube.Spec.OneAgent.ClassicFullStack.Image = image
 	} else {
-		builder.dynakube.Spec.OneAgent.ClassicFullStack = &dynatracev1beta2.HostInjectSpec{
+		builder.dynakube.Spec.OneAgent.ClassicFullStack = &dynakube.HostInjectSpec{
 			Image: image,
 		}
 	}
@@ -332,8 +332,8 @@ func (builder *testDynaKubeBuilder) withCloudNativeFullStackCustomImage(image st
 	if builder.dynakube.Spec.OneAgent.CloudNativeFullStack != nil {
 		builder.dynakube.Spec.OneAgent.CloudNativeFullStack.Image = image
 	} else {
-		builder.dynakube.Spec.OneAgent.CloudNativeFullStack = &dynatracev1beta2.CloudNativeFullStackSpec{
-			HostInjectSpec: dynatracev1beta2.HostInjectSpec{
+		builder.dynakube.Spec.OneAgent.CloudNativeFullStack = &dynakube.CloudNativeFullStackSpec{
+			HostInjectSpec: dynakube.HostInjectSpec{
 				Image: image,
 			},
 		}
@@ -347,7 +347,7 @@ func (builder *testDynaKubeBuilder) withHostMonitoringCustomImage(image string) 
 	if builder.dynakube.Spec.OneAgent.HostMonitoring != nil {
 		builder.dynakube.Spec.OneAgent.HostMonitoring.Image = image
 	} else {
-		builder.dynakube.Spec.OneAgent.HostMonitoring = &dynatracev1beta2.HostInjectSpec{
+		builder.dynakube.Spec.OneAgent.HostMonitoring = &dynakube.HostInjectSpec{
 			Image: image,
 		}
 	}
@@ -360,8 +360,8 @@ func (builder *testDynaKubeBuilder) withCloudNativeCodeModulesImage(image string
 	if builder.dynakube.Spec.OneAgent.CloudNativeFullStack != nil {
 		builder.dynakube.Spec.OneAgent.CloudNativeFullStack.CodeModulesImage = image
 	} else {
-		builder.dynakube.Spec.OneAgent.CloudNativeFullStack = &dynatracev1beta2.CloudNativeFullStackSpec{
-			AppInjectionSpec: dynatracev1beta2.AppInjectionSpec{
+		builder.dynakube.Spec.OneAgent.CloudNativeFullStack = &dynakube.CloudNativeFullStackSpec{
+			AppInjectionSpec: dynakube.AppInjectionSpec{
 				InitResources:    &corev1.ResourceRequirements{},
 				CodeModulesImage: image,
 			},
@@ -377,8 +377,8 @@ func (builder *testDynaKubeBuilder) withApplicationMonitoringCodeModulesImage(im
 		builder.dynakube.Spec.OneAgent.ApplicationMonitoring.CodeModulesImage = image
 		builder.dynakube.Spec.OneAgent.ApplicationMonitoring.UseCSIDriver = true
 	} else {
-		builder.dynakube.Spec.OneAgent.ApplicationMonitoring = &dynatracev1beta2.ApplicationMonitoringSpec{
-			AppInjectionSpec: dynatracev1beta2.AppInjectionSpec{
+		builder.dynakube.Spec.OneAgent.ApplicationMonitoring = &dynakube.ApplicationMonitoringSpec{
+			AppInjectionSpec: dynakube.AppInjectionSpec{
 				InitResources:    &corev1.ResourceRequirements{},
 				CodeModulesImage: image,
 			},
@@ -390,7 +390,7 @@ func (builder *testDynaKubeBuilder) withApplicationMonitoringCodeModulesImage(im
 	return builder
 }
 
-func (builder *testDynaKubeBuilder) build() *dynatracev1beta2.DynaKube {
+func (builder *testDynaKubeBuilder) build() *dynakube.DynaKube {
 	return builder.dynakube
 }
 

--- a/cmd/troubleshoot/dynakube_test.go
+++ b/cmd/troubleshoot/dynakube_test.go
@@ -79,11 +79,11 @@ func TestDynakube(t *testing.T) {
 
 func TestDynatraceSecret(t *testing.T) {
 	t.Run("Dynatrace secret exists", func(t *testing.T) {
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withTokens(testDynatraceSecret).build()
+		dk := testNewDynakubeBuilder(testNamespace, testDynakube).withTokens(testDynatraceSecret).build()
 		clt := fake.NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(
-				dynakube,
+				dk,
 				testBuildNamespace(testNamespace),
 				testNewSecretBuilder(testNamespace, testDynatraceSecret).build(),
 			).
@@ -102,67 +102,67 @@ func TestDynatraceSecret(t *testing.T) {
 			).
 			Build()
 
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).build()
-		_, err := checkIfDynatraceApiSecretHasApiToken(context.Background(), getNullLogger(t), clt, dynakube)
+		dk := testNewDynakubeBuilder(testNamespace, testDynakube).build()
+		_, err := checkIfDynatraceApiSecretHasApiToken(context.Background(), getNullLogger(t), clt, dk)
 		require.Errorf(t, err, "Dynatrace secret found")
 	})
 
 	t.Run("Dynatrace secret has apiToken token", func(t *testing.T) {
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withTokens(testDynatraceSecret).build()
+		dk := testNewDynakubeBuilder(testNamespace, testDynakube).withTokens(testDynatraceSecret).build()
 		clt := fake.NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(
-				dynakube,
+				dk,
 				testBuildNamespace(testNamespace),
 				testNewSecretBuilder(testNamespace, testDynatraceSecret).dataAppend("apiToken", testApiToken).dataAppend("paasToken", testPaasToken).build(),
 			).
 			Build()
 
-		_, err := checkIfDynatraceApiSecretHasApiToken(context.Background(), getNullLogger(t), clt, dynakube)
+		_, err := checkIfDynatraceApiSecretHasApiToken(context.Background(), getNullLogger(t), clt, dk)
 		require.NoErrorf(t, err, "Dynatrace secret does not have required tokens")
 	})
 	t.Run("Dynatrace secret - apiToken is missing", func(t *testing.T) {
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withTokens(testDynatraceSecret).build()
+		dk := testNewDynakubeBuilder(testNamespace, testDynakube).withTokens(testDynatraceSecret).build()
 		clt := fake.NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(
-				dynakube,
+				dk,
 				testBuildNamespace(testNamespace),
 				testNewSecretBuilder(testNamespace, testDynatraceSecret).dataAppend("paasToken", testPaasToken).build(),
 			).
 			Build()
 
-		_, err := checkIfDynatraceApiSecretHasApiToken(context.Background(), getNullLogger(t), clt, dynakube)
+		_, err := checkIfDynatraceApiSecretHasApiToken(context.Background(), getNullLogger(t), clt, dk)
 		require.Errorf(t, err, "Dynatrace secret does not have apiToken")
 	})
 }
 
 func TestPullSecret(t *testing.T) {
 	t.Run("custom pull secret exists", func(t *testing.T) {
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withCustomPullSecret(testSecretName).build()
+		dk := testNewDynakubeBuilder(testNamespace, testDynakube).withCustomPullSecret(testSecretName).build()
 		clt := fake.NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(
-				dynakube,
+				dk,
 				testBuildNamespace(testNamespace),
 				testNewSecretBuilder(testNamespace, testSecretName).build(),
 			).
 			Build()
 
-		_, err := checkPullSecretExists(context.Background(), getNullLogger(t), clt, dynakube)
+		_, err := checkPullSecretExists(context.Background(), getNullLogger(t), clt, dk)
 		require.NoErrorf(t, err, "custom pull secret not found")
 	})
 	t.Run("custom pull secret does not exist", func(t *testing.T) {
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withCustomPullSecret(testSecretName).build()
+		dk := testNewDynakubeBuilder(testNamespace, testDynakube).withCustomPullSecret(testSecretName).build()
 		clt := fake.NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(
-				dynakube,
+				dk,
 				testBuildNamespace(testNamespace),
 			).
 			Build()
 
-		_, err := checkPullSecretExists(context.Background(), getNullLogger(t), clt, dynakube)
+		_, err := checkPullSecretExists(context.Background(), getNullLogger(t), clt, dk)
 		require.Errorf(t, err, "custom pull secret found")
 	})
 	t.Run("custom pull secret has required tokens", func(t *testing.T) {
@@ -189,38 +189,38 @@ func TestProxySecret(t *testing.T) {
 		require.NoErrorf(t, err, "proxy secret not found")
 	})
 	t.Run("proxy secret does not exist", func(t *testing.T) {
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynakube.ProxyKey).build()
+		dk := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynakube.ProxyKey).build()
 		clt := fake.NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(
-				dynakube,
+				dk,
 				testBuildNamespace(testNamespace),
 			).
 			Build()
 
-		_, err := getProxyURL(context.Background(), clt, dynakube)
+		_, err := getProxyURL(context.Background(), clt, dk)
 		require.Errorf(t, err, "proxy secret found, should not exist")
 	})
 	t.Run("proxy secret has required tokens", func(t *testing.T) {
 		proxySecret := *testNewSecretBuilder(testNamespace, dynakube.ProxyKey).
 			dataAppend(dynakube.ProxyKey, testCustomPullSecretToken).
 			build()
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynakube.ProxyKey).build()
+		dk := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynakube.ProxyKey).build()
 		clt := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-			dynakube,
+			dk,
 			&proxySecret).
 			Build()
-		_, err := getProxyURL(context.Background(), clt, dynakube)
+		_, err := getProxyURL(context.Background(), clt, dk)
 		require.NoErrorf(t, err, "proxy secret does not have required tokens")
 	})
 	t.Run("proxy secret does not have required tokens", func(t *testing.T) {
 		secret := *testNewSecretBuilder(testNamespace, testSecretName).build()
-		dynakube := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynakube.ProxyKey).build()
+		dk := testNewDynakubeBuilder(testNamespace, testDynakube).withProxySecret(dynakube.ProxyKey).build()
 		clt := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-			dynakube,
+			dk,
 			&secret).
 			Build()
-		_, err := getProxyURL(context.Background(), clt, dynakube)
+		_, err := getProxyURL(context.Background(), clt, dk)
 		require.Errorf(t, err, "proxy secret has required tokens")
 	})
 }

--- a/cmd/troubleshoot/image.go
+++ b/cmd/troubleshoot/image.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -30,24 +30,24 @@ type Auths struct {
 
 type ImagePullFunc func(image string) error
 
-func verifyAllImagesAvailable(ctx context.Context, baseLog logd.Logger, keychain authn.Keychain, transport *http.Transport, dynakube *dynatracev1beta2.DynaKube) error {
+func verifyAllImagesAvailable(ctx context.Context, baseLog logd.Logger, keychain authn.Keychain, transport *http.Transport, dk *dynakube.DynaKube) error {
 	log := baseLog.WithName("imagepull")
 
 	imagePullFunc := CreateImagePullFunc(ctx, keychain, transport)
 
-	if dynakube.NeedsOneAgent() {
-		verifyImageIsAvailable(log, imagePullFunc, dynakube, componentOneAgent, false)
-		verifyImageIsAvailable(log, imagePullFunc, dynakube, componentCodeModules, true)
+	if dk.NeedsOneAgent() {
+		verifyImageIsAvailable(log, imagePullFunc, dk, componentOneAgent, false)
+		verifyImageIsAvailable(log, imagePullFunc, dk, componentCodeModules, true)
 	}
 
-	if dynakube.NeedsActiveGate() {
-		verifyImageIsAvailable(log, imagePullFunc, dynakube, componentActiveGate, false)
+	if dk.NeedsActiveGate() {
+		verifyImageIsAvailable(log, imagePullFunc, dk, componentActiveGate, false)
 	}
 
 	return nil
 }
 
-func verifyImageIsAvailable(log logd.Logger, pullImage ImagePullFunc, dynakube *dynatracev1beta2.DynaKube, comp component, proxyWarning bool) {
+func verifyImageIsAvailable(log logd.Logger, pullImage ImagePullFunc, dynakube *dynakube.DynaKube, comp component, proxyWarning bool) {
 	image, isCustomImage := comp.getImage(dynakube)
 	if comp.SkipImageCheck(image) {
 		logErrorf(log, "Unknown %s image", comp.String())

--- a/cmd/troubleshoot/image.go
+++ b/cmd/troubleshoot/image.go
@@ -47,8 +47,8 @@ func verifyAllImagesAvailable(ctx context.Context, baseLog logd.Logger, keychain
 	return nil
 }
 
-func verifyImageIsAvailable(log logd.Logger, pullImage ImagePullFunc, dynakube *dynakube.DynaKube, comp component, proxyWarning bool) {
-	image, isCustomImage := comp.getImage(dynakube)
+func verifyImageIsAvailable(log logd.Logger, pullImage ImagePullFunc, dk *dynakube.DynaKube, comp component, proxyWarning bool) {
+	image, isCustomImage := comp.getImage(dk)
 	if comp.SkipImageCheck(image) {
 		logErrorf(log, "Unknown %s image", comp.String())
 
@@ -64,7 +64,7 @@ func verifyImageIsAvailable(log logd.Logger, pullImage ImagePullFunc, dynakube *
 		return
 	}
 
-	if dynakube.HasProxy() && proxyWarning {
+	if dk.HasProxy() && proxyWarning {
 		logWarningf(log, "Proxy setting in Dynakube is ignored for %s image due to technical limitations.", componentName)
 	}
 

--- a/cmd/troubleshoot/image_test.go
+++ b/cmd/troubleshoot/image_test.go
@@ -91,26 +91,26 @@ func TestImagePullable(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		dynaKube     *dynakube.DynaKube
+		dk           *dynakube.DynaKube
 		component    component
 		proxyWarning bool
 	}{
 		// standard OneAgent images
 		{
 			name:         "Default CloudNative OneAgent image",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withCloudNativeFullStack().build(),
+			dk:           dynakubeBuilder(dockerServer.URL).withCloudNativeFullStack().build(),
 			component:    componentOneAgent,
 			proxyWarning: false,
 		},
 		{
 			name:         "Default ClassicFullstack OneAgent image",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withClassicFullStack().build(),
+			dk:           dynakubeBuilder(dockerServer.URL).withClassicFullStack().build(),
 			component:    componentOneAgent,
 			proxyWarning: false,
 		},
 		{
 			name:         "Default HostMonitoring OneAgent image",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withHostMonitoring().build(),
+			dk:           dynakubeBuilder(dockerServer.URL).withHostMonitoring().build(),
 			component:    componentOneAgent,
 			proxyWarning: false,
 		},
@@ -118,19 +118,19 @@ func TestImagePullable(t *testing.T) {
 		// custom OneAgent images
 		{
 			name:         "Custom CloudNative OneAgent image",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withCloudNativeFullStackCustomImage(server + "/" + testCustomOneAgentImage + ":" + testVersion).build(),
+			dk:           dynakubeBuilder(dockerServer.URL).withCloudNativeFullStackCustomImage(server + "/" + testCustomOneAgentImage + ":" + testVersion).build(),
 			component:    componentOneAgent,
 			proxyWarning: false,
 		},
 		{
 			name:         "Custom ClassicFullstack OneAgent image",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withClassicFullStackCustomImage(server + "/" + testCustomOneAgentImage + ":" + testVersion).build(),
+			dk:           dynakubeBuilder(dockerServer.URL).withClassicFullStackCustomImage(server + "/" + testCustomOneAgentImage + ":" + testVersion).build(),
 			component:    componentOneAgent,
 			proxyWarning: false,
 		},
 		{
 			name:         "Custom HostMonitoring OneAgent image",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withHostMonitoringCustomImage(server + "/" + testCustomOneAgentImage + ":" + testVersion).build(),
+			dk:           dynakubeBuilder(dockerServer.URL).withHostMonitoringCustomImage(server + "/" + testCustomOneAgentImage + ":" + testVersion).build(),
 			component:    componentOneAgent,
 			proxyWarning: false,
 		},
@@ -138,26 +138,26 @@ func TestImagePullable(t *testing.T) {
 		// OneAgent code modules images
 		{
 			name:         "Custom CloudNative CodeModulesImage",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withCloudNativeCodeModulesImage(server + "/" + testOneAgentCodeModulesImage + ":" + testVersion).build(),
+			dk:           dynakubeBuilder(dockerServer.URL).withCloudNativeCodeModulesImage(server + "/" + testOneAgentCodeModulesImage + ":" + testVersion).build(),
 			component:    componentCodeModules,
 			proxyWarning: true,
 		},
 		{
 			name:         "Custom ApplicationMonitoring CodeModulesImage",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withApplicationMonitoringCodeModulesImage(server + "/" + testOneAgentCodeModulesImage + ":" + testVersion).build(),
+			dk:           dynakubeBuilder(dockerServer.URL).withApplicationMonitoringCodeModulesImage(server + "/" + testOneAgentCodeModulesImage + ":" + testVersion).build(),
 			component:    componentCodeModules,
 			proxyWarning: true,
 		},
 		// Active Gate images
 		{
 			name:         "ActiveGate default image",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withActiveGateCapability(dynakube.RoutingCapability.DisplayName).build(),
+			dk:           dynakubeBuilder(dockerServer.URL).withActiveGateCapability(dynakube.RoutingCapability.DisplayName).build(),
 			component:    componentActiveGate,
 			proxyWarning: false,
 		},
 		{
 			name:         "ActiveGate custom image",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withActiveGateCustomImage(server + "/" + testActiveGateCustomImage + ":" + testVersion).build(),
+			dk:           dynakubeBuilder(dockerServer.URL).withActiveGateCustomImage(server + "/" + testActiveGateCustomImage + ":" + testVersion).build(),
 			component:    componentActiveGate,
 			proxyWarning: false,
 		},
@@ -168,12 +168,12 @@ func TestImagePullable(t *testing.T) {
 			logOutput := runWithTestLogger(func(log logd.Logger) {
 				ctx := context.Background()
 				clt := fake.NewClient(secret)
-				pullSecret, _ := checkDynakube(ctx, log, clt, test.dynaKube)
+				pullSecret, _ := checkDynakube(ctx, log, clt, test.dk)
 				keychain, _ := dockerkeychain.NewDockerKeychain(context.Background(), fake.NewClient(secret), pullSecret)
 
-				transport, _ := createTransport(ctx, clt, test.dynaKube, dockerServer.Client())
+				transport, _ := createTransport(ctx, clt, test.dk, dockerServer.Client())
 				pullImage := CreateImagePullFunc(ctx, keychain, transport)
-				verifyImageIsAvailable(log, pullImage, test.dynaKube, test.component, test.proxyWarning)
+				verifyImageIsAvailable(log, pullImage, test.dk, test.component, test.proxyWarning)
 			})
 
 			require.NotContains(t, logOutput, "failed")
@@ -192,54 +192,54 @@ func TestImageNotPullable(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		dynaKube  *dynakube.DynaKube
+		dk        *dynakube.DynaKube
 		component component
 	}{
 		{
 			name:      "OneAgent latest image for CloudNativeFullStack not available",
-			dynaKube:  dynakubeBuilder(dockerServer.URL).withCloudNativeFullStack().build(),
+			dk:        dynakubeBuilder(dockerServer.URL).withCloudNativeFullStack().build(),
 			component: componentOneAgent,
 		},
 		{
 			name:      "OneAgent CloudNativeFullStack non-existing custom image",
-			dynaKube:  dynakubeBuilder(dockerServer.URL).withCloudNativeFullStackCustomImage(server + "/foobar").build(),
+			dk:        dynakubeBuilder(dockerServer.URL).withCloudNativeFullStackCustomImage(server + "/foobar").build(),
 			component: componentOneAgent,
 		},
 		{
 			name:      "OneAgent latest image for ClassicFullStack not available",
-			dynaKube:  dynakubeBuilder(dockerServer.URL).withClassicFullStack().build(),
+			dk:        dynakubeBuilder(dockerServer.URL).withClassicFullStack().build(),
 			component: componentOneAgent,
 		},
 		{
 			name:      "OneAgent ClassicFullStack non-existing custom image",
-			dynaKube:  dynakubeBuilder(dockerServer.URL).withClassicFullStackCustomImage(server + "/foobar").build(),
+			dk:        dynakubeBuilder(dockerServer.URL).withClassicFullStackCustomImage(server + "/foobar").build(),
 			component: componentOneAgent,
 		},
 		{
 			name:      "OneAgent latest image for HostMonitoring not available",
-			dynaKube:  dynakubeBuilder(dockerServer.URL).withHostMonitoring().build(),
+			dk:        dynakubeBuilder(dockerServer.URL).withHostMonitoring().build(),
 			component: componentOneAgent,
 		},
 		{
 			name:      "OneAgent HostMonitoring non-existing custom image",
-			dynaKube:  dynakubeBuilder(dockerServer.URL).withHostMonitoringCustomImage(server + "/foobar").build(),
+			dk:        dynakubeBuilder(dockerServer.URL).withHostMonitoringCustomImage(server + "/foobar").build(),
 			component: componentOneAgent,
 		},
 		{
 			name:      "OneAgent HostMonitoring non-existing server",
-			dynaKube:  dynakubeBuilder(dockerServer.URL).withHostMonitoringCustomImage("myunknownserver.com/foobar/image").build(),
+			dk:        dynakubeBuilder(dockerServer.URL).withHostMonitoringCustomImage("myunknownserver.com/foobar/image").build(),
 			component: componentOneAgent,
 		},
 		{
 			name: "ActiveGate image",
-			dynaKube: dynakubeBuilder(dockerServer.URL).
+			dk: dynakubeBuilder(dockerServer.URL).
 				withActiveGateCapability(dynakube.RoutingCapability.DisplayName).
 				build(),
 			component: componentActiveGate,
 		},
 		{
 			name: "ActiveGate custom image",
-			dynaKube: dynakubeBuilder(dockerServer.URL).
+			dk: dynakubeBuilder(dockerServer.URL).
 				withActiveGateCustomImage(server + "/" + testActiveGateCustomImage).
 				withActiveGateCapability(dynakube.RoutingCapability.DisplayName).
 				build(),
@@ -247,7 +247,7 @@ func TestImageNotPullable(t *testing.T) {
 		},
 		{
 			name: "ActiveGate custom image non-existing server",
-			dynaKube: dynakubeBuilder(dockerServer.URL).
+			dk: dynakubeBuilder(dockerServer.URL).
 				withActiveGateCustomImage("myunknownserver.com/foobar/image").
 				withActiveGateCapability(dynakube.RoutingCapability.DisplayName).
 				build(),
@@ -260,12 +260,12 @@ func TestImageNotPullable(t *testing.T) {
 			logOutput := runWithTestLogger(func(log logd.Logger) {
 				ctx := context.Background()
 				clt := fake.NewClient(secret)
-				pullSecret, _ := checkDynakube(ctx, log, clt, test.dynaKube)
+				pullSecret, _ := checkDynakube(ctx, log, clt, test.dk)
 				keychain, _ := dockerkeychain.NewDockerKeychain(context.Background(), fake.NewClient(secret), pullSecret)
 
-				transport, _ := createTransport(ctx, clt, test.dynaKube, dockerServer.Client())
+				transport, _ := createTransport(ctx, clt, test.dk, dockerServer.Client())
 				pullImage := CreateImagePullFunc(ctx, keychain, transport)
-				verifyImageIsAvailable(log, pullImage, test.dynaKube, test.component, false)
+				verifyImageIsAvailable(log, pullImage, test.dk, test.component, false)
 			})
 
 			require.Contains(t, logOutput, "failed")
@@ -293,19 +293,19 @@ func TestOneAgentCodeModulesImageNotPullable(t *testing.T) {
 	defer dockerServer.Close()
 
 	t.Run("OneAgent code modules unreachable server", func(t *testing.T) {
-		dynakube := *testNewDynakubeBuilder(testNamespace, testDynakube).
+		dk := *testNewDynakubeBuilder(testNamespace, testDynakube).
 			withApiUrl(dockerServer.URL + "/api").
 			withCloudNativeCodeModulesImage("myunknownserver.com/myrepo/mymissingcodemodules").
 			build()
 		logOutput := runWithTestLogger(func(log logd.Logger) {
 			ctx := context.Background()
 			clt := fake.NewClient(secret)
-			pullSecret, _ := checkDynakube(ctx, log, clt, &dynakube)
+			pullSecret, _ := checkDynakube(ctx, log, clt, &dk)
 			keychain, _ := dockerkeychain.NewDockerKeychain(context.Background(), fake.NewClient(secret), pullSecret)
 
-			transport, _ := createTransport(ctx, clt, &dynakube, dockerServer.Client())
+			transport, _ := createTransport(ctx, clt, &dk, dockerServer.Client())
 			pullImage := CreateImagePullFunc(ctx, keychain, transport)
-			verifyImageIsAvailable(log, pullImage, &dynakube, componentCodeModules, true)
+			verifyImageIsAvailable(log, pullImage, &dk, componentCodeModules, true)
 		})
 		assert.Contains(t, logOutput, "failed")
 		assert.Contains(t, logOutput, "no such host")
@@ -313,7 +313,7 @@ func TestOneAgentCodeModulesImageNotPullable(t *testing.T) {
 	})
 
 	t.Run("OneAgent code modules image with unset image", func(t *testing.T) {
-		dynakube := *testNewDynakubeBuilder(testNamespace, testDynakube).
+		dk := *testNewDynakubeBuilder(testNamespace, testDynakube).
 			withApiUrl(dockerServer.URL + "/api").
 			withCloudNativeCodeModulesImage("").
 			build()
@@ -321,11 +321,11 @@ func TestOneAgentCodeModulesImageNotPullable(t *testing.T) {
 		logOutput := runWithTestLogger(func(log logd.Logger) {
 			ctx := context.Background()
 			clt := fake.NewClient(secret)
-			pullSecret, _ := checkDynakube(ctx, log, clt, &dynakube)
+			pullSecret, _ := checkDynakube(ctx, log, clt, &dk)
 			keychain, _ := dockerkeychain.NewDockerKeychain(context.Background(), fake.NewClient(secret), pullSecret)
-			transport, _ := createTransport(ctx, clt, &dynakube, dockerServer.Client())
+			transport, _ := createTransport(ctx, clt, &dk, dockerServer.Client())
 			pullImage := CreateImagePullFunc(ctx, keychain, transport)
-			verifyImageIsAvailable(log, pullImage, &dynakube, componentCodeModules, false)
+			verifyImageIsAvailable(log, pullImage, &dk, componentCodeModules, false)
 		})
 		assert.NotContains(t, logOutput, "Unknown OneAgentCodeModules image")
 	})

--- a/cmd/troubleshoot/image_test.go
+++ b/cmd/troubleshoot/image_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dtpullsecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/dockerkeychain"
@@ -79,10 +79,10 @@ func TestImagePullable(t *testing.T) {
 	dockerServer, secret, server, err := setupDockerMocker(
 		[]string{
 			"/v2/",
-			"/v2" + dynatracev1beta2.DefaultOneAgentImageRegistrySubPath + "/manifests/" + testVersion + "-raw",
+			"/v2" + dynakube.DefaultOneAgentImageRegistrySubPath + "/manifests/" + testVersion + "-raw",
 			"/v2/" + testCustomOneAgentImage + "/manifests/" + testVersion,
 			"/v2/" + testOneAgentCodeModulesImage + "/manifests/" + testVersion,
-			"/v2" + dynatracev1beta2.DefaultActiveGateImageRegistrySubPath + "/manifests/" + testVersion + "-raw",
+			"/v2" + dynakube.DefaultActiveGateImageRegistrySubPath + "/manifests/" + testVersion + "-raw",
 			"/v2/" + testActiveGateCustomImage + "/manifests/" + testVersion,
 		})
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestImagePullable(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		dynaKube     *dynatracev1beta2.DynaKube
+		dynaKube     *dynakube.DynaKube
 		component    component
 		proxyWarning bool
 	}{
@@ -151,7 +151,7 @@ func TestImagePullable(t *testing.T) {
 		// Active Gate images
 		{
 			name:         "ActiveGate default image",
-			dynaKube:     dynakubeBuilder(dockerServer.URL).withActiveGateCapability(dynatracev1beta2.RoutingCapability.DisplayName).build(),
+			dynaKube:     dynakubeBuilder(dockerServer.URL).withActiveGateCapability(dynakube.RoutingCapability.DisplayName).build(),
 			component:    componentActiveGate,
 			proxyWarning: false,
 		},
@@ -192,7 +192,7 @@ func TestImageNotPullable(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		dynaKube  *dynatracev1beta2.DynaKube
+		dynaKube  *dynakube.DynaKube
 		component component
 	}{
 		{
@@ -233,7 +233,7 @@ func TestImageNotPullable(t *testing.T) {
 		{
 			name: "ActiveGate image",
 			dynaKube: dynakubeBuilder(dockerServer.URL).
-				withActiveGateCapability(dynatracev1beta2.RoutingCapability.DisplayName).
+				withActiveGateCapability(dynakube.RoutingCapability.DisplayName).
 				build(),
 			component: componentActiveGate,
 		},
@@ -241,7 +241,7 @@ func TestImageNotPullable(t *testing.T) {
 			name: "ActiveGate custom image",
 			dynaKube: dynakubeBuilder(dockerServer.URL).
 				withActiveGateCustomImage(server + "/" + testActiveGateCustomImage).
-				withActiveGateCapability(dynatracev1beta2.RoutingCapability.DisplayName).
+				withActiveGateCapability(dynakube.RoutingCapability.DisplayName).
 				build(),
 			component: componentActiveGate,
 		},
@@ -249,7 +249,7 @@ func TestImageNotPullable(t *testing.T) {
 			name: "ActiveGate custom image non-existing server",
 			dynaKube: dynakubeBuilder(dockerServer.URL).
 				withActiveGateCustomImage("myunknownserver.com/foobar/image").
-				withActiveGateCapability(dynatracev1beta2.RoutingCapability.DisplayName).
+				withActiveGateCapability(dynakube.RoutingCapability.DisplayName).
 				build(),
 			component: componentActiveGate,
 		},

--- a/cmd/troubleshoot/proxy.go
+++ b/cmd/troubleshoot/proxy.go
@@ -3,13 +3,13 @@ package troubleshoot
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"golang.org/x/net/http/httpproxy"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func checkProxySettings(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, dynakube *dynatracev1beta2.DynaKube) error {
+func checkProxySettings(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, dk *dynakube.DynaKube) error {
 	log := baseLog.WithName("proxy")
 
 	var proxyURL string
@@ -17,7 +17,7 @@ func checkProxySettings(ctx context.Context, baseLog logd.Logger, apiReader clie
 	logNewCheckf(log, "Analyzing proxy settings ...")
 
 	proxySettingsAvailable := false
-	if dynakube.HasProxy() {
+	if dk.HasProxy() {
 		proxySettingsAvailable = true
 
 		logInfof(log, "Reminder: Proxy settings in the Dynakube do not apply to pulling of pod images. Please set your proxy on accordingly on node level.")
@@ -25,7 +25,7 @@ func checkProxySettings(ctx context.Context, baseLog logd.Logger, apiReader clie
 
 		var err error
 
-		proxyURL, err = getProxyURL(ctx, apiReader, dynakube)
+		proxyURL, err = getProxyURL(ctx, apiReader, dk)
 		if err != nil {
 			logErrorf(log, "Unexpected error when reading proxy settings from Dynakube: %v", err)
 
@@ -84,10 +84,10 @@ func getEnvProxySettings() *httpproxy.Config {
 	return nil
 }
 
-func getProxyURL(ctx context.Context, apiReader client.Reader, dynakube *dynatracev1beta2.DynaKube) (string, error) {
-	if !dynakube.HasProxy() {
+func getProxyURL(ctx context.Context, apiReader client.Reader, dk *dynakube.DynaKube) (string, error) {
+	if !dk.HasProxy() {
 		return "", nil
 	}
 
-	return dynakube.Proxy(ctx, apiReader)
+	return dk.Proxy(ctx, apiReader)
 }

--- a/cmd/troubleshoot/proxy_test.go
+++ b/cmd/troubleshoot/proxy_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,7 +18,7 @@ func TestCheckProxySettings(t *testing.T) {
 		t.Setenv("HTTPS_PROXY", "")
 
 		logOutput := runWithTestLogger(func(logger logd.Logger) {
-			checkProxySettings(context.Background(), logger, nil, &dynatracev1beta2.DynaKube{})
+			checkProxySettings(context.Background(), logger, nil, &dynakube.DynaKube{})
 		})
 
 		require.NotContains(t, logOutput, "Unexpected error")
@@ -32,7 +32,7 @@ func TestCheckProxySettings(t *testing.T) {
 		t.Setenv("HTTPS_PROXY", "")
 
 		logOutput := runWithTestLogger(func(logger logd.Logger) {
-			checkProxySettings(context.Background(), logger, nil, &dynatracev1beta2.DynaKube{})
+			checkProxySettings(context.Background(), logger, nil, &dynakube.DynaKube{})
 		})
 
 		require.NotContains(t, logOutput, "Unexpected error")
@@ -46,7 +46,7 @@ func TestCheckProxySettings(t *testing.T) {
 		t.Setenv("HTTPS_PROXY", "foobar:1234")
 
 		logOutput := runWithTestLogger(func(logger logd.Logger) {
-			checkProxySettings(context.Background(), logger, nil, &dynatracev1beta2.DynaKube{})
+			checkProxySettings(context.Background(), logger, nil, &dynakube.DynaKube{})
 		})
 
 		require.NotContains(t, logOutput, "Unexpected error")
@@ -59,12 +59,12 @@ func TestCheckProxySettings(t *testing.T) {
 		t.Setenv("HTTP_PROXY", "")
 		t.Setenv("HTTPS_PROXY", "")
 
-		dynakube := *testNewDynakubeBuilder(testNamespace, testDynakube).
+		dk := *testNewDynakubeBuilder(testNamespace, testDynakube).
 			withProxy("http://foobar:1234").
 			build()
 
 		logOutput := runWithTestLogger(func(logger logd.Logger) {
-			checkProxySettings(context.Background(), logger, nil, &dynakube)
+			checkProxySettings(context.Background(), logger, nil, &dk)
 		})
 
 		require.NotContains(t, logOutput, "Unexpected error")
@@ -78,7 +78,7 @@ func TestCheckProxySettings(t *testing.T) {
 		t.Setenv("HTTPS_PROXY", "")
 
 		proxySecret := testNewSecretBuilder(testNamespace, testSecretName)
-		proxySecret.dataAppend(dynatracev1beta2.ProxyKey, "foobar:1234")
+		proxySecret.dataAppend(dynakube.ProxyKey, "foobar:1234")
 
 		clt := fake.NewClientBuilder().
 			WithScheme(scheme.Scheme).
@@ -107,12 +107,12 @@ func TestCheckProxySettings(t *testing.T) {
 		t.Setenv("HTTP_PROXY", "foobar:1234")
 		t.Setenv("HTTPS_PROXY", "foobar:1234")
 
-		dynakube := *testNewDynakubeBuilder(testNamespace, testDynakube).
+		dk := *testNewDynakubeBuilder(testNamespace, testDynakube).
 			withProxy("http://foobar:1234").
 			build()
 
 		logOutput := runWithTestLogger(func(logger logd.Logger) {
-			checkProxySettings(context.Background(), logger, nil, &dynakube)
+			checkProxySettings(context.Background(), logger, nil, &dk)
 		})
 
 		require.NotContains(t, logOutput, "Unexpected error")

--- a/cmd/troubleshoot/proxy_test.go
+++ b/cmd/troubleshoot/proxy_test.go
@@ -89,12 +89,12 @@ func TestCheckProxySettings(t *testing.T) {
 			).
 			Build()
 
-		dynakube := *testNewDynakubeBuilder(testNamespace, testDynakube).
+		dk := *testNewDynakubeBuilder(testNamespace, testDynakube).
 			withProxySecret(testSecretName).
 			build()
 
 		logOutput := runWithTestLogger(func(logger logd.Logger) {
-			checkProxySettings(context.Background(), logger, clt, &dynakube)
+			checkProxySettings(context.Background(), logger, clt, &dk)
 		})
 
 		require.NotContains(t, logOutput, "Unexpected error")

--- a/cmd/webhook/builder.go
+++ b/cmd/webhook/builder.go
@@ -8,7 +8,7 @@ import (
 	cmdManager "github.com/Dynatrace/dynatrace-operator/cmd/manager"
 	dynakubev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
 	dynakubev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
-	dynatracev1beta2validation "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube/validation"
+	dynakubev1beta2validation "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube/validation"
 	dynakubev1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtotel"
@@ -161,7 +161,7 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 			return err
 		}
 
-		dkv1beta2Validator := dynatracev1beta2validation.New(webhookManager.GetAPIReader(), webhookManager.GetConfig())
+		dkv1beta2Validator := dynakubev1beta2validation.New(webhookManager.GetAPIReader(), webhookManager.GetConfig())
 
 		err = dynakubev1beta2.SetupWebhookWithManager(webhookManager, dkv1beta2Validator)
 		if err != nil {

--- a/pkg/api/scheme/scheme.go
+++ b/pkg/api/scheme/scheme.go
@@ -17,13 +17,13 @@ limitations under the License.
 package scheme
 
 import (
-	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
 	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
-	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1"
 	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2"
 	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
-	dynatracev1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3"
 	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,10 +38,10 @@ var Scheme = k8sruntime.NewScheme()
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
-	utilruntime.Must(dynatracev1alpha1.AddToScheme(Scheme))
-	utilruntime.Must(dynatracev1beta1.AddToScheme(Scheme))
-	utilruntime.Must(dynatracev1beta2.AddToScheme(Scheme))
-	utilruntime.Must(dynatracev1beta3.AddToScheme(Scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(Scheme))
+	utilruntime.Must(v1beta1.AddToScheme(Scheme))
+	utilruntime.Must(v1beta2.AddToScheme(Scheme))
+	utilruntime.Must(v1beta3.AddToScheme(Scheme))
 	utilruntime.Must(istiov1beta1.AddToScheme(Scheme))
 	utilruntime.Must(corev1.AddToScheme(Scheme))
 	utilruntime.Must(apiv1.AddToScheme(Scheme))

--- a/pkg/api/v1beta1/dynakube/feature_flags_test.go
+++ b/pkg/api/v1beta1/dynakube/feature_flags_test.go
@@ -58,7 +58,7 @@ func TestCreateDynakubeWithAnnotation(t *testing.T) {
 func testDeprecateDisableAnnotation(t *testing.T,
 	newAnnotation string,
 	deprecatedAnnotation string,
-	propertyFunction func(dynakube DynaKube) bool) {
+	propertyFunction func(dk DynaKube) bool) {
 	// New annotation works
 	dk := createDynakubeWithAnnotation(newAnnotation, "false")
 

--- a/pkg/api/v1beta1/dynakube/feature_flags_test.go
+++ b/pkg/api/v1beta1/dynakube/feature_flags_test.go
@@ -12,47 +12,47 @@ import (
 const testNamespace = "test-namespace"
 
 func createDynakubeWithAnnotation(keyValues ...string) DynaKube {
-	dynakube := DynaKube{
+	dk := DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},
 		},
 	}
 
 	for i := 0; i < len(keyValues); i += 2 {
-		dynakube.Annotations[keyValues[i]] = keyValues[i+1]
+		dk.Annotations[keyValues[i]] = keyValues[i+1]
 	}
 
-	return dynakube
+	return dk
 }
 
 func createDynakubeEmptyDynakube() DynaKube {
-	dynakube := DynaKube{
+	dk := DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},
 		},
 	}
 
-	return dynakube
+	return dk
 }
 
 func TestCreateDynakubeWithAnnotation(t *testing.T) {
-	dynakube := createDynakubeWithAnnotation("test", "true")
+	dk := createDynakubeWithAnnotation("test", "true")
 
-	assert.Contains(t, dynakube.Annotations, "test")
-	assert.Equal(t, "true", dynakube.Annotations["test"])
+	assert.Contains(t, dk.Annotations, "test")
+	assert.Equal(t, "true", dk.Annotations["test"])
 
-	dynakube = createDynakubeWithAnnotation("other test", "false")
+	dk = createDynakubeWithAnnotation("other test", "false")
 
-	assert.Contains(t, dynakube.Annotations, "other test")
-	assert.Equal(t, "false", dynakube.Annotations["other test"])
-	assert.NotContains(t, dynakube.Annotations, "test")
+	assert.Contains(t, dk.Annotations, "other test")
+	assert.Equal(t, "false", dk.Annotations["other test"])
+	assert.NotContains(t, dk.Annotations, "test")
 
-	dynakube = createDynakubeWithAnnotation("test", "true", "other test", "false")
+	dk = createDynakubeWithAnnotation("test", "true", "other test", "false")
 
-	assert.Contains(t, dynakube.Annotations, "other test")
-	assert.Equal(t, "false", dynakube.Annotations["other test"])
-	assert.Contains(t, dynakube.Annotations, "test")
-	assert.Equal(t, "true", dynakube.Annotations["test"])
+	assert.Contains(t, dk.Annotations, "other test")
+	assert.Equal(t, "false", dk.Annotations["other test"])
+	assert.Contains(t, dk.Annotations, "test")
+	assert.Equal(t, "true", dk.Annotations["test"])
 }
 
 func testDeprecateDisableAnnotation(t *testing.T,
@@ -60,40 +60,40 @@ func testDeprecateDisableAnnotation(t *testing.T,
 	deprecatedAnnotation string,
 	propertyFunction func(dynakube DynaKube) bool) {
 	// New annotation works
-	dynakube := createDynakubeWithAnnotation(newAnnotation, "false")
+	dk := createDynakubeWithAnnotation(newAnnotation, "false")
 
-	assert.True(t, propertyFunction(dynakube))
+	assert.True(t, propertyFunction(dk))
 
-	dynakube = createDynakubeWithAnnotation(newAnnotation, "true")
+	dk = createDynakubeWithAnnotation(newAnnotation, "true")
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 
 	// Old annotation works
-	dynakube = createDynakubeWithAnnotation(deprecatedAnnotation, "true")
+	dk = createDynakubeWithAnnotation(deprecatedAnnotation, "true")
 
-	assert.True(t, propertyFunction(dynakube))
+	assert.True(t, propertyFunction(dk))
 
-	dynakube = createDynakubeWithAnnotation(deprecatedAnnotation, "false")
+	dk = createDynakubeWithAnnotation(deprecatedAnnotation, "false")
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 
 	// New annotation takes precedent
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		newAnnotation, "true",
 		deprecatedAnnotation, "true")
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		newAnnotation, "false",
 		deprecatedAnnotation, "false")
 
-	assert.True(t, propertyFunction(dynakube))
+	assert.True(t, propertyFunction(dk))
 
 	// Default is false
-	dynakube = createDynakubeWithAnnotation()
+	dk = createDynakubeWithAnnotation()
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 }
 
 func TestDeprecatedDisableAnnotations(t *testing.T) {
@@ -101,58 +101,58 @@ func TestDeprecatedDisableAnnotations(t *testing.T) {
 		testDeprecateDisableAnnotation(t,
 			AnnotationFeatureActiveGateUpdates,
 			AnnotationFeatureDisableActiveGateUpdates,
-			func(dynakube DynaKube) bool {
-				return dynakube.FeatureDisableActiveGateUpdates()
+			func(dk DynaKube) bool {
+				return dk.FeatureDisableActiveGateUpdates()
 			})
 	})
 	t.Run(AnnotationFeatureMetadataEnrichment, func(t *testing.T) {
 		testDeprecateDisableAnnotation(t,
 			AnnotationFeatureMetadataEnrichment,
 			AnnotationFeatureDisableMetadataEnrichment,
-			func(dynakube DynaKube) bool {
-				return dynakube.FeatureDisableMetadataEnrichment()
+			func(dk DynaKube) bool {
+				return dk.FeatureDisableMetadataEnrichment()
 			})
 	})
 }
 
 func TestDeprecatedEnableAnnotations(t *testing.T) {
-	dynakube := createDynakubeWithAnnotation(AnnotationInjectionFailurePolicy, "fail")
-	assert.Equal(t, "fail", dynakube.FeatureInjectionFailurePolicy())
+	dk := createDynakubeWithAnnotation(AnnotationInjectionFailurePolicy, "fail")
+	assert.Equal(t, "fail", dk.FeatureInjectionFailurePolicy())
 }
 
 func TestMaxMountAttempts(t *testing.T) {
-	dynakube := createDynakubeWithAnnotation(
+	dk := createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "5")
 
-	assert.Equal(t, 5, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, 5, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "3")
 
-	assert.Equal(t, 3, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, 3, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation()
+	dk = createDynakubeWithAnnotation()
 
-	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "a")
 
-	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "-5")
 
-	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dk.FeatureMaxFailedCsiMountAttempts())
 }
 
 func TestDynaKube_FeatureIgnoredNamespaces(t *testing.T) {
-	dynakube := DynaKube{
+	dk := DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 		},
 	}
-	ignoredNamespaces := dynakube.getDefaultIgnoredNamespaces()
+	ignoredNamespaces := dk.getDefaultIgnoredNamespaces()
 	dynakubeNamespaceMatches := false
 
 	for _, namespace := range ignoredNamespaces {
@@ -160,7 +160,7 @@ func TestDynaKube_FeatureIgnoredNamespaces(t *testing.T) {
 
 		require.NoError(t, err)
 
-		match := regex.MatchString(dynakube.Namespace)
+		match := regex.MatchString(dk.Namespace)
 
 		if match {
 			dynakubeNamespaceMatches = true
@@ -171,19 +171,19 @@ func TestDynaKube_FeatureIgnoredNamespaces(t *testing.T) {
 }
 
 func TestDefaultEnabledFeatureFlags(t *testing.T) {
-	dynakube := createDynakubeEmptyDynakube()
+	dk := createDynakubeEmptyDynakube()
 
-	assert.True(t, dynakube.FeatureAutomaticKubernetesApiMonitoring())
-	assert.True(t, dynakube.FeatureAutomaticInjection())
-	assert.Equal(t, "silent", dynakube.FeatureInjectionFailurePolicy())
+	assert.True(t, dk.FeatureAutomaticKubernetesApiMonitoring())
+	assert.True(t, dk.FeatureAutomaticInjection())
+	assert.Equal(t, "silent", dk.FeatureInjectionFailurePolicy())
 
-	assert.False(t, dynakube.FeatureDisableActiveGateUpdates())
-	assert.False(t, dynakube.FeatureDisableMetadataEnrichment())
-	assert.False(t, dynakube.FeatureLabelVersionDetection())
+	assert.False(t, dk.FeatureDisableActiveGateUpdates())
+	assert.False(t, dk.FeatureDisableMetadataEnrichment())
+	assert.False(t, dk.FeatureLabelVersionDetection())
 }
 
 func TestInjectionFailurePolicy(t *testing.T) {
-	dynakube := createDynakubeEmptyDynakube()
+	dk := createDynakubeEmptyDynakube()
 
 	modes := map[string]string{
 		failPhrase:   failPhrase,
@@ -191,33 +191,33 @@ func TestInjectionFailurePolicy(t *testing.T) {
 	}
 	for configuredMode, expectedMode := range modes {
 		t.Run(`injection failure policy: `+configuredMode, func(t *testing.T) {
-			dynakube.Annotations[AnnotationInjectionFailurePolicy] = configuredMode
+			dk.Annotations[AnnotationInjectionFailurePolicy] = configuredMode
 
-			assert.Equal(t, expectedMode, dynakube.FeatureInjectionFailurePolicy())
+			assert.Equal(t, expectedMode, dk.FeatureInjectionFailurePolicy())
 		})
 	}
 }
 
 func TestAgentInitialConnectRetry(t *testing.T) {
 	t.Run("default => not set", func(t *testing.T) {
-		dynakube := createDynakubeEmptyDynakube()
+		dk := createDynakubeEmptyDynakube()
 
-		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		initialRetry := dk.FeatureAgentInitialConnectRetry()
 		require.Equal(t, -1, initialRetry)
 	})
 	t.Run("istio default => set", func(t *testing.T) {
-		dynakube := createDynakubeEmptyDynakube()
-		dynakube.Spec.EnableIstio = true
+		dk := createDynakubeEmptyDynakube()
+		dk.Spec.EnableIstio = true
 
-		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		initialRetry := dk.FeatureAgentInitialConnectRetry()
 		require.Equal(t, IstioDefaultOneAgentInitialConnectRetry, initialRetry)
 	})
 	t.Run("istio default can be overruled", func(t *testing.T) {
-		dynakube := createDynakubeEmptyDynakube()
-		dynakube.Spec.EnableIstio = true
-		dynakube.Annotations[AnnotationFeatureOneAgentInitialConnectRetry] = "5"
+		dk := createDynakubeEmptyDynakube()
+		dk.Spec.EnableIstio = true
+		dk.Annotations[AnnotationFeatureOneAgentInitialConnectRetry] = "5"
 
-		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		initialRetry := dk.FeatureAgentInitialConnectRetry()
 		require.Equal(t, 5, initialRetry)
 	})
 }

--- a/pkg/api/v1beta1/dynakube/properties_test.go
+++ b/pkg/api/v1beta1/dynakube/properties_test.go
@@ -53,9 +53,9 @@ func TestDefaultActiveGateImage(t *testing.T) {
 	t.Run(`ActiveGateImage truncates build date`, func(t *testing.T) {
 		version := "1.239.14.20220325-164521"
 		expectedImage := "test-endpoint/linux/activegate:1.239.14-raw"
-		dynakube := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
 
-		assert.Equal(t, expectedImage, dynakube.DefaultActiveGateImage(version))
+		assert.Equal(t, expectedImage, dk.DefaultActiveGateImage(version))
 	})
 }
 
@@ -125,9 +125,9 @@ func TestDefaultOneAgentImage(t *testing.T) {
 	t.Run(`OneAgentImage with custom version truncates build date`, func(t *testing.T) {
 		version := "1.239.14.20220325-164521"
 		expectedImage := "test-endpoint/linux/oneagent:1.239.14-raw"
-		dynakube := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
 
-		assert.Equal(t, expectedImage, dynakube.DefaultOneAgentImage(version))
+		assert.Equal(t, expectedImage, dk.DefaultOneAgentImage(version))
 	})
 }
 
@@ -145,12 +145,12 @@ func TestCustomOneAgentImage(t *testing.T) {
 }
 
 func TestOneAgentDaemonsetName(t *testing.T) {
-	instance := &DynaKube{
+	dk := &DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testName,
 		},
 	}
-	assert.Equal(t, "test-name-oneagent", instance.OneAgentDaemonsetName())
+	assert.Equal(t, "test-name-oneagent", dk.OneAgentDaemonsetName())
 }
 
 func TestTokens(t *testing.T) {
@@ -310,12 +310,12 @@ func TestGetRawImageTag(t *testing.T) {
 
 func TestIsOneAgentPrivileged(t *testing.T) {
 	t.Run("is false by default", func(t *testing.T) {
-		dynakube := DynaKube{}
+		dk := DynaKube{}
 
-		assert.False(t, dynakube.FeatureOneAgentPrivileged())
+		assert.False(t, dk.FeatureOneAgentPrivileged())
 	})
 	t.Run("is true when annotation is set to true", func(t *testing.T) {
-		dynakube := DynaKube{
+		dk := DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					AnnotationFeatureRunOneAgentContainerPrivileged: "true",
@@ -323,10 +323,10 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 			},
 		}
 
-		assert.True(t, dynakube.FeatureOneAgentPrivileged())
+		assert.True(t, dk.FeatureOneAgentPrivileged())
 	})
 	t.Run("is false when annotation is set to false", func(t *testing.T) {
-		dynakube := DynaKube{
+		dk := DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					AnnotationFeatureRunOneAgentContainerPrivileged: "false",
@@ -334,7 +334,7 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 			},
 		}
 
-		assert.False(t, dynakube.FeatureOneAgentPrivileged())
+		assert.False(t, dk.FeatureOneAgentPrivileged())
 	})
 }
 

--- a/pkg/api/v1beta2/dynakube/feature_flags_test.go
+++ b/pkg/api/v1beta2/dynakube/feature_flags_test.go
@@ -10,88 +10,88 @@ import (
 )
 
 func createDynakubeWithAnnotation(keyValues ...string) DynaKube {
-	dynakube := DynaKube{
+	dk := DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},
 		},
 	}
 
 	for i := 0; i < len(keyValues); i += 2 {
-		dynakube.Annotations[keyValues[i]] = keyValues[i+1]
+		dk.Annotations[keyValues[i]] = keyValues[i+1]
 	}
 
-	return dynakube
+	return dk
 }
 
 func createDynakubeEmptyDynakube() DynaKube {
-	dynakube := DynaKube{
+	dk := DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},
 		},
 	}
 
-	return dynakube
+	return dk
 }
 
 func TestCreateDynakubeWithAnnotation(t *testing.T) {
-	dynakube := createDynakubeWithAnnotation("test", "true")
+	dk := createDynakubeWithAnnotation("test", "true")
 
-	assert.Contains(t, dynakube.Annotations, "test")
-	assert.Equal(t, "true", dynakube.Annotations["test"])
+	assert.Contains(t, dk.Annotations, "test")
+	assert.Equal(t, "true", dk.Annotations["test"])
 
-	dynakube = createDynakubeWithAnnotation("other test", "false")
+	dk = createDynakubeWithAnnotation("other test", "false")
 
-	assert.Contains(t, dynakube.Annotations, "other test")
-	assert.Equal(t, "false", dynakube.Annotations["other test"])
-	assert.NotContains(t, dynakube.Annotations, "test")
+	assert.Contains(t, dk.Annotations, "other test")
+	assert.Equal(t, "false", dk.Annotations["other test"])
+	assert.NotContains(t, dk.Annotations, "test")
 
-	dynakube = createDynakubeWithAnnotation("test", "true", "other test", "false")
+	dk = createDynakubeWithAnnotation("test", "true", "other test", "false")
 
-	assert.Contains(t, dynakube.Annotations, "other test")
-	assert.Equal(t, "false", dynakube.Annotations["other test"])
-	assert.Contains(t, dynakube.Annotations, "test")
-	assert.Equal(t, "true", dynakube.Annotations["test"])
+	assert.Contains(t, dk.Annotations, "other test")
+	assert.Equal(t, "false", dk.Annotations["other test"])
+	assert.Contains(t, dk.Annotations, "test")
+	assert.Equal(t, "true", dk.Annotations["test"])
 }
 
 func testDeprecateDisableAnnotation(t *testing.T,
 	newAnnotation string,
 	deprecatedAnnotation string,
-	propertyFunction func(dynakube DynaKube) bool) {
+	propertyFunction func(dk DynaKube) bool) {
 	// New annotation works
-	dynakube := createDynakubeWithAnnotation(newAnnotation, "false")
+	dk := createDynakubeWithAnnotation(newAnnotation, "false")
 
-	assert.True(t, propertyFunction(dynakube))
+	assert.True(t, propertyFunction(dk))
 
-	dynakube = createDynakubeWithAnnotation(newAnnotation, "true")
+	dk = createDynakubeWithAnnotation(newAnnotation, "true")
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 
 	// Old annotation works
-	dynakube = createDynakubeWithAnnotation(deprecatedAnnotation, "true")
+	dk = createDynakubeWithAnnotation(deprecatedAnnotation, "true")
 
-	assert.True(t, propertyFunction(dynakube))
+	assert.True(t, propertyFunction(dk))
 
-	dynakube = createDynakubeWithAnnotation(deprecatedAnnotation, "false")
+	dk = createDynakubeWithAnnotation(deprecatedAnnotation, "false")
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 
 	// New annotation takes precedent
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		newAnnotation, "true",
 		deprecatedAnnotation, "true")
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		newAnnotation, "false",
 		deprecatedAnnotation, "false")
 
-	assert.True(t, propertyFunction(dynakube))
+	assert.True(t, propertyFunction(dk))
 
 	// Default is false
-	dynakube = createDynakubeWithAnnotation()
+	dk = createDynakubeWithAnnotation()
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 }
 
 func TestDeprecatedDisableAnnotations(t *testing.T) {
@@ -99,50 +99,50 @@ func TestDeprecatedDisableAnnotations(t *testing.T) {
 		testDeprecateDisableAnnotation(t,
 			AnnotationFeatureActiveGateUpdates,
 			AnnotationFeatureDisableActiveGateUpdates,
-			func(dynakube DynaKube) bool {
-				return dynakube.FeatureDisableActiveGateUpdates()
+			func(dk DynaKube) bool {
+				return dk.FeatureDisableActiveGateUpdates()
 			})
 	})
 }
 
 func TestDeprecatedEnableAnnotations(t *testing.T) {
-	dynakube := createDynakubeWithAnnotation(AnnotationInjectionFailurePolicy, "fail")
-	assert.Equal(t, "fail", dynakube.FeatureInjectionFailurePolicy())
+	dk := createDynakubeWithAnnotation(AnnotationInjectionFailurePolicy, "fail")
+	assert.Equal(t, "fail", dk.FeatureInjectionFailurePolicy())
 }
 
 func TestMaxMountAttempts(t *testing.T) {
-	dynakube := createDynakubeWithAnnotation(
+	dk := createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "5")
 
-	assert.Equal(t, 5, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, 5, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "3")
 
-	assert.Equal(t, 3, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, 3, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation()
+	dk = createDynakubeWithAnnotation()
 
-	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "a")
 
-	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "-5")
 
-	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dk.FeatureMaxFailedCsiMountAttempts())
 }
 
 func TestDynaKube_FeatureIgnoredNamespaces(t *testing.T) {
-	dynakube := DynaKube{
+	dk := DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
 		},
 	}
-	ignoredNamespaces := dynakube.getDefaultIgnoredNamespaces()
+	ignoredNamespaces := dk.getDefaultIgnoredNamespaces()
 	dynakubeNamespaceMatches := false
 
 	for _, namespace := range ignoredNamespaces {
@@ -150,7 +150,7 @@ func TestDynaKube_FeatureIgnoredNamespaces(t *testing.T) {
 
 		require.NoError(t, err)
 
-		match := regex.MatchString(dynakube.Namespace)
+		match := regex.MatchString(dk.Namespace)
 
 		if match {
 			dynakubeNamespaceMatches = true
@@ -161,18 +161,18 @@ func TestDynaKube_FeatureIgnoredNamespaces(t *testing.T) {
 }
 
 func TestDefaultEnabledFeatureFlags(t *testing.T) {
-	dynakube := createDynakubeEmptyDynakube()
+	dk := createDynakubeEmptyDynakube()
 
-	assert.True(t, dynakube.FeatureAutomaticKubernetesApiMonitoring())
-	assert.True(t, dynakube.FeatureAutomaticInjection())
-	assert.Equal(t, "silent", dynakube.FeatureInjectionFailurePolicy())
+	assert.True(t, dk.FeatureAutomaticKubernetesApiMonitoring())
+	assert.True(t, dk.FeatureAutomaticInjection())
+	assert.Equal(t, "silent", dk.FeatureInjectionFailurePolicy())
 
-	assert.False(t, dynakube.FeatureDisableActiveGateUpdates())
-	assert.False(t, dynakube.FeatureLabelVersionDetection())
+	assert.False(t, dk.FeatureDisableActiveGateUpdates())
+	assert.False(t, dk.FeatureLabelVersionDetection())
 }
 
 func TestInjectionFailurePolicy(t *testing.T) {
-	dynakube := createDynakubeEmptyDynakube()
+	dk := createDynakubeEmptyDynakube()
 
 	modes := map[string]string{
 		failPhrase:   failPhrase,
@@ -180,33 +180,33 @@ func TestInjectionFailurePolicy(t *testing.T) {
 	}
 	for configuredMode, expectedMode := range modes {
 		t.Run(`injection failure policy: `+configuredMode, func(t *testing.T) {
-			dynakube.Annotations[AnnotationInjectionFailurePolicy] = configuredMode
+			dk.Annotations[AnnotationInjectionFailurePolicy] = configuredMode
 
-			assert.Equal(t, expectedMode, dynakube.FeatureInjectionFailurePolicy())
+			assert.Equal(t, expectedMode, dk.FeatureInjectionFailurePolicy())
 		})
 	}
 }
 
 func TestAgentInitialConnectRetry(t *testing.T) {
 	t.Run("default => not set", func(t *testing.T) {
-		dynakube := createDynakubeEmptyDynakube()
+		dk := createDynakubeEmptyDynakube()
 
-		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		initialRetry := dk.FeatureAgentInitialConnectRetry()
 		require.Equal(t, -1, initialRetry)
 	})
 	t.Run("istio default => set", func(t *testing.T) {
-		dynakube := createDynakubeEmptyDynakube()
-		dynakube.Spec.EnableIstio = true
+		dk := createDynakubeEmptyDynakube()
+		dk.Spec.EnableIstio = true
 
-		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		initialRetry := dk.FeatureAgentInitialConnectRetry()
 		require.Equal(t, IstioDefaultOneAgentInitialConnectRetry, initialRetry)
 	})
 	t.Run("istio default can be overruled", func(t *testing.T) {
-		dynakube := createDynakubeEmptyDynakube()
-		dynakube.Spec.EnableIstio = true
-		dynakube.Annotations[AnnotationFeatureOneAgentInitialConnectRetry] = "5"
+		dk := createDynakubeEmptyDynakube()
+		dk.Spec.EnableIstio = true
+		dk.Annotations[AnnotationFeatureOneAgentInitialConnectRetry] = "5"
 
-		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		initialRetry := dk.FeatureAgentInitialConnectRetry()
 		require.Equal(t, 5, initialRetry)
 	})
 }

--- a/pkg/api/v1beta2/dynakube/properties_test.go
+++ b/pkg/api/v1beta2/dynakube/properties_test.go
@@ -49,9 +49,9 @@ func TestDefaultActiveGateImage(t *testing.T) {
 	t.Run(`ActiveGateImage truncates build date`, func(t *testing.T) {
 		version := "1.239.14.20220325-164521"
 		expectedImage := "test-endpoint/linux/activegate:1.239.14-raw"
-		dynakube := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
 
-		assert.Equal(t, expectedImage, dynakube.DefaultActiveGateImage(version))
+		assert.Equal(t, expectedImage, dk.DefaultActiveGateImage(version))
 	})
 }
 
@@ -121,9 +121,9 @@ func TestDefaultOneAgentImage(t *testing.T) {
 	t.Run(`OneAgentImage with custom version truncates build date`, func(t *testing.T) {
 		version := "1.239.14.20220325-164521"
 		expectedImage := "test-endpoint/linux/oneagent:1.239.14-raw"
-		dynakube := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
 
-		assert.Equal(t, expectedImage, dynakube.DefaultOneAgentImage(version))
+		assert.Equal(t, expectedImage, dk.DefaultOneAgentImage(version))
 	})
 }
 
@@ -141,12 +141,12 @@ func TestCustomOneAgentImage(t *testing.T) {
 }
 
 func TestOneAgentDaemonsetName(t *testing.T) {
-	instance := &DynaKube{
+	dk := &DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-name",
 		},
 	}
-	assert.Equal(t, "test-name-oneagent", instance.OneAgentDaemonsetName())
+	assert.Equal(t, "test-name-oneagent", dk.OneAgentDaemonsetName())
 }
 
 func TestTokens(t *testing.T) {
@@ -306,12 +306,12 @@ func TestGetRawImageTag(t *testing.T) {
 
 func TestIsOneAgentPrivileged(t *testing.T) {
 	t.Run("is false by default", func(t *testing.T) {
-		dynakube := DynaKube{}
+		dk := DynaKube{}
 
-		assert.False(t, dynakube.FeatureOneAgentPrivileged())
+		assert.False(t, dk.FeatureOneAgentPrivileged())
 	})
 	t.Run("is true when annotation is set to true", func(t *testing.T) {
-		dynakube := DynaKube{
+		dk := DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					AnnotationFeatureRunOneAgentContainerPrivileged: "true",
@@ -319,10 +319,10 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 			},
 		}
 
-		assert.True(t, dynakube.FeatureOneAgentPrivileged())
+		assert.True(t, dk.FeatureOneAgentPrivileged())
 	})
 	t.Run("is false when annotation is set to false", func(t *testing.T) {
-		dynakube := DynaKube{
+		dk := DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					AnnotationFeatureRunOneAgentContainerPrivileged: "false",
@@ -330,7 +330,7 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 			},
 		}
 
-		assert.False(t, dynakube.FeatureOneAgentPrivileged())
+		assert.False(t, dk.FeatureOneAgentPrivileged())
 	})
 }
 

--- a/pkg/api/v1beta2/dynakube/validation/api_url.go
+++ b/pkg/api/v1beta2/dynakube/validation/api_url.go
@@ -22,8 +22,8 @@ const (
 	out of it. Example: ` + ExampleApiUrl
 )
 
-func NoApiUrl(_ context.Context, _ *Validator, dynakube *dynakube.DynaKube) string {
-	apiUrl := dynakube.Spec.APIURL
+func NoApiUrl(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	apiUrl := dk.Spec.APIURL
 
 	if apiUrl == ExampleApiUrl {
 		log.Info("api url is an example url", "apiUrl", apiUrl)
@@ -32,7 +32,7 @@ func NoApiUrl(_ context.Context, _ *Validator, dynakube *dynakube.DynaKube) stri
 	}
 
 	if apiUrl == "" {
-		log.Info("requested dynakube has no api url", "name", dynakube.Name, "namespace", dynakube.Namespace)
+		log.Info("requested dynakube has no api url", "name", dk.Name, "namespace", dk.Namespace)
 
 		return errorNoApiUrl
 	}
@@ -40,8 +40,8 @@ func NoApiUrl(_ context.Context, _ *Validator, dynakube *dynakube.DynaKube) stri
 	return ""
 }
 
-func IsInvalidApiUrl(_ context.Context, _ *Validator, dynakube *dynakube.DynaKube) string {
-	apiUrl := dynakube.Spec.APIURL
+func IsInvalidApiUrl(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	apiUrl := dk.Spec.APIURL
 
 	if !strings.HasSuffix(apiUrl, "/api") {
 		log.Info("api url does not end with /api", "apiUrl", apiUrl)
@@ -70,8 +70,8 @@ func IsInvalidApiUrl(_ context.Context, _ *Validator, dynakube *dynakube.DynaKub
 	return ""
 }
 
-func IsThirdGenAPIUrl(_ context.Context, _ *Validator, dynakube *dynakube.DynaKube) string {
-	if strings.Contains(dynakube.ApiUrl(), ".apps.") {
+func IsThirdGenAPIUrl(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if strings.Contains(dk.ApiUrl(), ".apps.") {
 		return errorThirdGenApiUrl
 	}
 

--- a/pkg/api/v1beta2/dynakube/validation/api_url_test.go
+++ b/pkg/api/v1beta2/dynakube/validation/api_url_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestHasApiUrl(t *testing.T) {
-	instance := &dynakube.DynaKube{}
-	assert.Equal(t, errorNoApiUrl, NoApiUrl(context.Background(), nil, instance))
+	dk := &dynakube.DynaKube{}
+	assert.Equal(t, errorNoApiUrl, NoApiUrl(context.Background(), nil, dk))
 
-	instance.Spec.APIURL = testApiUrl
-	assert.Empty(t, NoApiUrl(context.Background(), nil, instance))
+	dk.Spec.APIURL = testApiUrl
+	assert.Empty(t, NoApiUrl(context.Background(), nil, dk))
 
 	t.Run(`happy path`, func(t *testing.T) {
 		assertAllowed(t, &dynakube.DynaKube{

--- a/pkg/api/v1beta2/dynakube/validation/validation.go
+++ b/pkg/api/v1beta2/dynakube/validation/validation.go
@@ -45,7 +45,7 @@ var (
 	}
 )
 
-type validatorFunc func(ctx context.Context, dv *Validator, dynakube *dynakube.DynaKube) string
+type validatorFunc func(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string
 
 func New(apiReader client.Reader, cfg *rest.Config) admission.CustomValidator {
 	return &Validator{

--- a/pkg/api/v1beta3/dynakube/feature_flags_test.go
+++ b/pkg/api/v1beta3/dynakube/feature_flags_test.go
@@ -10,88 +10,88 @@ import (
 )
 
 func createDynakubeWithAnnotation(keyValues ...string) DynaKube {
-	dynakube := DynaKube{
+	dk := DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},
 		},
 	}
 
 	for i := 0; i < len(keyValues); i += 2 {
-		dynakube.Annotations[keyValues[i]] = keyValues[i+1]
+		dk.Annotations[keyValues[i]] = keyValues[i+1]
 	}
 
-	return dynakube
+	return dk
 }
 
 func createDynakubeEmptyDynakube() DynaKube {
-	dynakube := DynaKube{
+	dk := DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},
 		},
 	}
 
-	return dynakube
+	return dk
 }
 
 func TestCreateDynakubeWithAnnotation(t *testing.T) {
-	dynakube := createDynakubeWithAnnotation("test", "true")
+	dk := createDynakubeWithAnnotation("test", "true")
 
-	assert.Contains(t, dynakube.Annotations, "test")
-	assert.Equal(t, "true", dynakube.Annotations["test"])
+	assert.Contains(t, dk.Annotations, "test")
+	assert.Equal(t, "true", dk.Annotations["test"])
 
-	dynakube = createDynakubeWithAnnotation("other test", "false")
+	dk = createDynakubeWithAnnotation("other test", "false")
 
-	assert.Contains(t, dynakube.Annotations, "other test")
-	assert.Equal(t, "false", dynakube.Annotations["other test"])
-	assert.NotContains(t, dynakube.Annotations, "test")
+	assert.Contains(t, dk.Annotations, "other test")
+	assert.Equal(t, "false", dk.Annotations["other test"])
+	assert.NotContains(t, dk.Annotations, "test")
 
-	dynakube = createDynakubeWithAnnotation("test", "true", "other test", "false")
+	dk = createDynakubeWithAnnotation("test", "true", "other test", "false")
 
-	assert.Contains(t, dynakube.Annotations, "other test")
-	assert.Equal(t, "false", dynakube.Annotations["other test"])
-	assert.Contains(t, dynakube.Annotations, "test")
-	assert.Equal(t, "true", dynakube.Annotations["test"])
+	assert.Contains(t, dk.Annotations, "other test")
+	assert.Equal(t, "false", dk.Annotations["other test"])
+	assert.Contains(t, dk.Annotations, "test")
+	assert.Equal(t, "true", dk.Annotations["test"])
 }
 
 func testDeprecateDisableAnnotation(t *testing.T,
 	newAnnotation string,
 	deprecatedAnnotation string,
-	propertyFunction func(dynakube DynaKube) bool) {
+	propertyFunction func(dk DynaKube) bool) {
 	// New annotation works
-	dynakube := createDynakubeWithAnnotation(newAnnotation, "false")
+	dk := createDynakubeWithAnnotation(newAnnotation, "false")
 
-	assert.True(t, propertyFunction(dynakube))
+	assert.True(t, propertyFunction(dk))
 
-	dynakube = createDynakubeWithAnnotation(newAnnotation, "true")
+	dk = createDynakubeWithAnnotation(newAnnotation, "true")
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 
 	// Old annotation works
-	dynakube = createDynakubeWithAnnotation(deprecatedAnnotation, "true")
+	dk = createDynakubeWithAnnotation(deprecatedAnnotation, "true")
 
-	assert.True(t, propertyFunction(dynakube))
+	assert.True(t, propertyFunction(dk))
 
-	dynakube = createDynakubeWithAnnotation(deprecatedAnnotation, "false")
+	dk = createDynakubeWithAnnotation(deprecatedAnnotation, "false")
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 
 	// New annotation takes precedent
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		newAnnotation, "true",
 		deprecatedAnnotation, "true")
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		newAnnotation, "false",
 		deprecatedAnnotation, "false")
 
-	assert.True(t, propertyFunction(dynakube))
+	assert.True(t, propertyFunction(dk))
 
 	// Default is false
-	dynakube = createDynakubeWithAnnotation()
+	dk = createDynakubeWithAnnotation()
 
-	assert.False(t, propertyFunction(dynakube))
+	assert.False(t, propertyFunction(dk))
 }
 
 func TestDeprecatedDisableAnnotations(t *testing.T) {
@@ -99,50 +99,50 @@ func TestDeprecatedDisableAnnotations(t *testing.T) {
 		testDeprecateDisableAnnotation(t,
 			AnnotationFeatureActiveGateUpdates,
 			AnnotationFeatureDisableActiveGateUpdates,
-			func(dynakube DynaKube) bool {
-				return dynakube.FeatureDisableActiveGateUpdates()
+			func(dk DynaKube) bool {
+				return dk.FeatureDisableActiveGateUpdates()
 			})
 	})
 }
 
 func TestDeprecatedEnableAnnotations(t *testing.T) {
-	dynakube := createDynakubeWithAnnotation(AnnotationInjectionFailurePolicy, "fail")
-	assert.Equal(t, "fail", dynakube.FeatureInjectionFailurePolicy())
+	dk := createDynakubeWithAnnotation(AnnotationInjectionFailurePolicy, "fail")
+	assert.Equal(t, "fail", dk.FeatureInjectionFailurePolicy())
 }
 
 func TestMaxMountAttempts(t *testing.T) {
-	dynakube := createDynakubeWithAnnotation(
+	dk := createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "5")
 
-	assert.Equal(t, 5, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, 5, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "3")
 
-	assert.Equal(t, 3, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, 3, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation()
+	dk = createDynakubeWithAnnotation()
 
-	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "a")
 
-	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dk.FeatureMaxFailedCsiMountAttempts())
 
-	dynakube = createDynakubeWithAnnotation(
+	dk = createDynakubeWithAnnotation(
 		AnnotationFeatureMaxFailedCsiMountAttempts, "-5")
 
-	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dynakube.FeatureMaxFailedCsiMountAttempts())
+	assert.Equal(t, DefaultMaxFailedCsiMountAttempts, dk.FeatureMaxFailedCsiMountAttempts())
 }
 
 func TestDynaKube_FeatureIgnoredNamespaces(t *testing.T) {
-	dynakube := DynaKube{
+	dk := DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
 		},
 	}
-	ignoredNamespaces := dynakube.getDefaultIgnoredNamespaces()
+	ignoredNamespaces := dk.getDefaultIgnoredNamespaces()
 	dynakubeNamespaceMatches := false
 
 	for _, namespace := range ignoredNamespaces {
@@ -150,7 +150,7 @@ func TestDynaKube_FeatureIgnoredNamespaces(t *testing.T) {
 
 		require.NoError(t, err)
 
-		match := regex.MatchString(dynakube.Namespace)
+		match := regex.MatchString(dk.Namespace)
 
 		if match {
 			dynakubeNamespaceMatches = true
@@ -161,18 +161,18 @@ func TestDynaKube_FeatureIgnoredNamespaces(t *testing.T) {
 }
 
 func TestDefaultEnabledFeatureFlags(t *testing.T) {
-	dynakube := createDynakubeEmptyDynakube()
+	dk := createDynakubeEmptyDynakube()
 
-	assert.True(t, dynakube.FeatureAutomaticKubernetesApiMonitoring())
-	assert.True(t, dynakube.FeatureAutomaticInjection())
-	assert.Equal(t, "silent", dynakube.FeatureInjectionFailurePolicy())
+	assert.True(t, dk.FeatureAutomaticKubernetesApiMonitoring())
+	assert.True(t, dk.FeatureAutomaticInjection())
+	assert.Equal(t, "silent", dk.FeatureInjectionFailurePolicy())
 
-	assert.False(t, dynakube.FeatureDisableActiveGateUpdates())
-	assert.False(t, dynakube.FeatureLabelVersionDetection())
+	assert.False(t, dk.FeatureDisableActiveGateUpdates())
+	assert.False(t, dk.FeatureLabelVersionDetection())
 }
 
 func TestInjectionFailurePolicy(t *testing.T) {
-	dynakube := createDynakubeEmptyDynakube()
+	dk := createDynakubeEmptyDynakube()
 
 	modes := map[string]string{
 		failPhrase:   failPhrase,
@@ -180,33 +180,33 @@ func TestInjectionFailurePolicy(t *testing.T) {
 	}
 	for configuredMode, expectedMode := range modes {
 		t.Run(`injection failure policy: `+configuredMode, func(t *testing.T) {
-			dynakube.Annotations[AnnotationInjectionFailurePolicy] = configuredMode
+			dk.Annotations[AnnotationInjectionFailurePolicy] = configuredMode
 
-			assert.Equal(t, expectedMode, dynakube.FeatureInjectionFailurePolicy())
+			assert.Equal(t, expectedMode, dk.FeatureInjectionFailurePolicy())
 		})
 	}
 }
 
 func TestAgentInitialConnectRetry(t *testing.T) {
 	t.Run("default => not set", func(t *testing.T) {
-		dynakube := createDynakubeEmptyDynakube()
+		dk := createDynakubeEmptyDynakube()
 
-		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		initialRetry := dk.FeatureAgentInitialConnectRetry()
 		require.Equal(t, -1, initialRetry)
 	})
 	t.Run("istio default => set", func(t *testing.T) {
-		dynakube := createDynakubeEmptyDynakube()
-		dynakube.Spec.EnableIstio = true
+		dk := createDynakubeEmptyDynakube()
+		dk.Spec.EnableIstio = true
 
-		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		initialRetry := dk.FeatureAgentInitialConnectRetry()
 		require.Equal(t, IstioDefaultOneAgentInitialConnectRetry, initialRetry)
 	})
 	t.Run("istio default can be overruled", func(t *testing.T) {
-		dynakube := createDynakubeEmptyDynakube()
-		dynakube.Spec.EnableIstio = true
-		dynakube.Annotations[AnnotationFeatureOneAgentInitialConnectRetry] = "5"
+		dk := createDynakubeEmptyDynakube()
+		dk.Spec.EnableIstio = true
+		dk.Annotations[AnnotationFeatureOneAgentInitialConnectRetry] = "5"
 
-		initialRetry := dynakube.FeatureAgentInitialConnectRetry()
+		initialRetry := dk.FeatureAgentInitialConnectRetry()
 		require.Equal(t, 5, initialRetry)
 	})
 }

--- a/pkg/api/v1beta3/dynakube/properties_test.go
+++ b/pkg/api/v1beta3/dynakube/properties_test.go
@@ -49,9 +49,9 @@ func TestDefaultActiveGateImage(t *testing.T) {
 	t.Run(`ActiveGateImage truncates build date`, func(t *testing.T) {
 		version := "1.239.14.20220325-164521"
 		expectedImage := "test-endpoint/linux/activegate:1.239.14-raw"
-		dynakube := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
 
-		assert.Equal(t, expectedImage, dynakube.DefaultActiveGateImage(version))
+		assert.Equal(t, expectedImage, dk.DefaultActiveGateImage(version))
 	})
 }
 
@@ -121,9 +121,9 @@ func TestDefaultOneAgentImage(t *testing.T) {
 	t.Run(`OneAgentImage with custom version truncates build date`, func(t *testing.T) {
 		version := "1.239.14.20220325-164521"
 		expectedImage := "test-endpoint/linux/oneagent:1.239.14-raw"
-		dynakube := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: testAPIURL}}
 
-		assert.Equal(t, expectedImage, dynakube.DefaultOneAgentImage(version))
+		assert.Equal(t, expectedImage, dk.DefaultOneAgentImage(version))
 	})
 }
 
@@ -141,12 +141,12 @@ func TestCustomOneAgentImage(t *testing.T) {
 }
 
 func TestOneAgentDaemonsetName(t *testing.T) {
-	instance := &DynaKube{
+	dk := &DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-name",
 		},
 	}
-	assert.Equal(t, "test-name-oneagent", instance.OneAgentDaemonsetName())
+	assert.Equal(t, "test-name-oneagent", dk.OneAgentDaemonsetName())
 }
 
 func TestTokens(t *testing.T) {
@@ -306,12 +306,12 @@ func TestGetRawImageTag(t *testing.T) {
 
 func TestIsOneAgentPrivileged(t *testing.T) {
 	t.Run("is false by default", func(t *testing.T) {
-		dynakube := DynaKube{}
+		dk := DynaKube{}
 
-		assert.False(t, dynakube.FeatureOneAgentPrivileged())
+		assert.False(t, dk.FeatureOneAgentPrivileged())
 	})
 	t.Run("is true when annotation is set to true", func(t *testing.T) {
-		dynakube := DynaKube{
+		dk := DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					AnnotationFeatureRunOneAgentContainerPrivileged: "true",
@@ -319,10 +319,10 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 			},
 		}
 
-		assert.True(t, dynakube.FeatureOneAgentPrivileged())
+		assert.True(t, dk.FeatureOneAgentPrivileged())
 	})
 	t.Run("is false when annotation is set to false", func(t *testing.T) {
-		dynakube := DynaKube{
+		dk := DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					AnnotationFeatureRunOneAgentContainerPrivileged: "false",
@@ -330,7 +330,7 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 			},
 		}
 
-		assert.False(t, dynakube.FeatureOneAgentPrivileged())
+		assert.False(t, dk.FeatureOneAgentPrivileged())
 	})
 }
 

--- a/pkg/clients/dynatrace/processmoduleconfig.go
+++ b/pkg/clients/dynatrace/processmoduleconfig.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/utils"
 	"github.com/pkg/errors"
 )
@@ -88,7 +88,7 @@ func (pmc *ProcessModuleConfig) removeProperty(index int) {
 	pmc.Properties = append(pmc.Properties[0:index], pmc.Properties[index+1:]...)
 }
 
-func (pmc *ProcessModuleConfig) AddConnectionInfo(oneAgentConnectionInfo dynatracev1beta2.OneAgentConnectionInfoStatus, tenantToken string) *ProcessModuleConfig {
+func (pmc *ProcessModuleConfig) AddConnectionInfo(oneAgentConnectionInfo dynakube.OneAgentConnectionInfoStatus, tenantToken string) *ProcessModuleConfig {
 	tenant := ProcessModuleProperty{
 		Section: generalSectionName,
 		Key:     "tenant",

--- a/pkg/clients/edgeconnect/edgeconnect.go
+++ b/pkg/clients/edgeconnect/edgeconnect.go
@@ -3,7 +3,7 @@ package edgeconnect
 import (
 	"time"
 
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 )
 
 type OauthClientStatus int
@@ -39,27 +39,27 @@ type ListResponse struct {
 }
 
 type CreateResponse struct {
-	ModificationInfo           ModificationInfo                  `json:"modificationInfo"`
-	Metadata                   Metadata                          `json:"metadata"`
-	ID                         string                            `json:"id,omitempty"`
-	Name                       string                            `json:"name"`
-	OauthClientId              string                            `json:"oauthClientId"`
-	OauthClientSecret          string                            `json:"oauthClientSecret"`
-	OauthClientResource        string                            `json:"oauthClientResource"`
-	HostPatterns               []string                          `json:"hostPatterns"`
-	HostMappings               []edgeconnectv1alpha1.HostMapping `json:"hostMappings"`
-	ManagedByDynatraceOperator bool                              `json:"managedByDynatraceOperator,omitempty"`
+	ModificationInfo           ModificationInfo          `json:"modificationInfo"`
+	Metadata                   Metadata                  `json:"metadata"`
+	ID                         string                    `json:"id,omitempty"`
+	Name                       string                    `json:"name"`
+	OauthClientId              string                    `json:"oauthClientId"`
+	OauthClientSecret          string                    `json:"oauthClientSecret"`
+	OauthClientResource        string                    `json:"oauthClientResource"`
+	HostPatterns               []string                  `json:"hostPatterns"`
+	HostMappings               []edgeconnect.HostMapping `json:"hostMappings"`
+	ManagedByDynatraceOperator bool                      `json:"managedByDynatraceOperator,omitempty"`
 }
 
 type Request struct {
-	Name                       string                            `json:"name"`
-	OauthClientId              string                            `json:"oauthClientId,omitempty"`
-	HostPatterns               []string                          `json:"hostPatterns"`
-	HostMappings               []edgeconnectv1alpha1.HostMapping `json:"hostMappings"`
-	ManagedByDynatraceOperator bool                              `json:"managedByDynatraceOperator,omitempty"`
+	Name                       string                    `json:"name"`
+	OauthClientId              string                    `json:"oauthClientId,omitempty"`
+	HostPatterns               []string                  `json:"hostPatterns"`
+	HostMappings               []edgeconnect.HostMapping `json:"hostMappings"`
+	ManagedByDynatraceOperator bool                      `json:"managedByDynatraceOperator,omitempty"`
 }
 
-func NewRequest(name string, hostPatterns []string, hostMappings []edgeconnectv1alpha1.HostMapping, oauthClientId string) *Request {
+func NewRequest(name string, hostPatterns []string, hostMappings []edgeconnect.HostMapping, oauthClientId string) *Request {
 	return &Request{
 		Name:                       name,
 		HostPatterns:               hostPatterns,

--- a/pkg/controllers/csi/gc/reconciler_test.go
+++ b/pkg/controllers/csi/gc/reconciler_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/spf13/afero"
@@ -24,22 +24,22 @@ func TestReconcile(t *testing.T) {
 	namespace := "test-namespace"
 
 	t.Run(`no latest version in status`, func(t *testing.T) {
-		dynakube := dynatracev1beta2.DynaKube{
+		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: apiUrl,
 			},
 		}
 		gc := CSIGarbageCollector{
-			apiReader:    fake.NewClient(&dynakube),
+			apiReader:    fake.NewClient(&dk),
 			fs:           afero.NewMemMapFs(),
 			db:           metadata.FakeMemoryDB(),
 			mounter:      mount.NewFakeMounter([]mount.MountPoint{}),
 			isNotMounted: mockIsNotMounted(map[string]error{}),
 		}
-		result, err := gc.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: dynakube.Name}})
+		result, err := gc.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: dk.Name}})
 
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{RequeueAfter: dtcsi.LongRequeueDuration}, result)

--- a/pkg/controllers/csi/metadata/correctness.go
+++ b/pkg/controllers/csi/metadata/correctness.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -103,9 +103,9 @@ func (checker *CorrectnessChecker) removeMissingDynakubes(ctx context.Context) e
 	pruned := []string{}
 
 	for _, tenantConfig := range tenantConfigs {
-		var dynakube dynatracev1beta2.DynaKube
+		var dk dynakube.DynaKube
 
-		if err := checker.apiReader.Get(ctx, client.ObjectKey{Name: tenantConfig.Name}, &dynakube); !k8serrors.IsNotFound(err) {
+		if err := checker.apiReader.Get(ctx, client.ObjectKey{Name: tenantConfig.Name}, &dk); !k8serrors.IsNotFound(err) {
 			continue
 		}
 

--- a/pkg/controllers/csi/metadata/correctness_test.go
+++ b/pkg/controllers/csi/metadata/correctness_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	testutil "github.com/Dynatrace/dynatrace-operator/pkg/util/testing"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -92,7 +92,7 @@ func TestCorrectCSI(t *testing.T) {
 		db.CreateTenantConfig(testTenantConfig1)
 		client := fake.NewClient(
 			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: testAppMount1.VolumeMeta.PodName}},
-			&dynatracev1beta2.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testTenantConfig1.Name}},
+			&dynakube.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testTenantConfig1.Name}},
 		)
 
 		checker := NewCorrectnessChecker(client, db, dtcsi.CSIOptions{})
@@ -129,7 +129,7 @@ func TestCorrectCSI(t *testing.T) {
 
 		client := fake.NewClient(
 			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: testAppMount1.VolumeMeta.PodName}},
-			&dynatracev1beta2.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testTenantConfig1.Name}},
+			&dynakube.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testTenantConfig1.Name}},
 		)
 
 		checker := NewCorrectnessChecker(client, db, dtcsi.CSIOptions{})

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -596,8 +596,8 @@ func TestUpdateAgentInstallation(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("updateAgentInstallation with codeModules enabled", func(t *testing.T) {
-		dynakube := getDynakube()
-		enableCodeModules(dynakube)
+		dk := getDynakube()
+		enableCodeModules(dk)
 
 		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 
@@ -607,9 +607,9 @@ func TestUpdateAgentInstallation(t *testing.T) {
 		dtc, err := mockDtcBuilder.Build()
 		require.NoError(t, err)
 
-		mockK8sClient := createMockK8sClient(ctx, dynakube)
+		mockK8sClient := createMockK8sClient(ctx, dk)
 		installerMock := installermock.NewInstaller(t)
-		base64Image := base64.StdEncoding.EncodeToString([]byte(dynakube.CodeModulesImage()))
+		base64Image := base64.StdEncoding.EncodeToString([]byte(dk.CodeModulesImage()))
 		installerMock.
 			On("InstallAgent", mock.AnythingOfType("*context.valueCtx"), "test/codemodules/"+base64Image).
 			Return(true, nil)
@@ -631,15 +631,15 @@ func TestUpdateAgentInstallation(t *testing.T) {
 		setUpFS(provisioner.fs, ruxitAgentProcPath, sourceRuxitAgentProcPath)
 
 		tenantConfig := metadata.TenantConfig{Name: dkName, TenantUUID: tenantUUID, DownloadedCodeModuleVersion: agentVersion}
-		isRequeue, err := provisioner.updateAgentInstallation(ctx, dtc, &tenantConfig, dynakube)
+		isRequeue, err := provisioner.updateAgentInstallation(ctx, dtc, &tenantConfig, dk)
 		require.NoError(t, err)
 
-		require.Equal(t, dynakube.CodeModulesImage(), tenantConfig.DownloadedCodeModuleVersion)
+		require.Equal(t, dk.CodeModulesImage(), tenantConfig.DownloadedCodeModuleVersion)
 		assert.False(t, isRequeue)
 	})
 	t.Run("updateAgentInstallation with codeModules enabled errors and requeues", func(t *testing.T) {
-		dynakube := getDynakube()
-		enableCodeModules(dynakube)
+		dk := getDynakube()
+		enableCodeModules(dk)
 
 		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 
@@ -649,8 +649,8 @@ func TestUpdateAgentInstallation(t *testing.T) {
 		dtc, err := mockDtcBuilder.Build()
 		require.NoError(t, err)
 
-		base64Image := base64.StdEncoding.EncodeToString([]byte(dynakube.CodeModulesImage()))
-		mockK8sClient := createMockK8sClient(ctx, dynakube)
+		base64Image := base64.StdEncoding.EncodeToString([]byte(dk.CodeModulesImage()))
+		mockK8sClient := createMockK8sClient(ctx, dk)
 		installerMock := installermock.NewInstaller(t)
 		installerMock.
 			On("InstallAgent", mock.AnythingOfType("*context.valueCtx"), "test/codemodules/"+base64Image).
@@ -668,14 +668,14 @@ func TestUpdateAgentInstallation(t *testing.T) {
 		}
 
 		tenantConfig := metadata.TenantConfig{TenantUUID: tenantUUID, DownloadedCodeModuleVersion: agentVersion, Name: dkName}
-		isRequeue, err := provisioner.updateAgentInstallation(ctx, dtc, &tenantConfig, dynakube)
+		isRequeue, err := provisioner.updateAgentInstallation(ctx, dtc, &tenantConfig, dk)
 		require.NoError(t, err)
 
 		require.Equal(t, "12345", tenantConfig.DownloadedCodeModuleVersion)
 		assert.True(t, isRequeue)
 	})
 	t.Run("updateAgentInstallation without codeModules", func(t *testing.T) {
-		dynakube := getDynakube()
+		dk := getDynakube()
 
 		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 
@@ -685,7 +685,7 @@ func TestUpdateAgentInstallation(t *testing.T) {
 		dtc, err := mockDtcBuilder.Build()
 		require.NoError(t, err)
 
-		mockK8sClient := createMockK8sClient(ctx, dynakube)
+		mockK8sClient := createMockK8sClient(ctx, dk)
 		installerMock := installermock.NewInstaller(t)
 		installerMock.
 			On("InstallAgent", mock.AnythingOfType("*context.valueCtx"), "test/codemodules").
@@ -707,7 +707,7 @@ func TestUpdateAgentInstallation(t *testing.T) {
 		setUpFS(provisioner.fs, ruxitAgentProcPath, sourceRuxitAgentProcPath)
 
 		tenantConfig := metadata.TenantConfig{TenantUUID: tenantUUID, DownloadedCodeModuleVersion: agentVersion, Name: dkName}
-		isRequeue, err := provisioner.updateAgentInstallation(ctx, dtc, &tenantConfig, dynakube)
+		isRequeue, err := provisioner.updateAgentInstallation(ctx, dtc, &tenantConfig, dk)
 		require.NoError(t, err)
 
 		require.Equal(t, "12345", tenantConfig.DownloadedCodeModuleVersion)

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
@@ -109,13 +109,13 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		gc.Mock.On("Reconcile", mock.Anything, mock.Anything).Return(reconcile.Result{RequeueAfter: dtcsi.LongRequeueDuration}, nil)
 		provisioner := &OneAgentProvisioner{
 			apiReader: fake.NewClient(
-				&dynatracev1beta2.DynaKube{
+				&dynakube.DynaKube{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: dynakubeName,
 					},
-					Spec: dynatracev1beta2.DynaKubeSpec{
-						OneAgent: dynatracev1beta2.OneAgentSpec{
-							ClassicFullStack: &dynatracev1beta2.HostInjectSpec{},
+					Spec: dynakube.DynaKubeSpec{
+						OneAgent: dynakube.OneAgentSpec{
+							ClassicFullStack: &dynakube.HostInjectSpec{},
 						},
 					},
 				},
@@ -132,14 +132,14 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 	t.Run("host monitoring used -> no app inject is needed", func(t *testing.T) {
 		fakeClient := fake.NewClient(
 			addFakeTenantUUID(
-				&dynatracev1beta2.DynaKube{
+				&dynakube.DynaKube{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: dkName,
 					},
-					Spec: dynatracev1beta2.DynaKubeSpec{
+					Spec: dynakube.DynaKubeSpec{
 						APIURL: testAPIURL,
-						OneAgent: dynatracev1beta2.OneAgentSpec{
-							HostMonitoring: &dynatracev1beta2.HostInjectSpec{},
+						OneAgent: dynakube.OneAgentSpec{
+							HostMonitoring: &dynakube.HostInjectSpec{},
 						},
 					},
 				},
@@ -184,18 +184,18 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		provisioner := &OneAgentProvisioner{
 			apiReader: fake.NewClient(
 				addFakeTenantUUID(
-					&dynatracev1beta2.DynaKube{
+					&dynakube.DynaKube{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: dkName,
 						},
-						Spec: dynatracev1beta2.DynaKubeSpec{
+						Spec: dynakube.DynaKubeSpec{
 							APIURL: testAPIURL,
-							OneAgent: dynatracev1beta2.OneAgentSpec{
+							OneAgent: dynakube.OneAgentSpec{
 								ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
 							},
 						},
-						Status: dynatracev1beta2.DynaKubeStatus{
-							CodeModules: dynatracev1beta2.CodeModulesStatus{
+						Status: dynakube.DynaKubeStatus{
+							CodeModules: dynakube.CodeModulesStatus{
 								VersionStatus: status.VersionStatus{
 									Version: "1.2.3",
 								},
@@ -225,18 +225,18 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		provisioner := &OneAgentProvisioner{
 			apiReader: fake.NewClient(
 				addFakeTenantUUID(
-					&dynatracev1beta2.DynaKube{
+					&dynakube.DynaKube{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: dkName,
 						},
-						Spec: dynatracev1beta2.DynaKubeSpec{
+						Spec: dynakube.DynaKubeSpec{
 							APIURL: testAPIURL,
-							OneAgent: dynatracev1beta2.OneAgentSpec{
+							OneAgent: dynakube.OneAgentSpec{
 								ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
 							},
 						},
-						Status: dynatracev1beta2.DynaKubeStatus{
-							CodeModules: dynatracev1beta2.CodeModulesStatus{
+						Status: dynakube.DynaKubeStatus{
+							CodeModules: dynakube.CodeModulesStatus{
 								VersionStatus: status.VersionStatus{
 									Version: "1.2.3",
 								},
@@ -273,13 +273,13 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		provisioner := &OneAgentProvisioner{
 			apiReader: fake.NewClient(
 				addFakeTenantUUID(
-					&dynatracev1beta2.DynaKube{
+					&dynakube.DynaKube{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: dkName,
 						},
-						Spec: dynatracev1beta2.DynaKubeSpec{
+						Spec: dynakube.DynaKubeSpec{
 							APIURL: testAPIURL,
-							OneAgent: dynatracev1beta2.OneAgentSpec{
+							OneAgent: dynakube.OneAgentSpec{
 								ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
 							},
 						},
@@ -312,14 +312,14 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		gc := reconcilermock.NewReconciler(t)
 		memFs := afero.NewMemMapFs()
 		mockDtcBuilder := dtbuildermock.NewBuilder(t)
-		dynakube := addFakeTenantUUID(
-			&dynatracev1beta2.DynaKube{
+		dk := addFakeTenantUUID(
+			&dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: dkName,
 				},
-				Spec: dynatracev1beta2.DynaKubeSpec{
+				Spec: dynakube.DynaKubeSpec{
 					APIURL: testAPIURL,
-					OneAgent: dynatracev1beta2.OneAgentSpec{
+					OneAgent: dynakube.OneAgentSpec{
 						ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
 					},
 				},
@@ -329,7 +329,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 
 		provisioner := &OneAgentProvisioner{
 			apiReader: fake.NewClient(
-				dynakube,
+				dk,
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: dkName,
@@ -340,7 +340,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: dynakube.OneagentTenantSecret(),
+						Name: dk.OneagentTenantSecret(),
 					},
 					Data: map[string][]byte{
 						connectioninfo.TenantTokenKey: []byte("tenant-token"),
@@ -376,18 +376,18 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 
 		provisioner := &OneAgentProvisioner{
 			apiReader: fake.NewClient(
-				&dynatracev1beta2.DynaKube{
+				&dynakube.DynaKube{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: dkName,
 					},
-					Spec: dynatracev1beta2.DynaKubeSpec{
+					Spec: dynakube.DynaKubeSpec{
 						APIURL: testAPIURL,
-						OneAgent: dynatracev1beta2.OneAgentSpec{
+						OneAgent: dynakube.OneAgentSpec{
 							ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
 						},
 					},
-					Status: dynatracev1beta2.DynaKubeStatus{
-						CodeModules: dynatracev1beta2.CodeModulesStatus{
+					Status: dynakube.DynaKubeStatus{
+						CodeModules: dynakube.CodeModulesStatus{
 							VersionStatus: status.VersionStatus{
 								Version: "1.2.3",
 							},
@@ -417,22 +417,22 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 
 		memFs := afero.NewMemMapFs()
 		memDB := metadata.FakeMemoryDB()
-		dynakube := addFakeTenantUUID(
-			&dynatracev1beta2.DynaKube{
+		dk := addFakeTenantUUID(
+			&dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: dkName,
 				},
-				Spec: dynatracev1beta2.DynaKubeSpec{
+				Spec: dynakube.DynaKubeSpec{
 					APIURL: testAPIURL,
-					OneAgent: dynatracev1beta2.OneAgentSpec{
-						HostMonitoring: &dynatracev1beta2.HostInjectSpec{},
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{},
 					},
 				},
 			},
 		)
 
 		r := &OneAgentProvisioner{
-			apiReader: fake.NewClient(dynakube),
+			apiReader: fake.NewClient(dk),
 			fs:        memFs,
 			db:        memDB,
 			gc:        gc,
@@ -457,7 +457,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 
 func TestHasCodeModulesWithCSIVolumeEnabled(t *testing.T) {
 	t.Run("default DynaKube object returns false", func(t *testing.T) {
-		dk := &dynatracev1beta2.DynaKube{}
+		dk := &dynakube.DynaKube{}
 
 		isEnabled := dk.NeedsCSIDriver()
 
@@ -465,9 +465,9 @@ func TestHasCodeModulesWithCSIVolumeEnabled(t *testing.T) {
 	})
 
 	t.Run("application monitoring enabled", func(t *testing.T) {
-		dk := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
 					ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
 				},
 			},
@@ -479,11 +479,11 @@ func TestHasCodeModulesWithCSIVolumeEnabled(t *testing.T) {
 	})
 
 	t.Run("application monitoring enabled without csi driver", func(t *testing.T) {
-		dk := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{
-						AppInjectionSpec: dynatracev1beta2.AppInjectionSpec{},
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+						AppInjectionSpec: dynakube.AppInjectionSpec{},
 					},
 				},
 			},
@@ -495,8 +495,8 @@ func TestHasCodeModulesWithCSIVolumeEnabled(t *testing.T) {
 	})
 }
 
-func buildValidApplicationMonitoringSpec(_ *testing.T) *dynatracev1beta2.ApplicationMonitoringSpec {
-	return &dynatracev1beta2.ApplicationMonitoringSpec{
+func buildValidApplicationMonitoringSpec(_ *testing.T) *dynakube.ApplicationMonitoringSpec {
+	return &dynakube.ApplicationMonitoringSpec{
 		UseCSIDriver: true,
 	}
 }
@@ -567,25 +567,25 @@ func TestProvisioner_UpdateDynakube(t *testing.T) {
 }
 
 func TestHandleMetadata(t *testing.T) {
-	dynakube := addFakeTenantUUID(&dynatracev1beta2.DynaKube{
+	dk := addFakeTenantUUID(&dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dkName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: testAPIURL,
 		},
 	})
 	provisioner := &OneAgentProvisioner{
 		db: metadata.FakeMemoryDB(),
 	}
-	dynakubeMetadata, err := provisioner.handleMetadata(dynakube)
+	dynakubeMetadata, err := provisioner.handleMetadata(dk)
 
 	require.NoError(t, err)
 	require.NotNil(t, dynakubeMetadata)
-	require.Equal(t, int64(dynatracev1beta2.DefaultMaxFailedCsiMountAttempts), dynakubeMetadata.MaxFailedMountAttempts)
+	require.Equal(t, int64(dynakube.DefaultMaxFailedCsiMountAttempts), dynakubeMetadata.MaxFailedMountAttempts)
 
-	dynakube.Annotations = map[string]string{dynatracev1beta2.AnnotationFeatureMaxFailedCsiMountAttempts: "5"}
-	dynakubeMetadata, err = provisioner.handleMetadata(dynakube)
+	dk.Annotations = map[string]string{dynakube.AnnotationFeatureMaxFailedCsiMountAttempts: "5"}
+	dynakubeMetadata, err = provisioner.handleMetadata(dk)
 
 	require.NoError(t, err)
 	require.NotNil(t, dynakubeMetadata)
@@ -715,8 +715,8 @@ func TestUpdateAgentInstallation(t *testing.T) {
 	})
 }
 
-func createMockK8sClient(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) client.Client {
-	mockK8sClient := fake.NewClient(dynakube)
+func createMockK8sClient(ctx context.Context, dk *dynakube.DynaKube) client.Client {
+	mockK8sClient := fake.NewClient(dk)
 	mockK8sClient.Create(ctx,
 		&corev1.Secret{
 			Data: map[string][]byte{processmoduleconfigsecret.SecretKeyProcessModuleConfig: []byte(`{"revision":0,"properties":[]}`)},
@@ -730,21 +730,21 @@ func createMockK8sClient(ctx context.Context, dynakube *dynatracev1beta2.DynaKub
 	return mockK8sClient
 }
 
-func getDynakube() *dynatracev1beta2.DynaKube {
-	return addFakeTenantUUID(&dynatracev1beta2.DynaKube{
+func getDynakube() *dynakube.DynaKube {
+	return addFakeTenantUUID(&dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dkName,
 			Namespace: testNamespace,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL:   testAPIURL,
-			OneAgent: dynatracev1beta2.OneAgentSpec{},
+			OneAgent: dynakube.OneAgentSpec{},
 		},
 	})
 }
 
-func enableCodeModules(dynakube *dynatracev1beta2.DynaKube) {
-	dynakube.Status.CodeModules = dynatracev1beta2.CodeModulesStatus{
+func enableCodeModules(dk *dynakube.DynaKube) {
+	dk.Status.CodeModules = dynakube.CodeModulesStatus{
 		VersionStatus: status.VersionStatus{
 			Version: testVersion,
 			ImageID: testImageID,
@@ -752,10 +752,10 @@ func enableCodeModules(dynakube *dynatracev1beta2.DynaKube) {
 	}
 }
 
-func addFakeTenantUUID(dynakube *dynatracev1beta2.DynaKube) *dynatracev1beta2.DynaKube {
-	dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID = tenantUUID
+func addFakeTenantUUID(dk *dynakube.DynaKube) *dynakube.DynaKube {
+	dk.Status.OneAgent.ConnectionInfoStatus.TenantUUID = tenantUUID
 
-	return dynakube
+	return dk
 }
 
 func setUpFS(fs afero.Fs, ruxitAgentProcPath string, sourceRuxitAgentProcPath string) {

--- a/pkg/controllers/csi/provisioner/events.go
+++ b/pkg/controllers/csi/provisioner/events.go
@@ -1,13 +1,13 @@
 package csiprovisioner
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 )
 
 type updaterEventRecorder struct {
-	dynakube *dynatracev1beta2.DynaKube
+	dynakube *dynakube.DynaKube
 	recorder record.EventRecorder
 }
 

--- a/pkg/controllers/csi/provisioner/events.go
+++ b/pkg/controllers/csi/provisioner/events.go
@@ -7,19 +7,19 @@ import (
 )
 
 type updaterEventRecorder struct {
-	dynakube *dynakube.DynaKube
+	dk       *dynakube.DynaKube
 	recorder record.EventRecorder
 }
 
 func (event *updaterEventRecorder) sendFailedInstallAgentVersionEvent(version, tenantUUID string) {
-	event.recorder.Eventf(event.dynakube,
+	event.recorder.Eventf(event.dk,
 		corev1.EventTypeWarning,
 		failedInstallAgentVersionEvent,
 		"Failed to install agent version: %s to tenant: %s", version, tenantUUID)
 }
 
 func (event *updaterEventRecorder) sendInstalledAgentVersionEvent(version, tenantUUID string) {
-	event.recorder.Eventf(event.dynakube,
+	event.recorder.Eventf(event.dk,
 		corev1.EventTypeNormal,
 		installAgentVersionEvent,
 		"Installed agent version: %s to tenant: %s", version, tenantUUID)

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	csiotel "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/internal/otel"
@@ -18,23 +18,23 @@ import (
 
 func (provisioner *OneAgentProvisioner) installAgentImage(
 	ctx context.Context,
-	dynakube dynatracev1beta2.DynaKube,
+	dk dynakube.DynaKube,
 	latestProcessModuleConfig *dtclient.ProcessModuleConfig,
 ) (
 	targetImage string,
 	err error,
 ) {
-	tenantUUID, err := dynakube.TenantUUIDFromConnectionInfoStatus()
+	tenantUUID, err := dk.TenantUUIDFromConnectionInfoStatus()
 	if err != nil {
 		return "", err
 	}
 
-	targetImage = dynakube.CodeModulesImage()
+	targetImage = dk.CodeModulesImage()
 	// An image URI often contains one or several /-s, which is problematic when trying to use it as a folder name.
 	// Easiest to just base64 encode it
 	base64Image := base64.StdEncoding.EncodeToString([]byte(targetImage))
 	targetDir := provisioner.path.AgentSharedBinaryDirForAgent(base64Image)
-	targetConfigDir := provisioner.path.AgentConfigDir(tenantUUID, dynakube.GetName())
+	targetConfigDir := provisioner.path.AgentConfigDir(tenantUUID, dk.GetName())
 
 	defer func() {
 		if err == nil {
@@ -52,7 +52,7 @@ func (provisioner *OneAgentProvisioner) installAgentImage(
 	props := &image.Properties{
 		ImageUri:     targetImage,
 		ApiReader:    provisioner.apiReader,
-		Dynakube:     &dynakube,
+		Dynakube:     &dk,
 		PathResolver: provisioner.path,
 		Metadata:     provisioner.db,
 	}
@@ -65,7 +65,7 @@ func (provisioner *OneAgentProvisioner) installAgentImage(
 	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
 	defer span.End()
 
-	err = provisioner.installAgent(ctx, imageInstaller, dynakube, targetDir, targetImage, tenantUUID)
+	err = provisioner.installAgent(ctx, imageInstaller, dk, targetDir, targetImage, tenantUUID)
 	if err != nil {
 		span.RecordError(err)
 
@@ -83,17 +83,17 @@ func (provisioner *OneAgentProvisioner) installAgentImage(
 	return targetImage, err
 }
 
-func (provisioner *OneAgentProvisioner) installAgentZip(ctx context.Context, dynakube dynatracev1beta2.DynaKube, dtc dtclient.Client, latestProcessModuleConfig *dtclient.ProcessModuleConfig) (string, error) {
-	tenantUUID, err := dynakube.TenantUUIDFromConnectionInfoStatus()
+func (provisioner *OneAgentProvisioner) installAgentZip(ctx context.Context, dk dynakube.DynaKube, dtc dtclient.Client, latestProcessModuleConfig *dtclient.ProcessModuleConfig) (string, error) {
+	tenantUUID, err := dk.TenantUUIDFromConnectionInfoStatus()
 	if err != nil {
 		return "", err
 	}
 
-	targetVersion := dynakube.CodeModulesVersion()
+	targetVersion := dk.CodeModulesVersion()
 	urlInstaller := provisioner.urlInstallerBuilder(provisioner.fs, dtc, getUrlProperties(targetVersion, provisioner.path))
 
 	targetDir := provisioner.path.AgentSharedBinaryDirForAgent(targetVersion)
-	targetConfigDir := provisioner.path.AgentConfigDir(tenantUUID, dynakube.GetName())
+	targetConfigDir := provisioner.path.AgentConfigDir(tenantUUID, dk.GetName())
 
 	defer func() {
 		if err == nil {
@@ -111,7 +111,7 @@ func (provisioner *OneAgentProvisioner) installAgentZip(ctx context.Context, dyn
 	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
 	defer span.End()
 
-	err = provisioner.installAgent(ctx, urlInstaller, dynakube, targetDir, targetVersion, tenantUUID)
+	err = provisioner.installAgent(ctx, urlInstaller, dk, targetDir, targetVersion, tenantUUID)
 	if err != nil {
 		span.RecordError(err)
 
@@ -129,10 +129,10 @@ func (provisioner *OneAgentProvisioner) installAgentZip(ctx context.Context, dyn
 	return targetVersion, nil
 }
 
-func (provisioner *OneAgentProvisioner) installAgent(ctx context.Context, agentInstaller installer.Installer, dynakube dynatracev1beta2.DynaKube, targetDir, targetVersion, tenantUUID string) error { //nolint: revive
+func (provisioner *OneAgentProvisioner) installAgent(ctx context.Context, agentInstaller installer.Installer, dk dynakube.DynaKube, targetDir, targetVersion, tenantUUID string) error { //nolint: revive
 	eventRecorder := updaterEventRecorder{
 		recorder: provisioner.recorder,
-		dynakube: &dynakube,
+		dynakube: &dk,
 	}
 	isNewlyInstalled, err := agentInstaller.InstallAgent(ctx, targetDir)
 

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -132,7 +132,7 @@ func (provisioner *OneAgentProvisioner) installAgentZip(ctx context.Context, dk 
 func (provisioner *OneAgentProvisioner) installAgent(ctx context.Context, agentInstaller installer.Installer, dk dynakube.DynaKube, targetDir, targetVersion, tenantUUID string) error { //nolint: revive
 	eventRecorder := updaterEventRecorder{
 		recorder: provisioner.recorder,
-		dynakube: &dk,
+		dk:       &dk,
 	}
 	isNewlyInstalled, err := agentInstaller.InstallAgent(ctx, targetDir)
 

--- a/pkg/controllers/csi/provisioner/install_test.go
+++ b/pkg/controllers/csi/provisioner/install_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer"
@@ -246,11 +246,11 @@ func mockFsAfterInstall(provisioner *OneAgentProvisioner, version string) func(m
 	}
 }
 
-func createMockedPullSecret(dynakube dynatracev1beta2.DynaKube, pullSecretContent string) *corev1.Secret {
+func createMockedPullSecret(dk dynakube.DynaKube, pullSecretContent string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dynakube.PullSecretName(),
-			Namespace: dynakube.Namespace,
+			Name:      dk.PullSecretName(),
+			Namespace: dk.Namespace,
 		},
 		Data: map[string][]byte{
 			".dockerconfigjson": []byte(pullSecretContent),
@@ -258,31 +258,31 @@ func createMockedPullSecret(dynakube dynatracev1beta2.DynaKube, pullSecretConten
 	}
 }
 
-func createMockedCAConfigMap(dynakube dynatracev1beta2.DynaKube, certContent string) *corev1.ConfigMap {
+func createMockedCAConfigMap(dk dynakube.DynaKube, certContent string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dynakube.Spec.TrustedCAs,
-			Namespace: dynakube.Namespace,
+			Name:      dk.Spec.TrustedCAs,
+			Namespace: dk.Namespace,
 		},
 		Data: map[string]string{
-			dynatracev1beta2.TrustedCAKey: certContent,
+			dynakube.TrustedCAKey: certContent,
 		},
 	}
 }
 
-func createTestDynaKubeWithImage() dynatracev1beta2.DynaKube {
+func createTestDynaKubeWithImage() dynakube.DynaKube {
 	imageID := "some.registry.com/image:1.234.345"
 
-	return *addFakeTenantUUID(&dynatracev1beta2.DynaKube{
+	return *addFakeTenantUUID(&dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dk",
 			Namespace: "test-ns",
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: "https://" + testTenantUUID + ".dynatrace.com",
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			CodeModules: dynatracev1beta2.CodeModulesStatus{
+		Status: dynakube.DynaKubeStatus{
+			CodeModules: dynakube.CodeModulesStatus{
 				VersionStatus: status.VersionStatus{
 					ImageID: imageID,
 				},
@@ -291,17 +291,17 @@ func createTestDynaKubeWithImage() dynatracev1beta2.DynaKube {
 	})
 }
 
-func createTestDynaKubeWithZip(version string) dynatracev1beta2.DynaKube {
-	return *addFakeTenantUUID(&dynatracev1beta2.DynaKube{
+func createTestDynaKubeWithZip(version string) dynakube.DynaKube {
+	return *addFakeTenantUUID(&dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dk",
 			Namespace: "test-ns",
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: "https://" + testTenantUUID + ".dynatrace.com",
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			CodeModules: dynatracev1beta2.CodeModulesStatus{
+		Status: dynakube.DynaKubeStatus{
+			CodeModules: dynakube.CodeModulesStatus{
 				VersionStatus: status.VersionStatus{
 					Version: version,
 				},

--- a/pkg/controllers/dynakube/activegate.go
+++ b/pkg/controllers/dynakube/activegate.go
@@ -9,29 +9,29 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (controller *Controller) reconcileActiveGate(ctx context.Context, dynakube *dynakube.DynaKube, dtc dynatrace.Client, istioClient *istio.Client) error {
-	reconciler := controller.activeGateReconcilerBuilder(controller.client, controller.apiReader, dynakube, dtc, istioClient, controller.tokens)
+func (controller *Controller) reconcileActiveGate(ctx context.Context, dk *dynakube.DynaKube, dtc dynatrace.Client, istioClient *istio.Client) error {
+	reconciler := controller.activeGateReconcilerBuilder(controller.client, controller.apiReader, dk, dtc, istioClient, controller.tokens)
 	err := reconciler.Reconcile(ctx)
 
 	if err != nil {
 		return errors.WithMessage(err, "failed to reconcile ActiveGate")
 	}
 
-	controller.setupAutomaticApiMonitoring(ctx, dtc, dynakube)
+	controller.setupAutomaticApiMonitoring(ctx, dtc, dk)
 
 	return nil
 }
 
-func (controller *Controller) setupAutomaticApiMonitoring(ctx context.Context, dtc dynatrace.Client, dynakube *dynakube.DynaKube) {
-	if dynakube.Status.KubeSystemUUID != "" &&
-		dynakube.FeatureAutomaticKubernetesApiMonitoring() &&
-		dynakube.IsKubernetesMonitoringActiveGateEnabled() {
-		clusterLabel := dynakube.FeatureAutomaticKubernetesApiMonitoringClusterName()
+func (controller *Controller) setupAutomaticApiMonitoring(ctx context.Context, dtc dynatrace.Client, dk *dynakube.DynaKube) {
+	if dk.Status.KubeSystemUUID != "" &&
+		dk.FeatureAutomaticKubernetesApiMonitoring() &&
+		dk.IsKubernetesMonitoringActiveGateEnabled() {
+		clusterLabel := dk.FeatureAutomaticKubernetesApiMonitoringClusterName()
 		if clusterLabel == "" {
-			clusterLabel = dynakube.Name
+			clusterLabel = dk.Name
 		}
 
-		err := controller.apiMonitoringReconcilerBuilder(dtc, dynakube, clusterLabel, dynakube.Status.KubeSystemUUID).
+		err := controller.apiMonitoringReconcilerBuilder(dtc, dk, clusterLabel, dk.Status.KubeSystemUUID).
 			Reconcile(ctx)
 		if err != nil {
 			log.Error(err, "could not create setting")

--- a/pkg/controllers/dynakube/activegate/capability/capability.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"k8s.io/utils/net"
 )
@@ -12,11 +12,11 @@ import (
 type baseFunc func() *capabilityBase
 
 var (
-	activeGateCapabilities = map[dynatracev1beta2.CapabilityDisplayName]baseFunc{
-		dynatracev1beta2.KubeMonCapability.DisplayName:       kubeMonBase,
-		dynatracev1beta2.RoutingCapability.DisplayName:       routingBase,
-		dynatracev1beta2.MetricsIngestCapability.DisplayName: metricsIngestBase,
-		dynatracev1beta2.DynatraceApiCapability.DisplayName:  dynatraceApiBase,
+	activeGateCapabilities = map[dynakube.CapabilityDisplayName]baseFunc{
+		dynakube.KubeMonCapability.DisplayName:       kubeMonBase,
+		dynakube.RoutingCapability.DisplayName:       routingBase,
+		dynakube.MetricsIngestCapability.DisplayName: metricsIngestBase,
+		dynakube.DynatraceApiCapability.DisplayName:  dynatraceApiBase,
 	}
 )
 
@@ -25,11 +25,11 @@ type Capability interface {
 	ShortName() string
 	ArgName() string
 	DisplayName() string
-	Properties() *dynatracev1beta2.CapabilityProperties
+	Properties() *dynakube.CapabilityProperties
 }
 
 type capabilityBase struct {
-	properties  *dynatracev1beta2.CapabilityProperties
+	properties  *dynakube.CapabilityProperties
 	shortName   string
 	argName     string
 	displayName string
@@ -40,7 +40,7 @@ func (capability *capabilityBase) Enabled() bool {
 	return capability.enabled
 }
 
-func (capability *capabilityBase) Properties() *dynatracev1beta2.CapabilityProperties {
+func (capability *capabilityBase) Properties() *dynakube.CapabilityProperties {
 	return capability.properties
 }
 
@@ -64,7 +64,7 @@ type MultiCapability struct {
 	capabilityBase
 }
 
-func NewMultiCapability(dk *dynatracev1beta2.DynaKube) Capability {
+func NewMultiCapability(dk *dynakube.DynaKube) Capability {
 	mc := MultiCapability{
 		capabilityBase{
 			shortName: consts.MultiActiveGateName,
@@ -98,9 +98,9 @@ func NewMultiCapability(dk *dynatracev1beta2.DynaKube) Capability {
 
 func kubeMonBase() *capabilityBase {
 	c := capabilityBase{
-		shortName:   dynatracev1beta2.KubeMonCapability.ShortName,
-		argName:     dynatracev1beta2.KubeMonCapability.ArgumentName,
-		displayName: string(dynatracev1beta2.KubeMonCapability.DisplayName),
+		shortName:   dynakube.KubeMonCapability.ShortName,
+		argName:     dynakube.KubeMonCapability.ArgumentName,
+		displayName: string(dynakube.KubeMonCapability.DisplayName),
 	}
 
 	return &c
@@ -108,9 +108,9 @@ func kubeMonBase() *capabilityBase {
 
 func routingBase() *capabilityBase {
 	c := capabilityBase{
-		shortName:   dynatracev1beta2.RoutingCapability.ShortName,
-		argName:     dynatracev1beta2.RoutingCapability.ArgumentName,
-		displayName: string(dynatracev1beta2.RoutingCapability.DisplayName),
+		shortName:   dynakube.RoutingCapability.ShortName,
+		argName:     dynakube.RoutingCapability.ArgumentName,
+		displayName: string(dynakube.RoutingCapability.DisplayName),
 	}
 
 	return &c
@@ -118,9 +118,9 @@ func routingBase() *capabilityBase {
 
 func metricsIngestBase() *capabilityBase {
 	c := capabilityBase{
-		shortName:   dynatracev1beta2.MetricsIngestCapability.ShortName,
-		argName:     dynatracev1beta2.MetricsIngestCapability.ArgumentName,
-		displayName: string(dynatracev1beta2.MetricsIngestCapability.DisplayName),
+		shortName:   dynakube.MetricsIngestCapability.ShortName,
+		argName:     dynakube.MetricsIngestCapability.ArgumentName,
+		displayName: string(dynakube.MetricsIngestCapability.DisplayName),
 	}
 
 	return &c
@@ -128,15 +128,15 @@ func metricsIngestBase() *capabilityBase {
 
 func dynatraceApiBase() *capabilityBase {
 	c := capabilityBase{
-		shortName:   dynatracev1beta2.DynatraceApiCapability.ShortName,
-		argName:     dynatracev1beta2.DynatraceApiCapability.ArgumentName,
-		displayName: string(dynatracev1beta2.DynatraceApiCapability.DisplayName),
+		shortName:   dynakube.DynatraceApiCapability.ShortName,
+		argName:     dynakube.DynatraceApiCapability.ArgumentName,
+		displayName: string(dynakube.DynatraceApiCapability.DisplayName),
 	}
 
 	return &c
 }
 
-func GenerateActiveGateCapabilities(dk *dynatracev1beta2.DynaKube) []Capability {
+func GenerateActiveGateCapabilities(dk *dynakube.DynaKube) []Capability {
 	return []Capability{
 		NewMultiCapability(dk),
 	}
@@ -150,7 +150,7 @@ func BuildDNSEntryPointWithoutEnvVars(dynakubeName, dynakubeNamespace string, ca
 	return fmt.Sprintf("%s.%s", BuildServiceName(dynakubeName, capability.ShortName()), dynakubeNamespace)
 }
 
-func BuildDNSEntryPoint(dk dynatracev1beta2.DynaKube, capability Capability) string {
+func BuildDNSEntryPoint(dk dynakube.DynaKube, capability Capability) string {
 	entries := []string{}
 
 	for _, ip := range dk.Status.ActiveGate.ServiceIPs {

--- a/pkg/controllers/dynakube/activegate/capability/capability_test.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability_test.go
@@ -59,8 +59,8 @@ func TestBuildServiceName(t *testing.T) {
 
 func TestNewMultiCapability(t *testing.T) {
 	t.Run(`creates new multicapability`, func(t *testing.T) {
-		dynakube := buildDynakube(capabilities)
-		mc := NewMultiCapability(dynakube)
+		dk := buildDynakube(capabilities)
+		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.True(t, mc.Enabled())
 		assert.Equal(t, expectedShortName, mc.ShortName())
@@ -68,8 +68,8 @@ func TestNewMultiCapability(t *testing.T) {
 	})
 	t.Run(`creates new multicapability without capabilities set in dynakube`, func(t *testing.T) {
 		var emptyCapabilites []dynakube.CapabilityDisplayName
-		dynakube := buildDynakube(emptyCapabilites)
-		mc := NewMultiCapability(dynakube)
+		dk := buildDynakube(emptyCapabilites)
+		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.False(t, mc.Enabled())
 		assert.Equal(t, expectedShortName, mc.ShortName())

--- a/pkg/controllers/dynakube/activegate/capability/capability_test.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability_test.go
@@ -3,7 +3,7 @@ package capability
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,21 +18,21 @@ const (
 	expectedArgName   = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface"
 )
 
-var capabilities = []dynatracev1beta2.CapabilityDisplayName{
-	dynatracev1beta2.RoutingCapability.DisplayName,
-	dynatracev1beta2.KubeMonCapability.DisplayName,
-	dynatracev1beta2.MetricsIngestCapability.DisplayName,
-	dynatracev1beta2.DynatraceApiCapability.DisplayName,
+var capabilities = []dynakube.CapabilityDisplayName{
+	dynakube.RoutingCapability.DisplayName,
+	dynakube.KubeMonCapability.DisplayName,
+	dynakube.MetricsIngestCapability.DisplayName,
+	dynakube.DynatraceApiCapability.DisplayName,
 }
 
-func buildDynakube(capabilities []dynatracev1beta2.CapabilityDisplayName) *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func buildDynakube(capabilities []dynakube.CapabilityDisplayName) *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace, Name: testName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: testApiUrl,
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
+			ActiveGate: dynakube.ActiveGateSpec{
 				Capabilities: capabilities,
 			},
 		},
@@ -67,7 +67,7 @@ func TestNewMultiCapability(t *testing.T) {
 		assert.Equal(t, expectedArgName, mc.ArgName())
 	})
 	t.Run(`creates new multicapability without capabilities set in dynakube`, func(t *testing.T) {
-		var emptyCapabilites []dynatracev1beta2.CapabilityDisplayName
+		var emptyCapabilites []dynakube.CapabilityDisplayName
 		dynakube := buildDynakube(emptyCapabilites)
 		mc := NewMultiCapability(dynakube)
 		require.NotNil(t, mc)
@@ -93,11 +93,11 @@ func TestBuildServiceDomainNameForDNSEntryPoint(t *testing.T) {
 }
 
 func TestBuildDNSEntryPoint(t *testing.T) {
-	type capabilityBuilder func(*dynatracev1beta2.DynaKube) Capability
+	type capabilityBuilder func(*dynakube.DynaKube) Capability
 
 	type testCase struct {
 		title       string
-		dk          *dynatracev1beta2.DynaKube
+		dk          *dynakube.DynaKube
 		capability  capabilityBuilder
 		expectedDNS string
 	}
@@ -105,20 +105,20 @@ func TestBuildDNSEntryPoint(t *testing.T) {
 	testCases := []testCase{
 		{
 			title: "DNSEntryPoint for ActiveGate routing capability",
-			dk: &dynatracev1beta2.DynaKube{
+			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dynakube",
 					Namespace: "dynatrace",
 				},
-				Spec: dynatracev1beta2.DynaKubeSpec{
-					ActiveGate: dynatracev1beta2.ActiveGateSpec{
-						Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-							dynatracev1beta2.RoutingCapability.DisplayName,
+				Spec: dynakube.DynaKubeSpec{
+					ActiveGate: dynakube.ActiveGateSpec{
+						Capabilities: []dynakube.CapabilityDisplayName{
+							dynakube.RoutingCapability.DisplayName,
 						},
 					},
 				},
-				Status: dynatracev1beta2.DynaKubeStatus{
-					ActiveGate: dynatracev1beta2.ActiveGateStatus{
+				Status: dynakube.DynaKubeStatus{
+					ActiveGate: dynakube.ActiveGateStatus{
 						ServiceIPs: []string{"1.2.3.4"},
 					},
 				},
@@ -128,20 +128,20 @@ func TestBuildDNSEntryPoint(t *testing.T) {
 		},
 		{
 			title: "DNSEntryPoint with multiple service IPs",
-			dk: &dynatracev1beta2.DynaKube{
+			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dynakube",
 					Namespace: "dynatrace",
 				},
-				Spec: dynatracev1beta2.DynaKubeSpec{
-					ActiveGate: dynatracev1beta2.ActiveGateSpec{
-						Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-							dynatracev1beta2.RoutingCapability.DisplayName,
+				Spec: dynakube.DynaKubeSpec{
+					ActiveGate: dynakube.ActiveGateSpec{
+						Capabilities: []dynakube.CapabilityDisplayName{
+							dynakube.RoutingCapability.DisplayName,
 						},
 					},
 				},
-				Status: dynatracev1beta2.DynaKubeStatus{
-					ActiveGate: dynatracev1beta2.ActiveGateStatus{
+				Status: dynakube.DynaKubeStatus{
+					ActiveGate: dynakube.ActiveGateStatus{
 						ServiceIPs: []string{"1.2.3.4", "4.3.2.1"},
 					},
 				},
@@ -151,20 +151,20 @@ func TestBuildDNSEntryPoint(t *testing.T) {
 		},
 		{
 			title: "DNSEntryPoint with multiple service IPs, dual-stack",
-			dk: &dynatracev1beta2.DynaKube{
+			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dynakube",
 					Namespace: "dynatrace",
 				},
-				Spec: dynatracev1beta2.DynaKubeSpec{
-					ActiveGate: dynatracev1beta2.ActiveGateSpec{
-						Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-							dynatracev1beta2.RoutingCapability.DisplayName,
+				Spec: dynakube.DynaKubeSpec{
+					ActiveGate: dynakube.ActiveGateSpec{
+						Capabilities: []dynakube.CapabilityDisplayName{
+							dynakube.RoutingCapability.DisplayName,
 						},
 					},
 				},
-				Status: dynatracev1beta2.DynaKubeStatus{
-					ActiveGate: dynatracev1beta2.ActiveGateStatus{
+				Status: dynakube.DynaKubeStatus{
+					ActiveGate: dynakube.ActiveGateStatus{
 						ServiceIPs: []string{"1.2.3.4", "2600:2d00:0:4:f9b7:bd67:1d97:5994", "4.3.2.1", "2600:2d00:0:4:f9b7:bd67:1d97:5996"},
 					},
 				},
@@ -174,20 +174,20 @@ func TestBuildDNSEntryPoint(t *testing.T) {
 		},
 		{
 			title: "DNSEntryPoint for ActiveGate k8s monitoring capability",
-			dk: &dynatracev1beta2.DynaKube{
+			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dynakube",
 					Namespace: "dynatrace",
 				},
-				Spec: dynatracev1beta2.DynaKubeSpec{
-					ActiveGate: dynatracev1beta2.ActiveGateSpec{
-						Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-							dynatracev1beta2.KubeMonCapability.DisplayName,
+				Spec: dynakube.DynaKubeSpec{
+					ActiveGate: dynakube.ActiveGateSpec{
+						Capabilities: []dynakube.CapabilityDisplayName{
+							dynakube.KubeMonCapability.DisplayName,
 						},
 					},
 				},
-				Status: dynatracev1beta2.DynaKubeStatus{
-					ActiveGate: dynatracev1beta2.ActiveGateStatus{
+				Status: dynakube.DynaKubeStatus{
+					ActiveGate: dynakube.ActiveGateStatus{
 						ServiceIPs: []string{"1.2.3.4"},
 					},
 				},
@@ -197,21 +197,21 @@ func TestBuildDNSEntryPoint(t *testing.T) {
 		},
 		{
 			title: "DNSEntryPoint for ActiveGate routing+kubemon capabilities",
-			dk: &dynatracev1beta2.DynaKube{
+			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dynakube",
 					Namespace: "dynatrace",
 				},
-				Spec: dynatracev1beta2.DynaKubeSpec{
-					ActiveGate: dynatracev1beta2.ActiveGateSpec{
-						Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-							dynatracev1beta2.KubeMonCapability.DisplayName,
-							dynatracev1beta2.RoutingCapability.DisplayName,
+				Spec: dynakube.DynaKubeSpec{
+					ActiveGate: dynakube.ActiveGateSpec{
+						Capabilities: []dynakube.CapabilityDisplayName{
+							dynakube.KubeMonCapability.DisplayName,
+							dynakube.RoutingCapability.DisplayName,
 						},
 					},
 				},
-				Status: dynatracev1beta2.DynaKubeStatus{
-					ActiveGate: dynatracev1beta2.ActiveGateStatus{
+				Status: dynakube.DynaKubeStatus{
+					ActiveGate: dynakube.ActiveGateStatus{
 						ServiceIPs: []string{"1.2.3.4"},
 					},
 				},
@@ -221,18 +221,18 @@ func TestBuildDNSEntryPoint(t *testing.T) {
 		},
 		{
 			title: "DNSEntryPoint for deprecated routing ActiveGate",
-			dk: &dynatracev1beta2.DynaKube{
+			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dynakube",
 					Namespace: "dynatrace",
 				},
-				Spec: dynatracev1beta2.DynaKubeSpec{
-					ActiveGate: dynatracev1beta2.ActiveGateSpec{
+				Spec: dynakube.DynaKubeSpec{
+					ActiveGate: dynakube.ActiveGateSpec{
 						Capabilities: capabilities,
 					},
 				},
-				Status: dynatracev1beta2.DynaKubeStatus{
-					ActiveGate: dynatracev1beta2.ActiveGateStatus{
+				Status: dynakube.DynaKubeStatus{
+					ActiveGate: dynakube.ActiveGateStatus{
 						ServiceIPs: []string{"1.2.3.4"},
 					},
 				},
@@ -242,14 +242,14 @@ func TestBuildDNSEntryPoint(t *testing.T) {
 		},
 		{
 			title: "DNSEntryPoint for deprecated kubernetes monitoring ActiveGate",
-			dk: &dynatracev1beta2.DynaKube{
+			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dynakube",
 					Namespace: "dynatrace",
 				},
-				Spec: dynatracev1beta2.DynaKubeSpec{},
-				Status: dynatracev1beta2.DynaKubeStatus{
-					ActiveGate: dynatracev1beta2.ActiveGateStatus{
+				Spec: dynakube.DynaKubeSpec{},
+				Status: dynakube.DynaKubeStatus{
+					ActiveGate: dynakube.ActiveGateStatus{
 						ServiceIPs: []string{"1.2.3.4"},
 					},
 				},

--- a/pkg/controllers/dynakube/activegate/consts/consts.go
+++ b/pkg/controllers/dynakube/activegate/consts/consts.go
@@ -1,7 +1,7 @@
 package consts
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 )
 
@@ -27,7 +27,7 @@ const (
 	EnvDtDnsEntryPoint   = "DT_DNS_ENTRY_POINT"
 	EnvDtHttpPort        = "DT_HTTP_PORT"
 
-	AnnotationActiveGateConfigurationHash = dynatracev1beta2.InternalFlagPrefix + "activegate-configuration-hash"
+	AnnotationActiveGateConfigurationHash = dynakube.InternalFlagPrefix + "activegate-configuration-hash"
 	AnnotationActiveGateContainerAppArmor = "container.apparmor.security.beta.kubernetes.io/" + ActiveGateContainerName
 
 	GatewayConfigVolumeName  = "ag-lib-gateway-config"

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
@@ -31,15 +31,15 @@ var _ controllers.Reconciler = &Reconciler{}
 type Reconciler struct {
 	client    client.Client
 	apiReader client.Reader
-	dynakube  *dynatracev1beta2.DynaKube
+	dynakube  *dynakube.DynaKube
 	dtc       dtclient.Client
 }
 
-func NewReconciler(clt client.Client, apiReader client.Reader, dynakube *dynatracev1beta2.DynaKube, dtc dtclient.Client) *Reconciler {
+func NewReconciler(clt client.Client, apiReader client.Reader, dk *dynakube.DynaKube, dtc dtclient.Client) *Reconciler {
 	return &Reconciler{
 		client:    clt,
 		apiReader: apiReader,
-		dynakube:  dynakube,
+		dynakube:  dk,
 		dtc:       dtc,
 	}
 }

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
@@ -23,7 +23,7 @@ import (
 const (
 	testDynakubeName = "test-dynakube"
 	testNamespace    = "test-namespace"
-	secretName       = testDynakubeName + dynatracev1beta2.AuthTokenSecretSuffix
+	secretName       = testDynakubeName + dynakube.AuthTokenSecretSuffix
 	testToken        = "dt.testtoken.test"
 )
 
@@ -34,24 +34,24 @@ var (
 	}
 )
 
-func newInstance() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func newInstance() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testDynakubeName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: "https://testing.dev.dynatracelabs.com/api",
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
-				Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-					dynatracev1beta2.RoutingCapability.DisplayName,
+			ActiveGate: dynakube.ActiveGateSpec{
+				Capabilities: []dynakube.CapabilityDisplayName{
+					dynakube.RoutingCapability.DisplayName,
 				},
 			},
 		},
 	}
 }
 
-func newTestReconciler(t *testing.T, client client.Client, instance *dynatracev1beta2.DynaKube) *Reconciler {
+func newTestReconciler(t *testing.T, client client.Client, instance *dynakube.DynaKube) *Reconciler {
 	dtc := dtclientmock.NewClient(t)
 	dtc.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testAgAuthTokenResponse, nil)
 

--- a/pkg/controllers/dynakube/activegate/internal/capability/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/capability/reconciler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"reflect"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/object"
@@ -22,20 +22,20 @@ type Reconciler struct {
 	capability                 capability.Capability
 	statefulsetReconciler      controllers.Reconciler
 	customPropertiesReconciler controllers.Reconciler
-	dynakube                   *dynatracev1beta2.DynaKube
+	dynakube                   *dynakube.DynaKube
 }
 
-func NewReconciler(clt client.Client, capability capability.Capability, dynakube *dynatracev1beta2.DynaKube, statefulsetReconciler controllers.Reconciler, customPropertiesReconciler controllers.Reconciler) controllers.Reconciler {
+func NewReconciler(clt client.Client, capability capability.Capability, dk *dynakube.DynaKube, statefulsetReconciler controllers.Reconciler, customPropertiesReconciler controllers.Reconciler) controllers.Reconciler {
 	return &Reconciler{
 		statefulsetReconciler:      statefulsetReconciler,
 		customPropertiesReconciler: customPropertiesReconciler,
 		capability:                 capability,
-		dynakube:                   dynakube,
+		dynakube:                   dk,
 		client:                     clt,
 	}
 }
 
-type NewReconcilerFunc = func(clt client.Client, capability capability.Capability, dynakube *dynatracev1beta2.DynaKube, statefulsetReconciler controllers.Reconciler, customPropertiesReconciler controllers.Reconciler) controllers.Reconciler
+type NewReconcilerFunc = func(clt client.Client, capability capability.Capability, dk *dynakube.DynaKube, statefulsetReconciler controllers.Reconciler, customPropertiesReconciler controllers.Reconciler) controllers.Reconciler
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
 	err := r.customPropertiesReconciler.Reconcile(ctx)

--- a/pkg/controllers/dynakube/activegate/internal/capability/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/capability/reconciler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/authtoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
@@ -26,15 +26,15 @@ const (
 	testDynakube = "test-dynakube"
 )
 
-var capabilitiesWithService = []dynatracev1beta2.CapabilityDisplayName{
-	dynatracev1beta2.RoutingCapability.DisplayName,
-	dynatracev1beta2.KubeMonCapability.DisplayName,
-	dynatracev1beta2.MetricsIngestCapability.DisplayName,
-	dynatracev1beta2.DynatraceApiCapability.DisplayName,
+var capabilitiesWithService = []dynakube.CapabilityDisplayName{
+	dynakube.RoutingCapability.DisplayName,
+	dynakube.KubeMonCapability.DisplayName,
+	dynakube.MetricsIngestCapability.DisplayName,
+	dynakube.DynatraceApiCapability.DisplayName,
 }
 
-var capabilitiesWithoutService = []dynatracev1beta2.CapabilityDisplayName{
-	dynatracev1beta2.KubeMonCapability.DisplayName,
+var capabilitiesWithoutService = []dynakube.CapabilityDisplayName{
+	dynakube.KubeMonCapability.DisplayName,
 }
 
 func createClient() client.WithWatch {
@@ -48,7 +48,7 @@ func createClient() client.WithWatch {
 		}).
 		WithObjects(&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      dynatracev1beta2.AuthTokenSecretSuffix,
+				Name:      dynakube.AuthTokenSecretSuffix,
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{authtoken.ActiveGateAuthTokenName: []byte(testToken)},
@@ -56,15 +56,15 @@ func createClient() client.WithWatch {
 		Build()
 }
 
-func buildDynakube(capabilities []dynatracev1beta2.CapabilityDisplayName) *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func buildDynakube(capabilities []dynakube.CapabilityDisplayName) *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testDynakube,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: testApiUrl,
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
+			ActiveGate: dynakube.ActiveGateSpec{
 				Capabilities: capabilities,
 			},
 		},

--- a/pkg/controllers/dynakube/activegate/internal/capability/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/capability/reconciler_test.go
@@ -82,18 +82,18 @@ func verifyReconciler(t *testing.T, r *Reconciler) {
 	require.NotNil(t, r)
 	require.NotNil(t, r.client)
 	require.NotNil(t, r)
-	require.NotNil(t, r.dynakube)
+	require.NotNil(t, r.dk)
 }
 
 func TestReconcile(t *testing.T) {
 	clt := createClient()
 
 	t.Run(`reconciler works with multiple capabilities`, func(t *testing.T) {
-		dynakube := buildDynakube(capabilitiesWithService)
+		dk := buildDynakube(capabilitiesWithService)
 		mockStatefulSetReconciler := getMockReconciler(t, nil)
 		mockCustompropertiesReconciler := getMockReconciler(t, nil)
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -103,11 +103,11 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run(`statefulSetReconciler errors`, func(t *testing.T) {
-		dynakube := buildDynakube(capabilitiesWithoutService)
+		dk := buildDynakube(capabilitiesWithoutService)
 		mockStatefulSetReconciler := getMockReconciler(t, errors.New(""))
 		mockCustompropertiesReconciler := getMockReconciler(t, nil)
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -117,11 +117,11 @@ func TestReconcile(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run(`customPropertiesReconciler errors`, func(t *testing.T) {
-		dynakube := buildDynakube(capabilitiesWithoutService)
+		dk := buildDynakube(capabilitiesWithoutService)
 		mockStatefulSetReconciler := getMockReconciler(t)
 		mockCustompropertiesReconciler := getMockReconciler(t, errors.New(""))
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -130,22 +130,22 @@ func TestReconcile(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run(`statefulSetReconciler and customPropertiesReconciler error`, func(t *testing.T) {
-		dynakube := buildDynakube(capabilitiesWithoutService)
+		dk := buildDynakube(capabilitiesWithoutService)
 		mockStatefulSetReconciler := getMockReconciler(t, errors.New(""))
 		mockCustompropertiesReconciler := getMockReconciler(t, errors.New(""))
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
 		require.Error(t, err)
 	})
 	t.Run(`service gets created`, func(t *testing.T) {
-		dynakube := buildDynakube(capabilitiesWithService)
+		dk := buildDynakube(capabilitiesWithService)
 		mockStatefulSetReconciler := getMockReconciler(t, nil)
 		mockCustompropertiesReconciler := getMockReconciler(t, nil)
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -155,18 +155,18 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		service := corev1.Service{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, &service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, &service)
 
 		assert.NotNil(t, service)
 		require.NoError(t, err)
 	})
 	t.Run(`service does not get created when missing capabilities`, func(t *testing.T) {
 		clt := createClient()
-		dynakube := buildDynakube(capabilitiesWithoutService)
+		dk := buildDynakube(capabilitiesWithoutService)
 		mockStatefulSetReconciler := getMockReconciler(t, nil)
 		mockCustompropertiesReconciler := getMockReconciler(t, nil)
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -176,7 +176,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		service := corev1.Service{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, &service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, &service)
 
 		assert.Empty(t, service)
 		require.Error(t, err)
@@ -185,16 +185,16 @@ func TestReconcile(t *testing.T) {
 
 func TestCreateOrUpdateService(t *testing.T) {
 	clt := createClient()
-	dynakube := buildDynakube(capabilitiesWithService)
+	dk := buildDynakube(capabilitiesWithService)
 	mockStatefulSetReconciler := getMockReconciler(t, nil)
 	mockCustompropertiesReconciler := getMockReconciler(t, nil)
 
 	t.Run(`create service works`, func(t *testing.T) {
-		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		service := &corev1.Service{}
-		err := r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err := r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, service)
 		require.Error(t, err)
 		assert.NotNil(t, service)
 
@@ -202,19 +202,19 @@ func TestCreateOrUpdateService(t *testing.T) {
 		require.NoError(t, err)
 
 		service = &corev1.Service{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 	})
 	t.Run(`ports get updated`, func(t *testing.T) {
-		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.createOrUpdateService(context.Background())
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 
@@ -225,7 +225,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 
 		actualService := &corev1.Service{}
 
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, actualService)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, actualService)
 		require.NoError(t, err)
 		assert.NotNil(t, actualService)
 
@@ -235,14 +235,14 @@ func TestCreateOrUpdateService(t *testing.T) {
 		require.NotEqual(t, actualService.Spec.Ports, service.Spec.Ports)
 	})
 	t.Run(`labels get updated`, func(t *testing.T) {
-		r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.createOrUpdateService(context.Background())
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 
@@ -253,7 +253,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 
 		actualService := &corev1.Service{}
 
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, actualService)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, actualService)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 
@@ -264,21 +264,21 @@ func TestCreateOrUpdateService(t *testing.T) {
 
 func TestPortsAreOutdated(t *testing.T) {
 	clt := createClient()
-	dynakube := buildDynakube(capabilitiesWithService)
+	dk := buildDynakube(capabilitiesWithService)
 	mockStatefulSetReconciler := getMockReconciler(t, nil)
 	mockCustompropertiesReconciler := getMockReconciler(t, nil)
 
-	r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+	r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 	verifyReconciler(t, r)
 
-	desiredService := CreateService(r.dynakube, r.capability.ShortName())
+	desiredService := CreateService(r.dk, r.capability.ShortName())
 
 	err := r.Reconcile(context.Background())
 	require.NoError(t, err)
 
 	t.Run(`ports are detected as outdated`, func(t *testing.T) {
 		service := &corev1.Service{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 
@@ -292,20 +292,20 @@ func TestPortsAreOutdated(t *testing.T) {
 
 func TestLabelsAreOutdated(t *testing.T) {
 	clt := createClient()
-	dynakube := buildDynakube(capabilitiesWithService)
+	dk := buildDynakube(capabilitiesWithService)
 	mockStatefulSetReconciler := getMockReconciler(t, nil)
 	mockCustompropertiesReconciler := getMockReconciler(t, nil)
-	r := NewReconciler(clt, capability.NewMultiCapability(dynakube), dynakube, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+	r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
 	verifyReconciler(t, r)
 
-	desiredService := CreateService(r.dynakube, r.capability.ShortName())
+	desiredService := CreateService(r.dk, r.capability.ShortName())
 
 	err := r.Reconcile(context.Background())
 	require.NoError(t, err)
 
 	t.Run(`labels are detected as outdated`, func(t *testing.T) {
 		service := &corev1.Service{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 
@@ -317,7 +317,7 @@ func TestLabelsAreOutdated(t *testing.T) {
 	})
 	t.Run(`labelSelectors are detected as outdated`, func(t *testing.T) {
 		service := &corev1.Service{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, service)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, service)
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 

--- a/pkg/controllers/dynakube/activegate/internal/capability/service.go
+++ b/pkg/controllers/dynakube/activegate/internal/capability/service.go
@@ -1,7 +1,7 @@
 package capability
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
@@ -10,10 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func CreateService(dynakube *dynatracev1beta2.DynaKube, feature string) *corev1.Service {
+func CreateService(dk *dynakube.DynaKube, feature string) *corev1.Service {
 	var ports []corev1.ServicePort
 
-	if dynakube.NeedsActiveGateServicePorts() {
+	if dk.NeedsActiveGateServicePorts() {
 		ports = append(ports,
 			corev1.ServicePort{
 				Name:       consts.HttpsServicePortName,
@@ -22,7 +22,7 @@ func CreateService(dynakube *dynatracev1beta2.DynaKube, feature string) *corev1.
 				TargetPort: intstr.FromString(consts.HttpsServicePortName),
 			},
 		)
-		if dynakube.IsMetricsIngestActiveGateEnabled() {
+		if dk.IsMetricsIngestActiveGateEnabled() {
 			ports = append(ports, corev1.ServicePort{
 				Name:       consts.HttpServicePortName,
 				Protocol:   corev1.ProtocolTCP,
@@ -32,17 +32,17 @@ func CreateService(dynakube *dynatracev1beta2.DynaKube, feature string) *corev1.
 		}
 	}
 
-	coreLabels := labels.NewCoreLabels(dynakube.Name, labels.ActiveGateComponentLabel)
+	coreLabels := labels.NewCoreLabels(dk.Name, labels.ActiveGateComponentLabel)
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      capability.BuildServiceName(dynakube.Name, feature),
-			Namespace: dynakube.Namespace,
+			Name:      capability.BuildServiceName(dk.Name, feature),
+			Namespace: dk.Namespace,
 			Labels:    coreLabels.BuildLabels(),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
-			Selector: buildSelectorLabels(dynakube.Name),
+			Selector: buildSelectorLabels(dk.Name),
 			Ports:    ports,
 		},
 	}

--- a/pkg/controllers/dynakube/activegate/internal/capability/service_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/capability/service_test.go
@@ -3,7 +3,7 @@ package capability
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
@@ -21,12 +21,12 @@ const (
 	testApiUrl           = "https://demo.dev.dynatracelabs.com/api"
 )
 
-func testCreateInstance() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func testCreateInstance() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace, Name: testName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: testApiUrl,
 		},
 	}
@@ -74,7 +74,7 @@ func TestCreateService(t *testing.T) {
 
 	t.Run("check AG service if metrics-ingest disabled", func(t *testing.T) {
 		instance := testCreateInstance()
-		activegate.SwitchCapability(instance, dynatracev1beta2.RoutingCapability, true)
+		activegate.SwitchCapability(instance, dynakube.RoutingCapability, true)
 
 		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports
@@ -84,7 +84,7 @@ func TestCreateService(t *testing.T) {
 	})
 	t.Run("check AG service if metrics-ingest enabled", func(t *testing.T) {
 		instance := testCreateInstance()
-		activegate.SwitchCapability(instance, dynatracev1beta2.MetricsIngestCapability, true)
+		activegate.SwitchCapability(instance, dynakube.MetricsIngestCapability, true)
 
 		service := CreateService(instance, testComponentFeature)
 		ports := service.Spec.Ports

--- a/pkg/controllers/dynakube/activegate/internal/capability/service_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/capability/service_test.go
@@ -21,7 +21,7 @@ const (
 	testApiUrl           = "https://demo.dev.dynatracelabs.com/api"
 )
 
-func testCreateInstance() *dynakube.DynaKube {
+func createTestDynaKube() *dynakube.DynaKube {
 	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace, Name: testName,
@@ -47,12 +47,12 @@ func TestCreateService(t *testing.T) {
 	}
 
 	t.Run("check service name, labels and selector", func(t *testing.T) {
-		instance := testCreateInstance()
-		service := CreateService(instance, testComponentFeature)
+		dk := createTestDynaKube()
+		service := CreateService(dk, testComponentFeature)
 
 		assert.NotNil(t, service)
-		assert.Equal(t, instance.Name+"-"+testComponentFeature, service.Name)
-		assert.Equal(t, instance.Namespace, service.Namespace)
+		assert.Equal(t, dk.Name+"-"+testComponentFeature, service.Name)
+		assert.Equal(t, dk.Namespace, service.Namespace)
 
 		expectedLabels := map[string]string{
 			labels.AppCreatedByLabel: testName,
@@ -73,20 +73,20 @@ func TestCreateService(t *testing.T) {
 	})
 
 	t.Run("check AG service if metrics-ingest disabled", func(t *testing.T) {
-		instance := testCreateInstance()
-		activegate.SwitchCapability(instance, dynakube.RoutingCapability, true)
+		dk := createTestDynaKube()
+		activegate.SwitchCapability(dk, dynakube.RoutingCapability, true)
 
-		service := CreateService(instance, testComponentFeature)
+		service := CreateService(dk, testComponentFeature)
 		ports := service.Spec.Ports
 
 		assert.Contains(t, ports, agHttpsPort)
 		assert.NotContains(t, ports, agHttpPort)
 	})
 	t.Run("check AG service if metrics-ingest enabled", func(t *testing.T) {
-		instance := testCreateInstance()
-		activegate.SwitchCapability(instance, dynakube.MetricsIngestCapability, true)
+		dk := createTestDynaKube()
+		activegate.SwitchCapability(dk, dynakube.MetricsIngestCapability, true)
 
-		service := CreateService(instance, testComponentFeature)
+		service := CreateService(dk, testComponentFeature)
 		ports := service.Spec.Ports
 
 		assert.Contains(t, ports, agHttpsPort)

--- a/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
 	"github.com/pkg/errors"
@@ -25,12 +25,12 @@ var _ controllers.Reconciler = &Reconciler{}
 
 type Reconciler struct {
 	client                    client.Client
-	customPropertiesSource    *dynatracev1beta2.DynaKubeValueSource
-	instance                  *dynatracev1beta2.DynaKube
+	customPropertiesSource    *dynakube.DynaKubeValueSource
+	instance                  *dynakube.DynaKube
 	customPropertiesOwnerName string
 }
 
-func NewReconciler(clt client.Client, instance *dynatracev1beta2.DynaKube, customPropertiesOwnerName string, customPropertiesSource *dynatracev1beta2.DynaKubeValueSource) *Reconciler {
+func NewReconciler(clt client.Client, instance *dynakube.DynaKube, customPropertiesOwnerName string, customPropertiesSource *dynakube.DynaKubeValueSource) *Reconciler {
 	return &Reconciler{
 		client:                    clt,
 		instance:                  instance,

--- a/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler.go
@@ -26,14 +26,14 @@ var _ controllers.Reconciler = &Reconciler{}
 type Reconciler struct {
 	client                    client.Client
 	customPropertiesSource    *dynakube.DynaKubeValueSource
-	instance                  *dynakube.DynaKube
+	dk                        *dynakube.DynaKube
 	customPropertiesOwnerName string
 }
 
-func NewReconciler(clt client.Client, instance *dynakube.DynaKube, customPropertiesOwnerName string, customPropertiesSource *dynakube.DynaKubeValueSource) *Reconciler {
+func NewReconciler(clt client.Client, dk *dynakube.DynaKube, customPropertiesOwnerName string, customPropertiesSource *dynakube.DynaKubeValueSource) *Reconciler {
 	return &Reconciler{
 		client:                    clt,
-		instance:                  instance,
+		dk:                        dk,
 		customPropertiesSource:    customPropertiesSource,
 		customPropertiesOwnerName: customPropertiesOwnerName,
 	}
@@ -69,7 +69,7 @@ func (r *Reconciler) createCustomPropertiesIfNotExists(ctx context.Context) (boo
 	var customPropertiesSecret corev1.Secret
 
 	err := r.client.Get(ctx,
-		client.ObjectKey{Name: r.buildCustomPropertiesName(r.instance.Name), Namespace: r.instance.Namespace}, &customPropertiesSecret)
+		client.ObjectKey{Name: r.buildCustomPropertiesName(r.dk.Name), Namespace: r.dk.Namespace}, &customPropertiesSecret)
 	if err != nil && k8serrors.IsNotFound(err) {
 		return true, r.createCustomProperties()
 	}
@@ -81,7 +81,7 @@ func (r *Reconciler) updateCustomPropertiesIfOutdated(ctx context.Context) error
 	var customPropertiesSecret corev1.Secret
 
 	err := r.client.Get(ctx,
-		client.ObjectKey{Name: r.buildCustomPropertiesName(r.instance.Name), Namespace: r.instance.Namespace},
+		client.ObjectKey{Name: r.buildCustomPropertiesName(r.dk.Name), Namespace: r.dk.Namespace},
 		&customPropertiesSecret)
 	if err != nil {
 		return errors.WithStack(err)
@@ -105,9 +105,9 @@ func (r *Reconciler) updateCustomProperties(ctx context.Context, customPropertie
 }
 
 func (r *Reconciler) createCustomProperties() error {
-	customPropertiesSecret, err := secret.Create(r.instance,
-		secret.NewNameModifier(r.buildCustomPropertiesName(r.instance.Name)),
-		secret.NewNamespaceModifier(r.instance.Namespace),
+	customPropertiesSecret, err := secret.Create(r.dk,
+		secret.NewNameModifier(r.buildCustomPropertiesName(r.dk.Name)),
+		secret.NewNamespaceModifier(r.dk.Namespace),
 		secret.NewDataModifier(map[string][]byte{
 			DataKey: []byte(r.customPropertiesSource.Value),
 		}))

--- a/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -23,13 +23,13 @@ const (
 
 func TestReconciler_Reconcile(t *testing.T) {
 	t.Run(`Create works with minimal setup`, func(t *testing.T) {
-		r := NewReconciler(nil, nil, "", &dynatracev1beta2.DynaKubeValueSource{})
+		r := NewReconciler(nil, nil, "", &dynakube.DynaKubeValueSource{})
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 	})
 	t.Run(`Create creates custom properties secret`, func(t *testing.T) {
-		valueSource := dynatracev1beta2.DynaKubeValueSource{Value: testValue}
-		instance := &dynatracev1beta2.DynaKube{
+		valueSource := dynakube.DynaKubeValueSource{Value: testValue}
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -50,8 +50,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.Equal(t, customPropertiesSecret.Data[DataKey], []byte(testValue))
 	})
 	t.Run(`Create updates custom properties only if data changed`, func(t *testing.T) {
-		valueSource := dynatracev1beta2.DynaKubeValueSource{Value: testValue}
-		instance := &dynatracev1beta2.DynaKube{
+		valueSource := dynakube.DynaKubeValueSource{Value: testValue}
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,

--- a/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler_test.go
@@ -29,13 +29,13 @@ func TestReconciler_Reconcile(t *testing.T) {
 	})
 	t.Run(`Create creates custom properties secret`, func(t *testing.T) {
 		valueSource := dynakube.DynaKubeValueSource{Value: testValue}
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			}}
-		fakeClient := fake.NewClient(instance)
-		r := NewReconciler(fakeClient, instance, testOwner, &valueSource)
+		fakeClient := fake.NewClient(dk)
+		r := NewReconciler(fakeClient, dk, testOwner, &valueSource)
 		err := r.Reconcile(context.Background())
 
 		require.NoError(t, err)
@@ -51,13 +51,13 @@ func TestReconciler_Reconcile(t *testing.T) {
 	})
 	t.Run(`Create updates custom properties only if data changed`, func(t *testing.T) {
 		valueSource := dynakube.DynaKubeValueSource{Value: testValue}
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			}}
-		fakeClient := fake.NewClient(instance)
-		r := NewReconciler(fakeClient, instance, testOwner, &valueSource)
+		fakeClient := fake.NewClient(dk)
+		r := NewReconciler(fakeClient, dk, testOwner, &valueSource)
 		err := r.Reconcile(context.Background())
 
 		require.NoError(t, err)

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/authtoken.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/authtoken.go
@@ -16,12 +16,12 @@ var _ builder.Modifier = AuthTokenModifier{}
 
 func NewAuthTokenModifier(dk dynakube.DynaKube) AuthTokenModifier {
 	return AuthTokenModifier{
-		dynakube: dk,
+		dk: dk,
 	}
 }
 
 type AuthTokenModifier struct {
-	dynakube dynakube.DynaKube
+	dk dynakube.DynaKube
 }
 
 func (mod AuthTokenModifier) Enabled() bool {
@@ -42,7 +42,7 @@ func (mod AuthTokenModifier) getVolumes() []corev1.Volume {
 			Name: consts.AuthTokenSecretVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: mod.dynakube.ActiveGateAuthTokenSecret(),
+					SecretName: mod.dk.ActiveGateAuthTokenSecret(),
 				},
 			},
 		},

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/authtoken.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/authtoken.go
@@ -1,7 +1,7 @@
 package modifiers
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/authtoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
@@ -14,14 +14,14 @@ var _ volumeModifier = AuthTokenModifier{}
 var _ volumeMountModifier = AuthTokenModifier{}
 var _ builder.Modifier = AuthTokenModifier{}
 
-func NewAuthTokenModifier(dynakube dynatracev1beta2.DynaKube) AuthTokenModifier {
+func NewAuthTokenModifier(dk dynakube.DynaKube) AuthTokenModifier {
 	return AuthTokenModifier{
-		dynakube: dynakube,
+		dynakube: dk,
 	}
 }
 
 type AuthTokenModifier struct {
-	dynakube dynatracev1beta2.DynaKube
+	dynakube dynakube.DynaKube
 }
 
 func (mod AuthTokenModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/authtoken_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/authtoken_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestAuthTokenModify(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		mod := NewAuthTokenModifier(dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		mod := NewAuthTokenModifier(dk)
 		builder := createBuilderForTesting()
 
 		sts, _ := builder.AddModifier(mod).Build()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
@@ -3,7 +3,7 @@ package modifiers
 import (
 	"path/filepath"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/container"
@@ -20,14 +20,14 @@ const (
 	secretsRootDir = "/var/lib/dynatrace/secrets/"
 )
 
-func NewCertificatesModifier(dynakube dynatracev1beta2.DynaKube) CertificatesModifier {
+func NewCertificatesModifier(dk dynakube.DynaKube) CertificatesModifier {
 	return CertificatesModifier{
-		dynakube: dynakube,
+		dynakube: dk,
 	}
 }
 
 type CertificatesModifier struct {
-	dynakube dynatracev1beta2.DynaKube
+	dynakube dynakube.DynaKube
 }
 
 func (mod CertificatesModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
@@ -22,16 +22,16 @@ const (
 
 func NewCertificatesModifier(dk dynakube.DynaKube) CertificatesModifier {
 	return CertificatesModifier{
-		dynakube: dk,
+		dk: dk,
 	}
 }
 
 type CertificatesModifier struct {
-	dynakube dynakube.DynaKube
+	dk dynakube.DynaKube
 }
 
 func (mod CertificatesModifier) Enabled() bool {
-	return mod.dynakube.HasActiveGateCaCert()
+	return mod.dk.HasActiveGateCaCert()
 }
 
 func (mod CertificatesModifier) Modify(sts *appsv1.StatefulSet) error {
@@ -48,7 +48,7 @@ func (mod CertificatesModifier) getVolumes() []corev1.Volume {
 			Name: jettyCerts,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: mod.dynakube.Spec.ActiveGate.TlsSecretName,
+					SecretName: mod.dk.Spec.ActiveGate.TlsSecretName,
 				},
 			},
 		},

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs_test.go
@@ -20,21 +20,21 @@ func setCertUsage(dk *dynakube.DynaKube, isUsed bool) {
 
 func TestCertEnabled(t *testing.T) {
 	t.Run("true", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		setCertUsage(&dynakube, true)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		setCertUsage(&dk, true)
 
-		mod := NewCertificatesModifier(dynakube)
+		mod := NewCertificatesModifier(dk)
 
 		assert.True(t, mod.Enabled())
 	})
 
 	t.Run("false", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		setCertUsage(&dynakube, false)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		setCertUsage(&dk, false)
 
-		mod := NewCertificatesModifier(dynakube)
+		mod := NewCertificatesModifier(dk)
 
 		assert.False(t, mod.Enabled())
 	})
@@ -42,10 +42,10 @@ func TestCertEnabled(t *testing.T) {
 
 func TestCertModify(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		setCertUsage(&dynakube, true)
-		mod := NewCertificatesModifier(dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		setCertUsage(&dk, true)
+		mod := NewCertificatesModifier(dk)
 		builder := createBuilderForTesting()
 
 		sts, _ := builder.AddModifier(mod).Build()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs_test.go
@@ -3,18 +3,18 @@ package modifiers
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const testTlsSecretName = "test-tls-secret"
 
-func setCertUsage(dynakube *dynatracev1beta2.DynaKube, isUsed bool) {
+func setCertUsage(dk *dynakube.DynaKube, isUsed bool) {
 	if isUsed {
-		dynakube.Spec.ActiveGate.TlsSecretName = testTlsSecretName
+		dk.Spec.ActiveGate.TlsSecretName = testTlsSecretName
 	} else {
-		dynakube.Spec.ActiveGate.TlsSecretName = ""
+		dk.Spec.ActiveGate.TlsSecretName = ""
 	}
 }
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
@@ -1,7 +1,7 @@
 package modifiers
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/prioritymap"
@@ -26,17 +26,17 @@ type initContainerModifier interface {
 	getInitContainers() []corev1.Container
 }
 
-func GenerateAllModifiers(dynakube dynatracev1beta2.DynaKube, capability capability.Capability, agBaseContainerEnvMap *prioritymap.Map) []builder.Modifier {
+func GenerateAllModifiers(dk dynakube.DynaKube, capability capability.Capability, agBaseContainerEnvMap *prioritymap.Map) []builder.Modifier {
 	return []builder.Modifier{
-		NewAuthTokenModifier(dynakube),
-		NewSSLVolumeModifier(dynakube),
-		NewCertificatesModifier(dynakube),
-		NewTrustedCAsVolumeModifier(dynakube),
-		NewCustomPropertiesModifier(dynakube, capability),
-		NewProxyModifier(dynakube),
-		NewRawImageModifier(dynakube, agBaseContainerEnvMap),
-		NewReadOnlyModifier(dynakube),
-		NewServicePortModifier(dynakube, capability, agBaseContainerEnvMap),
-		NewKubernetesMonitoringModifier(dynakube, capability),
+		NewAuthTokenModifier(dk),
+		NewSSLVolumeModifier(dk),
+		NewCertificatesModifier(dk),
+		NewTrustedCAsVolumeModifier(dk),
+		NewCustomPropertiesModifier(dk, capability),
+		NewProxyModifier(dk),
+		NewRawImageModifier(dk, agBaseContainerEnvMap),
+		NewReadOnlyModifier(dk),
+		NewServicePortModifier(dk, capability, agBaseContainerEnvMap),
+		NewKubernetesMonitoringModifier(dk, capability),
 	}
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config_test.go
@@ -3,7 +3,7 @@ package modifiers
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
@@ -51,19 +51,19 @@ func createBuilderForTesting() builder.Builder {
 	return builder
 }
 
-func getBaseDynakube() dynatracev1beta2.DynaKube {
-	return dynatracev1beta2.DynaKube{
+func getBaseDynakube() dynakube.DynaKube {
+	return dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        testDynakubeName,
 			Namespace:   testNamespaceName,
 			Annotations: map[string]string{},
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{},
+		Spec: dynakube.DynaKubeSpec{},
 	}
 }
 
-func enableKubeMonCapability(dynakube *dynatracev1beta2.DynaKube) {
-	dynakube.Spec.ActiveGate.Capabilities = append(dynakube.Spec.ActiveGate.Capabilities, dynatracev1beta2.KubeMonCapability.DisplayName)
+func enableKubeMonCapability(dk *dynakube.DynaKube) {
+	dk.Spec.ActiveGate.Capabilities = append(dk.Spec.ActiveGate.Capabilities, dynakube.KubeMonCapability.DisplayName)
 }
 
 func isSubset[T any](t *testing.T, subset, superset []T) {
@@ -72,21 +72,21 @@ func isSubset[T any](t *testing.T, subset, superset []T) {
 	}
 }
 
-func enableAllModifiers(dynakube *dynatracev1beta2.DynaKube, capability capability.Capability) {
-	setCertUsage(dynakube, true)
+func enableAllModifiers(dk *dynakube.DynaKube, capability capability.Capability) {
+	setCertUsage(dk, true)
 	setCustomPropertyUsage(capability, true)
-	setProxyUsage(dynakube, true)
-	setKubernetesMonitoringUsage(dynakube, true)
-	setServicePortUsage(dynakube, true)
+	setProxyUsage(dk, true)
+	setKubernetesMonitoringUsage(dk, true)
+	setServicePortUsage(dk, true)
 }
 
 func TestNoConflict(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		enableAllModifiers(&dynakube, multiCapability)
-		mods := GenerateAllModifiers(dynakube, multiCapability, prioritymap.New())
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		multiCapability := capability.NewMultiCapability(&dk)
+		enableAllModifiers(&dk, multiCapability)
+		mods := GenerateAllModifiers(dk, multiCapability, prioritymap.New())
 		builder := createBuilderForTesting()
 
 		sts, _ := builder.AddModifier(mods...).Build()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/customprops.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/customprops.go
@@ -3,7 +3,7 @@ package modifiers
 import (
 	"fmt"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/customproperties"
@@ -17,16 +17,16 @@ var _ volumeModifier = CustomPropertiesModifier{}
 var _ volumeMountModifier = CustomPropertiesModifier{}
 var _ builder.Modifier = CustomPropertiesModifier{}
 
-func NewCustomPropertiesModifier(dynakube dynatracev1beta2.DynaKube, capability capability.Capability) CustomPropertiesModifier {
+func NewCustomPropertiesModifier(dk dynakube.DynaKube, capability capability.Capability) CustomPropertiesModifier {
 	return CustomPropertiesModifier{
-		dynakube:   dynakube,
+		dynakube:   dk,
 		capability: capability,
 	}
 }
 
 type CustomPropertiesModifier struct {
 	capability capability.Capability
-	dynakube   dynatracev1beta2.DynaKube
+	dynakube   dynakube.DynaKube
 }
 
 func (mod CustomPropertiesModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/customprops.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/customprops.go
@@ -19,14 +19,14 @@ var _ builder.Modifier = CustomPropertiesModifier{}
 
 func NewCustomPropertiesModifier(dk dynakube.DynaKube, capability capability.Capability) CustomPropertiesModifier {
 	return CustomPropertiesModifier{
-		dynakube:   dk,
+		dk:         dk,
 		capability: capability,
 	}
 }
 
 type CustomPropertiesModifier struct {
 	capability capability.Capability
-	dynakube   dynakube.DynaKube
+	dk         dynakube.DynaKube
 }
 
 func (mod CustomPropertiesModifier) Enabled() bool {
@@ -79,7 +79,7 @@ func (mod CustomPropertiesModifier) hasCustomProperties() bool {
 
 func (mod CustomPropertiesModifier) determineCustomPropertiesSource() string {
 	if mod.capability.Properties().CustomProperties.ValueFrom == "" {
-		return fmt.Sprintf("%s-%s-%s", mod.dynakube.Name, mod.dynakube.ActiveGateServiceAccountOwner(), customproperties.Suffix)
+		return fmt.Sprintf("%s-%s-%s", mod.dk.Name, mod.dk.ActiveGateServiceAccountOwner(), customproperties.Suffix)
 	}
 
 	return mod.capability.Properties().CustomProperties.ValueFrom

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/customprops_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/customprops_test.go
@@ -3,7 +3,7 @@ package modifiers
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +13,7 @@ const testCustomPropertyValue = "testing-property"
 
 func setCustomPropertyUsage(capability capability.Capability, isUsed bool) {
 	if isUsed {
-		capability.Properties().CustomProperties = &dynatracev1beta2.DynaKubeValueSource{
+		capability.Properties().CustomProperties = &dynakube.DynaKubeValueSource{
 			Value: testCustomPropertyValue,
 		}
 	} else {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/customprops_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/customprops_test.go
@@ -23,23 +23,23 @@ func setCustomPropertyUsage(capability capability.Capability, isUsed bool) {
 
 func TestCustomPropertyEnabled(t *testing.T) {
 	t.Run("true", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		multiCapability := capability.NewMultiCapability(&dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		multiCapability := capability.NewMultiCapability(&dk)
 		setCustomPropertyUsage(multiCapability, true)
 
-		mod := NewCustomPropertiesModifier(dynakube, multiCapability)
+		mod := NewCustomPropertiesModifier(dk, multiCapability)
 
 		assert.True(t, mod.Enabled())
 	})
 
 	t.Run("false", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		multiCapability := capability.NewMultiCapability(&dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		multiCapability := capability.NewMultiCapability(&dk)
 		setCustomPropertyUsage(multiCapability, false)
 
-		mod := NewCustomPropertiesModifier(dynakube, multiCapability)
+		mod := NewCustomPropertiesModifier(dk, multiCapability)
 
 		assert.False(t, mod.Enabled())
 	})
@@ -47,11 +47,11 @@ func TestCustomPropertyEnabled(t *testing.T) {
 
 func TestCustomPropertyModify(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		multiCapability := capability.NewMultiCapability(&dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		multiCapability := capability.NewMultiCapability(&dk)
 		setCustomPropertyUsage(multiCapability, true)
-		mod := NewCustomPropertiesModifier(dynakube, multiCapability)
+		mod := NewCustomPropertiesModifier(dk, multiCapability)
 		builder := createBuilderForTesting()
 
 		sts, _ := builder.AddModifier(mod).Build()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
@@ -1,7 +1,7 @@
 package modifiers
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
@@ -28,16 +28,16 @@ const (
 	certLoaderWorkDirVolume = "cert-tmp"
 )
 
-func NewKubernetesMonitoringModifier(dynakube dynatracev1beta2.DynaKube, capability capability.Capability) KubernetesMonitoringModifier {
+func NewKubernetesMonitoringModifier(dk dynakube.DynaKube, capability capability.Capability) KubernetesMonitoringModifier {
 	return KubernetesMonitoringModifier{
-		dynakube:   dynakube,
+		dynakube:   dk,
 		capability: capability,
 	}
 }
 
 type KubernetesMonitoringModifier struct {
 	capability capability.Capability
-	dynakube   dynatracev1beta2.DynaKube
+	dynakube   dynakube.DynaKube
 }
 
 func (mod KubernetesMonitoringModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
@@ -30,18 +30,18 @@ const (
 
 func NewKubernetesMonitoringModifier(dk dynakube.DynaKube, capability capability.Capability) KubernetesMonitoringModifier {
 	return KubernetesMonitoringModifier{
-		dynakube:   dk,
+		dk:         dk,
 		capability: capability,
 	}
 }
 
 type KubernetesMonitoringModifier struct {
 	capability capability.Capability
-	dynakube   dynakube.DynaKube
+	dk         dynakube.DynaKube
 }
 
 func (mod KubernetesMonitoringModifier) Enabled() bool {
-	return mod.dynakube.IsKubernetesMonitoringActiveGateEnabled()
+	return mod.dk.IsKubernetesMonitoringActiveGateEnabled()
 }
 
 func (mod KubernetesMonitoringModifier) Modify(sts *appsv1.StatefulSet) error {
@@ -66,7 +66,7 @@ func (mod KubernetesMonitoringModifier) getInitContainers() []corev1.Container {
 	return []corev1.Container{
 		{
 			Name:            initContainerTemplateName,
-			Image:           mod.dynakube.ActiveGateImage(),
+			Image:           mod.dk.ActiveGateImage(),
 			ImagePullPolicy: corev1.PullAlways,
 			WorkingDir:      k8scrt2jksWorkingDir,
 			Command:         []string{"/bin/bash"},

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon_test.go
@@ -17,21 +17,21 @@ func setKubernetesMonitoringUsage(dk *dynakube.DynaKube, isUsed bool) {
 
 func TestKubernetesMonitoringEnabled(t *testing.T) {
 	t.Run("true", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		setKubernetesMonitoringUsage(&dynakube, true)
-		multiCapability := capability.NewMultiCapability(&dynakube)
+		dk := getBaseDynakube()
+		setKubernetesMonitoringUsage(&dk, true)
+		multiCapability := capability.NewMultiCapability(&dk)
 
-		mod := NewKubernetesMonitoringModifier(dynakube, multiCapability)
+		mod := NewKubernetesMonitoringModifier(dk, multiCapability)
 
 		assert.True(t, mod.Enabled())
 	})
 
 	t.Run("false", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		setKubernetesMonitoringUsage(&dynakube, false)
-		multiCapability := capability.NewMultiCapability(&dynakube)
+		dk := getBaseDynakube()
+		setKubernetesMonitoringUsage(&dk, false)
+		multiCapability := capability.NewMultiCapability(&dk)
 
-		mod := NewKubernetesMonitoringModifier(dynakube, multiCapability)
+		mod := NewKubernetesMonitoringModifier(dk, multiCapability)
 
 		assert.False(t, mod.Enabled())
 	})
@@ -39,10 +39,10 @@ func TestKubernetesMonitoringEnabled(t *testing.T) {
 
 func TestKubernetesMonitoringModify(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		setKubernetesMonitoringUsage(&dynakube, true)
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		mod := NewKubernetesMonitoringModifier(dynakube, multiCapability)
+		dk := getBaseDynakube()
+		setKubernetesMonitoringUsage(&dk, true)
+		multiCapability := capability.NewMultiCapability(&dk)
+		mod := NewKubernetesMonitoringModifier(dk, multiCapability)
 		builder := createBuilderForTesting()
 		expectedVolumes := mod.getVolumes()
 		expectedIniContainers := mod.getInitContainers()
@@ -57,10 +57,10 @@ func TestKubernetesMonitoringModify(t *testing.T) {
 		isSubset(t, expectedIniContainers, sts.Spec.Template.Spec.InitContainers)
 	})
 	t.Run("successfully modified with readonly feature flag", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		setKubernetesMonitoringUsage(&dynakube, true)
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		mod := NewKubernetesMonitoringModifier(dynakube, multiCapability)
+		dk := getBaseDynakube()
+		setKubernetesMonitoringUsage(&dk, true)
+		multiCapability := capability.NewMultiCapability(&dk)
+		mod := NewKubernetesMonitoringModifier(dk, multiCapability)
 		builder := createBuilderForTesting()
 		expectedVolumes := mod.getVolumes()
 		expectedIniContainers := mod.getInitContainers()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon_test.go
@@ -3,15 +3,15 @@ package modifiers
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func setKubernetesMonitoringUsage(dynakube *dynatracev1beta2.DynaKube, isUsed bool) {
+func setKubernetesMonitoringUsage(dk *dynakube.DynaKube, isUsed bool) {
 	if isUsed {
-		enableKubeMonCapability(dynakube)
+		enableKubeMonCapability(dk)
 	}
 }
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy.go
@@ -16,16 +16,16 @@ var _ builder.Modifier = ProxyModifier{}
 
 func NewProxyModifier(dk dynakube.DynaKube) ProxyModifier {
 	return ProxyModifier{
-		dynakube: dk,
+		dk: dk,
 	}
 }
 
 type ProxyModifier struct {
-	dynakube dynakube.DynaKube
+	dk dynakube.DynaKube
 }
 
 func (mod ProxyModifier) Enabled() bool {
-	return mod.dynakube.NeedsActiveGateProxy()
+	return mod.dk.NeedsActiveGateProxy()
 }
 
 func (mod ProxyModifier) Modify(sts *appsv1.StatefulSet) error {
@@ -42,7 +42,7 @@ func (mod ProxyModifier) getVolumes() []corev1.Volume {
 			Name: proxy.SecretVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: proxy.BuildSecretName(mod.dynakube.Name),
+					SecretName: proxy.BuildSecretName(mod.dk.Name),
 				},
 			},
 		},

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy.go
@@ -1,7 +1,7 @@
 package modifiers
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
@@ -14,14 +14,14 @@ var _ volumeModifier = ProxyModifier{}
 var _ volumeMountModifier = ProxyModifier{}
 var _ builder.Modifier = ProxyModifier{}
 
-func NewProxyModifier(dynakube dynatracev1beta2.DynaKube) ProxyModifier {
+func NewProxyModifier(dk dynakube.DynaKube) ProxyModifier {
 	return ProxyModifier{
-		dynakube: dynakube,
+		dynakube: dk,
 	}
 }
 
 type ProxyModifier struct {
-	dynakube dynatracev1beta2.DynaKube
+	dynakube dynakube.DynaKube
 }
 
 func (mod ProxyModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy_test.go
@@ -21,21 +21,21 @@ func setProxyUsage(dk *dynakube.DynaKube, isUsed bool) {
 
 func TestProxyEnabled(t *testing.T) {
 	t.Run("true", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		setProxyUsage(&dynakube, true)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		setProxyUsage(&dk, true)
 
-		mod := NewProxyModifier(dynakube)
+		mod := NewProxyModifier(dk)
 
 		assert.True(t, mod.Enabled())
 	})
 
 	t.Run("false", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		setProxyUsage(&dynakube, false)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		setProxyUsage(&dk, false)
 
-		mod := NewProxyModifier(dynakube)
+		mod := NewProxyModifier(dk)
 
 		assert.False(t, mod.Enabled())
 	})
@@ -43,10 +43,10 @@ func TestProxyEnabled(t *testing.T) {
 
 func TestProxyModify(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		setProxyUsage(&dynakube, true)
-		mod := NewProxyModifier(dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		setProxyUsage(&dk, true)
+		mod := NewProxyModifier(dk)
 		builder := createBuilderForTesting()
 
 		sts, _ := builder.AddModifier(mod).Build()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy_test.go
@@ -3,19 +3,19 @@ package modifiers
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const testProxyName = "test-proxy"
 
-func setProxyUsage(dynakube *dynatracev1beta2.DynaKube, isUsed bool) {
-	dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{}
+func setProxyUsage(dk *dynakube.DynaKube, isUsed bool) {
+	dk.Spec.Proxy = &dynakube.DynaKubeProxy{}
 	if isUsed {
-		dynakube.Spec.Proxy.ValueFrom = testProxyName
+		dk.Spec.Proxy.ValueFrom = testProxyName
 	} else {
-		dynakube.Spec.Proxy.ValueFrom = ""
+		dk.Spec.Proxy.ValueFrom = ""
 	}
 }
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/rawimage.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/rawimage.go
@@ -1,7 +1,7 @@
 package modifiers
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
@@ -17,16 +17,16 @@ var _ volumeModifier = RawImageModifier{}
 var _ volumeMountModifier = RawImageModifier{}
 var _ builder.Modifier = RawImageModifier{}
 
-func NewRawImageModifier(dynakube dynatracev1beta2.DynaKube, envMap *prioritymap.Map) RawImageModifier {
+func NewRawImageModifier(dk dynakube.DynaKube, envMap *prioritymap.Map) RawImageModifier {
 	return RawImageModifier{
-		dynakube: dynakube,
+		dynakube: dk,
 		envMap:   envMap,
 	}
 }
 
 type RawImageModifier struct {
 	envMap   *prioritymap.Map
-	dynakube dynatracev1beta2.DynaKube
+	dynakube dynakube.DynaKube
 }
 
 func (mod RawImageModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/rawimage.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/rawimage.go
@@ -19,14 +19,14 @@ var _ builder.Modifier = RawImageModifier{}
 
 func NewRawImageModifier(dk dynakube.DynaKube, envMap *prioritymap.Map) RawImageModifier {
 	return RawImageModifier{
-		dynakube: dk,
-		envMap:   envMap,
+		dk:     dk,
+		envMap: envMap,
 	}
 }
 
 type RawImageModifier struct {
-	envMap   *prioritymap.Map
-	dynakube dynakube.DynaKube
+	envMap *prioritymap.Map
+	dk     dynakube.DynaKube
 }
 
 func (mod RawImageModifier) Enabled() bool {
@@ -48,7 +48,7 @@ func (mod RawImageModifier) getVolumes() []corev1.Volume {
 			Name: connectioninfo.TenantSecretVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: mod.dynakube.ActivegateTenantSecret(),
+					SecretName: mod.dk.ActivegateTenantSecret(),
 				},
 			},
 		},
@@ -79,7 +79,7 @@ func (mod RawImageModifier) tenantUUIDEnvVar() corev1.EnvVar {
 		Name: connectioninfo.EnvDtTenant,
 		ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
-				Name: mod.dynakube.ActiveGateConnectionInfoConfigMapName(),
+				Name: mod.dk.ActiveGateConnectionInfoConfigMapName(),
 			},
 			Key:      connectioninfo.TenantUUIDKey,
 			Optional: address.Of(false),
@@ -91,7 +91,7 @@ func (mod RawImageModifier) communicationEndpointEnvVar() corev1.EnvVar {
 		Name: connectioninfo.EnvDtServer,
 		ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
-				Name: mod.dynakube.ActiveGateConnectionInfoConfigMapName(),
+				Name: mod.dk.ActiveGateConnectionInfoConfigMapName(),
 			},
 			Key:      connectioninfo.CommunicationEndpointsKey,
 			Optional: address.Of(false),

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/rawimage_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/rawimage_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestRawImageEnabled(t *testing.T) {
 	t.Run("true", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
 
-		mod := NewRawImageModifier(dynakube, prioritymap.New())
+		mod := NewRawImageModifier(dk, prioritymap.New())
 
 		assert.True(t, mod.Enabled())
 	})
@@ -21,9 +21,9 @@ func TestRawImageEnabled(t *testing.T) {
 
 func TestRawImageModify(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		mod := NewRawImageModifier(dynakube, prioritymap.New())
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		mod := NewRawImageModifier(dk, prioritymap.New())
 		builder := createBuilderForTesting()
 
 		sts, _ := builder.AddModifier(mod).Build()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/readonly.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/readonly.go
@@ -16,14 +16,14 @@ var _ builder.Modifier = ReadOnlyModifier{}
 
 func NewReadOnlyModifier(dk dynakube.DynaKube) ReadOnlyModifier {
 	return ReadOnlyModifier{
-		dynakube: dk,
+		dk: dk,
 	}
 }
 
 type ReadOnlyModifier struct {
 	presentVolumes []corev1.Volume
 	presentMounts  []corev1.VolumeMount
-	dynakube       dynakube.DynaKube
+	dk             dynakube.DynaKube
 }
 
 func (mod ReadOnlyModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/readonly.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/readonly.go
@@ -1,7 +1,7 @@
 package modifiers
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
@@ -14,16 +14,16 @@ var _ volumeModifier = ReadOnlyModifier{}
 var _ volumeMountModifier = ReadOnlyModifier{}
 var _ builder.Modifier = ReadOnlyModifier{}
 
-func NewReadOnlyModifier(dynakube dynatracev1beta2.DynaKube) ReadOnlyModifier {
+func NewReadOnlyModifier(dk dynakube.DynaKube) ReadOnlyModifier {
 	return ReadOnlyModifier{
-		dynakube: dynakube,
+		dynakube: dk,
 	}
 }
 
 type ReadOnlyModifier struct {
 	presentVolumes []corev1.Volume
 	presentMounts  []corev1.VolumeMount
-	dynakube       dynatracev1beta2.DynaKube
+	dynakube       dynakube.DynaKube
 }
 
 func (mod ReadOnlyModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/readonly_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/readonly_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestReadOnlyEnabled(t *testing.T) {
 	t.Run("true", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
 
-		mod := NewReadOnlyModifier(dynakube)
+		mod := NewReadOnlyModifier(dk)
 
 		assert.True(t, mod.Enabled())
 	})
@@ -20,9 +20,9 @@ func TestReadOnlyEnabled(t *testing.T) {
 
 func TestReadOnlyModify(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		mod := NewReadOnlyModifier(dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		mod := NewReadOnlyModifier(dk)
 		builder := createBuilderForTesting()
 		expectedVolumes := mod.getVolumes()
 		expectedVolumeMounts := mod.getVolumeMounts()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
@@ -1,7 +1,7 @@
 package modifiers
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
@@ -15,9 +15,9 @@ import (
 var _ envModifier = ServicePortModifier{}
 var _ builder.Modifier = ServicePortModifier{}
 
-func NewServicePortModifier(dynakube dynatracev1beta2.DynaKube, capability capability.Capability, envMap *prioritymap.Map) ServicePortModifier {
+func NewServicePortModifier(dk dynakube.DynaKube, capability capability.Capability, envMap *prioritymap.Map) ServicePortModifier {
 	return ServicePortModifier{
-		dynakube:   dynakube,
+		dynakube:   dk,
 		capability: capability,
 		envMap:     envMap,
 	}
@@ -26,7 +26,7 @@ func NewServicePortModifier(dynakube dynatracev1beta2.DynaKube, capability capab
 type ServicePortModifier struct {
 	capability capability.Capability
 	envMap     *prioritymap.Map
-	dynakube   dynatracev1beta2.DynaKube
+	dynakube   dynakube.DynaKube
 }
 
 func (mod ServicePortModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
@@ -17,7 +17,7 @@ var _ builder.Modifier = ServicePortModifier{}
 
 func NewServicePortModifier(dk dynakube.DynaKube, capability capability.Capability, envMap *prioritymap.Map) ServicePortModifier {
 	return ServicePortModifier{
-		dynakube:   dk,
+		dk:         dk,
 		capability: capability,
 		envMap:     envMap,
 	}
@@ -26,11 +26,11 @@ func NewServicePortModifier(dk dynakube.DynaKube, capability capability.Capabili
 type ServicePortModifier struct {
 	capability capability.Capability
 	envMap     *prioritymap.Map
-	dynakube   dynakube.DynaKube
+	dk         dynakube.DynaKube
 }
 
 func (mod ServicePortModifier) Enabled() bool {
-	return mod.dynakube.NeedsActiveGateServicePorts()
+	return mod.dk.NeedsActiveGateServicePorts()
 }
 
 func (mod ServicePortModifier) Modify(sts *appsv1.StatefulSet) error {
@@ -49,7 +49,7 @@ func (mod ServicePortModifier) getPorts() []corev1.ContainerPort {
 			ContainerPort: consts.HttpsContainerPort,
 		},
 	}
-	if mod.dynakube.IsMetricsIngestActiveGateEnabled() {
+	if mod.dk.IsMetricsIngestActiveGateEnabled() {
 		ports = append(ports, corev1.ContainerPort{
 			Name:          consts.HttpServicePortName,
 			ContainerPort: consts.HttpContainerPort,
@@ -73,5 +73,5 @@ func (mod ServicePortModifier) getEnvs() []corev1.EnvVar {
 }
 
 func (mod ServicePortModifier) buildDNSEntryPoint() string {
-	return capability.BuildDNSEntryPoint(mod.dynakube, mod.capability)
+	return capability.BuildDNSEntryPoint(mod.dk, mod.capability)
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport_test.go
@@ -19,21 +19,21 @@ func setServicePortUsage(dk *dynakube.DynaKube, isUsed bool) {
 
 func TestServicePortEnabled(t *testing.T) {
 	t.Run("true", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		setServicePortUsage(&dynakube, true)
-		multiCapability := capability.NewMultiCapability(&dynakube)
+		dk := getBaseDynakube()
+		setServicePortUsage(&dk, true)
+		multiCapability := capability.NewMultiCapability(&dk)
 
-		mod := NewServicePortModifier(dynakube, multiCapability, prioritymap.New())
+		mod := NewServicePortModifier(dk, multiCapability, prioritymap.New())
 
 		assert.True(t, mod.Enabled())
 	})
 
 	t.Run("false", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		setServicePortUsage(&dynakube, false)
-		multiCapability := capability.NewMultiCapability(&dynakube)
+		dk := getBaseDynakube()
+		setServicePortUsage(&dk, false)
+		multiCapability := capability.NewMultiCapability(&dk)
 
-		mod := NewServicePortModifier(dynakube, multiCapability, prioritymap.New())
+		mod := NewServicePortModifier(dk, multiCapability, prioritymap.New())
 
 		assert.False(t, mod.Enabled())
 	})
@@ -41,10 +41,10 @@ func TestServicePortEnabled(t *testing.T) {
 
 func TestServicePortModify(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		setServicePortUsage(&dynakube, true)
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		mod := NewServicePortModifier(dynakube, multiCapability, prioritymap.New())
+		dk := getBaseDynakube()
+		setServicePortUsage(&dk, true)
+		multiCapability := capability.NewMultiCapability(&dk)
+		mod := NewServicePortModifier(dk, multiCapability, prioritymap.New())
 		builder := createBuilderForTesting()
 		expectedPorts := mod.getPorts()
 		expectedEnv := mod.getEnvs()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport_test.go
@@ -3,7 +3,7 @@ package modifiers
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/prioritymap"
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setServicePortUsage(dynakube *dynatracev1beta2.DynaKube, isUsed bool) {
+func setServicePortUsage(dk *dynakube.DynaKube, isUsed bool) {
 	if isUsed {
-		dynakube.Spec.ActiveGate.Capabilities = append(dynakube.Spec.ActiveGate.Capabilities, dynatracev1beta2.MetricsIngestCapability.DisplayName)
+		dk.Spec.ActiveGate.Capabilities = append(dk.Spec.ActiveGate.Capabilities, dynakube.MetricsIngestCapability.DisplayName)
 	}
 }
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/ssl_volume.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/ssl_volume.go
@@ -15,16 +15,16 @@ var _ builder.Modifier = SSLVolumeModifier{}
 
 func NewSSLVolumeModifier(dk dynakube.DynaKube) SSLVolumeModifier {
 	return SSLVolumeModifier{
-		dynakube: dk,
+		dk: dk,
 	}
 }
 
 type SSLVolumeModifier struct {
-	dynakube dynakube.DynaKube
+	dk dynakube.DynaKube
 }
 
 func (mod SSLVolumeModifier) Enabled() bool {
-	return mod.dynakube.HasActiveGateCaCert() || mod.dynakube.Spec.TrustedCAs != ""
+	return mod.dk.HasActiveGateCaCert() || mod.dk.Spec.TrustedCAs != ""
 }
 
 func (mod SSLVolumeModifier) Modify(sts *appsv1.StatefulSet) error {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/ssl_volume.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/ssl_volume.go
@@ -1,7 +1,7 @@
 package modifiers
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/container"
@@ -13,14 +13,14 @@ var _ volumeModifier = SSLVolumeModifier{}
 var _ volumeMountModifier = SSLVolumeModifier{}
 var _ builder.Modifier = SSLVolumeModifier{}
 
-func NewSSLVolumeModifier(dynakube dynatracev1beta2.DynaKube) SSLVolumeModifier {
+func NewSSLVolumeModifier(dk dynakube.DynaKube) SSLVolumeModifier {
 	return SSLVolumeModifier{
-		dynakube: dynakube,
+		dynakube: dk,
 	}
 }
 
 type SSLVolumeModifier struct {
-	dynakube dynatracev1beta2.DynaKube
+	dynakube dynakube.DynaKube
 }
 
 func (mod SSLVolumeModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/ssl_volume_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/ssl_volume_test.go
@@ -9,30 +9,30 @@ import (
 
 func TestSSLVolumeEnabled(t *testing.T) {
 	t.Run("true - TlsSecretName", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		dynakube.Spec.ActiveGate.TlsSecretName = testTlsSecretName
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		dk.Spec.ActiveGate.TlsSecretName = testTlsSecretName
 
-		mod := NewSSLVolumeModifier(dynakube)
+		mod := NewSSLVolumeModifier(dk)
 
 		assert.True(t, mod.Enabled())
 	})
 
 	t.Run("true - TrustedCAs", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		dynakube.Spec.TrustedCAs = testTlsSecretName
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		dk.Spec.TrustedCAs = testTlsSecretName
 
-		mod := NewSSLVolumeModifier(dynakube)
+		mod := NewSSLVolumeModifier(dk)
 
 		assert.True(t, mod.Enabled())
 	})
 
 	t.Run("false", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
 
-		mod := NewSSLVolumeModifier(dynakube)
+		mod := NewSSLVolumeModifier(dk)
 
 		assert.False(t, mod.Enabled())
 	})
@@ -40,11 +40,11 @@ func TestSSLVolumeEnabled(t *testing.T) {
 
 func TestSSLVolumeModify(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		dynakube.Spec.ActiveGate.TlsSecretName = testTlsSecretName
+		dl := getBaseDynakube()
+		enableKubeMonCapability(&dl)
+		dl.Spec.ActiveGate.TlsSecretName = testTlsSecretName
 
-		mod := NewSSLVolumeModifier(dynakube)
+		mod := NewSSLVolumeModifier(dl)
 		builder := createBuilderForTesting()
 
 		sts, _ := builder.AddModifier(mod).Build()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume.go
@@ -21,16 +21,16 @@ const (
 
 func NewTrustedCAsVolumeModifier(dk dynakube.DynaKube) TrustedCAsModifier {
 	return TrustedCAsModifier{
-		dynakube: dk,
+		dk: dk,
 	}
 }
 
 type TrustedCAsModifier struct {
-	dynakube dynakube.DynaKube
+	dk dynakube.DynaKube
 }
 
 func (mod TrustedCAsModifier) Enabled() bool {
-	return mod.dynakube.Spec.TrustedCAs != ""
+	return mod.dk.Spec.TrustedCAs != ""
 }
 
 func (mod TrustedCAsModifier) Modify(sts *appsv1.StatefulSet) error {
@@ -48,7 +48,7 @@ func (mod TrustedCAsModifier) getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: mod.dynakube.Spec.TrustedCAs,
+						Name: mod.dk.Spec.TrustedCAs,
 					},
 					Items: []corev1.KeyToPath{
 						{

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume.go
@@ -1,7 +1,7 @@
 package modifiers
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/container"
@@ -19,14 +19,14 @@ const (
 	trustedCAsFile = "rootca.pem"
 )
 
-func NewTrustedCAsVolumeModifier(dynakube dynatracev1beta2.DynaKube) TrustedCAsModifier {
+func NewTrustedCAsVolumeModifier(dk dynakube.DynaKube) TrustedCAsModifier {
 	return TrustedCAsModifier{
-		dynakube: dynakube,
+		dynakube: dk,
 	}
 }
 
 type TrustedCAsModifier struct {
-	dynakube dynatracev1beta2.DynaKube
+	dynakube dynakube.DynaKube
 }
 
 func (mod TrustedCAsModifier) Enabled() bool {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume_test.go
@@ -9,30 +9,30 @@ import (
 
 func TestTrustedCAsVolumeEnabled(t *testing.T) {
 	t.Run("true", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		dynakube.Spec.TrustedCAs = testTlsSecretName
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		dk.Spec.TrustedCAs = testTlsSecretName
 
-		mod := NewTrustedCAsVolumeModifier(dynakube)
+		mod := NewTrustedCAsVolumeModifier(dk)
 
 		assert.True(t, mod.Enabled())
 	})
 
 	t.Run("false - TlsSecretName", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		dynakube.Spec.ActiveGate.TlsSecretName = testTlsSecretName
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		dk.Spec.ActiveGate.TlsSecretName = testTlsSecretName
 
-		mod := NewTrustedCAsVolumeModifier(dynakube)
+		mod := NewTrustedCAsVolumeModifier(dk)
 
 		assert.False(t, mod.Enabled())
 	})
 
 	t.Run("false", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
 
-		mod := NewTrustedCAsVolumeModifier(dynakube)
+		mod := NewTrustedCAsVolumeModifier(dk)
 
 		assert.False(t, mod.Enabled())
 	})
@@ -40,11 +40,11 @@ func TestTrustedCAsVolumeEnabled(t *testing.T) {
 
 func TestTrustedCAsVolumeModify(t *testing.T) {
 	t.Run("successfully modified", func(t *testing.T) {
-		dynakube := getBaseDynakube()
-		enableKubeMonCapability(&dynakube)
-		dynakube.Spec.TrustedCAs = testTlsSecretName
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		dk.Spec.TrustedCAs = testTlsSecretName
 
-		mod := NewTrustedCAsVolumeModifier(dynakube)
+		mod := NewTrustedCAsVolumeModifier(dk)
 		builder := createBuilderForTesting()
 
 		sts, _ := builder.AddModifier(mod).Build()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/authtoken"
@@ -30,7 +30,7 @@ var _ controllers.Reconciler = &Reconciler{}
 
 type Reconciler struct {
 	client     client.Client
-	dynakube   *dynatracev1beta2.DynaKube
+	dynakube   *dynakube.DynaKube
 	apiReader  client.Reader
 	capability capability.Capability
 	modifiers  []builder.Modifier
@@ -39,19 +39,19 @@ type Reconciler struct {
 func NewReconciler(
 	clt client.Client,
 	apiReader client.Reader,
-	dynakube *dynatracev1beta2.DynaKube,
+	dk *dynakube.DynaKube,
 	capability capability.Capability,
 ) controllers.Reconciler {
 	return &Reconciler{
 		client:     clt,
 		apiReader:  apiReader,
-		dynakube:   dynakube,
+		dynakube:   dk,
 		capability: capability,
 		modifiers:  []builder.Modifier{},
 	}
 }
 
-type NewReconcilerFunc = func(clt client.Client, apiReader client.Reader, dynakube *dynatracev1beta2.DynaKube, capability capability.Capability) controllers.Reconciler
+type NewReconcilerFunc = func(clt client.Client, apiReader client.Reader, dk *dynakube.DynaKube, capability capability.Capability) controllers.Reconciler
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
 	err := r.manageStatefulSet(ctx)
@@ -260,7 +260,7 @@ func (r *Reconciler) getAuthTokenValue() (string, error) {
 	return authTokenData, nil
 }
 
-func (r *Reconciler) getDataFromCustomProperty(customProperties *dynatracev1beta2.DynaKubeValueSource) (string, error) {
+func (r *Reconciler) getDataFromCustomProperty(customProperties *dynakube.DynaKubeValueSource) (string, error) {
 	if customProperties.ValueFrom != "" {
 		return secret.GetDataFromSecretName(r.apiReader, types.NamespacedName{Namespace: r.dynakube.Namespace, Name: customProperties.ValueFrom}, customproperties.DataKey, log)
 	}
@@ -272,6 +272,6 @@ func (r *Reconciler) getDataFromAuthTokenSecret() (string, error) {
 	return secret.GetDataFromSecretName(r.apiReader, types.NamespacedName{Namespace: r.dynakube.Namespace, Name: r.dynakube.ActiveGateAuthTokenSecret()}, authtoken.ActiveGateAuthTokenName, log)
 }
 
-func needsCustomPropertyHash(customProperties *dynatracev1beta2.DynaKubeValueSource) bool {
+func needsCustomPropertyHash(customProperties *dynakube.DynaKubeValueSource) bool {
 	return customProperties != nil && (customProperties.Value != "" || customProperties.ValueFrom != "")
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
 	dynafake "github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/authtoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/customproperties"
@@ -50,17 +50,17 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 		}).
 		WithObjects(&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      testName + dynatracev1beta2.AuthTokenSecretSuffix,
+				Name:      testName + dynakube.AuthTokenSecretSuffix,
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{authtoken.ActiveGateAuthTokenName: []byte(testToken)},
 		}).
 		Build()
-	instance := &dynatracev1beta2.DynaKube{
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
-				Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-					dynatracev1beta2.RoutingCapability.DisplayName,
+	instance := &dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
+			ActiveGate: dynakube.ActiveGateSpec{
+				Capabilities: []dynakube.CapabilityDisplayName{
+					dynakube.RoutingCapability.DisplayName,
 				}},
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -109,7 +109,7 @@ func TestReconcile(t *testing.T) {
 		assert.NotNil(t, statefulSet)
 		require.NoError(t, err)
 
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: testValue}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
 		err = r.Reconcile(context.Background())
 
 		require.NoError(t, err)
@@ -208,7 +208,7 @@ func TestReconcile_UpdateStatefulSetIfOutdated(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, updated)
 
-	r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: testValue}
+	r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
 	desiredSts, err = r.buildDesiredStatefulSet(context.Background())
 	require.NoError(t, err)
 
@@ -237,7 +237,7 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, deleted)
 
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: testValue}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
 		desiredSts, err = r.buildDesiredStatefulSet(context.Background())
 		require.NoError(t, err)
 
@@ -285,12 +285,12 @@ func TestReconcile_GetCustomPropertyHash(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, hash)
 
-	r.dynakube.Spec.ActiveGate.CustomProperties = &dynatracev1beta2.DynaKubeValueSource{Value: testValue}
+	r.dynakube.Spec.ActiveGate.CustomProperties = &dynakube.DynaKubeValueSource{Value: testValue}
 	hash, err = r.calculateActiveGateConfigurationHash()
 	require.NoError(t, err)
 	assert.NotEmpty(t, hash)
 
-	r.dynakube.Spec.ActiveGate.CustomProperties = &dynatracev1beta2.DynaKubeValueSource{ValueFrom: testName}
+	r.dynakube.Spec.ActiveGate.CustomProperties = &dynakube.DynaKubeValueSource{ValueFrom: testName}
 	hash, err = r.calculateActiveGateConfigurationHash()
 	require.Error(t, err)
 	assert.Empty(t, hash)

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
@@ -56,7 +56,7 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 			Data: map[string][]byte{authtoken.ActiveGateAuthTokenName: []byte(testToken)},
 		}).
 		Build()
-	instance := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		Spec: dynakube.DynaKubeSpec{
 			ActiveGate: dynakube.ActiveGateSpec{
 				Capabilities: []dynakube.CapabilityDisplayName{
@@ -68,13 +68,13 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 			Name:      testName,
 		}}
 
-	capability.NewMultiCapability(instance)
+	capability.NewMultiCapability(dk)
 
-	r := NewReconciler(clt, clt, instance, capability.NewMultiCapability(instance)).(*Reconciler)
-	r.dynakube.Annotations = map[string]string{}
+	r := NewReconciler(clt, clt, dk, capability.NewMultiCapability(dk)).(*Reconciler)
+	r.dk.Annotations = map[string]string{}
 	require.NotNil(t, r)
 	require.NotNil(t, r.client)
-	require.NotNil(t, r.dynakube)
+	require.NotNil(t, r.dk)
 
 	return r
 }
@@ -87,12 +87,12 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		statefulSet := &appsv1.StatefulSet{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, statefulSet)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, statefulSet)
 
 		assert.NotNil(t, statefulSet)
 		require.NoError(t, err)
 
-		condition := meta.FindStatusCondition(r.dynakube.Status.Conditions, ActiveGateStatefulSetConditionType)
+		condition := meta.FindStatusCondition(r.dk.Status.Conditions, ActiveGateStatefulSetConditionType)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 		assert.Equal(t, conditions.StatefulSetCreatedReason, condition.Reason)
 		assert.Equal(t, fmt.Sprintf("%s-activegate created", testName), condition.Message)
@@ -104,18 +104,18 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		statefulSet := &appsv1.StatefulSet{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, statefulSet)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, statefulSet)
 
 		assert.NotNil(t, statefulSet)
 		require.NoError(t, err)
 
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
 		err = r.Reconcile(context.Background())
 
 		require.NoError(t, err)
 
 		newStatefulSet := &appsv1.StatefulSet{}
-		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dynakube.Name + "-" + r.capability.ShortName(), Namespace: r.dynakube.Namespace}, newStatefulSet)
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.Name + "-" + r.capability.ShortName(), Namespace: r.dk.Namespace}, newStatefulSet)
 
 		assert.NotNil(t, statefulSet)
 		require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestReconcile(t *testing.T) {
 
 		assert.Equal(t, 1, found)
 
-		condition := meta.FindStatusCondition(r.dynakube.Status.Conditions, ActiveGateStatefulSetConditionType)
+		condition := meta.FindStatusCondition(r.dk.Status.Conditions, ActiveGateStatefulSetConditionType)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 		assert.Equal(t, conditions.StatefulSetUpdatedReason, condition.Reason)
 		assert.Equal(t, testName+"-activegate updated", condition.Message)
@@ -147,7 +147,7 @@ func TestReconcile(t *testing.T) {
 
 		require.Error(t, err)
 
-		condition := meta.FindStatusCondition(r.dynakube.Status.Conditions, ActiveGateStatefulSetConditionType)
+		condition := meta.FindStatusCondition(r.dk.Status.Conditions, ActiveGateStatefulSetConditionType)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 		assert.Equal(t, conditions.KubeApiErrorReason, condition.Reason)
 		assert.Equal(t, "A problem occurred when using the Kubernetes API: "+err.Error(), condition.Message)
@@ -166,7 +166,7 @@ func TestReconcile_GetStatefulSet(t *testing.T) {
 	desiredSts.Kind = "StatefulSet"
 	desiredSts.APIVersion = "apps/v1"
 	desiredSts.ResourceVersion = "1"
-	err = controllerutil.SetControllerReference(r.dynakube, desiredSts, scheme.Scheme)
+	err = controllerutil.SetControllerReference(r.dk, desiredSts, scheme.Scheme)
 	require.NoError(t, err)
 
 	sts, err := r.getStatefulSet(context.Background(), desiredSts)
@@ -208,7 +208,7 @@ func TestReconcile_UpdateStatefulSetIfOutdated(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, updated)
 
-	r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
+	r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
 	desiredSts, err = r.buildDesiredStatefulSet(context.Background())
 	require.NoError(t, err)
 
@@ -237,7 +237,7 @@ func TestReconcile_DeleteStatefulSetIfOldLabelsAreUsed(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, deleted)
 
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
 		desiredSts, err = r.buildDesiredStatefulSet(context.Background())
 		require.NoError(t, err)
 
@@ -285,12 +285,12 @@ func TestReconcile_GetCustomPropertyHash(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, hash)
 
-	r.dynakube.Spec.ActiveGate.CustomProperties = &dynakube.DynaKubeValueSource{Value: testValue}
+	r.dk.Spec.ActiveGate.CustomProperties = &dynakube.DynaKubeValueSource{Value: testValue}
 	hash, err = r.calculateActiveGateConfigurationHash()
 	require.NoError(t, err)
 	assert.NotEmpty(t, hash)
 
-	r.dynakube.Spec.ActiveGate.CustomProperties = &dynakube.DynaKubeValueSource{ValueFrom: testName}
+	r.dk.Spec.ActiveGate.CustomProperties = &dynakube.DynaKubeValueSource{ValueFrom: testName}
 	hash, err = r.calculateActiveGateConfigurationHash()
 	require.Error(t, err)
 	assert.Empty(t, hash)
@@ -319,8 +319,8 @@ func TestReconcile_GetActiveGateAuthTokenHash(t *testing.T) {
 
 	err = r.client.Create(context.Background(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.dynakube.ActiveGateAuthTokenSecret(),
-			Namespace: r.dynakube.Namespace,
+			Name:      r.dk.ActiveGateAuthTokenSecret(),
+			Namespace: r.dk.Namespace,
 		},
 		Data: map[string][]byte{
 			authtoken.ActiveGateAuthTokenName: []byte(testValue),

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
@@ -34,25 +34,25 @@ var (
 	testReplicas int32 = 69
 )
 
-func getTestDynakube() dynatracev1beta2.DynaKube {
-	return dynatracev1beta2.DynaKube{
+func getTestDynakube() dynakube.DynaKube {
+	return dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        testDynakubeName,
 			Namespace:   testNamespaceName,
 			Annotations: map[string]string{},
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
-				Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-					dynatracev1beta2.RoutingCapability.DisplayName,
+		Spec: dynakube.DynaKubeSpec{
+			ActiveGate: dynakube.ActiveGateSpec{
+				Capabilities: []dynakube.CapabilityDisplayName{
+					dynakube.RoutingCapability.DisplayName,
 				},
-				CapabilityProperties: dynatracev1beta2.CapabilityProperties{
+				CapabilityProperties: dynakube.CapabilityProperties{
 					Replicas: testReplicas,
 				},
 			},
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			ActiveGate: dynatracev1beta2.ActiveGateStatus{
+		Status: dynakube.DynaKubeStatus{
+			ActiveGate: dynakube.ActiveGateStatus{
 				VersionStatus: status.VersionStatus{},
 			},
 		},
@@ -60,22 +60,22 @@ func getTestDynakube() dynatracev1beta2.DynaKube {
 }
 
 func TestGetBaseObjectMeta(t *testing.T) {
-	dynakube := getTestDynakube()
+	dk := getTestDynakube()
 
 	t.Run("creating object meta", func(t *testing.T) {
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 
 		objectMeta := builder.getBaseObjectMeta()
 
 		require.NotEmpty(t, objectMeta)
-		assert.Contains(t, objectMeta.Name, dynakube.Name)
+		assert.Contains(t, objectMeta.Name, dk.Name)
 		assert.Contains(t, objectMeta.Name, multiCapability.ShortName())
 		assert.NotNil(t, objectMeta.Annotations)
 	})
 	t.Run("default annotations", func(t *testing.T) {
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts, _ := builder.CreateStatefulSet(nil)
 		expectedTemplateAnnotations := map[string]string{
 			consts.AnnotationActiveGateConfigurationHash: testConfigHash,
@@ -85,8 +85,8 @@ func TestGetBaseObjectMeta(t *testing.T) {
 		assert.Equal(t, expectedTemplateAnnotations, sts.Spec.Template.Annotations)
 	})
 	t.Run("has default node affinity", func(t *testing.T) {
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts, _ := builder.CreateStatefulSet(nil)
 		expectedNodeSelectorTerms := []corev1.NodeSelectorTerm{
 			{
@@ -108,11 +108,11 @@ func TestGetBaseObjectMeta(t *testing.T) {
 		assert.Contains(t, sts.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, expectedNodeSelectorTerms[0])
 	})
 	t.Run("add annotations", func(t *testing.T) {
-		dynakube.Spec.ActiveGate.Annotations = map[string]string{
+		dk.Spec.ActiveGate.Annotations = map[string]string{
 			"test": "test",
 		}
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts, _ := builder.CreateStatefulSet(nil)
 		expectedTemplateAnnotations := map[string]string{
 			consts.AnnotationActiveGateConfigurationHash: testConfigHash,
@@ -125,11 +125,11 @@ func TestGetBaseObjectMeta(t *testing.T) {
 }
 
 func TestGetBaseSpec(t *testing.T) {
-	dynakube := getTestDynakube()
+	dk := getTestDynakube()
 
 	t.Run("creating base statefulset spec", func(t *testing.T) {
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 
 		stsSpec := builder.getBaseSpec()
 
@@ -142,9 +142,9 @@ func TestGetBaseSpec(t *testing.T) {
 
 func TestAddLabels(t *testing.T) {
 	t.Run("adds labels", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk := getTestDynakube()
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts := appsv1.StatefulSet{}
 		appLabels := labels.NewAppLabels(labels.ActiveGateComponentLabel, builder.dynakube.Name, builder.capability.ShortName(), "")
 		expectedLabels := appLabels.BuildLabels()
@@ -159,12 +159,12 @@ func TestAddLabels(t *testing.T) {
 	})
 
 	t.Run("merge labels", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		dynakube.Spec.ActiveGate.Labels = map[string]string{
+		dk := getTestDynakube()
+		dk.Spec.ActiveGate.Labels = map[string]string{
 			"test": "test",
 		}
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts := appsv1.StatefulSet{}
 		appLabels := labels.NewAppLabels(labels.ActiveGateComponentLabel, builder.dynakube.Name, builder.capability.ShortName(), "")
 		expectedTemplateLabels := appLabels.BuildLabels()
@@ -179,9 +179,9 @@ func TestAddLabels(t *testing.T) {
 
 func TestAddTemplateSpec(t *testing.T) {
 	t.Run("adds template spec", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk := getTestDynakube()
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts := appsv1.StatefulSet{}
 
 		builder.addTemplateSpec(&sts)
@@ -189,31 +189,31 @@ func TestAddTemplateSpec(t *testing.T) {
 
 		assert.NotEmpty(t, spec.Containers)
 		assert.NotEmpty(t, spec.Affinity)
-		assert.Equal(t, len(dynakube.PullSecretNames()), len(spec.ImagePullSecrets))
-		assert.Equal(t, dynakube.PullSecretNames()[0], spec.ImagePullSecrets[0].Name)
+		assert.Equal(t, len(dk.PullSecretNames()), len(spec.ImagePullSecrets))
+		assert.Equal(t, dk.PullSecretNames()[0], spec.ImagePullSecrets[0].Name)
 	})
 
 	t.Run("adds capability specific stuff", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		dynakube.Spec.ActiveGate.Capabilities = append(dynakube.Spec.ActiveGate.Capabilities, dynatracev1beta2.KubeMonCapability.DisplayName)
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk := getTestDynakube()
+		dk.Spec.ActiveGate.Capabilities = append(dk.Spec.ActiveGate.Capabilities, dynakube.KubeMonCapability.DisplayName)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts := appsv1.StatefulSet{}
 
 		builder.addTemplateSpec(&sts)
 		spec := sts.Spec.Template.Spec
-		assert.Contains(t, spec.ServiceAccountName, dynakube.ActiveGateServiceAccountName())
+		assert.Contains(t, spec.ServiceAccountName, dk.ActiveGateServiceAccountName())
 	})
 
 	t.Run("set node selector", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		testNodeSelector := map[string]string{
 			"test": "test",
 		}
-		dynakube.Spec.ActiveGate.NodeSelector = testNodeSelector
+		dk.Spec.ActiveGate.NodeSelector = testNodeSelector
 
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts := appsv1.StatefulSet{}
 
 		builder.addTemplateSpec(&sts)
@@ -222,7 +222,7 @@ func TestAddTemplateSpec(t *testing.T) {
 		assert.Equal(t, testNodeSelector, spec.NodeSelector)
 	})
 	t.Run("set tolerations", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		testTolerations := []corev1.Toleration{
 			{
 				Key:      "test",
@@ -231,9 +231,9 @@ func TestAddTemplateSpec(t *testing.T) {
 				Effect:   "test",
 			},
 		}
-		dynakube.Spec.ActiveGate.Tolerations = testTolerations
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk.Spec.ActiveGate.Tolerations = testTolerations
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts := appsv1.StatefulSet{}
 
 		builder.addTemplateSpec(&sts)
@@ -244,11 +244,11 @@ func TestAddTemplateSpec(t *testing.T) {
 		}
 	})
 	t.Run("set DNSPolicy", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		testDNSPolicy := "test"
-		dynakube.Spec.ActiveGate.DNSPolicy = corev1.DNSPolicy(testDNSPolicy)
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk.Spec.ActiveGate.DNSPolicy = corev1.DNSPolicy(testDNSPolicy)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts := appsv1.StatefulSet{}
 
 		builder.addTemplateSpec(&sts)
@@ -256,11 +256,11 @@ func TestAddTemplateSpec(t *testing.T) {
 		assert.Equal(t, corev1.DNSPolicy(testDNSPolicy), spec.DNSPolicy)
 	})
 	t.Run("set priorityClass", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		testPriorityClass := "test"
-		dynakube.Spec.ActiveGate.PriorityClassName = testPriorityClass
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk.Spec.ActiveGate.PriorityClassName = testPriorityClass
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts := appsv1.StatefulSet{}
 
 		builder.addTemplateSpec(&sts)
@@ -269,34 +269,34 @@ func TestAddTemplateSpec(t *testing.T) {
 		assert.Equal(t, testPriorityClass, spec.PriorityClassName)
 	})
 	t.Run("default topologyConstraint", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts, err := builder.CreateStatefulSet(nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, builder.defaultTopologyConstraints(), sts.Spec.Template.Spec.TopologySpreadConstraints)
 	})
 	t.Run("set topologyConstraint", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		testTopologyConstraint := []corev1.TopologySpreadConstraint{
 			{
 				TopologyKey: "test",
 			},
 		}
-		dynakube.Spec.ActiveGate.TopologySpreadConstraints = testTopologyConstraint
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk.Spec.ActiveGate.TopologySpreadConstraints = testTopologyConstraint
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts, err := builder.CreateStatefulSet(nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, testTopologyConstraint, sts.Spec.Template.Spec.TopologySpreadConstraints)
 	})
 	t.Run("default readinessProbe timeout is 2s", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk := getTestDynakube()
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts, err := builder.CreateStatefulSet(nil)
 		require.NoError(t, err)
 
@@ -306,15 +306,15 @@ func TestAddTemplateSpec(t *testing.T) {
 
 func TestBuildBaseContainer(t *testing.T) {
 	t.Run("build container", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk := getTestDynakube()
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 
 		containers := builder.buildBaseContainer()
 
 		require.Len(t, containers, 1)
 		container := containers[0]
-		assert.Equal(t, dynakube.ActiveGateImage(), container.Image)
+		assert.Equal(t, dk.ActiveGateImage(), container.Image)
 		assert.NotEmpty(t, container.Env)
 		assert.NotNil(t, container.ReadinessProbe)
 		assert.NotNil(t, container.SecurityContext)
@@ -323,9 +323,9 @@ func TestBuildBaseContainer(t *testing.T) {
 
 func TestBuildCommonEnvs(t *testing.T) {
 	t.Run("build envs", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk := getTestDynakube()
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 
 		envs := builder.buildCommonEnvs()
 
@@ -336,7 +336,7 @@ func TestBuildCommonEnvs(t *testing.T) {
 
 		namespaceEnv := env.FindEnvVar(envs, consts.EnvDtIdSeedNamespace)
 		require.NotNil(t, namespaceEnv)
-		assert.Equal(t, dynakube.Namespace, namespaceEnv.Value)
+		assert.Equal(t, dk.Namespace, namespaceEnv.Value)
 
 		idEnv := env.FindEnvVar(envs, consts.EnvDtIdSeedClusterId)
 		require.NotNil(t, idEnv)
@@ -346,7 +346,7 @@ func TestBuildCommonEnvs(t *testing.T) {
 		require.NotNil(t, metadataEnv)
 		assert.NotEmpty(t, metadataEnv.ValueFrom.ConfigMapKeyRef)
 		assert.Equal(t, deploymentmetadata.ActiveGateMetadataKey, metadataEnv.ValueFrom.ConfigMapKeyRef.Key)
-		assert.Equal(t, deploymentmetadata.GetDeploymentMetadataConfigMapName(dynakube.Name), metadataEnv.ValueFrom.ConfigMapKeyRef.Name)
+		assert.Equal(t, deploymentmetadata.GetDeploymentMetadataConfigMapName(dk.Name), metadataEnv.ValueFrom.ConfigMapKeyRef.Name)
 
 		// metrics-ingest disabled -> HTTP port disabled
 		dtHttpPortEnv := env.FindEnvVar(envs, consts.EnvDtHttpPort)
@@ -389,10 +389,10 @@ func TestBuildCommonEnvs(t *testing.T) {
 
 	t.Run("adds group env", func(t *testing.T) {
 		testGroup := "test-group"
-		dynakube := getTestDynakube()
-		dynakube.Spec.ActiveGate.Group = testGroup
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk := getTestDynakube()
+		dk.Spec.ActiveGate.Group = testGroup
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 
 		envs := builder.buildCommonEnvs()
 
@@ -403,13 +403,13 @@ func TestBuildCommonEnvs(t *testing.T) {
 	})
 
 	t.Run("metrics-ingest env", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 
-		activegate.SwitchCapability(&dynakube, dynatracev1beta2.RoutingCapability, false)
-		activegate.SwitchCapability(&dynakube, dynatracev1beta2.MetricsIngestCapability, true)
+		activegate.SwitchCapability(&dk, dynakube.RoutingCapability, false)
+		activegate.SwitchCapability(&dk, dynakube.MetricsIngestCapability, true)
 
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 
 		envs := builder.buildCommonEnvs()
 
@@ -421,31 +421,31 @@ func TestBuildCommonEnvs(t *testing.T) {
 
 	t.Run("adds group env", func(t *testing.T) {
 		testNetworkZone := "test-zone"
-		dynakube := getTestDynakube()
-		dynakube.Spec.NetworkZone = testNetworkZone
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk := getTestDynakube()
+		dk.Spec.NetworkZone = testNetworkZone
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 
 		envs := builder.buildCommonEnvs()
 
 		require.NotEmpty(t, envs)
 		zoneEnv := env.FindEnvVar(envs, consts.EnvDtNetworkZone)
 		require.NotNil(t, zoneEnv)
-		assert.Equal(t, dynakube.Spec.NetworkZone, zoneEnv.Value)
+		assert.Equal(t, dk.Spec.NetworkZone, zoneEnv.Value)
 	})
 }
 
 func TestSecurityContexts(t *testing.T) {
 	t.Run("containers have the same security context if read-only filesystem", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		dynakube.Spec.ActiveGate.Capabilities = append(dynakube.Spec.ActiveGate.Capabilities, dynatracev1beta2.KubeMonCapability.DisplayName)
+		dk := getTestDynakube()
+		dk.Spec.ActiveGate.Capabilities = append(dk.Spec.ActiveGate.Capabilities, dynakube.KubeMonCapability.DisplayName)
 
-		multiCapability := capability.NewMultiCapability(&dynakube)
+		multiCapability := capability.NewMultiCapability(&dk)
 
-		statefulsetBuilder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		statefulsetBuilder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 		sts, _ := statefulsetBuilder.CreateStatefulSet([]builder.Modifier{
-			modifiers.NewKubernetesMonitoringModifier(dynakube, multiCapability),
-			modifiers.NewReadOnlyModifier(dynakube),
+			modifiers.NewKubernetesMonitoringModifier(dk, multiCapability),
+			modifiers.NewReadOnlyModifier(dk),
 		})
 
 		require.NotEmpty(t, sts)

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
@@ -368,10 +368,10 @@ func TestBuildCommonEnvs(t *testing.T) {
 				Value: "ns-override",
 			},
 		}
-		dynakube := getTestDynakube()
-		dynakube.Spec.ActiveGate.Env = testEnvs
-		multiCapability := capability.NewMultiCapability(&dynakube)
-		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dynakube, multiCapability)
+		dk := getTestDynakube()
+		dk.Spec.ActiveGate.Env = testEnvs
+		multiCapability := capability.NewMultiCapability(&dk)
+		builder := NewStatefulSetBuilder(testKubeUID, testConfigHash, dk, multiCapability)
 
 		envs := builder.buildCommonEnvs()
 

--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -29,7 +29,7 @@ import (
 
 type Reconciler struct {
 	client                            client.Client
-	dynakube                          *dynakube.DynaKube
+	dk                                *dynakube.DynaKube
 	apiReader                         client.Reader
 	authTokenReconciler               controllers.Reconciler
 	istioReconciler                   istio.Reconciler
@@ -45,7 +45,7 @@ var _ controllers.Reconciler = (*Reconciler)(nil)
 
 type ReconcilerBuilder func(clt client.Client,
 	apiReader client.Reader,
-	dynakube *dynakube.DynaKube,
+	dk *dynakube.DynaKube,
 	dtc dtclient.Client,
 	istioClient *istio.Client,
 	tokens token.Tokens,
@@ -74,7 +74,7 @@ func NewReconciler(clt client.Client, //nolint
 	return &Reconciler{
 		client:                            clt,
 		apiReader:                         apiReader,
-		dynakube:                          dk,
+		dk:                                dk,
 		authTokenReconciler:               authTokenReconciler,
 		istioReconciler:                   istioReconciler,
 		connectionReconciler:              connectionInfoReconciler,
@@ -97,7 +97,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		return err
 	}
 
-	err = r.versionReconciler.ReconcileActiveGate(ctx, r.dynakube)
+	err = r.versionReconciler.ReconcileActiveGate(ctx, r.dk)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	}
 
 	if r.istioReconciler != nil {
-		err = r.istioReconciler.ReconcileActiveGateCommunicationHosts(ctx, r.dynakube)
+		err = r.istioReconciler.ReconcileActiveGateCommunicationHosts(ctx, r.dk)
 		if err != nil {
 			return err
 		}
@@ -119,7 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		return errors.WithMessage(err, "could not reconcile Dynatrace ActiveGateAuthToken secrets")
 	}
 
-	for _, agCapability := range capability.GenerateActiveGateCapabilities(r.dynakube) {
+	for _, agCapability := range capability.GenerateActiveGateCapabilities(r.dk) {
 		if agCapability.Enabled() {
 			return r.createCapability(ctx, agCapability)
 		} else {
@@ -130,22 +130,22 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	}
 
 	// TODO: move cleanup to ActiveGate reconciler
-	meta.RemoveStatusCondition(r.dynakube.Conditions(), statefulset.ActiveGateStatefulSetConditionType)
+	meta.RemoveStatusCondition(r.dk.Conditions(), statefulset.ActiveGateStatefulSetConditionType)
 
 	return nil
 }
 
 func (r *Reconciler) createActiveGateTenantConnectionInfoConfigMap(ctx context.Context) error {
-	if !r.dynakube.NeedsActiveGate() {
+	if !r.dk.NeedsActiveGate() {
 		// TODO: Add clean up of the config map
 		return nil
 	}
 
-	configMapData := extractPublicData(r.dynakube)
+	configMapData := extractPublicData(r.dk)
 
-	configMap, err := configmap.CreateConfigMap(r.dynakube,
-		configmap.NewModifier(r.dynakube.ActiveGateConnectionInfoConfigMapName()),
-		configmap.NewNamespaceModifier(r.dynakube.Namespace),
+	configMap, err := configmap.CreateConfigMap(r.dk,
+		configmap.NewModifier(r.dk.ActiveGateConnectionInfoConfigMapName()),
+		configmap.NewNamespaceModifier(r.dk.Namespace),
 		configmap.NewConfigMapDataModifier(configMapData))
 	if err != nil {
 		return errors.WithStack(err)
@@ -178,10 +178,10 @@ func extractPublicData(dk *dynakube.DynaKube) map[string]string {
 }
 
 func (r *Reconciler) createCapability(ctx context.Context, agCapability capability.Capability) error {
-	customPropertiesReconciler := r.newCustomPropertiesReconcilerFunc(r.dynakube.ActiveGateServiceAccountOwner(), agCapability.Properties().CustomProperties) //nolint:typeCheck
-	statefulsetReconciler := r.newStatefulsetReconcilerFunc(r.client, r.apiReader, r.dynakube, agCapability)                                                  //nolint:typeCheck
+	customPropertiesReconciler := r.newCustomPropertiesReconcilerFunc(r.dk.ActiveGateServiceAccountOwner(), agCapability.Properties().CustomProperties) //nolint:typeCheck
+	statefulsetReconciler := r.newStatefulsetReconcilerFunc(r.client, r.apiReader, r.dk, agCapability)                                                  //nolint:typeCheck
 
-	capabilityReconciler := r.newCapabilityReconcilerFunc(r.client, agCapability, r.dynakube, statefulsetReconciler, customPropertiesReconciler)
+	capabilityReconciler := r.newCapabilityReconcilerFunc(r.client, agCapability, r.dk, statefulsetReconciler, customPropertiesReconciler)
 
 	return capabilityReconciler.Reconcile(ctx)
 }
@@ -199,14 +199,14 @@ func (r *Reconciler) deleteCapability(ctx context.Context, agCapability capabili
 }
 
 func (r *Reconciler) deleteService(ctx context.Context, agCapability capability.Capability) error {
-	if r.dynakube.NeedsActiveGateService() {
+	if r.dk.NeedsActiveGateService() {
 		return nil
 	}
 
 	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      capability.BuildServiceName(r.dynakube.Name, agCapability.ShortName()),
-			Namespace: r.dynakube.Namespace,
+			Name:      capability.BuildServiceName(r.dk.Name, agCapability.ShortName()),
+			Namespace: r.dk.Namespace,
 		},
 	}
 
@@ -216,8 +216,8 @@ func (r *Reconciler) deleteService(ctx context.Context, agCapability capability.
 func (r *Reconciler) deleteStatefulset(ctx context.Context, agCapability capability.Capability) error {
 	sts := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      capability.CalculateStatefulSetName(agCapability, r.dynakube.Name),
-			Namespace: r.dynakube.Namespace,
+			Name:      capability.CalculateStatefulSetName(agCapability, r.dk.Name),
+			Namespace: r.dk.Namespace,
 		},
 	}
 

--- a/pkg/controllers/dynakube/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/reconciler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
@@ -48,7 +48,7 @@ var (
 
 func TestReconciler_Reconcile(t *testing.T) {
 	t.Run(`Create works with minimal setup`, func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 				Name:      testName,
@@ -59,12 +59,12 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run(`Pull secret reconciler is called even if ActiveGate disabled`, func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 				Name:      testName,
 			},
-			Status: dynatracev1beta2.DynaKubeStatus{
+			Status: dynakube.DynaKubeStatus{
 				Conditions: []metav1.Condition{
 					{
 						Type:   dtpullsecret.PullSecretConditionType,
@@ -90,15 +90,15 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.Nil(t, meta.FindStatusCondition(instance.Status.Conditions, dtpullsecret.PullSecretConditionType))
 	})
 	t.Run(`Create AG capability (creation and deletion)`, func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 				Name:      testName,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				EnableIstio: true,
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{
-					Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.RoutingCapability.DisplayName},
+				ActiveGate: dynakube.ActiveGateSpec{
+					Capabilities: []dynakube.CapabilityDisplayName{dynakube.RoutingCapability.DisplayName},
 				},
 			},
 		}
@@ -118,7 +118,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		// remove AG from spec
-		instance.Spec.ActiveGate = dynatracev1beta2.ActiveGateSpec{}
+		instance.Spec.ActiveGate = dynakube.ActiveGateSpec{}
 		r.connectionReconciler = createGenericReconcilerMock(t)
 		r.versionReconciler = createVersionReconcilerMock(t)
 		r.pullSecretReconciler = createGenericReconcilerMock(t)
@@ -129,23 +129,23 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run("Reconcile DynaKube without Proxy after a DynaKube with proxy must not interfere with the second DKs Proxy Secret", func(t *testing.T) { // TODO: This is not a unit test, it tests the functionality of another package, it should use a mock for that
-		dynaKubeWithProxy := &dynatracev1beta2.DynaKube{
+		dynaKubeWithProxy := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 				Name:      "proxyDk",
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				Proxy:      &dynatracev1beta2.DynaKubeProxy{Value: testProxyName},
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.KubeMonCapability.DisplayName}},
+			Spec: dynakube.DynaKubeSpec{
+				Proxy:      &dynakube.DynaKubeProxy{Value: testProxyName},
+				ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}},
 			},
 		}
-		dynaKubeNoProxy := &dynatracev1beta2.DynaKube{
+		dynaKubeNoProxy := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 				Name:      "noProxyDk",
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.KubeMonCapability.DisplayName}},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}},
 			},
 		}
 		fakeClient := fake.NewClient()
@@ -157,13 +157,13 @@ func TestReconciler_Reconcile(t *testing.T) {
 			dynakube:             dynaKubeWithProxy,
 			authTokenReconciler:  fakeReconciler,
 			pullSecretReconciler: fakeReconciler,
-			newStatefulsetReconcilerFunc: func(_ client.Client, _ client.Reader, _ *dynatracev1beta2.DynaKube, _ capability.Capability) controllers.Reconciler {
+			newStatefulsetReconcilerFunc: func(_ client.Client, _ client.Reader, _ *dynakube.DynaKube, _ capability.Capability) controllers.Reconciler {
 				return fakeReconciler
 			},
-			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynatracev1beta2.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
+			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynakube.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
 				return fakeReconciler
 			},
-			newCustomPropertiesReconcilerFunc: func(_ string, customPropertiesSource *dynatracev1beta2.DynaKubeValueSource) controllers.Reconciler {
+			newCustomPropertiesReconcilerFunc: func(_ string, customPropertiesSource *dynakube.DynaKubeValueSource) controllers.Reconciler {
 				return fakeReconciler
 			},
 			connectionReconciler: createGenericReconcilerMock(t),
@@ -178,13 +178,13 @@ func TestReconciler_Reconcile(t *testing.T) {
 			dynakube:             dynaKubeNoProxy,
 			authTokenReconciler:  fakeReconciler,
 			pullSecretReconciler: fakeReconciler,
-			newStatefulsetReconcilerFunc: func(_ client.Client, _ client.Reader, _ *dynatracev1beta2.DynaKube, _ capability.Capability) controllers.Reconciler {
+			newStatefulsetReconcilerFunc: func(_ client.Client, _ client.Reader, _ *dynakube.DynaKube, _ capability.Capability) controllers.Reconciler {
 				return fakeReconciler
 			},
-			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynatracev1beta2.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
+			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynakube.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
 				return fakeReconciler
 			},
-			newCustomPropertiesReconcilerFunc: func(_ string, customPropertiesSource *dynatracev1beta2.DynaKubeValueSource) controllers.Reconciler {
+			newCustomPropertiesReconcilerFunc: func(_ string, customPropertiesSource *dynakube.DynaKubeValueSource) controllers.Reconciler {
 				return fakeReconciler
 			},
 			connectionReconciler: createGenericReconcilerMock(t),
@@ -194,16 +194,16 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run(`Reconciles Kubernetes Monitoring`, func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: "test-api-url",
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{
-					Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-						dynatracev1beta2.KubeMonCapability.DisplayName,
+				ActiveGate: dynakube.ActiveGateSpec{
+					Capabilities: []dynakube.CapabilityDisplayName{
+						dynakube.KubeMonCapability.DisplayName,
 					},
 				},
 			},
@@ -236,40 +236,40 @@ func TestServiceCreation(t *testing.T) {
 	dynatraceClient := dtclientmock.NewClient(t)
 	dynatraceClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 
-	dynakube := &dynatracev1beta2.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{},
+		Spec: dynakube.DynaKubeSpec{
+			ActiveGate: dynakube.ActiveGateSpec{},
 		},
 	}
 
 	t.Run("service exposes correct ports for single capabilities", func(t *testing.T) {
-		expectedCapabilityPorts := map[dynatracev1beta2.CapabilityDisplayName][]string{
-			dynatracev1beta2.RoutingCapability.DisplayName: {
+		expectedCapabilityPorts := map[dynakube.CapabilityDisplayName][]string{
+			dynakube.RoutingCapability.DisplayName: {
 				consts.HttpsServicePortName,
 			},
-			dynatracev1beta2.MetricsIngestCapability.DisplayName: {
+			dynakube.MetricsIngestCapability.DisplayName: {
 				consts.HttpsServicePortName,
 				consts.HttpServicePortName,
 			},
-			dynatracev1beta2.DynatraceApiCapability.DisplayName: {
+			dynakube.DynatraceApiCapability.DisplayName: {
 				consts.HttpsServicePortName,
 			},
-			dynatracev1beta2.KubeMonCapability.DisplayName: {},
+			dynakube.KubeMonCapability.DisplayName: {},
 		}
 
 		for capName, expectedPorts := range expectedCapabilityPorts {
 			fakeClient := fake.NewClient(testKubeSystemNamespace)
 
-			reconciler := NewReconciler(fakeClient, fakeClient, dynakube, dynatraceClient, nil, nil).(*Reconciler)
+			reconciler := NewReconciler(fakeClient, fakeClient, dk, dynatraceClient, nil, nil).(*Reconciler)
 			reconciler.connectionReconciler = createGenericReconcilerMock(t)
 			reconciler.versionReconciler = createVersionReconcilerMock(t)
 			reconciler.pullSecretReconciler = createGenericReconcilerMock(t)
 
-			dynakube.Spec.ActiveGate.Capabilities = []dynatracev1beta2.CapabilityDisplayName{
+			dk.Spec.ActiveGate.Capabilities = []dynakube.CapabilityDisplayName{
 				capName,
 			}
 
@@ -292,13 +292,13 @@ func TestServiceCreation(t *testing.T) {
 	t.Run("service exposes correct ports for multiple capabilities", func(t *testing.T) {
 		fakeClient := fake.NewClient(testKubeSystemNamespace)
 
-		reconciler := NewReconciler(fakeClient, fakeClient, dynakube, dynatraceClient, nil, nil).(*Reconciler)
+		reconciler := NewReconciler(fakeClient, fakeClient, dk, dynatraceClient, nil, nil).(*Reconciler)
 		reconciler.connectionReconciler = createGenericReconcilerMock(t)
 		reconciler.versionReconciler = createVersionReconcilerMock(t)
 		reconciler.pullSecretReconciler = createGenericReconcilerMock(t)
 
-		dynakube.Spec.ActiveGate.Capabilities = []dynatracev1beta2.CapabilityDisplayName{
-			dynatracev1beta2.RoutingCapability.DisplayName,
+		dk.Spec.ActiveGate.Capabilities = []dynakube.CapabilityDisplayName{
+			dynakube.RoutingCapability.DisplayName,
 		}
 		expectedPorts := []string{
 			consts.HttpsServicePortName,
@@ -341,18 +341,18 @@ func TestReconcile_ActivegateConfigMap(t *testing.T) {
 		testTenantEndpoints = "test-endpoints"
 	)
 
-	dynakube := &dynatracev1beta2.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.KubeMonCapability.DisplayName}},
+		Spec: dynakube.DynaKubeSpec{
+			ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}},
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			ActiveGate: dynatracev1beta2.ActiveGateStatus{
-				ConnectionInfoStatus: dynatracev1beta2.ActiveGateConnectionInfoStatus{
-					ConnectionInfoStatus: dynatracev1beta2.ConnectionInfoStatus{
+		Status: dynakube.DynaKubeStatus{
+			ActiveGate: dynakube.ActiveGateStatus{
+				ConnectionInfoStatus: dynakube.ActiveGateConnectionInfoStatus{
+					ConnectionInfoStatus: dynakube.ConnectionInfoStatus{
 						TenantUUID: testTenantUUID,
 						Endpoints:  testTenantEndpoints,
 					},
@@ -369,16 +369,16 @@ func TestReconcile_ActivegateConfigMap(t *testing.T) {
 		r := Reconciler{
 			client:               fakeClient,
 			apiReader:            fakeClient,
-			dynakube:             dynakube,
+			dynakube:             dk,
 			authTokenReconciler:  fakeReconciler,
 			pullSecretReconciler: fakeReconciler,
-			newStatefulsetReconcilerFunc: func(_ client.Client, _ client.Reader, _ *dynatracev1beta2.DynaKube, _ capability.Capability) controllers.Reconciler {
+			newStatefulsetReconcilerFunc: func(_ client.Client, _ client.Reader, _ *dynakube.DynaKube, _ capability.Capability) controllers.Reconciler {
 				return fakeReconciler
 			},
-			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynatracev1beta2.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
+			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynakube.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
 				return fakeReconciler
 			},
-			newCustomPropertiesReconcilerFunc: func(_ string, _ *dynatracev1beta2.DynaKubeValueSource) controllers.Reconciler {
+			newCustomPropertiesReconcilerFunc: func(_ string, _ *dynakube.DynaKubeValueSource) controllers.Reconciler {
 				return fakeReconciler
 			},
 			connectionReconciler: createGenericReconcilerMock(t),
@@ -388,7 +388,7 @@ func TestReconcile_ActivegateConfigMap(t *testing.T) {
 		require.NoError(t, err)
 
 		var actual corev1.ConfigMap
-		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: dynakube.ActiveGateConnectionInfoConfigMapName(), Namespace: testNamespace}, &actual)
+		err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: dk.ActiveGateConnectionInfoConfigMapName(), Namespace: testNamespace}, &actual)
 		require.NoError(t, err)
 		assert.Equal(t, testTenantUUID, actual.Data[connectioninfo.TenantUUIDKey])
 		assert.Equal(t, testTenantEndpoints, actual.Data[connectioninfo.CommunicationEndpointsKey])

--- a/pkg/controllers/dynakube/activegate_test.go
+++ b/pkg/controllers/dynakube/activegate_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestReconcileActiveGate(t *testing.T) {
 	ctx := context.Background()
-	dynakubeBase := &dynakube.DynaKube{
+	dkBase := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "this-is-a-name",
 			Namespace: "dynatrace",
@@ -28,7 +28,7 @@ func TestReconcileActiveGate(t *testing.T) {
 	}
 
 	t.Run("no active-gate configured => nothing happens (only call active-gate reconciler)", func(t *testing.T) {
-		dk := dynakubeBase.DeepCopy()
+		dk := dkBase.DeepCopy()
 		dk.Spec.ActiveGate = dynakube.ActiveGateSpec{}
 
 		fakeClient := fake.NewClientWithIndex(dk)
@@ -46,7 +46,7 @@ func TestReconcileActiveGate(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("no active-gate configured => active-gate reconcile returns error => returns error", func(t *testing.T) {
-		dk := dynakubeBase.DeepCopy()
+		dk := dkBase.DeepCopy()
 		dk.Spec.ActiveGate = dynakube.ActiveGateSpec{}
 
 		fakeClient := fake.NewClientWithIndex(dk)

--- a/pkg/controllers/dynakube/activegate_test.go
+++ b/pkg/controllers/dynakube/activegate_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/apimonitoring"
 	controllermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
@@ -17,21 +17,21 @@ import (
 
 func TestReconcileActiveGate(t *testing.T) {
 	ctx := context.Background()
-	dynakubeBase := &dynatracev1beta2.DynaKube{
+	dynakubeBase := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "this-is-a-name",
 			Namespace: "dynatrace",
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.KubeMonCapability.DisplayName}},
+		Spec: dynakube.DynaKubeSpec{
+			ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}},
 		},
 	}
 
 	t.Run("no active-gate configured => nothing happens (only call active-gate reconciler)", func(t *testing.T) {
-		dynakube := dynakubeBase.DeepCopy()
-		dynakube.Spec.ActiveGate = dynatracev1beta2.ActiveGateSpec{}
+		dk := dynakubeBase.DeepCopy()
+		dk.Spec.ActiveGate = dynakube.ActiveGateSpec{}
 
-		fakeClient := fake.NewClientWithIndex(dynakube)
+		fakeClient := fake.NewClientWithIndex(dk)
 
 		mockActiveGateReconciler := controllermock.NewReconciler(t)
 		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(nil)
@@ -42,14 +42,14 @@ func TestReconcileActiveGate(t *testing.T) {
 			activeGateReconcilerBuilder: createActivegateReconcilerBuilder(mockActiveGateReconciler),
 		}
 
-		err := controller.reconcileActiveGate(ctx, dynakube, nil, nil)
+		err := controller.reconcileActiveGate(ctx, dk, nil, nil)
 		require.NoError(t, err)
 	})
 	t.Run("no active-gate configured => active-gate reconcile returns error => returns error", func(t *testing.T) {
-		dynakube := dynakubeBase.DeepCopy()
-		dynakube.Spec.ActiveGate = dynatracev1beta2.ActiveGateSpec{}
+		dk := dynakubeBase.DeepCopy()
+		dk.Spec.ActiveGate = dynakube.ActiveGateSpec{}
 
-		fakeClient := fake.NewClientWithIndex(dynakube)
+		fakeClient := fake.NewClientWithIndex(dk)
 
 		mockActiveGateReconciler := controllermock.NewReconciler(t)
 		mockActiveGateReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(errors.New("BOOM"))
@@ -60,32 +60,32 @@ func TestReconcileActiveGate(t *testing.T) {
 			activeGateReconcilerBuilder: createActivegateReconcilerBuilder(mockActiveGateReconciler),
 		}
 
-		err := controller.reconcileActiveGate(ctx, dynakube, nil, nil)
+		err := controller.reconcileActiveGate(ctx, dk, nil, nil)
 		require.Error(t, err)
 		require.Equal(t, "failed to reconcile ActiveGate: BOOM", err.Error())
 	})
 	t.Run(`reconcile automatic kubernetes api monitoring`, func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 				Annotations: map[string]string{
-					dynatracev1beta2.AnnotationFeatureAutomaticK8sApiMonitoring: "true",
+					dynakube.AnnotationFeatureAutomaticK8sApiMonitoring: "true",
 				},
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{
-					Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-						dynatracev1beta2.KubeMonCapability.DisplayName,
+				ActiveGate: dynakube.ActiveGateSpec{
+					Capabilities: []dynakube.CapabilityDisplayName{
+						dynakube.KubeMonCapability.DisplayName,
 					},
 				},
 			},
-			Status: dynatracev1beta2.DynaKubeStatus{
+			Status: dynakube.DynaKubeStatus{
 				KubeSystemUUID: testUID,
 			},
 		}
-		fakeClient := fake.NewClientWithIndex(instance)
+		fakeClient := fake.NewClientWithIndex(dk)
 
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{})
 
@@ -99,7 +99,7 @@ func TestReconcileActiveGate(t *testing.T) {
 			apiMonitoringReconcilerBuilder: apimonitoring.NewReconciler, // TODO: actually mock it
 		}
 
-		err := controller.reconcileActiveGate(ctx, instance, mockClient, nil)
+		err := controller.reconcileActiveGate(ctx, dk, mockClient, nil)
 		require.NoError(t, err)
 		mockClient.AssertCalled(t, "CreateOrUpdateKubernetesSetting",
 			mock.AnythingOfType("context.backgroundCtx"),
@@ -111,28 +111,28 @@ func TestReconcileActiveGate(t *testing.T) {
 	t.Run(`reconcile automatic kubernetes api monitoring with custom cluster name`, func(t *testing.T) {
 		const clusterLabel = "..blabla..;.🙃"
 
-		instance := &dynatracev1beta2.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 				Annotations: map[string]string{
-					dynatracev1beta2.AnnotationFeatureAutomaticK8sApiMonitoring:            "true",
-					dynatracev1beta2.AnnotationFeatureAutomaticK8sApiMonitoringClusterName: clusterLabel,
+					dynakube.AnnotationFeatureAutomaticK8sApiMonitoring:            "true",
+					dynakube.AnnotationFeatureAutomaticK8sApiMonitoringClusterName: clusterLabel,
 				},
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{
-					Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-						dynatracev1beta2.KubeMonCapability.DisplayName,
+				ActiveGate: dynakube.ActiveGateSpec{
+					Capabilities: []dynakube.CapabilityDisplayName{
+						dynakube.KubeMonCapability.DisplayName,
 					},
 				},
 			},
-			Status: dynatracev1beta2.DynaKubeStatus{
+			Status: dynakube.DynaKubeStatus{
 				KubeSystemUUID: testUID,
 			},
 		}
-		fakeClient := fake.NewClientWithIndex(instance)
+		fakeClient := fake.NewClientWithIndex(dk)
 
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{})
 		mockClient.On("CreateOrUpdateKubernetesSetting",
@@ -151,7 +151,7 @@ func TestReconcileActiveGate(t *testing.T) {
 			apiMonitoringReconcilerBuilder: apimonitoring.NewReconciler, // TODO: actually mock it
 		}
 
-		err := controller.reconcileActiveGate(ctx, instance, mockClient, nil)
+		err := controller.reconcileActiveGate(ctx, dk, mockClient, nil)
 		require.NoError(t, err)
 		mockClient.AssertCalled(t, "CreateOrUpdateKubernetesSetting",
 			mock.AnythingOfType("context.backgroundCtx"),

--- a/pkg/controllers/dynakube/apimonitoring/reconciler.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler.go
@@ -10,7 +10,7 @@ import (
 
 type Reconciler struct {
 	dtc            dtclient.Client
-	dynakube       *dynakube.DynaKube
+	dk             *dynakube.DynaKube
 	clusterLabel   string
 	kubeSystemUUID string
 }
@@ -79,7 +79,7 @@ func (r *Reconciler) createObjectIdIfNotExists(ctx context.Context) (string, err
 }
 
 func (r *Reconciler) handleKubernetesAppEnabled(ctx context.Context, monitoredEntities []dtclient.MonitoredEntity) (string, error) {
-	if r.dynakube.FeatureEnableK8sAppEnabled() {
+	if r.dk.FeatureEnableK8sAppEnabled() {
 		appSettings, err := r.dtc.GetSettingsForMonitoredEntities(ctx, monitoredEntities, dtclient.AppTransitionSchemaId)
 		if err != nil {
 			return "", errors.WithMessage(err, "error trying to check if app setting exists")

--- a/pkg/controllers/dynakube/apimonitoring/reconciler.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler.go
@@ -3,24 +3,24 @@ package apimonitoring
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/pkg/errors"
 )
 
 type Reconciler struct {
 	dtc            dtclient.Client
-	dynakube       *dynatracev1beta2.DynaKube
+	dynakube       *dynakube.DynaKube
 	clusterLabel   string
 	kubeSystemUUID string
 }
 
-type ReconcilerBuilder func(dtc dtclient.Client, dynakube *dynatracev1beta2.DynaKube, clusterLabel, kubeSystemUUID string) *Reconciler
+type ReconcilerBuilder func(dtc dtclient.Client, dk *dynakube.DynaKube, clusterLabel, kubeSystemUUID string) *Reconciler
 
-func NewReconciler(dtc dtclient.Client, dynakube *dynatracev1beta2.DynaKube, clusterLabel, kubeSystemUUID string) *Reconciler {
+func NewReconciler(dtc dtclient.Client, dk *dynakube.DynaKube, clusterLabel, kubeSystemUUID string) *Reconciler {
 	return &Reconciler{
 		dtc,
-		dynakube,
+		dk,
 		clusterLabel,
 		kubeSystemUUID,
 	}

--- a/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/pkg/errors"
@@ -28,7 +28,7 @@ func createDefaultReconciler(t *testing.T) *Reconciler {
 	return createReconciler(t, newDynaKube(), testUID, []dtclient.MonitoredEntity{}, dtclient.GetSettingsResponse{TotalCount: 0}, "", "")
 }
 
-func createReconciler(t *testing.T, dynakube *dynatracev1beta2.DynaKube, uid string, monitoredEntities []dtclient.MonitoredEntity, getSettingsResponse dtclient.GetSettingsResponse, objectID string, meID interface{}) *Reconciler { //nolint:revive // argument-limit doesn't apply to constructors
+func createReconciler(t *testing.T, dk *dynakube.DynaKube, uid string, monitoredEntities []dtclient.MonitoredEntity, getSettingsResponse dtclient.GetSettingsResponse, objectID string, meID interface{}) *Reconciler { //nolint:revive // argument-limit doesn't apply to constructors
 	mockClient := dtclientmock.NewClient(t)
 	mockClient.On("GetMonitoredEntitiesForKubeSystemUUID", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
 		Return(monitoredEntities, nil)
@@ -43,14 +43,14 @@ func createReconciler(t *testing.T, dynakube *dynatracev1beta2.DynaKube, uid str
 		call.Maybe()
 	}
 
-	r := NewReconciler(mockClient, dynakube, testName, uid)
+	r := NewReconciler(mockClient, dk, testName, uid)
 	require.NotNil(t, r)
 	require.NotNil(t, r.dtc)
 
 	return r
 }
 
-func createReconcilerWithError(t *testing.T, dynakube *dynatracev1beta2.DynaKube, monitoredEntitiesError error, getSettingsResponseError error, createSettingsResponseError error, createAppSettingsResponseError error) *Reconciler { //nolint:revive
+func createReconcilerWithError(t *testing.T, dk *dynakube.DynaKube, monitoredEntitiesError error, getSettingsResponseError error, createSettingsResponseError error, createAppSettingsResponseError error) *Reconciler { //nolint:revive
 	mockClient := dtclientmock.NewClient(t)
 	mockClient.On("GetMonitoredEntitiesForKubeSystemUUID", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
 		Return([]dtclient.MonitoredEntity{}, monitoredEntitiesError)
@@ -68,7 +68,7 @@ func createReconcilerWithError(t *testing.T, dynakube *dynatracev1beta2.DynaKube
 		call.Maybe()
 	}
 
-	r := NewReconciler(mockClient, dynakube, testName, testUID)
+	r := NewReconciler(mockClient, dk, testName, testUID)
 	require.NotNil(t, r)
 	require.NotNil(t, r.dtc)
 
@@ -291,8 +291,8 @@ func TestDetermineNewestMonitoredEntity(t *testing.T) {
 	})
 }
 
-func newDynaKube() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func newDynaKube() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DynaKube",
 			APIVersion: "dynatrace.com/v1beta1",
@@ -302,12 +302,12 @@ func newDynaKube() *dynatracev1beta2.DynaKube {
 			Namespace: "my-namespace",
 			UID:       "69e98f18-805a-42de-84b5-3eae66534f75",
 			Annotations: map[string]string{
-				dynatracev1beta2.AnnotationFeatureK8sAppEnabled: "true",
+				dynakube.AnnotationFeatureK8sAppEnabled: "true",
 			},
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				HostMonitoring: &dynatracev1beta2.HostInjectSpec{},
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: dynakube.OneAgentSpec{
+				HostMonitoring: &dynakube.HostInjectSpec{},
 			},
 		},
 	}

--- a/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
@@ -84,7 +84,7 @@ func createMonitoredEntities() []dtclient.MonitoredEntity {
 
 func TestReconcile(t *testing.T) {
 	ctx := context.Background()
-	dynakube := newDynaKube()
+	dk := newDynaKube()
 
 	t.Run(`reconciler does not fail in with defaults`, func(t *testing.T) {
 		// arrange
@@ -99,7 +99,7 @@ func TestReconcile(t *testing.T) {
 
 	t.Run(`create setting when no monitored entities are existing`, func(t *testing.T) {
 		// arrange
-		r := createReconciler(t, dynakube, testUID, []dtclient.MonitoredEntity{}, dtclient.GetSettingsResponse{}, testObjectID, "")
+		r := createReconciler(t, dk, testUID, []dtclient.MonitoredEntity{}, dtclient.GetSettingsResponse{}, testObjectID, "")
 
 		// act
 		actual, err := r.createObjectIdIfNotExists(ctx)
@@ -112,7 +112,7 @@ func TestReconcile(t *testing.T) {
 	t.Run(`create setting when no settings for the found monitored entities are existing`, func(t *testing.T) {
 		// arrange
 		entities := createMonitoredEntities()
-		r := createReconciler(t, dynakube, testUID, entities, dtclient.GetSettingsResponse{}, testObjectID, "")
+		r := createReconciler(t, dk, testUID, entities, dtclient.GetSettingsResponse{}, testObjectID, "")
 
 		// act
 		actual, err := r.createObjectIdIfNotExists(ctx)
@@ -125,7 +125,7 @@ func TestReconcile(t *testing.T) {
 	t.Run(`don't create setting when settings for the found monitored entities are existing`, func(t *testing.T) {
 		// arrange
 		entities := createMonitoredEntities()
-		r := createReconciler(t, dynakube, testUID, entities, dtclient.GetSettingsResponse{TotalCount: 1}, testObjectID, "")
+		r := createReconciler(t, dk, testUID, entities, dtclient.GetSettingsResponse{TotalCount: 1}, testObjectID, "")
 
 		// act
 		actual, err := r.createObjectIdIfNotExists(ctx)
@@ -138,11 +138,11 @@ func TestReconcile(t *testing.T) {
 
 func TestReconcileErrors(t *testing.T) {
 	ctx := context.Background()
-	dynakube := newDynaKube()
+	dk := newDynaKube()
 
 	t.Run(`don't create setting when no kube-system uuid is given`, func(t *testing.T) {
 		// arrange
-		r := createReconciler(t, dynakube, "", []dtclient.MonitoredEntity{}, dtclient.GetSettingsResponse{}, testObjectID, "")
+		r := createReconciler(t, dk, "", []dtclient.MonitoredEntity{}, dtclient.GetSettingsResponse{}, testObjectID, "")
 
 		// act
 		actual, err := r.createObjectIdIfNotExists(ctx)
@@ -154,7 +154,7 @@ func TestReconcileErrors(t *testing.T) {
 
 	t.Run(`don't create setting when get entities api response is error`, func(t *testing.T) {
 		// arrange
-		r := createReconcilerWithError(t, dynakube, errors.New("could not get monitored entities"), nil, nil, nil)
+		r := createReconcilerWithError(t, dk, errors.New("could not get monitored entities"), nil, nil, nil)
 
 		// act
 		actual, err := r.createObjectIdIfNotExists(ctx)
@@ -166,7 +166,7 @@ func TestReconcileErrors(t *testing.T) {
 
 	t.Run(`don't create setting when get settings api response is error`, func(t *testing.T) {
 		// arrange
-		r := createReconcilerWithError(t, dynakube, nil, errors.New("could not get settings for monitored entities"), nil, nil)
+		r := createReconcilerWithError(t, dk, nil, errors.New("could not get settings for monitored entities"), nil, nil)
 
 		// act
 		actual, err := r.createObjectIdIfNotExists(ctx)
@@ -178,7 +178,7 @@ func TestReconcileErrors(t *testing.T) {
 
 	t.Run(`don't create setting when create settings api response is error`, func(t *testing.T) {
 		// arrange
-		r := createReconcilerWithError(t, dynakube, nil, nil, errors.New("could not create monitored entity"), nil)
+		r := createReconcilerWithError(t, dk, nil, nil, errors.New("could not create monitored entity"), nil)
 
 		// act
 		actual, err := r.createObjectIdIfNotExists(ctx)
@@ -190,7 +190,7 @@ func TestReconcileErrors(t *testing.T) {
 
 	t.Run(`create settings successful in case of CreateOrUpdateKubernetesAppSetting error`, func(t *testing.T) {
 		// arrange
-		r := createReconcilerWithError(t, dynakube, nil, nil, nil, errors.New("could not create monitored entity"))
+		r := createReconcilerWithError(t, dk, nil, nil, nil, errors.New("could not create monitored entity"))
 
 		// act
 		_, err := r.createObjectIdIfNotExists(ctx)
@@ -202,11 +202,11 @@ func TestReconcileErrors(t *testing.T) {
 
 func TestHandleKubernetesAppEnabled(t *testing.T) {
 	ctx := context.Background()
-	dynakube := newDynaKube()
+	dk := newDynaKube()
 
 	t.Run(`don't create app setting due to empty MonitoredEntitys`, func(t *testing.T) {
 		// arrange
-		r := createReconciler(t, dynakube, "", []dtclient.MonitoredEntity{}, dtclient.GetSettingsResponse{}, "", "")
+		r := createReconciler(t, dk, "", []dtclient.MonitoredEntity{}, dtclient.GetSettingsResponse{}, "", "")
 
 		// act
 		_, err := r.handleKubernetesAppEnabled(ctx, []dtclient.MonitoredEntity{})
@@ -221,7 +221,7 @@ func TestHandleKubernetesAppEnabled(t *testing.T) {
 			{EntityId: "KUBERNETES_CLUSTER-0E30FE4BF2007587", DisplayName: "operator test entity newest", LastSeenTms: 1639483869085},
 			{EntityId: "KUBERNETES_CLUSTER-119C75CCDA94799F", DisplayName: "operator test entity 1", LastSeenTms: 1639034988126},
 		}
-		r := createReconciler(t, dynakube, "", entities, dtclient.GetSettingsResponse{TotalCount: 1}, "", "")
+		r := createReconciler(t, dk, "", entities, dtclient.GetSettingsResponse{TotalCount: 1}, "", "")
 
 		// act
 		_, err := r.handleKubernetesAppEnabled(ctx, entities)
@@ -232,7 +232,7 @@ func TestHandleKubernetesAppEnabled(t *testing.T) {
 
 	t.Run(`don't create app setting when get entities api response is error`, func(t *testing.T) {
 		// arrange
-		r := createReconcilerWithError(t, dynakube, nil, errors.New("could not get monitored entities"), nil, nil)
+		r := createReconcilerWithError(t, dk, nil, errors.New("could not get monitored entities"), nil, nil)
 
 		// act
 		_, err := r.handleKubernetesAppEnabled(ctx, []dtclient.MonitoredEntity{})
@@ -243,7 +243,7 @@ func TestHandleKubernetesAppEnabled(t *testing.T) {
 
 	t.Run(`don't create app setting when get CreateOrUpdateKubernetesAppSetting response is error`, func(t *testing.T) {
 		// arrange
-		r := createReconcilerWithError(t, dynakube, nil, nil, nil, errors.New("could not get monitored entities"))
+		r := createReconcilerWithError(t, dk, nil, nil, nil, errors.New("could not get monitored entities"))
 		meID := "KUBERNETES_CLUSTER-0E30FE4BF2007587"
 		entities := []dtclient.MonitoredEntity{
 			{EntityId: meID, DisplayName: "operator test entity newest", LastSeenTms: 1639483869085},
@@ -261,7 +261,7 @@ func TestHandleKubernetesAppEnabled(t *testing.T) {
 		entities := []dtclient.MonitoredEntity{
 			{EntityId: meID, DisplayName: "operator test entity newest", LastSeenTms: 1639483869085},
 		}
-		r := createReconciler(t, dynakube, "", entities, dtclient.GetSettingsResponse{}, "", meID)
+		r := createReconciler(t, dk, "", entities, dtclient.GetSettingsResponse{}, "", meID)
 		// act
 		id, err := r.handleKubernetesAppEnabled(ctx, entities)
 		// assert

--- a/pkg/controllers/dynakube/conditions.go
+++ b/pkg/controllers/dynakube/conditions.go
@@ -34,7 +34,7 @@ func (controller *Controller) setAndLogCondition(dk *dynakube.DynaKube, newCondi
 
 	if newCondition.Reason != dynakube.ReasonTokenReady {
 		log.Info("problem with token detected",
-			"dk", dk.Name, "namespace", dk.Namespace,
+			"dynakube", dk.Name, "namespace", dk.Namespace,
 			"token", newCondition.Type,
 			"message", newCondition.Message)
 	}

--- a/pkg/controllers/dynakube/conditions.go
+++ b/pkg/controllers/dynakube/conditions.go
@@ -1,40 +1,40 @@
 package dynakube
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (controller *Controller) setConditionTokenError(dynakube *dynatracev1beta2.DynaKube, err error) {
+func (controller *Controller) setConditionTokenError(dk *dynakube.DynaKube, err error) {
 	tokenErrorCondition := metav1.Condition{
-		Type:    dynatracev1beta2.TokenConditionType,
+		Type:    dynakube.TokenConditionType,
 		Status:  metav1.ConditionFalse,
-		Reason:  dynatracev1beta2.ReasonTokenError,
+		Reason:  dynakube.ReasonTokenError,
 		Message: err.Error(),
 	}
 
-	controller.setAndLogCondition(dynakube, tokenErrorCondition)
+	controller.setAndLogCondition(dk, tokenErrorCondition)
 }
 
-func (controller *Controller) setConditionTokenReady(dynakube *dynatracev1beta2.DynaKube) {
+func (controller *Controller) setConditionTokenReady(dk *dynakube.DynaKube) {
 	tokenErrorCondition := metav1.Condition{
-		Type:   dynatracev1beta2.TokenConditionType,
+		Type:   dynakube.TokenConditionType,
 		Status: metav1.ConditionTrue,
-		Reason: dynatracev1beta2.ReasonTokenReady,
+		Reason: dynakube.ReasonTokenReady,
 	}
 
-	controller.setAndLogCondition(dynakube, tokenErrorCondition)
+	controller.setAndLogCondition(dk, tokenErrorCondition)
 }
 
 // TODO: Probably should be removed, as most of this is done inside meta.SetStatusCondition (except the logging) the removeDeprecatedConditionTypes already did its job, as it has been in since forever
-func (controller *Controller) setAndLogCondition(dynakube *dynatracev1beta2.DynaKube, newCondition metav1.Condition) {
-	controller.removeDeprecatedConditionTypes(dynakube)
-	statusCondition := meta.FindStatusCondition(dynakube.Status.Conditions, newCondition.Type)
+func (controller *Controller) setAndLogCondition(dk *dynakube.DynaKube, newCondition metav1.Condition) {
+	controller.removeDeprecatedConditionTypes(dk)
+	statusCondition := meta.FindStatusCondition(dk.Status.Conditions, newCondition.Type)
 
-	if newCondition.Reason != dynatracev1beta2.ReasonTokenReady {
+	if newCondition.Reason != dynakube.ReasonTokenReady {
 		log.Info("problem with token detected",
-			"dynakube", dynakube.Name, "namespace", dynakube.Namespace,
+			"dk", dk.Name, "namespace", dk.Namespace,
 			"token", newCondition.Type,
 			"message", newCondition.Message)
 	}
@@ -44,7 +44,7 @@ func (controller *Controller) setAndLogCondition(dynakube *dynatracev1beta2.Dyna
 	}
 
 	newCondition.LastTransitionTime = metav1.Now()
-	meta.SetStatusCondition(&dynakube.Status.Conditions, newCondition)
+	meta.SetStatusCondition(&dk.Status.Conditions, newCondition)
 }
 
 func areStatusesEqual(statusCondition *metav1.Condition, newCondition metav1.Condition) bool {
@@ -54,16 +54,16 @@ func areStatusesEqual(statusCondition *metav1.Condition, newCondition metav1.Con
 		statusCondition.Status == newCondition.Status
 }
 
-func (controller *Controller) removeDeprecatedConditionTypes(dynakube *dynatracev1beta2.DynaKube) {
-	if meta.FindStatusCondition(dynakube.Status.Conditions, dynatracev1beta2.PaaSTokenConditionType) != nil {
-		meta.RemoveStatusCondition(&dynakube.Status.Conditions, dynatracev1beta2.PaaSTokenConditionType)
+func (controller *Controller) removeDeprecatedConditionTypes(dk *dynakube.DynaKube) {
+	if meta.FindStatusCondition(dk.Status.Conditions, dynakube.PaaSTokenConditionType) != nil {
+		meta.RemoveStatusCondition(&dk.Status.Conditions, dynakube.PaaSTokenConditionType)
 	}
 
-	if meta.FindStatusCondition(dynakube.Status.Conditions, dynatracev1beta2.APITokenConditionType) != nil {
-		meta.RemoveStatusCondition(&dynakube.Status.Conditions, dynatracev1beta2.APITokenConditionType)
+	if meta.FindStatusCondition(dk.Status.Conditions, dynakube.APITokenConditionType) != nil {
+		meta.RemoveStatusCondition(&dk.Status.Conditions, dynakube.APITokenConditionType)
 	}
 
-	if meta.FindStatusCondition(dynakube.Status.Conditions, dynatracev1beta2.DataIngestTokenConditionType) != nil {
-		meta.RemoveStatusCondition(&dynakube.Status.Conditions, dynatracev1beta2.DataIngestTokenConditionType)
+	if meta.FindStatusCondition(dk.Status.Conditions, dynakube.DataIngestTokenConditionType) != nil {
+		meta.RemoveStatusCondition(&dk.Status.Conditions, dynakube.DataIngestTokenConditionType)
 	}
 }

--- a/pkg/controllers/dynakube/connectioninfo/activegate/communication_hosts.go
+++ b/pkg/controllers/dynakube/connectioninfo/activegate/communication_hosts.go
@@ -14,8 +14,8 @@ const (
 	DefaultHttpPort = uint32(80)
 )
 
-func GetEndpointsAsCommunicationHosts(dynakube *dynakube.DynaKube) []dtclient.CommunicationHost {
-	activegateEndpointsString := dynakube.Status.ActiveGate.ConnectionInfoStatus.Endpoints
+func GetEndpointsAsCommunicationHosts(dk *dynakube.DynaKube) []dtclient.CommunicationHost {
+	activegateEndpointsString := dk.Status.ActiveGate.ConnectionInfoStatus.Endpoints
 	if activegateEndpointsString == "" {
 		return []dtclient.CommunicationHost{}
 	}

--- a/pkg/controllers/dynakube/connectioninfo/activegate/communication_hosts_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/activegate/communication_hosts_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestParseCommunicationHostsFromActiveGateEndpoints(t *testing.T) {
-	dynakube := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-namespace",
 			Name:      "test-name",
@@ -29,27 +29,27 @@ func TestParseCommunicationHostsFromActiveGateEndpoints(t *testing.T) {
 	})
 
 	t.Run(`activegate endpoint set`, func(t *testing.T) {
-		dynakube.Status.ActiveGate.ConnectionInfoStatus.Endpoints = "https://abcd123.some.activegate.endpointurl.com:443"
+		dk.Status.ActiveGate.ConnectionInfoStatus.Endpoints = "https://abcd123.some.activegate.endpointurl.com:443"
 
-		hosts := GetEndpointsAsCommunicationHosts(dynakube)
+		hosts := GetEndpointsAsCommunicationHosts(dk)
 		assert.Len(t, hosts, 1)
 		assert.Equal(t, "abcd123.some.activegate.endpointurl.com", hosts[0].Host)
 		assert.Equal(t, "https", hosts[0].Protocol)
 		assert.Equal(t, uint32(443), hosts[0].Port)
 	})
 	t.Run(`activegate multiple endpoints set`, func(t *testing.T) {
-		dynakube.Status.ActiveGate.ConnectionInfoStatus.Endpoints = "https://abcd123.some.activegate.endpointurl.com:443,https://efg5678.some.other.activegate.endpointurl.com"
+		dk.Status.ActiveGate.ConnectionInfoStatus.Endpoints = "https://abcd123.some.activegate.endpointurl.com:443,https://efg5678.some.other.activegate.endpointurl.com"
 
-		hosts := GetEndpointsAsCommunicationHosts(dynakube)
+		hosts := GetEndpointsAsCommunicationHosts(dk)
 		assert.Len(t, hosts, 2)
 		hostNames := []string{hosts[0].Host, hosts[1].Host}
 		assert.Contains(t, hostNames, "abcd123.some.activegate.endpointurl.com")
 		assert.Contains(t, hostNames, "efg5678.some.other.activegate.endpointurl.com")
 	})
 	t.Run(`activegate duplicate endpoints set`, func(t *testing.T) {
-		dynakube.Status.ActiveGate.ConnectionInfoStatus.Endpoints = "https://abcd123.some.activegate.endpointurl.com:443,https://abcd123.some.activegate.endpointurl.com:443,https://abcd123.some.activegate.endpointurl.com:443"
+		dk.Status.ActiveGate.ConnectionInfoStatus.Endpoints = "https://abcd123.some.activegate.endpointurl.com:443,https://abcd123.some.activegate.endpointurl.com:443,https://abcd123.some.activegate.endpointurl.com:443"
 
-		hosts := GetEndpointsAsCommunicationHosts(dynakube)
+		hosts := GetEndpointsAsCommunicationHosts(dk)
 		assert.Len(t, hosts, 1)
 		assert.Equal(t, "abcd123.some.activegate.endpointurl.com", hosts[0].Host)
 		assert.Equal(t, "https", hosts[0].Protocol)

--- a/pkg/controllers/dynakube/connectioninfo/activegate/communication_hosts_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/activegate/communication_hosts_test.go
@@ -3,21 +3,21 @@ package activegate
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestParseCommunicationHostsFromActiveGateEndpoints(t *testing.T) {
-	dynakube := &dynatracev1beta2.DynaKube{
+	dynakube := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-namespace",
 			Name:      "test-name",
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			OneAgent: dynatracev1beta2.OneAgentStatus{
-				ConnectionInfoStatus: dynatracev1beta2.OneAgentConnectionInfoStatus{
-					ConnectionInfoStatus: dynatracev1beta2.ConnectionInfoStatus{},
+		Status: dynakube.DynaKubeStatus{
+			OneAgent: dynakube.OneAgentStatus{
+				ConnectionInfoStatus: dynakube.OneAgentConnectionInfoStatus{
+					ConnectionInfoStatus: dynakube.ConnectionInfoStatus{},
 				},
 			},
 		},

--- a/pkg/controllers/dynakube/connectioninfo/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/activegate/reconciler.go
@@ -3,7 +3,7 @@ package activegate
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
@@ -23,18 +23,18 @@ type reconciler struct {
 	dtc          dtclient.Client
 	timeProvider *timeprovider.Provider
 
-	dynakube *dynatracev1beta2.DynaKube
+	dynakube *dynakube.DynaKube
 }
 
-type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dynakube *dynatracev1beta2.DynaKube) controllers.Reconciler
+type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Reconciler
 
 var _ ReconcilerBuilder = NewReconciler
 
-func NewReconciler(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dynakube *dynatracev1beta2.DynaKube) controllers.Reconciler {
+func NewReconciler(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Reconciler {
 	return &reconciler{
 		client:       clt,
 		apiReader:    apiReader,
-		dynakube:     dynakube,
+		dynakube:     dk,
 		dtc:          dtc,
 		timeProvider: timeprovider.New(),
 	}
@@ -46,7 +46,7 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 			return nil
 		}
 
-		r.dynakube.Status.ActiveGate.ConnectionInfoStatus = dynatracev1beta2.ActiveGateConnectionInfoStatus{}
+		r.dynakube.Status.ActiveGate.ConnectionInfoStatus = dynakube.ActiveGateConnectionInfoStatus{}
 		query := k8ssecret.NewQuery(ctx, r.client, r.apiReader, log)
 
 		err := query.Delete(r.dynakube.ActivegateTenantSecret(), r.dynakube.Namespace)
@@ -79,7 +79,7 @@ func (r *reconciler) reconcileConnectionInfo(ctx context.Context) error {
 
 		condition := meta.FindStatusCondition(*r.dynakube.Conditions(), activeGateConnectionInfoConditionType)
 		if isSecretPresent {
-			log.Info(dynatracev1beta2.GetCacheValidMessage(
+			log.Info(dynakube.GetCacheValidMessage(
 				"activegate connection info update",
 				condition.LastTransitionTime,
 				r.dynakube.ApiRequestThreshold()))

--- a/pkg/controllers/dynakube/connectioninfo/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/activegate/reconciler.go
@@ -23,7 +23,7 @@ type reconciler struct {
 	dtc          dtclient.Client
 	timeProvider *timeprovider.Provider
 
-	dynakube *dynakube.DynaKube
+	dk *dynakube.DynaKube
 }
 
 type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Reconciler
@@ -34,27 +34,27 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dtc dtclient.Clie
 	return &reconciler{
 		client:       clt,
 		apiReader:    apiReader,
-		dynakube:     dk,
+		dk:           dk,
 		dtc:          dtc,
 		timeProvider: timeprovider.New(),
 	}
 }
 
 func (r *reconciler) Reconcile(ctx context.Context) error {
-	if !r.dynakube.NeedsActiveGate() {
-		if meta.FindStatusCondition(*r.dynakube.Conditions(), activeGateConnectionInfoConditionType) == nil {
+	if !r.dk.NeedsActiveGate() {
+		if meta.FindStatusCondition(*r.dk.Conditions(), activeGateConnectionInfoConditionType) == nil {
 			return nil
 		}
 
-		r.dynakube.Status.ActiveGate.ConnectionInfoStatus = dynakube.ActiveGateConnectionInfoStatus{}
+		r.dk.Status.ActiveGate.ConnectionInfoStatus = dynakube.ActiveGateConnectionInfoStatus{}
 		query := k8ssecret.NewQuery(ctx, r.client, r.apiReader, log)
 
-		err := query.Delete(r.dynakube.ActivegateTenantSecret(), r.dynakube.Namespace)
+		err := query.Delete(r.dk.ActivegateTenantSecret(), r.dk.Namespace)
 		if err != nil {
 			log.Error(err, "failed to clean-up ActiveGate tenant-secret")
 		}
 
-		meta.RemoveStatusCondition(r.dynakube.Conditions(), activeGateConnectionInfoConditionType)
+		meta.RemoveStatusCondition(r.dk.Conditions(), activeGateConnectionInfoConditionType)
 
 		return nil // clean-up shouldn't cause a failure
 	}
@@ -69,30 +69,30 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 }
 
 func (r *reconciler) reconcileConnectionInfo(ctx context.Context) error {
-	secretNamespacedName := types.NamespacedName{Name: r.dynakube.ActivegateTenantSecret(), Namespace: r.dynakube.Namespace}
+	secretNamespacedName := types.NamespacedName{Name: r.dk.ActivegateTenantSecret(), Namespace: r.dk.Namespace}
 
-	if !conditions.IsOutdated(r.timeProvider, r.dynakube, activeGateConnectionInfoConditionType) {
+	if !conditions.IsOutdated(r.timeProvider, r.dk, activeGateConnectionInfoConditionType) {
 		isSecretPresent, err := connectioninfo.IsTenantSecretPresent(ctx, r.apiReader, secretNamespacedName, log)
 		if err != nil {
 			return err
 		}
 
-		condition := meta.FindStatusCondition(*r.dynakube.Conditions(), activeGateConnectionInfoConditionType)
+		condition := meta.FindStatusCondition(*r.dk.Conditions(), activeGateConnectionInfoConditionType)
 		if isSecretPresent {
 			log.Info(dynakube.GetCacheValidMessage(
 				"activegate connection info update",
 				condition.LastTransitionTime,
-				r.dynakube.ApiRequestThreshold()))
+				r.dk.ApiRequestThreshold()))
 
 			return nil
 		}
 	}
 
-	conditions.SetSecretOutdated(r.dynakube.Conditions(), activeGateConnectionInfoConditionType, secretNamespacedName.Name+" is not present or outdated, update in progress") // Necessary to update the LastTransitionTime, also it is a nice failsafe
+	conditions.SetSecretOutdated(r.dk.Conditions(), activeGateConnectionInfoConditionType, secretNamespacedName.Name+" is not present or outdated, update in progress") // Necessary to update the LastTransitionTime, also it is a nice failsafe
 
 	connectionInfo, err := r.dtc.GetActiveGateConnectionInfo(ctx)
 	if err != nil {
-		conditions.SetDynatraceApiError(r.dynakube.Conditions(), activeGateConnectionInfoConditionType, err)
+		conditions.SetDynatraceApiError(r.dk.Conditions(), activeGateConnectionInfoConditionType, err)
 
 		return errors.WithMessage(err, "failed to get ActiveGate connection info")
 	}
@@ -103,7 +103,7 @@ func (r *reconciler) reconcileConnectionInfo(ctx context.Context) error {
 		log.Info("tenant has no endpoints", "tenant", connectionInfo.TenantUUID)
 	}
 
-	err = r.createTenantTokenSecret(ctx, r.dynakube.ActivegateTenantSecret(), r.dynakube, connectionInfo.ConnectionInfo)
+	err = r.createTenantTokenSecret(ctx, r.dk.ActivegateTenantSecret(), r.dk, connectionInfo.ConnectionInfo)
 	if err != nil {
 		return err
 	}
@@ -114,8 +114,8 @@ func (r *reconciler) reconcileConnectionInfo(ctx context.Context) error {
 }
 
 func (r *reconciler) setDynakubeStatus(connectionInfo dtclient.ActiveGateConnectionInfo) {
-	r.dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID = connectionInfo.TenantUUID
-	r.dynakube.Status.ActiveGate.ConnectionInfoStatus.Endpoints = connectionInfo.Endpoints
+	r.dk.Status.ActiveGate.ConnectionInfoStatus.TenantUUID = connectionInfo.TenantUUID
+	r.dk.Status.ActiveGate.ConnectionInfoStatus.Endpoints = connectionInfo.Endpoints
 }
 
 func (r *reconciler) createTenantTokenSecret(ctx context.Context, secretName string, owner metav1.Object, connectionInfo dtclient.ConnectionInfo) error {
@@ -129,12 +129,12 @@ func (r *reconciler) createTenantTokenSecret(ctx context.Context, secretName str
 	err = query.CreateOrUpdate(*secret)
 	if err != nil {
 		log.Info("could not create or update secret for connection info", "name", secret.Name)
-		conditions.SetKubeApiError(r.dynakube.Conditions(), activeGateConnectionInfoConditionType, err)
+		conditions.SetKubeApiError(r.dk.Conditions(), activeGateConnectionInfoConditionType, err)
 
 		return err
 	}
 
-	conditions.SetSecretCreated(r.dynakube.Conditions(), activeGateConnectionInfoConditionType, secret.Name)
+	conditions.SetSecretCreated(r.dk.Conditions(), activeGateConnectionInfoConditionType, secret.Name)
 
 	return nil
 }

--- a/pkg/controllers/dynakube/connectioninfo/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/activegate/reconciler_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
@@ -36,119 +36,119 @@ func TestReconcile(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("cleanup when activegate is not needed", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		dynakube.Spec = dynatracev1beta2.DynaKubeSpec{}
-		meta.SetStatusCondition(&dynakube.Status.Conditions, metav1.Condition{
+		dk := getTestDynakube()
+		dk.Spec = dynakube.DynaKubeSpec{}
+		meta.SetStatusCondition(&dk.Status.Conditions, metav1.Condition{
 			Type:   activeGateConnectionInfoConditionType,
 			Status: metav1.ConditionTrue,
 		})
 
-		fakeClient := fake.NewClient(buildActiveGateSecret(*dynakube, testTenantUUID))
+		fakeClient := fake.NewClient(buildActiveGateSecret(*dk, testTenantUUID))
 		dtc := dtclientmock.NewClient(t)
 
-		r := NewReconciler(fakeClient, fakeClient, dtc, dynakube)
+		r := NewReconciler(fakeClient, fakeClient, dtc, dk)
 		err := r.Reconcile(ctx)
 		require.NoError(t, err)
-		assert.Empty(t, dynakube.Status.ActiveGate.ConnectionInfoStatus)
-		assert.Nil(t, meta.FindStatusCondition(dynakube.Status.Conditions, activeGateConnectionInfoConditionType))
+		assert.Empty(t, dk.Status.ActiveGate.ConnectionInfoStatus)
+		assert.Nil(t, meta.FindStatusCondition(dk.Status.Conditions, activeGateConnectionInfoConditionType))
 
 		var actualSecret corev1.Secret
-		err = fakeClient.Get(ctx, client.ObjectKey{Name: dynakube.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: dk.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
 		require.Error(t, err)
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 
 	t.Run(`store ActiveGate connection info to DynaKube status + create tenant secret`, func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 
 		dtc := dtclientmock.NewClient(t)
 		dtc.On("GetActiveGateConnectionInfo", mock.AnythingOfType("context.backgroundCtx")).Return(getTestActiveGateConnectionInfo(), nil)
 
-		fakeClient := fake.NewClient(dynakube)
-		r := NewReconciler(fakeClient, fakeClient, dtc, dynakube)
+		fakeClient := fake.NewClient(dk)
+		r := NewReconciler(fakeClient, fakeClient, dtc, dk)
 		err := r.Reconcile(ctx)
 		require.NoError(t, err)
 
-		condition := meta.FindStatusCondition(dynakube.Status.Conditions, activeGateConnectionInfoConditionType)
+		condition := meta.FindStatusCondition(dk.Status.Conditions, activeGateConnectionInfoConditionType)
 		require.NotNil(t, condition)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
 
-		assert.Equal(t, testTenantUUID, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
-		assert.Equal(t, testTenantEndpoints, dynakube.Status.ActiveGate.ConnectionInfoStatus.Endpoints)
+		assert.Equal(t, testTenantUUID, dk.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
+		assert.Equal(t, testTenantEndpoints, dk.Status.ActiveGate.ConnectionInfoStatus.Endpoints)
 
 		var actualSecret corev1.Secret
-		err = fakeClient.Get(ctx, client.ObjectKey{Name: dynakube.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: dk.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
 		require.NoError(t, err)
 		assert.Equal(t, []byte(testTenantToken), actualSecret.Data[connectioninfo.TenantTokenKey])
 	})
 
 	t.Run(`update ActiveGate connection info + update tenant secret`, func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 
 		dtc := dtclientmock.NewClient(t)
 		dtc.On("GetActiveGateConnectionInfo", mock.AnythingOfType("context.backgroundCtx")).Return(getTestActiveGateConnectionInfo(), nil)
 
-		fakeClient := fake.NewClient(dynakube, buildActiveGateSecret(*dynakube, testTenantUUID))
-		dynakube.Status.ActiveGate.ConnectionInfoStatus = dynatracev1beta2.ActiveGateConnectionInfoStatus{
-			ConnectionInfoStatus: dynatracev1beta2.ConnectionInfoStatus{
+		fakeClient := fake.NewClient(dk, buildActiveGateSecret(*dk, testTenantUUID))
+		dk.Status.ActiveGate.ConnectionInfoStatus = dynakube.ActiveGateConnectionInfoStatus{
+			ConnectionInfoStatus: dynakube.ConnectionInfoStatus{
 				TenantUUID: testOutdated,
 				Endpoints:  testOutdated,
 			},
 		}
 
-		r := NewReconciler(fakeClient, fakeClient, dtc, dynakube)
+		r := NewReconciler(fakeClient, fakeClient, dtc, dk)
 		rec := r.(*reconciler)
 		rec.timeProvider.Set(rec.timeProvider.Now().Add(time.Minute * 20))
 
 		err := r.Reconcile(ctx)
 		require.NoError(t, err)
 
-		condition := meta.FindStatusCondition(dynakube.Status.Conditions, activeGateConnectionInfoConditionType)
+		condition := meta.FindStatusCondition(dk.Status.Conditions, activeGateConnectionInfoConditionType)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
 
-		assert.Equal(t, testTenantUUID, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
-		assert.Equal(t, testTenantEndpoints, dynakube.Status.ActiveGate.ConnectionInfoStatus.Endpoints)
+		assert.Equal(t, testTenantUUID, dk.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
+		assert.Equal(t, testTenantEndpoints, dk.Status.ActiveGate.ConnectionInfoStatus.Endpoints)
 
 		var actualSecret corev1.Secret
-		err = fakeClient.Get(ctx, client.ObjectKey{Name: dynakube.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: dk.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
 		require.NoError(t, err)
 		assert.Equal(t, []byte(testTenantToken), actualSecret.Data[connectioninfo.TenantTokenKey])
 	})
 	t.Run(`update ActiveGate connection info if tenant secret is missing, ignore timestamp`, func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 
 		dtc := dtclientmock.NewClient(t)
 		dtc.On("GetActiveGateConnectionInfo", mock.AnythingOfType("context.backgroundCtx")).Return(getTestActiveGateConnectionInfo(), nil)
 
-		fakeClient := fake.NewClient(dynakube)
+		fakeClient := fake.NewClient(dk)
 
-		dynakube.Status.ActiveGate.ConnectionInfoStatus = dynatracev1beta2.ActiveGateConnectionInfoStatus{
-			ConnectionInfoStatus: dynatracev1beta2.ConnectionInfoStatus{
+		dk.Status.ActiveGate.ConnectionInfoStatus = dynakube.ActiveGateConnectionInfoStatus{
+			ConnectionInfoStatus: dynakube.ConnectionInfoStatus{
 				TenantUUID: testOutdated,
 				Endpoints:  testOutdated,
 			},
 		}
 
-		r := NewReconciler(fakeClient, fakeClient, dtc, dynakube)
+		r := NewReconciler(fakeClient, fakeClient, dtc, dk)
 		err := r.Reconcile(ctx)
 		require.NoError(t, err)
 
-		condition := meta.FindStatusCondition(dynakube.Status.Conditions, activeGateConnectionInfoConditionType)
+		condition := meta.FindStatusCondition(dk.Status.Conditions, activeGateConnectionInfoConditionType)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
 
-		assert.Equal(t, testTenantUUID, dynakube.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
-		assert.Equal(t, testTenantEndpoints, dynakube.Status.ActiveGate.ConnectionInfoStatus.Endpoints)
+		assert.Equal(t, testTenantUUID, dk.Status.ActiveGate.ConnectionInfoStatus.TenantUUID)
+		assert.Equal(t, testTenantEndpoints, dk.Status.ActiveGate.ConnectionInfoStatus.Endpoints)
 
 		var actualSecret corev1.Secret
-		err = fakeClient.Get(ctx, client.ObjectKey{Name: dynakube.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: dk.ActivegateTenantSecret(), Namespace: testNamespace}, &actualSecret)
 		require.NoError(t, err)
 		assert.Equal(t, []byte(testTenantToken), actualSecret.Data[connectioninfo.TenantTokenKey])
 	})
 	t.Run(`ActiveGate connection info error shown in conditions`, func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		fakeClient := fake.NewClientWithInterceptors(interceptor.Funcs{
 			Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 				return fmt.Errorf("BOOM")
@@ -158,11 +158,11 @@ func TestReconcile(t *testing.T) {
 		dtc := dtclientmock.NewClient(t)
 		dtc.On("GetActiveGateConnectionInfo", mock.AnythingOfType("context.backgroundCtx")).Return(getTestActiveGateConnectionInfo(), nil).Maybe()
 
-		r := NewReconciler(fakeClient, fakeClient, dtc, dynakube)
+		r := NewReconciler(fakeClient, fakeClient, dtc, dk)
 		err := r.Reconcile(ctx)
 		require.Error(t, err)
 
-		condition := meta.FindStatusCondition(dynakube.Status.Conditions, activeGateConnectionInfoConditionType)
+		condition := meta.FindStatusCondition(dk.Status.Conditions, activeGateConnectionInfoConditionType)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 		assert.Equal(t, conditions.KubeApiErrorReason, condition.Reason)
 		assert.Equal(t, "A problem occurred when using the Kubernetes API: "+err.Error(), condition.Message)
@@ -179,26 +179,26 @@ func getTestActiveGateConnectionInfo() dtclient.ActiveGateConnectionInfo {
 	}
 }
 
-func getTestDynakube() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func getTestDynakube() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
-				Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-					dynatracev1beta2.RoutingCapability.DisplayName,
+		Spec: dynakube.DynaKubeSpec{
+			ActiveGate: dynakube.ActiveGateSpec{
+				Capabilities: []dynakube.CapabilityDisplayName{
+					dynakube.RoutingCapability.DisplayName,
 				},
 			},
 		},
 	}
 }
 
-func buildActiveGateSecret(dynakube dynatracev1beta2.DynaKube, token string) *corev1.Secret {
+func buildActiveGateSecret(dk dynakube.DynaKube, token string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dynakube.ActivegateTenantSecret(),
+			Name:      dk.ActivegateTenantSecret(),
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/communication_hosts.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/communication_hosts.go
@@ -1,13 +1,13 @@
 package oaconnectioninfo
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 )
 
-func GetCommunicationHosts(dynakube *dynatracev1beta2.DynaKube) []dtclient.CommunicationHost {
-	communicationHosts := make([]dtclient.CommunicationHost, 0, len(dynakube.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts))
-	for _, host := range dynakube.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts {
+func GetCommunicationHosts(dk *dynakube.DynaKube) []dtclient.CommunicationHost {
+	communicationHosts := make([]dtclient.CommunicationHost, 0, len(dk.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts))
+	for _, host := range dk.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts {
 		communicationHosts = append(communicationHosts, dtclient.CommunicationHost{
 			Protocol: host.Protocol,
 			Host:     host.Host,

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/communication_hosts_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/communication_hosts_test.go
@@ -3,22 +3,22 @@ package oaconnectioninfo
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetCommunicationHosts(t *testing.T) {
-	dynakube := &dynatracev1beta2.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testName,
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			OneAgent: dynatracev1beta2.OneAgentStatus{
-				ConnectionInfoStatus: dynatracev1beta2.OneAgentConnectionInfoStatus{
-					ConnectionInfoStatus: dynatracev1beta2.ConnectionInfoStatus{},
+		Status: dynakube.DynaKubeStatus{
+			OneAgent: dynakube.OneAgentStatus{
+				ConnectionInfoStatus: dynakube.OneAgentConnectionInfoStatus{
+					ConnectionInfoStatus: dynakube.ConnectionInfoStatus{},
 				},
 			},
 		},
@@ -33,12 +33,12 @@ func TestGetCommunicationHosts(t *testing.T) {
 	}
 
 	t.Run(`communications host empty`, func(t *testing.T) {
-		hosts := GetCommunicationHosts(dynakube)
+		hosts := GetCommunicationHosts(dk)
 		assert.Empty(t, hosts)
 	})
 
 	t.Run(`communication-hosts field found`, func(t *testing.T) {
-		dynakube.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts = []dynatracev1beta2.CommunicationHostStatus{
+		dk.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts = []dynakube.CommunicationHostStatus{
 			{
 				Protocol: "protocol",
 				Host:     "host",
@@ -46,7 +46,7 @@ func TestGetCommunicationHosts(t *testing.T) {
 			},
 		}
 
-		hosts := GetCommunicationHosts(dynakube)
+		hosts := GetCommunicationHosts(dk)
 		assert.NotNil(t, hosts)
 		assert.Equal(t, expectedCommunicationHosts[0].Host, hosts[0].Host)
 		assert.Equal(t, expectedCommunicationHosts[0].Protocol, hosts[0].Protocol)

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
@@ -1,7 +1,7 @@
 package oaconnectioninfo
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
@@ -23,17 +23,17 @@ type reconciler struct {
 	dtc          dtclient.Client
 	timeProvider *timeprovider.Provider
 
-	dynakube *dynatracev1beta2.DynaKube
+	dynakube *dynakube.DynaKube
 }
-type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dynakube *dynatracev1beta2.DynaKube) controllers.Reconciler
+type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Reconciler
 
 var _ ReconcilerBuilder = NewReconciler
 
-func NewReconciler(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dynakube *dynatracev1beta2.DynaKube) controllers.Reconciler {
+func NewReconciler(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Reconciler {
 	return &reconciler{
 		client:       clt,
 		apiReader:    apiReader,
-		dynakube:     dynakube,
+		dynakube:     dk,
 		dtc:          dtc,
 		timeProvider: timeprovider.New(),
 	}
@@ -55,7 +55,7 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		}
 
 		meta.RemoveStatusCondition(r.dynakube.Conditions(), oaConnectionInfoConditionType)
-		r.dynakube.Status.OneAgent.ConnectionInfoStatus = dynatracev1beta2.OneAgentConnectionInfoStatus{}
+		r.dynakube.Status.OneAgent.ConnectionInfoStatus = dynakube.OneAgentConnectionInfoStatus{}
 
 		return nil // clean-up shouldn't cause a failure
 	}
@@ -88,7 +88,7 @@ func (r *reconciler) reconcileConnectionInfo(ctx context.Context) error {
 
 		condition := meta.FindStatusCondition(*r.dynakube.Conditions(), oaConnectionInfoConditionType)
 		if isSecretPresent {
-			log.Info(dynatracev1beta2.GetCacheValidMessage(
+			log.Info(dynakube.GetCacheValidMessage(
 				"OneAgent connection info update",
 				condition.LastTransitionTime,
 				r.dynakube.ApiRequestThreshold()))
@@ -137,10 +137,10 @@ func (r *reconciler) setDynakubeStatus(connectionInfo dtclient.OneAgentConnectio
 	copyCommunicationHosts(&r.dynakube.Status.OneAgent.ConnectionInfoStatus, connectionInfo.CommunicationHosts)
 }
 
-func copyCommunicationHosts(dest *dynatracev1beta2.OneAgentConnectionInfoStatus, src []dtclient.CommunicationHost) {
-	dest.CommunicationHosts = make([]dynatracev1beta2.CommunicationHostStatus, 0, len(src))
+func copyCommunicationHosts(dest *dynakube.OneAgentConnectionInfoStatus, src []dtclient.CommunicationHost) {
+	dest.CommunicationHosts = make([]dynakube.CommunicationHostStatus, 0, len(src))
 	for _, host := range src {
-		dest.CommunicationHosts = append(dest.CommunicationHosts, dynatracev1beta2.CommunicationHostStatus{
+		dest.CommunicationHosts = append(dest.CommunicationHosts, dynakube.CommunicationHostStatus{
 			Protocol: host.Protocol,
 			Host:     host.Host,
 			Port:     host.Port,

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
@@ -23,7 +23,7 @@ type reconciler struct {
 	dtc          dtclient.Client
 	timeProvider *timeprovider.Provider
 
-	dynakube *dynakube.DynaKube
+	dk *dynakube.DynaKube
 }
 type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Reconciler
 
@@ -33,7 +33,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dtc dtclient.Clie
 	return &reconciler{
 		client:       clt,
 		apiReader:    apiReader,
-		dynakube:     dk,
+		dk:           dk,
 		dtc:          dtc,
 		timeProvider: timeprovider.New(),
 	}
@@ -42,66 +42,66 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dtc dtclient.Clie
 var NoOneAgentCommunicationHostsError = errors.New("no communication hosts for OneAgent are available")
 
 func (r *reconciler) Reconcile(ctx context.Context) error {
-	if !r.dynakube.NeedAppInjection() && !r.dynakube.NeedsOneAgent() {
-		if meta.FindStatusCondition(*r.dynakube.Conditions(), oaConnectionInfoConditionType) == nil {
+	if !r.dk.NeedAppInjection() && !r.dk.NeedsOneAgent() {
+		if meta.FindStatusCondition(*r.dk.Conditions(), oaConnectionInfoConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}
 
 		query := k8ssecret.NewQuery(ctx, r.client, r.apiReader, log)
-		err := query.Delete(r.dynakube.OneagentTenantSecret(), r.dynakube.Namespace)
+		err := query.Delete(r.dk.OneagentTenantSecret(), r.dk.Namespace)
 
 		if err != nil {
 			log.Error(err, "failed to clean-up OneAgent tenant-secret")
 		}
 
-		meta.RemoveStatusCondition(r.dynakube.Conditions(), oaConnectionInfoConditionType)
-		r.dynakube.Status.OneAgent.ConnectionInfoStatus = dynakube.OneAgentConnectionInfoStatus{}
+		meta.RemoveStatusCondition(r.dk.Conditions(), oaConnectionInfoConditionType)
+		r.dk.Status.OneAgent.ConnectionInfoStatus = dynakube.OneAgentConnectionInfoStatus{}
 
 		return nil // clean-up shouldn't cause a failure
 	}
 
-	oldStatus := r.dynakube.Status.DeepCopy()
+	oldStatus := r.dk.Status.DeepCopy()
 
 	err := r.reconcileConnectionInfo(ctx)
 	if err != nil {
 		return err
 	}
 
-	needStatusUpdate, err := hasher.IsDifferent(oldStatus, r.dynakube.Status)
+	needStatusUpdate, err := hasher.IsDifferent(oldStatus, r.dk.Status)
 	if err != nil {
 		return errors.WithMessage(err, "failed to compare connection info status hashes")
 	} else if needStatusUpdate {
-		err = r.dynakube.UpdateStatus(ctx, r.client)
+		err = r.dk.UpdateStatus(ctx, r.client)
 	}
 
 	return err
 }
 
 func (r *reconciler) reconcileConnectionInfo(ctx context.Context) error {
-	secretNamespacedName := types.NamespacedName{Name: r.dynakube.OneagentTenantSecret(), Namespace: r.dynakube.Namespace}
+	secretNamespacedName := types.NamespacedName{Name: r.dk.OneagentTenantSecret(), Namespace: r.dk.Namespace}
 
-	if !conditions.IsOutdated(r.timeProvider, r.dynakube, oaConnectionInfoConditionType) {
+	if !conditions.IsOutdated(r.timeProvider, r.dk, oaConnectionInfoConditionType) {
 		isSecretPresent, err := connectioninfo.IsTenantSecretPresent(ctx, r.apiReader, secretNamespacedName, log)
 		if err != nil {
 			return err
 		}
 
-		condition := meta.FindStatusCondition(*r.dynakube.Conditions(), oaConnectionInfoConditionType)
+		condition := meta.FindStatusCondition(*r.dk.Conditions(), oaConnectionInfoConditionType)
 		if isSecretPresent {
 			log.Info(dynakube.GetCacheValidMessage(
 				"OneAgent connection info update",
 				condition.LastTransitionTime,
-				r.dynakube.ApiRequestThreshold()))
+				r.dk.ApiRequestThreshold()))
 
 			return nil
 		}
 	}
 
-	conditions.SetSecretOutdated(r.dynakube.Conditions(), oaConnectionInfoConditionType, secretNamespacedName.Name+" is not present or outdated, update in progress") // Necessary to update the LastTransitionTime, also it is a nice failsafe
+	conditions.SetSecretOutdated(r.dk.Conditions(), oaConnectionInfoConditionType, secretNamespacedName.Name+" is not present or outdated, update in progress") // Necessary to update the LastTransitionTime, also it is a nice failsafe
 
 	connectionInfo, err := r.dtc.GetOneAgentConnectionInfo(ctx)
 	if err != nil {
-		conditions.SetDynatraceApiError(r.dynakube.Conditions(), oaConnectionInfoConditionType, err)
+		conditions.SetDynatraceApiError(r.dk.Conditions(), oaConnectionInfoConditionType, err)
 
 		return errors.WithMessage(err, "failed to get OneAgent connection info")
 	}
@@ -116,12 +116,12 @@ func (r *reconciler) reconcileConnectionInfo(ctx context.Context) error {
 
 	if len(connectionInfo.CommunicationHosts) == 0 {
 		log.Info("no OneAgent communication hosts received, tenant API requests not yet throttled")
-		setEmptyCommunicationHostsCondition(r.dynakube.Conditions())
+		setEmptyCommunicationHostsCondition(r.dk.Conditions())
 
 		return NoOneAgentCommunicationHostsError
 	}
 
-	err = r.createTenantTokenSecret(ctx, r.dynakube.OneagentTenantSecret(), r.dynakube, connectionInfo.ConnectionInfo)
+	err = r.createTenantTokenSecret(ctx, r.dk.OneagentTenantSecret(), r.dk, connectionInfo.ConnectionInfo)
 	if err != nil {
 		return err
 	}
@@ -132,9 +132,9 @@ func (r *reconciler) reconcileConnectionInfo(ctx context.Context) error {
 }
 
 func (r *reconciler) setDynakubeStatus(connectionInfo dtclient.OneAgentConnectionInfo) {
-	r.dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID = connectionInfo.TenantUUID
-	r.dynakube.Status.OneAgent.ConnectionInfoStatus.Endpoints = connectionInfo.Endpoints
-	copyCommunicationHosts(&r.dynakube.Status.OneAgent.ConnectionInfoStatus, connectionInfo.CommunicationHosts)
+	r.dk.Status.OneAgent.ConnectionInfoStatus.TenantUUID = connectionInfo.TenantUUID
+	r.dk.Status.OneAgent.ConnectionInfoStatus.Endpoints = connectionInfo.Endpoints
+	copyCommunicationHosts(&r.dk.Status.OneAgent.ConnectionInfoStatus, connectionInfo.CommunicationHosts)
 }
 
 func copyCommunicationHosts(dest *dynakube.OneAgentConnectionInfoStatus, src []dtclient.CommunicationHost) {
@@ -159,12 +159,12 @@ func (r *reconciler) createTenantTokenSecret(ctx context.Context, secretName str
 	err = query.CreateOrUpdate(*secret)
 	if err != nil {
 		log.Info("could not create or update secret for connection info", "name", secret.Name)
-		conditions.SetKubeApiError(r.dynakube.Conditions(), oaConnectionInfoConditionType, err)
+		conditions.SetKubeApiError(r.dk.Conditions(), oaConnectionInfoConditionType, err)
 
 		return err
 	}
 
-	conditions.SetSecretCreated(r.dynakube.Conditions(), oaConnectionInfoConditionType, secret.Name)
+	conditions.SetSecretCreated(r.dk.Conditions(), oaConnectionInfoConditionType, secret.Name)
 
 	return nil
 }

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler_test.go
@@ -278,7 +278,7 @@ func TestReconcile(t *testing.T) {
 
 func TestReconcile_NoOneAgentCommunicationHosts(t *testing.T) {
 	ctx := context.Background()
-	dynakube := dynakube.DynaKube{
+	dk := dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testName,
@@ -300,17 +300,17 @@ func TestReconcile_NoOneAgentCommunicationHosts(t *testing.T) {
 		CommunicationHosts: nil,
 	}, nil)
 
-	fakeClient := fake.NewClient(&dynakube)
+	fakeClient := fake.NewClient(&dk)
 
-	r := NewReconciler(fakeClient, fakeClient, dtc, &dynakube)
+	r := NewReconciler(fakeClient, fakeClient, dtc, &dk)
 	err := r.Reconcile(ctx)
 	require.ErrorIs(t, err, NoOneAgentCommunicationHostsError)
 
-	assert.Equal(t, testTenantUUID, dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
-	assert.Empty(t, dynakube.Status.OneAgent.ConnectionInfoStatus.Endpoints)
-	assert.Empty(t, dynakube.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts)
+	assert.Equal(t, testTenantUUID, dk.Status.OneAgent.ConnectionInfoStatus.TenantUUID)
+	assert.Empty(t, dk.Status.OneAgent.ConnectionInfoStatus.Endpoints)
+	assert.Empty(t, dk.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts)
 
-	condition := meta.FindStatusCondition(*dynakube.Conditions(), oaConnectionInfoConditionType)
+	condition := meta.FindStatusCondition(*dk.Conditions(), oaConnectionInfoConditionType)
 	require.NotNil(t, condition)
 	assert.Equal(t, EmptyCommunicationHostsReason, condition.Reason)
 	assert.Equal(t, metav1.ConditionFalse, condition.Status)

--- a/pkg/controllers/dynakube/controller.go
+++ b/pkg/controllers/dynakube/controller.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	dynatracestatus "github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
-	dynatracev1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	dynakubev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	dynakubev1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/apimonitoring"
@@ -81,7 +81,7 @@ func NewDynaKubeController(kubeClient client.Client, apiReader client.Reader, co
 
 func (controller *Controller) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&dynatracev1beta2.DynaKube{}).
+		For(&dynakubev1beta2.DynaKube{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&appsv1.DaemonSet{}).
 		Owns(&corev1.ConfigMap{}).
@@ -144,8 +144,8 @@ func (controller *Controller) Reconcile(ctx context.Context, request reconcile.R
 	return result, err
 }
 
-func (controller *Controller) getDynakubeOrCleanup(ctx context.Context, dkName, dkNamespace string) (*dynatracev1beta2.DynaKube, error) {
-	dynakube := &dynatracev1beta2.DynaKube{
+func (controller *Controller) getDynakubeOrCleanup(ctx context.Context, dkName, dkNamespace string) (*dynakubev1beta2.DynaKube, error) {
+	dynakube := &dynakubev1beta2.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dkName,
 			Namespace: dkNamespace,
@@ -169,9 +169,9 @@ func (controller *Controller) getDynakubeOrCleanup(ctx context.Context, dkName, 
 
 func (controller *Controller) handleError(
 	ctx context.Context,
-	dynaKube *dynatracev1beta2.DynaKube,
+	dynaKube *dynakubev1beta2.DynaKube,
 	err error,
-	oldStatus dynatracev1beta2.DynaKubeStatus,
+	oldStatus dynakubev1beta2.DynaKubeStatus,
 ) (reconcile.Result, error) {
 	switch {
 	case dynatraceapi.IsUnreachable(err):
@@ -213,7 +213,7 @@ func (controller *Controller) setRequeueAfterIfNewIsShorter(requeueAfter time.Du
 	}
 }
 
-func (controller *Controller) reconcileDynaKube(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error {
+func (controller *Controller) reconcileDynaKube(ctx context.Context, dynakube *dynakubev1beta2.DynaKube) error {
 	var istioClient *istio.Client
 
 	var err error
@@ -253,7 +253,7 @@ func (controller *Controller) reconcileDynaKube(ctx context.Context, dynakube *d
 	return controller.reconcileComponents(ctx, dynatraceClient, istioClient, dynakube)
 }
 
-func (controller *Controller) setupIstioClient(dynakube *dynatracev1beta2.DynaKube) (*istio.Client, error) {
+func (controller *Controller) setupIstioClient(dynakube *dynakubev1beta2.DynaKube) (*istio.Client, error) {
 	istioClient, err := controller.istioClientBuilder(controller.config, dynakube)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to initialize istio client")
@@ -269,7 +269,7 @@ func (controller *Controller) setupIstioClient(dynakube *dynatracev1beta2.DynaKu
 	return istioClient, nil
 }
 
-func (controller *Controller) setupTokensAndClient(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) (dtclient.Client, error) {
+func (controller *Controller) setupTokensAndClient(ctx context.Context, dynakube *dynakubev1beta2.DynaKube) (dtclient.Client, error) {
 	tokenReader := token.NewReader(controller.apiReader, dynakube)
 
 	tokens, err := tokenReader.ReadTokens(ctx)
@@ -298,7 +298,7 @@ func (controller *Controller) setupTokensAndClient(ctx context.Context, dynakube
 	return dynatraceClient, nil
 }
 
-func (controller *Controller) reconcileComponents(ctx context.Context, dynatraceClient dtclient.Client, istioClient *istio.Client, dynakube *dynatracev1beta2.DynaKube) error {
+func (controller *Controller) reconcileComponents(ctx context.Context, dynatraceClient dtclient.Client, istioClient *istio.Client, dynakube *dynakubev1beta2.DynaKube) error {
 	var componentErrors []error
 
 	log.Info("start reconciling ActiveGate")
@@ -310,7 +310,7 @@ func (controller *Controller) reconcileComponents(ctx context.Context, dynatrace
 		componentErrors = append(componentErrors, err)
 	}
 
-	dynakubeV1beta3 := &dynatracev1beta3.DynaKube{}
+	dynakubeV1beta3 := &dynakubev1beta3.DynaKube{}
 
 	err = dynakubeV1beta3.ConvertFrom(dynakube)
 	if err != nil {
@@ -381,7 +381,7 @@ func (controller *Controller) reconcileComponents(ctx context.Context, dynatrace
 	return goerrors.Join(componentErrors...)
 }
 
-func (controller *Controller) createDynakubeMapper(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) *mapper.DynakubeMapper {
+func (controller *Controller) createDynakubeMapper(ctx context.Context, dynakube *dynakubev1beta2.DynaKube) *mapper.DynakubeMapper {
 	dkMapper := mapper.NewDynakubeMapper(ctx, controller.client, controller.apiReader, controller.operatorNamespace, dynakube)
 
 	return &dkMapper

--- a/pkg/controllers/dynakube/controller.go
+++ b/pkg/controllers/dynakube/controller.go
@@ -298,12 +298,12 @@ func (controller *Controller) setupTokensAndClient(ctx context.Context, dk *dyna
 	return dynatraceClient, nil
 }
 
-func (controller *Controller) reconcileComponents(ctx context.Context, dynatraceClient dtclient.Client, istioClient *istio.Client, dynakube *dynakubev1beta2.DynaKube) error {
+func (controller *Controller) reconcileComponents(ctx context.Context, dynatraceClient dtclient.Client, istioClient *istio.Client, dk *dynakubev1beta2.DynaKube) error {
 	var componentErrors []error
 
 	log.Info("start reconciling ActiveGate")
 
-	err := controller.reconcileActiveGate(ctx, dynakube, dynatraceClient, istioClient)
+	err := controller.reconcileActiveGate(ctx, dk, dynatraceClient, istioClient)
 	if err != nil {
 		log.Info("could not reconcile ActiveGate")
 
@@ -312,7 +312,7 @@ func (controller *Controller) reconcileComponents(ctx context.Context, dynatrace
 
 	dynakubeV1beta3 := &dynakubev1beta3.DynaKube{}
 
-	err = dynakubeV1beta3.ConvertFrom(dynakube)
+	err = dynakubeV1beta3.ConvertFrom(dk)
 	if err != nil {
 		return err
 	}
@@ -324,7 +324,7 @@ func (controller *Controller) reconcileComponents(ctx context.Context, dynatrace
 		return err
 	}
 
-	proxyReconciler := proxy.NewReconciler(controller.client, controller.apiReader, dynakube)
+	proxyReconciler := proxy.NewReconciler(controller.client, controller.apiReader, dk)
 
 	err = proxyReconciler.Reconcile(ctx)
 	if err != nil {
@@ -337,7 +337,7 @@ func (controller *Controller) reconcileComponents(ctx context.Context, dynatrace
 		controller.apiReader,
 		dynatraceClient,
 		istioClient,
-		dynakube).
+		dk).
 		Reconcile(ctx)
 	if err != nil {
 		if errors.Is(err, oaconnectioninfo.NoOneAgentCommunicationHostsError) {
@@ -359,7 +359,7 @@ func (controller *Controller) reconcileComponents(ctx context.Context, dynatrace
 		controller.client,
 		controller.apiReader,
 		dynatraceClient,
-		dynakube,
+		dk,
 		controller.tokens,
 		controller.clusterID,
 	).
@@ -381,8 +381,8 @@ func (controller *Controller) reconcileComponents(ctx context.Context, dynatrace
 	return goerrors.Join(componentErrors...)
 }
 
-func (controller *Controller) createDynakubeMapper(ctx context.Context, dynakube *dynakubev1beta2.DynaKube) *mapper.DynakubeMapper {
-	dkMapper := mapper.NewDynakubeMapper(ctx, controller.client, controller.apiReader, controller.operatorNamespace, dynakube)
+func (controller *Controller) createDynakubeMapper(ctx context.Context, dk *dynakubev1beta2.DynaKube) *mapper.DynakubeMapper {
+	dkMapper := mapper.NewDynakubeMapper(ctx, controller.client, controller.apiReader, controller.operatorNamespace, dk)
 
 	return &dkMapper
 }

--- a/pkg/controllers/dynakube/controller_system_test.go
+++ b/pkg/controllers/dynakube/controller_system_test.go
@@ -49,7 +49,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 	t.Run(`Create works with minimal setup and interface`, func(t *testing.T) { // keep as integration test?
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
 
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -58,7 +58,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 				APIURL: testApiUrl,
 			},
 		}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+		controller := createFakeClientAndReconciler(t, mockClient, dk, testPaasToken, testAPIToken)
 
 		result, err := controller.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
@@ -72,7 +72,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 		mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -88,7 +88,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 
 			Status: *getTestDynkubeStatus(),
 		}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+		controller := createFakeClientAndReconciler(t, mockClient, dk, testPaasToken, testAPIToken)
 
 		result, err := controller.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
@@ -111,7 +111,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 		mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -129,7 +129,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 			},
 			Status: *getTestDynkubeStatus(),
 		}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+		controller := createFakeClientAndReconciler(t, mockClient, dk, testPaasToken, testAPIToken)
 		// Remove existing StatefulSet created by createFakeClientAndReconciler
 		require.NoError(t, controller.client.Delete(context.Background(), &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: testName + "-activegate", Namespace: testNamespace}}))
 
@@ -150,8 +150,8 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 
 		require.NoError(t,
 			controller.client.Get(context.Background(), client.ObjectKey{Name: testName + "-activegate", Namespace: testNamespace}, &activeGateStatefulSet))
-		require.NoError(t, controller.client.Get(context.Background(), client.ObjectKey{Name: testName, Namespace: testNamespace}, instance))
-		assert.Equal(t, status.Running, instance.Status.Phase)
+		require.NoError(t, controller.client.Get(context.Background(), client.ObjectKey{Name: testName, Namespace: testNamespace}, dk))
+		assert.Equal(t, status.Running, dk.Status.Phase)
 	})
 }
 
@@ -159,7 +159,7 @@ func TestReconcileOnlyOneTokenProvided_Reconcile(t *testing.T) {
 	t.Run(`Create validates apiToken correctly if apiToken with "InstallerDownload"-scope is provided`, func(t *testing.T) {
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeInstallerDownload, dtclient.TokenScopeActiveGateTokenCreate})
 
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -167,7 +167,7 @@ func TestReconcileOnlyOneTokenProvided_Reconcile(t *testing.T) {
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
 			}}
-		controller := createFakeClientAndReconciler(t, mockClient, instance, "", testAPIToken)
+		controller := createFakeClientAndReconciler(t, mockClient, dk, "", testAPIToken)
 
 		result, err := controller.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
@@ -195,7 +195,7 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 	mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 	mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
-	instance := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -212,7 +212,7 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 		},
 	}
 
-	r := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+	r := createFakeClientAndReconciler(t, mockClient, dk, testPaasToken, testAPIToken)
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
 	}
@@ -224,7 +224,7 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 	_, err = r.Reconcile(context.Background(), request)
 	require.NoError(t, err)
 
-	multiCapability := capability.NewMultiCapability(instance)
+	multiCapability := capability.NewMultiCapability(dk)
 	stsName := capability.CalculateStatefulSetName(multiCapability, testName)
 
 	routingSts := &appsv1.StatefulSet{}
@@ -243,11 +243,11 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, routingSvc)
 
-	err = r.client.Get(context.Background(), client.ObjectKey{Name: instance.Name, Namespace: instance.Namespace}, instance)
+	err = r.client.Get(context.Background(), client.ObjectKey{Name: dk.Name, Namespace: dk.Namespace}, dk)
 	require.NoError(t, err)
 
-	instance.Spec.ActiveGate.Capabilities = []dynakube.CapabilityDisplayName{}
-	err = r.client.Update(context.Background(), instance)
+	dk.Spec.ActiveGate.Capabilities = []dynakube.CapabilityDisplayName{}
+	err = r.client.Update(context.Background(), dk)
 	require.NoError(t, err)
 
 	_, err = r.Reconcile(context.Background(), request)
@@ -272,7 +272,7 @@ func TestAPIError(t *testing.T) {
 	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
 	mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
-	instance := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -291,7 +291,7 @@ func TestAPIError(t *testing.T) {
 
 	t.Run("should return error result on 503", func(t *testing.T) {
 		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, dtclient.ServerError{Code: http.StatusServiceUnavailable, Message: "Service unavailable"})
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+		controller := createFakeClientAndReconciler(t, mockClient, dk, testPaasToken, testAPIToken)
 
 		result, err := controller.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
@@ -302,7 +302,7 @@ func TestAPIError(t *testing.T) {
 	})
 	t.Run("should return error result on 429", func(t *testing.T) {
 		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{}, dtclient.ServerError{Code: http.StatusTooManyRequests, Message: "Too many requests"})
-		controller := createFakeClientAndReconciler(t, mockClient, instance, testPaasToken, testAPIToken)
+		controller := createFakeClientAndReconciler(t, mockClient, dk, testPaasToken, testAPIToken)
 
 		result, err := controller.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
@@ -370,7 +370,7 @@ func createDTMockClient(t *testing.T, paasTokenScopes, apiTokenScopes dtclient.T
 	return mockClient
 }
 
-func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, instance *dynakube.DynaKube, paasToken, apiToken string) *Controller {
+func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, dk *dynakube.DynaKube, paasToken, apiToken string) *Controller {
 	data := map[string][]byte{
 		dtclient.ApiToken: []byte(apiToken),
 	}
@@ -379,7 +379,7 @@ func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, ins
 	}
 
 	objects := []client.Object{
-		instance,
+		dk,
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
@@ -395,7 +395,7 @@ func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, ins
 	}
 
 	objects = append(objects, generateStatefulSetForTesting(testName, testNamespace, "activegate", testUID))
-	objects = append(objects, createTenantSecrets(instance)...)
+	objects = append(objects, createTenantSecrets(dk)...)
 
 	fakeClient := fake.NewClientWithIndex(objects...)
 

--- a/pkg/controllers/dynakube/controller_system_test.go
+++ b/pkg/controllers/dynakube/controller_system_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
@@ -49,12 +49,12 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 	t.Run(`Create works with minimal setup and interface`, func(t *testing.T) { // keep as integration test?
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
 
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
 			},
 		}
@@ -72,18 +72,18 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 		mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				Proxy: &dynatracev1beta2.DynaKubeProxy{
+				Proxy: &dynakube.DynaKubeProxy{
 					Value:     "https://proxy:1234",
 					ValueFrom: "",
 				},
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.KubeMonCapability.DisplayName}},
+				ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}},
 			},
 
 			Status: *getTestDynkubeStatus(),
@@ -111,19 +111,19 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 		mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 				Annotations: map[string]string{
-					dynatracev1beta2.AnnotationFeatureAutomaticK8sApiMonitoring: "true",
+					dynakube.AnnotationFeatureAutomaticK8sApiMonitoring: "true",
 				},
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{
-					Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-						dynatracev1beta2.KubeMonCapability.DisplayName,
+				ActiveGate: dynakube.ActiveGateSpec{
+					Capabilities: []dynakube.CapabilityDisplayName{
+						dynakube.KubeMonCapability.DisplayName,
 					},
 				},
 			},
@@ -159,12 +159,12 @@ func TestReconcileOnlyOneTokenProvided_Reconcile(t *testing.T) {
 	t.Run(`Create validates apiToken correctly if apiToken with "InstallerDownload"-scope is provided`, func(t *testing.T) {
 		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeInstallerDownload, dtclient.TokenScopeActiveGateTokenCreate})
 
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
 			}}
 		controller := createFakeClientAndReconciler(t, mockClient, instance, "", testAPIToken)
@@ -195,18 +195,18 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 	mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)
 	mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
-	instance := &dynatracev1beta2.DynaKube{
+	instance := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: testApiUrl,
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
-				Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-					dynatracev1beta2.MetricsIngestCapability.DisplayName,
-					dynatracev1beta2.KubeMonCapability.DisplayName,
-					dynatracev1beta2.RoutingCapability.DisplayName,
+			ActiveGate: dynakube.ActiveGateSpec{
+				Capabilities: []dynakube.CapabilityDisplayName{
+					dynakube.MetricsIngestCapability.DisplayName,
+					dynakube.KubeMonCapability.DisplayName,
+					dynakube.RoutingCapability.DisplayName,
 				},
 			},
 		},
@@ -246,7 +246,7 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 	err = r.client.Get(context.Background(), client.ObjectKey{Name: instance.Name, Namespace: instance.Namespace}, instance)
 	require.NoError(t, err)
 
-	instance.Spec.ActiveGate.Capabilities = []dynatracev1beta2.CapabilityDisplayName{}
+	instance.Spec.ActiveGate.Capabilities = []dynakube.CapabilityDisplayName{}
 	err = r.client.Update(context.Background(), instance)
 	require.NoError(t, err)
 
@@ -272,17 +272,17 @@ func TestAPIError(t *testing.T) {
 	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeDataExport, dtclient.TokenScopeActiveGateTokenCreate})
 	mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
-	instance := &dynatracev1beta2.DynaKube{
+	instance := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL:   testApiUrl,
-			OneAgent: dynatracev1beta2.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{HostInjectSpec: dynatracev1beta2.HostInjectSpec{}}},
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
-				Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-					dynatracev1beta2.KubeMonCapability.DisplayName,
+			OneAgent: dynakube.OneAgentSpec{CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{HostInjectSpec: dynakube.HostInjectSpec{}}},
+			ActiveGate: dynakube.ActiveGateSpec{
+				Capabilities: []dynakube.CapabilityDisplayName{
+					dynakube.KubeMonCapability.DisplayName,
 				},
 			},
 		},
@@ -370,7 +370,7 @@ func createDTMockClient(t *testing.T, paasTokenScopes, apiTokenScopes dtclient.T
 	return mockClient
 }
 
-func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, instance *dynatracev1beta2.DynaKube, paasToken, apiToken string) *Controller {
+func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, instance *dynakube.DynaKube, paasToken, apiToken string) *Controller {
 	data := map[string][]byte{
 		dtclient.ApiToken: []byte(apiToken),
 	}

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate"
@@ -96,12 +96,12 @@ func TestGetDynakubeOrCleanup(t *testing.T) {
 	})
 
 	t.Run("dynakube exists => return dynakube", func(t *testing.T) {
-		expectedDynakube := &dynatracev1beta2.DynaKube{
+		expectedDynakube := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      request.Name,
 				Namespace: request.Namespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{APIURL: "this-is-an-api-url"},
+			Spec: dynakube.DynaKubeSpec{APIURL: "this-is-an-api-url"},
 		}
 		fakeClient := fake.NewClientWithIndex(expectedDynakube)
 		controller := &Controller{
@@ -131,12 +131,12 @@ func TestMinimalRequest(t *testing.T) {
 
 func TestHandleError(t *testing.T) {
 	ctx := context.Background()
-	dynakubeBase := &dynatracev1beta2.DynaKube{
+	dynakubeBase := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "this-is-a-name",
 			Namespace: "dynatrace",
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{APIURL: "this-is-an-api-url"},
+		Spec: dynakube.DynaKubeSpec{APIURL: "this-is-an-api-url"},
 	}
 
 	t.Run("no error => update status", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestHandleError(t *testing.T) {
 			requeueAfter: 12345 * time.Second,
 		}
 		expectedDynakube := dynakubeBase.DeepCopy()
-		expectedDynakube.Status = dynatracev1beta2.DynaKubeStatus{
+		expectedDynakube.Status = dynakube.DynaKubeStatus{
 			Phase: status.Running,
 		}
 
@@ -157,7 +157,7 @@ func TestHandleError(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, controller.requeueAfter, result.RequeueAfter)
 
-		dynakube := &dynatracev1beta2.DynaKube{}
+		dynakube := &dynakube.DynaKube{}
 		err = fakeClient.Get(ctx, types.NamespacedName{Name: expectedDynakube.Name, Namespace: expectedDynakube.Namespace}, dynakube)
 		require.NoError(t, err)
 		assert.Equal(t, expectedDynakube.Status.Phase, dynakube.Status.Phase)
@@ -200,7 +200,7 @@ func TestHandleError(t *testing.T) {
 		assert.Empty(t, result)
 		require.Error(t, err)
 
-		dynakube := &dynatracev1beta2.DynaKube{}
+		dynakube := &dynakube.DynaKube{}
 		err = fakeClient.Get(ctx, types.NamespacedName{Name: oldDynakube.Name, Namespace: oldDynakube.Namespace}, dynakube)
 		require.NoError(t, err)
 		assert.Equal(t, status.Error, dynakube.Status.Phase)
@@ -209,12 +209,12 @@ func TestHandleError(t *testing.T) {
 
 func TestSetupTokensAndClient(t *testing.T) {
 	ctx := context.Background()
-	dynakubeBase := &dynatracev1beta2.DynaKube{
+	dynakubeBase := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "this-is-a-name",
 			Namespace: "dynatrace",
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{APIURL: "https://test123.dev.dynatracelabs.com/api"},
+		Spec: dynakube.DynaKubeSpec{APIURL: "https://test123.dev.dynatracelabs.com/api"},
 	}
 
 	t.Run("no tokens => error + condition", func(t *testing.T) {
@@ -298,36 +298,36 @@ func TestSetupTokensAndClient(t *testing.T) {
 	})
 }
 
-func assertTokenCondition(t *testing.T, dynakube *dynatracev1beta2.DynaKube, hasError bool) {
-	condition := dynakube.Status.Conditions[0]
-	assert.Equal(t, dynatracev1beta2.TokenConditionType, condition.Type)
+func assertTokenCondition(t *testing.T, dk *dynakube.DynaKube, hasError bool) {
+	condition := dk.Status.Conditions[0]
+	assert.Equal(t, dynakube.TokenConditionType, condition.Type)
 
 	if hasError {
-		assert.Equal(t, dynatracev1beta2.ReasonTokenError, condition.Reason)
+		assert.Equal(t, dynakube.ReasonTokenError, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	} else {
-		assert.Equal(t, dynatracev1beta2.ReasonTokenReady, condition.Reason)
+		assert.Equal(t, dynakube.ReasonTokenReady, condition.Reason)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	}
 }
 
 func TestReconcileComponents(t *testing.T) {
 	ctx := context.Background()
-	dynakubeBase := &dynatracev1beta2.DynaKube{
+	dynakubeBase := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "this-is-a-name",
 			Namespace: "dynatrace",
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL:     "this-is-an-api-url",
-			OneAgent:   dynatracev1beta2.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{}},
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.KubeMonCapability.DisplayName}},
+			OneAgent:   dynakube.OneAgentSpec{CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}},
+			ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}},
 		},
 	}
 
 	t.Run("all components reconciled, even in case of errors", func(t *testing.T) {
-		dynakube := dynakubeBase.DeepCopy()
-		fakeClient := fake.NewClientWithIndex(dynakube)
+		dk := dynakubeBase.DeepCopy()
+		fakeClient := fake.NewClientWithIndex(dk)
 		// ReconcileCodeModuleCommunicationHosts
 		mockOneAgentReconciler := controllermock.NewReconciler(t)
 		mockOneAgentReconciler.On("Reconcile", mock.Anything).Return(errors.New("BOOM"))
@@ -348,7 +348,7 @@ func TestReconcileComponents(t *testing.T) {
 			oneAgentReconcilerBuilder:   createOneAgentReconcilerBuilder(mockOneAgentReconciler),
 		}
 		mockedDtc := dtclientmock.NewClient(t)
-		err := controller.reconcileComponents(ctx, mockedDtc, nil, dynakube)
+		err := controller.reconcileComponents(ctx, mockedDtc, nil, dk)
 
 		require.Error(t, err)
 		// goerrors.Join concats errors with \n
@@ -356,8 +356,8 @@ func TestReconcileComponents(t *testing.T) {
 	})
 
 	t.Run("exit early in case of no oneagent conncection info", func(t *testing.T) {
-		dynakube := dynakubeBase.DeepCopy()
-		fakeClient := fake.NewClientWithIndex(dynakube)
+		dk := dynakubeBase.DeepCopy()
+		fakeClient := fake.NewClientWithIndex(dk)
 
 		mockActiveGateReconciler := controllermock.NewReconciler(t)
 		mockActiveGateReconciler.On("Reconcile", mock.Anything).Return(errors.New("BOOM"))
@@ -373,7 +373,7 @@ func TestReconcileComponents(t *testing.T) {
 			injectionReconcilerBuilder:  createInjectionReconcilerBuilder(mockInjectionReconciler),
 		}
 		mockedDtc := dtclientmock.NewClient(t)
-		err := controller.reconcileComponents(ctx, mockedDtc, nil, dynakube)
+		err := controller.reconcileComponents(ctx, mockedDtc, nil, dk)
 
 		require.Error(t, err)
 		// goerrors.Join concats errors with \n
@@ -382,19 +382,19 @@ func TestReconcileComponents(t *testing.T) {
 }
 
 func createActivegateReconcilerBuilder(reconciler controllers.Reconciler) activegate.ReconcilerBuilder {
-	return func(_ client.Client, _ client.Reader, _ *dynatracev1beta2.DynaKube, _ dtclient.Client, _ *istio.Client, _ token.Tokens) controllers.Reconciler {
+	return func(_ client.Client, _ client.Reader, _ *dynakube.DynaKube, _ dtclient.Client, _ *istio.Client, _ token.Tokens) controllers.Reconciler {
 		return reconciler
 	}
 }
 
 func createOneAgentReconcilerBuilder(reconciler controllers.Reconciler) oneagent.ReconcilerBuilder {
-	return func(_ client.Client, _ client.Reader, _ dtclient.Client, _ *dynatracev1beta2.DynaKube, _ token.Tokens, _ string) controllers.Reconciler {
+	return func(_ client.Client, _ client.Reader, _ dtclient.Client, _ *dynakube.DynaKube, _ token.Tokens, _ string) controllers.Reconciler {
 		return reconciler
 	}
 }
 
 func createInjectionReconcilerBuilder(reconciler *injectionmock.Reconciler) injection.ReconcilerBuilder {
-	return func(_ client.Client, _ client.Reader, _ dtclient.Client, _ *istio.Client, _ *dynatracev1beta2.DynaKube) controllers.Reconciler {
+	return func(_ client.Client, _ client.Reader, _ dtclient.Client, _ *istio.Client, _ *dynakube.DynaKube) controllers.Reconciler {
 		return reconciler
 	}
 }
@@ -409,14 +409,14 @@ func (clt errorClient) Get(_ context.Context, _ client.ObjectKey, _ client.Objec
 
 func TestGetDynakube(t *testing.T) {
 	t.Run("get dynakube", func(t *testing.T) {
-		fakeClient := fake.NewClient(&dynatracev1beta2.DynaKube{
+		fakeClient := fake.NewClient(&dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 				},
 			},
 		})
@@ -463,9 +463,9 @@ func TestGetDynakube(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		dynakube, err := controller.getDynakubeOrCleanup(ctx, testName, testNamespace)
+		dk, err := controller.getDynakubeOrCleanup(ctx, testName, testNamespace)
 
-		assert.Nil(t, dynakube)
+		assert.Nil(t, dk)
 		require.EqualError(t, err, "fake error")
 	})
 }
@@ -475,20 +475,20 @@ func TestTokenConditions(t *testing.T) {
 
 	t.Run("token condition error is set if token are invalid", func(t *testing.T) {
 		fakeClient := fake.NewClient()
-		dynakube := &dynatracev1beta2.DynaKube{}
+		dk := &dynakube.DynaKube{}
 		controller := &Controller{
 			client:    fakeClient,
 			apiReader: fakeClient,
 		}
 
-		_, err := controller.setupTokensAndClient(ctx, dynakube)
+		_, err := controller.setupTokensAndClient(ctx, dk)
 
 		require.Error(t, err)
-		assertCondition(t, dynakube, dynatracev1beta2.TokenConditionType, metav1.ConditionFalse, dynatracev1beta2.ReasonTokenError, "secrets \"\" not found")
-		assert.Empty(t, dynakube.Status.DynatraceApi.LastTokenScopeRequest, "LastTokenProbeTimestamp should be Nil if token retrieval did not work.")
+		assertCondition(t, dk, dynakube.TokenConditionType, metav1.ConditionFalse, dynakube.ReasonTokenError, "secrets \"\" not found")
+		assert.Empty(t, dk.Status.DynatraceApi.LastTokenScopeRequest, "LastTokenProbeTimestamp should be Nil if token retrieval did not work.")
 	})
 	t.Run("token condition is set if token are valid", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -516,61 +516,61 @@ func TestTokenConditions(t *testing.T) {
 			dynatraceClientBuilder: mockDtcBuilder,
 		}
 
-		_, err := controller.setupTokensAndClient(ctx, dynakube)
+		_, err := controller.setupTokensAndClient(ctx, dk)
 
 		require.NoError(t, err)
-		assertCondition(t, dynakube, dynatracev1beta2.TokenConditionType, metav1.ConditionTrue, dynatracev1beta2.ReasonTokenReady, "")
+		assertCondition(t, dk, dynakube.TokenConditionType, metav1.ConditionTrue, dynakube.ReasonTokenReady, "")
 	})
 }
 
 func TestSetupIstio(t *testing.T) {
 	ctx := context.Background()
-	dynakubeBase := &dynatracev1beta2.DynaKube{
+	dynakubeBase := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL:      testApiUrl,
 			EnableIstio: true,
 		},
 	}
 
 	t.Run("no istio installed + EnableIstio: true => error", func(t *testing.T) {
-		dynakube := dynakubeBase.DeepCopy()
+		dk := dynakubeBase.DeepCopy()
 		fakeIstio := fakeistio.NewSimpleClientset()
 		isIstioInstalled := false
 		controller := &Controller{
 			istioClientBuilder: fakeIstioClientBuilder(t, fakeIstio, isIstioInstalled),
 		}
-		istioClient, err := controller.setupIstioClient(dynakube)
+		istioClient, err := controller.setupIstioClient(dk)
 		require.Error(t, err)
 		assert.Nil(t, istioClient)
 	})
 	t.Run("success", func(t *testing.T) {
-		dynakube := dynakubeBase.DeepCopy()
+		dk := dynakubeBase.DeepCopy()
 		fakeIstio := fakeistio.NewSimpleClientset()
 		isIstioInstalled := true
 		controller := &Controller{
 			istioClientBuilder: fakeIstioClientBuilder(t, fakeIstio, isIstioInstalled),
 		}
-		istioClient, err := controller.setupIstioClient(dynakube)
+		istioClient, err := controller.setupIstioClient(dk)
 		require.NoError(t, err)
 		require.NotNil(t, istioClient)
 
 		istioReconciler := istio.NewReconciler(istioClient)
 		require.NotNil(t, istioClient)
 
-		err = istioReconciler.ReconcileAPIUrl(ctx, dynakube)
+		err = istioReconciler.ReconcileAPIUrl(ctx, dk)
 
 		require.NoError(t, err)
 
-		expectedName := istio.BuildNameForFQDNServiceEntry(dynakube.GetName(), istio.OperatorComponent)
-		serviceEntry, err := fakeIstio.NetworkingV1beta1().ServiceEntries(dynakube.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
+		expectedName := istio.BuildNameForFQDNServiceEntry(dk.GetName(), istio.OperatorComponent)
+		serviceEntry, err := fakeIstio.NetworkingV1beta1().ServiceEntries(dk.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, serviceEntry)
 
-		virtualService, err := fakeIstio.NetworkingV1beta1().VirtualServices(dynakube.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
+		virtualService, err := fakeIstio.NetworkingV1beta1().VirtualServices(dk.GetNamespace()).Get(ctx, expectedName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, virtualService)
 	})
@@ -594,7 +594,7 @@ func fakeIstioClientBuilder(t *testing.T, fakeIstio *fakeistio.Clientset, isIsti
 	}
 }
 
-func assertCondition(t *testing.T, dk *dynatracev1beta2.DynaKube, expectedConditionType string, expectedConditionStatus metav1.ConditionStatus, expectedReason string, expectedMessage string) { //nolint:revive // argument-limit
+func assertCondition(t *testing.T, dk *dynakube.DynaKube, expectedConditionType string, expectedConditionStatus metav1.ConditionStatus, expectedReason string, expectedMessage string) { //nolint:revive // argument-limit
 	t.Helper()
 
 	actualCondition := meta.FindStatusCondition(dk.Status.Conditions, expectedConditionType)
@@ -604,23 +604,23 @@ func assertCondition(t *testing.T, dk *dynatracev1beta2.DynaKube, expectedCondit
 	assert.Equal(t, expectedMessage, actualCondition.Message)
 }
 
-func getTestDynkubeStatus() *dynatracev1beta2.DynaKubeStatus {
-	return &dynatracev1beta2.DynaKubeStatus{
-		ActiveGate: dynatracev1beta2.ActiveGateStatus{
-			ConnectionInfoStatus: dynatracev1beta2.ActiveGateConnectionInfoStatus{
-				ConnectionInfoStatus: dynatracev1beta2.ConnectionInfoStatus{
+func getTestDynkubeStatus() *dynakube.DynaKubeStatus {
+	return &dynakube.DynaKubeStatus{
+		ActiveGate: dynakube.ActiveGateStatus{
+			ConnectionInfoStatus: dynakube.ActiveGateConnectionInfoStatus{
+				ConnectionInfoStatus: dynakube.ConnectionInfoStatus{
 					TenantUUID: testUUID,
 					Endpoints:  "endpoint",
 				},
 			},
 		},
-		OneAgent: dynatracev1beta2.OneAgentStatus{
-			ConnectionInfoStatus: dynatracev1beta2.OneAgentConnectionInfoStatus{
-				ConnectionInfoStatus: dynatracev1beta2.ConnectionInfoStatus{
+		OneAgent: dynakube.OneAgentStatus{
+			ConnectionInfoStatus: dynakube.OneAgentConnectionInfoStatus{
+				ConnectionInfoStatus: dynakube.ConnectionInfoStatus{
 					TenantUUID: testUUID,
 					Endpoints:  "endpoint",
 				},
-				CommunicationHosts: []dynatracev1beta2.CommunicationHostStatus{
+				CommunicationHosts: []dynakube.CommunicationHostStatus{
 					{
 						Protocol: "http",
 						Host:     "localhost",
@@ -633,11 +633,11 @@ func getTestDynkubeStatus() *dynatracev1beta2.DynaKubeStatus {
 	}
 }
 
-func createTenantSecrets(dynakube *dynatracev1beta2.DynaKube) []client.Object {
+func createTenantSecrets(dk *dynakube.DynaKube) []client.Object {
 	return []client.Object{
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      dynakube.OneagentTenantSecret(),
+				Name:      dk.OneagentTenantSecret(),
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
@@ -646,7 +646,7 @@ func createTenantSecrets(dynakube *dynatracev1beta2.DynaKube) []client.Object {
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      dynakube.ActivegateTenantSecret(),
+				Name:      dk.ActivegateTenantSecret(),
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{

--- a/pkg/controllers/dynakube/deploymentmetadata/deploymentmetadata.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/deploymentmetadata.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 )
 
@@ -13,15 +13,15 @@ type DeploymentMetadata struct {
 	DeploymentType string
 }
 
-func GetOneAgentDeploymentType(dynakube dynatracev1beta2.DynaKube) string {
+func GetOneAgentDeploymentType(dk dynakube.DynaKube) string {
 	switch {
-	case dynakube.HostMonitoringMode():
+	case dk.HostMonitoringMode():
 		return HostMonitoringDeploymentType
-	case dynakube.CloudNativeFullstackMode():
+	case dk.CloudNativeFullstackMode():
 		return CloudNativeDeploymentType
-	case dynakube.ClassicFullStackMode():
+	case dk.ClassicFullStackMode():
 		return ClassicFullStackDeploymentType
-	case dynakube.ApplicationMonitoringMode():
+	case dk.ApplicationMonitoringMode():
 		return ApplicationMonitoringDeploymentType
 	}
 

--- a/pkg/controllers/dynakube/deploymentmetadata/deploymentmetadata_test.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/deploymentmetadata_test.go
@@ -3,7 +3,7 @@ package deploymentmetadata
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,18 +46,18 @@ func TestFormatKeyValue(t *testing.T) {
 
 func TestGetOneAgentDeploymentType(t *testing.T) {
 	tests := []struct {
-		oneAgentSpec           dynatracev1beta2.OneAgentSpec
+		oneAgentSpec           dynakube.OneAgentSpec
 		expectedDeploymentType string
 	}{
-		{dynatracev1beta2.OneAgentSpec{HostMonitoring: &dynatracev1beta2.HostInjectSpec{}}, HostMonitoringDeploymentType},
-		{dynatracev1beta2.OneAgentSpec{ClassicFullStack: &dynatracev1beta2.HostInjectSpec{}}, ClassicFullStackDeploymentType},
-		{dynatracev1beta2.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{}}, CloudNativeDeploymentType},
-		{dynatracev1beta2.OneAgentSpec{ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{}}, ApplicationMonitoringDeploymentType},
+		{dynakube.OneAgentSpec{HostMonitoring: &dynakube.HostInjectSpec{}}, HostMonitoringDeploymentType},
+		{dynakube.OneAgentSpec{ClassicFullStack: &dynakube.HostInjectSpec{}}, ClassicFullStackDeploymentType},
+		{dynakube.OneAgentSpec{CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}}, CloudNativeDeploymentType},
+		{dynakube.OneAgentSpec{ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{}}, ApplicationMonitoringDeploymentType},
 	}
 
 	for _, test := range tests {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
+		dynakube := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
 				OneAgent: test.oneAgentSpec,
 			},
 		}

--- a/pkg/controllers/dynakube/deploymentmetadata/deploymentmetadata_test.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/deploymentmetadata_test.go
@@ -56,12 +56,12 @@ func TestGetOneAgentDeploymentType(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		dynakube := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				OneAgent: test.oneAgentSpec,
 			},
 		}
-		deploymentType := GetOneAgentDeploymentType(*dynakube)
+		deploymentType := GetOneAgentDeploymentType(*dk)
 		assert.Equal(t, test.expectedDeploymentType, deploymentType)
 	}
 }

--- a/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
@@ -15,7 +15,7 @@ type Reconciler struct {
 	client    client.Client
 	apiReader client.Reader
 	clusterID string
-	dynakube  dynakube.DynaKube
+	dk        dynakube.DynaKube
 }
 
 type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dk dynakube.DynaKube, clusterID string) controllers.Reconciler
@@ -24,7 +24,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dk dynakube.DynaK
 	return &Reconciler{
 		client:    clt,
 		apiReader: apiReader,
-		dynakube:  dk,
+		dk:        dk,
 		clusterID: clusterID,
 	}
 }
@@ -40,15 +40,15 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 }
 
 func (r *Reconciler) addOneAgentDeploymentMetadata(configMapData map[string]string) {
-	if !r.dynakube.NeedsOneAgent() {
+	if !r.dk.NeedsOneAgent() {
 		return
 	}
 
-	configMapData[OneAgentMetadataKey] = NewDeploymentMetadata(r.clusterID, GetOneAgentDeploymentType(r.dynakube)).AsString()
+	configMapData[OneAgentMetadataKey] = NewDeploymentMetadata(r.clusterID, GetOneAgentDeploymentType(r.dk)).AsString()
 }
 
 func (r *Reconciler) addActiveGateDeploymentMetadata(configMapData map[string]string) {
-	if !r.dynakube.NeedsActiveGate() {
+	if !r.dk.NeedsActiveGate() {
 		return
 	}
 
@@ -56,7 +56,7 @@ func (r *Reconciler) addActiveGateDeploymentMetadata(configMapData map[string]st
 }
 
 func (r *Reconciler) addOperatorVersionInfo(configMapData map[string]string) {
-	if !r.dynakube.NeedsOneAgent() { // Currently only used for oneAgent args
+	if !r.dk.NeedsOneAgent() { // Currently only used for oneAgent args
 		return
 	}
 
@@ -66,9 +66,9 @@ func (r *Reconciler) addOperatorVersionInfo(configMapData map[string]string) {
 func (r *Reconciler) maintainMetadataConfigMap(ctx context.Context, configMapData map[string]string) error {
 	configMapQuery := configmap.NewQuery(ctx, r.client, r.apiReader, log)
 
-	configMap, err := configmap.CreateConfigMap(&r.dynakube,
-		configmap.NewModifier(GetDeploymentMetadataConfigMapName(r.dynakube.Name)),
-		configmap.NewNamespaceModifier(r.dynakube.Namespace),
+	configMap, err := configmap.CreateConfigMap(&r.dk,
+		configmap.NewModifier(GetDeploymentMetadataConfigMapName(r.dk.Name)),
+		configmap.NewNamespaceModifier(r.dk.Namespace),
 		configmap.NewConfigMapDataModifier(configMapData))
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
@@ -3,7 +3,7 @@ package deploymentmetadata
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/configmap"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
@@ -15,16 +15,16 @@ type Reconciler struct {
 	client    client.Client
 	apiReader client.Reader
 	clusterID string
-	dynakube  dynatracev1beta2.DynaKube
+	dynakube  dynakube.DynaKube
 }
 
-type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dynakube dynatracev1beta2.DynaKube, clusterID string) controllers.Reconciler
+type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dk dynakube.DynaKube, clusterID string) controllers.Reconciler
 
-func NewReconciler(clt client.Client, apiReader client.Reader, dynakube dynatracev1beta2.DynaKube, clusterID string) controllers.Reconciler {
+func NewReconciler(clt client.Client, apiReader client.Reader, dk dynakube.DynaKube, clusterID string) controllers.Reconciler {
 	return &Reconciler{
 		client:    clt,
 		apiReader: apiReader,
-		dynakube:  dynakube,
+		dynakube:  dk,
 		clusterID: clusterID,
 	}
 }

--- a/pkg/controllers/dynakube/deploymentmetadata/reconciler_test.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/reconciler_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -25,8 +25,8 @@ func createTestDynakubeObjectMeta() metav1.ObjectMeta {
 	}
 }
 
-func createTestDynakube(spec *dynatracev1beta2.DynaKubeSpec) *dynatracev1beta2.DynaKube {
-	dynakube := &dynatracev1beta2.DynaKube{ObjectMeta: createTestDynakubeObjectMeta()}
+func createTestDynakube(spec *dynakube.DynaKubeSpec) *dynakube.DynaKube {
+	dynakube := &dynakube.DynaKube{ObjectMeta: createTestDynakubeObjectMeta()}
 	if spec != nil {
 		dynakube.Spec = *spec
 	}
@@ -69,9 +69,9 @@ func TestReconcile(t *testing.T) {
 
 	t.Run(`create configmap with 1 key, if only oneagent is needed`, func(t *testing.T) {
 		dynakube := createTestDynakube(
-			&dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+			&dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 				},
 			})
 
@@ -89,10 +89,10 @@ func TestReconcile(t *testing.T) {
 
 	t.Run(`create configmap with 1 key, if only activegate is needed`, func(t *testing.T) {
 		dynakube := createTestDynakube(
-			&dynatracev1beta2.DynaKubeSpec{
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{
-					Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-						dynatracev1beta2.KubeMonCapability.DisplayName,
+			&dynakube.DynaKubeSpec{
+				ActiveGate: dynakube.ActiveGateSpec{
+					Capabilities: []dynakube.CapabilityDisplayName{
+						dynakube.KubeMonCapability.DisplayName,
 					},
 				},
 			})
@@ -110,13 +110,13 @@ func TestReconcile(t *testing.T) {
 	})
 	t.Run(`create configmap with 2 keys, if both oneagent and activegate is needed`, func(t *testing.T) {
 		dynakube := createTestDynakube(
-			&dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+			&dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 				},
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{
-					Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-						dynatracev1beta2.KubeMonCapability.DisplayName,
+				ActiveGate: dynakube.ActiveGateSpec{
+					Capabilities: []dynakube.CapabilityDisplayName{
+						dynakube.KubeMonCapability.DisplayName,
 					},
 				},
 			})

--- a/pkg/controllers/dynakube/deploymentmetadata/reconciler_test.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/reconciler_test.go
@@ -26,21 +26,21 @@ func createTestDynakubeObjectMeta() metav1.ObjectMeta {
 }
 
 func createTestDynakube(spec *dynakube.DynaKubeSpec) *dynakube.DynaKube {
-	dynakube := &dynakube.DynaKube{ObjectMeta: createTestDynakubeObjectMeta()}
+	dk := &dynakube.DynaKube{ObjectMeta: createTestDynakubeObjectMeta()}
 	if spec != nil {
-		dynakube.Spec = *spec
+		dk.Spec = *spec
 	}
 
-	return dynakube
+	return dk
 }
 
 func TestReconcile(t *testing.T) {
 	clusterID := "test"
 
 	t.Run(`don't create anything, if no mode is configured`, func(t *testing.T) {
-		dynakube := createTestDynakube(nil)
+		dk := createTestDynakube(nil)
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(fakeClient, fakeClient, *dynakube, clusterID)
+		r := NewReconciler(fakeClient, fakeClient, *dk, clusterID)
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -49,7 +49,7 @@ func TestReconcile(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run(`delete configmap, if no mode is configured`, func(t *testing.T) {
-		dynakube := createTestDynakube(nil)
+		dk := createTestDynakube(nil)
 		fakeClient := fake.NewClientBuilder().WithObjects(
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -58,7 +58,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		).Build()
-		r := NewReconciler(fakeClient, fakeClient, *dynakube, clusterID)
+		r := NewReconciler(fakeClient, fakeClient, *dk, clusterID)
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -68,7 +68,7 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run(`create configmap with 1 key, if only oneagent is needed`, func(t *testing.T) {
-		dynakube := createTestDynakube(
+		dk := createTestDynakube(
 			&dynakube.DynaKubeSpec{
 				OneAgent: dynakube.OneAgentSpec{
 					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
@@ -76,7 +76,7 @@ func TestReconcile(t *testing.T) {
 			})
 
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(fakeClient, fakeClient, *dynakube, clusterID)
+		r := NewReconciler(fakeClient, fakeClient, *dk, clusterID)
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -88,7 +88,7 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run(`create configmap with 1 key, if only activegate is needed`, func(t *testing.T) {
-		dynakube := createTestDynakube(
+		dk := createTestDynakube(
 			&dynakube.DynaKubeSpec{
 				ActiveGate: dynakube.ActiveGateSpec{
 					Capabilities: []dynakube.CapabilityDisplayName{
@@ -98,7 +98,7 @@ func TestReconcile(t *testing.T) {
 			})
 
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(fakeClient, fakeClient, *dynakube, clusterID)
+		r := NewReconciler(fakeClient, fakeClient, *dk, clusterID)
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -109,7 +109,7 @@ func TestReconcile(t *testing.T) {
 		assert.NotEmpty(t, actualConfigMap.Data[ActiveGateMetadataKey])
 	})
 	t.Run(`create configmap with 2 keys, if both oneagent and activegate is needed`, func(t *testing.T) {
-		dynakube := createTestDynakube(
+		dk := createTestDynakube(
 			&dynakube.DynaKubeSpec{
 				OneAgent: dynakube.OneAgentSpec{
 					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
@@ -122,7 +122,7 @@ func TestReconcile(t *testing.T) {
 			})
 
 		fakeClient := fake.NewClientBuilder().Build()
-		r := NewReconciler(fakeClient, fakeClient, *dynakube, clusterID)
+		r := NewReconciler(fakeClient, fakeClient, *dk, clusterID)
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 

--- a/pkg/controllers/dynakube/dtpullsecret/find.go
+++ b/pkg/controllers/dynakube/dtpullsecret/find.go
@@ -9,10 +9,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetImagePullSecret(clt client.Client, instance *dynakube.DynaKube) (*corev1.Secret, error) {
+func GetImagePullSecret(clt client.Client, dk *dynakube.DynaKube) (*corev1.Secret, error) {
 	imagePullSecret := &corev1.Secret{}
 
-	err := clt.Get(context.TODO(), client.ObjectKey{Namespace: instance.Namespace, Name: extendWithPullSecretSuffix(instance.Name)}, imagePullSecret)
+	err := clt.Get(context.TODO(), client.ObjectKey{Namespace: dk.Namespace, Name: extendWithPullSecretSuffix(dk.Name)}, imagePullSecret)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/controllers/dynakube/dtpullsecret/find.go
+++ b/pkg/controllers/dynakube/dtpullsecret/find.go
@@ -3,13 +3,13 @@ package dtpullsecret
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetImagePullSecret(clt client.Client, instance *dynatracev1beta2.DynaKube) (*corev1.Secret, error) {
+func GetImagePullSecret(clt client.Client, instance *dynakube.DynaKube) (*corev1.Secret, error) {
 	imagePullSecret := &corev1.Secret{}
 
 	err := clt.Get(context.TODO(), client.ObjectKey{Namespace: instance.Namespace, Name: extendWithPullSecretSuffix(instance.Name)}, imagePullSecret)

--- a/pkg/controllers/dynakube/dtpullsecret/find_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/find_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +24,7 @@ const (
 
 func TestGetImagePullSecret(t *testing.T) {
 	fakeClient := fake.NewClient()
-	instance := &dynatracev1beta2.DynaKube{
+	instance := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,

--- a/pkg/controllers/dynakube/dtpullsecret/find_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/find_test.go
@@ -24,12 +24,12 @@ const (
 
 func TestGetImagePullSecret(t *testing.T) {
 	fakeClient := fake.NewClient()
-	instance := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
 		}}
-	secret, err := GetImagePullSecret(fakeClient, instance)
+	secret, err := GetImagePullSecret(fakeClient, dk)
 
 	assert.Nil(t, secret)
 	require.Error(t, err)
@@ -45,7 +45,7 @@ func TestGetImagePullSecret(t *testing.T) {
 
 	require.NoError(t, err)
 
-	secret, err = GetImagePullSecret(fakeClient, instance)
+	secret, err = GetImagePullSecret(fakeClient, dk)
 
 	assert.NotNil(t, secret)
 	require.NoError(t, err)

--- a/pkg/controllers/dynakube/dtpullsecret/generate.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate.go
@@ -38,7 +38,7 @@ func newDockerConfigWithAuth(username string, password string, registry string, 
 func (r *Reconciler) GenerateData() (map[string][]byte, error) {
 	var registryToken string
 
-	registry, err := getImageRegistryFromAPIURL(r.dynakube.Spec.APIURL)
+	registry, err := getImageRegistryFromAPIURL(r.dk.Spec.APIURL)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (r *Reconciler) GenerateData() (map[string][]byte, error) {
 		return nil, errors.New("token secret does not contain a paas or api token, cannot generate docker config")
 	}
 
-	tenantUUID, err := r.dynakube.TenantUUIDFromConnectionInfoStatus()
+	tenantUUID, err := r.dk.TenantUUIDFromConnectionInfoStatus()
 	if err != nil {
 		return nil, errors.WithMessage(err, "cannot generate docker config")
 	}

--- a/pkg/controllers/dynakube/dtpullsecret/generate_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
@@ -33,14 +33,14 @@ func TestGetImageRegistryFromAPIURL(t *testing.T) {
 }
 
 func TestReconciler_GenerateData(t *testing.T) {
-	dynakube := &dynatracev1beta2.DynaKube{
-		Spec: dynatracev1beta2.DynaKubeSpec{
+	dynakube := &dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: testApiUrl,
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			OneAgent: dynatracev1beta2.OneAgentStatus{
-				ConnectionInfoStatus: dynatracev1beta2.OneAgentConnectionInfoStatus{
-					ConnectionInfoStatus: dynatracev1beta2.ConnectionInfoStatus{
+		Status: dynakube.DynaKubeStatus{
+			OneAgent: dynakube.OneAgentStatus{
+				ConnectionInfoStatus: dynakube.OneAgentConnectionInfoStatus{
+					ConnectionInfoStatus: dynakube.ConnectionInfoStatus{
 						TenantUUID: testTenant,
 					},
 				},

--- a/pkg/controllers/dynakube/dtpullsecret/generate_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate_test.go
@@ -33,7 +33,7 @@ func TestGetImageRegistryFromAPIURL(t *testing.T) {
 }
 
 func TestReconciler_GenerateData(t *testing.T) {
-	dynakube := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		Spec: dynakube.DynaKubeSpec{
 			APIURL: testApiUrl,
 		},
@@ -48,7 +48,7 @@ func TestReconciler_GenerateData(t *testing.T) {
 		},
 	}
 	r := &Reconciler{
-		dynakube: dynakube,
+		dk: dk,
 		tokens: token.Tokens{
 			dtclient.PaasToken: &token.Token{Value: testPaasToken},
 		},

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"reflect"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
@@ -23,16 +23,16 @@ const (
 type Reconciler struct {
 	client       client.Client
 	apiReader    client.Reader
-	dynakube     *dynatracev1beta2.DynaKube
+	dynakube     *dynakube.DynaKube
 	tokens       token.Tokens
 	timeprovider *timeprovider.Provider
 }
 
-func NewReconciler(clt client.Client, apiReader client.Reader, dynakube *dynatracev1beta2.DynaKube, tokens token.Tokens) *Reconciler {
+func NewReconciler(clt client.Client, apiReader client.Reader, dk *dynakube.DynaKube, tokens token.Tokens) *Reconciler {
 	return &Reconciler{
 		client:       clt,
 		apiReader:    apiReader,
-		dynakube:     dynakube,
+		dynakube:     dk,
 		tokens:       tokens,
 		timeprovider: timeprovider.New(),
 	}

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -23,7 +23,7 @@ const (
 type Reconciler struct {
 	client       client.Client
 	apiReader    client.Reader
-	dynakube     *dynakube.DynaKube
+	dk           *dynakube.DynaKube
 	tokens       token.Tokens
 	timeprovider *timeprovider.Provider
 }
@@ -32,15 +32,15 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dk *dynakube.Dyna
 	return &Reconciler{
 		client:       clt,
 		apiReader:    apiReader,
-		dynakube:     dk,
+		dk:           dk,
 		tokens:       tokens,
 		timeprovider: timeprovider.New(),
 	}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	if !(r.dynakube.NeedsOneAgent() || r.dynakube.NeedsActiveGate()) {
-		if meta.FindStatusCondition(*r.dynakube.Conditions(), PullSecretConditionType) == nil {
+	if !(r.dk.NeedsOneAgent() || r.dk.NeedsActiveGate()) {
+		if meta.FindStatusCondition(*r.dk.Conditions(), PullSecretConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}
 
@@ -49,14 +49,14 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 			log.Error(err, "failed to clean-up pull secret")
 		}
 
-		meta.RemoveStatusCondition(r.dynakube.Conditions(), PullSecretConditionType)
+		meta.RemoveStatusCondition(r.dk.Conditions(), PullSecretConditionType)
 
 		return nil
 	}
 
-	if conditions.IsOutdated(r.timeprovider, r.dynakube, PullSecretConditionType) {
-		conditions.SetSecretOutdated(r.dynakube.Conditions(), PullSecretConditionType,
-			extendWithPullSecretSuffix(r.dynakube.Name)+" is not present or outdated")
+	if conditions.IsOutdated(r.timeprovider, r.dk, PullSecretConditionType) {
+		conditions.SetSecretOutdated(r.dk.Conditions(), PullSecretConditionType,
+			extendWithPullSecretSuffix(r.dk.Name)+" is not present or outdated")
 
 		err := r.reconcilePullSecret(ctx)
 		if err != nil {
@@ -86,7 +86,7 @@ func (r *Reconciler) reconcilePullSecret(ctx context.Context) error {
 func (r *Reconciler) createPullSecretIfNotExists(ctx context.Context, pullSecretData map[string][]byte) (*corev1.Secret, error) {
 	var config corev1.Secret
 
-	err := r.apiReader.Get(ctx, client.ObjectKey{Name: extendWithPullSecretSuffix(r.dynakube.Name), Namespace: r.dynakube.Namespace}, &config)
+	err := r.apiReader.Get(ctx, client.ObjectKey{Name: extendWithPullSecretSuffix(r.dk.Name), Namespace: r.dk.Namespace}, &config)
 	if k8serrors.IsNotFound(err) {
 		log.Info("creating pull secret")
 
@@ -99,7 +99,7 @@ func (r *Reconciler) createPullSecretIfNotExists(ctx context.Context, pullSecret
 func (r *Reconciler) deletePullSecretIfExists(ctx context.Context) error {
 	var config corev1.Secret
 
-	err := r.apiReader.Get(ctx, client.ObjectKey{Name: extendWithPullSecretSuffix(r.dynakube.Name), Namespace: r.dynakube.Namespace}, &config)
+	err := r.apiReader.Get(ctx, client.ObjectKey{Name: extendWithPullSecretSuffix(r.dk.Name), Namespace: r.dk.Namespace}, &config)
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
@@ -123,9 +123,9 @@ func (r *Reconciler) updatePullSecretIfOutdated(ctx context.Context, pullSecret 
 }
 
 func (r *Reconciler) createPullSecret(ctx context.Context, pullSecretData map[string][]byte) (*corev1.Secret, error) {
-	pullSecret, err := secret.Create(r.dynakube,
-		secret.NewNameModifier(extendWithPullSecretSuffix(r.dynakube.Name)),
-		secret.NewNamespaceModifier(r.dynakube.Namespace),
+	pullSecret, err := secret.Create(r.dk,
+		secret.NewNameModifier(extendWithPullSecretSuffix(r.dk.Name)),
+		secret.NewNamespaceModifier(r.dk.Namespace),
 		secret.NewTypeModifier(corev1.SecretTypeDockerConfigJson),
 		secret.NewDataModifier(pullSecretData))
 	if err != nil {
@@ -134,12 +134,12 @@ func (r *Reconciler) createPullSecret(ctx context.Context, pullSecretData map[st
 
 	err = r.client.Create(ctx, pullSecret)
 	if err != nil {
-		conditions.SetKubeApiError(r.dynakube.Conditions(), PullSecretConditionType, err)
+		conditions.SetKubeApiError(r.dk.Conditions(), PullSecretConditionType, err)
 
-		return nil, errors.WithMessagef(err, "failed to create secret %s", extendWithPullSecretSuffix(r.dynakube.Name))
+		return nil, errors.WithMessagef(err, "failed to create secret %s", extendWithPullSecretSuffix(r.dk.Name))
 	}
 
-	conditions.SetSecretCreated(r.dynakube.Conditions(), PullSecretConditionType, pullSecret.Name)
+	conditions.SetSecretCreated(r.dk.Conditions(), PullSecretConditionType, pullSecret.Name)
 
 	return pullSecret, nil
 }
@@ -149,12 +149,12 @@ func (r *Reconciler) updatePullSecret(ctx context.Context, pullSecret *corev1.Se
 
 	pullSecret.Data = desiredPullSecretData
 	if err := r.client.Update(ctx, pullSecret); err != nil {
-		conditions.SetKubeApiError(r.dynakube.Conditions(), PullSecretConditionType, err)
+		conditions.SetKubeApiError(r.dk.Conditions(), PullSecretConditionType, err)
 
 		return errors.WithMessagef(err, "failed to update secret %s", pullSecret.Name)
 	}
 
-	conditions.SetSecretUpdated(r.dynakube.Conditions(), PullSecretConditionType, pullSecret.Name)
+	conditions.SetSecretUpdated(r.dk.Conditions(), PullSecretConditionType, pullSecret.Name)
 
 	return nil
 }

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
@@ -37,9 +37,9 @@ func (clt errorClient) Create(_ context.Context, _ client.Object, _ ...client.Cr
 
 func TestReconciler_Reconcile(t *testing.T) {
 	t.Run(`Create works with minimal setup`, func(t *testing.T) {
-		dynakube := createTestDynakube()
+		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
-		r := NewReconciler(fakeClient, fakeClient, dynakube, token.Tokens{
+		r := NewReconciler(fakeClient, fakeClient, dk, token.Tokens{
 			dtclient.ApiToken: &token.Token{Value: testValue},
 		})
 
@@ -59,9 +59,9 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.NotEmpty(t, pullSecret.Data[".dockerconfigjson"])
 	})
 	t.Run(`Error when accessing K8s API`, func(t *testing.T) {
-		dynakube := createTestDynakube()
+		dk := createTestDynakube()
 		fakeClient := errorClient{}
-		r := NewReconciler(fakeClient, fakeClient, dynakube, token.Tokens{
+		r := NewReconciler(fakeClient, fakeClient, dk, token.Tokens{
 			dtclient.ApiToken: &token.Token{Value: testValue},
 		})
 
@@ -69,17 +69,17 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run(`Error when tenant UUID is missing`, func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 				Name:      testName,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{}},
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}},
 			},
 		}
 		fakeClient := errorClient{}
-		r := NewReconciler(fakeClient, fakeClient, dynakube, token.Tokens{
+		r := NewReconciler(fakeClient, fakeClient, dk, token.Tokens{
 			dtclient.ApiToken: &token.Token{Value: testValue},
 		})
 
@@ -87,10 +87,10 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run(`Error when creating secret`, func(t *testing.T) {
-		dynakube := createTestDynakube()
+		dk := createTestDynakube()
 		fakeErrorClient := errorClient{}
 		fakeClient := fake.NewClient()
-		r := NewReconciler(fakeErrorClient, fakeClient, dynakube, token.Tokens{
+		r := NewReconciler(fakeErrorClient, fakeClient, dk, token.Tokens{
 			dtclient.ApiToken: &token.Token{Value: testValue},
 		})
 
@@ -99,24 +99,24 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.Equal(t, "failed to create or update secret: failed to create secret test-name-pull-secret: fake error", err.Error())
 	})
 	t.Run(`Create does not reconcile with custom pull secret`, func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 				Name:      testName,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				CustomPullSecret: testValue,
 			}}
-		r := NewReconciler(nil, nil, dynakube, nil)
+		r := NewReconciler(nil, nil, dk, nil)
 		err := r.Reconcile(context.Background())
 
 		require.NoError(t, err)
 	})
 	t.Run(`Create creates correct docker config`, func(t *testing.T) {
 		expectedJSON := `{"auths":{"test-api-url":{"username":"test-tenant","password":"test-value","auth":"dGVzdC10ZW5hbnQ6dGVzdC12YWx1ZQ=="}}}`
-		dynakube := createTestDynakube()
+		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
-		r := NewReconciler(fakeClient, fakeClient, dynakube, token.Tokens{
+		r := NewReconciler(fakeClient, fakeClient, dk, token.Tokens{
 			dtclient.ApiToken: &token.Token{Value: testValue},
 		})
 
@@ -138,9 +138,9 @@ func TestReconciler_Reconcile(t *testing.T) {
 	})
 	t.Run(`Create update secret if data changed`, func(t *testing.T) {
 		expectedJSON := `{"auths":{"test-api-url":{"username":"test-tenant","password":"test-value","auth":"dGVzdC10ZW5hbnQ6dGVzdC12YWx1ZQ=="}}}`
-		dynakube := createTestDynakube()
+		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
-		r := NewReconciler(fakeClient, fakeClient, dynakube, token.Tokens{
+		r := NewReconciler(fakeClient, fakeClient, dk, token.Tokens{
 			dtclient.ApiToken: &token.Token{Value: testValue},
 		})
 
@@ -177,10 +177,10 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.Equal(t, expectedJSON, string(pullSecret.Data[".dockerconfigjson"]))
 	})
 	t.Run(`Reconciliation only runs every 15 min`, func(t *testing.T) {
-		dynakube := createTestDynakube()
-		dynakube.Spec.DynatraceApiRequestThreshold = dynatracev1beta2.DefaultMinRequestThresholdMinutes
+		dk := createTestDynakube()
+		dk.Spec.DynatraceApiRequestThreshold = dynakube.DefaultMinRequestThresholdMinutes
 		fakeClient := fake.NewClient()
-		r := NewReconciler(fakeClient, fakeClient, dynakube, token.Tokens{
+		r := NewReconciler(fakeClient, fakeClient, dk, token.Tokens{
 			dtclient.ApiToken: &token.Token{Value: testValue},
 		})
 
@@ -213,16 +213,16 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.Empty(t, pullSecret.Data)
 	})
 	t.Run(`Cleanup works`, func(t *testing.T) {
-		dynakube := createTestDynakube()
+		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
-		r := NewReconciler(fakeClient, fakeClient, dynakube, token.Tokens{
+		r := NewReconciler(fakeClient, fakeClient, dk, token.Tokens{
 			dtclient.ApiToken: &token.Token{Value: testValue},
 		})
 
 		err := r.Reconcile(context.Background())
 
 		require.NoError(t, err)
-		assert.NotEmpty(t, meta.FindStatusCondition(*dynakube.Conditions(), PullSecretConditionType))
+		assert.NotEmpty(t, meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType))
 
 		var pullSecret corev1.Secret
 		err = fakeClient.Get(context.Background(),
@@ -231,7 +231,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 		require.NoError(t, err)
 
-		dynakube.Spec.OneAgent = dynatracev1beta2.OneAgentSpec{}
+		dk.Spec.OneAgent = dynakube.OneAgentSpec{}
 		err = r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -240,25 +240,25 @@ func TestReconciler_Reconcile(t *testing.T) {
 			&pullSecret)
 
 		assert.True(t, k8serrors.IsNotFound(err))
-		assert.Empty(t, meta.FindStatusCondition(*dynakube.Conditions(), PullSecretConditionType))
+		assert.Empty(t, meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType))
 	})
 }
 
-func createTestDynakube() *dynatracev1beta2.DynaKube {
-	return addFakeTennantUUID(&dynatracev1beta2.DynaKube{
+func createTestDynakube() *dynakube.DynaKube {
+	return addFakeTennantUUID(&dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL:   testApiUrl,
-			OneAgent: dynatracev1beta2.OneAgentSpec{CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{}},
+			OneAgent: dynakube.OneAgentSpec{CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}},
 		},
 	})
 }
 
-func addFakeTennantUUID(dynakube *dynatracev1beta2.DynaKube) *dynatracev1beta2.DynaKube {
-	dynakube.Status.OneAgent.ConnectionInfoStatus.ConnectionInfoStatus.TenantUUID = testTenant
+func addFakeTennantUUID(dk *dynakube.DynaKube) *dynakube.DynaKube {
+	dk.Status.OneAgent.ConnectionInfoStatus.ConnectionInfoStatus.TenantUUID = testTenant
 
-	return dynakube
+	return dk
 }

--- a/pkg/controllers/dynakube/dynatraceclient/builder_test.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder_test.go
@@ -22,21 +22,21 @@ const (
 
 func TestBuildDynatraceClient(t *testing.T) {
 	t.Run(`BuildDynatraceClient works with minimal setup`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 			},
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testEndpoint,
 			}}
-		fakeClient := fake.NewClient(instance)
+		fakeClient := fake.NewClient(dk)
 		dynatraceClientBuilder := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
 				dtclient.ApiToken:  {Value: testValue},
 				dtclient.PaasToken: {Value: testValueAlternative},
 			},
-			dynakube: *instance,
+			dk: *dk,
 		}
 		dtc, err := dynatraceClientBuilder.Build()
 
@@ -49,14 +49,14 @@ func TestBuildDynatraceClient(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run(`BuildDynatraceClient handles invalid token secret`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 			},
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testEndpoint,
 			}}
-		fakeClient := fake.NewClient(instance)
+		fakeClient := fake.NewClient(dk)
 		dynatraceClientBuilder := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
@@ -64,7 +64,7 @@ func TestBuildDynatraceClient(t *testing.T) {
 				dtclient.ApiToken:  {Value: ""},
 				dtclient.PaasToken: {Value: ""},
 			},
-			dynakube: *instance,
+			dk: *dk,
 		}
 
 		dtc, err := dynatraceClientBuilder.Build()
@@ -74,7 +74,7 @@ func TestBuildDynatraceClient(t *testing.T) {
 
 		dynatraceClientBuilder = builder{
 			apiReader: fakeClient,
-			dynakube:  *instance,
+			dk:        *dk,
 		}
 		dtc, err = dynatraceClientBuilder.Build()
 
@@ -82,7 +82,7 @@ func TestBuildDynatraceClient(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run(`BuildDynatraceClient handles missing proxy secret`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 			},
@@ -91,14 +91,14 @@ func TestBuildDynatraceClient(t *testing.T) {
 				Proxy: &dynakube.DynaKubeProxy{
 					ValueFrom: testKey,
 				}}}
-		fakeClient := fake.NewClient(instance)
+		fakeClient := fake.NewClient(dk)
 		dynatraceClientBuilder := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
 				dtclient.ApiToken:  {Value: testValue},
 				dtclient.PaasToken: {Value: testValueAlternative},
 			},
-			dynakube: *instance,
+			dk: *dk,
 		}
 		dtc, err := dynatraceClientBuilder.Build()
 
@@ -106,7 +106,7 @@ func TestBuildDynatraceClient(t *testing.T) {
 		assert.Nil(t, dtc)
 	})
 	t.Run(`BuildDynatraceClient handles missing trusted certificate config map`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 			},
@@ -115,14 +115,14 @@ func TestBuildDynatraceClient(t *testing.T) {
 				TrustedCAs: testKey,
 			}}
 
-		fakeClient := fake.NewClient(instance)
+		fakeClient := fake.NewClient(dk)
 		dtf := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
 				dtclient.ApiToken:  {Value: testValue},
 				dtclient.PaasToken: {Value: testValueAlternative},
 			},
-			dynakube: *instance,
+			dk: *dk,
 		}
 		dtc, err := dtf.Build()
 

--- a/pkg/controllers/dynakube/dynatraceclient/builder_test.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
@@ -22,11 +22,11 @@ const (
 
 func TestBuildDynatraceClient(t *testing.T) {
 	t.Run(`BuildDynatraceClient works with minimal setup`, func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testEndpoint,
 			}}
 		fakeClient := fake.NewClient(instance)
@@ -49,11 +49,11 @@ func TestBuildDynatraceClient(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run(`BuildDynatraceClient handles invalid token secret`, func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testEndpoint,
 			}}
 		fakeClient := fake.NewClient(instance)
@@ -82,13 +82,13 @@ func TestBuildDynatraceClient(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run(`BuildDynatraceClient handles missing proxy secret`, func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testEndpoint,
-				Proxy: &dynatracev1beta2.DynaKubeProxy{
+				Proxy: &dynakube.DynaKubeProxy{
 					ValueFrom: testKey,
 				}}}
 		fakeClient := fake.NewClient(instance)
@@ -106,11 +106,11 @@ func TestBuildDynatraceClient(t *testing.T) {
 		assert.Nil(t, dtc)
 	})
 	t.Run(`BuildDynatraceClient handles missing trusted certificate config map`, func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL:     testEndpoint,
 				TrustedCAs: testKey,
 			}}

--- a/pkg/controllers/dynakube/dynatraceclient/options.go
+++ b/pkg/controllers/dynakube/dynatraceclient/options.go
@@ -3,7 +3,7 @@ package dynatraceclient
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -38,12 +38,12 @@ func (opts *options) appendCertCheck(skipCertCheck bool) {
 	opts.Opts = append(opts.Opts, dtclient.SkipCertificateValidation(skipCertCheck))
 }
 
-func (opts *options) appendProxySettings(apiReader client.Reader, dynakube *dynatracev1beta2.DynaKube) error {
-	if dynakube == nil || !dynakube.HasProxy() {
+func (opts *options) appendProxySettings(apiReader client.Reader, dk *dynakube.DynaKube) error {
+	if dk == nil || !dk.HasProxy() {
 		return nil
 	}
 
-	proxyOption, err := opts.createProxyOption(apiReader, dynakube)
+	proxyOption, err := opts.createProxyOption(apiReader, dk)
 	if err != nil {
 		return err
 	}
@@ -53,15 +53,15 @@ func (opts *options) appendProxySettings(apiReader client.Reader, dynakube *dyna
 	return nil
 }
 
-func (opts *options) createProxyOption(apiReader client.Reader, dynakube *dynatracev1beta2.DynaKube) (dtclient.Option, error) {
+func (opts *options) createProxyOption(apiReader client.Reader, dk *dynakube.DynaKube) (dtclient.Option, error) {
 	var proxyOption dtclient.Option
 
-	proxyUrl, err := dynakube.Proxy(opts.ctx, apiReader)
+	proxyUrl, err := dk.Proxy(opts.ctx, apiReader)
 	if err != nil {
 		return proxyOption, err
 	}
 
-	proxyOption = dtclient.Proxy(proxyUrl, dynakube.FeatureNoProxy())
+	proxyOption = dtclient.Proxy(proxyUrl, dk.FeatureNoProxy())
 
 	return proxyOption, nil
 }
@@ -73,11 +73,11 @@ func (opts *options) appendTrustedCerts(apiReader client.Reader, trustedCerts st
 			return errors.WithMessage(err, "failed to get certificate configmap")
 		}
 
-		if certs.Data[dynatracev1beta2.TrustedCAKey] == "" {
+		if certs.Data[dynakube.TrustedCAKey] == "" {
 			return errors.New("failed to extract certificate configmap field: missing field certs")
 		}
 
-		opts.Opts = append(opts.Opts, dtclient.Certs([]byte(certs.Data[dynatracev1beta2.TrustedCAKey])))
+		opts.Opts = append(opts.Opts, dtclient.Certs([]byte(certs.Data[dynakube.TrustedCAKey])))
 	}
 
 	return nil

--- a/pkg/controllers/dynakube/dynatraceclient/options_test.go
+++ b/pkg/controllers/dynakube/dynatraceclient/options_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -17,9 +17,9 @@ const (
 	testNetworkZone = "zone-1"
 )
 
-func createTestDynakubeWithProxy(proxy dynatracev1beta2.DynaKubeProxy) *dynatracev1beta2.DynaKube {
-	dk := &dynatracev1beta2.DynaKube{
-		Spec: dynatracev1beta2.DynaKubeSpec{
+func createTestDynakubeWithProxy(proxy dynakube.DynaKubeProxy) *dynakube.DynaKube {
+	dk := &dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
 			Proxy: &proxy,
 		},
 	}
@@ -70,7 +70,7 @@ func TestOptions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, opts.Opts)
 
-		err = opts.appendProxySettings(nil, createTestDynakubeWithProxy(dynatracev1beta2.DynaKubeProxy{Value: testValue}))
+		err = opts.appendProxySettings(nil, createTestDynakubeWithProxy(dynakube.DynaKubeProxy{Value: testValue}))
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, opts.Opts)
@@ -82,11 +82,11 @@ func TestOptions(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
-					dynatracev1beta2.ProxyKey: []byte(testValue),
+					dynakube.ProxyKey: []byte(testValue),
 				},
 			})
 		opts = newOptions(context.Background())
-		err = opts.appendProxySettings(fakeClient, createTestDynakubeWithProxy(dynatracev1beta2.DynaKubeProxy{ValueFrom: testName}))
+		err = opts.appendProxySettings(fakeClient, createTestDynakubeWithProxy(dynakube.DynaKubeProxy{ValueFrom: testName}))
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, opts.Opts)
@@ -94,7 +94,7 @@ func TestOptions(t *testing.T) {
 	t.Run(`AppendProxySettings handles missing or malformed secret`, func(t *testing.T) {
 		fakeClient := fake.NewClient()
 		opts := newOptions(context.Background())
-		err := opts.appendProxySettings(fakeClient, createTestDynakubeWithProxy(dynatracev1beta2.DynaKubeProxy{ValueFrom: testName}))
+		err := opts.appendProxySettings(fakeClient, createTestDynakubeWithProxy(dynakube.DynaKubeProxy{ValueFrom: testName}))
 
 		require.Error(t, err)
 		assert.Empty(t, opts.Opts)
@@ -108,7 +108,7 @@ func TestOptions(t *testing.T) {
 				Data: map[string][]byte{},
 			})
 		opts = newOptions(context.Background())
-		err = opts.appendProxySettings(fakeClient, createTestDynakubeWithProxy(dynatracev1beta2.DynaKubeProxy{ValueFrom: testName}))
+		err = opts.appendProxySettings(fakeClient, createTestDynakubeWithProxy(dynakube.DynaKubeProxy{ValueFrom: testName}))
 
 		require.Error(t, err)
 		assert.Empty(t, opts.Opts)
@@ -131,7 +131,7 @@ func TestOptions(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string]string{
-					dynatracev1beta2.TrustedCAKey: testValue,
+					dynakube.TrustedCAKey: testValue,
 				}})
 		err = opts.appendTrustedCerts(fakeClient, testName, testNamespace)
 

--- a/pkg/controllers/dynakube/extension/reconciler.go
+++ b/pkg/controllers/dynakube/extension/reconciler.go
@@ -14,7 +14,7 @@ type reconciler struct {
 	apiReader    client.Reader
 	timeProvider *timeprovider.Provider
 
-	dynakube *dynakube.DynaKube
+	dk *dynakube.DynaKube
 }
 
 type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dk *dynakube.DynaKube) controllers.Reconciler
@@ -25,13 +25,13 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dk *dynakube.Dyna
 	return &reconciler{
 		client:       clt,
 		apiReader:    apiReader,
-		dynakube:     dk,
+		dk:           dk,
 		timeProvider: timeprovider.New(),
 	}
 }
 
 func (r *reconciler) Reconcile(_ context.Context) error {
-	if r.dynakube.PrometheusEnabled() {
+	if r.dk.PrometheusEnabled() {
 		log.Info("reconcile extensions")
 
 		return nil

--- a/pkg/controllers/dynakube/extension/reconciler.go
+++ b/pkg/controllers/dynakube/extension/reconciler.go
@@ -3,7 +3,7 @@ package extension
 import (
 	"context"
 
-	dynatracev1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,18 +14,18 @@ type reconciler struct {
 	apiReader    client.Reader
 	timeProvider *timeprovider.Provider
 
-	dynakube *dynatracev1beta3.DynaKube
+	dynakube *dynakube.DynaKube
 }
 
-type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dynakube *dynatracev1beta3.DynaKube) controllers.Reconciler
+type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dk *dynakube.DynaKube) controllers.Reconciler
 
 var _ ReconcilerBuilder = NewReconciler
 
-func NewReconciler(clt client.Client, apiReader client.Reader, dynakube *dynatracev1beta3.DynaKube) controllers.Reconciler {
+func NewReconciler(clt client.Client, apiReader client.Reader, dk *dynakube.DynaKube) controllers.Reconciler {
 	return &reconciler{
 		client:       clt,
 		apiReader:    apiReader,
-		dynakube:     dynakube,
+		dynakube:     dk,
 		timeProvider: timeprovider.New(),
 	}
 }

--- a/pkg/controllers/dynakube/injection/reconciler.go
+++ b/pkg/controllers/dynakube/injection/reconciler.go
@@ -5,7 +5,7 @@ import (
 	goerrors "errors"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	oaconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
@@ -27,7 +27,7 @@ import (
 type reconciler struct {
 	client                    client.Client
 	apiReader                 client.Reader
-	dynakube                  *dynatracev1beta2.DynaKube
+	dynakube                  *dynakube.DynaKube
 	istioReconciler           istio.Reconciler
 	versionReconciler         version.Reconciler
 	pmcSecretreconciler       controllers.Reconciler
@@ -40,7 +40,7 @@ type ReconcilerBuilder func(
 	apiReader client.Reader,
 	dynatraceClient dynatrace.Client,
 	istioClient *istio.Client,
-	dynakube *dynatracev1beta2.DynaKube,
+	dynakube *dynakube.DynaKube,
 ) controllers.Reconciler
 
 //nolint:revive
@@ -49,7 +49,7 @@ func NewReconciler(
 	apiReader client.Reader,
 	dynatraceClient dynatrace.Client,
 	istioClient *istio.Client,
-	dynakube *dynatracev1beta2.DynaKube,
+	dynakube *dynakube.DynaKube,
 ) controllers.Reconciler {
 	var istioReconciler istio.Reconciler = nil
 

--- a/pkg/controllers/dynakube/injection/reconciler_test.go
+++ b/pkg/controllers/dynakube/injection/reconciler_test.go
@@ -77,7 +77,7 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		}
-		dynakube := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testDynakube,
 				Namespace: testNamespaceDynatrace,
@@ -112,7 +112,7 @@ func TestReconciler(t *testing.T) {
 				dtclient.ApiToken:  []byte(testAPIToken),
 				dtclient.PaasToken: []byte(testPaasToken),
 			}),
-			dynakube,
+			dk,
 		)
 		dtClient := dtclientmock.NewClient(t)
 		dtClient.On("GetLatestAgentVersion", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("", nil)
@@ -120,30 +120,30 @@ func TestReconciler(t *testing.T) {
 		dtClient.On("GetProcessModuleConfig", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("uint")).Return(&dtclient.ProcessModuleConfig{}, nil)
 		dtClient.On("GetRulesSettings", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).Return(dtclient.GetRulesSettingsResponse{}, nil)
 
-		istioClient := newIstioTestingClient(fakeistio.NewSimpleClientset(), dynakube)
+		istioClient := newIstioTestingClient(fakeistio.NewSimpleClientset(), dk)
 
-		rec := NewReconciler(clt, clt, dtClient, istioClient, dynakube)
+		rec := NewReconciler(clt, clt, dtClient, istioClient, dk)
 		err := rec.Reconcile(context.Background())
 		require.NoError(t, err)
 
-		assertSecretFound(t, clt, dynakube.OneagentTenantSecret(), dynakube.Namespace)
+		assertSecretFound(t, clt, dk.OneagentTenantSecret(), dk.Namespace)
 		assertSecretFound(t, clt, consts.AgentInitSecretName, testNamespace)
 		assertSecretNotFound(t, clt, consts.AgentInitSecretName, testNamespace2)
 		assertSecretFound(t, clt, consts.EnrichmentEndpointSecretName, testNamespace)
 		assertSecretNotFound(t, clt, consts.EnrichmentEndpointSecretName, testNamespace2)
 
-		_, err = istioClient.GetServiceEntry(context.Background(), istio.BuildNameForIPServiceEntry(dynakube.GetName(), istio.OneAgentComponent))
+		_, err = istioClient.GetServiceEntry(context.Background(), istio.BuildNameForIPServiceEntry(dk.GetName(), istio.OneAgentComponent))
 		require.NoError(t, err)
-		_, err = istioClient.GetServiceEntry(context.Background(), istio.BuildNameForFQDNServiceEntry(dynakube.GetName(), istio.OneAgentComponent))
+		_, err = istioClient.GetServiceEntry(context.Background(), istio.BuildNameForFQDNServiceEntry(dk.GetName(), istio.OneAgentComponent))
 		require.NoError(t, err)
 
-		_, err = istioClient.GetVirtualService(context.Background(), istio.BuildNameForIPServiceEntry(dynakube.GetName(), istio.OneAgentComponent))
+		_, err = istioClient.GetVirtualService(context.Background(), istio.BuildNameForIPServiceEntry(dk.GetName(), istio.OneAgentComponent))
 		require.NoError(t, err)
-		_, err = istioClient.GetVirtualService(context.Background(), istio.BuildNameForFQDNServiceEntry(dynakube.GetName(), istio.OneAgentComponent))
+		_, err = istioClient.GetVirtualService(context.Background(), istio.BuildNameForFQDNServiceEntry(dk.GetName(), istio.OneAgentComponent))
 		require.NoError(t, err)
 	})
 	t.Run("remove injection", func(t *testing.T) {
-		dynakube := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testDynakube,
 				Namespace: testNamespaceDynatrace,
@@ -153,8 +153,8 @@ func TestReconciler(t *testing.T) {
 				EnableIstio: true,
 			},
 		}
-		setMetadataEnrichmentCreatedCondition(dynakube.Conditions())
-		setCodeModulesInjectionCreatedCondition(dynakube.Conditions())
+		setMetadataEnrichmentCreatedCondition(dk.Conditions())
+		setCodeModulesInjectionCreatedCondition(dk.Conditions())
 
 		clt := fake.NewClientWithIndex(
 			clientInjectedNamespace(testNamespace, testDynakube),
@@ -167,48 +167,48 @@ func TestReconciler(t *testing.T) {
 				dtclient.ApiToken:  []byte(testAPIToken),
 				dtclient.PaasToken: []byte(testPaasToken),
 			}),
-			dynakube,
+			dk,
 		)
 		dtClient := dtclientmock.NewClient(t)
-		istioClient := setupIstioClientWithObjects(dynakube)
+		istioClient := setupIstioClientWithObjects(dk)
 
-		rec := NewReconciler(clt, clt, dtClient, istioClient, dynakube)
+		rec := NewReconciler(clt, clt, dtClient, istioClient, dk)
 		err := rec.Reconcile(context.Background())
 		require.NoError(t, err)
 
 		assertSecretNotFound(t, clt, consts.EnrichmentEndpointSecretName, testNamespace)
 		assertSecretFound(t, clt, consts.EnrichmentEndpointSecretName, testNamespace2)
-		assert.Nil(t, meta.FindStatusCondition(*dynakube.Conditions(), metaDataEnrichmentConditionType))
+		assert.Nil(t, meta.FindStatusCondition(*dk.Conditions(), metaDataEnrichmentConditionType))
 
 		assertSecretNotFound(t, clt, consts.AgentInitSecretName, testNamespace)
 		assertSecretFound(t, clt, consts.AgentInitSecretName, testNamespace2)
-		assert.Nil(t, meta.FindStatusCondition(*dynakube.Conditions(), codeModulesInjectionConditionType))
+		assert.Nil(t, meta.FindStatusCondition(*dk.Conditions(), codeModulesInjectionConditionType))
 
-		obj, err := istioClient.GetServiceEntry(context.Background(), istio.BuildNameForIPServiceEntry(dynakube.GetName(), istio.OneAgentComponent))
+		obj, err := istioClient.GetServiceEntry(context.Background(), istio.BuildNameForIPServiceEntry(dk.GetName(), istio.OneAgentComponent))
 		require.NoError(t, err)
 		assert.Nil(t, obj)
-		obj, err = istioClient.GetServiceEntry(context.Background(), istio.BuildNameForFQDNServiceEntry(dynakube.GetName(), istio.OneAgentComponent))
+		obj, err = istioClient.GetServiceEntry(context.Background(), istio.BuildNameForFQDNServiceEntry(dk.GetName(), istio.OneAgentComponent))
 		require.NoError(t, err)
 		assert.Nil(t, obj)
 
-		virtualService, err := istioClient.GetVirtualService(context.Background(), istio.BuildNameForFQDNServiceEntry(dynakube.GetName(), istio.OneAgentComponent))
+		virtualService, err := istioClient.GetVirtualService(context.Background(), istio.BuildNameForFQDNServiceEntry(dk.GetName(), istio.OneAgentComponent))
 		require.NoError(t, err)
 		assert.Nil(t, virtualService)
 
 		istioClient.Owner.SetNamespace(testNamespace2)
-		obj, err = istioClient.GetServiceEntry(context.Background(), istio.BuildNameForIPServiceEntry(dynakube.GetName(), istio.OneAgentComponent))
+		obj, err = istioClient.GetServiceEntry(context.Background(), istio.BuildNameForIPServiceEntry(dk.GetName(), istio.OneAgentComponent))
 		require.NoError(t, err)
 		assert.NotNil(t, obj)
-		obj, err = istioClient.GetServiceEntry(context.Background(), istio.BuildNameForIPServiceEntry(dynakube.GetName(), istio.OneAgentComponent))
+		obj, err = istioClient.GetServiceEntry(context.Background(), istio.BuildNameForIPServiceEntry(dk.GetName(), istio.OneAgentComponent))
 		require.NoError(t, err)
 		assert.NotNil(t, obj)
 
-		virtualService, err = istioClient.GetVirtualService(context.Background(), istio.BuildNameForFQDNServiceEntry(dynakube.GetName(), istio.OneAgentComponent))
+		virtualService, err = istioClient.GetVirtualService(context.Background(), istio.BuildNameForFQDNServiceEntry(dk.GetName(), istio.OneAgentComponent))
 		require.NoError(t, err)
 		assert.NotNil(t, virtualService)
 	})
 	t.Run(`failure is logged in condition`, func(t *testing.T) {
-		dynakube := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testDynakube,
 				Namespace: testNamespaceDynatrace,
@@ -234,11 +234,11 @@ func TestReconciler(t *testing.T) {
 			},
 		})
 
-		istioClient := newIstioTestingClient(fakeistio.NewSimpleClientset(), dynakube)
+		istioClient := newIstioTestingClient(fakeistio.NewSimpleClientset(), dk)
 		fakeReconciler := createGenericReconcilerMock(t)
 		fakeVersionReconciler := createVersionReconcilerMock(t)
 
-		rec := NewReconciler(boomClient, boomClient, nil, istioClient, dynakube).(*reconciler)
+		rec := NewReconciler(boomClient, boomClient, nil, istioClient, dk).(*reconciler)
 		rec.connectionInfoReconciler = fakeReconciler
 		rec.pmcSecretreconciler = fakeReconciler
 		rec.versionReconciler = fakeVersionReconciler
@@ -246,7 +246,7 @@ func TestReconciler(t *testing.T) {
 		err := rec.Reconcile(context.Background())
 		require.Error(t, err)
 
-		condition := meta.FindStatusCondition(*dynakube.Conditions(), codeModulesInjectionConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), codeModulesInjectionConditionType)
 		require.NotNil(t, condition)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	})
@@ -257,8 +257,8 @@ func TestRemoveAppInjection(t *testing.T) {
 	rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynakube.OneAgentSpec{
 		CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 	})
-	setCodeModulesInjectionCreatedCondition(rec.dynakube.Conditions())
-	setMetadataEnrichmentCreatedCondition(rec.dynakube.Conditions())
+	setCodeModulesInjectionCreatedCondition(rec.dk.Conditions())
+	setMetadataEnrichmentCreatedCondition(rec.dk.Conditions())
 
 	err := rec.removeAppInjection(context.Background())
 	require.NoError(t, err)
@@ -358,7 +358,7 @@ func TestSetupEnrichmentInjection(t *testing.T) {
 		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynakube.OneAgentSpec{
 			CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 		})
-		rec.dynakube.Spec.MetadataEnrichment.Enabled = false
+		rec.dk.Spec.MetadataEnrichment.Enabled = false
 
 		err := rec.setupEnrichmentInjection(context.Background())
 		require.NoError(t, err)
@@ -372,7 +372,7 @@ func TestSetupEnrichmentInjection(t *testing.T) {
 		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynakube.OneAgentSpec{
 			CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 		})
-		rec.dynakube.Spec.MetadataEnrichment.Enabled = true
+		rec.dk.Spec.MetadataEnrichment.Enabled = true
 
 		err := rec.setupEnrichmentInjection(context.Background())
 		require.NoError(t, err)
@@ -393,7 +393,7 @@ func createReconciler(clt client.Client, dynakubeName string, dynakubeNamespace 
 	return reconciler{
 		client:    clt,
 		apiReader: clt,
-		dynakube: &dynakube.DynaKube{
+		dk: &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      dynakubeName,
 				Namespace: dynakubeNamespace,

--- a/pkg/controllers/dynakube/injection/reconciler_test.go
+++ b/pkg/controllers/dynakube/injection/reconciler_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
@@ -77,16 +77,16 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		}
-		dynakube := &dynatracev1beta2.DynaKube{
+		dynakube := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testDynakube,
 				Namespace: testNamespaceDynatrace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{
-						AppInjectionSpec: dynatracev1beta2.AppInjectionSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+						AppInjectionSpec: dynakube.AppInjectionSpec{
 							NamespaceSelector: metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									testNamespaceSelectorLabel: testDynakube,
@@ -95,7 +95,7 @@ func TestReconciler(t *testing.T) {
 						},
 					},
 				},
-				MetadataEnrichment: dynatracev1beta2.MetadataEnrichment{
+				MetadataEnrichment: dynakube.MetadataEnrichment{
 					Enabled: true,
 					NamespaceSelector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -143,12 +143,12 @@ func TestReconciler(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("remove injection", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
+		dynakube := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testDynakube,
 				Namespace: testNamespaceDynatrace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL:      testApiUrl,
 				EnableIstio: true,
 			},
@@ -208,16 +208,16 @@ func TestReconciler(t *testing.T) {
 		assert.NotNil(t, virtualService)
 	})
 	t.Run(`failure is logged in condition`, func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
+		dynakube := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testDynakube,
 				Namespace: testNamespaceDynatrace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{
-						AppInjectionSpec: dynatracev1beta2.AppInjectionSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+						AppInjectionSpec: dynakube.AppInjectionSpec{
 							NamespaceSelector: metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									testNamespaceSelectorLabel: testDynakube,
@@ -254,8 +254,8 @@ func TestReconciler(t *testing.T) {
 
 func TestRemoveAppInjection(t *testing.T) {
 	clt := clientRemoveAppInjection()
-	rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynatracev1beta2.OneAgentSpec{
-		CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+	rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynakube.OneAgentSpec{
+		CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 	})
 	setCodeModulesInjectionCreatedCondition(rec.dynakube.Conditions())
 	setMetadataEnrichmentCreatedCondition(rec.dynakube.Conditions())
@@ -283,8 +283,8 @@ func TestRemoveAppInjection(t *testing.T) {
 func TestSetupOneAgentInjection(t *testing.T) {
 	t.Run(`no injection - ClassicFullStack`, func(t *testing.T) {
 		clt := clientNoInjection()
-		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynatracev1beta2.OneAgentSpec{
-			ClassicFullStack: &dynatracev1beta2.HostInjectSpec{},
+		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynakube.OneAgentSpec{
+			ClassicFullStack: &dynakube.HostInjectSpec{},
 		})
 
 		err := rec.setupOneAgentInjection(context.Background())
@@ -296,8 +296,8 @@ func TestSetupOneAgentInjection(t *testing.T) {
 
 	t.Run(`no injection - HostMonitoring`, func(t *testing.T) {
 		clt := clientNoInjection()
-		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynatracev1beta2.OneAgentSpec{
-			HostMonitoring: &dynatracev1beta2.HostInjectSpec{},
+		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynakube.OneAgentSpec{
+			HostMonitoring: &dynakube.HostInjectSpec{},
 		})
 
 		err := rec.setupOneAgentInjection(context.Background())
@@ -309,8 +309,8 @@ func TestSetupOneAgentInjection(t *testing.T) {
 
 	t.Run(`injection - ApplicationMonitoring`, func(t *testing.T) {
 		clt := clientOneAgentInjection()
-		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynatracev1beta2.OneAgentSpec{
-			ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{},
+		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynakube.OneAgentSpec{
+			ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
 		})
 
 		err := rec.setupOneAgentInjection(context.Background())
@@ -331,8 +331,8 @@ func TestSetupOneAgentInjection(t *testing.T) {
 
 	t.Run(`injection - CloudNativeFullStack`, func(t *testing.T) {
 		clt := clientOneAgentInjection()
-		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynatracev1beta2.OneAgentSpec{
-			CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynakube.OneAgentSpec{
+			CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 		})
 
 		err := rec.setupOneAgentInjection(context.Background())
@@ -355,8 +355,8 @@ func TestSetupOneAgentInjection(t *testing.T) {
 func TestSetupEnrichmentInjection(t *testing.T) {
 	t.Run(`no enrichment injection`, func(t *testing.T) {
 		clt := clientNoInjection()
-		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynatracev1beta2.OneAgentSpec{
-			CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynakube.OneAgentSpec{
+			CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 		})
 		rec.dynakube.Spec.MetadataEnrichment.Enabled = false
 
@@ -369,8 +369,8 @@ func TestSetupEnrichmentInjection(t *testing.T) {
 
 	t.Run(`enrichment injection`, func(t *testing.T) {
 		clt := clientEnrichmentInjection()
-		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynatracev1beta2.OneAgentSpec{
-			CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+		rec := createReconciler(clt, testDynakube, testNamespaceDynatrace, dynakube.OneAgentSpec{
+			CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 		})
 		rec.dynakube.Spec.MetadataEnrichment.Enabled = true
 
@@ -382,23 +382,23 @@ func TestSetupEnrichmentInjection(t *testing.T) {
 	})
 }
 
-func newIstioTestingClient(fakeClient *fakeistio.Clientset, dynakube *dynatracev1beta2.DynaKube) *istio.Client {
+func newIstioTestingClient(fakeClient *fakeistio.Clientset, dk *dynakube.DynaKube) *istio.Client {
 	return &istio.Client{
 		IstioClientset: fakeClient,
-		Owner:          dynakube,
+		Owner:          dk,
 	}
 }
 
-func createReconciler(clt client.Client, dynakubeName string, dynakubeNamespace string, oneAgentSpec dynatracev1beta2.OneAgentSpec) reconciler {
+func createReconciler(clt client.Client, dynakubeName string, dynakubeNamespace string, oneAgentSpec dynakube.OneAgentSpec) reconciler {
 	return reconciler{
 		client:    clt,
 		apiReader: clt,
-		dynakube: &dynatracev1beta2.DynaKube{
+		dynakube: &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      dynakubeName,
 				Namespace: dynakubeNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL:      testApiUrl,
 				OneAgent:    oneAgentSpec,
 				EnableIstio: true,
@@ -446,16 +446,16 @@ func clientEnrichmentInjection() client.Client {
 	)
 }
 
-func setupIstioClientWithObjects(dynakube *dynatracev1beta2.DynaKube) *istio.Client {
+func setupIstioClientWithObjects(dk *dynakube.DynaKube) *istio.Client {
 	return newIstioTestingClient(fakeistio.NewSimpleClientset(
-		clientServiceEntry(istio.BuildNameForIPServiceEntry(dynakube.Name, istio.OneAgentComponent), testNamespace),
-		clientServiceEntry(istio.BuildNameForFQDNServiceEntry(dynakube.Name, istio.OneAgentComponent), testNamespace),
-		clientServiceEntry(istio.BuildNameForIPServiceEntry(dynakube.Name, istio.OneAgentComponent), testNamespace2),
-		clientServiceEntry(istio.BuildNameForFQDNServiceEntry(dynakube.Name, istio.OneAgentComponent), testNamespace2),
+		clientServiceEntry(istio.BuildNameForIPServiceEntry(dk.Name, istio.OneAgentComponent), testNamespace),
+		clientServiceEntry(istio.BuildNameForFQDNServiceEntry(dk.Name, istio.OneAgentComponent), testNamespace),
+		clientServiceEntry(istio.BuildNameForIPServiceEntry(dk.Name, istio.OneAgentComponent), testNamespace2),
+		clientServiceEntry(istio.BuildNameForFQDNServiceEntry(dk.Name, istio.OneAgentComponent), testNamespace2),
 
-		clientVirtualService(istio.BuildNameForFQDNServiceEntry(dynakube.Name, istio.OneAgentComponent), testNamespace),
-		clientVirtualService(istio.BuildNameForFQDNServiceEntry(dynakube.Name, istio.OneAgentComponent), testNamespace2),
-	), dynakube)
+		clientVirtualService(istio.BuildNameForFQDNServiceEntry(dk.Name, istio.OneAgentComponent), testNamespace),
+		clientVirtualService(istio.BuildNameForFQDNServiceEntry(dk.Name, istio.OneAgentComponent), testNamespace2),
+	), dk)
 }
 
 func clientInjectedNamespace(namespaceName string, dynakubeName string) *corev1.Namespace {

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"strings"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/activegate"
 	oaconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
@@ -19,9 +19,9 @@ import (
 )
 
 type Reconciler interface {
-	ReconcileAPIUrl(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error
-	ReconcileCodeModuleCommunicationHosts(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error
-	ReconcileActiveGateCommunicationHosts(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error
+	ReconcileAPIUrl(ctx context.Context, dk *dynakube.DynaKube) error
+	ReconcileCodeModuleCommunicationHosts(ctx context.Context, dk *dynakube.DynaKube) error
+	ReconcileActiveGateCommunicationHosts(ctx context.Context, dk *dynakube.DynaKube) error
 }
 
 type reconciler struct {
@@ -38,7 +38,7 @@ func NewReconciler(istio *Client) Reconciler {
 	}
 }
 
-func (r *reconciler) ReconcileAPIUrl(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error {
+func (r *reconciler) ReconcileAPIUrl(ctx context.Context, dynakube *dynakube.DynaKube) error {
 	log.Info("reconciling istio components for the Dynatrace API url")
 
 	if dynakube == nil {
@@ -60,7 +60,7 @@ func (r *reconciler) ReconcileAPIUrl(ctx context.Context, dynakube *dynatracev1b
 	return nil
 }
 
-func (r *reconciler) ReconcileCodeModuleCommunicationHosts(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error {
+func (r *reconciler) ReconcileCodeModuleCommunicationHosts(ctx context.Context, dynakube *dynakube.DynaKube) error {
 	log.Info("reconciling istio components for oneagent-code-modules communication hosts")
 
 	if dynakube == nil {
@@ -97,7 +97,7 @@ func (r *reconciler) ReconcileCodeModuleCommunicationHosts(ctx context.Context, 
 	return nil
 }
 
-func (r *reconciler) ReconcileActiveGateCommunicationHosts(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error {
+func (r *reconciler) ReconcileActiveGateCommunicationHosts(ctx context.Context, dynakube *dynakube.DynaKube) error {
 	log.Info("reconciling istio components for activegate communication hosts")
 
 	if dynakube == nil {
@@ -140,7 +140,7 @@ func (r *reconciler) ReconcileActiveGateCommunicationHosts(ctx context.Context, 
 	return nil
 }
 
-func (r *reconciler) CleanupIstio(ctx context.Context, dynakube *dynatracev1beta2.DynaKube, conditionComponent string, component string) error {
+func (r *reconciler) CleanupIstio(ctx context.Context, dynakube *dynakube.DynaKube, conditionComponent string, component string) error {
 	meta.RemoveStatusCondition(dynakube.Conditions(), getConditionTypeName(conditionComponent))
 
 	err1 := r.cleanupIPServiceEntry(ctx, component)
@@ -150,7 +150,7 @@ func (r *reconciler) CleanupIstio(ctx context.Context, dynakube *dynatracev1beta
 	return goerrors.Join(err1, err2)
 }
 
-func isIstioConfigured(dynakube *dynatracev1beta2.DynaKube, conditionComponent string) bool {
+func isIstioConfigured(dynakube *dynakube.DynaKube, conditionComponent string) bool {
 	istioCondition := meta.FindStatusCondition(*dynakube.Conditions(), getConditionTypeName(conditionComponent))
 
 	return istioCondition != nil

--- a/pkg/controllers/dynakube/metadata/rules/reconciler.go
+++ b/pkg/controllers/dynakube/metadata/rules/reconciler.go
@@ -18,12 +18,12 @@ type Reconciler struct {
 	timeProvider *timeprovider.Provider
 }
 
-type ReconcilerBuilder func(dtc dtclient.Client, dynakube *dynakube.DynaKube) controllers.Reconciler
+type ReconcilerBuilder func(dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Reconciler
 
-func NewReconciler(dtc dtclient.Client, dynakube *dynakube.DynaKube) controllers.Reconciler {
+func NewReconciler(dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Reconciler {
 	return &Reconciler{
 		dtc:          dtc,
-		dk:           dynakube,
+		dk:           dk,
 		timeProvider: timeprovider.New(),
 	}
 }

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -41,7 +41,7 @@ func TestArguments(t *testing.T) {
 		assert.Equal(t, expectedDefaultArguments, arguments)
 	})
 	t.Run("classic fullstack", func(t *testing.T) {
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testURL,
 				OneAgent: dynakube.OneAgentSpec{
@@ -53,8 +53,8 @@ func TestArguments(t *testing.T) {
 		}
 		dsBuilder := classicFullStack{
 			builder{
-				dk:             &instance,
-				hostInjectSpec: instance.Spec.OneAgent.ClassicFullStack,
+				dk:             &dk,
+				hostInjectSpec: dk.Spec.OneAgent.ClassicFullStack,
 				clusterID:      testClusterID,
 			},
 		}
@@ -160,7 +160,7 @@ func TestArguments(t *testing.T) {
 }
 
 func TestPodSpec_Arguments(t *testing.T) {
-	instance := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		Spec: dynakube.DynaKubeSpec{
 			OneAgent: dynakube.OneAgentSpec{
 				ClassicFullStack: &dynakube.HostInjectSpec{
@@ -169,17 +169,17 @@ func TestPodSpec_Arguments(t *testing.T) {
 			},
 		},
 	}
-	hostInjectSpecs := instance.Spec.OneAgent.ClassicFullStack
+	hostInjectSpecs := dk.Spec.OneAgent.ClassicFullStack
 	dsBuilder := classicFullStack{
 		builder{
-			dk:             instance,
+			dk:             dk,
 			hostInjectSpec: hostInjectSpecs,
 			clusterID:      testClusterID,
 			deploymentType: deploymentmetadata.ClassicFullStackDeploymentType,
 		},
 	}
 
-	instance.Annotations = map[string]string{}
+	dk.Annotations = map[string]string{}
 	podSpecs, _ := dsBuilder.podSpec()
 	require.NotNil(t, podSpecs)
 	require.NotEmpty(t, podSpecs.Containers)
@@ -192,29 +192,29 @@ func TestPodSpec_Arguments(t *testing.T) {
 
 	// deprecated
 	t.Run(`has proxy arg`, func(t *testing.T) {
-		instance.Status.OneAgent.Version = "1.272.0.0-0"
-		instance.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
+		dk.Status.OneAgent.Version = "1.272.0.0-0"
+		dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
 		podSpecs, _ = dsBuilder.podSpec()
 		assert.Contains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
 
-		instance.Spec.Proxy = nil
-		instance.Status.OneAgent.Version = ""
+		dk.Spec.Proxy = nil
+		dk.Status.OneAgent.Version = ""
 		podSpecs, _ = dsBuilder.podSpec()
 		assert.NotContains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
 	})
 	// deprecated
 	t.Run(`has proxy arg but feature flag to ignore is enabled`, func(t *testing.T) {
-		instance.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
-		instance.Annotations[dynakube.AnnotationFeatureOneAgentIgnoreProxy] = "true"
+		dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: testValue}
+		dk.Annotations[dynakube.AnnotationFeatureOneAgentIgnoreProxy] = "true"
 		podSpecs, _ = dsBuilder.podSpec()
 		assert.NotContains(t, podSpecs.Containers[0].Args, "--set-proxy=$(https_proxy)")
 	})
 	t.Run(`has network zone arg`, func(t *testing.T) {
-		instance.Spec.NetworkZone = testValue
+		dk.Spec.NetworkZone = testValue
 		podSpecs, _ = dsBuilder.podSpec()
 		assert.Contains(t, podSpecs.Containers[0].Args, "--set-network-zone="+testValue)
 
-		instance.Spec.NetworkZone = ""
+		dk.Spec.NetworkZone = ""
 		podSpecs, _ = dsBuilder.podSpec()
 		assert.NotContains(t, podSpecs.Containers[0].Args, "--set-network-zone="+testValue)
 	})

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -68,33 +68,33 @@ type Builder interface {
 	BuildDaemonSet() (*appsv1.DaemonSet, error)
 }
 
-func NewHostMonitoring(instance *dynakube.DynaKube, clusterId string) Builder {
+func NewHostMonitoring(dk *dynakube.DynaKube, clusterId string) Builder {
 	return &hostMonitoring{
 		builder{
-			dk:             instance,
-			hostInjectSpec: instance.Spec.OneAgent.HostMonitoring,
+			dk:             dk,
+			hostInjectSpec: dk.Spec.OneAgent.HostMonitoring,
 			clusterID:      clusterId,
 			deploymentType: deploymentmetadata.HostMonitoringDeploymentType,
 		},
 	}
 }
 
-func NewCloudNativeFullStack(instance *dynakube.DynaKube, clusterId string) Builder {
+func NewCloudNativeFullStack(dk *dynakube.DynaKube, clusterId string) Builder {
 	return &hostMonitoring{
 		builder{
-			dk:             instance,
-			hostInjectSpec: &instance.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec,
+			dk:             dk,
+			hostInjectSpec: &dk.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec,
 			clusterID:      clusterId,
 			deploymentType: deploymentmetadata.CloudNativeDeploymentType,
 		},
 	}
 }
 
-func NewClassicFullStack(instance *dynakube.DynaKube, clusterId string) Builder {
+func NewClassicFullStack(dk *dynakube.DynaKube, clusterId string) Builder {
 	return &classicFullStack{
 		builder{
-			dk:             instance,
-			hostInjectSpec: instance.Spec.OneAgent.ClassicFullStack,
+			dk:             dk,
+			hostInjectSpec: dk.Spec.OneAgent.ClassicFullStack,
 			clusterID:      clusterId,
 			deploymentType: deploymentmetadata.ClassicFullStackDeploymentType,
 		},

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -27,7 +27,7 @@ const (
 func TestUseImmutableImage(t *testing.T) {
 	t.Run(`use image from status`, func(t *testing.T) {
 		imageID := "my.repo.com/image:my-tag"
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testURL,
 				OneAgent: dynakube.OneAgentSpec{
@@ -42,7 +42,7 @@ func TestUseImmutableImage(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewClassicFullStack(&instance, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -56,7 +56,7 @@ func TestLabels(t *testing.T) {
 	feature := strings.ReplaceAll(deploymentmetadata.ClassicFullStackDeploymentType, "_", "")
 
 	t.Run("use version when set", func(t *testing.T) {
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testURL,
 				OneAgent: dynakube.OneAgentSpec{
@@ -73,17 +73,17 @@ func TestLabels(t *testing.T) {
 		}
 		expectedLabels := map[string]string{
 			labels.AppNameLabel:      labels.OneAgentComponentLabel,
-			labels.AppCreatedByLabel: instance.Name,
+			labels.AppCreatedByLabel: dk.Name,
 			labels.AppComponentLabel: feature,
 			labels.AppVersionLabel:   testImageTag,
 			labels.AppManagedByLabel: version.AppName,
 		}
 		expectedMatchLabels := map[string]string{
 			labels.AppNameLabel:      labels.OneAgentComponentLabel,
-			labels.AppCreatedByLabel: instance.Name,
+			labels.AppCreatedByLabel: dk.Name,
 			labels.AppManagedByLabel: version.AppName,
 		}
-		dsBuilder := NewClassicFullStack(&instance, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -94,7 +94,7 @@ func TestLabels(t *testing.T) {
 		assert.Equal(t, expectedLabels, ds.Spec.Template.Labels)
 	})
 	t.Run("if no version is set, no version label", func(t *testing.T) {
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testURL,
 				OneAgent: dynakube.OneAgentSpec{
@@ -105,18 +105,18 @@ func TestLabels(t *testing.T) {
 
 		expectedLabels := map[string]string{
 			labels.AppNameLabel:      labels.OneAgentComponentLabel,
-			labels.AppCreatedByLabel: instance.Name,
+			labels.AppCreatedByLabel: dk.Name,
 			labels.AppVersionLabel:   "",
 			labels.AppComponentLabel: feature,
 			labels.AppManagedByLabel: version.AppName,
 		}
 		expectedMatchLabels := map[string]string{
 			labels.AppNameLabel:      labels.OneAgentComponentLabel,
-			labels.AppCreatedByLabel: instance.Name,
+			labels.AppCreatedByLabel: dk.Name,
 			labels.AppManagedByLabel: version.AppName,
 		}
 
-		dsBuilder := NewClassicFullStack(&instance, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -129,7 +129,7 @@ func TestLabels(t *testing.T) {
 }
 
 func TestCustomPullSecret(t *testing.T) {
-	instance := dynakube.DynaKube{
+	dk := dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testDynakubeName,
 		},
@@ -141,7 +141,7 @@ func TestCustomPullSecret(t *testing.T) {
 			CustomPullSecret: testName,
 		},
 	}
-	dsBuilder := NewClassicFullStack(&instance, testClusterID)
+	dsBuilder := NewClassicFullStack(&dk, testClusterID)
 	ds, err := dsBuilder.BuildDaemonSet()
 	require.NoError(t, err)
 
@@ -154,7 +154,7 @@ func TestCustomPullSecret(t *testing.T) {
 
 func TestResources(t *testing.T) {
 	t.Run(`minimal cpu request of 100mC is set if no resources specified`, func(t *testing.T) {
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testURL,
 				OneAgent: dynakube.OneAgentSpec{
@@ -162,7 +162,7 @@ func TestResources(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewClassicFullStack(&instance, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -179,7 +179,7 @@ func TestResources(t *testing.T) {
 		memoryRequest := resource.NewScaledQuantity(1, 3)
 		memoryLimit := resource.NewScaledQuantity(2, 3)
 
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testURL,
 				OneAgent: dynakube.OneAgentSpec{
@@ -199,7 +199,7 @@ func TestResources(t *testing.T) {
 			},
 		}
 
-		dsBuilder := NewClassicFullStack(&instance, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -253,7 +253,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		assert.Equal(t, defaultSecurityContextCapabilities(), securityContext.Capabilities)
 	})
 	t.Run(`User and group id set when read only mode is enabled`, func(t *testing.T) {
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testURL,
 				OneAgent: dynakube.OneAgentSpec{
@@ -261,7 +261,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewHostMonitoring(&instance, testClusterID)
+		dsBuilder := NewHostMonitoring(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -280,7 +280,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 	})
 
 	t.Run("old version does not have ReadOnlyRootFilesystem", func(t *testing.T) {
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testURL,
 				OneAgent: dynakube.OneAgentSpec{
@@ -295,7 +295,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewHostMonitoring(&instance, testClusterID)
+		dsBuilder := NewHostMonitoring(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -309,7 +309,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 	})
 
 	t.Run("newer version has ReadOnlyRootFilesystem", func(t *testing.T) {
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testURL,
 				OneAgent: dynakube.OneAgentSpec{
@@ -324,7 +324,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewHostMonitoring(&instance, testClusterID)
+		dsBuilder := NewHostMonitoring(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -338,7 +338,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 	})
 
 	t.Run(`privileged security context when feature flag is enabled`, func(t *testing.T) {
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					dynakube.AnnotationFeatureRunOneAgentContainerPrivileged: "true",
@@ -351,7 +351,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewHostMonitoring(&instance, testClusterID)
+		dsBuilder := NewHostMonitoring(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -369,7 +369,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 	})
 
 	t.Run(`privileged security context when feature flag is enabled for classic fullstack`, func(t *testing.T) {
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					dynakube.AnnotationFeatureRunOneAgentContainerPrivileged: "true",
@@ -382,7 +382,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewClassicFullStack(&instance, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -401,7 +401,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 
 	t.Run(`localhost seccomp profile when feature flag is enabled`, func(t *testing.T) {
 		customSecCompProfile := "seccomp.json"
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{},
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testURL,
@@ -412,7 +412,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewClassicFullStack(&instance, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -432,7 +432,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 
 	t.Run(`localhost seccomp profile disabled if privileged security context enabled`, func(t *testing.T) {
 		customSecCompProfile := "seccomp.json"
-		instance := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					dynakube.AnnotationFeatureRunOneAgentContainerPrivileged: "true",
@@ -447,7 +447,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewClassicFullStack(&instance, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 

--- a/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
@@ -2,7 +2,7 @@ package daemonset
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
@@ -111,7 +111,7 @@ func (b *builder) addProxyEnv(envVarMap *prioritymap.Map) {
 		addDefaultValueSource(envVarMap, proxyEnv, &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: b.dk.Spec.Proxy.ValueFrom},
-				Key:                  dynatracev1beta2.ProxyKey,
+				Key:                  dynakube.ProxyKey,
 			},
 		})
 	} else {

--- a/pkg/controllers/dynakube/oneagent/daemonset/env_vars_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/env_vars_test.go
@@ -167,11 +167,11 @@ func TestAddConnectionInfoEnvs(t *testing.T) {
 	})
 }
 
-func assertConnectionInfoEnv(t *testing.T, envs []corev1.EnvVar, dynakube *dynakube.DynaKube) {
+func assertConnectionInfoEnv(t *testing.T, envs []corev1.EnvVar, dk *dynakube.DynaKube) {
 	env := k8senv.FindEnvVar(envs, connectioninfo.EnvDtTenant)
 	assert.Equal(t, connectioninfo.EnvDtTenant, env.Name)
 	assert.Equal(t,
-		dynakube.OneAgentConnectionInfoConfigMapName(),
+		dk.OneAgentConnectionInfoConfigMapName(),
 		env.ValueFrom.ConfigMapKeyRef.Name,
 	)
 	assert.Equal(t,
@@ -182,7 +182,7 @@ func assertConnectionInfoEnv(t *testing.T, envs []corev1.EnvVar, dynakube *dynak
 	env = k8senv.FindEnvVar(envs, connectioninfo.EnvDtServer)
 	assert.Equal(t, connectioninfo.EnvDtServer, env.Name)
 	assert.Equal(t,
-		dynakube.OneAgentConnectionInfoConfigMapName(),
+		dk.OneAgentConnectionInfoConfigMapName(),
 		env.ValueFrom.ConfigMapKeyRef.Name,
 	)
 	assert.Equal(t,
@@ -235,13 +235,13 @@ func TestAddProxyEnvs(t *testing.T) {
 }
 
 // deprecated
-func assertProxyEnv(t *testing.T, envs []corev1.EnvVar, dynakube *dynakube.DynaKube) {
+func assertProxyEnv(t *testing.T, envs []corev1.EnvVar, dk *dynakube.DynaKube) {
 	env := k8senv.FindEnvVar(envs, proxyEnv)
 	assert.Equal(t, proxyEnv, env.Name)
-	assert.Equal(t, dynakube.Spec.Proxy.Value, env.Value)
+	assert.Equal(t, dk.Spec.Proxy.Value, env.Value)
 
-	if dynakube.Spec.Proxy.ValueFrom != "" {
-		assert.Equal(t, dynakube.Spec.Proxy.ValueFrom, env.ValueFrom.SecretKeyRef.LocalObjectReference.Name)
+	if dk.Spec.Proxy.ValueFrom != "" {
+		assert.Equal(t, dk.Spec.Proxy.ValueFrom, env.ValueFrom.SecretKeyRef.LocalObjectReference.Name)
 		assert.Equal(t, "proxy", env.ValueFrom.SecretKeyRef.Key)
 	}
 }

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -1,7 +1,7 @@
 package daemonset
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver/volumes"
 	hostvolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver/volumes/host"
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func prepareVolumeMounts(instance *dynatracev1beta2.DynaKube) []corev1.VolumeMount {
+func prepareVolumeMounts(instance *dynakube.DynaKube) []corev1.VolumeMount {
 	var volumeMounts []corev1.VolumeMount
 
 	volumeMounts = append(volumeMounts, getOneAgentSecretVolumeMount())
@@ -85,7 +85,7 @@ func getHttpProxyMount() corev1.VolumeMount {
 	return proxy.BuildVolumeMount()
 }
 
-func prepareVolumes(instance *dynatracev1beta2.DynaKube) []corev1.Volume {
+func prepareVolumes(instance *dynakube.DynaKube) []corev1.Volume {
 	volumes := []corev1.Volume{getRootVolume()}
 
 	if instance == nil {
@@ -113,7 +113,7 @@ func prepareVolumes(instance *dynatracev1beta2.DynaKube) []corev1.Volume {
 	return volumes
 }
 
-func getCertificateVolume(instance *dynatracev1beta2.DynaKube) corev1.Volume {
+func getCertificateVolume(instance *dynakube.DynaKube) corev1.Volume {
 	return corev1.Volume{
 		Name: clusterCaCertVolumeName,
 		VolumeSource: corev1.VolumeSource{
@@ -132,7 +132,7 @@ func getCertificateVolume(instance *dynatracev1beta2.DynaKube) corev1.Volume {
 	}
 }
 
-func getCSIStorageVolume(instance *dynatracev1beta2.DynaKube) corev1.Volume {
+func getCSIStorageVolume(instance *dynakube.DynaKube) corev1.Volume {
 	return corev1.Volume{
 		Name: csiStorageVolumeName,
 		VolumeSource: corev1.VolumeSource{
@@ -147,7 +147,7 @@ func getCSIStorageVolume(instance *dynatracev1beta2.DynaKube) corev1.Volume {
 	}
 }
 
-func getActiveGateCaCertVolume(instance *dynatracev1beta2.DynaKube) corev1.Volume {
+func getActiveGateCaCertVolume(instance *dynakube.DynaKube) corev1.Volume {
 	return corev1.Volume{
 		Name: activeGateCaCertVolumeName,
 		VolumeSource: corev1.VolumeSource{
@@ -164,7 +164,7 @@ func getActiveGateCaCertVolume(instance *dynatracev1beta2.DynaKube) corev1.Volum
 	}
 }
 
-func buildHttpProxyVolume(instance *dynatracev1beta2.DynaKube) corev1.Volume {
+func buildHttpProxyVolume(instance *dynakube.DynaKube) corev1.Volume {
 	return corev1.Volume{
 		Name: proxy.SecretVolumeName,
 		VolumeSource: corev1.VolumeSource{
@@ -175,7 +175,7 @@ func buildHttpProxyVolume(instance *dynatracev1beta2.DynaKube) corev1.Volume {
 	}
 }
 
-func getOneAgentSecretVolume(instance *dynatracev1beta2.DynaKube) corev1.Volume {
+func getOneAgentSecretVolume(instance *dynakube.DynaKube) corev1.Volume {
 	return corev1.Volume{
 		Name: connectioninfo.TenantSecretVolumeName,
 		VolumeSource: corev1.VolumeSource{

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -11,36 +11,36 @@ import (
 )
 
 func TestPrepareVolumes(t *testing.T) {
-	t.Run("has defaults if instance is nil", func(t *testing.T) {
+	t.Run("has defaults if dk is nil", func(t *testing.T) {
 		volumes := prepareVolumes(nil)
 
 		assert.Contains(t, volumes, getRootVolume())
 	})
 	t.Run(`has root volume`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				OneAgent: dynakube.OneAgentSpec{
 					HostMonitoring: &dynakube.HostInjectSpec{},
 				},
 			},
 		}
-		volumes := prepareVolumes(instance)
+		volumes := prepareVolumes(dk)
 
 		assert.Contains(t, volumes, getRootVolume())
-		assert.NotContains(t, volumes, getCertificateVolume(instance))
+		assert.NotContains(t, volumes, getCertificateVolume(dk))
 	})
 	t.Run(`has tenant secret volume`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: corev1.ObjectMeta{
 				Name: testName,
 			},
 		}
-		volumes := prepareVolumes(instance)
+		volumes := prepareVolumes(dk)
 
-		assert.Contains(t, volumes, getOneAgentSecretVolume(instance))
+		assert.Contains(t, volumes, getOneAgentSecretVolume(dk))
 	})
 	t.Run(`has certificate volume`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				TrustedCAs: testName,
 				OneAgent: dynakube.OneAgentSpec{
@@ -48,25 +48,25 @@ func TestPrepareVolumes(t *testing.T) {
 				},
 			},
 		}
-		volumes := prepareVolumes(instance)
+		volumes := prepareVolumes(dk)
 
 		assert.Contains(t, volumes, getRootVolume())
-		assert.Contains(t, volumes, getCertificateVolume(instance))
+		assert.Contains(t, volumes, getCertificateVolume(dk))
 	})
 	t.Run(`has http_proxy volume`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{}
-		instance.Spec =
+		dk := &dynakube.DynaKube{}
+		dk.Spec =
 			dynakube.DynaKubeSpec{
-				Proxy: &dynakube.DynaKubeProxy{ValueFrom: proxy.BuildSecretName(instance.Name)},
+				Proxy: &dynakube.DynaKubeProxy{ValueFrom: proxy.BuildSecretName(dk.Name)},
 			}
 
-		volumes := prepareVolumes(instance)
+		volumes := prepareVolumes(dk)
 
 		assert.Contains(t, volumes, getRootVolume())
-		assert.Contains(t, volumes, buildHttpProxyVolume(instance))
+		assert.Contains(t, volumes, buildHttpProxyVolume(dk))
 	})
 	t.Run(`has tls volume`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				TrustedCAs: testName,
 				ActiveGate: dynakube.ActiveGateSpec{
@@ -80,22 +80,22 @@ func TestPrepareVolumes(t *testing.T) {
 				},
 			},
 		}
-		volumes := prepareVolumes(instance)
-		assert.Contains(t, volumes, getActiveGateCaCertVolume(instance))
+		volumes := prepareVolumes(dk)
+		assert.Contains(t, volumes, getActiveGateCaCertVolume(dk))
 	})
 	t.Run(`csi volume not supported on classicFullStack`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				OneAgent: dynakube.OneAgentSpec{
 					ClassicFullStack: &dynakube.HostInjectSpec{},
 				},
 			},
 		}
-		volumes := prepareVolumes(instance)
-		assert.NotContains(t, volumes, getCSIStorageVolume(instance))
+		volumes := prepareVolumes(dk)
+		assert.NotContains(t, volumes, getCSIStorageVolume(dk))
 	})
 	t.Run(`has all volumes`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				TrustedCAs: testName,
 				OneAgent: dynakube.OneAgentSpec{
@@ -111,8 +111,8 @@ func TestPrepareVolumes(t *testing.T) {
 		}
 		dsBuilder := hostMonitoring{
 			builder{
-				dk:             instance,
-				hostInjectSpec: instance.Spec.OneAgent.HostMonitoring,
+				dk:             dk,
+				hostInjectSpec: dk.Spec.OneAgent.HostMonitoring,
 				clusterID:      "",
 			},
 		}
@@ -122,33 +122,33 @@ func TestPrepareVolumes(t *testing.T) {
 		volumes := ds.Spec.Template.Spec.Volumes
 
 		assert.Contains(t, volumes, getRootVolume())
-		assert.Contains(t, volumes, getCertificateVolume(instance))
-		assert.Contains(t, volumes, getActiveGateCaCertVolume(instance))
-		assert.Contains(t, volumes, getCSIStorageVolume(instance))
+		assert.Contains(t, volumes, getCertificateVolume(dk))
+		assert.Contains(t, volumes, getActiveGateCaCertVolume(dk))
+		assert.Contains(t, volumes, getCSIStorageVolume(dk))
 	})
 }
 
 func TestPrepareVolumeMounts(t *testing.T) {
-	t.Run("has defaults if instance is nil", func(t *testing.T) {
+	t.Run("has defaults if dk is nil", func(t *testing.T) {
 		volumeMounts := prepareVolumeMounts(nil)
 
 		assert.Contains(t, volumeMounts, getRootMount())
 	})
 	t.Run(`has root volume mount`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				OneAgent: dynakube.OneAgentSpec{
 					HostMonitoring: &dynakube.HostInjectSpec{},
 				},
 			},
 		}
-		volumeMounts := prepareVolumeMounts(instance)
+		volumeMounts := prepareVolumeMounts(dk)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
 		assert.NotContains(t, volumeMounts, getActiveGateCaCertVolumeMount())
 	})
 	t.Run(`has cluster certificate volume mount`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				OneAgent: dynakube.OneAgentSpec{
 					HostMonitoring: &dynakube.HostInjectSpec{},
@@ -156,14 +156,14 @@ func TestPrepareVolumeMounts(t *testing.T) {
 				TrustedCAs: testName,
 			},
 		}
-		volumeMounts := prepareVolumeMounts(instance)
+		volumeMounts := prepareVolumeMounts(dk)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
 		assert.Contains(t, volumeMounts, getClusterCaCertVolumeMount())
 		assert.NotContains(t, volumeMounts, getActiveGateCaCertVolumeMount())
 	})
 	t.Run(`has ActiveGate CA volume mount`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				OneAgent: dynakube.OneAgentSpec{
 					HostMonitoring: &dynakube.HostInjectSpec{},
@@ -178,26 +178,26 @@ func TestPrepareVolumeMounts(t *testing.T) {
 			},
 		}
 
-		volumeMounts := prepareVolumeMounts(instance)
+		volumeMounts := prepareVolumeMounts(dk)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
 		assert.Contains(t, volumeMounts, getActiveGateCaCertVolumeMount())
 	})
 	t.Run(`readonly volume not supported on classicFullStack`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				OneAgent: dynakube.OneAgentSpec{
 					ClassicFullStack: &dynakube.HostInjectSpec{},
 				},
 			},
 		}
-		volumeMounts := prepareVolumeMounts(instance)
+		volumeMounts := prepareVolumeMounts(dk)
 
 		assert.Contains(t, volumeMounts, getRootMount())
 		assert.NotContains(t, volumeMounts, getCSIStorageMount())
 	})
 	t.Run(`has all volume mounts`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				TrustedCAs: testName,
 				OneAgent: dynakube.OneAgentSpec{
@@ -213,8 +213,8 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		}
 		dsBuilder := hostMonitoring{
 			builder{
-				dk:             instance,
-				hostInjectSpec: instance.Spec.OneAgent.HostMonitoring,
+				dk:             dk,
+				hostInjectSpec: dk.Spec.OneAgent.HostMonitoring,
 				clusterID:      "",
 			},
 		}
@@ -228,7 +228,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		assert.Contains(t, volumeMounts, getCSIStorageMount())
 	})
 	t.Run(`has no volume if proxy is set and proxy ignore feature-flags is used`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: corev1.ObjectMeta{
 				Name:      "Dynakube",
 				Namespace: "dynatrace",
@@ -244,10 +244,10 @@ func TestPrepareVolumeMounts(t *testing.T) {
 			},
 		}
 
-		volumes := prepareVolumes(instance)
-		mounts := prepareVolumeMounts(instance)
+		volumes := prepareVolumes(dk)
+		mounts := prepareVolumeMounts(dk)
 
-		assert.NotContains(t, volumes, buildHttpProxyVolume(instance))
+		assert.NotContains(t, volumes, buildHttpProxyVolume(dk))
 		assert.NotContains(t, mounts, getHttpProxyMount())
 	})
 }

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -58,7 +58,7 @@ func TestReconcile(t *testing.T) {
 		reconciler := &Reconciler{
 			client:                   fakeClient,
 			apiReader:                fakeClient,
-			dynakube:                 dk,
+			dk:                       dk,
 			versionReconciler:        createVersionReconcilerMock(t),
 			connectionInfoReconciler: createConnectionInfoReconcilerMock(t),
 			tokens:                   createTokens(),
@@ -84,7 +84,7 @@ func TestReconcile(t *testing.T) {
 		reconciler := &Reconciler{
 			client:                   fakeClient,
 			apiReader:                fakeClient,
-			dynakube:                 dk,
+			dk:                       dk,
 			versionReconciler:        createVersionReconcilerMock(t),
 			connectionInfoReconciler: createConnectionInfoReconcilerMock(t),
 		}
@@ -107,7 +107,7 @@ func TestReconcile(t *testing.T) {
 		reconciler := &Reconciler{
 			client:                   fakeClient,
 			apiReader:                fakeClient,
-			dynakube:                 dk,
+			dk:                       dk,
 			versionReconciler:        createVersionReconcilerMock(t),
 			connectionInfoReconciler: createConnectionInfoReconcilerMock(t),
 		}
@@ -136,7 +136,7 @@ func TestReconcile(t *testing.T) {
 		reconciler := &Reconciler{
 			client:                   fakeClient,
 			apiReader:                fakeClient,
-			dynakube:                 &dk,
+			dk:                       &dk,
 			connectionInfoReconciler: connectionInfoReconciler,
 			versionReconciler:        createVersionReconcilerMock(t),
 		}
@@ -165,7 +165,7 @@ func TestReconcile(t *testing.T) {
 		reconciler := &Reconciler{
 			client:                   fakeClient,
 			apiReader:                fakeClient,
-			dynakube:                 &dk,
+			dk:                       &dk,
 			connectionInfoReconciler: controllermock.NewReconciler(t),
 			versionReconciler:        versionReconciler,
 		}
@@ -214,7 +214,7 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironmentAndDNSPolicy(t *testing.T)
 	reconciler := &Reconciler{
 		client:                   fakeClient,
 		apiReader:                fakeClient,
-		dynakube:                 dk,
+		dk:                       dk,
 		connectionInfoReconciler: createConnectionInfoReconcilerMock(t),
 		versionReconciler:        createVersionReconcilerMock(t),
 		tokens:                   createTokens(),
@@ -283,7 +283,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 
 	t.Run("Status.OneAgent.Instances set, if autoUpdate is true", func(t *testing.T) {
 		dk := base.DeepCopy()
-		reconciler.dynakube = dk
+		reconciler.dk = dk
 		reconciler.connectionInfoReconciler = createConnectionInfoReconcilerMock(t)
 		reconciler.versionReconciler = createVersionReconcilerMock(t)
 		reconciler.tokens = createTokens()
@@ -315,7 +315,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 	t.Run("Status.OneAgent.Instances set, if autoUpdate is false", func(t *testing.T) {
 		dk := base.DeepCopy()
 		autoUpdate := false
-		reconciler.dynakube = dk
+		reconciler.dk = dk
 		reconciler.connectionInfoReconciler = createConnectionInfoReconcilerMock(t)
 		reconciler.versionReconciler = createVersionReconcilerMock(t)
 		reconciler.tokens = createTokens()
@@ -744,7 +744,7 @@ func TestReconcile_OneAgentConfigMap(t *testing.T) {
 
 	t.Run(`create OneAgent connection info ConfigMap`, func(t *testing.T) {
 		reconciler := Reconciler{
-			dynakube:                 dk,
+			dk:                       dk,
 			client:                   fakeClient,
 			apiReader:                fakeClient,
 			versionReconciler:        createVersionReconcilerMock(t),

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -618,7 +618,7 @@ func TestInstanceStatus(t *testing.T) {
 	namespace := "dynatrace"
 	dkName := "dynakube"
 
-	dynakube := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{Name: dkName, Namespace: namespace},
 		Spec: dynakube.DynaKubeSpec{
 			APIURL: "https://ENVIRONMENTID.live.dynatrace.com/api",
@@ -650,7 +650,7 @@ func TestInstanceStatus(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClient(
-		dynakube,
+		dk,
 		pod)
 
 	reconciler := &Reconciler{
@@ -658,21 +658,21 @@ func TestInstanceStatus(t *testing.T) {
 		apiReader: fakeClient,
 	}
 
-	err := reconciler.reconcileInstanceStatuses(context.Background(), dynakube)
+	err := reconciler.reconcileInstanceStatuses(context.Background(), dk)
 	require.NoError(t, err)
-	assert.NotEmpty(t, t, dynakube.Status.OneAgent.Instances)
-	instances := dynakube.Status.OneAgent.Instances
+	assert.NotEmpty(t, t, dk.Status.OneAgent.Instances)
+	instances := dk.Status.OneAgent.Instances
 
-	err = reconciler.reconcileInstanceStatuses(context.Background(), dynakube)
+	err = reconciler.reconcileInstanceStatuses(context.Background(), dk)
 	require.NoError(t, err)
-	assert.Equal(t, instances, dynakube.Status.OneAgent.Instances)
+	assert.Equal(t, instances, dk.Status.OneAgent.Instances)
 }
 
 func TestEmptyInstancesWithWrongLabels(t *testing.T) {
 	namespace := "dynatrace"
 	dkName := "dynakube"
 
-	dynakube := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{Name: dkName, Namespace: namespace},
 		Spec: dynakube.DynaKubeSpec{
 			APIURL: "https://ENVIRONMENTID.live.dynatrace.com/api",
@@ -700,7 +700,7 @@ func TestEmptyInstancesWithWrongLabels(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClient(
-		dynakube,
+		dk,
 		pod)
 
 	reconciler := &Reconciler{
@@ -708,9 +708,9 @@ func TestEmptyInstancesWithWrongLabels(t *testing.T) {
 		apiReader: fakeClient,
 	}
 
-	err := reconciler.reconcileInstanceStatuses(context.Background(), dynakube)
+	err := reconciler.reconcileInstanceStatuses(context.Background(), dk)
 	require.NoError(t, err)
-	assert.Empty(t, dynakube.Status.OneAgent.Instances)
+	assert.Empty(t, dk.Status.OneAgent.Instances)
 }
 
 func TestReconcile_OneAgentConfigMap(t *testing.T) {

--- a/pkg/controllers/dynakube/phase.go
+++ b/pkg/controllers/dynakube/phase.go
@@ -4,14 +4,14 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (controller *Controller) determineDynaKubePhase(dynakube *dynatracev1beta2.DynaKube) status.DeploymentPhase {
+func (controller *Controller) determineDynaKubePhase(dynakube *dynakube.DynaKube) status.DeploymentPhase {
 	if dynakube.NeedsActiveGate() {
 		activeGatePods, err := controller.numberOfMissingActiveGatePods(dynakube)
 		if err != nil {
@@ -57,7 +57,7 @@ func (controller *Controller) determineDynaKubePhase(dynakube *dynatracev1beta2.
 	return status.Running
 }
 
-func (controller *Controller) numberOfMissingOneagentPods(dynakube *dynatracev1beta2.DynaKube) (int32, error) {
+func (controller *Controller) numberOfMissingOneagentPods(dynakube *dynakube.DynaKube) (int32, error) {
 	oneAgentDaemonSet := &appsv1.DaemonSet{}
 	instanceName := dynakube.OneAgentDaemonsetName()
 
@@ -69,7 +69,7 @@ func (controller *Controller) numberOfMissingOneagentPods(dynakube *dynatracev1b
 	return oneAgentDaemonSet.Status.CurrentNumberScheduled - oneAgentDaemonSet.Status.NumberReady, nil
 }
 
-func (controller *Controller) numberOfMissingActiveGatePods(dynakube *dynatracev1beta2.DynaKube) (int32, error) {
+func (controller *Controller) numberOfMissingActiveGatePods(dynakube *dynakube.DynaKube) (int32, error) {
 	capabilities := capability.GenerateActiveGateCapabilities(dynakube)
 
 	sum := int32(0)

--- a/pkg/controllers/dynakube/phase_test.go
+++ b/pkg/controllers/dynakube/phase_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestActiveGatePhaseChanges(t *testing.T) {
-	dynakube := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -29,7 +29,7 @@ func TestActiveGatePhaseChanges(t *testing.T) {
 			client:    fakeClient,
 			apiReader: fakeClient,
 		}
-		phase := controller.determineDynaKubePhase(dynakube)
+		phase := controller.determineDynaKubePhase(dk)
 		assert.Equal(t, status.Deploying, phase)
 	})
 	t.Run("error accessing k8s api -> error", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestActiveGatePhaseChanges(t *testing.T) {
 			client:    fakeClient,
 			apiReader: fakeClient,
 		}
-		phase := controller.determineDynaKubePhase(dynakube)
+		phase := controller.determineDynaKubePhase(dk)
 		assert.Equal(t, status.Error, phase)
 	})
 	t.Run("activegate pods not ready -> deploying", func(t *testing.T) {
@@ -54,7 +54,7 @@ func TestActiveGatePhaseChanges(t *testing.T) {
 			client:    fakeClient,
 			apiReader: fakeClient,
 		}
-		phase := controller.determineDynaKubePhase(dynakube)
+		phase := controller.determineDynaKubePhase(dk)
 		assert.Equal(t, status.Deploying, phase)
 	})
 	t.Run("activegate deployed -> running", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestActiveGatePhaseChanges(t *testing.T) {
 			client:    fakeClient,
 			apiReader: fakeClient,
 		}
-		phase := controller.determineDynaKubePhase(dynakube)
+		phase := controller.determineDynaKubePhase(dk)
 		assert.Equal(t, status.Running, phase)
 	})
 }
@@ -92,7 +92,7 @@ func createStatefulset(namespace, name string, replicas, readyReplicas int32) *a
 }
 
 func TestOneAgentPhaseChanges(t *testing.T) {
-	dynakube := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -110,7 +110,7 @@ func TestOneAgentPhaseChanges(t *testing.T) {
 			client:    fakeClient,
 			apiReader: fakeClient,
 		}
-		phase := controller.determineDynaKubePhase(dynakube)
+		phase := controller.determineDynaKubePhase(dk)
 		assert.Equal(t, status.Deploying, phase)
 	})
 	t.Run("Error accessing k8s api", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestOneAgentPhaseChanges(t *testing.T) {
 			client:    fakeClient,
 			apiReader: fakeClient,
 		}
-		phase := controller.determineDynaKubePhase(dynakube)
+		phase := controller.determineDynaKubePhase(dk)
 		assert.Equal(t, status.Error, phase)
 	})
 	t.Run("OneAgent daemonsets in cluster not all ready -> deploying", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestOneAgentPhaseChanges(t *testing.T) {
 			client:    fakeClient,
 			apiReader: fakeClient,
 		}
-		phase := controller.determineDynaKubePhase(dynakube)
+		phase := controller.determineDynaKubePhase(dk)
 		assert.Equal(t, status.Deploying, phase)
 	})
 	t.Run("OneAgent daemonsets in cluster all ready -> running", func(t *testing.T) {
@@ -161,7 +161,7 @@ func TestOneAgentPhaseChanges(t *testing.T) {
 			client:    fakeClient,
 			apiReader: fakeClient,
 		}
-		phase := controller.determineDynaKubePhase(dynakube)
+		phase := controller.determineDynaKubePhase(dk)
 		assert.Equal(t, status.Running, phase)
 	})
 }

--- a/pkg/controllers/dynakube/phase_test.go
+++ b/pkg/controllers/dynakube/phase_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,13 +13,13 @@ import (
 )
 
 func TestActiveGatePhaseChanges(t *testing.T) {
-	dynakube := &dynatracev1beta2.DynaKube{
+	dynakube := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.KubeMonCapability.DisplayName}},
+		Spec: dynakube.DynaKubeSpec{
+			ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}},
 		},
 	}
 
@@ -92,14 +92,14 @@ func createStatefulset(namespace, name string, replicas, readyReplicas int32) *a
 }
 
 func TestOneAgentPhaseChanges(t *testing.T) {
-	dynakube := &dynatracev1beta2.DynaKube{
+	dynakube := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				ClassicFullStack: &dynatracev1beta2.HostInjectSpec{},
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: dynakube.OneAgentSpec{
+				ClassicFullStack: &dynakube.HostInjectSpec{},
 			},
 		},
 	}

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
@@ -28,14 +28,14 @@ type Reconciler struct {
 	client       client.Client
 	apiReader    client.Reader
 	dtClient     dtclient.Client
-	dynakube     *dynatracev1beta2.DynaKube
+	dynakube     *dynakube.DynaKube
 	timeProvider *timeprovider.Provider
 }
 
 func NewReconciler(clt client.Client,
 	apiReader client.Reader,
 	dtClient dtclient.Client,
-	dynakube *dynatracev1beta2.DynaKube,
+	dynakube *dynakube.DynaKube,
 	timeProvider *timeprovider.Provider) *Reconciler {
 	return &Reconciler{
 		client:       clt,

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
@@ -33,8 +33,8 @@ const (
 
 func TestReconcile(t *testing.T) {
 	t.Run("Create and update works with minimal setup", func(t *testing.T) {
-		dynakube := createDynakube(dynatracev1beta2.OneAgentSpec{
-			CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{}})
+		dynakube := createDynakube(dynakube.OneAgentSpec{
+			CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}})
 
 		mockK8sClient := fake.NewClient(dynakube)
 		_ = mockK8sClient.Create(context.Background(),
@@ -88,8 +88,8 @@ func TestReconcile(t *testing.T) {
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	})
 	t.Run("Only runs when required, and cleans up condition", func(t *testing.T) {
-		dynakube := createDynakube(dynatracev1beta2.OneAgentSpec{
-			ClassicFullStack: &dynatracev1beta2.HostInjectSpec{}})
+		dynakube := createDynakube(dynakube.OneAgentSpec{
+			ClassicFullStack: &dynakube.HostInjectSpec{}})
 		conditions.SetSecretCreated(dynakube.Conditions(), pmcConditionType, "this is a test")
 
 		reconciler := NewReconciler(nil, nil, nil, dynakube, timeprovider.New())
@@ -100,8 +100,8 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("problem with k8s request => visible in conditions", func(t *testing.T) {
-		dynakube := createDynakube(dynatracev1beta2.OneAgentSpec{
-			CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{}})
+		dynakube := createDynakube(dynakube.OneAgentSpec{
+			CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}})
 
 		boomClient := createBOOMK8sClient()
 
@@ -120,8 +120,8 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("problem with dynatrace request => visible in conditions", func(t *testing.T) {
-		dynakube := createDynakube(dynatracev1beta2.OneAgentSpec{
-			CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{}})
+		dynakube := createDynakube(dynakube.OneAgentSpec{
+			CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}})
 
 		mockK8sClient := fake.NewClient(dynakube)
 		_ = mockK8sClient.Create(context.Background(),
@@ -159,13 +159,13 @@ func checkSecretForValue(t *testing.T, k8sClient client.Client, shouldContain st
 	require.True(t, strings.Contains(string(processModuleConfig), shouldContain))
 }
 
-func createDynakube(oneAgentSpec dynatracev1beta2.OneAgentSpec) *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func createDynakube(oneAgentSpec dynakube.OneAgentSpec) *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			OneAgent: oneAgentSpec,
 		},
 	}
@@ -210,8 +210,8 @@ func createBOOMK8sClient() client.Client {
 func TestGetSecretData(t *testing.T) {
 	t.Run("unmarshal secret data into struct", func(t *testing.T) {
 		// use Reconcile to automatically create the secret to test
-		dynakube := createDynakube(dynatracev1beta2.OneAgentSpec{
-			CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{}})
+		dynakube := createDynakube(dynakube.OneAgentSpec{
+			CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}})
 		mockK8sClient := fake.NewClient(dynakube)
 		_ = mockK8sClient.Create(context.Background(),
 			&corev1.Secret{

--- a/pkg/controllers/dynakube/proxy/reconciler.go
+++ b/pkg/controllers/dynakube/proxy/reconciler.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"strings"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
@@ -22,7 +22,7 @@ var _ controllers.Reconciler = &Reconciler{}
 type Reconciler struct {
 	client    client.Client
 	apiReader client.Reader
-	dynakube  *dynatracev1beta2.DynaKube
+	dynakube  *dynakube.DynaKube
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
@@ -33,7 +33,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	return r.ensureDeleted(ctx, r.dynakube)
 }
 
-func NewReconciler(client client.Client, apiReader client.Reader, dynakube *dynatracev1beta2.DynaKube) *Reconciler {
+func NewReconciler(client client.Client, apiReader client.Reader, dynakube *dynakube.DynaKube) *Reconciler {
 	return &Reconciler{
 		client:    client,
 		apiReader: apiReader,
@@ -41,7 +41,7 @@ func NewReconciler(client client.Client, apiReader client.Reader, dynakube *dyna
 	}
 }
 
-func (r *Reconciler) generateForDynakube(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error {
+func (r *Reconciler) generateForDynakube(ctx context.Context, dynakube *dynakube.DynaKube) error {
 	data, err := r.createProxyMap(ctx, dynakube)
 	if err != nil {
 		return errors.WithStack(err)
@@ -63,7 +63,7 @@ func (r *Reconciler) generateForDynakube(ctx context.Context, dynakube *dynatrac
 	return errors.WithStack(err)
 }
 
-func (r *Reconciler) ensureDeleted(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error {
+func (r *Reconciler) ensureDeleted(ctx context.Context, dynakube *dynakube.DynaKube) error {
 	secretName := BuildSecretName(dynakube.Name)
 
 	secret := corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: dynakube.Namespace}}
@@ -77,7 +77,7 @@ func (r *Reconciler) ensureDeleted(ctx context.Context, dynakube *dynatracev1bet
 	return nil
 }
 
-func (r *Reconciler) createProxyMap(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) (map[string][]byte, error) {
+func (r *Reconciler) createProxyMap(ctx context.Context, dynakube *dynakube.DynaKube) (map[string][]byte, error) {
 	if !dynakube.HasProxy() {
 		// the parsed-proxy secret is expected to exist and the entrypoint.sh script handles empty values properly
 		return map[string][]byte{

--- a/pkg/controllers/dynakube/proxy/reconciler_test.go
+++ b/pkg/controllers/dynakube/proxy/reconciler_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -28,14 +28,14 @@ const (
 )
 
 func newTestReconcilerWithInstance(client client.Client) *Reconciler {
-	instance := &dynatracev1beta2.DynaKube{
+	instance := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testDynakubeName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL:     "https://testing.dev.dynatracelabs.com/api",
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.KubeMonCapability.DisplayName}},
+			ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}},
 		},
 	}
 
@@ -79,20 +79,20 @@ func TestReconcileWithoutProxy(t *testing.T) {
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run(`ensure no proxy is used when supplying a secret but disabling proxy via feature flag`, func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testDynakubeName,
 				Namespace: testNamespace,
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: "https://testing.dev.dynatracelabs.com/api",
-				Proxy: &dynatracev1beta2.DynaKubeProxy{
+				Proxy: &dynakube.DynaKubeProxy{
 					Value:     "https://proxy:1234",
 					ValueFrom: "",
 				}}}
 		instance.Annotations = map[string]string{
-			dynatracev1beta2.AnnotationFeatureActiveGateIgnoreProxy: "true",
-			dynatracev1beta2.AnnotationFeatureOneAgentIgnoreProxy:   "true",
+			dynakube.AnnotationFeatureActiveGateIgnoreProxy: "true",
+			dynakube.AnnotationFeatureOneAgentIgnoreProxy:   "true",
 		}
 
 		var testClient = fake.NewClientBuilder().WithObjects(&corev1.Secret{
@@ -122,7 +122,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl("", "", "", proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: proxyValue}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -139,7 +139,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl("", proxyUsername, proxyPassword, proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: proxyValue}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -156,7 +156,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl(proxyHttpScheme, "", "", proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: proxyValue}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -173,7 +173,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl(proxyHttpsScheme, "", "", proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: proxyValue}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -190,7 +190,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl(proxyHttpScheme, proxyUsername, proxyPassword, proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: proxyValue}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -207,7 +207,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl("https", proxyUsername, proxyPassword, proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: proxyValue}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -222,7 +222,7 @@ func TestReconcileProxyValue(t *testing.T) {
 	})
 	t.Run(`reconcile empty proxy Value`, func(t *testing.T) {
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: ""}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: ""}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -244,7 +244,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 	r := newTestReconcilerWithInstance(testClient)
 
 	t.Run(`reconcile proxy ValueFrom`, func(t *testing.T) {
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{ValueFrom: customProxySecret}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{ValueFrom: customProxySecret}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -258,7 +258,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		assert.Equal(t, []byte(proxyHttpScheme), proxySecret.Data[schemeField])
 	})
 	t.Run(`Change of Proxy ValueFrom to Value`, func(t *testing.T) {
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{ValueFrom: customProxySecret}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{ValueFrom: customProxySecret}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -287,7 +287,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		assert.Equal(t, []byte(proxyHttpScheme), proxySecret.Data[schemeField])
 	})
 	t.Run(`reconcile proxy ValueFrom with non existing secret`, func(t *testing.T) {
-		r.dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{ValueFrom: "secret"}
+		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{ValueFrom: "secret"}
 		err := r.Reconcile(context.Background())
 
 		require.Error(t, err)
@@ -300,7 +300,7 @@ func createProxySecret(proxyUrl string) *corev1.Secret {
 			Name:      customProxySecret,
 			Namespace: testNamespace,
 		},
-		Data: map[string][]byte{dynatracev1beta2.ProxyKey: []byte(proxyUrl)},
+		Data: map[string][]byte{dynakube.ProxyKey: []byte(proxyUrl)},
 	}
 }
 

--- a/pkg/controllers/dynakube/proxy/reconciler_test.go
+++ b/pkg/controllers/dynakube/proxy/reconciler_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 func newTestReconcilerWithInstance(client client.Client) *Reconciler {
-	instance := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testDynakubeName,
@@ -39,7 +39,7 @@ func newTestReconcilerWithInstance(client client.Client) *Reconciler {
 		},
 	}
 
-	r := NewReconciler(client, client, instance)
+	r := NewReconciler(client, client, dk)
 
 	return r
 }
@@ -79,7 +79,7 @@ func TestReconcileWithoutProxy(t *testing.T) {
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run(`ensure no proxy is used when supplying a secret but disabling proxy via feature flag`, func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testDynakubeName,
 				Namespace: testNamespace,
@@ -90,7 +90,7 @@ func TestReconcileWithoutProxy(t *testing.T) {
 					Value:     "https://proxy:1234",
 					ValueFrom: "",
 				}}}
-		instance.Annotations = map[string]string{
+		dk.Annotations = map[string]string{
 			dynakube.AnnotationFeatureActiveGateIgnoreProxy: "true",
 			dynakube.AnnotationFeatureOneAgentIgnoreProxy:   "true",
 		}
@@ -102,7 +102,7 @@ func TestReconcileWithoutProxy(t *testing.T) {
 			},
 		}).Build()
 
-		r := NewReconciler(testClient, testClient, instance)
+		r := NewReconciler(testClient, testClient, dk)
 		err := r.Reconcile(context.Background())
 
 		require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl("", "", "", proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -139,7 +139,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl("", proxyUsername, proxyPassword, proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -156,7 +156,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl(proxyHttpScheme, "", "", proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -173,7 +173,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl(proxyHttpsScheme, "", "", proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -190,7 +190,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl(proxyHttpScheme, proxyUsername, proxyPassword, proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -207,7 +207,7 @@ func TestReconcileProxyValue(t *testing.T) {
 		var proxyValue = buildProxyUrl("https", proxyUsername, proxyPassword, proxyHost, proxyPort)
 
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: proxyValue}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -222,7 +222,7 @@ func TestReconcileProxyValue(t *testing.T) {
 	})
 	t.Run(`reconcile empty proxy Value`, func(t *testing.T) {
 		r := newTestReconcilerWithInstance(fake.NewClientBuilder().Build())
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{Value: ""}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: ""}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -244,7 +244,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 	r := newTestReconcilerWithInstance(testClient)
 
 	t.Run(`reconcile proxy ValueFrom`, func(t *testing.T) {
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{ValueFrom: customProxySecret}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{ValueFrom: customProxySecret}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -258,7 +258,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		assert.Equal(t, []byte(proxyHttpScheme), proxySecret.Data[schemeField])
 	})
 	t.Run(`Change of Proxy ValueFrom to Value`, func(t *testing.T) {
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{ValueFrom: customProxySecret}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{ValueFrom: customProxySecret}
 		err := r.Reconcile(context.Background())
 		require.NoError(t, err)
 
@@ -272,8 +272,8 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		assert.Equal(t, []byte(proxyUsername), proxySecret.Data[usernameField])
 		assert.Equal(t, []byte(proxyHttpScheme), proxySecret.Data[schemeField])
 
-		r.dynakube.Spec.Proxy.ValueFrom = ""
-		r.dynakube.Spec.Proxy.Value = buildProxyUrl(proxyHttpScheme, proxyDifferentUsername, proxyPassword, proxyHost, proxyPort)
+		r.dk.Spec.Proxy.ValueFrom = ""
+		r.dk.Spec.Proxy.Value = buildProxyUrl(proxyHttpScheme, proxyDifferentUsername, proxyPassword, proxyHost, proxyPort)
 		err = r.Reconcile(context.Background())
 
 		require.NoError(t, err)
@@ -287,7 +287,7 @@ func TestReconcileProxyValueFrom(t *testing.T) {
 		assert.Equal(t, []byte(proxyHttpScheme), proxySecret.Data[schemeField])
 	})
 	t.Run(`reconcile proxy ValueFrom with non existing secret`, func(t *testing.T) {
-		r.dynakube.Spec.Proxy = &dynakube.DynaKubeProxy{ValueFrom: "secret"}
+		r.dk.Spec.Proxy = &dynakube.DynaKubeProxy{ValueFrom: "secret"}
 		err := r.Reconcile(context.Background())
 
 		require.Error(t, err)

--- a/pkg/controllers/dynakube/token/feature.go
+++ b/pkg/controllers/dynakube/token/feature.go
@@ -1,13 +1,13 @@
 package token
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"golang.org/x/exp/slices"
 )
 
 type Feature struct {
-	IsEnabled      func(dynakube dynatracev1beta2.DynaKube) bool
+	IsEnabled      func(dk dynakube.DynaKube) bool
 	Name           string
 	RequiredScopes []string
 }
@@ -29,7 +29,7 @@ func getFeaturesForAPIToken(paasTokenExists bool) []Feature {
 		{
 			Name:           "Access problem and event feed, metrics, and topology",
 			RequiredScopes: []string{dtclient.TokenScopeDataExport},
-			IsEnabled: func(dynakube dynatracev1beta2.DynaKube) bool {
+			IsEnabled: func(dk dynakube.DynaKube) bool {
 				return true
 			},
 		},
@@ -39,22 +39,22 @@ func getFeaturesForAPIToken(paasTokenExists bool) []Feature {
 				dtclient.TokenScopeEntitiesRead,
 				dtclient.TokenScopeSettingsRead,
 				dtclient.TokenScopeSettingsWrite},
-			IsEnabled: func(dynakube dynatracev1beta2.DynaKube) bool {
-				return dynakube.IsKubernetesMonitoringActiveGateEnabled() &&
-					dynakube.FeatureAutomaticKubernetesApiMonitoring()
+			IsEnabled: func(dk dynakube.DynaKube) bool {
+				return dk.IsKubernetesMonitoringActiveGateEnabled() &&
+					dk.FeatureAutomaticKubernetesApiMonitoring()
 			},
 		},
 		{
 			Name:           "Automatic ActiveGate Token Creation",
 			RequiredScopes: []string{dtclient.TokenScopeActiveGateTokenCreate},
-			IsEnabled: func(dynakube dynatracev1beta2.DynaKube) bool {
-				return dynakube.NeedsActiveGate()
+			IsEnabled: func(dk dynakube.DynaKube) bool {
+				return dk.NeedsActiveGate()
 			},
 		},
 		{
 			Name:           "Download Installer",
 			RequiredScopes: []string{dtclient.TokenScopeInstallerDownload},
-			IsEnabled: func(dynakube dynatracev1beta2.DynaKube) bool {
+			IsEnabled: func(dk dynakube.DynaKube) bool {
 				return !paasTokenExists
 			},
 		},
@@ -66,7 +66,7 @@ func getFeaturesForPaaSToken() []Feature {
 		{
 			Name:           "PaaS Token",
 			RequiredScopes: []string{dtclient.TokenScopeInstallerDownload},
-			IsEnabled: func(dynakube dynatracev1beta2.DynaKube) bool {
+			IsEnabled: func(dk dynakube.DynaKube) bool {
 				return true
 			},
 		},
@@ -78,8 +78,8 @@ func getFeaturesForDataIngest() []Feature {
 		{
 			Name:           "Data Ingest",
 			RequiredScopes: []string{dtclient.TokenScopeMetricsIngest},
-			IsEnabled: func(dynakube dynatracev1beta2.DynaKube) bool {
-				return dynakube.IsMetricsIngestActiveGateEnabled()
+			IsEnabled: func(dk dynakube.DynaKube) bool {
+				return dk.IsMetricsIngestActiveGateEnabled()
 			},
 		},
 	}

--- a/pkg/controllers/dynakube/token/feature.go
+++ b/pkg/controllers/dynakube/token/feature.go
@@ -54,7 +54,7 @@ func getFeaturesForAPIToken(paasTokenExists bool) []Feature {
 		{
 			Name:           "Download Installer",
 			RequiredScopes: []string{dtclient.TokenScopeInstallerDownload},
-			IsEnabled: func(dk dynakube.DynaKube) bool {
+			IsEnabled: func(_ dynakube.DynaKube) bool {
 				return !paasTokenExists
 			},
 		},
@@ -66,7 +66,7 @@ func getFeaturesForPaaSToken() []Feature {
 		{
 			Name:           "PaaS Token",
 			RequiredScopes: []string{dtclient.TokenScopeInstallerDownload},
-			IsEnabled: func(dk dynakube.DynaKube) bool {
+			IsEnabled: func(_ dynakube.DynaKube) bool {
 				return true
 			},
 		},

--- a/pkg/controllers/dynakube/token/feature_test.go
+++ b/pkg/controllers/dynakube/token/feature_test.go
@@ -3,7 +3,7 @@ package token
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,7 +12,7 @@ func TestFeature_IsScopeMissing(t *testing.T) {
 		feature := Feature{
 			Name:           "Access problem and event feed, metrics, and topology",
 			RequiredScopes: []string{"scope1", "scope2"},
-			IsEnabled: func(dynakube dynatracev1beta2.DynaKube) bool {
+			IsEnabled: func(dk dynakube.DynaKube) bool {
 				return true
 			},
 		}
@@ -25,7 +25,7 @@ func TestFeature_IsScopeMissing(t *testing.T) {
 		feature := Feature{
 			Name:           "Access problem and event feed, metrics, and topology",
 			RequiredScopes: []string{"scope1", "scope2"},
-			IsEnabled: func(dynakube dynatracev1beta2.DynaKube) bool {
+			IsEnabled: func(dk dynakube.DynaKube) bool {
 				return true
 			},
 		}
@@ -38,7 +38,7 @@ func TestFeature_IsScopeMissing(t *testing.T) {
 		feature := Feature{
 			Name:           "Access problem and event feed, metrics, and topology",
 			RequiredScopes: []string{"scope1", "scope2"},
-			IsEnabled: func(dynakube dynatracev1beta2.DynaKube) bool {
+			IsEnabled: func(dk dynakube.DynaKube) bool {
 				return true
 			},
 		}

--- a/pkg/controllers/dynakube/token/reader.go
+++ b/pkg/controllers/dynakube/token/reader.go
@@ -13,13 +13,13 @@ import (
 
 type Reader struct {
 	apiReader client.Reader
-	dynakube  *dynakube.DynaKube
+	dk        *dynakube.DynaKube
 }
 
-func NewReader(apiReader client.Reader, dynakube *dynakube.DynaKube) Reader {
+func NewReader(apiReader client.Reader, dk *dynakube.DynaKube) Reader {
 	return Reader{
 		apiReader: apiReader,
-		dynakube:  dynakube,
+		dk:        dk,
 	}
 }
 
@@ -43,8 +43,8 @@ func (reader Reader) readTokens(ctx context.Context) (Tokens, error) {
 	result := make(Tokens)
 
 	err := reader.apiReader.Get(ctx, client.ObjectKey{
-		Name:      reader.dynakube.Tokens(),
-		Namespace: reader.dynakube.Namespace,
+		Name:      reader.dk.Tokens(),
+		Namespace: reader.dk.Namespace,
 	}, &tokenSecret)
 
 	if err != nil {
@@ -63,7 +63,7 @@ func (reader Reader) verifyApiTokenExists(tokens Tokens) error {
 	apiToken, hasApiToken := tokens[dtclient.ApiToken]
 
 	if !hasApiToken || len(apiToken.Value) == 0 {
-		return errors.New(fmt.Sprintf("the API token is missing from the token secret '%s:%s'", reader.dynakube.Namespace, reader.dynakube.Tokens()))
+		return errors.New(fmt.Sprintf("the API token is missing from the token secret '%s:%s'", reader.dk.Namespace, reader.dk.Tokens()))
 	}
 
 	return nil

--- a/pkg/controllers/dynakube/token/reader.go
+++ b/pkg/controllers/dynakube/token/reader.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -13,10 +13,10 @@ import (
 
 type Reader struct {
 	apiReader client.Reader
-	dynakube  *dynatracev1beta2.DynaKube
+	dynakube  *dynakube.DynaKube
 }
 
-func NewReader(apiReader client.Reader, dynakube *dynatracev1beta2.DynaKube) Reader {
+func NewReader(apiReader client.Reader, dynakube *dynakube.DynaKube) Reader {
 	return Reader{
 		apiReader: apiReader,
 		dynakube:  dynakube,

--- a/pkg/controllers/dynakube/token/reader_test.go
+++ b/pkg/controllers/dynakube/token/reader_test.go
@@ -34,8 +34,8 @@ func TestReader(t *testing.T) {
 func testReadTokens(t *testing.T) {
 	t.Run("error when tokens are not found", func(t *testing.T) {
 		clt := fake.NewClient()
-		dynakube := dynakube.DynaKube{}
-		reader := NewReader(clt, &dynakube)
+		dk := dynakube.DynaKube{}
+		reader := NewReader(clt, &dk)
 
 		_, err := reader.readTokens(context.Background())
 
@@ -43,13 +43,13 @@ func testReadTokens(t *testing.T) {
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run("tokens are found if secret exists", func(t *testing.T) {
-		dynakube := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dynakube",
 				Namespace: "dynatrace",
 			},
 		}
-		testSecret, err := secret.Create(&dynakube, secret.NewNameModifier("dynakube"), secret.NewNamespaceModifier("dynatrace"), secret.NewDataModifier(map[string][]byte{
+		testSecret, err := secret.Create(&dk, secret.NewNameModifier("dynakube"), secret.NewNamespaceModifier("dynatrace"), secret.NewDataModifier(map[string][]byte{
 			dtclient.ApiToken:        []byte(testApiToken),
 			dtclient.PaasToken:       []byte(testPaasToken),
 			dtclient.DataIngestToken: []byte(testDataIngestToken),
@@ -57,9 +57,9 @@ func testReadTokens(t *testing.T) {
 		}))
 		require.NoError(t, err)
 
-		clt := fake.NewClient(testSecret, &dynakube)
+		clt := fake.NewClient(testSecret, &dk)
 
-		reader := NewReader(clt, &dynakube)
+		reader := NewReader(clt, &dk)
 
 		tokens, err := reader.readTokens(context.Background())
 

--- a/pkg/controllers/dynakube/token/reader_test.go
+++ b/pkg/controllers/dynakube/token/reader_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +34,7 @@ func TestReader(t *testing.T) {
 func testReadTokens(t *testing.T) {
 	t.Run("error when tokens are not found", func(t *testing.T) {
 		clt := fake.NewClient()
-		dynakube := dynatracev1beta2.DynaKube{}
+		dynakube := dynakube.DynaKube{}
 		reader := NewReader(clt, &dynakube)
 
 		_, err := reader.readTokens(context.Background())
@@ -43,7 +43,7 @@ func testReadTokens(t *testing.T) {
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run("tokens are found if secret exists", func(t *testing.T) {
-		dynakube := dynatracev1beta2.DynaKube{
+		dynakube := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dynakube",
 				Namespace: "dynatrace",
@@ -78,7 +78,7 @@ func testReadTokens(t *testing.T) {
 
 func testVerifyTokens(t *testing.T) {
 	t.Run("error if api token is missing", func(t *testing.T) {
-		reader := NewReader(nil, &dynatracev1beta2.DynaKube{ObjectMeta: metav1.ObjectMeta{
+		reader := NewReader(nil, &dynakube.DynaKube{ObjectMeta: metav1.ObjectMeta{
 			Name:      dynakubeName,
 			Namespace: dynatraceNamespace,
 		}})

--- a/pkg/controllers/dynakube/token/token.go
+++ b/pkg/controllers/dynakube/token/token.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/pkg/errors"
 )
@@ -27,7 +27,7 @@ func (token *Token) addFeatures(features []Feature) {
 	token.Features = append(token.Features, features...)
 }
 
-func (token *Token) verifyScopes(ctx context.Context, dtClient dtclient.Client, dynakube dynatracev1beta2.DynaKube) error {
+func (token *Token) verifyScopes(ctx context.Context, dtClient dtclient.Client, dk dynakube.DynaKube) error {
 	if len(token.Features) == 0 {
 		return nil
 	}
@@ -40,7 +40,7 @@ func (token *Token) verifyScopes(ctx context.Context, dtClient dtclient.Client, 
 	collectedErrors := make([]error, 0)
 
 	for _, feature := range token.Features {
-		if feature.IsEnabled(dynakube) {
+		if feature.IsEnabled(dk) {
 			isMissing, missingScopes := feature.IsScopeMissing(scopes)
 			if isMissing {
 				collectedErrors = append(collectedErrors,

--- a/pkg/controllers/dynakube/token/tokens.go
+++ b/pkg/controllers/dynakube/token/tokens.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceapi"
 )
@@ -49,11 +49,11 @@ func (tokens Tokens) AddFeatureScopesToTokens() Tokens {
 	return tokens
 }
 
-func (tokens Tokens) VerifyScopes(ctx context.Context, dtClient dtclient.Client, dynakube dynatracev1beta2.DynaKube) error {
+func (tokens Tokens) VerifyScopes(ctx context.Context, dtClient dtclient.Client, dk dynakube.DynaKube) error {
 	scopeErrors := make([]error, 0)
 
 	for _, token := range tokens {
-		if err := token.verifyScopes(ctx, dtClient, dynakube); err != nil {
+		if err := token.verifyScopes(ctx, dtClient, dk); err != nil {
 			scopeErrors = append(scopeErrors, err)
 		}
 	}

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/pkg/errors"
@@ -73,7 +73,7 @@ func TestTokens(t *testing.T) {
 			dtclient.ApiToken: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
-		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynatracev1beta2.DynaKube{})
+		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynakube.DynaKube{})
 
 		assert.Len(t, tokens.ApiToken().Features, 4)
 		assert.Empty(t, tokens.PaasToken().Features)
@@ -88,7 +88,7 @@ func TestTokens(t *testing.T) {
 			dtclient.PaasToken: &paasToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
-		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynatracev1beta2.DynaKube{})
+		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynakube.DynaKube{})
 
 		assert.Len(t, tokens.ApiToken().Features, 4)
 		assert.Len(t, tokens.PaasToken().Features, 1)
@@ -101,7 +101,7 @@ func TestTokens(t *testing.T) {
 			dtclient.ApiToken: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
-		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynatracev1beta2.DynaKube{})
+		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynakube.DynaKube{})
 
 		assert.Len(t, tokens.ApiToken().Features, 4)
 		assert.Empty(t, tokens.PaasToken().Features)
@@ -109,9 +109,9 @@ func TestTokens(t *testing.T) {
 		assert.NoError(t, err, "")
 	})
 	t.Run("activegate enabled dynakube, no permissions in api token => fail", func(t *testing.T) {
-		dynakube := dynatracev1beta2.DynaKube{}
-		dynakube.Spec.ActiveGate.Capabilities = []dynatracev1beta2.CapabilityDisplayName{
-			dynatracev1beta2.KubeMonCapability.DisplayName,
+		dk := dynakube.DynaKube{}
+		dk.Spec.ActiveGate.Capabilities = []dynakube.CapabilityDisplayName{
+			dynakube.KubeMonCapability.DisplayName,
 		}
 
 		apiToken := newToken(dtclient.ApiToken, fakeTokenNoPermissions)
@@ -119,7 +119,7 @@ func TestTokens(t *testing.T) {
 			dtclient.ApiToken: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
-		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynakube)
+		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dk)
 
 		assert.Len(t, tokens.ApiToken().Features, 4)
 		assert.Empty(t, tokens.PaasToken().Features)
@@ -127,7 +127,7 @@ func TestTokens(t *testing.T) {
 		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Access problem and event feed, metrics, and topology' is missing scope 'DataExport' feature 'Kubernetes API Monitoring' is missing scope 'entities.read, settings.read, settings.write' feature 'Automatic ActiveGate Token Creation' is missing scope 'activeGateTokenManagement.create' feature 'Download Installer' is missing scope 'InstallerDownload']")
 	})
 	t.Run("data ingest enabled => dataingest token missing rights => fail", func(t *testing.T) {
-		dynakube := dynatracev1beta2.DynaKube{}
+		dynakube := dynakube.DynaKube{}
 		enableKubernetesMonitoringAndMetricsIngest(&dynakube)
 
 		apiToken := newToken(dtclient.ApiToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
@@ -152,7 +152,7 @@ func TestTokens(t *testing.T) {
 			dtclient.DataIngestToken: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
-		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynatracev1beta2.DynaKube{})
+		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynakube.DynaKube{})
 
 		assert.Len(t, tokens.ApiToken().Features, 4)
 		assert.Empty(t, tokens.PaasToken().Features)
@@ -161,13 +161,13 @@ func TestTokens(t *testing.T) {
 	})
 }
 
-func enableKubernetesMonitoringAndMetricsIngest(dynakube *dynatracev1beta2.DynaKube) *dynatracev1beta2.DynaKube {
-	dynakube.Spec.ActiveGate.Capabilities = []dynatracev1beta2.CapabilityDisplayName{
-		dynatracev1beta2.KubeMonCapability.DisplayName,
-		dynatracev1beta2.MetricsIngestCapability.DisplayName,
+func enableKubernetesMonitoringAndMetricsIngest(dk *dynakube.DynaKube) *dynakube.DynaKube {
+	dk.Spec.ActiveGate.Capabilities = []dynakube.CapabilityDisplayName{
+		dynakube.KubeMonCapability.DisplayName,
+		dynakube.MetricsIngestCapability.DisplayName,
 	}
 
-	return dynakube
+	return dk
 }
 
 func TestTokens_VerifyValues(t *testing.T) {

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -127,8 +127,8 @@ func TestTokens(t *testing.T) {
 		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Access problem and event feed, metrics, and topology' is missing scope 'DataExport' feature 'Kubernetes API Monitoring' is missing scope 'entities.read, settings.read, settings.write' feature 'Automatic ActiveGate Token Creation' is missing scope 'activeGateTokenManagement.create' feature 'Download Installer' is missing scope 'InstallerDownload']")
 	})
 	t.Run("data ingest enabled => dataingest token missing rights => fail", func(t *testing.T) {
-		dynakube := dynakube.DynaKube{}
-		enableKubernetesMonitoringAndMetricsIngest(&dynakube)
+		dk := dynakube.DynaKube{}
+		enableKubernetesMonitoringAndMetricsIngest(&dk)
 
 		apiToken := newToken(dtclient.ApiToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
 		dataingestToken := newToken(dtclient.DataIngestToken, fakeTokenNoPermissions)
@@ -137,7 +137,7 @@ func TestTokens(t *testing.T) {
 			dtclient.DataIngestToken: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
-		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynakube)
+		err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dk)
 
 		assert.Len(t, tokens.ApiToken().Features, 4)
 		assert.Empty(t, tokens.PaasToken().Features)

--- a/pkg/controllers/dynakube/version/activegate.go
+++ b/pkg/controllers/dynakube/version/activegate.go
@@ -17,18 +17,18 @@ const (
 )
 
 type activeGateUpdater struct {
-	dynakube  *dynakube.DynaKube
+	dk        *dynakube.DynaKube
 	apiReader client.Reader
 	dtClient  dtclient.Client
 }
 
 func newActiveGateUpdater(
-	dynakube *dynakube.DynaKube,
+	dk *dynakube.DynaKube,
 	apiReader client.Reader,
 	dtClient dtclient.Client,
 ) *activeGateUpdater {
 	return &activeGateUpdater{
-		dynakube:  dynakube,
+		dk:        dk,
 		apiReader: apiReader,
 		dtClient:  dtClient,
 	}
@@ -39,24 +39,24 @@ func (updater activeGateUpdater) Name() string {
 }
 
 func (updater activeGateUpdater) IsEnabled() bool {
-	if updater.dynakube.NeedsActiveGate() {
+	if updater.dk.NeedsActiveGate() {
 		return true
 	}
 
-	meta.RemoveStatusCondition(updater.dynakube.Conditions(), activeGateVersionConditionType)
-	updater.dynakube.Status.ActiveGate.VersionStatus = status.VersionStatus{}
+	meta.RemoveStatusCondition(updater.dk.Conditions(), activeGateVersionConditionType)
+	updater.dk.Status.ActiveGate.VersionStatus = status.VersionStatus{}
 
 	return false
 }
 
 func (updater *activeGateUpdater) Target() *status.VersionStatus {
-	return &updater.dynakube.Status.ActiveGate.VersionStatus
+	return &updater.dk.Status.ActiveGate.VersionStatus
 }
 
 func (updater activeGateUpdater) CustomImage() string {
-	customImage := updater.dynakube.CustomActiveGateImage()
+	customImage := updater.dk.CustomActiveGateImage()
 	if customImage != "" {
-		setVerificationSkippedReasonCondition(updater.dynakube.Conditions(), activeGateVersionConditionType)
+		setVerificationSkippedReasonCondition(updater.dk.Conditions(), activeGateVersionConditionType)
 	}
 
 	return customImage
@@ -67,13 +67,13 @@ func (updater activeGateUpdater) CustomVersion() string {
 }
 
 func (updater activeGateUpdater) IsAutoUpdateEnabled() bool {
-	return !updater.dynakube.FeatureDisableActiveGateUpdates()
+	return !updater.dk.FeatureDisableActiveGateUpdates()
 }
 
 func (updater activeGateUpdater) IsPublicRegistryEnabled() bool {
-	isPublicRegistry := updater.dynakube.FeaturePublicRegistry() && !updater.dynakube.ClassicFullStackMode()
+	isPublicRegistry := updater.dk.FeaturePublicRegistry() && !updater.dk.ClassicFullStackMode()
 	if isPublicRegistry {
-		setVerifiedCondition(updater.dynakube.Conditions(), activeGateVersionConditionType) // Bit hacky, as things can still go wrong, but if so we will just overwrite this is LatestImageInfo.
+		setVerifiedCondition(updater.dk.Conditions(), activeGateVersionConditionType) // Bit hacky, as things can still go wrong, but if so we will just overwrite this is LatestImageInfo.
 	}
 
 	return isPublicRegistry
@@ -82,7 +82,7 @@ func (updater activeGateUpdater) IsPublicRegistryEnabled() bool {
 func (updater activeGateUpdater) LatestImageInfo(ctx context.Context) (*dtclient.LatestImageInfo, error) {
 	imageInfo, err := updater.dtClient.GetLatestActiveGateImage(ctx)
 	if err != nil {
-		conditions.SetDynatraceApiError(updater.dynakube.Conditions(), activeGateVersionConditionType, err)
+		conditions.SetDynatraceApiError(updater.dk.Conditions(), activeGateVersionConditionType, err)
 	}
 
 	return imageInfo, err
@@ -96,19 +96,19 @@ func (updater *activeGateUpdater) UseTenantRegistry(ctx context.Context) error {
 	latestVersion, err := updater.dtClient.GetLatestActiveGateVersion(ctx, dtclient.OsUnix)
 	if err != nil {
 		log.Info("failed to determine image version", "error", err)
-		conditions.SetDynatraceApiError(updater.dynakube.Conditions(), activeGateVersionConditionType, err)
+		conditions.SetDynatraceApiError(updater.dk.Conditions(), activeGateVersionConditionType, err)
 
 		return err
 	}
 
-	defaultImage := updater.dynakube.DefaultActiveGateImage(latestVersion)
+	defaultImage := updater.dk.DefaultActiveGateImage(latestVersion)
 
 	err = updateVersionStatusForTenantRegistry(updater.Target(), defaultImage, latestVersion)
 	if err != nil {
 		return err
 	}
 
-	setVerifiedCondition(updater.dynakube.Conditions(), activeGateVersionConditionType)
+	setVerifiedCondition(updater.dk.Conditions(), activeGateVersionConditionType)
 
 	return nil
 }

--- a/pkg/controllers/dynakube/version/activegate.go
+++ b/pkg/controllers/dynakube/version/activegate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/pkg/errors"
@@ -17,13 +17,13 @@ const (
 )
 
 type activeGateUpdater struct {
-	dynakube  *dynatracev1beta2.DynaKube
+	dynakube  *dynakube.DynaKube
 	apiReader client.Reader
 	dtClient  dtclient.Client
 }
 
 func newActiveGateUpdater(
-	dynakube *dynatracev1beta2.DynaKube,
+	dynakube *dynakube.DynaKube,
 	apiReader client.Reader,
 	dtClient dtclient.Client,
 ) *activeGateUpdater {

--- a/pkg/controllers/dynakube/version/activegate_test.go
+++ b/pkg/controllers/dynakube/version/activegate_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
@@ -23,16 +23,16 @@ func TestActiveGateUpdater(t *testing.T) {
 	}
 
 	t.Run("Getters work as expected", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
+		dynakube := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					dynatracev1beta2.AnnotationFeatureDisableActiveGateUpdates: "true",
+					dynakube.AnnotationFeatureDisableActiveGateUpdates: "true",
 				},
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{
-					Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.DynatraceApiCapability.DisplayName},
-					CapabilityProperties: dynatracev1beta2.CapabilityProperties{
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: dynakube.ActiveGateSpec{
+					Capabilities: []dynakube.CapabilityDisplayName{dynakube.DynatraceApiCapability.DisplayName},
+					CapabilityProperties: dynakube.CapabilityProperties{
 						Image: testImage.String(),
 					},
 				},
@@ -56,15 +56,15 @@ func TestActiveGateUpdater(t *testing.T) {
 
 func TestActiveGateUseDefault(t *testing.T) {
 	t.Run("Set according to defaults, unset previous status", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
+		dynakube := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{
-					CapabilityProperties: dynatracev1beta2.CapabilityProperties{},
+				ActiveGate: dynakube.ActiveGateSpec{
+					CapabilityProperties: dynakube.CapabilityProperties{},
 				},
 			},
-			Status: dynatracev1beta2.DynaKubeStatus{
-				ActiveGate: dynatracev1beta2.ActiveGateStatus{
+			Status: dynakube.DynaKubeStatus{
+				ActiveGate: dynakube.ActiveGateStatus{
 					VersionStatus: status.VersionStatus{
 						Version: "prev",
 					},
@@ -88,9 +88,9 @@ func TestActiveGateUseDefault(t *testing.T) {
 
 func TestActiveGateIsEnabled(t *testing.T) {
 	t.Run("cleans up if not enabled", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Status: dynatracev1beta2.DynaKubeStatus{
-				ActiveGate: dynatracev1beta2.ActiveGateStatus{
+		dynakube := &dynakube.DynaKube{
+			Status: dynakube.DynaKubeStatus{
+				ActiveGate: dynakube.ActiveGateStatus{
 					VersionStatus: status.VersionStatus{
 						Version: "prev",
 					},

--- a/pkg/controllers/dynakube/version/codemodules.go
+++ b/pkg/controllers/dynakube/version/codemodules.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -15,11 +15,11 @@ const (
 )
 
 type codeModulesUpdater struct {
-	dynakube *dynatracev1beta2.DynaKube
+	dynakube *dynakube.DynaKube
 	dtClient dtclient.Client
 }
 
-func newCodeModulesUpdater(dynakube *dynatracev1beta2.DynaKube, dtClient dtclient.Client) *codeModulesUpdater {
+func newCodeModulesUpdater(dynakube *dynakube.DynaKube, dtClient dtclient.Client) *codeModulesUpdater {
 	return &codeModulesUpdater{
 		dynakube: dynakube,
 		dtClient: dtClient,
@@ -87,7 +87,7 @@ func (updater *codeModulesUpdater) CheckForDowngrade(_ string) (bool, error) {
 func (updater *codeModulesUpdater) UseTenantRegistry(ctx context.Context) error {
 	customVersion := updater.CustomVersion()
 	if customVersion != "" {
-		updater.dynakube.Status.CodeModules = dynatracev1beta2.CodeModulesStatus{
+		updater.dynakube.Status.CodeModules = dynakube.CodeModulesStatus{
 			VersionStatus: status.VersionStatus{
 				Version: customVersion,
 			},
@@ -106,7 +106,7 @@ func (updater *codeModulesUpdater) UseTenantRegistry(ctx context.Context) error 
 		return err
 	}
 
-	updater.dynakube.Status.CodeModules = dynatracev1beta2.CodeModulesStatus{
+	updater.dynakube.Status.CodeModules = dynakube.CodeModulesStatus{
 		VersionStatus: status.VersionStatus{
 			Version: latestAgentVersionUnixPaas,
 		},

--- a/pkg/controllers/dynakube/version/codemodules_test.go
+++ b/pkg/controllers/dynakube/version/codemodules_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
@@ -23,13 +23,13 @@ func TestCodeModulesUpdater(t *testing.T) {
 	}
 
 	t.Run("Getters work as expected", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{
+		dynakube := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
 						Version:      testImage.Tag,
 						UseCSIDriver: true,
-						AppInjectionSpec: dynatracev1beta2.AppInjectionSpec{
+						AppInjectionSpec: dynakube.AppInjectionSpec{
 							CodeModulesImage: testImage.String(),
 						},
 					},
@@ -56,15 +56,15 @@ func TestCodeModulesUseDefault(t *testing.T) {
 	testVersion := "1.2.3.4-5"
 
 	t.Run("Set according to version field, unset previous status", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{
+		dynakube := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
 						Version: testVersion,
 					},
 				},
 			},
-			Status: dynatracev1beta2.DynaKubeStatus{
+			Status: dynakube.DynaKubeStatus{
 				CodeModules: oldCodeModulesStatus(),
 			},
 		}
@@ -79,13 +79,13 @@ func TestCodeModulesUseDefault(t *testing.T) {
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	})
 	t.Run("Set according to default, unset previous status", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{},
+		dynakube := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
 				},
 			},
-			Status: dynatracev1beta2.DynaKubeStatus{
+			Status: dynakube.DynaKubeStatus{
 				CodeModules: oldCodeModulesStatus(),
 			},
 		}
@@ -101,13 +101,13 @@ func TestCodeModulesUseDefault(t *testing.T) {
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	})
 	t.Run("problem with Dynatrace request => visible in conditions", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{},
+		dynakube := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
 				},
 			},
-			Status: dynatracev1beta2.DynaKubeStatus{
+			Status: dynakube.DynaKubeStatus{
 				CodeModules: oldCodeModulesStatus(),
 			},
 		}
@@ -124,9 +124,9 @@ func TestCodeModulesUseDefault(t *testing.T) {
 
 func TestCodeModulesIsEnabled(t *testing.T) {
 	t.Run("cleans up condition if not enabled", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Status: dynatracev1beta2.DynaKubeStatus{
-				CodeModules: dynatracev1beta2.CodeModulesStatus{
+		dynakube := &dynakube.DynaKube{
+			Status: dynakube.DynaKubeStatus{
+				CodeModules: dynakube.CodeModulesStatus{
 					VersionStatus: status.VersionStatus{
 						Version: "prev",
 					},
@@ -149,10 +149,10 @@ func TestCodeModulesIsEnabled(t *testing.T) {
 
 func TestCodeModulesPublicRegistry(t *testing.T) {
 	t.Run("sets condition if enabled", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
+		dynakube := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					dynatracev1beta2.AnnotationFeaturePublicRegistry: "true",
+					dynakube.AnnotationFeaturePublicRegistry: "true",
 				},
 			},
 		}
@@ -168,7 +168,7 @@ func TestCodeModulesPublicRegistry(t *testing.T) {
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	})
 	t.Run("ignores conditions if not enabled", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{}
+		dynakube := &dynakube.DynaKube{}
 
 		updater := newCodeModulesUpdater(dynakube, nil)
 
@@ -182,10 +182,10 @@ func TestCodeModulesPublicRegistry(t *testing.T) {
 
 func TestCodeModulesLatestImageInfo(t *testing.T) {
 	t.Run("problem with Dynatrace request => visible in conditions", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
+		dynakube := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					dynatracev1beta2.AnnotationFeaturePublicRegistry: "true",
+					dynakube.AnnotationFeaturePublicRegistry: "true",
 				},
 			},
 		}
@@ -202,15 +202,15 @@ func TestCodeModulesLatestImageInfo(t *testing.T) {
 	})
 }
 
-func oldCodeModulesStatus() dynatracev1beta2.CodeModulesStatus {
-	return dynatracev1beta2.CodeModulesStatus{
+func oldCodeModulesStatus() dynakube.CodeModulesStatus {
+	return dynakube.CodeModulesStatus{
 		VersionStatus: status.VersionStatus{
 			ImageID: "prev",
 		},
 	}
 }
 
-func assertDefaultCodeModulesStatus(t *testing.T, expectedVersion string, codeModulesStatus dynatracev1beta2.CodeModulesStatus) {
+func assertDefaultCodeModulesStatus(t *testing.T, expectedVersion string, codeModulesStatus dynakube.CodeModulesStatus) {
 	assert.Equal(t, expectedVersion, codeModulesStatus.Version)
 	assert.Empty(t, codeModulesStatus.ImageID)
 }

--- a/pkg/controllers/dynakube/version/oneagent.go
+++ b/pkg/controllers/dynakube/version/oneagent.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/pkg/errors"
@@ -17,13 +17,13 @@ const (
 )
 
 type oneAgentUpdater struct {
-	dynakube  *dynatracev1beta2.DynaKube
+	dynakube  *dynakube.DynaKube
 	apiReader client.Reader
 	dtClient  dtclient.Client
 }
 
 func newOneAgentUpdater(
-	dynakube *dynatracev1beta2.DynaKube,
+	dynakube *dynakube.DynaKube,
 	apiReader client.Reader,
 	dtClient dtclient.Client,
 ) *oneAgentUpdater {

--- a/pkg/controllers/dynakube/version/oneagent_test.go
+++ b/pkg/controllers/dynakube/version/oneagent_test.go
@@ -286,7 +286,7 @@ func TestOneAgentUseDefault(t *testing.T) {
 
 type CheckForDowngradeTestCase struct {
 	testName    string
-	dynakube    *dynakube.DynaKube
+	dk          *dynakube.DynaKube
 	newVersion  string
 	isDowngrade bool
 }
@@ -307,7 +307,7 @@ func TestCheckForDowngrade(t *testing.T) {
 	testCases := []CheckForDowngradeTestCase{
 		{
 			testName: "is downgrade, tenant registry",
-			dynakube: newDynakubeWithOneAgentStatus(status.VersionStatus{
+			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
 				ImageID: "does-not-matter",
 				Version: newerVersion,
 				Source:  status.TenantRegistryVersionSource,
@@ -317,7 +317,7 @@ func TestCheckForDowngrade(t *testing.T) {
 		},
 		{
 			testName: "is downgrade, public registry",
-			dynakube: newDynakubeWithOneAgentStatus(status.VersionStatus{
+			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
 				ImageID: "some.registry.com:" + newerVersion,
 				Source:  status.PublicRegistryVersionSource,
 			}),
@@ -326,7 +326,7 @@ func TestCheckForDowngrade(t *testing.T) {
 		},
 		{
 			testName: "is NOT downgrade, tenant registry",
-			dynakube: newDynakubeWithOneAgentStatus(status.VersionStatus{
+			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
 				ImageID: "does-not-matter",
 				Version: olderVersion,
 				Source:  status.TenantRegistryVersionSource,
@@ -336,7 +336,7 @@ func TestCheckForDowngrade(t *testing.T) {
 		},
 		{
 			testName: "is NOT downgrade, public registry",
-			dynakube: newDynakubeWithOneAgentStatus(status.VersionStatus{
+			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
 				ImageID: "some.registry.com:" + olderVersion,
 				Source:  status.PublicRegistryVersionSource,
 			}),
@@ -345,7 +345,7 @@ func TestCheckForDowngrade(t *testing.T) {
 		},
 		{
 			testName: "is NOT downgrade, custom image - no logic",
-			dynakube: newDynakubeWithOneAgentStatus(status.VersionStatus{
+			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
 				ImageID: "some.registry.com:" + newerVersion,
 				Source:  status.CustomImageVersionSource,
 			}),
@@ -354,7 +354,7 @@ func TestCheckForDowngrade(t *testing.T) {
 		},
 		{
 			testName: "is NOT downgrade, custom version - no logic",
-			dynakube: newDynakubeWithOneAgentStatus(status.VersionStatus{
+			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
 				ImageID: "some.registry.com:" + newerVersion,
 				Source:  status.CustomVersionVersionSource,
 			}),
@@ -365,7 +365,7 @@ func TestCheckForDowngrade(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
-			updater := newOneAgentUpdater(testCase.dynakube, fake.NewClient(), nil)
+			updater := newOneAgentUpdater(testCase.dk, fake.NewClient(), nil)
 
 			isDowngrade, err := updater.CheckForDowngrade(testCase.newVersion)
 			require.NoError(t, err)

--- a/pkg/controllers/dynakube/version/oneagent_test.go
+++ b/pkg/controllers/dynakube/version/oneagent_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
@@ -24,10 +24,10 @@ func TestOneAgentUpdater(t *testing.T) {
 	}
 
 	t.Run("Getters work as expected", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ClassicFullStack: &dynatracev1beta2.HostInjectSpec{
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: &dynakube.HostInjectSpec{
 						AutoUpdate: false,
 						Image:      testImage.String(),
 						Version:    testImage.Tag,
@@ -38,12 +38,12 @@ func TestOneAgentUpdater(t *testing.T) {
 		mockClient := dtclientmock.NewClient(t)
 		mockOneAgentImageInfo(mockClient, testImage)
 
-		updater := newOneAgentUpdater(dynakube, fake.NewClient(), mockClient)
+		updater := newOneAgentUpdater(dk, fake.NewClient(), mockClient)
 
 		assert.Equal(t, "oneagent", updater.Name())
 		assert.True(t, updater.IsEnabled())
-		assert.Equal(t, dynakube.Spec.OneAgent.ClassicFullStack.Image, updater.CustomImage())
-		assert.Equal(t, dynakube.Spec.OneAgent.ClassicFullStack.Version, updater.CustomVersion())
+		assert.Equal(t, dk.Spec.OneAgent.ClassicFullStack.Image, updater.CustomImage())
+		assert.Equal(t, dk.Spec.OneAgent.ClassicFullStack.Version, updater.CustomVersion())
 		assert.False(t, updater.IsAutoUpdateEnabled())
 		imageInfo, err := updater.LatestImageInfo(ctx)
 		require.NoError(t, err)
@@ -53,9 +53,9 @@ func TestOneAgentUpdater(t *testing.T) {
 
 func TestOneAgentIsEnabled(t *testing.T) {
 	t.Run("cleans up condition if not enabled", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Status: dynatracev1beta2.DynaKubeStatus{
-				OneAgent: dynatracev1beta2.OneAgentStatus{
+		dk := &dynakube.DynaKube{
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: dynakube.OneAgentStatus{
 					VersionStatus: status.VersionStatus{
 						Version: "prev",
 					},
@@ -63,70 +63,70 @@ func TestOneAgentIsEnabled(t *testing.T) {
 				},
 			},
 		}
-		setVerifiedCondition(dynakube.Conditions(), oaConditionType)
+		setVerifiedCondition(dk.Conditions(), oaConditionType)
 
-		updater := newOneAgentUpdater(dynakube, nil, nil)
+		updater := newOneAgentUpdater(dk, nil, nil)
 
 		isEnabled := updater.IsEnabled()
 		require.False(t, isEnabled)
 
-		condition := meta.FindStatusCondition(*dynakube.Conditions(), oaConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), oaConditionType)
 		assert.Nil(t, condition)
 
 		assert.Empty(t, updater.Target())
-		assert.Empty(t, dynakube.Status.OneAgent.Healthcheck)
+		assert.Empty(t, dk.Status.OneAgent.Healthcheck)
 	})
 }
 
 func TestOneAgentPublicRegistry(t *testing.T) {
 	t.Run("sets condition if enabled", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					dynatracev1beta2.AnnotationFeaturePublicRegistry: "true",
+					dynakube.AnnotationFeaturePublicRegistry: "true",
 				},
 			},
 		}
 
-		updater := newOneAgentUpdater(dynakube, nil, nil)
+		updater := newOneAgentUpdater(dk, nil, nil)
 
 		isEnabled := updater.IsPublicRegistryEnabled()
 		require.True(t, isEnabled)
 
-		condition := meta.FindStatusCondition(*dynakube.Conditions(), oaConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), oaConditionType)
 		require.NotNil(t, condition)
 		assert.Equal(t, verifiedReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	})
 	t.Run("ignores conditions if not enabled", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{}
+		dk := &dynakube.DynaKube{}
 
-		updater := newOneAgentUpdater(dynakube, nil, nil)
+		updater := newOneAgentUpdater(dk, nil, nil)
 
 		isEnabled := updater.IsPublicRegistryEnabled()
 		require.False(t, isEnabled)
 
-		condition := meta.FindStatusCondition(*dynakube.Conditions(), oaConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), oaConditionType)
 		require.Nil(t, condition)
 	})
 }
 
 func TestOneAgentLatestImageInfo(t *testing.T) {
 	t.Run("problem with Dynatrace request => visible in conditions", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					dynatracev1beta2.AnnotationFeaturePublicRegistry: "true",
+					dynakube.AnnotationFeaturePublicRegistry: "true",
 				},
 			},
 		}
 
-		updater := newOneAgentUpdater(dynakube, nil, createErrorDTClient(t))
+		updater := newOneAgentUpdater(dk, nil, createErrorDTClient(t))
 
 		_, err := updater.LatestImageInfo(context.Background())
 		require.Error(t, err)
 
-		condition := meta.FindStatusCondition(*dynakube.Conditions(), oaConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), oaConditionType)
 		require.NotNil(t, condition)
 		assert.Equal(t, conditions.DynatraceApiErrorReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
@@ -137,65 +137,65 @@ func TestOneAgentUseDefault(t *testing.T) {
 	testVersion := "1.2.3.4-5"
 
 	t.Run("Set according to version field", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ClassicFullStack: &dynatracev1beta2.HostInjectSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: &dynakube.HostInjectSpec{
 						Version: testVersion,
 					},
 				},
 			},
 		}
-		expectedImage := dynakube.DefaultOneAgentImage(testVersion)
+		expectedImage := dk.DefaultOneAgentImage(testVersion)
 
 		mockClient := dtclientmock.NewClient(t)
 
-		updater := newOneAgentUpdater(dynakube, fake.NewClient(), mockClient)
+		updater := newOneAgentUpdater(dk, fake.NewClient(), mockClient)
 
 		err := updater.UseTenantRegistry(context.TODO())
 
 		require.NoError(t, err)
-		assertStatusBasedOnTenantRegistry(t, expectedImage, testVersion, dynakube.Status.OneAgent.VersionStatus)
-		condition := meta.FindStatusCondition(*dynakube.Conditions(), oaConditionType)
+		assertStatusBasedOnTenantRegistry(t, expectedImage, testVersion, dk.Status.OneAgent.VersionStatus)
+		condition := meta.FindStatusCondition(*dk.Conditions(), oaConditionType)
 		assert.Equal(t, verifiedReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	})
 	t.Run("Set according to default", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ClassicFullStack: &dynatracev1beta2.HostInjectSpec{},
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: &dynakube.HostInjectSpec{},
 				},
 			},
 		}
-		expectedImage := dynakube.DefaultOneAgentImage(testVersion)
+		expectedImage := dk.DefaultOneAgentImage(testVersion)
 
 		mockClient := dtclientmock.NewClient(t)
 		mockLatestAgentVersion(mockClient, testVersion)
 
-		updater := newOneAgentUpdater(dynakube, fake.NewClient(), mockClient)
+		updater := newOneAgentUpdater(dk, fake.NewClient(), mockClient)
 
 		err := updater.UseTenantRegistry(context.Background())
 
 		require.NoError(t, err)
-		assertStatusBasedOnTenantRegistry(t, expectedImage, testVersion, dynakube.Status.OneAgent.VersionStatus)
-		condition := meta.FindStatusCondition(*dynakube.Conditions(), oaConditionType)
+		assertStatusBasedOnTenantRegistry(t, expectedImage, testVersion, dk.Status.OneAgent.VersionStatus)
+		condition := meta.FindStatusCondition(*dk.Conditions(), oaConditionType)
 		assert.Equal(t, verifiedReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	})
 	t.Run("Don't allow downgrades", func(t *testing.T) {
 		previousVersion := "999.999.999.999-999"
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ClassicFullStack: &dynatracev1beta2.HostInjectSpec{},
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: &dynakube.HostInjectSpec{},
 				},
 			},
-			Status: dynatracev1beta2.DynaKubeStatus{
-				OneAgent: dynatracev1beta2.OneAgentStatus{
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: dynakube.OneAgentStatus{
 					VersionStatus: status.VersionStatus{
 						ImageID: "some.registry.com:" + previousVersion,
 						Version: previousVersion,
@@ -208,28 +208,28 @@ func TestOneAgentUseDefault(t *testing.T) {
 		mockClient := dtclientmock.NewClient(t)
 		mockLatestAgentVersion(mockClient, testVersion)
 
-		updater := newOneAgentUpdater(dynakube, fake.NewClient(), mockClient)
+		updater := newOneAgentUpdater(dk, fake.NewClient(), mockClient)
 
 		err := updater.UseTenantRegistry(context.Background())
 		require.NoError(t, err) // we only log the downgrade problem, not fail the reconcile
-		assert.Equal(t, previousVersion, dynakube.Status.OneAgent.Version)
+		assert.Equal(t, previousVersion, dk.Status.OneAgent.Version)
 
-		condition := meta.FindStatusCondition(*dynakube.Conditions(), oaConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), oaConditionType)
 		assert.Equal(t, downgradeReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	})
 
 	t.Run("Verification fails due to malformed version", func(t *testing.T) {
 		previousVersion := "1.2.3.4444-555"
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ClassicFullStack: &dynatracev1beta2.HostInjectSpec{},
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: &dynakube.HostInjectSpec{},
 				},
 			},
-			Status: dynatracev1beta2.DynaKubeStatus{
-				OneAgent: dynatracev1beta2.OneAgentStatus{
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: dynakube.OneAgentStatus{
 					VersionStatus: status.VersionStatus{
 						ImageID: "some.registry.com:" + previousVersion,
 						Version: previousVersion,
@@ -242,26 +242,26 @@ func TestOneAgentUseDefault(t *testing.T) {
 		mockClient := dtclientmock.NewClient(t)
 		mockLatestAgentVersion(mockClient, "BOOM")
 
-		updater := newOneAgentUpdater(dynakube, fake.NewClient(), mockClient)
+		updater := newOneAgentUpdater(dk, fake.NewClient(), mockClient)
 
 		err := updater.UseTenantRegistry(context.Background())
 		require.Error(t, err)
-		assert.Equal(t, previousVersion, dynakube.Status.OneAgent.Version)
+		assert.Equal(t, previousVersion, dk.Status.OneAgent.Version)
 
-		condition := meta.FindStatusCondition(*dynakube.Conditions(), oaConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), oaConditionType)
 		assert.Equal(t, verificationFailedReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	})
 	t.Run("Verification fails due to malformed ImageID", func(t *testing.T) {
-		dynakube := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
 				APIURL: testApiUrl,
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 				},
 			},
-			Status: dynatracev1beta2.DynaKubeStatus{
-				OneAgent: dynatracev1beta2.OneAgentStatus{
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: dynakube.OneAgentStatus{
 					VersionStatus: status.VersionStatus{
 						ImageID: "BOOM",
 						Source:  status.PublicRegistryVersionSource,
@@ -273,12 +273,12 @@ func TestOneAgentUseDefault(t *testing.T) {
 		mockClient := dtclientmock.NewClient(t)
 		mockLatestAgentVersion(mockClient, testVersion)
 
-		updater := newOneAgentUpdater(dynakube, fake.NewClient(), mockClient)
+		updater := newOneAgentUpdater(dk, fake.NewClient(), mockClient)
 
 		err := updater.UseTenantRegistry(context.Background())
 		require.Error(t, err)
 
-		condition := meta.FindStatusCondition(*dynakube.Conditions(), oaConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), oaConditionType)
 		assert.Equal(t, verificationFailedReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	})
@@ -286,15 +286,15 @@ func TestOneAgentUseDefault(t *testing.T) {
 
 type CheckForDowngradeTestCase struct {
 	testName    string
-	dynakube    *dynatracev1beta2.DynaKube
+	dynakube    *dynakube.DynaKube
 	newVersion  string
 	isDowngrade bool
 }
 
-func newDynakubeWithOneAgentStatus(status status.VersionStatus) *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
-		Status: dynatracev1beta2.DynaKubeStatus{
-			OneAgent: dynatracev1beta2.OneAgentStatus{
+func newDynakubeWithOneAgentStatus(status status.VersionStatus) *dynakube.DynaKube {
+	return &dynakube.DynaKube{
+		Status: dynakube.DynaKubeStatus{
+			OneAgent: dynakube.OneAgentStatus{
 				VersionStatus: status,
 			},
 		},
@@ -374,13 +374,13 @@ func TestCheckForDowngrade(t *testing.T) {
 	}
 }
 
-func newDynakubeForCheckLabelTest(versionStatus status.VersionStatus) *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			OneAgent: dynatracev1beta2.OneAgentSpec{},
+func newDynakubeForCheckLabelTest(versionStatus status.VersionStatus) *dynakube.DynaKube {
+	return &dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: dynakube.OneAgentSpec{},
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			OneAgent: dynatracev1beta2.OneAgentStatus{
+		Status: dynakube.DynaKubeStatus{
+			OneAgent: dynakube.OneAgentStatus{
 				VersionStatus: versionStatus,
 			},
 		},
@@ -398,29 +398,29 @@ func TestCheckLabels(t *testing.T) {
 	}
 
 	t.Run("Validate immutable oneAgent image with default cloudNative", func(t *testing.T) {
-		dynakube := newDynakubeForCheckLabelTest(versionStatus)
-		dynakube.Spec.OneAgent.CloudNativeFullStack = &dynatracev1beta2.CloudNativeFullStackSpec{}
-		updater := newOneAgentUpdater(dynakube, fake.NewClient(), nil)
+		dk := newDynakubeForCheckLabelTest(versionStatus)
+		dk.Spec.OneAgent.CloudNativeFullStack = &dynakube.CloudNativeFullStackSpec{}
+		updater := newOneAgentUpdater(dk, fake.NewClient(), nil)
 		require.NoError(t, updater.ValidateStatus())
 	})
 	t.Run("Validate immutable oneAgent image with classicFullStack", func(t *testing.T) {
-		dynakube := newDynakubeForCheckLabelTest(versionStatus)
-		dynakube.Spec.OneAgent.ClassicFullStack = &dynatracev1beta2.HostInjectSpec{}
-		updater := newOneAgentUpdater(dynakube, fake.NewClient(), nil)
+		dk := newDynakubeForCheckLabelTest(versionStatus)
+		dk.Spec.OneAgent.ClassicFullStack = &dynakube.HostInjectSpec{}
+		updater := newOneAgentUpdater(dk, fake.NewClient(), nil)
 		require.Error(t, updater.ValidateStatus())
 	})
 	t.Run("Validate immutable oneAgent image when image version is not set", func(t *testing.T) {
-		dynakube := newDynakubeForCheckLabelTest(versionStatus)
-		dynakube.Spec.OneAgent.CloudNativeFullStack = &dynatracev1beta2.CloudNativeFullStackSpec{}
-		dynakube.Status.OneAgent.VersionStatus.Version = ""
-		updater := newOneAgentUpdater(dynakube, fake.NewClient(), nil)
+		dk := newDynakubeForCheckLabelTest(versionStatus)
+		dk.Spec.OneAgent.CloudNativeFullStack = &dynakube.CloudNativeFullStackSpec{}
+		dk.Status.OneAgent.VersionStatus.Version = ""
+		updater := newOneAgentUpdater(dk, fake.NewClient(), nil)
 		require.Error(t, updater.ValidateStatus())
 	})
 	t.Run("Validate mutable oneAgent image with classicFullStack", func(t *testing.T) {
-		dynakube := newDynakubeForCheckLabelTest(versionStatus)
-		dynakube.Spec.OneAgent.ClassicFullStack = &dynatracev1beta2.HostInjectSpec{}
-		dynakube.Status.OneAgent.VersionStatus.Type = "mutable"
-		updater := newOneAgentUpdater(dynakube, fake.NewClient(), nil)
+		dk := newDynakubeForCheckLabelTest(versionStatus)
+		dk.Spec.OneAgent.ClassicFullStack = &dynakube.HostInjectSpec{}
+		dk.Status.OneAgent.VersionStatus.Type = "mutable"
+		updater := newOneAgentUpdater(dk, fake.NewClient(), nil)
 		require.NoError(t, updater.ValidateStatus())
 	})
 }

--- a/pkg/controllers/dynakube/version/reconciler.go
+++ b/pkg/controllers/dynakube/version/reconciler.go
@@ -5,16 +5,16 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Reconciler interface {
-	ReconcileCodeModules(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error
-	ReconcileOneAgent(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error
-	ReconcileActiveGate(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error
+	ReconcileCodeModules(ctx context.Context, dynakube *dynakube.DynaKube) error
+	ReconcileOneAgent(ctx context.Context, dynakube *dynakube.DynaKube) error
+	ReconcileActiveGate(ctx context.Context, dynakube *dynakube.DynaKube) error
 }
 
 type reconciler struct {
@@ -34,7 +34,7 @@ func NewReconciler(apiReader client.Reader, dtClient dtclient.Client, timeProvid
 	}
 }
 
-func (r *reconciler) ReconcileCodeModules(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error {
+func (r *reconciler) ReconcileCodeModules(ctx context.Context, dynakube *dynakube.DynaKube) error {
 	updater := newCodeModulesUpdater(dynakube, r.dtClient)
 	if r.needsUpdate(updater, dynakube) {
 		return r.updateVersionStatuses(ctx, updater, dynakube)
@@ -43,7 +43,7 @@ func (r *reconciler) ReconcileCodeModules(ctx context.Context, dynakube *dynatra
 	return nil
 }
 
-func (r *reconciler) ReconcileOneAgent(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error {
+func (r *reconciler) ReconcileOneAgent(ctx context.Context, dynakube *dynakube.DynaKube) error {
 	updater := newOneAgentUpdater(dynakube, r.apiReader, r.dtClient)
 	if r.needsUpdate(updater, dynakube) {
 		return r.updateVersionStatuses(ctx, updater, dynakube)
@@ -52,7 +52,7 @@ func (r *reconciler) ReconcileOneAgent(ctx context.Context, dynakube *dynatracev
 	return nil
 }
 
-func (r *reconciler) ReconcileActiveGate(ctx context.Context, dynakube *dynatracev1beta2.DynaKube) error {
+func (r *reconciler) ReconcileActiveGate(ctx context.Context, dynakube *dynakube.DynaKube) error {
 	updater := newActiveGateUpdater(dynakube, r.apiReader, r.dtClient)
 	if r.needsUpdate(updater, dynakube) {
 		err := r.updateVersionStatuses(ctx, updater, dynakube)
@@ -63,7 +63,7 @@ func (r *reconciler) ReconcileActiveGate(ctx context.Context, dynakube *dynatrac
 	return nil
 }
 
-func (r *reconciler) updateVersionStatuses(ctx context.Context, updater StatusUpdater, dynakube *dynatracev1beta2.DynaKube) error {
+func (r *reconciler) updateVersionStatuses(ctx context.Context, updater StatusUpdater, dynakube *dynakube.DynaKube) error {
 	log.Info("updating version status", "updater", updater.Name())
 
 	err := r.run(ctx, updater)
@@ -90,7 +90,7 @@ func (r *reconciler) updateVersionStatuses(ctx context.Context, updater StatusUp
 	return nil
 }
 
-func (r *reconciler) needsUpdate(updater StatusUpdater, dynakube *dynatracev1beta2.DynaKube) bool {
+func (r *reconciler) needsUpdate(updater StatusUpdater, dynakube *dynakube.DynaKube) bool {
 	if !updater.IsEnabled() {
 		log.Info("skipping version status update for disabled section", "updater", updater.Name())
 

--- a/pkg/controllers/dynakube/version/reconciler.go
+++ b/pkg/controllers/dynakube/version/reconciler.go
@@ -12,9 +12,9 @@ import (
 )
 
 type Reconciler interface {
-	ReconcileCodeModules(ctx context.Context, dynakube *dynakube.DynaKube) error
-	ReconcileOneAgent(ctx context.Context, dynakube *dynakube.DynaKube) error
-	ReconcileActiveGate(ctx context.Context, dynakube *dynakube.DynaKube) error
+	ReconcileCodeModules(ctx context.Context, dk *dynakube.DynaKube) error
+	ReconcileOneAgent(ctx context.Context, dk *dynakube.DynaKube) error
+	ReconcileActiveGate(ctx context.Context, dk *dynakube.DynaKube) error
 }
 
 type reconciler struct {
@@ -34,28 +34,28 @@ func NewReconciler(apiReader client.Reader, dtClient dtclient.Client, timeProvid
 	}
 }
 
-func (r *reconciler) ReconcileCodeModules(ctx context.Context, dynakube *dynakube.DynaKube) error {
-	updater := newCodeModulesUpdater(dynakube, r.dtClient)
-	if r.needsUpdate(updater, dynakube) {
-		return r.updateVersionStatuses(ctx, updater, dynakube)
+func (r *reconciler) ReconcileCodeModules(ctx context.Context, dk *dynakube.DynaKube) error {
+	updater := newCodeModulesUpdater(dk, r.dtClient)
+	if r.needsUpdate(updater, dk) {
+		return r.updateVersionStatuses(ctx, updater, dk)
 	}
 
 	return nil
 }
 
-func (r *reconciler) ReconcileOneAgent(ctx context.Context, dynakube *dynakube.DynaKube) error {
-	updater := newOneAgentUpdater(dynakube, r.apiReader, r.dtClient)
-	if r.needsUpdate(updater, dynakube) {
-		return r.updateVersionStatuses(ctx, updater, dynakube)
+func (r *reconciler) ReconcileOneAgent(ctx context.Context, dk *dynakube.DynaKube) error {
+	updater := newOneAgentUpdater(dk, r.apiReader, r.dtClient)
+	if r.needsUpdate(updater, dk) {
+		return r.updateVersionStatuses(ctx, updater, dk)
 	}
 
 	return nil
 }
 
-func (r *reconciler) ReconcileActiveGate(ctx context.Context, dynakube *dynakube.DynaKube) error {
-	updater := newActiveGateUpdater(dynakube, r.apiReader, r.dtClient)
-	if r.needsUpdate(updater, dynakube) {
-		err := r.updateVersionStatuses(ctx, updater, dynakube)
+func (r *reconciler) ReconcileActiveGate(ctx context.Context, dk *dynakube.DynaKube) error {
+	updater := newActiveGateUpdater(dk, r.apiReader, r.dtClient)
+	if r.needsUpdate(updater, dk) {
+		err := r.updateVersionStatuses(ctx, updater, dk)
 
 		return err
 	}
@@ -63,7 +63,7 @@ func (r *reconciler) ReconcileActiveGate(ctx context.Context, dynakube *dynakube
 	return nil
 }
 
-func (r *reconciler) updateVersionStatuses(ctx context.Context, updater StatusUpdater, dynakube *dynakube.DynaKube) error {
+func (r *reconciler) updateVersionStatuses(ctx context.Context, updater StatusUpdater, dk *dynakube.DynaKube) error {
 	log.Info("updating version status", "updater", updater.Name())
 
 	err := r.run(ctx, updater)
@@ -79,18 +79,18 @@ func (r *reconciler) updateVersionStatuses(ctx context.Context, updater StatusUp
 
 	_, ok := updater.(*oneAgentUpdater)
 	if ok {
-		healthConfig, err := getOneAgentHealthConfig(dynakube.OneAgentVersion())
+		healthConfig, err := getOneAgentHealthConfig(dk.OneAgentVersion())
 		if err != nil {
 			log.Error(err, "could not set OneAgent healthcheck")
 		} else {
-			dynakube.Status.OneAgent.Healthcheck = healthConfig
+			dk.Status.OneAgent.Healthcheck = healthConfig
 		}
 	}
 
 	return nil
 }
 
-func (r *reconciler) needsUpdate(updater StatusUpdater, dynakube *dynakube.DynaKube) bool {
+func (r *reconciler) needsUpdate(updater StatusUpdater, dk *dynakube.DynaKube) bool {
 	if !updater.IsEnabled() {
 		log.Info("skipping version status update for disabled section", "updater", updater.Name())
 
@@ -107,7 +107,7 @@ func (r *reconciler) needsUpdate(updater StatusUpdater, dynakube *dynakube.DynaK
 		return true
 	}
 
-	if !r.timeProvider.IsOutdated(updater.Target().LastProbeTimestamp, dynakube.ApiRequestThreshold()) {
+	if !r.timeProvider.IsOutdated(updater.Target().LastProbeTimestamp, dk.ApiRequestThreshold()) {
 		log.Info("status timestamp still valid, skipping version status updater", "updater", updater.Name())
 
 		return false

--- a/pkg/controllers/dynakube/version/reconciler_test.go
+++ b/pkg/controllers/dynakube/version/reconciler_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dtpullsecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
@@ -34,16 +34,16 @@ const (
 func TestReconcile(t *testing.T) {
 	ctx := context.Background()
 	latestAgentVersion := "1.2.3.4-5"
-	dynakubeTemplate := dynatracev1beta2.DynaKube{
+	dk := dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: testApiUrl,
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+			OneAgent: dynakube.OneAgentSpec{
+				CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 			},
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
-				Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-					dynatracev1beta2.CapabilityDisplayName(dynatracev1beta2.KubeMonCapability.ShortName),
+			ActiveGate: dynakube.ActiveGateSpec{
+				Capabilities: []dynakube.CapabilityDisplayName{
+					dynakube.CapabilityDisplayName(dynakube.KubeMonCapability.ShortName),
 				},
 			},
 		},
@@ -58,11 +58,11 @@ func TestReconcile(t *testing.T) {
 			apiReader:    fake.NewClient(),
 			timeProvider: timeprovider.New().Freeze(),
 		}
-		dynakube := dynakubeTemplate.DeepCopy()
-		err := versionReconciler.ReconcileActiveGate(ctx, dynakube)
+		dkCopy := dk.DeepCopy()
+		err := versionReconciler.ReconcileActiveGate(ctx, dkCopy)
 		require.Error(t, err)
 
-		condition := meta.FindStatusCondition(dynakube.Status.Conditions, activeGateVersionConditionType)
+		condition := meta.FindStatusCondition(dkCopy.Status.Conditions, activeGateVersionConditionType)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 		assert.Equal(t, conditions.DynatraceApiErrorReason, condition.Reason)
 	})
@@ -70,13 +70,13 @@ func TestReconcile(t *testing.T) {
 	t.Run("all image versions were updated", func(t *testing.T) {
 		testActiveGateImage := getTestActiveGateImageInfo()
 		testOneAgentImage := getTestOneAgentImageInfo()
-		dynakube := dynakubeTemplate.DeepCopy()
+		dkCopy := dk.DeepCopy()
 		fakeClient := fake.NewClient()
 		timeProvider := timeprovider.New().Freeze()
 
-		setupPullSecret(t, fakeClient, *dynakube)
+		setupPullSecret(t, fakeClient, *dkCopy)
 
-		dkStatus := &dynakube.Status
+		dkStatus := &dkCopy.Status
 		mockClient := dtclientmock.NewClient(t)
 		mockLatestAgentVersion(mockClient, latestAgentVersion)
 		mockLatestActiveGateVersion(mockClient, latestActiveGateVersion)
@@ -86,32 +86,32 @@ func TestReconcile(t *testing.T) {
 			timeProvider: timeProvider,
 			dtClient:     mockClient,
 		}
-		err := versionReconciler.ReconcileCodeModules(ctx, dynakube)
+		err := versionReconciler.ReconcileCodeModules(ctx, dkCopy)
 		require.NoError(t, err)
-		err = versionReconciler.ReconcileActiveGate(ctx, dynakube)
+		err = versionReconciler.ReconcileActiveGate(ctx, dkCopy)
 		require.NoError(t, err)
-		err = versionReconciler.ReconcileOneAgent(ctx, dynakube)
+		err = versionReconciler.ReconcileOneAgent(ctx, dkCopy)
 		require.NoError(t, err)
 
-		condition := meta.FindStatusCondition(dynakube.Status.Conditions, activeGateVersionConditionType)
+		condition := meta.FindStatusCondition(dkCopy.Status.Conditions, activeGateVersionConditionType)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 		assert.Equal(t, verifiedReason, condition.Reason)
 		assert.Equal(t, "Version verified for component.", condition.Message)
 
-		assertStatusBasedOnTenantRegistry(t, dynakube.DefaultActiveGateImage(testActiveGateImage.Tag), testActiveGateImage.Tag, dkStatus.ActiveGate.VersionStatus)
-		assertStatusBasedOnTenantRegistry(t, dynakube.DefaultOneAgentImage(testOneAgentImage.Tag), testOneAgentImage.Tag, dkStatus.OneAgent.VersionStatus)
+		assertStatusBasedOnTenantRegistry(t, dkCopy.DefaultActiveGateImage(testActiveGateImage.Tag), testActiveGateImage.Tag, dkStatus.ActiveGate.VersionStatus)
+		assertStatusBasedOnTenantRegistry(t, dkCopy.DefaultOneAgentImage(testOneAgentImage.Tag), testOneAgentImage.Tag, dkStatus.OneAgent.VersionStatus)
 		assert.Equal(t, latestAgentVersion, dkStatus.CodeModules.VersionStatus.Version)
 
 		// no change if probe not old enough
 		previousProbe := *dkStatus.CodeModules.VersionStatus.LastProbeTimestamp
-		err = versionReconciler.ReconcileCodeModules(ctx, dynakube)
+		err = versionReconciler.ReconcileCodeModules(ctx, dkCopy)
 		require.NoError(t, err)
 		assert.Equal(t, previousProbe, *dkStatus.CodeModules.VersionStatus.LastProbeTimestamp)
 
 		// change if probe old enough
 		changeTime(timeProvider, 15*time.Minute+1*time.Second)
 
-		err = versionReconciler.ReconcileCodeModules(ctx, dynakube)
+		err = versionReconciler.ReconcileCodeModules(ctx, dkCopy)
 		require.NoError(t, err)
 		assert.NotEqual(t, previousProbe, *dkStatus.CodeModules.VersionStatus.LastProbeTimestamp)
 	})
@@ -120,7 +120,7 @@ func TestReconcile(t *testing.T) {
 		testActiveGateImage := getTestActiveGateImageInfo()
 		testOneAgentImage := getTestOneAgentImageInfo()
 		testCodeModulesImage := getTestCodeModulesImage()
-		dynakube := dynakubeTemplate.DeepCopy()
+		dynakube := dk.DeepCopy()
 		enablePublicRegistry(dynakube)
 
 		fakeClient := fake.NewClient()
@@ -170,7 +170,7 @@ func TestUpdateVersionStatuses(t *testing.T) {
 			apiReader:    fake.NewClient(),
 			timeProvider: timeprovider.New().Freeze(),
 		}
-		err := versionReconciler.updateVersionStatuses(ctx, newFailingUpdater(t, &status.VersionStatus{}), &dynatracev1beta2.DynaKube{})
+		err := versionReconciler.updateVersionStatuses(ctx, newFailingUpdater(t, &status.VersionStatus{}), &dynakube.DynaKube{})
 		require.Error(t, err)
 	})
 
@@ -181,7 +181,7 @@ func TestUpdateVersionStatuses(t *testing.T) {
 			apiReader:    fake.NewClient(),
 			timeProvider: timeprovider.New().Freeze(),
 		}
-		err := versionReconciler.updateVersionStatuses(ctx, newFailingUpdater(t, &status.VersionStatus{Version: "1.2.3"}), &dynatracev1beta2.DynaKube{})
+		err := versionReconciler.updateVersionStatuses(ctx, newFailingUpdater(t, &status.VersionStatus{Version: "1.2.3"}), &dynakube.DynaKube{})
 		require.NoError(t, err)
 	})
 
@@ -192,7 +192,7 @@ func TestUpdateVersionStatuses(t *testing.T) {
 			apiReader:    fake.NewClient(),
 			timeProvider: timeprovider.New().Freeze(),
 		}
-		err := versionReconciler.updateVersionStatuses(ctx, newFailingUpdater(t, &status.VersionStatus{ImageID: "1.2.3"}), &dynatracev1beta2.DynaKube{})
+		err := versionReconciler.updateVersionStatuses(ctx, newFailingUpdater(t, &status.VersionStatus{ImageID: "1.2.3"}), &dynakube.DynaKube{})
 		require.NoError(t, err)
 	})
 }
@@ -200,15 +200,15 @@ func TestUpdateVersionStatuses(t *testing.T) {
 func TestNeedsUpdate(t *testing.T) {
 	timeProvider := timeprovider.New().Freeze()
 
-	dynakube := dynatracev1beta2.DynaKube{
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				ClassicFullStack: &dynatracev1beta2.HostInjectSpec{},
+	dk := dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: dynakube.OneAgentSpec{
+				ClassicFullStack: &dynakube.HostInjectSpec{},
 			},
-			DynatraceApiRequestThreshold: dynatracev1beta2.DefaultMinRequestThresholdMinutes,
+			DynatraceApiRequestThreshold: dynakube.DefaultMinRequestThresholdMinutes,
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			OneAgent: dynatracev1beta2.OneAgentStatus{
+		Status: dynakube.DynaKubeStatus{
+			OneAgent: dynakube.OneAgentStatus{
 				VersionStatus: status.VersionStatus{
 					Source: status.TenantRegistryVersionSource,
 				},
@@ -217,73 +217,73 @@ func TestNeedsUpdate(t *testing.T) {
 	}
 
 	t.Run("needs", func(t *testing.T) {
-		updatedDynakube := dynakube.DeepCopy()
+		dkCopy := dk.DeepCopy()
 		reconciler := reconciler{
 			timeProvider: timeProvider,
 		}
-		assert.True(t, reconciler.needsUpdate(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil), updatedDynakube))
+		assert.True(t, reconciler.needsUpdate(newOneAgentUpdater(dkCopy, fake.NewClient(), nil), dkCopy))
 	})
 	t.Run("does not need", func(t *testing.T) {
-		reconciler := reconciler{
+		r := reconciler{
 			timeProvider: timeProvider,
 		}
-		assert.False(t, reconciler.needsUpdate(newOneAgentUpdater(&dynatracev1beta2.DynaKube{}, fake.NewClient(), nil), &dynatracev1beta2.DynaKube{}))
+		assert.False(t, r.needsUpdate(newOneAgentUpdater(&dynakube.DynaKube{}, fake.NewClient(), nil), &dynakube.DynaKube{}))
 	})
 	t.Run("does not need, because not old enough", func(t *testing.T) {
 		oldImage := "repo.com:tag@sha256:123"
 		newImage := "repo.com:tag"
-		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube := dk.DeepCopy()
 		setOneAgentCustomImageStatus(updatedDynakube, oldImage)
 		updatedDynakube.Spec.OneAgent.ClassicFullStack.Image = newImage
 		updatedDynakube.Status.OneAgent.LastProbeTimestamp = timeProvider.Now()
-		reconciler := reconciler{
+		r := reconciler{
 			timeProvider: timeProvider,
 		}
-		assert.False(t, reconciler.needsUpdate(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil), updatedDynakube))
+		assert.False(t, r.needsUpdate(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil), updatedDynakube))
 	})
 
 	t.Run("needs, because source changed", func(t *testing.T) {
-		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube := dk.DeepCopy()
 		setOneAgentCustomImageStatus(updatedDynakube, "")
 
-		reconciler := reconciler{
+		r := reconciler{
 			timeProvider: timeProvider,
 		}
-		assert.True(t, reconciler.needsUpdate(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil), updatedDynakube))
+		assert.True(t, r.needsUpdate(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil), updatedDynakube))
 	})
 
 	t.Run("needs, because custom image changed", func(t *testing.T) {
 		oldImage := "repo.com:tag@sha256:123"
 		newImage := "repo.com:newTag"
-		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube := dk.DeepCopy()
 		updatedDynakube.Spec.OneAgent.ClassicFullStack.Image = newImage
 		setOneAgentCustomImageStatus(updatedDynakube, oldImage)
 
-		reconciler := reconciler{
+		r := reconciler{
 			timeProvider: timeProvider,
 		}
-		assert.True(t, reconciler.needsUpdate(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil), updatedDynakube))
+		assert.True(t, r.needsUpdate(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil), updatedDynakube))
 	})
 
 	t.Run("needs, because custom version changed", func(t *testing.T) {
 		oldVersion := "1.2.3.4-5"
 		newVersion := "2.4.5.6-7"
-		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube := dk.DeepCopy()
 		updatedDynakube.Spec.OneAgent.ClassicFullStack.Version = newVersion
 		setOneAgentCustomVersionStatus(updatedDynakube, oldVersion)
 
-		reconciler := reconciler{
+		r := reconciler{
 			timeProvider: timeProvider,
 		}
-		assert.True(t, reconciler.needsUpdate(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil), updatedDynakube))
+		assert.True(t, r.needsUpdate(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil), updatedDynakube))
 	})
 }
 
 func TestHasCustomFieldChanged(t *testing.T) {
-	dynakube := dynatracev1beta2.DynaKube{
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				ClassicFullStack: &dynatracev1beta2.HostInjectSpec{},
+	dk := dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: dynakube.OneAgentSpec{
+				ClassicFullStack: &dynakube.HostInjectSpec{},
 			},
 		},
 	}
@@ -291,7 +291,7 @@ func TestHasCustomFieldChanged(t *testing.T) {
 	t.Run("version changed", func(t *testing.T) {
 		oldVersion := "1.2.3.4-5"
 		newVersion := "2.4.5.6-7"
-		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube := dk.DeepCopy()
 		updatedDynakube.Spec.OneAgent.ClassicFullStack.Version = newVersion
 		setOneAgentCustomVersionStatus(updatedDynakube, oldVersion)
 		assert.True(t, hasCustomFieldChanged(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil)))
@@ -299,7 +299,7 @@ func TestHasCustomFieldChanged(t *testing.T) {
 
 	t.Run("no change; version", func(t *testing.T) {
 		version := "1.2.3.4-5"
-		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube := dk.DeepCopy()
 		updatedDynakube.Spec.OneAgent.ClassicFullStack.Version = version
 		setOneAgentCustomVersionStatus(updatedDynakube, version)
 		assert.False(t, hasCustomFieldChanged(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil)))
@@ -308,7 +308,7 @@ func TestHasCustomFieldChanged(t *testing.T) {
 	t.Run("image changed", func(t *testing.T) {
 		oldImage := "repo.com:tag@sha256:123"
 		newImage := "repo.com:Tag"
-		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube := dk.DeepCopy()
 		updatedDynakube.Spec.OneAgent.ClassicFullStack.Image = newImage
 		setOneAgentCustomImageStatus(updatedDynakube, oldImage)
 		assert.True(t, hasCustomFieldChanged(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil)))
@@ -317,21 +317,21 @@ func TestHasCustomFieldChanged(t *testing.T) {
 	t.Run("no change; image", func(t *testing.T) {
 		oldImage := "repo.com:tag@sha256:123"
 		newImage := "repo.com:tag"
-		updatedDynakube := dynakube.DeepCopy()
+		updatedDynakube := dk.DeepCopy()
 		updatedDynakube.Spec.OneAgent.ClassicFullStack.Version = newImage
 		setOneAgentCustomImageStatus(updatedDynakube, oldImage)
 		assert.False(t, hasCustomFieldChanged(newOneAgentUpdater(updatedDynakube, fake.NewClient(), nil)))
 	})
 }
 
-func setOneAgentCustomVersionStatus(dynakube *dynatracev1beta2.DynaKube, version string) {
-	dynakube.Status.OneAgent.Source = status.CustomVersionVersionSource
-	dynakube.Status.OneAgent.Version = version
+func setOneAgentCustomVersionStatus(dk *dynakube.DynaKube, version string) {
+	dk.Status.OneAgent.Source = status.CustomVersionVersionSource
+	dk.Status.OneAgent.Version = version
 }
 
-func setOneAgentCustomImageStatus(dynakube *dynatracev1beta2.DynaKube, image string) {
-	dynakube.Status.OneAgent.Source = status.CustomImageVersionSource
-	dynakube.Status.OneAgent.ImageID = image
+func setOneAgentCustomImageStatus(dk *dynakube.DynaKube, image string) {
+	dk.Status.OneAgent.Source = status.CustomImageVersionSource
+	dk.Status.OneAgent.ImageID = image
 }
 
 func getTestOneAgentImageInfo() dtclient.LatestImageInfo {
@@ -355,8 +355,8 @@ func getTestCodeModulesImage() dtclient.LatestImageInfo {
 	}
 }
 
-func setupPullSecret(t *testing.T, fakeClient client.Client, dynakube dynatracev1beta2.DynaKube) {
-	err := createTestPullSecret(fakeClient, dynakube)
+func setupPullSecret(t *testing.T, fakeClient client.Client, dk dynakube.DynaKube) {
+	err := createTestPullSecret(fakeClient, dk)
 	require.NoError(t, err)
 }
 
@@ -364,11 +364,11 @@ func changeTime(timeProvider *timeprovider.Provider, duration time.Duration) {
 	timeProvider.Set(timeProvider.Now().Add(duration))
 }
 
-func createTestPullSecret(fakeClient client.Client, dynakube dynatracev1beta2.DynaKube) error {
+func createTestPullSecret(fakeClient client.Client, dk dynakube.DynaKube) error {
 	return fakeClient.Create(context.TODO(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: dynakube.Namespace,
-			Name:      dynakube.Name + dtpullsecret.PullSecretSuffix,
+			Namespace: dk.Namespace,
+			Name:      dk.Name + dtpullsecret.PullSecretSuffix,
 		},
 		Data: map[string][]byte{
 			".dockerconfigjson": []byte("{}"),

--- a/pkg/controllers/dynakube/version/updater_test.go
+++ b/pkg/controllers/dynakube/version/updater_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	versionmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers/dynakube/version"
@@ -274,14 +274,14 @@ func TestGetTagFromImageID(t *testing.T) {
 	})
 }
 
-func enablePublicRegistry(dynakube *dynatracev1beta2.DynaKube) *dynatracev1beta2.DynaKube {
-	if dynakube.Annotations == nil {
-		dynakube.Annotations = make(map[string]string)
+func enablePublicRegistry(dk *dynakube.DynaKube) *dynakube.DynaKube {
+	if dk.Annotations == nil {
+		dk.Annotations = make(map[string]string)
 	}
 
-	dynakube.Annotations[dynatracev1beta2.AnnotationFeaturePublicRegistry] = "true"
+	dk.Annotations[dynakube.AnnotationFeaturePublicRegistry] = "true"
 
-	return dynakube
+	return dk
 }
 
 func newCustomImageUpdater(t *testing.T, target *status.VersionStatus, image string) *versionmock.StatusUpdater {

--- a/pkg/controllers/edgeconnect/controller_test.go
+++ b/pkg/controllers/edgeconnect/controller_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
-	ecclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/edgeconnect"
+	edgeconnectClient "github.com/Dynatrace/dynatrace-operator/pkg/clients/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/edgeconnect/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
 	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
@@ -58,11 +58,11 @@ var (
 	}
 	testObjectId = "my:default"
 
-	testEnvironmentSetting = ecclient.EnvironmentSetting{
+	testEnvironmentSetting = edgeconnectClient.EnvironmentSetting{
 		ObjectId: &testObjectId,
-		SchemaId: ecclient.KubernetesConnectionSchemaID,
-		Scope:    ecclient.KubernetesConnectionScope,
-		Value: ecclient.EnvironmentSettingValue{
+		SchemaId: edgeconnectClient.KubernetesConnectionSchemaID,
+		Scope:    edgeconnectClient.KubernetesConnectionScope,
+		Value: edgeconnectClient.EnvironmentSettingValue{
 			Name:      testName,
 			Namespace: testNamespace,
 			UID:       testUID,
@@ -72,7 +72,7 @@ var (
 
 func TestReconcile(t *testing.T) {
 	t.Run("Create works with minimal setup", func(t *testing.T) {
-		instance := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -87,8 +87,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		}
-		controller := createFakeClientAndReconciler(t, instance,
-			createClientSecret(testOauthClientSecret, instance.Namespace),
+		controller := createFakeClientAndReconciler(t, ec,
+			createClientSecret(testOauthClientSecret, ec.Namespace),
 			createKubernetesService(),
 			createKubeSystemNamespace(),
 		)
@@ -102,7 +102,7 @@ func TestReconcile(t *testing.T) {
 	})
 	t.Run("Timestamp update in EdgeConnect status works", func(t *testing.T) {
 		now := metav1.Now()
-		instance := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -120,13 +120,13 @@ func TestReconcile(t *testing.T) {
 				UpdatedTimestamp: metav1.NewTime(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)),
 				Version: status.VersionStatus{
 					LastProbeTimestamp: &now,
-					ImageID:            "docker.io/dynatrace/ecclient:latest",
+					ImageID:            "docker.io/dynatrace/edgeconnectClient:latest",
 				},
 			},
 		}
 
-		controller := createFakeClientAndReconciler(t, instance,
-			createClientSecret(testOauthClientSecret, instance.Namespace),
+		controller := createFakeClientAndReconciler(t, ec,
+			createClientSecret(testOauthClientSecret, ec.Namespace),
 			createKubernetesService(),
 			createKubeSystemNamespace(),
 		)
@@ -138,14 +138,14 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
-		err = controller.apiReader.Get(context.TODO(), client.ObjectKey{Name: instance.Name, Namespace: instance.Namespace}, instance)
+		err = controller.apiReader.Get(context.TODO(), client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, ec)
 		require.NoError(t, err)
 		// Fake client drops seconds, so we have to do the same
 		expectedTimestamp := controller.timeProvider.Now().Truncate(time.Second)
-		assert.Equal(t, expectedTimestamp, instance.Status.UpdatedTimestamp.Time)
+		assert.Equal(t, expectedTimestamp, ec.Status.UpdatedTimestamp.Time)
 	})
 	t.Run(`Reconciles phase change correctly`, func(t *testing.T) {
-		instance := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -160,8 +160,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		}
-		controller := createFakeClientAndReconciler(t, instance,
-			createClientSecret(testOauthClientSecret, instance.Namespace),
+		controller := createFakeClientAndReconciler(t, ec,
+			createClientSecret(testOauthClientSecret, ec.Namespace),
 			createKubernetesService(),
 			createKubeSystemNamespace(),
 		)
@@ -177,10 +177,10 @@ func TestReconcile(t *testing.T) {
 
 		require.NoError(t,
 			controller.client.Get(context.TODO(), client.ObjectKey{Name: testName, Namespace: testNamespace}, &edgeConnectDeployment))
-		require.NoError(t, controller.client.Get(context.TODO(), client.ObjectKey{Name: testName, Namespace: testNamespace}, instance))
-		assert.Equal(t, status.Running, instance.Status.DeploymentPhase)
+		require.NoError(t, controller.client.Get(context.TODO(), client.ObjectKey{Name: testName, Namespace: testNamespace}, ec))
+		assert.Equal(t, status.Running, ec.Status.DeploymentPhase)
 	})
-	t.Run(`Reconciles doesn't fail if ecclient not found`, func(t *testing.T) {
+	t.Run(`Reconciles doesn't fail if edgeconnectClient not found`, func(t *testing.T) {
 		controller := createFakeClientAndReconciler(t, nil)
 
 		_, err := controller.Reconcile(context.TODO(), reconcile.Request{
@@ -190,7 +190,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run(`Reconciles custom CA provided`, func(t *testing.T) {
-		instance := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -209,10 +209,10 @@ func TestReconcile(t *testing.T) {
 
 		data := make(map[string]string)
 		data[consts.EdgeConnectCAConfigMapKey] = "dummy"
-		customCA := newConfigMap(testCAConfigMapName, instance.Namespace, data)
-		clientSecret := createClientSecret(testOauthClientSecret, instance.Namespace)
+		customCA := newConfigMap(testCAConfigMapName, ec.Namespace, data)
+		clientSecret := createClientSecret(testOauthClientSecret, ec.Namespace)
 
-		controller := createFakeClientAndReconciler(t, instance, clientSecret, customCA, createKubernetesService(), createKubeSystemNamespace())
+		controller := createFakeClientAndReconciler(t, ec, clientSecret, customCA, createKubernetesService(), createKubeSystemNamespace())
 
 		_, err := controller.Reconcile(context.TODO(), reconcile.Request{
 			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
@@ -227,7 +227,7 @@ func TestReconcileProvisionerCreate(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSettings").Return([]ecclient.EnvironmentSetting{testEnvironmentSetting}, nil)
+		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
 		edgeConnectClient.On("UpdateConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -279,7 +279,7 @@ func TestReconcileProvisionerCreate(t *testing.T) {
 		assert.Equal(t, "edge-connect", edgeConnectDeployment.Spec.Template.Spec.Containers[0].Name)
 
 		edgeConnectClient.AssertCalled(t, "GetEdgeConnects", testName)
-		edgeConnectClient.AssertCalled(t, "CreateEdgeConnect", ecclient.NewRequest(testName, testHostPatterns, testHostMappings, ""))
+		edgeConnectClient.AssertCalled(t, "CreateEdgeConnect", edgeconnectClient.NewRequest(testName, testHostPatterns, testHostMappings, ""))
 	})
 }
 
@@ -288,7 +288,7 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSettings").Return([]ecclient.EnvironmentSetting{testEnvironmentSetting}, nil)
+		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
 		edgeConnectClient.On("UpdateConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -341,14 +341,14 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 
 		edgeConnectClient.AssertCalled(t, "GetEdgeConnects", testName)
 		edgeConnectClient.AssertCalled(t, "DeleteEdgeConnect", testCreatedId)
-		edgeConnectClient.AssertCalled(t, "CreateEdgeConnect", ecclient.NewRequest(testName, testHostPatterns, testHostMappings, ""))
+		edgeConnectClient.AssertCalled(t, "CreateEdgeConnect", edgeconnectClient.NewRequest(testName, testHostPatterns, testHostMappings, ""))
 	})
 
 	t.Run("recreate EdgeConnect due to invalid id", func(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSettings").Return([]ecclient.EnvironmentSetting{testEnvironmentSetting}, nil)
+		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
 		edgeConnectClient.On("UpdateConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -402,7 +402,7 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 
 		edgeConnectClient.AssertCalled(t, "GetEdgeConnects", testName)
 		edgeConnectClient.AssertCalled(t, "DeleteEdgeConnect", testRecreatedInvalidId)
-		edgeConnectClient.AssertCalled(t, "CreateEdgeConnect", ecclient.NewRequest(testName, testHostPatterns, testHostMappings, ""))
+		edgeConnectClient.AssertCalled(t, "CreateEdgeConnect", edgeconnectClient.NewRequest(testName, testHostPatterns, testHostMappings, ""))
 	})
 }
 
@@ -411,7 +411,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSettings").Return([]ecclient.EnvironmentSetting{testEnvironmentSetting}, nil)
+		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
 		edgeConnectClient.On("DeleteConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -441,7 +441,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 		instance := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSettings").Return([]ecclient.EnvironmentSetting{testEnvironmentSetting}, nil)
+		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
 		edgeConnectClient.On("DeleteConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -519,7 +519,7 @@ func TestReconcileProvisionerUpdate(t *testing.T) {
 
 		edgeConnectClient.AssertCalled(t, "GetEdgeConnects", testName)
 		edgeConnectClient.AssertCalled(t, "GetEdgeConnect", testCreatedId)
-		edgeConnectClient.AssertCalled(t, "UpdateEdgeConnect", testCreatedId, ecclient.NewRequest(testName, testHostPatterns2, testHostMappings, testCreatedOauthClientId))
+		edgeConnectClient.AssertCalled(t, "UpdateEdgeConnect", testCreatedId, edgeconnectClient.NewRequest(testName, testHostPatterns2, testHostMappings, testCreatedOauthClientId))
 	})
 }
 
@@ -531,7 +531,7 @@ func TestReconcileProvisionerWithK8sAutomationsCreate(t *testing.T) {
 		}
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSettings").Return([]ecclient.EnvironmentSetting{testEnvironmentSetting}, nil)
+		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
 		edgeConnectClient.On("UpdateConnectionSetting", mock.Anything).Return(nil)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
@@ -583,7 +583,7 @@ func TestReconcileProvisionerWithK8sAutomationsCreate(t *testing.T) {
 		assert.Equal(t, "edge-connect", edgeConnectDeployment.Spec.Template.Spec.Containers[0].Name)
 
 		edgeConnectClient.AssertCalled(t, "GetEdgeConnects", testName)
-		edgeConnectClient.AssertCalled(t, "CreateEdgeConnect", ecclient.NewRequest(testName, testHostPatterns, testHostMappings, ""))
+		edgeConnectClient.AssertCalled(t, "CreateEdgeConnect", edgeconnectClient.NewRequest(testName, testHostPatterns, testHostMappings, ""))
 	})
 }
 
@@ -615,7 +615,7 @@ func TestReconcileProvisionerWithK8sAutomationsUpdate(t *testing.T) {
 
 		edgeConnectClient.AssertCalled(t, "GetEdgeConnects", testName)
 		edgeConnectClient.AssertCalled(t, "GetEdgeConnect", testCreatedId)
-		edgeConnectClient.AssertCalled(t, "UpdateEdgeConnect", testCreatedId, ecclient.NewRequest(testName, testHostPatterns2, testHostMappings, testCreatedOauthClientId))
+		edgeConnectClient.AssertCalled(t, "UpdateEdgeConnect", testCreatedId, edgeconnectClient.NewRequest(testName, testHostPatterns2, testHostMappings, testCreatedOauthClientId))
 	})
 }
 
@@ -684,7 +684,7 @@ func createFakeClientAndReconciler(t *testing.T, instance *edgeconnect.EdgeConne
 
 	mockEdgeConnectClient := edgeconnectmock.NewClient(t)
 
-	mockEdgeConnectClientBuilder := func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
+	mockEdgeConnectClientBuilder := func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
 		return mockEdgeConnectClient, nil
 	}
 
@@ -729,18 +729,18 @@ func createFakeClientAndReconcilerForProvisioner(t *testing.T, instance *edgecon
 	return controller
 }
 
-func mockNewEdgeConnectClientCreate(edgeConnectClient *edgeconnectmock.Client, hostPatterns []string) func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
-	return func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
+func mockNewEdgeConnectClientCreate(edgeConnectClient *edgeconnectmock.Client, hostPatterns []string) func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
+	return func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
 		edgeConnectClient.On("GetEdgeConnects", testName).Return(
-			ecclient.ListResponse{
+			edgeconnectClient.ListResponse{
 				TotalCount: 0,
 			},
 			nil,
 		)
 
 		// CreateEdgeConnect creates edge connect
-		edgeConnectClient.On("CreateEdgeConnect", ecclient.NewRequest(testName, hostPatterns, testHostMappings, "")).Return(
-			ecclient.CreateResponse{
+		edgeConnectClient.On("CreateEdgeConnect", edgeconnectClient.NewRequest(testName, hostPatterns, testHostMappings, "")).Return(
+			edgeconnectClient.CreateResponse{
 				ID:                  testCreatedId,
 				Name:                testName,
 				HostPatterns:        hostPatterns,
@@ -755,11 +755,11 @@ func mockNewEdgeConnectClientCreate(edgeConnectClient *edgeconnectmock.Client, h
 	}
 }
 
-func mockNewEdgeConnectClientRecreate(edgeConnectClient *edgeconnectmock.Client, id string) func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
-	return func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
+func mockNewEdgeConnectClientRecreate(edgeConnectClient *edgeconnectmock.Client, id string) func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
+	return func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
 		edgeConnectClient.On("GetEdgeConnects", testName).Return(
-			ecclient.ListResponse{
-				EdgeConnects: []ecclient.GetResponse{
+			edgeconnectClient.ListResponse{
+				EdgeConnects: []edgeconnectClient.GetResponse{
 					{
 						ID:                         id,
 						Name:                       testName,
@@ -775,8 +775,8 @@ func mockNewEdgeConnectClientRecreate(edgeConnectClient *edgeconnectmock.Client,
 
 		edgeConnectClient.On("DeleteEdgeConnect", id).Return(nil)
 		// CreateEdgeConnect creates edge connect
-		edgeConnectClient.On("CreateEdgeConnect", ecclient.NewRequest(testName, testHostPatterns, testHostMappings, "")).Return(
-			ecclient.CreateResponse{
+		edgeConnectClient.On("CreateEdgeConnect", edgeconnectClient.NewRequest(testName, testHostPatterns, testHostMappings, "")).Return(
+			edgeconnectClient.CreateResponse{
 				ID:                  testCreatedId,
 				Name:                testName,
 				HostPatterns:        testHostPatterns,
@@ -791,11 +791,11 @@ func mockNewEdgeConnectClientRecreate(edgeConnectClient *edgeconnectmock.Client,
 	}
 }
 
-func mockNewEdgeConnectClientDelete(edgeConnectClient *edgeconnectmock.Client) func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
-	return func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
+func mockNewEdgeConnectClientDelete(edgeConnectClient *edgeconnectmock.Client) func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
+	return func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
 		edgeConnectClient.On("GetEdgeConnects", testName).Return(
-			ecclient.ListResponse{
-				EdgeConnects: []ecclient.GetResponse{
+			edgeconnectClient.ListResponse{
+				EdgeConnects: []edgeconnectClient.GetResponse{
 					{
 						ID:                         testCreatedId,
 						Name:                       testName,
@@ -814,10 +814,10 @@ func mockNewEdgeConnectClientDelete(edgeConnectClient *edgeconnectmock.Client) f
 	}
 }
 
-func mockNewEdgeConnectClientDeleteNotFoundOnTenant(edgeConnectClient *edgeconnectmock.Client) func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
-	return func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
+func mockNewEdgeConnectClientDeleteNotFoundOnTenant(edgeConnectClient *edgeconnectmock.Client) func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
+	return func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
 		edgeConnectClient.On("GetEdgeConnects", testName).Return(
-			ecclient.ListResponse{
+			edgeconnectClient.ListResponse{
 				TotalCount: 0,
 			},
 			nil,
@@ -828,11 +828,11 @@ func mockNewEdgeConnectClientDeleteNotFoundOnTenant(edgeConnectClient *edgeconne
 	}
 }
 
-func mockNewEdgeConnectClientUpdate(edgeConnectClient *edgeconnectmock.Client, fromHostPatterns []string, toHostPatterns []string) func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
-	return func(ctx context.Context, edgeConnect *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (ecclient.Client, error) {
+func mockNewEdgeConnectClientUpdate(edgeConnectClient *edgeconnectmock.Client, fromHostPatterns []string, toHostPatterns []string) func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
+	return func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
 		edgeConnectClient.On("GetEdgeConnects", testName).Return(
-			ecclient.ListResponse{
-				EdgeConnects: []ecclient.GetResponse{
+			edgeconnectClient.ListResponse{
+				EdgeConnects: []edgeconnectClient.GetResponse{
 					{
 						ID:                         testCreatedId,
 						Name:                       testName,
@@ -847,7 +847,7 @@ func mockNewEdgeConnectClientUpdate(edgeConnectClient *edgeconnectmock.Client, f
 		)
 
 		edgeConnectClient.On("GetEdgeConnect", testCreatedId).Return(
-			ecclient.GetResponse{
+			edgeconnectClient.GetResponse{
 				ID:            testCreatedId,
 				Name:          testName,
 				HostPatterns:  fromHostPatterns,
@@ -857,9 +857,9 @@ func mockNewEdgeConnectClientUpdate(edgeConnectClient *edgeconnectmock.Client, f
 		)
 
 		// CreateEdgeConnect creates edge connect
-		edgeConnectClient.On("UpdateEdgeConnect", testCreatedId, ecclient.NewRequest(testName, toHostPatterns, testHostMappings, testCreatedOauthClientId)).Return(nil)
+		edgeConnectClient.On("UpdateEdgeConnect", testCreatedId, edgeconnectClient.NewRequest(testName, toHostPatterns, testHostMappings, testCreatedOauthClientId)).Return(nil)
 
-		edgeConnectClient.On("GetConnectionSettings").Return([]ecclient.EnvironmentSetting{testEnvironmentSetting}, nil)
+		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
 		edgeConnectClient.On("UpdateConnectionSetting", mock.Anything).Return(nil)
 
 		return edgeConnectClient, nil
@@ -913,7 +913,7 @@ func TestController_createOrUpdateConnectionSetting(t *testing.T) {
 	t.Run("Create Connection Setting object", func(t *testing.T) {
 		controller := mockController()
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSettings").Return([]ecclient.EnvironmentSetting{}, nil)
+		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{}, nil)
 		edgeConnectClient.On("CreateConnectionSetting", mock.Anything).Return(nil)
 		err := controller.createOrUpdateConnectionSetting(edgeConnectClient, createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns), "")
 		require.NoError(t, err)
@@ -921,7 +921,7 @@ func TestController_createOrUpdateConnectionSetting(t *testing.T) {
 	t.Run("Existing Connection Setting object", func(t *testing.T) {
 		controller := mockController()
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSettings").Return([]ecclient.EnvironmentSetting{testEnvironmentSetting}, nil)
+		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
 		err := controller.createOrUpdateConnectionSetting(edgeConnectClient, createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns), "")
 		require.NoError(t, err)
 		edgeConnectClient.AssertNotCalled(t, "CreateConnectionSetting", mock.Anything)
@@ -933,7 +933,7 @@ func TestController_createOrUpdateConnectionSetting(t *testing.T) {
 		differentEnvironmentSetting.Value.Namespace = "different-namespace"
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
-		edgeConnectClient.On("GetConnectionSettings").Return([]ecclient.EnvironmentSetting{differentEnvironmentSetting}, nil)
+		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{differentEnvironmentSetting}, nil)
 		edgeConnectClient.On("CreateConnectionSetting", mock.Anything).Return(nil)
 		err := controller.createOrUpdateConnectionSetting(edgeConnectClient, createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns), "")
 		require.NoError(t, err)

--- a/pkg/controllers/edgeconnect/controller_test.go
+++ b/pkg/controllers/edgeconnect/controller_test.go
@@ -224,7 +224,7 @@ func TestReconcile(t *testing.T) {
 
 func TestReconcileProvisionerCreate(t *testing.T) {
 	t.Run("create EdgeConnect", func(t *testing.T) {
-		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
+		ec := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
 		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
@@ -232,9 +232,9 @@ func TestReconcileProvisionerCreate(t *testing.T) {
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
-			instance,
+			ec,
 			mockNewEdgeConnectClientCreate(edgeConnectClient, testHostPatterns),
-			createOauthSecret(instance.Spec.OAuth.ClientSecret, instance.Namespace),
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
 			createKubernetesService(),
 			createKubeSystemNamespace(),
 		)
@@ -246,23 +246,23 @@ func TestReconcileProvisionerCreate(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 
-		edgeConnectCR, err := getEdgeConnectCR(controller.apiReader, instance.Name, instance.Namespace)
+		edgeConnectCR, err := getEdgeConnectCR(controller.apiReader, ec.Name, ec.Namespace)
 		require.NoError(t, err)
 		require.NotEmpty(t, edgeConnectCR.Finalizers)
 
-		edgeConnectOauthClientID, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthClientID, log)
+		edgeConnectOauthClientID, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthClientID, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientId, edgeConnectOauthClientID)
 
-		edgeConnectOauthClientSecret, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthClientSecret, log)
+		edgeConnectOauthClientSecret, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthClientSecret, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientSecret, edgeConnectOauthClientSecret)
 
-		edgeConnectOauthResource, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthResource, log)
+		edgeConnectOauthResource, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthResource, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientResource, edgeConnectOauthResource)
 
-		edgeConnectId, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectId, log)
+		edgeConnectId, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectId, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedId, edgeConnectId)
 
@@ -270,8 +270,8 @@ func TestReconcileProvisionerCreate(t *testing.T) {
 		err = controller.apiReader.Get(
 			context.Background(),
 			client.ObjectKey{
-				Name:      instance.Name,
-				Namespace: instance.Namespace,
+				Name:      ec.Name,
+				Namespace: ec.Namespace,
 			},
 			&edgeConnectDeployment,
 		)
@@ -285,7 +285,7 @@ func TestReconcileProvisionerCreate(t *testing.T) {
 
 func TestReconcileProvisionerRecreate(t *testing.T) {
 	t.Run("recreate EdgeConnect due to missing client secret", func(t *testing.T) {
-		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
+		ec := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
 		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
@@ -293,9 +293,9 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
-			instance,
+			ec,
 			mockNewEdgeConnectClientRecreate(edgeConnectClient, testCreatedId),
-			createOauthSecret(instance.Spec.OAuth.ClientSecret, instance.Namespace),
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
 			createKubernetesService(),
 			createKubeSystemNamespace(),
 		)
@@ -307,23 +307,23 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 
-		edgeConnectCR, err := getEdgeConnectCR(controller.apiReader, instance.Name, instance.Namespace)
+		edgeConnectCR, err := getEdgeConnectCR(controller.apiReader, ec.Name, ec.Namespace)
 		require.NoError(t, err)
 		require.NotEmpty(t, edgeConnectCR.Finalizers)
 
-		edgeConnectOauthClientID, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthClientID, log)
+		edgeConnectOauthClientID, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthClientID, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientId, edgeConnectOauthClientID)
 
-		edgeConnectOauthClientSecret, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthClientSecret, log)
+		edgeConnectOauthClientSecret, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthClientSecret, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientSecret, edgeConnectOauthClientSecret)
 
-		edgeConnectOauthResource, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthResource, log)
+		edgeConnectOauthResource, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthResource, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientResource, edgeConnectOauthResource)
 
-		edgeConnectId, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectId, log)
+		edgeConnectId, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectId, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedId, edgeConnectId)
 
@@ -331,8 +331,8 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 		err = controller.apiReader.Get(
 			context.Background(),
 			client.ObjectKey{
-				Name:      instance.Name,
-				Namespace: instance.Namespace,
+				Name:      ec.Name,
+				Namespace: ec.Namespace,
 			},
 			&edgeConnectDeployment,
 		)
@@ -345,7 +345,7 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 	})
 
 	t.Run("recreate EdgeConnect due to invalid id", func(t *testing.T) {
-		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
+		ec := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
 		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
@@ -353,10 +353,10 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
-			instance,
+			ec,
 			mockNewEdgeConnectClientRecreate(edgeConnectClient, testRecreatedInvalidId),
-			createOauthSecret(instance.Spec.OAuth.ClientSecret, instance.Namespace),
-			createClientSecret(instance.ClientSecretName(), instance.Namespace),
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
+			createClientSecret(ec.ClientSecretName(), ec.Namespace),
 			createKubernetesService(),
 			createKubeSystemNamespace(),
 		)
@@ -368,23 +368,23 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 
-		edgeConnectCR, err := getEdgeConnectCR(controller.apiReader, instance.Name, instance.Namespace)
+		edgeConnectCR, err := getEdgeConnectCR(controller.apiReader, ec.Name, ec.Namespace)
 		require.NoError(t, err)
 		require.NotEmpty(t, edgeConnectCR.Finalizers)
 
-		edgeConnectOauthClientID, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthClientID, log)
+		edgeConnectOauthClientID, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthClientID, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientId, edgeConnectOauthClientID)
 
-		edgeConnectOauthClientSecret, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthClientSecret, log)
+		edgeConnectOauthClientSecret, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthClientSecret, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientSecret, edgeConnectOauthClientSecret)
 
-		edgeConnectOauthResource, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthResource, log)
+		edgeConnectOauthResource, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthResource, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientResource, edgeConnectOauthResource)
 
-		edgeConnectId, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectId, log)
+		edgeConnectId, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectId, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedId, edgeConnectId)
 
@@ -392,8 +392,8 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 		err = controller.apiReader.Get(
 			context.Background(),
 			client.ObjectKey{
-				Name:      instance.Name,
-				Namespace: instance.Namespace,
+				Name:      ec.Name,
+				Namespace: ec.Namespace,
 			},
 			&edgeConnectDeployment,
 		)
@@ -408,7 +408,7 @@ func TestReconcileProvisionerRecreate(t *testing.T) {
 
 func TestReconcileProvisionerDelete(t *testing.T) {
 	t.Run("delete EdgeConnect", func(t *testing.T) {
-		instance := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
+		ec := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
 		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
@@ -416,10 +416,10 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
-			instance,
+			ec,
 			mockNewEdgeConnectClientDelete(edgeConnectClient),
-			createOauthSecret(instance.Spec.OAuth.ClientSecret, instance.Namespace),
-			createClientSecret(instance.ClientSecretName(), instance.Namespace),
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
+			createClientSecret(ec.ClientSecretName(), ec.Namespace),
 			createKubeSystemNamespace(),
 		)
 
@@ -430,7 +430,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 
-		_, err = getEdgeConnectCR(controller.apiReader, instance.Name, instance.Namespace)
+		_, err = getEdgeConnectCR(controller.apiReader, ec.Name, ec.Namespace)
 		require.Error(t, err)
 		require.True(t, k8serrors.IsNotFound(err))
 
@@ -438,7 +438,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 	})
 
 	t.Run("delete EdgeConnect - missing client secret", func(t *testing.T) {
-		instance := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
+		ec := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
 		edgeConnectClient.On("GetConnectionSettings").Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
@@ -446,9 +446,9 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
-			instance,
+			ec,
 			mockNewEdgeConnectClientDelete(edgeConnectClient),
-			createOauthSecret(instance.Spec.OAuth.ClientSecret, instance.Namespace),
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
 			createKubeSystemNamespace(),
 		)
 
@@ -459,7 +459,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 
-		_, err = getEdgeConnectCR(controller.apiReader, instance.Name, instance.Namespace)
+		_, err = getEdgeConnectCR(controller.apiReader, ec.Name, ec.Namespace)
 		require.Error(t, err)
 		require.True(t, k8serrors.IsNotFound(err))
 
@@ -467,16 +467,16 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 	})
 
 	t.Run("delete EdgeConnect - missing EdgeConnect on the tenant", func(t *testing.T) {
-		instance := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
+		ec := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
-			instance,
+			ec,
 			mockNewEdgeConnectClientDeleteNotFoundOnTenant(edgeConnectClient),
-			createOauthSecret(instance.Spec.OAuth.ClientSecret, instance.Namespace),
-			createClientSecret(instance.ClientSecretName(), instance.Namespace),
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
+			createClientSecret(ec.ClientSecretName(), ec.Namespace),
 		)
 
 		result, err := controller.Reconcile(context.Background(), reconcile.Request{
@@ -486,7 +486,7 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 
-		_, err = getEdgeConnectCR(controller.apiReader, instance.Name, instance.Namespace)
+		_, err = getEdgeConnectCR(controller.apiReader, ec.Name, ec.Namespace)
 		require.Error(t, err)
 		require.True(t, k8serrors.IsNotFound(err))
 
@@ -496,16 +496,16 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 
 func TestReconcileProvisionerUpdate(t *testing.T) {
 	t.Run("update EdgeConnect", func(t *testing.T) {
-		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns2)
+		ec := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns2)
 
 		edgeConnectClient := edgeconnectmock.NewClient(t)
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
-			instance,
+			ec,
 			mockNewEdgeConnectClientUpdate(edgeConnectClient, testHostPatterns, testHostPatterns2),
-			createOauthSecret(instance.Spec.OAuth.ClientSecret, instance.Namespace),
-			createClientSecret(instance.ClientSecretName(), instance.Namespace),
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
+			createClientSecret(ec.ClientSecretName(), ec.Namespace),
 			createKubernetesService(),
 			createKubeSystemNamespace(),
 		)
@@ -525,8 +525,8 @@ func TestReconcileProvisionerUpdate(t *testing.T) {
 
 func TestReconcileProvisionerWithK8sAutomationsCreate(t *testing.T) {
 	t.Run("create EdgeConnect", func(t *testing.T) {
-		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
-		instance.Spec.KubernetesAutomation = &edgeconnect.KubernetesAutomationSpec{
+		ec := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns)
+		ec.Spec.KubernetesAutomation = &edgeconnect.KubernetesAutomationSpec{
 			Enabled: true,
 		}
 
@@ -536,9 +536,9 @@ func TestReconcileProvisionerWithK8sAutomationsCreate(t *testing.T) {
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
-			instance,
+			ec,
 			mockNewEdgeConnectClientCreate(edgeConnectClient, testHostPatterns),
-			createOauthSecret(instance.Spec.OAuth.ClientSecret, instance.Namespace),
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
 			createKubernetesService(),
 			createKubeSystemNamespace(),
 		)
@@ -550,23 +550,23 @@ func TestReconcileProvisionerWithK8sAutomationsCreate(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 
-		edgeConnectCR, err := getEdgeConnectCR(controller.apiReader, instance.Name, instance.Namespace)
+		edgeConnectCR, err := getEdgeConnectCR(controller.apiReader, ec.Name, ec.Namespace)
 		require.NoError(t, err)
 		require.NotEmpty(t, edgeConnectCR.Finalizers)
 
-		edgeConnectOauthClientID, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthClientID, log)
+		edgeConnectOauthClientID, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthClientID, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientId, edgeConnectOauthClientID)
 
-		edgeConnectOauthClientSecret, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthClientSecret, log)
+		edgeConnectOauthClientSecret, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthClientSecret, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientSecret, edgeConnectOauthClientSecret)
 
-		edgeConnectOauthResource, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectOauthResource, log)
+		edgeConnectOauthResource, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectOauthResource, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedOauthClientResource, edgeConnectOauthResource)
 
-		edgeConnectId, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: instance.ClientSecretName(), Namespace: instance.Namespace}, consts.KeyEdgeConnectId, log)
+		edgeConnectId, err := k8ssecret.GetDataFromSecretName(controller.apiReader, types.NamespacedName{Name: ec.ClientSecretName(), Namespace: ec.Namespace}, consts.KeyEdgeConnectId, log)
 		require.NoError(t, err)
 		assert.Equal(t, testCreatedId, edgeConnectId)
 
@@ -574,8 +574,8 @@ func TestReconcileProvisionerWithK8sAutomationsCreate(t *testing.T) {
 		err = controller.apiReader.Get(
 			context.Background(),
 			client.ObjectKey{
-				Name:      instance.Name,
-				Namespace: instance.Namespace,
+				Name:      ec.Name,
+				Namespace: ec.Namespace,
 			},
 			&edgeConnectDeployment,
 		)
@@ -589,8 +589,8 @@ func TestReconcileProvisionerWithK8sAutomationsCreate(t *testing.T) {
 
 func TestReconcileProvisionerWithK8sAutomationsUpdate(t *testing.T) {
 	t.Run("update EdgeConnect", func(t *testing.T) {
-		instance := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns2)
-		instance.Spec.KubernetesAutomation = &edgeconnect.KubernetesAutomationSpec{
+		ec := createEdgeConnectProvisionerCR([]string{}, nil, testHostPatterns2)
+		ec.Spec.KubernetesAutomation = &edgeconnect.KubernetesAutomationSpec{
 			Enabled: true,
 		}
 
@@ -598,10 +598,10 @@ func TestReconcileProvisionerWithK8sAutomationsUpdate(t *testing.T) {
 
 		controller := createFakeClientAndReconcilerForProvisioner(
 			t,
-			instance,
+			ec,
 			mockNewEdgeConnectClientUpdate(edgeConnectClient, testHostPatterns, testHostPatterns2),
-			createOauthSecret(instance.Spec.OAuth.ClientSecret, instance.Namespace),
-			createClientSecret(instance.ClientSecretName(), instance.Namespace),
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
+			createClientSecret(ec.ClientSecretName(), ec.Namespace),
 			createKubernetesService(),
 			createKubeSystemNamespace(),
 		)
@@ -663,11 +663,11 @@ func getEdgeConnectCR(apiReader client.Reader, name string, namespace string) (e
 	return edgeConnectCR, err
 }
 
-func createFakeClientAndReconciler(t *testing.T, instance *edgeconnect.EdgeConnect, objects ...client.Object) *Controller {
+func createFakeClientAndReconciler(t *testing.T, ec *edgeconnect.EdgeConnect, objects ...client.Object) *Controller {
 	fakeClient := fake.NewClientWithIndex()
 
-	if instance != nil {
-		objs := []client.Object{instance}
+	if ec != nil {
+		objs := []client.Object{ec}
 		objs = append(objs, objects...)
 		fakeClient = fake.NewClientWithIndex(objs...)
 	}
@@ -699,11 +699,11 @@ func createFakeClientAndReconciler(t *testing.T, instance *edgeconnect.EdgeConne
 	return controller
 }
 
-func createFakeClientAndReconcilerForProvisioner(t *testing.T, instance *edgeconnect.EdgeConnect, builder edgeConnectClientBuilderType, objects ...client.Object) *Controller {
+func createFakeClientAndReconcilerForProvisioner(t *testing.T, ec *edgeconnect.EdgeConnect, builder edgeConnectClientBuilderType, objects ...client.Object) *Controller {
 	fakeClient := fake.NewClientWithIndex()
 
-	if instance != nil {
-		objs := []client.Object{instance}
+	if ec != nil {
+		objs := []client.Object{ec}
 		objs = append(objs, objects...)
 		fakeClient = fake.NewClientWithIndex(objs...)
 	}

--- a/pkg/controllers/edgeconnect/deployment/deployment.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment.go
@@ -21,14 +21,14 @@ const (
 	unprivilegedGroup  = int64(1000)
 )
 
-func New(instance *edgeconnect.EdgeConnect) *appsv1.Deployment {
-	return create(instance)
+func New(ec *edgeconnect.EdgeConnect) *appsv1.Deployment {
+	return create(ec)
 }
 
-func create(instance *edgeconnect.EdgeConnect) *appsv1.Deployment {
-	appLabels := buildAppLabels(instance)
+func create(ec *edgeconnect.EdgeConnect) *appsv1.Deployment {
+	appLabels := buildAppLabels(ec)
 	labels := maputils.MergeMap(
-		instance.Labels,
+		ec.Labels,
 		appLabels.BuildLabels(),
 	)
 
@@ -36,13 +36,13 @@ func create(instance *edgeconnect.EdgeConnect) *appsv1.Deployment {
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        instance.Name,
-			Namespace:   instance.Namespace,
+			Name:        ec.Name,
+			Namespace:   ec.Namespace,
 			Labels:      labels,
-			Annotations: buildAnnotations(instance),
+			Annotations: buildAnnotations(ec),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: instance.Spec.Replicas,
+			Replicas: ec.Spec.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: appLabels.BuildMatchLabels(),
 			},
@@ -51,15 +51,15 @@ func create(instance *edgeconnect.EdgeConnect) *appsv1.Deployment {
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					Containers:                    []corev1.Container{edgeConnectContainer(instance)},
-					ImagePullSecrets:              prepareImagePullSecrets(instance),
-					ServiceAccountName:            instance.Spec.ServiceAccountName,
-					DeprecatedServiceAccount:      instance.Spec.ServiceAccountName,
+					Containers:                    []corev1.Container{edgeConnectContainer(ec)},
+					ImagePullSecrets:              prepareImagePullSecrets(ec),
+					ServiceAccountName:            ec.Spec.ServiceAccountName,
+					DeprecatedServiceAccount:      ec.Spec.ServiceAccountName,
 					TerminationGracePeriodSeconds: address.Of(int64(30)),
-					Volumes:                       prepareVolumes(instance),
-					NodeSelector:                  instance.Spec.NodeSelector,
-					Tolerations:                   instance.Spec.Tolerations,
-					TopologySpreadConstraints:     instance.Spec.TopologySpreadConstraints,
+					Volumes:                       prepareVolumes(ec),
+					NodeSelector:                  ec.Spec.NodeSelector,
+					Tolerations:                   ec.Spec.Tolerations,
+					TopologySpreadConstraints:     ec.Spec.TopologySpreadConstraints,
 				},
 			},
 			Strategy: appsv1.DeploymentStrategy{
@@ -74,41 +74,41 @@ func create(instance *edgeconnect.EdgeConnect) *appsv1.Deployment {
 	}
 }
 
-func prepareImagePullSecrets(instance *edgeconnect.EdgeConnect) []corev1.LocalObjectReference {
-	if instance.Spec.CustomPullSecret != "" {
+func prepareImagePullSecrets(ec *edgeconnect.EdgeConnect) []corev1.LocalObjectReference {
+	if ec.Spec.CustomPullSecret != "" {
 		return []corev1.LocalObjectReference{
-			{Name: instance.Spec.CustomPullSecret},
+			{Name: ec.Spec.CustomPullSecret},
 		}
 	}
 
 	return nil
 }
 
-func buildAppLabels(instance *edgeconnect.EdgeConnect) *labels.AppLabels {
+func buildAppLabels(ec *edgeconnect.EdgeConnect) *labels.AppLabels {
 	return labels.NewAppLabels(
 		labels.EdgeConnectComponentLabel,
-		instance.Name,
+		ec.Name,
 		consts.EdgeConnectUserProvisioned,
-		instance.Status.Version.Version)
+		ec.Status.Version.Version)
 }
 
-func buildAnnotations(instance *edgeconnect.EdgeConnect) map[string]string {
+func buildAnnotations(ec *edgeconnect.EdgeConnect) map[string]string {
 	annotations := map[string]string{
 		consts.AnnotationEdgeConnectContainerAppArmor: "runtime/default",
 		webhook.AnnotationDynatraceInject:             "false",
 	}
-	annotations = maputils.MergeMap(instance.Annotations, annotations)
+	annotations = maputils.MergeMap(ec.Annotations, annotations)
 
 	return annotations
 }
 
-func edgeConnectContainer(instance *edgeconnect.EdgeConnect) corev1.Container {
+func edgeConnectContainer(ec *edgeconnect.EdgeConnect) corev1.Container {
 	return corev1.Container{
 		Name:            consts.EdgeConnectContainerName,
-		Image:           instance.Status.Version.ImageID,
+		Image:           ec.Status.Version.ImageID,
 		ImagePullPolicy: corev1.PullAlways,
-		Env:             instance.Spec.Env,
-		Resources:       prepareResourceRequirements(instance),
+		Env:             ec.Spec.Env,
+		Resources:       prepareResourceRequirements(ec),
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: address.Of(false),
 			Privileged:               address.Of(false),
@@ -117,20 +117,20 @@ func edgeConnectContainer(instance *edgeconnect.EdgeConnect) corev1.Container {
 			RunAsUser:                address.Of(unprivilegedUser),
 			RunAsNonRoot:             address.Of(true),
 		},
-		VolumeMounts: prepareVolumeMounts(instance),
+		VolumeMounts: prepareVolumeMounts(ec),
 	}
 }
 
-func prepareVolumes(instance *edgeconnect.EdgeConnect) []corev1.Volume {
-	volumes := []corev1.Volume{prepareConfigVolume(instance)}
+func prepareVolumes(ec *edgeconnect.EdgeConnect) []corev1.Volume {
+	volumes := []corev1.Volume{prepareConfigVolume(ec)}
 
-	if instance.Spec.CaCertsRef != "" {
+	if ec.Spec.CaCertsRef != "" {
 		volumes = append(volumes, corev1.Volume{
 			Name: consts.EdgeConnectCustomCAVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: instance.Spec.CaCertsRef,
+						Name: ec.Spec.CaCertsRef,
 					},
 					Items: []corev1.KeyToPath{
 						{
@@ -146,24 +146,24 @@ func prepareVolumes(instance *edgeconnect.EdgeConnect) []corev1.Volume {
 	return volumes
 }
 
-func prepareVolumeMounts(instance *edgeconnect.EdgeConnect) []corev1.VolumeMount {
+func prepareVolumeMounts(ec *edgeconnect.EdgeConnect) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
-		{MountPath: consts.EdgeConnectConfigPath, SubPath: consts.EdgeConnectConfigFileName, Name: instance.Name + "-" + consts.EdgeConnectConfigVolumeMountName},
+		{MountPath: consts.EdgeConnectConfigPath, SubPath: consts.EdgeConnectConfigFileName, Name: ec.Name + "-" + consts.EdgeConnectConfigVolumeMountName},
 	}
 
-	if instance.Spec.CaCertsRef != "" {
+	if ec.Spec.CaCertsRef != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{MountPath: consts.EdgeConnectMountPath, Name: consts.EdgeConnectCustomCAVolumeName})
 	}
 
 	return volumeMounts
 }
 
-func prepareConfigVolume(instance *edgeconnect.EdgeConnect) corev1.Volume {
+func prepareConfigVolume(ec *edgeconnect.EdgeConnect) corev1.Volume {
 	return corev1.Volume{
-		Name: instance.Name + "-" + consts.EdgeConnectConfigVolumeMountName,
+		Name: ec.Name + "-" + consts.EdgeConnectConfigVolumeMountName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: instance.Name + "-" + consts.EdgeConnectSecretSuffix,
+				SecretName: ec.Name + "-" + consts.EdgeConnectSecretSuffix,
 				Items: []corev1.KeyToPath{
 					{Key: consts.EdgeConnectConfigFileName, Path: consts.EdgeConnectConfigFileName},
 				},
@@ -172,16 +172,16 @@ func prepareConfigVolume(instance *edgeconnect.EdgeConnect) corev1.Volume {
 	}
 }
 
-func prepareResourceRequirements(instance *edgeconnect.EdgeConnect) corev1.ResourceRequirements {
+func prepareResourceRequirements(ec *edgeconnect.EdgeConnect) corev1.ResourceRequirements {
 	limits := resources.NewResourceList("100m", "128Mi")
 	requests := resources.NewResourceList("100m", "128Mi")
 
-	if instance.Spec.Resources.Limits != nil {
-		limits = instance.Spec.Resources.Limits
+	if ec.Spec.Resources.Limits != nil {
+		limits = ec.Spec.Resources.Limits
 	}
 
-	if instance.Spec.Resources.Requests != nil {
-		requests = instance.Spec.Resources.Requests
+	if ec.Spec.Resources.Requests != nil {
+		requests = ec.Spec.Resources.Requests
 	}
 
 	return corev1.ResourceRequirements{

--- a/pkg/controllers/edgeconnect/deployment/deployment.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment.go
@@ -1,7 +1,7 @@
 package deployment
 
 import (
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/edgeconnect/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
@@ -21,11 +21,11 @@ const (
 	unprivilegedGroup  = int64(1000)
 )
 
-func New(instance *edgeconnectv1alpha1.EdgeConnect) *appsv1.Deployment {
+func New(instance *edgeconnect.EdgeConnect) *appsv1.Deployment {
 	return create(instance)
 }
 
-func create(instance *edgeconnectv1alpha1.EdgeConnect) *appsv1.Deployment {
+func create(instance *edgeconnect.EdgeConnect) *appsv1.Deployment {
 	appLabels := buildAppLabels(instance)
 	labels := maputils.MergeMap(
 		instance.Labels,
@@ -74,7 +74,7 @@ func create(instance *edgeconnectv1alpha1.EdgeConnect) *appsv1.Deployment {
 	}
 }
 
-func prepareImagePullSecrets(instance *edgeconnectv1alpha1.EdgeConnect) []corev1.LocalObjectReference {
+func prepareImagePullSecrets(instance *edgeconnect.EdgeConnect) []corev1.LocalObjectReference {
 	if instance.Spec.CustomPullSecret != "" {
 		return []corev1.LocalObjectReference{
 			{Name: instance.Spec.CustomPullSecret},
@@ -84,7 +84,7 @@ func prepareImagePullSecrets(instance *edgeconnectv1alpha1.EdgeConnect) []corev1
 	return nil
 }
 
-func buildAppLabels(instance *edgeconnectv1alpha1.EdgeConnect) *labels.AppLabels {
+func buildAppLabels(instance *edgeconnect.EdgeConnect) *labels.AppLabels {
 	return labels.NewAppLabels(
 		labels.EdgeConnectComponentLabel,
 		instance.Name,
@@ -92,7 +92,7 @@ func buildAppLabels(instance *edgeconnectv1alpha1.EdgeConnect) *labels.AppLabels
 		instance.Status.Version.Version)
 }
 
-func buildAnnotations(instance *edgeconnectv1alpha1.EdgeConnect) map[string]string {
+func buildAnnotations(instance *edgeconnect.EdgeConnect) map[string]string {
 	annotations := map[string]string{
 		consts.AnnotationEdgeConnectContainerAppArmor: "runtime/default",
 		webhook.AnnotationDynatraceInject:             "false",
@@ -102,7 +102,7 @@ func buildAnnotations(instance *edgeconnectv1alpha1.EdgeConnect) map[string]stri
 	return annotations
 }
 
-func edgeConnectContainer(instance *edgeconnectv1alpha1.EdgeConnect) corev1.Container {
+func edgeConnectContainer(instance *edgeconnect.EdgeConnect) corev1.Container {
 	return corev1.Container{
 		Name:            consts.EdgeConnectContainerName,
 		Image:           instance.Status.Version.ImageID,
@@ -121,7 +121,7 @@ func edgeConnectContainer(instance *edgeconnectv1alpha1.EdgeConnect) corev1.Cont
 	}
 }
 
-func prepareVolumes(instance *edgeconnectv1alpha1.EdgeConnect) []corev1.Volume {
+func prepareVolumes(instance *edgeconnect.EdgeConnect) []corev1.Volume {
 	volumes := []corev1.Volume{prepareConfigVolume(instance)}
 
 	if instance.Spec.CaCertsRef != "" {
@@ -146,7 +146,7 @@ func prepareVolumes(instance *edgeconnectv1alpha1.EdgeConnect) []corev1.Volume {
 	return volumes
 }
 
-func prepareVolumeMounts(instance *edgeconnectv1alpha1.EdgeConnect) []corev1.VolumeMount {
+func prepareVolumeMounts(instance *edgeconnect.EdgeConnect) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{MountPath: consts.EdgeConnectConfigPath, SubPath: consts.EdgeConnectConfigFileName, Name: instance.Name + "-" + consts.EdgeConnectConfigVolumeMountName},
 	}
@@ -158,7 +158,7 @@ func prepareVolumeMounts(instance *edgeconnectv1alpha1.EdgeConnect) []corev1.Vol
 	return volumeMounts
 }
 
-func prepareConfigVolume(instance *edgeconnectv1alpha1.EdgeConnect) corev1.Volume {
+func prepareConfigVolume(instance *edgeconnect.EdgeConnect) corev1.Volume {
 	return corev1.Volume{
 		Name: instance.Name + "-" + consts.EdgeConnectConfigVolumeMountName,
 		VolumeSource: corev1.VolumeSource{
@@ -172,7 +172,7 @@ func prepareConfigVolume(instance *edgeconnectv1alpha1.EdgeConnect) corev1.Volum
 	}
 }
 
-func prepareResourceRequirements(instance *edgeconnectv1alpha1.EdgeConnect) corev1.ResourceRequirements {
+func prepareResourceRequirements(instance *edgeconnect.EdgeConnect) corev1.ResourceRequirements {
 	limits := resources.NewResourceList("100m", "128Mi")
 	requests := resources.NewResourceList("100m", "128Mi")
 

--- a/pkg/controllers/edgeconnect/deployment/deployment_test.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment_test.go
@@ -19,7 +19,7 @@ const (
 
 func TestNew(t *testing.T) {
 	t.Run("Create new edgeconnect deployment", func(t *testing.T) {
-		instance := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -32,14 +32,14 @@ func TestNew(t *testing.T) {
 			},
 		}
 
-		deployment := New(instance)
+		deployment := New(ec)
 
 		assert.NotNil(t, deployment)
 	})
 }
 
 func Test_buildAppLabels(t *testing.T) {
-	testEdgeConnect := &edgeconnect.EdgeConnect{
+	ec := &edgeconnect.EdgeConnect{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -61,13 +61,13 @@ func Test_buildAppLabels(t *testing.T) {
 	}
 
 	t.Run("Check version label set correctly", func(t *testing.T) {
-		labels := buildAppLabels(testEdgeConnect)
+		labels := buildAppLabels(ec)
 		assert.Equal(t, "", labels.Version)
 	})
 }
 
 func Test_prepareResourceRequirements(t *testing.T) {
-	testEdgeConnect := &edgeconnect.EdgeConnect{
+	ec := &edgeconnect.EdgeConnect{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -92,8 +92,8 @@ func Test_prepareResourceRequirements(t *testing.T) {
 		customResources := corev1.ResourceRequirements{
 			Limits: resources.NewResourceList("500m", "256Mi"),
 		}
-		testEdgeConnect.Spec.Resources = customResources
-		resourceRequirements := prepareResourceRequirements(testEdgeConnect)
+		ec.Spec.Resources = customResources
+		resourceRequirements := prepareResourceRequirements(ec)
 		assert.Equal(t, customResources.Limits, resourceRequirements.Limits)
 		// check that we use default requests when not provided
 		assert.Equal(t, resources.NewResourceList("100m", "128Mi"), resourceRequirements.Requests)
@@ -103,8 +103,8 @@ func Test_prepareResourceRequirements(t *testing.T) {
 		customResources := corev1.ResourceRequirements{
 			Requests: resources.NewResourceList("500m", "256Mi"),
 		}
-		testEdgeConnect.Spec.Resources = customResources
-		resourceRequirements := prepareResourceRequirements(testEdgeConnect)
+		ec.Spec.Resources = customResources
+		resourceRequirements := prepareResourceRequirements(ec)
 		assert.Equal(t, customResources.Requests, resourceRequirements.Requests)
 		// check that we use default requests when not provided
 		assert.Equal(t, resources.NewResourceList("100m", "128Mi"), resourceRequirements.Limits)

--- a/pkg/controllers/edgeconnect/deployment/deployment_test.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/resources"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -13,21 +13,21 @@ import (
 )
 
 const (
-	testName      = "test-name-edgeconnectv1alpha1"
+	testName      = "test-name-edgeconnect"
 	testNamespace = "test-namespace"
 )
 
 func TestNew(t *testing.T) {
 	t.Run("Create new edgeconnect deployment", func(t *testing.T) {
-		instance := &edgeconnectv1alpha1.EdgeConnect{
+		instance := &edgeconnect.EdgeConnect{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			},
-			Spec: edgeconnectv1alpha1.EdgeConnectSpec{
+			Spec: edgeconnect.EdgeConnectSpec{
 				ApiServer: "abc12345.dynatrace.com",
 			},
-			Status: edgeconnectv1alpha1.EdgeConnectStatus{
+			Status: edgeconnect.EdgeConnectStatus{
 				UpdatedTimestamp: metav1.NewTime(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)),
 			},
 		}
@@ -39,20 +39,20 @@ func TestNew(t *testing.T) {
 }
 
 func Test_buildAppLabels(t *testing.T) {
-	testEdgeConnect := &edgeconnectv1alpha1.EdgeConnect{
+	testEdgeConnect := &edgeconnect.EdgeConnect{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
 		},
-		Spec: edgeconnectv1alpha1.EdgeConnectSpec{
+		Spec: edgeconnect.EdgeConnectSpec{
 			ApiServer: "abc12345.dynatrace.com",
-			OAuth: edgeconnectv1alpha1.OAuthSpec{
+			OAuth: edgeconnect.OAuthSpec{
 				ClientSecret: "secret-name",
 				Endpoint:     "https://test.com/sso/oauth2/token",
 				Resource:     "urn:dtenvironment:test12345",
 			},
 		},
-		Status: edgeconnectv1alpha1.EdgeConnectStatus{
+		Status: edgeconnect.EdgeConnectStatus{
 			Version: status.VersionStatus{
 				Version: "",
 			},
@@ -67,20 +67,20 @@ func Test_buildAppLabels(t *testing.T) {
 }
 
 func Test_prepareResourceRequirements(t *testing.T) {
-	testEdgeConnect := &edgeconnectv1alpha1.EdgeConnect{
+	testEdgeConnect := &edgeconnect.EdgeConnect{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
 		},
-		Spec: edgeconnectv1alpha1.EdgeConnectSpec{
+		Spec: edgeconnect.EdgeConnectSpec{
 			ApiServer: "abc12345.dynatrace.com",
-			OAuth: edgeconnectv1alpha1.OAuthSpec{
+			OAuth: edgeconnect.OAuthSpec{
 				ClientSecret: "secret-name",
 				Endpoint:     "https://test.com/sso/oauth2/token",
 				Resource:     "urn:dtenvironment:test12345",
 			},
 		},
-		Status: edgeconnectv1alpha1.EdgeConnectStatus{
+		Status: edgeconnect.EdgeConnectStatus{
 			Version: status.VersionStatus{
 				Version: "",
 			},

--- a/pkg/controllers/edgeconnect/secret/secret.go
+++ b/pkg/controllers/edgeconnect/secret/secret.go
@@ -3,14 +3,14 @@ package secret
 import (
 	"context"
 
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/edgeconnect/config"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/edgeconnect/consts"
 	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func PrepareConfigFile(ctx context.Context, instance *edgeconnectv1alpha1.EdgeConnect, apiReader client.Reader, token string) ([]byte, error) {
+func PrepareConfigFile(ctx context.Context, instance *edgeconnect.EdgeConnect, apiReader client.Reader, token string) ([]byte, error) {
 	cfg := config.EdgeConnect{
 		Name:            instance.ObjectMeta.Name,
 		ApiEndpointHost: instance.Spec.ApiServer,
@@ -93,6 +93,6 @@ func createKubernetesApiSecret(token string) config.Secret {
 		Name:            "K8S_SERVICE_ACCOUNT_TOKEN",
 		Token:           token,
 		FromFile:        "/var/run/secrets/kubernetes.io/serviceaccount/token",
-		RestrictHostsTo: []string{edgeconnectv1alpha1.KubernetesDefaultDNS},
+		RestrictHostsTo: []string{edgeconnect.KubernetesDefaultDNS},
 	}
 }

--- a/pkg/controllers/edgeconnect/secret/secret.go
+++ b/pkg/controllers/edgeconnect/secret/secret.go
@@ -10,20 +10,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func PrepareConfigFile(ctx context.Context, instance *edgeconnect.EdgeConnect, apiReader client.Reader, token string) ([]byte, error) {
+func PrepareConfigFile(ctx context.Context, ec *edgeconnect.EdgeConnect, apiReader client.Reader, token string) ([]byte, error) {
 	cfg := config.EdgeConnect{
-		Name:            instance.ObjectMeta.Name,
-		ApiEndpointHost: instance.Spec.ApiServer,
+		Name:            ec.ObjectMeta.Name,
+		ApiEndpointHost: ec.Spec.ApiServer,
 		OAuth: config.OAuth{
-			Endpoint: instance.Spec.OAuth.Endpoint,
-			Resource: instance.Spec.OAuth.Resource,
+			Endpoint: ec.Spec.OAuth.Endpoint,
+			Resource: ec.Spec.OAuth.Resource,
 		},
-		RestrictHostsTo: instance.Spec.HostRestrictions,
+		RestrictHostsTo: ec.Spec.HostRestrictions,
 	}
 
 	// For provisioned we need to read another secret, which later we mount to EdgeConnect pod
-	if instance.IsProvisionerModeEnabled() {
-		oAuth, err := instance.GetOAuthClientFromSecret(ctx, apiReader, instance.ClientSecretName())
+	if ec.IsProvisionerModeEnabled() {
+		oAuth, err := ec.GetOAuthClientFromSecret(ctx, apiReader, ec.ClientSecretName())
 		if err != nil {
 			return []byte{}, err
 		}
@@ -33,7 +33,7 @@ func PrepareConfigFile(ctx context.Context, instance *edgeconnect.EdgeConnect, a
 		cfg.OAuth.Resource = oAuth.Resource
 	} else {
 		// For regular, we use default secret
-		oAuth, err := instance.GetOAuthClientFromSecret(ctx, apiReader, instance.Spec.OAuth.ClientSecret)
+		oAuth, err := ec.GetOAuthClientFromSecret(ctx, apiReader, ec.Spec.OAuth.ClientSecret)
 		if err != nil {
 			return []byte{}, err
 		}
@@ -42,26 +42,26 @@ func PrepareConfigFile(ctx context.Context, instance *edgeconnect.EdgeConnect, a
 		cfg.OAuth.ClientSecret = oAuth.ClientSecret
 	}
 
-	if instance.Spec.CaCertsRef != "" {
+	if ec.Spec.CaCertsRef != "" {
 		cfg.RootCertificatePaths = append(cfg.RootCertificatePaths, consts.EdgeConnectMountPath+"/"+consts.EdgeConnectCustomCertificateName)
 	}
 
 	// Always add certificates
 	cfg.RootCertificatePaths = append(cfg.RootCertificatePaths, consts.EdgeConnectServiceAccountCAPath)
 
-	if instance.IsK8SAutomationEnabled() {
+	if ec.IsK8SAutomationEnabled() {
 		cfg.Secrets = append(cfg.Secrets, createKubernetesApiSecret(token))
 	}
 
-	if instance.Spec.Proxy != nil {
+	if ec.Spec.Proxy != nil {
 		cfg.Proxy = config.Proxy{
-			Server:     instance.Spec.Proxy.Host,
-			Port:       instance.Spec.Proxy.Port,
-			Exceptions: instance.Spec.Proxy.NoProxy,
+			Server:     ec.Spec.Proxy.Host,
+			Port:       ec.Spec.Proxy.Port,
+			Exceptions: ec.Spec.Proxy.NoProxy,
 		}
 
-		if instance.Spec.Proxy.AuthRef != "" {
-			user, pass, err := instance.ProxyAuth(context.Background(), apiReader)
+		if ec.Spec.Proxy.AuthRef != "" {
+			user, pass, err := ec.ProxyAuth(context.Background(), apiReader)
 			if err != nil {
 				return []byte{}, err
 			}

--- a/pkg/controllers/edgeconnect/secret/secret_test.go
+++ b/pkg/controllers/edgeconnect/secret/secret_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/edgeconnect/config"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/edgeconnect/consts"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	testName                       = "test-name-edgeconnectv1alpha1"
+	testName                       = "test-name-edgeconnect"
 	testNamespace                  = "test-namespace"
 	testOauthClientId              = "client-id"
 	testOauthClientSecret          = "client-secret"
@@ -30,14 +30,14 @@ const (
 
 func Test_prepareEdgeConnectConfigFile(t *testing.T) {
 	t.Run("Create basic config", func(t *testing.T) {
-		testEdgeConnect := &edgeconnectv1alpha1.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			},
-			Spec: edgeconnectv1alpha1.EdgeConnectSpec{
+			Spec: edgeconnect.EdgeConnectSpec{
 				ApiServer: "abc12345.dynatrace.com",
-				OAuth: edgeconnectv1alpha1.OAuthSpec{
+				OAuth: edgeconnect.OAuthSpec{
 					Endpoint:     "https://test.com/sso/oauth2/token",
 					Resource:     "urn:dtenvironment:test12345",
 					ClientSecret: "test-secret",
@@ -47,11 +47,11 @@ func Test_prepareEdgeConnectConfigFile(t *testing.T) {
 
 		testSecretName := "test-secret"
 		kubeReader := fake.NewClient(createClientSecret(testSecretName, testNamespace))
-		cfg, err := PrepareConfigFile(context.Background(), testEdgeConnect, kubeReader, testToken)
+		cfg, err := PrepareConfigFile(context.Background(), ec, kubeReader, testToken)
 
 		require.NoError(t, err)
 
-		expected := `name: test-name-edgeconnectv1alpha1
+		expected := `name: test-name-edgeconnect
 api_endpoint_host: abc12345.dynatrace.com
 oauth:
     endpoint: https://test.com/sso/oauth2/token
@@ -65,21 +65,21 @@ root_certificate_paths:
 	})
 
 	t.Run("Create full config", func(t *testing.T) {
-		testEdgeConnect := &edgeconnectv1alpha1.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			},
-			Spec: edgeconnectv1alpha1.EdgeConnectSpec{
+			Spec: edgeconnect.EdgeConnectSpec{
 				ApiServer: "abc12345.dynatrace.com",
-				OAuth: edgeconnectv1alpha1.OAuthSpec{
+				OAuth: edgeconnect.OAuthSpec{
 					Endpoint:     "https://test.com/sso/oauth2/token",
 					Resource:     "urn:dtenvironment:test12345",
 					ClientSecret: "test-secret",
 				},
 				CaCertsRef:         "certs",
 				ServiceAccountName: "test",
-				Proxy: &edgeconnectv1alpha1.ProxySpec{
+				Proxy: &edgeconnect.ProxySpec{
 					Host:    "proxy.com",
 					NoProxy: "*.internal.com",
 					Port:    443,
@@ -88,16 +88,16 @@ root_certificate_paths:
 			},
 		}
 		testSecretName := "test-secret"
-		authRef := newSecret(testProxyAuthRef, testEdgeConnect.Namespace, map[string]string{
-			edgeconnectv1alpha1.ProxyAuthUserKey:     "user",
-			edgeconnectv1alpha1.ProxyAuthPasswordKey: "pass",
+		authRef := newSecret(testProxyAuthRef, ec.Namespace, map[string]string{
+			edgeconnect.ProxyAuthUserKey:     "user",
+			edgeconnect.ProxyAuthPasswordKey: "pass",
 		})
 		kubeReader := fake.NewClient(createClientSecret(testSecretName, testNamespace), authRef)
-		cfg, err := PrepareConfigFile(context.Background(), testEdgeConnect, kubeReader, testToken)
+		cfg, err := PrepareConfigFile(context.Background(), ec, kubeReader, testToken)
 
 		require.NoError(t, err)
 
-		expected := `name: test-name-edgeconnectv1alpha1
+		expected := `name: test-name-edgeconnect
 api_endpoint_host: abc12345.dynatrace.com
 oauth:
     endpoint: https://test.com/sso/oauth2/token
@@ -118,19 +118,19 @@ proxy:
 		assert.Equal(t, expected, string(cfg))
 	})
 	t.Run("Create config k8s automation enabled", func(t *testing.T) {
-		testEdgeConnect := &edgeconnectv1alpha1.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
 			},
-			Spec: edgeconnectv1alpha1.EdgeConnectSpec{
+			Spec: edgeconnect.EdgeConnectSpec{
 				ApiServer: "abc12345.dynatrace.com",
-				OAuth: edgeconnectv1alpha1.OAuthSpec{
+				OAuth: edgeconnect.OAuthSpec{
 					Endpoint:     "https://test.com/sso/oauth2/token",
 					Resource:     "urn:dtenvironment:test12345",
 					ClientSecret: "test-secret",
 				},
-				KubernetesAutomation: &edgeconnectv1alpha1.KubernetesAutomationSpec{
+				KubernetesAutomation: &edgeconnect.KubernetesAutomationSpec{
 					Enabled: true,
 				},
 				ServiceAccountName: "test",
@@ -138,11 +138,11 @@ proxy:
 		}
 		testSecretName := "test-secret"
 		kubeReader := fake.NewClient(createClientSecret(testSecretName, testNamespace))
-		cfg, err := PrepareConfigFile(context.Background(), testEdgeConnect, kubeReader, testToken)
+		cfg, err := PrepareConfigFile(context.Background(), ec, kubeReader, testToken)
 
 		require.NoError(t, err)
 
-		expected := `name: test-name-edgeconnectv1alpha1
+		expected := `name: test-name-edgeconnect
 api_endpoint_host: abc12345.dynatrace.com
 oauth:
     endpoint: https://test.com/sso/oauth2/token

--- a/pkg/controllers/edgeconnect/version/reconciler.go
+++ b/pkg/controllers/edgeconnect/version/reconciler.go
@@ -3,21 +3,21 @@ package version
 import (
 	"context"
 
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Reconciler struct {
-	edgeConnect  *edgeconnectv1alpha1.EdgeConnect
+	edgeConnect  *edgeconnect.EdgeConnect
 	timeProvider *timeprovider.Provider
 
 	apiReader      client.Reader
 	registryClient registry.ImageGetter
 }
 
-func NewReconciler(apiReader client.Reader, registryClient registry.ImageGetter, timeProvider *timeprovider.Provider, edgeConnect *edgeconnectv1alpha1.EdgeConnect) *Reconciler {
+func NewReconciler(apiReader client.Reader, registryClient registry.ImageGetter, timeProvider *timeprovider.Provider, edgeConnect *edgeconnect.EdgeConnect) *Reconciler {
 	return &Reconciler{
 		edgeConnect:    edgeConnect,
 		apiReader:      apiReader,

--- a/pkg/controllers/edgeconnect/version/reconciler.go
+++ b/pkg/controllers/edgeconnect/version/reconciler.go
@@ -17,9 +17,9 @@ type Reconciler struct {
 	registryClient registry.ImageGetter
 }
 
-func NewReconciler(apiReader client.Reader, registryClient registry.ImageGetter, timeProvider *timeprovider.Provider, edgeConnect *edgeconnect.EdgeConnect) *Reconciler {
+func NewReconciler(apiReader client.Reader, registryClient registry.ImageGetter, timeProvider *timeprovider.Provider, ec *edgeconnect.EdgeConnect) *Reconciler {
 	return &Reconciler{
-		edgeConnect:    edgeConnect,
+		edgeConnect:    ec,
 		apiReader:      apiReader,
 		timeProvider:   timeProvider,
 		registryClient: registryClient,

--- a/pkg/controllers/edgeconnect/version/updater.go
+++ b/pkg/controllers/edgeconnect/version/updater.go
@@ -27,10 +27,10 @@ func newUpdater(
 	apiReader client.Reader,
 	timeprovider *timeprovider.Provider,
 	registryClient registry.ImageGetter,
-	edgeConnect *edgeconnect.EdgeConnect,
+	ec *edgeconnect.EdgeConnect,
 ) *updater {
 	return &updater{
-		edgeConnect:    edgeConnect,
+		edgeConnect:    ec,
 		apiReader:      apiReader,
 		timeProvider:   timeprovider,
 		registryClient: registryClient,

--- a/pkg/controllers/edgeconnect/version/updater.go
+++ b/pkg/controllers/edgeconnect/version/updater.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -15,7 +15,7 @@ import (
 )
 
 type updater struct {
-	edgeConnect    *edgeconnectv1alpha1.EdgeConnect
+	edgeConnect    *edgeconnect.EdgeConnect
 	apiReader      client.Reader
 	timeProvider   *timeprovider.Provider
 	registryClient registry.ImageGetter
@@ -27,7 +27,7 @@ func newUpdater(
 	apiReader client.Reader,
 	timeprovider *timeprovider.Provider,
 	registryClient registry.ImageGetter,
-	edgeConnect *edgeconnectv1alpha1.EdgeConnect,
+	edgeConnect *edgeconnect.EdgeConnect,
 ) *updater {
 	return &updater{
 		edgeConnect:    edgeConnect,
@@ -40,7 +40,7 @@ func newUpdater(
 func (u updater) RequiresReconcile() bool {
 	version := u.edgeConnect.Status.Version
 
-	isRequestOutdated := u.timeProvider.IsOutdated(version.LastProbeTimestamp, edgeconnectv1alpha1.DefaultMinRequestThreshold)
+	isRequestOutdated := u.timeProvider.IsOutdated(version.LastProbeTimestamp, edgeconnect.DefaultMinRequestThreshold)
 	didCustomImageChange := !strings.HasPrefix(version.ImageID, u.edgeConnect.Image())
 
 	if didCustomImageChange || version.ImageID == "" {

--- a/pkg/controllers/edgeconnect/version/updater_test.go
+++ b/pkg/controllers/edgeconnect/version/updater_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/registry"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	registrymock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/oci/registry"
@@ -145,7 +145,7 @@ func TestReconcileRequired(t *testing.T) {
 		edgeConnectTime := metav1.Now()
 		edgeConnect.Status.Version.LastProbeTimestamp = &edgeConnectTime
 		edgeConnect.Status.Version.ImageID = edgeConnect.Image()
-		edgeConnect.Spec.ImageRef = edgeconnectv1alpha1.ImageRefSpec{
+		edgeConnect.Spec.ImageRef = edgeconnect.ImageRefSpec{
 			Repository: "docker.io/dynatrace/superfancynew",
 		}
 
@@ -153,11 +153,11 @@ func TestReconcileRequired(t *testing.T) {
 	})
 }
 
-func createBasicEdgeConnect() *edgeconnectv1alpha1.EdgeConnect {
-	return &edgeconnectv1alpha1.EdgeConnect{
-		Spec: edgeconnectv1alpha1.EdgeConnectSpec{
+func createBasicEdgeConnect() *edgeconnect.EdgeConnect {
+	return &edgeconnect.EdgeConnect{
+		Spec: edgeconnect.EdgeConnectSpec{
 			ApiServer: "superfancy.dev.apps.dynatracelabs.com",
 		},
-		Status: edgeconnectv1alpha1.EdgeConnectStatus{},
+		Status: edgeconnect.EdgeConnectStatus{},
 	}
 }

--- a/pkg/controllers/nodes/nodes_controller.go
+++ b/pkg/controllers/nodes/nodes_controller.go
@@ -63,7 +63,7 @@ func NewController(mgr manager.Manager) *Controller {
 
 func (controller *Controller) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	nodeName := request.NamespacedName.Name
-	dynakube, err := controller.determineDynakubeForNode(nodeName)
+	dk, err := controller.determineDynakubeForNode(nodeName)
 	log.Info("reconciling node name", "node", nodeName)
 
 	if err != nil {
@@ -86,10 +86,10 @@ func (controller *Controller) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	// Node is found in the cluster, add or update to cache
-	if dynakube != nil {
-		ipAddress := dynakube.Status.OneAgent.Instances[nodeName].IPAddress
+	if dk != nil {
+		ipAddress := dk.Status.OneAgent.Instances[nodeName].IPAddress
 		cacheEntry := CacheEntry{
-			Instance:  dynakube.Name,
+			Instance:  dk.Name,
 			IPAddress: ipAddress,
 			LastSeen:  controller.timeProvider.Now().UTC(),
 		}
@@ -110,7 +110,7 @@ func (controller *Controller) Reconcile(ctx context.Context, request reconcile.R
 				nodeName:   nodeName,
 			}
 
-			if err := controller.markForTermination(ctx, dynakube, cachedNodeData); err != nil {
+			if err := controller.markForTermination(ctx, dk, cachedNodeData); err != nil {
 				return reconcile.Result{}, err
 			}
 		}

--- a/pkg/controllers/nodes/nodes_controller_test.go
+++ b/pkg/controllers/nodes/nodes_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceclient"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
@@ -37,11 +37,11 @@ func TestReconcile(t *testing.T) {
 
 		fakeClient := fake.NewClient(
 			node,
-			&dynatracev1beta2.DynaKube{
+			&dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{Name: "oneagent1", Namespace: testNamespace},
-				Status: dynatracev1beta2.DynaKubeStatus{
-					OneAgent: dynatracev1beta2.OneAgentStatus{
-						Instances: map[string]dynatracev1beta2.OneAgentInstance{node.Name: {IPAddress: "1.2.3.4"}},
+				Status: dynakube.DynaKubeStatus{
+					OneAgent: dynakube.OneAgentStatus{
+						Instances: map[string]dynakube.OneAgentInstance{node.Name: {IPAddress: "1.2.3.4"}},
 					},
 				},
 			},
@@ -224,7 +224,7 @@ func (builder mockDynatraceClientBuilder) SetContext(context.Context) dynatracec
 	return builder
 }
 
-func (builder mockDynatraceClientBuilder) SetDynakube(dynatracev1beta2.DynaKube) dynatraceclient.Builder {
+func (builder mockDynatraceClientBuilder) SetDynakube(dynakube.DynaKube) dynatraceclient.Builder {
 	return builder
 }
 
@@ -240,7 +240,7 @@ func (builder mockDynatraceClientBuilder) Build() (dtclient.Client, error) {
 	return builder.dynatraceClient, nil
 }
 
-func (builder mockDynatraceClientBuilder) BuildWithTokenVerification(*dynatracev1beta2.DynaKubeStatus) (dtclient.Client, error) {
+func (builder mockDynatraceClientBuilder) BuildWithTokenVerification(*dynakube.DynaKubeStatus) (dtclient.Client, error) {
 	return builder.dynatraceClient, nil
 }
 
@@ -286,19 +286,19 @@ func createDefaultFakeClient() client.Client {
 	return fake.NewClient(
 		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
 		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
-		&dynatracev1beta2.DynaKube{
+		&dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: "oneagent1", Namespace: testNamespace},
-			Status: dynatracev1beta2.DynaKubeStatus{
-				OneAgent: dynatracev1beta2.OneAgentStatus{
-					Instances: map[string]dynatracev1beta2.OneAgentInstance{"node1": {IPAddress: "1.2.3.4"}},
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: dynakube.OneAgentStatus{
+					Instances: map[string]dynakube.OneAgentInstance{"node1": {IPAddress: "1.2.3.4"}},
 				},
 			},
 		},
-		&dynatracev1beta2.DynaKube{
+		&dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: "oneagent2", Namespace: testNamespace},
-			Status: dynatracev1beta2.DynaKubeStatus{
-				OneAgent: dynatracev1beta2.OneAgentStatus{
-					Instances: map[string]dynatracev1beta2.OneAgentInstance{"node2": {IPAddress: "5.6.7.8"}},
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: dynakube.OneAgentStatus{
+					Instances: map[string]dynakube.OneAgentInstance{"node2": {IPAddress: "5.6.7.8"}},
 				},
 			},
 		},

--- a/pkg/controllers/nodes/oneagent_dao.go
+++ b/pkg/controllers/nodes/oneagent_dao.go
@@ -3,11 +3,11 @@ package nodes
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (controller *Controller) determineDynakubeForNode(nodeName string) (*dynatracev1beta2.DynaKube, error) {
+func (controller *Controller) determineDynakubeForNode(nodeName string) (*dynakube.DynaKube, error) {
 	dks, err := controller.getDynakubeList()
 	if err != nil {
 		return nil, err
@@ -16,8 +16,8 @@ func (controller *Controller) determineDynakubeForNode(nodeName string) (*dynatr
 	return controller.filterDynakubeFromList(dks, nodeName), nil
 }
 
-func (controller *Controller) getDynakubeList() (*dynatracev1beta2.DynaKubeList, error) {
-	var dynakubeList dynatracev1beta2.DynaKubeList
+func (controller *Controller) getDynakubeList() (*dynakube.DynaKubeList, error) {
+	var dynakubeList dynakube.DynaKubeList
 
 	err := controller.apiReader.List(context.TODO(), &dynakubeList, client.InNamespace(controller.podNamespace))
 	if err != nil {
@@ -27,8 +27,8 @@ func (controller *Controller) getDynakubeList() (*dynatracev1beta2.DynaKubeList,
 	return &dynakubeList, nil
 }
 
-func (controller *Controller) filterDynakubeFromList(dkList *dynatracev1beta2.DynaKubeList,
-	nodeName string) *dynatracev1beta2.DynaKube {
+func (controller *Controller) filterDynakubeFromList(dkList *dynakube.DynaKubeList,
+	nodeName string) *dynakube.DynaKube {
 	for _, dynakube := range dkList.Items {
 		items := dynakube.Status.OneAgent.Instances
 		if _, ok := items[nodeName]; ok {

--- a/pkg/controllers/nodes/oneagent_dao.go
+++ b/pkg/controllers/nodes/oneagent_dao.go
@@ -29,10 +29,10 @@ func (controller *Controller) getDynakubeList() (*dynakube.DynaKubeList, error) 
 
 func (controller *Controller) filterDynakubeFromList(dkList *dynakube.DynaKubeList,
 	nodeName string) *dynakube.DynaKube {
-	for _, dynakube := range dkList.Items {
-		items := dynakube.Status.OneAgent.Instances
+	for _, dk := range dkList.Items {
+		items := dk.Status.OneAgent.Instances
 		if _, ok := items[nodeName]; ok {
-			return &dynakube
+			return &dk
 		}
 	}
 

--- a/pkg/injection/codemodule/installer/image/installer.go
+++ b/pkg/injection/codemodule/installer/image/installer.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/common"
@@ -23,7 +23,7 @@ import (
 type Properties struct {
 	ImageUri     string
 	ApiReader    client.Reader
-	Dynakube     *dynatracev1beta2.DynaKube
+	Dynakube     *dynakube.DynaKube
 	PathResolver metadata.PathResolver
 	Metadata     metadata.Access
 	ImageDigest  string

--- a/pkg/injection/codemodule/installer/image/installer_test.go
+++ b/pkg/injection/codemodule/installer/image/installer_test.go
@@ -62,7 +62,7 @@ func testFileSystemWithSharedDirPresent(pathResolver metadata.PathResolver, imag
 func TestNewImageInstaller(t *testing.T) {
 	ctx := context.Background()
 	testFS := afero.NewMemMapFs()
-	dynakube := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "dynakube",
@@ -71,8 +71,8 @@ func TestNewImageInstaller(t *testing.T) {
 	}
 	pullSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dynakube.PullSecretName(),
-			Namespace: dynakube.Namespace,
+			Name:      dk.PullSecretName(),
+			Namespace: dk.Namespace,
 		},
 	}
 	pullSecret.Data = map[string][]byte{
@@ -83,7 +83,7 @@ func TestNewImageInstaller(t *testing.T) {
 	props := &Properties{
 		PathResolver: metadata.PathResolver{RootDir: "/tmp"},
 		ImageUri:     testImageURL,
-		Dynakube:     dynakube,
+		Dynakube:     dk,
 		ImageDigest:  testImageDigest,
 		ApiReader:    fakeClient,
 	}

--- a/pkg/injection/codemodule/installer/image/installer_test.go
+++ b/pkg/injection/codemodule/installer/image/installer_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/zip"
@@ -62,12 +62,12 @@ func testFileSystemWithSharedDirPresent(pathResolver metadata.PathResolver, imag
 func TestNewImageInstaller(t *testing.T) {
 	ctx := context.Background()
 	testFS := afero.NewMemMapFs()
-	dynakube := &dynatracev1beta2.DynaKube{
+	dynakube := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "dynakube",
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{},
+		Spec: dynakube.DynaKubeSpec{},
 	}
 	pullSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -137,12 +137,12 @@ func TestInstaller_InstallAgent(t *testing.T) {
 				props: &Properties{
 					PathResolver: metadata.PathResolver{RootDir: "/tmp"},
 					ImageUri:     testImageURL,
-					Dynakube: &dynatracev1beta2.DynaKube{
+					Dynakube: &dynakube.DynaKube{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test",
 							Namespace: "dynakube",
 						},
-						Spec: dynatracev1beta2.DynaKubeSpec{},
+						Spec: dynakube.DynaKubeSpec{},
 					},
 					ImageDigest: testImageDigest,
 				},

--- a/pkg/injection/namespace/ingestendpoint/secret_test.go
+++ b/pkg/injection/namespace/ingestendpoint/secret_test.go
@@ -55,8 +55,8 @@ DT_METRICS_INGEST_API_TOKEN=test-data-ingest-token
 
 func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 	t.Run(`metadata-enrichment endpoint secret created but not updated`, func(t *testing.T) {
-		instance := buildTestDynakube()
-		fakeClient := buildTestClientBeforeGenerate(instance)
+		dk := buildTestDynakube()
+		fakeClient := buildTestClientBeforeGenerate(dk)
 		endpointSecretGenerator := NewSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		{
@@ -77,8 +77,8 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 		}
 	})
 	t.Run(`metadata-enrichment endpoint secret created and token updated`, func(t *testing.T) {
-		instance := buildTestDynakube()
-		fakeClient := buildTestClientBeforeGenerate(instance)
+		dk := buildTestDynakube()
+		fakeClient := buildTestClientBeforeGenerate(dk)
 		endpointSecretGenerator := NewSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		{
@@ -102,8 +102,8 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 		}
 	})
 	t.Run(`metadata-enrichment endpoint secret created and apiUrl updated`, func(t *testing.T) {
-		instance := buildTestDynakube()
-		fakeClient := buildTestClientBeforeGenerate(instance)
+		dk := buildTestDynakube()
+		fakeClient := buildTestClientBeforeGenerate(dk)
 		endpointSecretGenerator := NewSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 		{
@@ -128,26 +128,26 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 	})
 
 	t.Run(`metadata-enrichment endpoint secret created in all namespaces but not updated`, func(t *testing.T) {
-		instance := buildTestDynakube()
-		fakeClient := buildTestClientBeforeGenerate(instance)
+		dk := buildTestDynakube()
+		fakeClient := buildTestClientBeforeGenerate(dk)
 
 		{
-			testGenerateEndpointsSecret(t, instance, fakeClient)
+			testGenerateEndpointsSecret(t, dk, fakeClient)
 
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: consts.EnrichmentEndpointSecretName}, testMetadataEnrichmentSecretWithMetrics)
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: consts.EnrichmentEndpointSecretName}, testMetadataEnrichmentSecretWithMetrics)
 			checkTestSecretDoesntExist(t, fakeClient, types.NamespacedName{Namespace: testNamespaceDynatrace, Name: consts.EnrichmentEndpointSecretName})
 		}
 		{
-			testGenerateEndpointsSecret(t, instance, fakeClient)
+			testGenerateEndpointsSecret(t, dk, fakeClient)
 		}
 	})
 	t.Run(`metadata-enrichment endpoint secret created in all namespaces and token updated`, func(t *testing.T) {
-		instance := buildTestDynakube()
-		fakeClient := buildTestClientBeforeGenerate(instance)
+		dk := buildTestDynakube()
+		fakeClient := buildTestClientBeforeGenerate(dk)
 
 		{
-			testGenerateEndpointsSecret(t, instance, fakeClient)
+			testGenerateEndpointsSecret(t, dk, fakeClient)
 
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: consts.EnrichmentEndpointSecretName}, testMetadataEnrichmentSecretWithMetrics)
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: consts.EnrichmentEndpointSecretName}, testMetadataEnrichmentSecretWithMetrics)
@@ -156,7 +156,7 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 		updateTestSecret(t, fakeClient)
 
 		{
-			testGenerateEndpointsSecret(t, instance, fakeClient)
+			testGenerateEndpointsSecret(t, dk, fakeClient)
 
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: consts.EnrichmentEndpointSecretName}, testUpdatedTokenMetadataEnrichmentSecretWithMetrics)
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: consts.EnrichmentEndpointSecretName}, testUpdatedTokenMetadataEnrichmentSecretWithMetrics)
@@ -168,9 +168,9 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 		fakeClient := buildTestClientBeforeGenerate(buildTestDynakube())
 
 		{
-			instance := buildTestDynakube()
+			dk := buildTestDynakube()
 
-			testGenerateEndpointsSecret(t, instance, fakeClient)
+			testGenerateEndpointsSecret(t, dk, fakeClient)
 
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: consts.EnrichmentEndpointSecretName}, testMetadataEnrichmentSecretWithMetrics)
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: consts.EnrichmentEndpointSecretName}, testMetadataEnrichmentSecretWithMetrics)
@@ -189,13 +189,13 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 	t.Run(`metadata-enrichment endpoint secret created (local AG) in all namespaces and apiUrl updated`, func(t *testing.T) {
 		fakeClient := buildTestClientBeforeGenerate(buildTestDynakube())
 		{
-			instance := buildTestDynakubeWithMetricsIngestCapability([]dynakube.CapabilityDisplayName{
+			dk := buildTestDynakubeWithMetricsIngestCapability([]dynakube.CapabilityDisplayName{
 				dynakube.CapabilityDisplayName(dynakube.KubeMonCapability.ShortName),
 				dynakube.CapabilityDisplayName(dynakube.MetricsIngestCapability.ShortName),
 			})
-			addFakeTenantUUID(instance)
+			addFakeTenantUUID(dk)
 
-			testGenerateEndpointsSecret(t, instance, fakeClient)
+			testGenerateEndpointsSecret(t, dk, fakeClient)
 
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: consts.EnrichmentEndpointSecretName}, testMetadataEnrichmentSecretLocalAGWithMetrics)
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: consts.EnrichmentEndpointSecretName}, testMetadataEnrichmentSecretLocalAGWithMetrics)
@@ -219,10 +219,10 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 		fakeClient := buildTestClientBeforeGenerate(buildTestDynakube())
 
 		{
-			instance := buildTestDynakube()
-			instance.Spec.MetadataEnrichment.Enabled = false
+			dk := buildTestDynakube()
+			dk.Spec.MetadataEnrichment.Enabled = false
 
-			testGenerateEndpointsSecret(t, instance, fakeClient)
+			testGenerateEndpointsSecret(t, dk, fakeClient)
 
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace1, Name: consts.EnrichmentEndpointSecretName}, testEmptyFile)
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: consts.EnrichmentEndpointSecretName}, testEmptyFile)
@@ -237,10 +237,10 @@ func addFakeTenantUUID(dynakube *dynakube.DynaKube) *dynakube.DynaKube {
 	return dynakube
 }
 
-func testGenerateEndpointsSecret(t *testing.T, instance *dynakube.DynaKube, fakeClient client.Client) {
+func testGenerateEndpointsSecret(t *testing.T, dk *dynakube.DynaKube, fakeClient client.Client) {
 	endpointSecretGenerator := NewSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
-	err := endpointSecretGenerator.GenerateForDynakube(context.TODO(), instance)
+	err := endpointSecretGenerator.GenerateForDynakube(context.TODO(), dk)
 	require.NoError(t, err)
 }
 
@@ -348,7 +348,7 @@ func buildTestDynakube() *dynakube.DynaKube {
 }
 
 func buildTestDynakubeWithMetricsIngestCapability(capabilities []dynakube.CapabilityDisplayName) *dynakube.DynaKube {
-	dynakube := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testDynakubeName,
 			Namespace: testNamespaceDynatrace,
@@ -364,7 +364,7 @@ func buildTestDynakubeWithMetricsIngestCapability(capabilities []dynakube.Capabi
 		},
 	}
 
-	return addFakeTenantUUID(dynakube)
+	return addFakeTenantUUID(dk)
 }
 
 func buildTestClientBeforeGenerate(dk *dynakube.DynaKube) client.Client {

--- a/pkg/injection/namespace/ingestendpoint/secret_test.go
+++ b/pkg/injection/namespace/ingestendpoint/secret_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/mapper"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
@@ -189,9 +189,9 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 	t.Run(`metadata-enrichment endpoint secret created (local AG) in all namespaces and apiUrl updated`, func(t *testing.T) {
 		fakeClient := buildTestClientBeforeGenerate(buildTestDynakube())
 		{
-			instance := buildTestDynakubeWithMetricsIngestCapability([]dynatracev1beta2.CapabilityDisplayName{
-				dynatracev1beta2.CapabilityDisplayName(dynatracev1beta2.KubeMonCapability.ShortName),
-				dynatracev1beta2.CapabilityDisplayName(dynatracev1beta2.MetricsIngestCapability.ShortName),
+			instance := buildTestDynakubeWithMetricsIngestCapability([]dynakube.CapabilityDisplayName{
+				dynakube.CapabilityDisplayName(dynakube.KubeMonCapability.ShortName),
+				dynakube.CapabilityDisplayName(dynakube.MetricsIngestCapability.ShortName),
 			})
 			addFakeTenantUUID(instance)
 
@@ -201,9 +201,9 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 			checkTestSecretContains(t, fakeClient, types.NamespacedName{Namespace: testNamespace2, Name: consts.EnrichmentEndpointSecretName}, testMetadataEnrichmentSecretLocalAGWithMetrics)
 		}
 		{
-			newInstance := updatedTestDynakubeWithMetricsIngestCapability([]dynatracev1beta2.CapabilityDisplayName{
-				dynatracev1beta2.CapabilityDisplayName(dynatracev1beta2.KubeMonCapability.ShortName),
-				dynatracev1beta2.CapabilityDisplayName(dynatracev1beta2.MetricsIngestCapability.ShortName),
+			newInstance := updatedTestDynakubeWithMetricsIngestCapability([]dynakube.CapabilityDisplayName{
+				dynakube.CapabilityDisplayName(dynakube.KubeMonCapability.ShortName),
+				dynakube.CapabilityDisplayName(dynakube.MetricsIngestCapability.ShortName),
 			})
 			addFakeTenantUUID(newInstance)
 
@@ -231,13 +231,13 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 	})
 }
 
-func addFakeTenantUUID(dynakube *dynatracev1beta2.DynaKube) *dynatracev1beta2.DynaKube {
+func addFakeTenantUUID(dynakube *dynakube.DynaKube) *dynakube.DynaKube {
 	dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID = testTenant
 
 	return dynakube
 }
 
-func testGenerateEndpointsSecret(t *testing.T, instance *dynatracev1beta2.DynaKube, fakeClient client.Client) {
+func testGenerateEndpointsSecret(t *testing.T, instance *dynakube.DynaKube, fakeClient client.Client) {
 	endpointSecretGenerator := NewSecretGenerator(fakeClient, fakeClient, testNamespaceDynatrace)
 
 	err := endpointSecretGenerator.GenerateForDynakube(context.TODO(), instance)
@@ -294,37 +294,37 @@ func updateTestSecret(t *testing.T, fakeClient client.Client) {
 	require.NoError(t, err)
 }
 
-func updatedTestDynakube() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func updatedTestDynakube() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testDynakubeName,
 			Namespace: testNamespaceDynatrace,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL:             testUpdatedApiUrl,
-			MetadataEnrichment: dynatracev1beta2.MetadataEnrichment{Enabled: true},
+			MetadataEnrichment: dynakube.MetadataEnrichment{Enabled: true},
 		},
 	}
 }
 
-func updatedTestDynakubeWithMetricsIngestCapability(capabilities []dynatracev1beta2.CapabilityDisplayName) *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func updatedTestDynakubeWithMetricsIngestCapability(capabilities []dynakube.CapabilityDisplayName) *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testDynakubeName,
 			Namespace: testNamespaceDynatrace,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
+		Spec: dynakube.DynaKubeSpec{
+			ActiveGate: dynakube.ActiveGateSpec{
 				Capabilities: capabilities,
 			},
 			APIURL:             testUpdatedApiUrl,
-			MetadataEnrichment: dynatracev1beta2.MetadataEnrichment{Enabled: true},
+			MetadataEnrichment: dynakube.MetadataEnrichment{Enabled: true},
 		},
 	}
 }
 
 func updateTestDynakube(t *testing.T, fakeClient client.Client) {
-	var dk dynatracev1beta2.DynaKube
+	var dk dynakube.DynaKube
 	err := fakeClient.Get(context.TODO(), client.ObjectKey{Name: testDynakubeName, Namespace: testNamespaceDynatrace}, &dk)
 	require.NoError(t, err)
 
@@ -334,31 +334,31 @@ func updateTestDynakube(t *testing.T, fakeClient client.Client) {
 	require.NoError(t, err)
 }
 
-func buildTestDynakube() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func buildTestDynakube() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testDynakubeName,
 			Namespace: testNamespaceDynatrace,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL:             testApiUrl,
-			MetadataEnrichment: dynatracev1beta2.MetadataEnrichment{Enabled: true},
+			MetadataEnrichment: dynakube.MetadataEnrichment{Enabled: true},
 		},
 	}
 }
 
-func buildTestDynakubeWithMetricsIngestCapability(capabilities []dynatracev1beta2.CapabilityDisplayName) *dynatracev1beta2.DynaKube {
-	dynakube := &dynatracev1beta2.DynaKube{
+func buildTestDynakubeWithMetricsIngestCapability(capabilities []dynakube.CapabilityDisplayName) *dynakube.DynaKube {
+	dynakube := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testDynakubeName,
 			Namespace: testNamespaceDynatrace,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
+		Spec: dynakube.DynaKubeSpec{
+			ActiveGate: dynakube.ActiveGateSpec{
 				Capabilities: capabilities,
 			},
 			APIURL: testApiUrl,
-			MetadataEnrichment: dynatracev1beta2.MetadataEnrichment{
+			MetadataEnrichment: dynakube.MetadataEnrichment{
 				Enabled: true,
 			},
 		},
@@ -367,7 +367,7 @@ func buildTestDynakubeWithMetricsIngestCapability(capabilities []dynatracev1beta
 	return addFakeTenantUUID(dynakube)
 }
 
-func buildTestClientBeforeGenerate(dk *dynatracev1beta2.DynaKube) client.Client {
+func buildTestClientBeforeGenerate(dk *dynakube.DynaKube) client.Client {
 	return fake.NewClientWithIndex(dk,
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -403,7 +403,7 @@ func buildTestClientBeforeGenerate(dk *dynatracev1beta2.DynaKube) client.Client 
 		})
 }
 
-func buildTestClientAfterGenerate(dk *dynatracev1beta2.DynaKube) client.Client {
+func buildTestClientAfterGenerate(dk *dynakube.DynaKube) client.Client {
 	return fake.NewClient(dk,
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/injection/namespace/ingestendpoint/secret_test.go
+++ b/pkg/injection/namespace/ingestendpoint/secret_test.go
@@ -231,10 +231,10 @@ func TestGenerateMetadataEnrichmentSecret_ForDynakube(t *testing.T) {
 	})
 }
 
-func addFakeTenantUUID(dynakube *dynakube.DynaKube) *dynakube.DynaKube {
-	dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID = testTenant
+func addFakeTenantUUID(dk *dynakube.DynaKube) *dynakube.DynaKube {
+	dk.Status.OneAgent.ConnectionInfoStatus.TenantUUID = testTenant
 
-	return dynakube
+	return dk
 }
 
 func testGenerateEndpointsSecret(t *testing.T, dk *dynakube.DynaKube, fakeClient client.Client) {

--- a/pkg/injection/namespace/initgeneration/initgeneration_test.go
+++ b/pkg/injection/namespace/initgeneration/initgeneration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/startup"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
@@ -292,72 +292,72 @@ func TestCreateSecretConfigForDynaKube(t *testing.T) {
 	})
 
 	t.Run("Create SecretConfig without proxy if feature-flag is set", func(t *testing.T) {
-		dynakube := baseDynakube.DeepCopy()
+		dk := baseDynakube.DeepCopy()
 		expectedSecretConfig := *baseExpectedSecretConfig
 		proxyValue := "proxy-test-value"
-		setProxy(dynakube, proxyValue)
-		setAnnotation(dynakube, map[string]string{
-			dynatracev1beta2.AnnotationFeatureOneAgentIgnoreProxy: "true",
+		setProxy(dk, proxyValue)
+		setAnnotation(dk, map[string]string{
+			dynakube.AnnotationFeatureOneAgentIgnoreProxy: "true",
 		})
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, nil)
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dk, nil)
 		require.NoError(t, err)
 		assert.Equal(t, expectedSecretConfig, *secretConfig)
 	})
 
 	t.Run("Create SecretConfig with no-proxy", func(t *testing.T) {
-		dynakube := baseDynakube.DeepCopy()
+		dk := baseDynakube.DeepCopy()
 		expectedSecretConfig := *baseExpectedSecretConfig
 		proxyValue := "proxy-test-value"
-		setNoProxy(dynakube, proxyValue)
+		setNoProxy(dk, proxyValue)
 		expectedSecretConfig.NoProxy = proxyValue
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, nil)
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dk, nil)
 		require.NoError(t, err)
 		assert.Equal(t, expectedSecretConfig, *secretConfig)
 	})
 
 	t.Run("Create SecretConfig with initial connect retry", func(t *testing.T) {
-		dynakube := baseDynakube.DeepCopy()
+		dk := baseDynakube.DeepCopy()
 		expectedSecretConfig := *baseExpectedSecretConfig
 		retryValue := "123"
-		setInitialConnectRetry(dynakube, retryValue)
+		setInitialConnectRetry(dk, retryValue)
 
 		expectedSecretConfig.InitialConnectRetry = 123
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, nil)
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dk, nil)
 		require.NoError(t, err)
 		assert.Equal(t, expectedSecretConfig, *secretConfig)
 	})
 
 	t.Run("Create SecretConfig with tlsSecret", func(t *testing.T) {
-		dynakube := baseDynakube.DeepCopy()
-		setTlsSecret(dynakube, "tls-test")
+		dk := baseDynakube.DeepCopy()
+		setTlsSecret(dk, "tls-test")
 
 		expectedSecretConfig := *baseExpectedSecretConfig
 		tlsValue := "tls-test-value"
-		tlsSecret := createTestTlsSecret(dynakube, tlsValue)
+		tlsSecret := createTestTlsSecret(dk, tlsValue)
 
 		// since we have ActiveGate we add it by default as noProxy
 		expectedSecretConfig.OneAgentNoProxy = "dynakube-test-activegate.dynatrace-test"
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy(), tlsSecret)
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		secretData, err := ig.generate(context.TODO(), dynakube)
+		secretData, err := ig.generate(context.TODO(), dk)
 		require.NoError(t, err)
 
 		var secretConfig startup.SecretConfig
@@ -372,49 +372,49 @@ func TestCreateSecretConfigForDynaKube(t *testing.T) {
 	})
 
 	t.Run("Create SecretConfig with networkZone", func(t *testing.T) {
-		dynakube := baseDynakube.DeepCopy()
+		dk := baseDynakube.DeepCopy()
 		expectedSecretConfig := *baseExpectedSecretConfig
 		networkZone := "test-network"
-		dynakube.Spec.NetworkZone = networkZone
+		dk.Spec.NetworkZone = networkZone
 		expectedSecretConfig.NetworkZone = networkZone
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, nil)
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dk, nil)
 		require.NoError(t, err)
 		assert.Equal(t, expectedSecretConfig, *secretConfig)
 	})
 
 	t.Run("Create SecretConfig with skipCertCheck", func(t *testing.T) {
-		dynakube := baseDynakube.DeepCopy()
+		dk := baseDynakube.DeepCopy()
 		expectedSecretConfig := *baseExpectedSecretConfig
-		dynakube.Spec.SkipCertCheck = true
+		dk.Spec.SkipCertCheck = true
 		expectedSecretConfig.SkipCertCheck = true
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, nil)
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dk, nil)
 		require.NoError(t, err)
 		assert.Equal(t, expectedSecretConfig, *secretConfig)
 	})
 
 	t.Run("Create SecretConfig with monitoring node", func(t *testing.T) {
-		dynakube := baseDynakube.DeepCopy()
+		dk := baseDynakube.DeepCopy()
 		expectedSecretConfig := *baseExpectedSecretConfig
 		monitoringNodes := map[string]string{
 			"node-1": "tenant-1",
 		}
 		expectedSecretConfig.MonitoringNodes = monitoringNodes
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, monitoringNodes)
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dk, monitoringNodes)
 		require.NoError(t, err)
 		assert.Equal(t, expectedSecretConfig, *secretConfig)
 	})
@@ -424,25 +424,25 @@ func getTestSelectorLabels() map[string]string {
 	return map[string]string{"test": "label"}
 }
 
-func createDynakube() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func createDynakube() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "dynakube-test",
 			Namespace:   "dynatrace-test",
 			Annotations: map[string]string{},
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: "https://test-url/e/tenant/api",
 			Tokens: "dynakube-test",
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{
-					HostInjectSpec: dynatracev1beta2.HostInjectSpec{},
+			OneAgent: dynakube.OneAgentSpec{
+				CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+					HostInjectSpec: dynakube.HostInjectSpec{},
 				}},
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			OneAgent: dynatracev1beta2.OneAgentStatus{
-				ConnectionInfoStatus: dynatracev1beta2.OneAgentConnectionInfoStatus{
-					ConnectionInfoStatus: dynatracev1beta2.ConnectionInfoStatus{
+		Status: dynakube.DynaKubeStatus{
+			OneAgent: dynakube.OneAgentStatus{
+				ConnectionInfoStatus: dynakube.OneAgentConnectionInfoStatus{
+					ConnectionInfoStatus: dynakube.ConnectionInfoStatus{
 						TenantUUID: "test-tenant",
 						Endpoints:  "beep.com;bop.com",
 					},
@@ -452,68 +452,68 @@ func createDynakube() *dynatracev1beta2.DynaKube {
 	}
 }
 
-func setProxy(dynakube *dynatracev1beta2.DynaKube, value string) {
-	dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: value}
+func setProxy(dk *dynakube.DynaKube, value string) {
+	dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: value}
 }
 
-func setAnnotation(dynakube *dynatracev1beta2.DynaKube, value map[string]string) {
-	dynakube.ObjectMeta.Annotations = value
+func setAnnotation(dk *dynakube.DynaKube, value map[string]string) {
+	dk.ObjectMeta.Annotations = value
 }
 
-func setTrustedCA(dynakube *dynatracev1beta2.DynaKube, value string) {
-	dynakube.Spec.TrustedCAs = value
+func setTrustedCA(dk *dynakube.DynaKube, value string) {
+	dk.Spec.TrustedCAs = value
 }
 
 func checkProxy(t *testing.T, generatedSecret corev1.Secret, expectedValue string) {
-	proxy, ok := generatedSecret.Data[dynatracev1beta2.ProxyKey]
+	proxy, ok := generatedSecret.Data[dynakube.ProxyKey]
 	require.True(t, ok)
 	assert.NotNil(t, proxy)
 	assert.Equal(t, expectedValue, string(proxy))
 }
 
-func setNoProxy(dynakube *dynatracev1beta2.DynaKube, value string) {
-	dynakube.Annotations[dynatracev1beta2.AnnotationFeatureNoProxy] = value
+func setNoProxy(dk *dynakube.DynaKube, value string) {
+	dk.Annotations[dynakube.AnnotationFeatureNoProxy] = value
 }
 
-func setInitialConnectRetry(dynakube *dynatracev1beta2.DynaKube, value string) {
-	dynakube.Annotations[dynatracev1beta2.AnnotationFeatureOneAgentInitialConnectRetry] = value
+func setInitialConnectRetry(dk *dynakube.DynaKube, value string) {
+	dk.Annotations[dynakube.AnnotationFeatureOneAgentInitialConnectRetry] = value
 }
 
-func setTlsSecret(dynakube *dynatracev1beta2.DynaKube, value string) {
-	dynakube.Spec.ActiveGate = dynatracev1beta2.ActiveGateSpec{
-		Capabilities: []dynatracev1beta2.CapabilityDisplayName{
-			dynatracev1beta2.KubeMonCapability.DisplayName,
+func setTlsSecret(dk *dynakube.DynaKube, value string) {
+	dk.Spec.ActiveGate = dynakube.ActiveGateSpec{
+		Capabilities: []dynakube.CapabilityDisplayName{
+			dynakube.KubeMonCapability.DisplayName,
 		},
 		TlsSecretName: value,
 	}
 }
 
-func setNodesToInstances(dynakube *dynatracev1beta2.DynaKube, nodeNames ...string) {
-	instances := map[string]dynatracev1beta2.OneAgentInstance{}
+func setNodesToInstances(dk *dynakube.DynaKube, nodeNames ...string) {
+	instances := map[string]dynakube.OneAgentInstance{}
 	for _, name := range nodeNames {
-		instances[name] = dynatracev1beta2.OneAgentInstance{}
+		instances[name] = dynakube.OneAgentInstance{}
 	}
 
-	dynakube.Status.OneAgent.Instances = instances
+	dk.Status.OneAgent.Instances = instances
 }
 
-func setNodesSelector(dynakube *dynatracev1beta2.DynaKube, selector map[string]string) {
-	dynakube.Spec.OneAgent.CloudNativeFullStack.NodeSelector = selector
+func setNodesSelector(dk *dynakube.DynaKube, selector map[string]string) {
+	dk.Spec.OneAgent.CloudNativeFullStack.NodeSelector = selector
 }
 
-func createTestCaConfigMap(dynakube *dynatracev1beta2.DynaKube, value string) *corev1.ConfigMap {
+func createTestCaConfigMap(dk *dynakube.DynaKube, value string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: dynakube.Spec.TrustedCAs, Namespace: dynakube.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: dk.Spec.TrustedCAs, Namespace: dk.Namespace},
 		Data: map[string]string{
-			dynatracev1beta2.TrustedCAKey: value,
+			dynakube.TrustedCAKey: value,
 		},
 	}
 }
 
-func createTestTlsSecret(dynakube *dynatracev1beta2.DynaKube, value string) *corev1.Secret {
+func createTestTlsSecret(dk *dynakube.DynaKube, value string) *corev1.Secret {
 	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: dynakube.Spec.ActiveGate.TlsSecretName, Namespace: dynakube.Namespace},
-		Data:       map[string][]byte{dynatracev1beta2.TlsCertKey: []byte(value)},
+		ObjectMeta: metav1.ObjectMeta{Name: dk.Spec.ActiveGate.TlsSecretName, Namespace: dk.Namespace},
+		Data:       map[string][]byte{dynakube.TlsCertKey: []byte(value)},
 	}
 }
 
@@ -523,9 +523,9 @@ func getKubeNamespace() *corev1.Namespace {
 	}
 }
 
-func createApiTokenSecret(dynakube *dynatracev1beta2.DynaKube, apiToken, paasToken string) *corev1.Secret {
+func createApiTokenSecret(dk *dynakube.DynaKube, apiToken, paasToken string) *corev1.Secret {
 	tokenSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: dynakube.Name, Namespace: dynakube.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: dk.Name, Namespace: dk.Namespace},
 		Data:       map[string][]byte{},
 	}
 	if apiToken != "" {
@@ -548,11 +548,11 @@ func createTestNode(name string, selector map[string]string) *corev1.Node {
 	}
 }
 
-func createTestInjectedNamespace(dynakube *dynatracev1beta2.DynaKube, name string) *corev1.Namespace {
+func createTestInjectedNamespace(dk *dynakube.DynaKube, name string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
-			Labels: map[string]string{dtwebhook.InjectionInstanceLabel: dynakube.Name},
+			Labels: map[string]string{dtwebhook.InjectionInstanceLabel: dk.Name},
 		},
 	}
 }

--- a/pkg/injection/namespace/initgeneration/initgeneration_test.go
+++ b/pkg/injection/namespace/initgeneration/initgeneration_test.go
@@ -26,34 +26,34 @@ const (
 
 func TestGenerateForNamespace(t *testing.T) {
 	t.Run("Add secret for namespace (dynakube with all relevant fields)", func(t *testing.T) {
-		dynakube := createDynakube()
+		dk := createDynakube()
 
 		// setup tokens
 		apiToken := "api-test"
 		paasToken := "paas-test"
-		apiTokenSecret := createApiTokenSecret(dynakube, apiToken, paasToken)
+		apiTokenSecret := createApiTokenSecret(dk, apiToken, paasToken)
 
 		// add TrustedCA
-		setTrustedCA(dynakube, "ca-configmap")
+		setTrustedCA(dk, "ca-configmap")
 
 		caValue := "ca-test"
-		caConfigMap := createTestCaConfigMap(dynakube, caValue)
+		caConfigMap := createTestCaConfigMap(dk, caValue)
 
 		// add Proxy
 		proxyValue := "proxy-test-value"
-		setProxy(dynakube, proxyValue)
+		setProxy(dk, proxyValue)
 
 		// add TLS secret
-		setTlsSecret(dynakube, "tls-test")
+		setTlsSecret(dk, "tls-test")
 
 		tlsValue := "tls-test-value"
-		tlsSecret := createTestTlsSecret(dynakube, tlsValue)
+		tlsSecret := createTestTlsSecret(dk, tlsValue)
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
-		clt := fake.NewClient(dynakube, testNamespace, apiTokenSecret, getKubeNamespace(), caConfigMap, tlsSecret)
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		testNamespace := createTestInjectedNamespace(dk, "test")
+		clt := fake.NewClient(dk, testNamespace, apiTokenSecret, getKubeNamespace(), caConfigMap, tlsSecret)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		err := ig.GenerateForNamespace(context.TODO(), *dynakube, testNamespace.Name)
+		err := ig.GenerateForNamespace(context.TODO(), *dk, testNamespace.Name)
 		require.NoError(t, err)
 
 		initSecret := retrieveInitSecret(t, clt, testNamespace.Name)
@@ -61,17 +61,17 @@ func TestGenerateForNamespace(t *testing.T) {
 		checkProxy(t, initSecret, proxyValue)
 	})
 	t.Run("Add secret for namespace (simple dynakube)", func(t *testing.T) {
-		dynakube := createDynakube()
+		dk := createDynakube()
 
 		// setup tokens
 		apiToken := "api-test"
-		apiTokenSecret := createApiTokenSecret(dynakube, apiToken, apiToken)
+		apiTokenSecret := createApiTokenSecret(dk, apiToken, apiToken)
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
-		clt := fake.NewClient(dynakube, testNamespace, apiTokenSecret, getKubeNamespace())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		testNamespace := createTestInjectedNamespace(dk, "test")
+		clt := fake.NewClient(dk, testNamespace, apiTokenSecret, getKubeNamespace())
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		err := ig.GenerateForNamespace(context.TODO(), *dynakube, testNamespace.Name)
+		err := ig.GenerateForNamespace(context.TODO(), *dk, testNamespace.Name)
 		require.NoError(t, err)
 
 		initSecret := retrieveInitSecret(t, clt, testNamespace.Name)
@@ -82,34 +82,34 @@ func TestGenerateForNamespace(t *testing.T) {
 
 func TestGenerateForDynakube(t *testing.T) {
 	t.Run("Add secret for namespace (dynakube with all the fields)", func(t *testing.T) {
-		dynakube := createDynakube()
+		dk := createDynakube()
 
 		// setup tokens
 		apiToken := "api-test"
 		paasToken := "paas-test"
-		apiTokenSecret := createApiTokenSecret(dynakube, apiToken, paasToken)
+		apiTokenSecret := createApiTokenSecret(dk, apiToken, paasToken)
 
 		// add TrustedCA
-		setTrustedCA(dynakube, "ca-configmap")
+		setTrustedCA(dk, "ca-configmap")
 
 		caValue := "ca-test"
-		caConfigMap := createTestCaConfigMap(dynakube, caValue)
+		caConfigMap := createTestCaConfigMap(dk, caValue)
 
 		// add Proxy
 		proxyValue := "proxy-test-value"
-		setProxy(dynakube, proxyValue)
+		setProxy(dk, proxyValue)
 
 		// add TLS secret
-		setTlsSecret(dynakube, "tls-test")
+		setTlsSecret(dk, "tls-test")
 
 		tlsValue := "tls-test-value"
-		tlsSecret := createTestTlsSecret(dynakube, tlsValue)
+		tlsSecret := createTestTlsSecret(dk, tlsValue)
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret, getKubeNamespace(), caConfigMap, tlsSecret)
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		err := ig.GenerateForDynakube(context.TODO(), dynakube)
+		err := ig.GenerateForDynakube(context.TODO(), dk)
 		require.NoError(t, err)
 
 		initSecret := retrieveInitSecret(t, clt, testNamespace.Name)
@@ -117,16 +117,16 @@ func TestGenerateForDynakube(t *testing.T) {
 		checkProxy(t, initSecret, proxyValue)
 	})
 	t.Run("Add secret for namespace (simple dynakube)", func(t *testing.T) {
-		dynakube := createDynakube()
+		dk := createDynakube()
 		// setup tokens
 		apiToken := "api-test"
-		apiTokenSecret := createApiTokenSecret(dynakube, apiToken, apiToken)
+		apiTokenSecret := createApiTokenSecret(dk, apiToken, apiToken)
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret, getKubeNamespace())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		err := ig.GenerateForDynakube(context.TODO(), dynakube)
+		err := ig.GenerateForDynakube(context.TODO(), dk)
 		require.NoError(t, err)
 
 		initSecret := retrieveInitSecret(t, clt, testNamespace.Name)
@@ -134,17 +134,17 @@ func TestGenerateForDynakube(t *testing.T) {
 		checkProxy(t, initSecret, "")
 	})
 	t.Run("Add secret to multiple namespaces (simple dynakube)", func(t *testing.T) {
-		dynakube := createDynakube()
+		dk := createDynakube()
 		// setup tokens
 		apiToken := "api-test"
-		apiTokenSecret := createApiTokenSecret(dynakube, apiToken, apiToken)
+		apiTokenSecret := createApiTokenSecret(dk, apiToken, apiToken)
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
-		testOtherNamespace := createTestInjectedNamespace(dynakube, "test-other")
+		testNamespace := createTestInjectedNamespace(dk, "test")
+		testOtherNamespace := createTestInjectedNamespace(dk, "test-other")
 		clt := fake.NewClientWithIndex(testNamespace, testOtherNamespace, apiTokenSecret, getKubeNamespace())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		err := ig.GenerateForDynakube(context.TODO(), dynakube)
+		err := ig.GenerateForDynakube(context.TODO(), dk)
 		require.NoError(t, err)
 
 		initSecret := retrieveInitSecret(t, clt, testNamespace.Name)
@@ -161,13 +161,13 @@ func TestGetInfraMonitoringNodes(t *testing.T) {
 	t.Run("Get Monitoring Nodes using nodes", func(t *testing.T) {
 		node1 := createTestNode("node-1", nil)
 		node2 := createTestNode("node-2", nil)
-		dynakube := createDynakube()
-		tenantUUID := dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID
+		dk := createDynakube()
+		tenantUUID := dk.Status.OneAgent.ConnectionInfoStatus.TenantUUID
 
 		clt := fake.NewClient(node1, node2)
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 		ig.canWatchNodes = true
-		monitoringNodes, err := ig.getHostMonitoringNodes(dynakube)
+		monitoringNodes, err := ig.getHostMonitoringNodes(dk)
 		require.NoError(t, err)
 		assert.Len(t, monitoringNodes, 2)
 		assert.Equal(t, tenantUUID, monitoringNodes[node1.Name])
@@ -176,14 +176,14 @@ func TestGetInfraMonitoringNodes(t *testing.T) {
 	t.Run("Get Monitoring Nodes from dynakubes (without node access)", func(t *testing.T) {
 		node1 := createTestNode("node-1", nil)
 		node2 := createTestNode("node-2", nil)
-		dynakube := createDynakube()
-		setNodesToInstances(dynakube, node1.Name, node2.Name)
-		tenantUUID := dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID
+		dk := createDynakube()
+		setNodesToInstances(dk, node1.Name, node2.Name)
+		tenantUUID := dk.Status.OneAgent.ConnectionInfoStatus.TenantUUID
 
 		clt := fake.NewClient()
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 		ig.canWatchNodes = false
-		monitoringNodes, err := ig.getHostMonitoringNodes(dynakube)
+		monitoringNodes, err := ig.getHostMonitoringNodes(dk)
 		require.NoError(t, err)
 		assert.Len(t, monitoringNodes, 2)
 		assert.Equal(t, tenantUUID, monitoringNodes[node1.Name])
@@ -193,14 +193,14 @@ func TestGetInfraMonitoringNodes(t *testing.T) {
 		node1 := createTestNode("node-1", nil)
 		node2 := createTestNode("node-2", nil)
 		labeledNode := createTestNode("node-labeled", getTestSelectorLabels())
-		dynakube := createDynakube()
-		setNodesSelector(dynakube, getTestSelectorLabels())
-		tenantUUID := dynakube.Status.OneAgent.ConnectionInfoStatus.TenantUUID
+		dk := createDynakube()
+		setNodesSelector(dk, getTestSelectorLabels())
+		tenantUUID := dk.Status.OneAgent.ConnectionInfoStatus.TenantUUID
 
 		clt := fake.NewClient(labeledNode, node1, node2)
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 		ig.canWatchNodes = true
-		monitoringNodes, err := ig.getHostMonitoringNodes(dynakube)
+		monitoringNodes, err := ig.getHostMonitoringNodes(dk)
 		require.NoError(t, err)
 		assert.Len(t, monitoringNodes, 3)
 		assert.Equal(t, tenantUUID, monitoringNodes[labeledNode.Name])
@@ -234,31 +234,31 @@ func TestCreateSecretConfigForDynaKube(t *testing.T) {
 	}
 
 	t.Run("Create SecretConfig with default content", func(t *testing.T) {
-		dynakube := baseDynakube.DeepCopy()
+		dk := baseDynakube.DeepCopy()
 		expectedSecretConfig := *baseExpectedSecretConfig
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, nil)
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dk, nil)
 		require.NoError(t, err)
 		assert.Equal(t, expectedSecretConfig, *secretConfig)
 	})
 
 	t.Run("Create SecretConfig with trustedCA", func(t *testing.T) {
-		dynakube := baseDynakube.DeepCopy()
+		dk := baseDynakube.DeepCopy()
 		expectedSecretConfig := *baseExpectedSecretConfig
 
-		setTrustedCA(dynakube, "ca-configmap")
+		setTrustedCA(dk, "ca-configmap")
 
 		caValue := "ca-test"
-		caConfigMap := createTestCaConfigMap(dynakube, caValue)
+		caConfigMap := createTestCaConfigMap(dk, caValue)
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy(), caConfigMap.DeepCopy())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		secretData, err := ig.generate(context.TODO(), dynakube)
+		secretData, err := ig.generate(context.TODO(), dk)
 		require.NoError(t, err)
 
 		_, ok := secretData[consts.AgentInitSecretConfigField]
@@ -276,17 +276,17 @@ func TestCreateSecretConfigForDynaKube(t *testing.T) {
 	})
 
 	t.Run("Create SecretConfig with proxy", func(t *testing.T) {
-		dynakube := baseDynakube.DeepCopy()
+		dk := baseDynakube.DeepCopy()
 		expectedSecretConfig := *baseExpectedSecretConfig
 		proxyValue := "proxy-test-value"
-		setProxy(dynakube, proxyValue)
+		setProxy(dk, proxyValue)
 		expectedSecretConfig.Proxy = proxyValue
 
-		testNamespace := createTestInjectedNamespace(dynakube, "test")
+		testNamespace := createTestInjectedNamespace(dk, "test")
 		clt := fake.NewClientWithIndex(testNamespace, apiTokenSecret.DeepCopy(), getKubeNamespace().DeepCopy())
-		ig := NewInitGenerator(clt, clt, dynakube.Namespace)
+		ig := NewInitGenerator(clt, clt, dk.Namespace)
 
-		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dynakube, nil)
+		secretConfig, err := ig.createSecretConfigForDynaKube(context.TODO(), dk, nil)
 		require.NoError(t, err)
 		assert.Equal(t, expectedSecretConfig, *secretConfig)
 	})

--- a/pkg/injection/namespace/mapper/dynakube_test.go
+++ b/pkg/injection/namespace/mapper/dynakube_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -121,7 +121,7 @@ func TestMapFromDynakube(t *testing.T) {
 	t.Run("ComponentFeature flag for monitoring system namespaces", func(t *testing.T) {
 		dk := createDynakubeWithAppInject("appMonitoring", metav1.LabelSelector{})
 		dk.Annotations = map[string]string{
-			dynatracev1beta2.AnnotationFeatureIgnoredNamespaces: "[]",
+			dynakube.AnnotationFeatureIgnoredNamespaces: "[]",
 		}
 		namespace := createNamespace("openshift-something", nil)
 		clt := fake.NewClient(dk, namespace)

--- a/pkg/injection/namespace/mapper/dynakubes.go
+++ b/pkg/injection/namespace/mapper/dynakubes.go
@@ -3,7 +3,7 @@ package mapper
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -15,11 +15,11 @@ type DynakubeMapper struct {
 	ctx        context.Context
 	client     client.Client
 	apiReader  client.Reader
-	dk         *dynatracev1beta2.DynaKube
+	dk         *dynakube.DynaKube
 	operatorNs string
 }
 
-func NewDynakubeMapper(ctx context.Context, clt client.Client, apiReader client.Reader, operatorNs string, dk *dynatracev1beta2.DynaKube) DynakubeMapper {
+func NewDynakubeMapper(ctx context.Context, clt client.Client, apiReader client.Reader, operatorNs string, dk *dynakube.DynaKube) DynakubeMapper {
 	return DynakubeMapper{ctx: ctx, client: clt, apiReader: apiReader, operatorNs: operatorNs, dk: dk}
 }
 
@@ -41,7 +41,7 @@ func (dm DynakubeMapper) MatchingNamespaces() ([]*corev1.Namespace, error) {
 		return nil, errors.Cause(err)
 	}
 
-	dkList := &dynatracev1beta2.DynaKubeList{}
+	dkList := &dynakube.DynaKubeList{}
 	if err := dm.apiReader.List(dm.ctx, dkList, &client.ListOptions{Namespace: dm.operatorNs}); err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -62,7 +62,7 @@ func (dm DynakubeMapper) UnmapFromDynaKube(namespaces []corev1.Namespace) error 
 	return nil
 }
 
-func (dm DynakubeMapper) mapFromDynakube(nsList *corev1.NamespaceList, dkList *dynatracev1beta2.DynaKubeList) ([]*corev1.Namespace, error) {
+func (dm DynakubeMapper) mapFromDynakube(nsList *corev1.NamespaceList, dkList *dynakube.DynaKubeList) ([]*corev1.Namespace, error) {
 	var updated bool
 
 	var err error

--- a/pkg/injection/namespace/mapper/mapper.go
+++ b/pkg/injection/namespace/mapper/mapper.go
@@ -115,23 +115,23 @@ func updateNamespace(namespace *corev1.Namespace, deployedDynakubes *dynakube.Dy
 	conflict := ConflictChecker{}
 
 	for i := range deployedDynakubes.Items {
-		dynakube := &deployedDynakubes.Items[i]
-		if isIgnoredNamespace(dynakube, namespace.Name) {
+		dk := &deployedDynakubes.Items[i]
+		if isIgnoredNamespace(dk, namespace.Name) {
 			continue
 		}
 
-		matches, err := match(dynakube, namespace)
+		matches, err := match(dk, namespace)
 		if err != nil {
 			return namespaceUpdated, err
 		}
 
 		if matches {
-			if err := conflict.check(dynakube); err != nil {
+			if err := conflict.check(dk); err != nil {
 				return namespaceUpdated, err
 			}
 		}
 
-		labelsUpdated := updateLabels(matches, dynakube, namespace)
+		labelsUpdated := updateLabels(matches, dk, namespace)
 		namespaceUpdated = labelsUpdated || namespaceUpdated
 	}
 

--- a/pkg/injection/namespace/mapper/mapper_test.go
+++ b/pkg/injection/namespace/mapper/mapper_test.go
@@ -3,7 +3,7 @@ package mapper
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,39 +11,39 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func createBaseDynakube(name string, appInjection bool, metadataEnrichment bool) *dynatracev1beta2.DynaKube {
-	dk := &dynatracev1beta2.DynaKube{
+func createBaseDynakube(name string, appInjection bool, metadataEnrichment bool) *dynakube.DynaKube {
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "dynatrace"},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			MetadataEnrichment: dynatracev1beta2.MetadataEnrichment{
+		Spec: dynakube.DynaKubeSpec{
+			MetadataEnrichment: dynakube.MetadataEnrichment{
 				Enabled: metadataEnrichment,
 			},
 		},
 	}
 
 	if appInjection {
-		dk.Spec.OneAgent = dynatracev1beta2.OneAgentSpec{
-			ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{}}
+		dk.Spec.OneAgent = dynakube.OneAgentSpec{
+			ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{}}
 	}
 
 	return dk
 }
 
-func createDynakubeWithAppInject(name string, selector metav1.LabelSelector) *dynatracev1beta2.DynaKube {
+func createDynakubeWithAppInject(name string, selector metav1.LabelSelector) *dynakube.DynaKube {
 	dk := createBaseDynakube(name, true, false)
 	dk.Spec.OneAgent.ApplicationMonitoring.NamespaceSelector = selector
 
 	return dk
 }
 
-func createDynakubeWithMetadataEnrichment(name string, selector metav1.LabelSelector) *dynatracev1beta2.DynaKube {
+func createDynakubeWithMetadataEnrichment(name string, selector metav1.LabelSelector) *dynakube.DynaKube {
 	dk := createBaseDynakube(name, false, true)
 	dk.Spec.MetadataEnrichment.NamespaceSelector = selector
 
 	return dk
 }
 
-func createDynakubeWithMetadataAndAppInjection(name string, selector metav1.LabelSelector) *dynatracev1beta2.DynaKube {
+func createDynakubeWithMetadataAndAppInjection(name string, selector metav1.LabelSelector) *dynakube.DynaKube {
 	dk := createBaseDynakube(name, true, true)
 
 	dk.Spec.MetadataEnrichment.NamespaceSelector = selector
@@ -71,7 +71,7 @@ func TestUpdateNamespace(t *testing.T) {
 		dk := createDynakubeWithAppInject("dk-test", convertToLabelSelector(labels))
 		namespace := createNamespace("test-namespace", labels)
 
-		updated, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*dk}})
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*dk}})
 
 		require.NoError(t, err)
 		require.True(t, updated)
@@ -82,7 +82,7 @@ func TestUpdateNamespace(t *testing.T) {
 		dk := createDynakubeWithMetadataEnrichment("dk-test", convertToLabelSelector(labels))
 		namespace := createNamespace("test-namespace", labels)
 
-		updated, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*dk}})
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*dk}})
 
 		require.NoError(t, err)
 		require.True(t, updated)
@@ -94,7 +94,7 @@ func TestUpdateNamespace(t *testing.T) {
 
 		namespace := createNamespace("test", labels)
 
-		updated, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*dk}})
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*dk}})
 
 		require.NoError(t, err)
 		require.True(t, updated)
@@ -109,7 +109,7 @@ func TestUpdateNamespace(t *testing.T) {
 		}
 		namespace := createNamespace("test-namespace", nsLabels)
 
-		updated, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*dk}})
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*dk}})
 
 		require.NoError(t, err)
 		require.True(t, updated)
@@ -124,7 +124,7 @@ func TestUpdateNamespace(t *testing.T) {
 		}
 		namespace := createNamespace("test-namespace", nsLabels)
 
-		updated, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*movedDk}})
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*movedDk}})
 		require.NoError(t, err)
 		require.True(t, updated)
 		assert.Empty(t, namespace.Labels)
@@ -139,7 +139,7 @@ func TestUpdateNamespace(t *testing.T) {
 		}
 		namespace := createNamespace("test-namespace", nsLabels)
 
-		_, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*conflictingDk, *dk}})
+		_, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*conflictingDk, *dk}})
 
 		require.Error(t, err)
 	})
@@ -147,7 +147,7 @@ func TestUpdateNamespace(t *testing.T) {
 		dk := createDynakubeWithAppInject("appMonitoring", metav1.LabelSelector{})
 		namespace := createNamespace("kube-something", nil)
 
-		updated, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*dk}})
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*dk}})
 
 		require.NoError(t, err)
 		require.False(t, updated)
@@ -158,7 +158,7 @@ func TestUpdateNamespace(t *testing.T) {
 		dk := createDynakubeWithAppInject("appMonitoring", metav1.LabelSelector{})
 		namespace := createNamespace("openshift-something", nil)
 
-		updated, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*dk}})
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*dk}})
 
 		require.NoError(t, err)
 		require.False(t, updated)
@@ -170,11 +170,11 @@ func TestUpdateNamespace(t *testing.T) {
 		ignoreDk := createDynakubeWithAppInject("appMonitoring", convertToLabelSelector(otherLabels))
 		notIgnoreDk := createDynakubeWithAppInject("boom", convertToLabelSelector(labels))
 		notIgnoreDk.Annotations = map[string]string{
-			dynatracev1beta2.AnnotationFeatureIgnoredNamespaces: "[\"asd\"]",
+			dynakube.AnnotationFeatureIgnoredNamespaces: "[\"asd\"]",
 		}
 		namespace := createNamespace("openshift-something", labels)
 
-		updated, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*ignoreDk, *notIgnoreDk}})
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*ignoreDk, *notIgnoreDk}})
 
 		require.NoError(t, err)
 		require.True(t, updated)
@@ -187,11 +187,11 @@ func TestUpdateNamespace(t *testing.T) {
 		ignoreDk := createDynakubeWithAppInject("appMonitoring", convertToLabelSelector(otherLabels))
 		notIgnoreDk := createDynakubeWithAppInject("boom", convertToLabelSelector(labels))
 		notIgnoreDk.Annotations = map[string]string{
-			dynatracev1beta2.AnnotationFeatureIgnoredNamespaces: "[\"asd\"]",
+			dynakube.AnnotationFeatureIgnoredNamespaces: "[\"asd\"]",
 		}
 		namespace := createNamespace("openshift-something", labels)
 
-		updated, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*notIgnoreDk, *ignoreDk}})
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*notIgnoreDk, *ignoreDk}})
 
 		require.NoError(t, err)
 		require.True(t, updated)
@@ -206,7 +206,7 @@ func TestUpdateNamespace(t *testing.T) {
 		}
 		namespace := createNamespace("test-namespace", nsLabels)
 
-		updated, err := updateNamespace(namespace, &dynatracev1beta2.DynaKubeList{Items: []dynatracev1beta2.DynaKube{*movedDk}})
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*movedDk}})
 		require.NoError(t, err)
 		require.True(t, updated)
 		assert.Empty(t, namespace.Labels)

--- a/pkg/injection/namespace/mapper/namespaces.go
+++ b/pkg/injection/namespace/mapper/namespaces.go
@@ -3,7 +3,7 @@ package mapper
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	injectionotel "github.com/Dynatrace/dynatrace-operator/pkg/injection/internal/otel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtotel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtotel/controller_runtime"
@@ -43,7 +43,7 @@ func (nm NamespaceMapper) updateNamespace(ctx context.Context) (bool, error) {
 	ctx, span := dtotel.StartSpan(ctx, injectionotel.Tracer())
 	defer span.End()
 
-	deployedDynakubes := &dynatracev1beta2.DynaKubeList{}
+	deployedDynakubes := &dynakube.DynaKubeList{}
 
 	err := nm.client.List(ctx, deployedDynakubes)
 	if err != nil {

--- a/pkg/injection/namespace/mapper/namespaces_test.go
+++ b/pkg/injection/namespace/mapper/namespaces_test.go
@@ -17,14 +17,14 @@ func TestMatchForNamespaceNothingEverything(t *testing.T) {
 		"type":   "app",
 		"inject": "true",
 	}
-	dynakubes := []*dynakube.DynaKube{
+	dks := []*dynakube.DynaKube{
 		createDynakubeWithAppInject("appMonitoring-1", metav1.LabelSelector{}),
 		createDynakubeWithAppInject("appMonitoring-2", convertToLabelSelector(matchLabels)),
 	}
 
 	t.Run(`Match to unlabeled namespace`, func(t *testing.T) {
 		namespace := createNamespace("test-namespace", nil)
-		clt := fake.NewClient(dynakubes[0], dynakubes[1])
+		clt := fake.NewClient(dks[0], dks[1])
 		nm := NewNamespaceMapper(clt, clt, "dynatrace", namespace)
 
 		updated, err := nm.updateNamespace(context.Background())

--- a/pkg/injection/namespace/mapper/namespaces_test.go
+++ b/pkg/injection/namespace/mapper/namespaces_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,7 +17,7 @@ func TestMatchForNamespaceNothingEverything(t *testing.T) {
 		"type":   "app",
 		"inject": "true",
 	}
-	dynakubes := []*dynatracev1beta2.DynaKube{
+	dynakubes := []*dynakube.DynaKube{
 		createDynakubeWithAppInject("appMonitoring-1", metav1.LabelSelector{}),
 		createDynakubeWithAppInject("appMonitoring-2", convertToLabelSelector(matchLabels)),
 	}
@@ -104,7 +104,7 @@ func TestMapFromNamespace(t *testing.T) {
 	t.Run("ComponentFeature flag for monitoring system namespaces", func(t *testing.T) {
 		dk := createDynakubeWithAppInject("appMonitoring", metav1.LabelSelector{})
 		dk.Annotations = map[string]string{
-			dynatracev1beta2.AnnotationFeatureIgnoredNamespaces: "[]",
+			dynakube.AnnotationFeatureIgnoredNamespaces: "[]",
 		}
 		namespace := createNamespace("openshift-something", nil)
 		clt := fake.NewClient(dk)

--- a/pkg/oci/registry/client.go
+++ b/pkg/oci/registry/client.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
 	"github.com/Dynatrace/dynatrace-operator/pkg/oci/dockerkeychain"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -228,7 +228,7 @@ func addSkipCertCheck(transport *http.Transport, skipCertCheck bool) *http.Trans
 }
 
 // PrepareTransportForDynaKube creates default http transport and add proxy or trustedCAs if any
-func PrepareTransportForDynaKube(ctx context.Context, apiReader client.Reader, transport *http.Transport, dynakube *dynatracev1beta2.DynaKube) (*http.Transport, error) {
+func PrepareTransportForDynaKube(ctx context.Context, apiReader client.Reader, transport *http.Transport, dynakube *dynakube.DynaKube) (*http.Transport, error) {
 	var (
 		proxy      string
 		trustedCAs []byte

--- a/pkg/oci/registry/client.go
+++ b/pkg/oci/registry/client.go
@@ -228,29 +228,29 @@ func addSkipCertCheck(transport *http.Transport, skipCertCheck bool) *http.Trans
 }
 
 // PrepareTransportForDynaKube creates default http transport and add proxy or trustedCAs if any
-func PrepareTransportForDynaKube(ctx context.Context, apiReader client.Reader, transport *http.Transport, dynakube *dynakube.DynaKube) (*http.Transport, error) {
+func PrepareTransportForDynaKube(ctx context.Context, apiReader client.Reader, transport *http.Transport, dk *dynakube.DynaKube) (*http.Transport, error) {
 	var (
 		proxy      string
 		trustedCAs []byte
 		err        error
 	)
 
-	if dynakube.HasProxy() {
-		proxy, err = dynakube.Proxy(ctx, apiReader)
+	if dk.HasProxy() {
+		proxy, err = dk.Proxy(ctx, apiReader)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if dynakube.Spec.TrustedCAs != "" {
-		trustedCAs, err = dynakube.TrustedCAs(ctx, apiReader)
+	if dk.Spec.TrustedCAs != "" {
+		trustedCAs, err = dk.TrustedCAs(ctx, apiReader)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if proxy != "" {
-		transport, err = addProxy(transport, proxy, dynakube.FeatureNoProxy())
+		transport, err = addProxy(transport, proxy, dk.FeatureNoProxy())
 		if err != nil {
 			return nil, errors.WithMessage(err, "failed to add proxy to default transport")
 		}
@@ -263,7 +263,7 @@ func PrepareTransportForDynaKube(ctx context.Context, apiReader client.Reader, t
 		}
 	}
 
-	transport = addSkipCertCheck(transport, dynakube.Spec.SkipCertCheck)
+	transport = addSkipCertCheck(transport, dk.Spec.SkipCertCheck)
 
 	return transport, nil
 }

--- a/pkg/oci/registry/client_test.go
+++ b/pkg/oci/registry/client_test.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,19 +16,19 @@ func TestProxy(t *testing.T) {
 	proxyRawURL := "proxy.url"
 
 	t.Run("set NO_PROXY", func(t *testing.T) {
-		instance := &dynatracev1beta2.DynaKube{
+		instance := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "Dynakube",
 				Namespace: "dynatrace",
 				Annotations: map[string]string{
-					dynatracev1beta2.AnnotationFeatureNoProxy: "working.url,url.working",
+					dynakube.AnnotationFeatureNoProxy: "working.url,url.working",
 				},
 			},
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				Proxy:  &dynatracev1beta2.DynaKubeProxy{Value: proxyRawURL},
+			Spec: dynakube.DynaKubeSpec{
+				Proxy:  &dynakube.DynaKubeProxy{Value: proxyRawURL},
 				APIURL: "https://testApiUrl.dev.dynatracelabs.com/api",
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 				},
 			},
 		}
@@ -49,15 +49,15 @@ func TestProxy(t *testing.T) {
 }
 
 func TestSkipCertCheck(t *testing.T) {
-	instance := &dynatracev1beta2.DynaKube{
+	instance := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "Dynakube",
 			Namespace: "dynatrace",
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: "https://testApiUrl.dev.dynatracelabs.com/api",
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+			OneAgent: dynakube.OneAgentSpec{
+				CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 			},
 		},
 	}

--- a/pkg/oci/registry/client_test.go
+++ b/pkg/oci/registry/client_test.go
@@ -16,7 +16,7 @@ func TestProxy(t *testing.T) {
 	proxyRawURL := "proxy.url"
 
 	t.Run("set NO_PROXY", func(t *testing.T) {
-		instance := &dynakube.DynaKube{
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "Dynakube",
 				Namespace: "dynatrace",
@@ -33,7 +33,7 @@ func TestProxy(t *testing.T) {
 			},
 		}
 		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport, err := PrepareTransportForDynaKube(context.TODO(), nil, transport, instance)
+		transport, err := PrepareTransportForDynaKube(context.TODO(), nil, transport, dk)
 
 		require.NoError(t, err)
 
@@ -49,7 +49,7 @@ func TestProxy(t *testing.T) {
 }
 
 func TestSkipCertCheck(t *testing.T) {
-	instance := &dynakube.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "Dynakube",
 			Namespace: "dynatrace",
@@ -63,16 +63,16 @@ func TestSkipCertCheck(t *testing.T) {
 	}
 
 	t.Run("has skipCertCheck enabled", func(t *testing.T) {
-		instance.Spec.SkipCertCheck = true
+		dk.Spec.SkipCertCheck = true
 		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport, err := PrepareTransportForDynaKube(context.TODO(), nil, transport, instance)
+		transport, err := PrepareTransportForDynaKube(context.TODO(), nil, transport, dk)
 		require.NoError(t, err)
 		assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
 	})
 	t.Run("has skipCertCheck disabled", func(t *testing.T) {
-		instance.Spec.SkipCertCheck = false
+		dk.Spec.SkipCertCheck = false
 		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport, err := PrepareTransportForDynaKube(context.TODO(), nil, transport, instance)
+		transport, err := PrepareTransportForDynaKube(context.TODO(), nil, transport, dk)
 		require.NoError(t, err)
 		assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
 	})

--- a/pkg/util/conditions/time.go
+++ b/pkg/util/conditions/time.go
@@ -1,7 +1,7 @@
 package conditions
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,7 +9,7 @@ import (
 
 // IsOutdated determines if a given is considered outdated according to the DynaKube's FeatureApiRequestThreshold
 // This is used for those conditions that are (also) used for limiting API requests.
-func IsOutdated(timeProvider *timeprovider.Provider, dynakube *dynatracev1beta2.DynaKube, conditionType string) bool {
+func IsOutdated(timeProvider *timeprovider.Provider, dynakube *dynakube.DynaKube, conditionType string) bool {
 	condition := meta.FindStatusCondition(*dynakube.Conditions(), conditionType)
 	if condition == nil {
 		return true

--- a/pkg/util/conditions/time.go
+++ b/pkg/util/conditions/time.go
@@ -9,11 +9,11 @@ import (
 
 // IsOutdated determines if a given is considered outdated according to the DynaKube's FeatureApiRequestThreshold
 // This is used for those conditions that are (also) used for limiting API requests.
-func IsOutdated(timeProvider *timeprovider.Provider, dynakube *dynakube.DynaKube, conditionType string) bool {
-	condition := meta.FindStatusCondition(*dynakube.Conditions(), conditionType)
+func IsOutdated(timeProvider *timeprovider.Provider, dk *dynakube.DynaKube, conditionType string) bool {
+	condition := meta.FindStatusCondition(*dk.Conditions(), conditionType)
 	if condition == nil {
 		return true
 	}
 
-	return condition.Status == metav1.ConditionFalse || timeProvider.IsOutdated(&condition.LastTransitionTime, dynakube.ApiRequestThreshold())
+	return condition.Status == metav1.ConditionFalse || timeProvider.IsOutdated(&condition.LastTransitionTime, dk.ApiRequestThreshold())
 }

--- a/pkg/util/conditions/time_test.go
+++ b/pkg/util/conditions/time_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -15,14 +15,14 @@ func TestIsOutdated(t *testing.T) {
 
 	t.Run("empty condition => outdated", func(t *testing.T) {
 		tp := timeprovider.New()
-		dk := &dynatracev1beta2.DynaKube{}
+		dk := &dynakube.DynaKube{}
 
 		assert.True(t, IsOutdated(tp, dk, testingConditionType))
 	})
 
 	t.Run("False condition => outdated", func(t *testing.T) {
 		tp := timeprovider.New()
-		dk := &dynatracev1beta2.DynaKube{}
+		dk := &dynakube.DynaKube{}
 
 		SetDynatraceApiError(dk.Conditions(), testingConditionType, errors.New("boom"))
 
@@ -31,9 +31,9 @@ func TestIsOutdated(t *testing.T) {
 
 	t.Run("True condition + current timestamp => NOT outdated", func(t *testing.T) {
 		tp := timeprovider.New()
-		dk := &dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				DynatraceApiRequestThreshold: dynatracev1beta2.DefaultMinRequestThresholdMinutes,
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				DynatraceApiRequestThreshold: dynakube.DefaultMinRequestThresholdMinutes,
 			},
 		}
 
@@ -44,7 +44,7 @@ func TestIsOutdated(t *testing.T) {
 
 	t.Run("old timestamp => outdated", func(t *testing.T) {
 		tp := timeprovider.New()
-		dk := &dynatracev1beta2.DynaKube{}
+		dk := &dynakube.DynaKube{}
 
 		SetSecretCreated(dk.Conditions(), testingConditionType, "")
 		tp.Set(tp.Now().Add(time.Minute * 60))

--- a/pkg/util/hasher/hasher.go
+++ b/pkg/util/hasher/hasher.go
@@ -6,12 +6,12 @@ import (
 	"reflect"
 	"strconv"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const AnnotationHash = dynatracev1beta2.InternalFlagPrefix + "template-hash"
+const AnnotationHash = dynakube.InternalFlagPrefix + "template-hash"
 
 func GenerateHash(ds any) (string, error) {
 	data, err := json.Marshal(ds)

--- a/pkg/util/kubeobjects/activegate/capability.go
+++ b/pkg/util/kubeobjects/activegate/capability.go
@@ -1,10 +1,10 @@
 package activegate
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 )
 
-func SwitchCapability(instance *dynatracev1beta2.DynaKube, capability dynatracev1beta2.ActiveGateCapability, wantEnabled bool) {
+func SwitchCapability(instance *dynakube.DynaKube, capability dynakube.ActiveGateCapability, wantEnabled bool) {
 	hasEnabled := instance.IsActiveGateMode(capability.DisplayName)
 	capabilities := &instance.Spec.ActiveGate.Capabilities
 
@@ -17,7 +17,7 @@ func SwitchCapability(instance *dynatracev1beta2.DynaKube, capability dynatracev
 	}
 }
 
-func removeCapability(capabilities []dynatracev1beta2.CapabilityDisplayName, removeMe dynatracev1beta2.CapabilityDisplayName) []dynatracev1beta2.CapabilityDisplayName {
+func removeCapability(capabilities []dynakube.CapabilityDisplayName, removeMe dynakube.CapabilityDisplayName) []dynakube.CapabilityDisplayName {
 	for i, capability := range capabilities {
 		if capability == removeMe {
 			return append(capabilities[:i], capabilities[i+1:]...)

--- a/pkg/util/kubeobjects/activegate/capability.go
+++ b/pkg/util/kubeobjects/activegate/capability.go
@@ -4,9 +4,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 )
 
-func SwitchCapability(instance *dynakube.DynaKube, capability dynakube.ActiveGateCapability, wantEnabled bool) {
-	hasEnabled := instance.IsActiveGateMode(capability.DisplayName)
-	capabilities := &instance.Spec.ActiveGate.Capabilities
+func SwitchCapability(dk *dynakube.DynaKube, capability dynakube.ActiveGateCapability, wantEnabled bool) {
+	hasEnabled := dk.IsActiveGateMode(capability.DisplayName)
+	capabilities := &dk.Spec.ActiveGate.Capabilities
 
 	if wantEnabled && !hasEnabled {
 		*capabilities = append(*capabilities, capability.DisplayName)

--- a/pkg/webhook/mutation/namespace/webhook_test.go
+++ b/pkg/webhook/mutation/namespace/webhook_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/stretchr/testify/assert"
@@ -19,12 +19,12 @@ import (
 )
 
 func TestInjection(t *testing.T) {
-	dk := &dynatracev1beta2.DynaKube{
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{Name: "codeModules-1", Namespace: "dynatrace"},
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{
-					AppInjectionSpec: dynatracev1beta2.AppInjectionSpec{
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: dynakube.OneAgentSpec{
+				ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+					AppInjectionSpec: dynakube.AppInjectionSpec{
 						NamespaceSelector: metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"inject": "true",

--- a/pkg/webhook/mutation/pod/events.go
+++ b/pkg/webhook/mutation/pod/events.go
@@ -1,14 +1,14 @@
 package pod
 
 import (
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 )
 
 type eventRecorder struct {
-	dk       *dynatracev1beta2.DynaKube
+	dk       *dynakube.DynaKube
 	pod      *corev1.Pod
 	recorder record.EventRecorder
 }
@@ -34,7 +34,7 @@ func (er *eventRecorder) sendPodUpdateEvent() {
 func (er *eventRecorder) sendMissingDynaKubeEvent(namespaceName, dynakubeName string) {
 	template := "Namespace '%s' is assigned to DynaKube instance '%s' but this instance doesn't exist"
 	er.recorder.Eventf(
-		&dynatracev1beta2.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: dynakubeName, Namespace: namespaceName}},
+		&dynakube.DynaKube{ObjectMeta: metav1.ObjectMeta{Name: dynakubeName, Namespace: namespaceName}},
 		corev1.EventTypeWarning,
 		missingDynakubeEvent,
 		template, namespaceName, dynakubeName)

--- a/pkg/webhook/mutation/pod/init_container_test.go
+++ b/pkg/webhook/mutation/pod/init_container_test.go
@@ -3,7 +3,7 @@ package pod
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
@@ -14,14 +14,14 @@ import (
 
 func TestCreateInstallInitContainerBase(t *testing.T) {
 	t.Run("should create the init container with set container sec ctx but without user and group", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		pod := getTestPod()
 		pod.Spec.Containers[0].SecurityContext.RunAsUser = nil
 		pod.Spec.Containers[0].SecurityContext.RunAsGroup = nil
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 
 		require.NotNil(t, initContainer)
 		assert.Equal(t, initContainer.Image, webhookImage)
@@ -48,7 +48,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		assert.Nil(t, initContainer.SecurityContext.SeccompProfile)
 	})
 	t.Run("should overwrite partially", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		pod := getTestPod()
 		testUser := address.Of(int64(420))
 		pod.Spec.Containers[0].SecurityContext.RunAsUser = nil
@@ -56,7 +56,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 
 		require.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
 		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
@@ -68,7 +68,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, *testUser)
 	})
 	t.Run("container SecurityContext overrules defaults", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		pod := getTestPod()
 		overruledUser := address.Of(int64(420))
 		testUser := address.Of(int64(420))
@@ -80,7 +80,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 		require.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
 		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
 
@@ -91,7 +91,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		assert.Equal(t, *initContainer.SecurityContext.RunAsGroup, *testUser)
 	})
 	t.Run("PodSecurityContext overrules defaults", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		testUser := address.Of(int64(420))
 		pod := getTestPod()
 		pod.Spec.Containers[0].SecurityContext = nil
@@ -101,7 +101,7 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 
 		require.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
 		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
@@ -113,14 +113,14 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		assert.Equal(t, *testUser, *initContainer.SecurityContext.RunAsGroup)
 	})
 	t.Run("should set RunAsNonRoot if root user is used", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		pod := getTestPod()
 		pod.Spec.Containers[0].SecurityContext.RunAsUser = address.Of(rootUserGroup)
 		pod.Spec.Containers[0].SecurityContext.RunAsGroup = address.Of(rootUserGroup)
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 
 		assert.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
 		assert.False(t, *initContainer.SecurityContext.RunAsNonRoot)
@@ -132,78 +132,78 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 		assert.Equal(t, rootUserGroup, *initContainer.SecurityContext.RunAsGroup)
 	})
 	t.Run("should handle failure policy feature flag correctly", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		dynakube.Annotations = map[string]string{dynatracev1beta2.AnnotationInjectionFailurePolicy: "fail"}
+		dk := getTestDynakube()
+		dk.Annotations = map[string]string{dynakube.AnnotationInjectionFailurePolicy: "fail"}
 		pod := getTestPod()
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 
 		assert.Equal(t, "fail", env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value)
 		assert.NotEqual(t, "silent", env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value)
 	})
 	t.Run("should set default failure policy to silent", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		dynakube.Annotations = map[string]string{dynatracev1beta2.AnnotationInjectionFailurePolicy: "test"}
+		dk := getTestDynakube()
+		dk.Annotations = map[string]string{dynakube.AnnotationInjectionFailurePolicy: "test"}
 		pod := getTestPod()
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 
 		assert.NotEqual(t, "fail", env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value)
 		assert.Equal(t, "silent", env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value)
 	})
 	t.Run("should take silent as failure policy if set explicitly", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		dynakube.Annotations = map[string]string{dynatracev1beta2.AnnotationInjectionFailurePolicy: "silent"}
+		dk := getTestDynakube()
+		dk.Annotations = map[string]string{dynakube.AnnotationInjectionFailurePolicy: "silent"}
 		pod := getTestPod()
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 
 		assert.NotEqual(t, "fail", env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value)
 		assert.Equal(t, "silent", env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value)
 	})
 	t.Run("should take pod annotation when set", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		dynakube.Annotations = map[string]string{dynatracev1beta2.AnnotationInjectionFailurePolicy: "silent"}
+		dk := getTestDynakube()
+		dk.Annotations = map[string]string{dynakube.AnnotationInjectionFailurePolicy: "silent"}
 		pod := getTestPod()
 		pod.Annotations = map[string]string{}
 		pod.Annotations[dtwebhook.AnnotationFailurePolicy] = "fail"
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 
 		assert.Equal(t, "fail", env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value)
 		assert.NotEqual(t, "silent", env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value)
 	})
 	t.Run("should fall back to feature flag if invalid value is set to pod annotation", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		dynakube.Annotations = map[string]string{dynatracev1beta2.AnnotationInjectionFailurePolicy: "fail"}
+		dk := getTestDynakube()
+		dk.Annotations = map[string]string{dynakube.AnnotationInjectionFailurePolicy: "fail"}
 		pod := getTestPod()
 		pod.Annotations = map[string]string{}
 		pod.Annotations[dtwebhook.AnnotationFailurePolicy] = "silent"
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 
 		assert.NotEqual(t, "fail", env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value)
 		assert.Equal(t, "silent", env.FindEnvVar(initContainer.Env, "FAILURE_POLICY").Value)
 	})
 	t.Run("should set seccomp profile if feature flag is enabled", func(t *testing.T) {
-		dynakube := getTestDynakube()
-		dynakube.Annotations = map[string]string{dynatracev1beta2.AnnotationFeatureInitContainerSeccomp: "true"}
+		dk := getTestDynakube()
+		dk.Annotations = map[string]string{dynakube.AnnotationFeatureInitContainerSeccomp: "true"}
 		pod := getTestPod()
 		pod.Annotations = map[string]string{}
 		webhookImage := "test-image"
 		clusterID := "id"
 
-		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dynakube)
+		initContainer := createInstallInitContainerBase(webhookImage, clusterID, pod, *dk)
 
 		assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, initContainer.SecurityContext.SeccompProfile.Type)
 	})
@@ -211,27 +211,27 @@ func TestCreateInstallInitContainerBase(t *testing.T) {
 
 func TestInitContainerResources(t *testing.T) {
 	t.Run("should return default if nothing is set", func(t *testing.T) {
-		dynakube := getTestDynakubeNoInitLimits()
+		dk := getTestDynakubeNoInitLimits()
 
-		initResources := initContainerResources(*dynakube)
+		initResources := initContainerResources(*dk)
 
 		require.NotNil(t, initResources)
 		assert.Equal(t, defaultInitContainerResources(), initResources)
 	})
 
 	t.Run("should return custom if set in dynakube", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 
-		initResources := initContainerResources(*dynakube)
+		initResources := initContainerResources(*dk)
 
 		require.NotNil(t, initResources)
 		assert.Equal(t, testResourceRequirements, initResources)
 	})
 
 	t.Run("should ignore if csi not used", func(t *testing.T) {
-		dynakube := getTestDynakubeDefaultAppMon()
+		dk := getTestDynakubeDefaultAppMon()
 
-		initResources := initContainerResources(*dynakube)
+		initResources := initContainerResources(*dk)
 
 		require.Empty(t, initResources)
 	})

--- a/pkg/webhook/mutation/pod/metadata/containers_test.go
+++ b/pkg/webhook/mutation/pod/metadata/containers_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMutateUserContainers(t *testing.T) {
-	dynakube := getTestDynakube()
+	dk := getTestDynakube()
 	annotations := map[string]string{"container.inject.dyantrace/container": "false"}
 
 	t.Run("Add volume mounts to containers", func(t *testing.T) {
@@ -21,9 +21,9 @@ func TestMutateUserContainers(t *testing.T) {
 	})
 
 	t.Run("Do not inject container if excluded in dynkube", func(t *testing.T) {
-		dynakube.Annotations = annotations
+		dk.Annotations = annotations
 
-		request := createTestMutationRequest(dynakube, nil, false)
+		request := createTestMutationRequest(dk, nil, false)
 		mutateUserContainers(request.BaseRequest)
 
 		for _, container := range request.Pod.Spec.Containers {
@@ -32,7 +32,7 @@ func TestMutateUserContainers(t *testing.T) {
 	})
 
 	t.Run("Do not inject container if excluded in pod", func(t *testing.T) {
-		request := createTestMutationRequest(dynakube, annotations, false)
+		request := createTestMutationRequest(dk, annotations, false)
 		mutateUserContainers(request.BaseRequest)
 
 		for _, container := range request.Pod.Spec.Containers {
@@ -42,11 +42,11 @@ func TestMutateUserContainers(t *testing.T) {
 }
 
 func TestReinvokeUserContainers(t *testing.T) {
-	dynakube := getTestDynakube()
+	dk := getTestDynakube()
 	annotations := map[string]string{"container.inject.dyantrace/container": "false"}
 
 	t.Run("Add volume mounts to containers", func(t *testing.T) {
-		request := createTestReinvocationRequest(dynakube, nil)
+		request := createTestReinvocationRequest(dk, nil)
 		reinvokeUserContainers(request.BaseRequest)
 		request.Pod.Spec.Containers = append(request.Pod.Spec.Containers, corev1.Container{})
 		reinvokeUserContainers(request.BaseRequest)
@@ -57,9 +57,9 @@ func TestReinvokeUserContainers(t *testing.T) {
 	})
 
 	t.Run("Do not inject container if excluded in dynkube", func(t *testing.T) {
-		dynakube.Annotations = annotations
+		dk.Annotations = annotations
 
-		request := createTestReinvocationRequest(dynakube, nil)
+		request := createTestReinvocationRequest(dk, nil)
 		reinvokeUserContainers(request.BaseRequest)
 		request.Pod.Spec.Containers = append(request.Pod.Spec.Containers, corev1.Container{})
 		reinvokeUserContainers(request.BaseRequest)
@@ -70,7 +70,7 @@ func TestReinvokeUserContainers(t *testing.T) {
 	})
 
 	t.Run("Do not inject container if excluded in pod", func(t *testing.T) {
-		request := createTestReinvocationRequest(dynakube, annotations)
+		request := createTestReinvocationRequest(dk, annotations)
 		reinvokeUserContainers(request.BaseRequest)
 		request.Pod.Spec.Containers = append(request.Pod.Spec.Containers, corev1.Container{})
 		reinvokeUserContainers(request.BaseRequest)

--- a/pkg/webhook/mutation/pod/metadata/mutator_test.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
@@ -42,7 +42,7 @@ func TestEnabled(t *testing.T) {
 		mutator := createTestPodMutator(nil)
 		request := createTestMutationRequest(nil, nil, false)
 		request.DynaKube.Spec.MetadataEnrichment.Enabled = true
-		request.DynaKube.Annotations = map[string]string{dynatracev1beta2.AnnotationFeatureAutomaticInjection: "false"}
+		request.DynaKube.Annotations = map[string]string{dynakube.AnnotationFeatureAutomaticInjection: "false"}
 
 		enabled := mutator.Enabled(request.BaseRequest)
 
@@ -50,13 +50,13 @@ func TestEnabled(t *testing.T) {
 	})
 	t.Run("on with feature flag", func(t *testing.T) {
 		mutator := createTestPodMutator(nil)
-		dynakube := dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				MetadataEnrichment: dynatracev1beta2.MetadataEnrichment{Enabled: true},
+		dk := dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				MetadataEnrichment: dynakube.MetadataEnrichment{Enabled: true},
 			},
 		}
-		request := createTestMutationRequest(&dynakube, nil, false)
-		request.DynaKube.Annotations = map[string]string{dynatracev1beta2.AnnotationFeatureAutomaticInjection: "true"}
+		request := createTestMutationRequest(&dk, nil, false)
+		request.DynaKube.Annotations = map[string]string{dynakube.AnnotationFeatureAutomaticInjection: "true"}
 
 		enabled := mutator.Enabled(request.BaseRequest)
 
@@ -64,9 +64,9 @@ func TestEnabled(t *testing.T) {
 	})
 	t.Run("on with namespaceselector", func(t *testing.T) {
 		mutator := createTestPodMutator(nil)
-		dynakube := dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				MetadataEnrichment: dynatracev1beta2.MetadataEnrichment{
+		dk := dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				MetadataEnrichment: dynakube.MetadataEnrichment{
 					Enabled: true,
 					NamespaceSelector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -76,8 +76,8 @@ func TestEnabled(t *testing.T) {
 				},
 			},
 		}
-		request := createTestMutationRequest(&dynakube, nil, true)
-		request.DynaKube.Annotations = map[string]string{dynatracev1beta2.AnnotationFeatureAutomaticInjection: "true"}
+		request := createTestMutationRequest(&dk, nil, true)
+		request.DynaKube.Annotations = map[string]string{dynakube.AnnotationFeatureAutomaticInjection: "true"}
 
 		enabled := mutator.Enabled(request.BaseRequest)
 
@@ -85,9 +85,9 @@ func TestEnabled(t *testing.T) {
 	})
 	t.Run("off due to mismatching namespaceselector", func(t *testing.T) {
 		mutator := createTestPodMutator(nil)
-		dynakube := dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				MetadataEnrichment: dynatracev1beta2.MetadataEnrichment{
+		dk := dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				MetadataEnrichment: dynakube.MetadataEnrichment{
 					Enabled: true,
 					NamespaceSelector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -97,8 +97,8 @@ func TestEnabled(t *testing.T) {
 				},
 			},
 		}
-		request := createTestMutationRequest(&dynakube, nil, true)
-		request.DynaKube.Annotations = map[string]string{dynatracev1beta2.AnnotationFeatureAutomaticInjection: "true"}
+		request := createTestMutationRequest(&dk, nil, true)
+		request.DynaKube.Annotations = map[string]string{dynakube.AnnotationFeatureAutomaticInjection: "true"}
 
 		enabled := mutator.Enabled(request.BaseRequest)
 
@@ -213,11 +213,11 @@ func TestCopyMetadataFromNamespace(t *testing.T) {
 		mutator := createTestPodMutator(nil)
 		request := createTestMutationRequest(nil, nil, false)
 		request.Namespace.Labels = map[string]string{
-			dynatracev1beta2.MetadataPrefix + "/nocopyoflabels": "nocopyoflabels",
+			dynakube.MetadataPrefix + "/nocopyoflabels": "nocopyoflabels",
 			"test-label": "test-value",
 		}
 		request.Namespace.Annotations = map[string]string{
-			dynatracev1beta2.MetadataPrefix + "/copyofannotations": "copyofannotations",
+			dynakube.MetadataPrefix + "/copyofannotations": "copyofannotations",
 			"test-annotation": "test-value",
 		}
 
@@ -225,46 +225,46 @@ func TestCopyMetadataFromNamespace(t *testing.T) {
 		copyMetadataFromNamespace(request.Pod, request.Namespace, request.DynaKube)
 		require.Len(t, request.Pod.Annotations, 1)
 		require.Empty(t, request.Pod.Labels)
-		require.Equal(t, "copyofannotations", request.Pod.Annotations[dynatracev1beta2.MetadataPrefix+"/copyofannotations"])
+		require.Equal(t, "copyofannotations", request.Pod.Annotations[dynakube.MetadataPrefix+"/copyofannotations"])
 	})
 
 	t.Run("should copy all labels and annotations defined without override", func(t *testing.T) {
 		mutator := createTestPodMutator(nil)
 		request := createTestMutationRequest(nil, nil, false)
 		request.Namespace.Labels = map[string]string{
-			dynatracev1beta2.MetadataPrefix + "/nocopyoflabels":   "nocopyoflabels",
-			dynatracev1beta2.MetadataPrefix + "/copyifruleexists": "copyifruleexists",
+			dynakube.MetadataPrefix + "/nocopyoflabels":   "nocopyoflabels",
+			dynakube.MetadataPrefix + "/copyifruleexists": "copyifruleexists",
 			"test-label": "test-value",
 		}
 		request.Namespace.Annotations = map[string]string{
-			dynatracev1beta2.MetadataPrefix + "/copyofannotations": "copyofannotations",
+			dynakube.MetadataPrefix + "/copyofannotations": "copyofannotations",
 			"test-annotation": "test-value",
 		}
 
-		request.DynaKube.Status.MetadataEnrichment.Rules = []dynatracev1beta2.EnrichmentRule{
+		request.DynaKube.Status.MetadataEnrichment.Rules = []dynakube.EnrichmentRule{
 			{
-				Type:    dynatracev1beta2.EnrichmentAnnotationRule,
+				Type:    dynakube.EnrichmentAnnotationRule,
 				Key:     "test-annotation",
 				Mapping: "dt.test-annotation",
 			},
 			{
-				Type:    dynatracev1beta2.EnrichmentLabelRule,
+				Type:    dynakube.EnrichmentLabelRule,
 				Key:     "test-label",
 				Mapping: "test-label",
 			},
 			{
-				Type:    dynatracev1beta2.EnrichmentLabelRule,
-				Key:     dynatracev1beta2.MetadataPrefix + "/copyifruleexists",
+				Type:    dynakube.EnrichmentLabelRule,
+				Key:     dynakube.MetadataPrefix + "/copyifruleexists",
 				Mapping: "dt.copyifruleexists",
 			},
 			{
-				Type:    dynatracev1beta2.EnrichmentLabelRule,
+				Type:    dynakube.EnrichmentLabelRule,
 				Key:     "does-not-exist-in-namespace",
 				Mapping: "dt.does-not-exist-in-namespace",
 			},
 		}
 		request.Pod.Annotations = map[string]string{
-			dynatracev1beta2.MetadataPrefix + "/copyofannotations": "do-not-overwrite",
+			dynakube.MetadataPrefix + "/copyofannotations": "do-not-overwrite",
 		}
 
 		require.False(t, mutator.Injected(request.BaseRequest))
@@ -272,11 +272,11 @@ func TestCopyMetadataFromNamespace(t *testing.T) {
 		require.Len(t, request.Pod.Annotations, 4)
 		require.Empty(t, request.Pod.Labels)
 
-		require.Equal(t, "do-not-overwrite", request.Pod.Annotations[dynatracev1beta2.MetadataPrefix+"/copyofannotations"])
-		require.Equal(t, "copyifruleexists", request.Pod.Annotations[dynatracev1beta2.MetadataPrefix+"/dt.copyifruleexists"])
+		require.Equal(t, "do-not-overwrite", request.Pod.Annotations[dynakube.MetadataPrefix+"/copyofannotations"])
+		require.Equal(t, "copyifruleexists", request.Pod.Annotations[dynakube.MetadataPrefix+"/dt.copyifruleexists"])
 
-		require.Equal(t, "test-value", request.Pod.Annotations[dynatracev1beta2.MetadataPrefix+"/dt.test-annotation"])
-		require.Equal(t, "test-value", request.Pod.Annotations[dynatracev1beta2.MetadataPrefix+"/test-label"])
+		require.Equal(t, "test-value", request.Pod.Annotations[dynakube.MetadataPrefix+"/dt.test-annotation"])
+		require.Equal(t, "test-value", request.Pod.Annotations[dynakube.MetadataPrefix+"/test-label"])
 	})
 
 	t.Run("are custom rule types handled correctly", func(t *testing.T) {
@@ -291,14 +291,14 @@ func TestCopyMetadataFromNamespace(t *testing.T) {
 			"test2": "test-annotation-value2",
 		}
 
-		request.DynaKube.Status.MetadataEnrichment.Rules = []dynatracev1beta2.EnrichmentRule{
+		request.DynaKube.Status.MetadataEnrichment.Rules = []dynakube.EnrichmentRule{
 			{
-				Type:    dynatracev1beta2.EnrichmentLabelRule,
+				Type:    dynakube.EnrichmentLabelRule,
 				Key:     "test",
 				Mapping: "dt.test-label",
 			},
 			{
-				Type:    dynatracev1beta2.EnrichmentAnnotationRule,
+				Type:    dynakube.EnrichmentAnnotationRule,
 				Key:     "test2",
 				Mapping: "dt.test-annotation",
 			},
@@ -308,8 +308,8 @@ func TestCopyMetadataFromNamespace(t *testing.T) {
 		copyMetadataFromNamespace(request.Pod, request.Namespace, request.DynaKube)
 		require.Len(t, request.Pod.Annotations, 2)
 		require.Empty(t, request.Pod.Labels)
-		require.Equal(t, "test-label-value", request.Pod.Annotations[dynatracev1beta2.MetadataPrefix+"/dt.test-label"])
-		require.Equal(t, "test-annotation-value2", request.Pod.Annotations[dynatracev1beta2.MetadataPrefix+"/dt.test-annotation"])
+		require.Equal(t, "test-label-value", request.Pod.Annotations[dynakube.MetadataPrefix+"/dt.test-label"])
+		require.Equal(t, "test-annotation-value2", request.Pod.Annotations[dynakube.MetadataPrefix+"/dt.test-annotation"])
 	})
 }
 
@@ -354,9 +354,9 @@ func TestContainerIsInjected(t *testing.T) {
 	})
 }
 
-func createTestMutationRequest(dk *dynatracev1beta2.DynaKube, annotations map[string]string, withLabelSelector bool) *dtwebhook.MutationRequest {
+func createTestMutationRequest(dk *dynakube.DynaKube, annotations map[string]string, withLabelSelector bool) *dtwebhook.MutationRequest {
 	if dk == nil {
-		dk = &dynatracev1beta2.DynaKube{}
+		dk = &dynakube.DynaKube{}
 	}
 
 	namespace := getTestNamespace()
@@ -375,7 +375,7 @@ func createTestMutationRequest(dk *dynatracev1beta2.DynaKube, annotations map[st
 	)
 }
 
-func createTestReinvocationRequest(dynakube *dynatracev1beta2.DynaKube, annotations map[string]string) *dtwebhook.ReinvocationRequest {
+func createTestReinvocationRequest(dynakube *dynakube.DynaKube, annotations map[string]string) *dtwebhook.ReinvocationRequest {
 	request := createTestMutationRequest(dynakube, annotations, false).ToReinvocationRequest()
 	request.Pod.Spec.InitContainers = append(request.Pod.Spec.InitContainers, corev1.Container{Name: dtwebhook.InstallContainerName})
 
@@ -452,25 +452,25 @@ func getTestTokensSecret() *corev1.Secret {
 	}
 }
 
-func getTestDynakube() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func getTestDynakube() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testDynakubeName,
 			Namespace: testNamespaceName,
 		},
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			APIURL: testApiUrl,
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{},
+			OneAgent: dynakube.OneAgentSpec{
+				ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
 			},
-			ActiveGate: dynatracev1beta2.ActiveGateSpec{
-				Capabilities: []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.MetricsIngestCapability.DisplayName},
+			ActiveGate: dynakube.ActiveGateSpec{
+				Capabilities: []dynakube.CapabilityDisplayName{dynakube.MetricsIngestCapability.DisplayName},
 			},
 		},
-		Status: dynatracev1beta2.DynaKubeStatus{
-			OneAgent: dynatracev1beta2.OneAgentStatus{
-				ConnectionInfoStatus: dynatracev1beta2.OneAgentConnectionInfoStatus{
-					ConnectionInfoStatus: dynatracev1beta2.ConnectionInfoStatus{
+		Status: dynakube.DynaKubeStatus{
+			OneAgent: dynakube.OneAgentStatus{
+				ConnectionInfoStatus: dynakube.OneAgentConnectionInfoStatus{
+					ConnectionInfoStatus: dynakube.ConnectionInfoStatus{
 						TenantUUID: "test-tenant",
 					},
 				},

--- a/pkg/webhook/mutation/pod/metadata/mutator_test.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator_test.go
@@ -375,8 +375,8 @@ func createTestMutationRequest(dk *dynakube.DynaKube, annotations map[string]str
 	)
 }
 
-func createTestReinvocationRequest(dynakube *dynakube.DynaKube, annotations map[string]string) *dtwebhook.ReinvocationRequest {
-	request := createTestMutationRequest(dynakube, annotations, false).ToReinvocationRequest()
+func createTestReinvocationRequest(dk *dynakube.DynaKube, annotations map[string]string) *dtwebhook.ReinvocationRequest {
+	request := createTestMutationRequest(dk, annotations, false).ToReinvocationRequest()
 	request.Pod.Spec.InitContainers = append(request.Pod.Spec.InitContainers, corev1.Container{Name: dtwebhook.InstallContainerName})
 
 	return request

--- a/pkg/webhook/mutation/pod/oneagent/annotations.go
+++ b/pkg/webhook/mutation/pod/oneagent/annotations.go
@@ -3,7 +3,7 @@ package oneagent
 import (
 	"net/url"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
@@ -34,12 +34,12 @@ func setNotInjectedAnnotations(pod *corev1.Pod, reason string) {
 	pod.Annotations[dtwebhook.AnnotationOneAgentReason] = reason
 }
 
-func getInstallerInfo(pod *corev1.Pod, dynakube dynatracev1beta2.DynaKube) installerInfo {
+func getInstallerInfo(pod *corev1.Pod, dk dynakube.DynaKube) installerInfo {
 	return installerInfo{
 		flavor:       maputils.GetField(pod.Annotations, dtwebhook.AnnotationFlavor, ""),
 		technologies: url.QueryEscape(maputils.GetField(pod.Annotations, dtwebhook.AnnotationTechnologies, "all")),
 		installPath:  maputils.GetField(pod.Annotations, dtwebhook.AnnotationInstallPath, dtwebhook.DefaultInstallPath),
 		installerURL: maputils.GetField(pod.Annotations, dtwebhook.AnnotationInstallerUrl, ""),
-		version:      dynakube.CodeModulesVersion(),
+		version:      dk.CodeModulesVersion(),
 	}
 }

--- a/pkg/webhook/mutation/pod/oneagent/containers.go
+++ b/pkg/webhook/mutation/pod/oneagent/containers.go
@@ -89,27 +89,27 @@ func (mut *Mutator) addOneAgentToContainer(request *dtwebhook.ReinvocationReques
 
 	installPath := maputils.GetField(request.Pod.Annotations, dtwebhook.AnnotationInstallPath, dtwebhook.DefaultInstallPath)
 
-	dynakube := request.DynaKube
+	dk := request.DynaKube
 
 	addOneAgentVolumeMounts(container, installPath)
-	addDeploymentMetadataEnv(container, dynakube, mut.clusterID)
+	addDeploymentMetadataEnv(container, dk, mut.clusterID)
 	addPreloadEnv(container, installPath)
 
-	addCertVolumeMounts(container, dynakube)
+	addCertVolumeMounts(container, dk)
 
-	if dynakube.FeatureAgentInitialConnectRetry() > 0 {
+	if dk.FeatureAgentInitialConnectRetry() > 0 {
 		addCurlOptionsVolumeMount(container)
 	}
 
-	if dynakube.Spec.NetworkZone != "" {
-		addNetworkZoneEnv(container, dynakube.Spec.NetworkZone)
+	if dk.Spec.NetworkZone != "" {
+		addNetworkZoneEnv(container, dk.Spec.NetworkZone)
 	}
 
-	if dynakube.FeatureLabelVersionDetection() {
+	if dk.FeatureLabelVersionDetection() {
 		addVersionDetectionEnvs(container, newVersionLabelMapping(request.Namespace))
 	}
 
-	if dynakube.FeatureReadOnlyCsiVolume() {
+	if dk.FeatureReadOnlyCsiVolume() {
 		addVolumeMountsForReadOnlyCSI(container)
 	}
 }

--- a/pkg/webhook/mutation/pod/oneagent/containers_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/containers_test.go
@@ -51,7 +51,7 @@ func TestConfigureInitContainer(t *testing.T) {
 
 type mutateUserContainerTestCase struct {
 	name                               string
-	dynakube                           dynakube.DynaKube
+	dk                                 dynakube.DynaKube
 	expectedAdditionalEnvCount         int
 	expectedAdditionalVolumeMountCount int
 }
@@ -60,19 +60,19 @@ func TestMutateUserContainers(t *testing.T) {
 	testCases := []mutateUserContainerTestCase{
 		{
 			name:                               "add envs and volume mounts (simple dynakube)",
-			dynakube:                           *getTestDynakube(),
+			dk:                                 *getTestDynakube(),
 			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 3, // 3 oneagent mounts(preload,bin,conf)
 		},
 		{
 			name:                               "add envs and volume mounts (complex dynakube)",
-			dynakube:                           *getTestComplexDynakube(),
+			dk:                                 *getTestComplexDynakube(),
 			expectedAdditionalEnvCount:         5, // 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
 			expectedAdditionalVolumeMountCount: 5, // 3 oneagent mounts(preload,bin,conf) + 1 cert mount + 1 curl-options
 		},
 		{
 			name:                               "add envs and volume mounts (readonly-csi)",
-			dynakube:                           *getTestReadOnlyCSIDynakube(),
+			dk:                                 *getTestReadOnlyCSIDynakube(),
 			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 6, // 3 oneagent mounts(preload,bin,conf) +3 oneagent mounts for readonly csi (agent-conf,data-storage,agent-log)
 		},
@@ -80,7 +80,7 @@ func TestMutateUserContainers(t *testing.T) {
 	for index, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
-			request := createTestMutationRequest(&testCases[index].dynakube, nil, getTestNamespace(nil))
+			request := createTestMutationRequest(&testCases[index].dk, nil, getTestNamespace(nil))
 			initialNumberOfContainerEnvsLen := len(request.Pod.Spec.Containers[0].Env)
 			initialContainerVolumeMountsLen := len(request.Pod.Spec.Containers[0].VolumeMounts)
 
@@ -99,19 +99,19 @@ func TestReinvokeUserContainers(t *testing.T) {
 	testCases := []mutateUserContainerTestCase{
 		{
 			name:                               "add envs and volume mounts (simple dynakube)",
-			dynakube:                           *getTestDynakube(),
+			dk:                                 *getTestDynakube(),
 			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 3, // 3 oneagent mounts(preload,bin,conf)
 		},
 		{
 			name:                               "add envs and volume mounts (complex dynakube)",
-			dynakube:                           *getTestComplexDynakube(),
+			dk:                                 *getTestComplexDynakube(),
 			expectedAdditionalEnvCount:         5, // 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
 			expectedAdditionalVolumeMountCount: 5, // 3 oneagent mounts(preload,bin,conf) + 1 cert mount + 1 curl-options
 		},
 		{
 			name:                               "add envs and volume mounts (readonly-csi)",
-			dynakube:                           *getTestReadOnlyCSIDynakube(),
+			dk:                                 *getTestReadOnlyCSIDynakube(),
 			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 6, // 3 oneagent mounts(preload,bin,conf) +3 oneagent mounts for readonly csi (agent-conf,data-storage,agent-log)
 		},
@@ -119,7 +119,7 @@ func TestReinvokeUserContainers(t *testing.T) {
 	for index, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
-			request := createTestMutationRequest(&testCases[index].dynakube, nil, getTestNamespace(nil)).ToReinvocationRequest()
+			request := createTestMutationRequest(&testCases[index].dk, nil, getTestNamespace(nil)).ToReinvocationRequest()
 			initialNumberOfContainerEnvsLen := len(request.Pod.Spec.Containers[0].Env)
 			initialContainerVolumeMountsLen := len(request.Pod.Spec.Containers[0].VolumeMounts)
 			request.Pod.Spec.InitContainers = append(request.Pod.Spec.InitContainers, corev1.Container{
@@ -149,7 +149,7 @@ func TestReinvokeUserContainers(t *testing.T) {
 func TestContainerExclusion(t *testing.T) {
 	testCases := []struct {
 		name                               string
-		dynakube                           dynakube.DynaKube
+		dk                                 dynakube.DynaKube
 		expectedAdditionalEnvCount         int
 		expectedAdditionalVolumeMountCount int
 		expectedInitContainerEnvCount      int
@@ -158,7 +158,7 @@ func TestContainerExclusion(t *testing.T) {
 	}{
 		{
 			name:                               "container exclusion on dynakube level",
-			dynakube:                           *getTestDynakubeWithContainerExclusion(),
+			dk:                                 *getTestDynakubeWithContainerExclusion(),
 			expectedAdditionalEnvCount:         0,
 			expectedAdditionalVolumeMountCount: 0,
 			expectedInitContainerEnvCount:      3,
@@ -168,7 +168,7 @@ func TestContainerExclusion(t *testing.T) {
 		},
 		{
 			name:                               "container exclusion on dynakube level, do not exclude",
-			dynakube:                           *getTestDynakubeWithContainerExclusion(),
+			dk:                                 *getTestDynakubeWithContainerExclusion(),
 			expectedAdditionalEnvCount:         2,
 			expectedAdditionalVolumeMountCount: 3,
 			expectedInitContainerEnvCount:      5,
@@ -178,7 +178,7 @@ func TestContainerExclusion(t *testing.T) {
 		},
 		{
 			name:                               "container exclusion on pod level",
-			dynakube:                           *getTestDynakube(),
+			dk:                                 *getTestDynakube(),
 			expectedAdditionalEnvCount:         0,
 			expectedAdditionalVolumeMountCount: 0,
 			expectedInitContainerEnvCount:      3,
@@ -188,7 +188,7 @@ func TestContainerExclusion(t *testing.T) {
 		},
 		{
 			name:                               "container exclusion on pod level, do not exclude",
-			dynakube:                           *getTestDynakube(),
+			dk:                                 *getTestDynakube(),
 			expectedAdditionalEnvCount:         2,
 			expectedAdditionalVolumeMountCount: 3,
 			expectedInitContainerEnvCount:      5,
@@ -201,7 +201,7 @@ func TestContainerExclusion(t *testing.T) {
 	for index, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
-			request := createTestMutationRequest(&testCases[index].dynakube, testCase.podAnnotations, getTestNamespace(nil)).ToReinvocationRequest()
+			request := createTestMutationRequest(&testCases[index].dk, testCase.podAnnotations, getTestNamespace(nil)).ToReinvocationRequest()
 
 			maps.Copy(request.DynaKube.Annotations, testCase.dynakubeAnnotations)
 

--- a/pkg/webhook/mutation/pod/oneagent/containers_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/containers_test.go
@@ -4,7 +4,7 @@ import (
 	"maps"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/stretchr/testify/assert"
@@ -51,7 +51,7 @@ func TestConfigureInitContainer(t *testing.T) {
 
 type mutateUserContainerTestCase struct {
 	name                               string
-	dynakube                           dynatracev1beta2.DynaKube
+	dynakube                           dynakube.DynaKube
 	expectedAdditionalEnvCount         int
 	expectedAdditionalVolumeMountCount int
 }
@@ -149,7 +149,7 @@ func TestReinvokeUserContainers(t *testing.T) {
 func TestContainerExclusion(t *testing.T) {
 	testCases := []struct {
 		name                               string
-		dynakube                           dynatracev1beta2.DynaKube
+		dynakube                           dynakube.DynaKube
 		expectedAdditionalEnvCount         int
 		expectedAdditionalVolumeMountCount int
 		expectedInitContainerEnvCount      int

--- a/pkg/webhook/mutation/pod/oneagent/env.go
+++ b/pkg/webhook/mutation/pod/oneagent/env.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
@@ -93,12 +93,12 @@ func getContainerImageEnv(containerIndex int) string {
 	return fmt.Sprintf(consts.AgentContainerImageEnvTemplate, containerIndex)
 }
 
-func addDeploymentMetadataEnv(container *corev1.Container, dynakube dynatracev1beta2.DynaKube, clusterID string) {
+func addDeploymentMetadataEnv(container *corev1.Container, dk dynakube.DynaKube, clusterID string) {
 	if env.IsIn(container.Env, dynatraceMetadataEnv) {
 		return
 	}
 
-	deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(clusterID, deploymentmetadata.GetOneAgentDeploymentType(dynakube))
+	deploymentMetadata := deploymentmetadata.NewDeploymentMetadata(clusterID, deploymentmetadata.GetOneAgentDeploymentType(dk))
 	container.Env = append(container.Env,
 		corev1.EnvVar{
 			Name:  dynatraceMetadataEnv,

--- a/pkg/webhook/mutation/pod/oneagent/env_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/env_test.go
@@ -3,7 +3,7 @@ package oneagent
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"github.com/stretchr/testify/assert"
@@ -113,10 +113,10 @@ func TestAddContainerInfoInitEnv(t *testing.T) {
 func TestAddDeploymentMetadataEnv(t *testing.T) {
 	t.Run("Add cloudNative deployment metadata env", func(t *testing.T) {
 		container := &corev1.Container{}
-		dynakube := dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+		dynakube := dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 				},
 			},
 		}
@@ -128,10 +128,10 @@ func TestAddDeploymentMetadataEnv(t *testing.T) {
 
 	t.Run("Add appMonitoring deployment metadata env", func(t *testing.T) {
 		container := &corev1.Container{}
-		dynakube := dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				OneAgent: dynatracev1beta2.OneAgentSpec{
-					ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{},
+		dynakube := dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
 				},
 			},
 		}

--- a/pkg/webhook/mutation/pod/oneagent/env_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/env_test.go
@@ -113,14 +113,14 @@ func TestAddContainerInfoInitEnv(t *testing.T) {
 func TestAddDeploymentMetadataEnv(t *testing.T) {
 	t.Run("Add cloudNative deployment metadata env", func(t *testing.T) {
 		container := &corev1.Container{}
-		dynakube := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				OneAgent: dynakube.OneAgentSpec{
 					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 				},
 			},
 		}
-		addDeploymentMetadataEnv(container, dynakube, testClusterID)
+		addDeploymentMetadataEnv(container, dk, testClusterID)
 		require.Len(t, container.Env, 1)
 		assert.Contains(t, container.Env[0].Value, testClusterID)
 		assert.Contains(t, container.Env[0].Value, deploymentmetadata.CloudNativeDeploymentType)
@@ -128,14 +128,14 @@ func TestAddDeploymentMetadataEnv(t *testing.T) {
 
 	t.Run("Add appMonitoring deployment metadata env", func(t *testing.T) {
 		container := &corev1.Container{}
-		dynakube := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				OneAgent: dynakube.OneAgentSpec{
 					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
 				},
 			},
 		}
-		addDeploymentMetadataEnv(container, dynakube, testClusterID)
+		addDeploymentMetadataEnv(container, dk, testClusterID)
 		require.Len(t, container.Env, 1)
 		assert.Contains(t, container.Env[0].Value, testClusterID)
 		assert.Contains(t, container.Env[0].Value, deploymentmetadata.ApplicationMonitoringDeploymentType)

--- a/pkg/webhook/mutation/pod/oneagent/mutator_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/mutator_test.go
@@ -116,7 +116,7 @@ func TestEnsureInitSecret(t *testing.T) {
 
 type mutateTestCase struct {
 	name                                   string
-	dynakube                               dynakube.DynaKube
+	dk                                     dynakube.DynaKube
 	expectedAdditionalEnvCount             int
 	expectedAdditionalVolumeCount          int
 	expectedAdditionalVolumeMountCount     int
@@ -127,7 +127,7 @@ func TestMutate(t *testing.T) {
 	testCases := []mutateTestCase{
 		{
 			name:                                   "basic, should mutate the pod and init container in the request",
-			dynakube:                               *getTestDynakube(),
+			dk:                                     *getTestDynakube(),
 			expectedAdditionalEnvCount:             2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeCount:          3, // bin, share, injection-config
 			expectedAdditionalVolumeMountCount:     3, // 3 oneagent mounts(preload,bin,conf)
@@ -135,7 +135,7 @@ func TestMutate(t *testing.T) {
 		},
 		{
 			name:                                   "everything turned on, should mutate the pod and init container in the request",
-			dynakube:                               *getTestComplexDynakube(),
+			dk:                                     *getTestComplexDynakube(),
 			expectedAdditionalEnvCount:             5, // 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
 			expectedAdditionalVolumeCount:          3, // bin, share, injection-config
 			expectedAdditionalVolumeMountCount:     5, // 3 oneagent mounts(preload,bin,conf) + 1 cert mount + 1 curl-options
@@ -143,7 +143,7 @@ func TestMutate(t *testing.T) {
 		},
 		{
 			name:                                   "basic + readonly-csi, should mutate the pod and init container in the request",
-			dynakube:                               *getTestReadOnlyCSIDynakube(),
+			dk:                                     *getTestReadOnlyCSIDynakube(),
 			expectedAdditionalEnvCount:             2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeCount:          6, // bin, share, injection-config +  agent-conf, data-storage, agent-log
 			expectedAdditionalVolumeMountCount:     6, // 3 oneagent mounts(preload,bin,conf) +3 oneagent mounts for readonly csi (agent-conf,data-storage,agent-log)
@@ -154,7 +154,7 @@ func TestMutate(t *testing.T) {
 	for index, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
-			request := createTestMutationRequest(&testCases[index].dynakube, nil, getTestNamespace(nil))
+			request := createTestMutationRequest(&testCases[index].dk, nil, getTestNamespace(nil))
 
 			initialNumberOfContainerEnvsLen := len(request.Pod.Spec.Containers[0].Env)
 			initialNumberOfVolumesLen := len(request.Pod.Spec.Volumes)
@@ -182,10 +182,10 @@ func TestMutate(t *testing.T) {
 }
 
 func TestNoCommunicationHostsMutate(t *testing.T) {
-	dynaKube := getTestNoCommunicationHostDynakube()
+	dk := getTestNoCommunicationHostDynakube()
 
 	mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
-	request := createTestMutationRequest(dynaKube, nil, getTestNamespace(nil))
+	request := createTestMutationRequest(dk, nil, getTestNamespace(nil))
 
 	initialNumberOfContainerEnvsLen := len(request.Pod.Spec.Containers[0].Env)
 	initialNumberOfVolumesLen := len(request.Pod.Spec.Volumes)
@@ -216,7 +216,7 @@ func TestNoCommunicationHostsMutate(t *testing.T) {
 
 type reinvokeTestCase struct {
 	name                               string
-	dynakube                           dynakube.DynaKube
+	dk                                 dynakube.DynaKube
 	expectedAdditionalEnvCount         int
 	expectedAdditionalVolumeMountCount int
 }
@@ -225,19 +225,19 @@ func TestReinvoke(t *testing.T) {
 	testCases := []reinvokeTestCase{
 		{
 			name:                               "basic, should mutate the pod and init container in the request",
-			dynakube:                           *getTestDynakube(),
+			dk:                                 *getTestDynakube(),
 			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 3, // 3 oneagent mounts(preload,bin,conf)
 		},
 		{
 			name:                               "everything turned on, should mutate the pod and init container in the request",
-			dynakube:                           *getTestComplexDynakube(),
+			dk:                                 *getTestComplexDynakube(),
 			expectedAdditionalEnvCount:         5, // 1 deployment-metadata + 1 network-zone + 1 preload + 2 version-detection
 			expectedAdditionalVolumeMountCount: 5, // 3 oneagent mounts(preload,bin,conf) + 1 cert mount + 1 curl-options
 		},
 		{
 			name:                               "basic + readonly-csi, should mutate the pod and init container in the request",
-			dynakube:                           *getTestReadOnlyCSIDynakube(),
+			dk:                                 *getTestReadOnlyCSIDynakube(),
 			expectedAdditionalEnvCount:         2, // 1 deployment-metadata + 1 preload
 			expectedAdditionalVolumeMountCount: 6, // 3 oneagent mounts(preload,bin,conf) +3 oneagent mounts for readonly csi (agent-conf,data-storage,agent-log)
 		},
@@ -246,7 +246,7 @@ func TestReinvoke(t *testing.T) {
 	for index, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			mutator := createTestPodMutator([]client.Object{getTestInitSecret()})
-			request := createTestReinvocationRequest(&testCases[index].dynakube, map[string]string{dtwebhook.AnnotationOneAgentInjected: "true"})
+			request := createTestReinvocationRequest(&testCases[index].dk, map[string]string{dtwebhook.AnnotationOneAgentInjected: "true"})
 
 			initialNumberOfContainerEnvsLen := len(request.Pod.Spec.Containers[0].Env)
 			initialNumberOfVolumesLen := len(request.Pod.Spec.Volumes)

--- a/pkg/webhook/mutation/pod/oneagent/mutator_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/mutator_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +38,7 @@ func TestEnabled(t *testing.T) {
 	t.Run("on by default", func(t *testing.T) {
 		mutator := createTestPodMutator(nil)
 		request := createTestMutationRequest(nil, nil, getTestNamespace(nil))
-		request.DynaKube.Spec.OneAgent.ApplicationMonitoring = &dynatracev1beta2.ApplicationMonitoringSpec{}
+		request.DynaKube.Spec.OneAgent.ApplicationMonitoring = &dynakube.ApplicationMonitoringSpec{}
 
 		enabled := mutator.Enabled(request.BaseRequest)
 
@@ -47,7 +47,7 @@ func TestEnabled(t *testing.T) {
 	t.Run("off by feature flag", func(t *testing.T) {
 		mutator := createTestPodMutator(nil)
 		request := createTestMutationRequest(nil, nil, getTestNamespace(nil))
-		request.DynaKube.Annotations = map[string]string{dynatracev1beta2.AnnotationFeatureAutomaticInjection: "false"}
+		request.DynaKube.Annotations = map[string]string{dynakube.AnnotationFeatureAutomaticInjection: "false"}
 
 		enabled := mutator.Enabled(request.BaseRequest)
 
@@ -56,8 +56,8 @@ func TestEnabled(t *testing.T) {
 	t.Run("on with feature flag", func(t *testing.T) {
 		mutator := createTestPodMutator(nil)
 		request := createTestMutationRequest(nil, nil, getTestNamespace(nil))
-		request.DynaKube.Spec.OneAgent.ApplicationMonitoring = &dynatracev1beta2.ApplicationMonitoringSpec{}
-		request.DynaKube.Annotations = map[string]string{dynatracev1beta2.AnnotationFeatureAutomaticInjection: "true"}
+		request.DynaKube.Spec.OneAgent.ApplicationMonitoring = &dynakube.ApplicationMonitoringSpec{}
+		request.DynaKube.Annotations = map[string]string{dynakube.AnnotationFeatureAutomaticInjection: "true"}
 
 		enabled := mutator.Enabled(request.BaseRequest)
 
@@ -66,7 +66,7 @@ func TestEnabled(t *testing.T) {
 	t.Run("on with namespaceselector", func(t *testing.T) {
 		mutator := createTestPodMutator(nil)
 		request := createTestMutationRequest(nil, nil, getTestNamespaceWithMatchingLabel(nil, testLabelKeyMatching, testLabelValue))
-		request.DynaKube.Annotations = map[string]string{dynatracev1beta2.AnnotationFeatureAutomaticInjection: "true"}
+		request.DynaKube.Annotations = map[string]string{dynakube.AnnotationFeatureAutomaticInjection: "true"}
 		request.DynaKube = *addNamespaceSelector(&request.DynaKube)
 
 		enabled := mutator.Enabled(request.BaseRequest)
@@ -76,7 +76,7 @@ func TestEnabled(t *testing.T) {
 	t.Run("off due to not matching namespaceselector", func(t *testing.T) {
 		mutator := createTestPodMutator(nil)
 		request := createTestMutationRequest(nil, nil, getTestNamespaceWithMatchingLabel(nil, testLabelKeyNotMatching, testLabelValue))
-		request.DynaKube.Annotations = map[string]string{dynatracev1beta2.AnnotationFeatureAutomaticInjection: "true"}
+		request.DynaKube.Annotations = map[string]string{dynakube.AnnotationFeatureAutomaticInjection: "true"}
 		request.DynaKube = *addNamespaceSelector(&request.DynaKube)
 
 		enabled := mutator.Enabled(request.BaseRequest)
@@ -116,7 +116,7 @@ func TestEnsureInitSecret(t *testing.T) {
 
 type mutateTestCase struct {
 	name                                   string
-	dynakube                               dynatracev1beta2.DynaKube
+	dynakube                               dynakube.DynaKube
 	expectedAdditionalEnvCount             int
 	expectedAdditionalVolumeCount          int
 	expectedAdditionalVolumeMountCount     int
@@ -216,7 +216,7 @@ func TestNoCommunicationHostsMutate(t *testing.T) {
 
 type reinvokeTestCase struct {
 	name                               string
-	dynakube                           dynatracev1beta2.DynaKube
+	dynakube                           dynakube.DynaKube
 	expectedAdditionalEnvCount         int
 	expectedAdditionalVolumeMountCount int
 }
@@ -302,21 +302,21 @@ func getTestInitSecret() *corev1.Secret {
 	}
 }
 
-func addNamespaceSelector(dynakube *dynatracev1beta2.DynaKube) *dynatracev1beta2.DynaKube {
-	dynakube.Spec.OneAgent.ApplicationMonitoring = &dynatracev1beta2.ApplicationMonitoringSpec{}
+func addNamespaceSelector(dk *dynakube.DynaKube) *dynakube.DynaKube {
+	dk.Spec.OneAgent.ApplicationMonitoring = &dynakube.ApplicationMonitoringSpec{}
 
-	dynakube.Spec.OneAgent.ApplicationMonitoring.NamespaceSelector = metav1.LabelSelector{
+	dk.Spec.OneAgent.ApplicationMonitoring.NamespaceSelector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			testLabelKeyMatching: testLabelValue,
 		},
 	}
 
-	return dynakube
+	return dk
 }
 
-func createTestMutationRequest(dynakube *dynatracev1beta2.DynaKube, podAnnotations map[string]string, namespace corev1.Namespace) *dtwebhook.MutationRequest {
-	if dynakube == nil {
-		dynakube = &dynatracev1beta2.DynaKube{}
+func createTestMutationRequest(dk *dynakube.DynaKube, podAnnotations map[string]string, namespace corev1.Namespace) *dtwebhook.MutationRequest {
+	if dk == nil {
+		dk = &dynakube.DynaKube{}
 	}
 
 	return dtwebhook.NewMutationRequest(
@@ -326,61 +326,61 @@ func createTestMutationRequest(dynakube *dynatracev1beta2.DynaKube, podAnnotatio
 			Name: dtwebhook.InstallContainerName,
 		},
 		getTestPod(podAnnotations),
-		*dynakube,
+		*dk,
 	)
 }
 
-func createTestReinvocationRequest(dynakube *dynatracev1beta2.DynaKube, annotations map[string]string) *dtwebhook.ReinvocationRequest {
-	request := createTestMutationRequest(dynakube, annotations, getTestNamespace(nil)).ToReinvocationRequest()
+func createTestReinvocationRequest(dk *dynakube.DynaKube, annotations map[string]string) *dtwebhook.ReinvocationRequest {
+	request := createTestMutationRequest(dk, annotations, getTestNamespace(nil)).ToReinvocationRequest()
 	request.Pod.Spec.InitContainers = append(request.Pod.Spec.InitContainers, corev1.Container{Name: dtwebhook.InstallContainerName})
 
 	return request
 }
 
-func getTestCSIDynakube() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func getTestCSIDynakube() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: getTestDynakubeMeta(),
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{},
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: dynakube.OneAgentSpec{
+				CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 			},
 		},
 		Status: getTestDynakubeCommunicationHostStatus(),
 	}
 }
 
-func getTestReadOnlyCSIDynakube() *dynatracev1beta2.DynaKube {
+func getTestReadOnlyCSIDynakube() *dynakube.DynaKube {
 	dk := getTestCSIDynakube()
-	dk.Annotations[dynatracev1beta2.AnnotationFeatureReadOnlyCsiVolume] = "true"
+	dk.Annotations[dynakube.AnnotationFeatureReadOnlyCsiVolume] = "true"
 
 	return dk
 }
 
-func getTestNoCommunicationHostDynakube() *dynatracev1beta2.DynaKube {
+func getTestNoCommunicationHostDynakube() *dynakube.DynaKube {
 	dk := getTestCSIDynakube()
-	dk.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts = []dynatracev1beta2.CommunicationHostStatus{}
+	dk.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts = []dynakube.CommunicationHostStatus{}
 
 	return dk
 }
 
-func getTestDynakube() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func getTestDynakube() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: getTestDynakubeMeta(),
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{},
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: dynakube.OneAgentSpec{
+				ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
 			},
 		},
 		Status: getTestDynakubeCommunicationHostStatus(),
 	}
 }
 
-func getTestDynakubeWithContainerExclusion() *dynatracev1beta2.DynaKube {
-	dk := &dynatracev1beta2.DynaKube{
+func getTestDynakubeWithContainerExclusion() *dynakube.DynaKube {
+	dk := &dynakube.DynaKube{
 		ObjectMeta: getTestDynakubeMeta(),
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{},
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: dynakube.OneAgentSpec{
+				ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
 			},
 		},
 		Status: getTestDynakubeCommunicationHostStatus(),
@@ -390,11 +390,11 @@ func getTestDynakubeWithContainerExclusion() *dynatracev1beta2.DynaKube {
 	return dk
 }
 
-func getTestDynakubeCommunicationHostStatus() dynatracev1beta2.DynaKubeStatus {
-	return dynatracev1beta2.DynaKubeStatus{
-		OneAgent: dynatracev1beta2.OneAgentStatus{
-			ConnectionInfoStatus: dynatracev1beta2.OneAgentConnectionInfoStatus{
-				CommunicationHosts: []dynatracev1beta2.CommunicationHostStatus{
+func getTestDynakubeCommunicationHostStatus() dynakube.DynaKubeStatus {
+	return dynakube.DynaKubeStatus{
+		OneAgent: dynakube.OneAgentStatus{
+			ConnectionInfoStatus: dynakube.OneAgentConnectionInfoStatus{
+				CommunicationHosts: []dynakube.CommunicationHostStatus{
 					{
 						Protocol: "http",
 						Host:     "dummyhost",
@@ -414,20 +414,20 @@ func getTestDynakubeMeta() metav1.ObjectMeta {
 	}
 }
 
-func getTestComplexDynakube() *dynatracev1beta2.DynaKube {
-	dynakube := getTestCSIDynakube()
-	dynakube.Spec.Proxy = &dynatracev1beta2.DynaKubeProxy{Value: "test-proxy"}
-	dynakube.Spec.NetworkZone = "test-network-zone"
-	dynakube.Spec.ActiveGate = dynatracev1beta2.ActiveGateSpec{
-		Capabilities:  []dynatracev1beta2.CapabilityDisplayName{dynatracev1beta2.KubeMonCapability.DisplayName},
+func getTestComplexDynakube() *dynakube.DynaKube {
+	dk := getTestCSIDynakube()
+	dk.Spec.Proxy = &dynakube.DynaKubeProxy{Value: "test-proxy"}
+	dk.Spec.NetworkZone = "test-network-zone"
+	dk.Spec.ActiveGate = dynakube.ActiveGateSpec{
+		Capabilities:  []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName},
 		TlsSecretName: "super-secret",
 	}
-	dynakube.Annotations = map[string]string{
-		dynatracev1beta2.AnnotationFeatureOneAgentInitialConnectRetry: "5",
-		dynatracev1beta2.AnnotationFeatureLabelVersionDetection:       "true",
+	dk.Annotations = map[string]string{
+		dynakube.AnnotationFeatureOneAgentInitialConnectRetry: "5",
+		dynakube.AnnotationFeatureLabelVersionDetection:       "true",
 	}
 
-	return dynakube
+	return dk
 }
 
 func getTestPod(annotations map[string]string) *corev1.Pod {

--- a/pkg/webhook/mutation/pod/oneagent/volumes.go
+++ b/pkg/webhook/mutation/pod/oneagent/volumes.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver/volumes"
@@ -13,11 +13,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (mut *Mutator) addVolumes(pod *corev1.Pod, dynakube dynatracev1beta2.DynaKube) {
+func (mut *Mutator) addVolumes(pod *corev1.Pod, dk dynakube.DynaKube) {
 	addInjectionConfigVolume(pod)
-	addOneAgentVolumes(pod, dynakube)
+	addOneAgentVolumes(pod, dk)
 
-	if dynakube.FeatureReadOnlyCsiVolume() {
+	if dk.FeatureReadOnlyCsiVolume() {
 		addVolumesForReadOnlyCSI(pod)
 	}
 }
@@ -62,8 +62,8 @@ func getContainerConfSubPath(containerName string) string {
 	return fmt.Sprintf(consts.AgentContainerConfFilenameTemplate, containerName)
 }
 
-func addCertVolumeMounts(container *corev1.Container, dynakube dynatracev1beta2.DynaKube) {
-	if dynakube.HasActiveGateCaCert() || dynakube.Spec.TrustedCAs != "" {
+func addCertVolumeMounts(container *corev1.Container, dk dynakube.DynaKube) {
+	if dk.HasActiveGateCaCert() || dk.Spec.TrustedCAs != "" {
 		container.VolumeMounts = append(container.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      oneAgentShareVolumeName,
@@ -72,7 +72,7 @@ func addCertVolumeMounts(container *corev1.Container, dynakube dynatracev1beta2.
 			})
 	}
 
-	if dynakube.Spec.TrustedCAs != "" {
+	if dk.Spec.TrustedCAs != "" {
 		container.VolumeMounts = append(container.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      oneAgentShareVolumeName,
@@ -82,12 +82,12 @@ func addCertVolumeMounts(container *corev1.Container, dynakube dynatracev1beta2.
 	}
 }
 
-func addInitVolumeMounts(initContainer *corev1.Container, dynakube dynatracev1beta2.DynaKube) {
+func addInitVolumeMounts(initContainer *corev1.Container, dk dynakube.DynaKube) {
 	volumeMounts := []corev1.VolumeMount{
 		{Name: OneAgentBinVolumeName, MountPath: consts.AgentBinDirMount},
 		{Name: oneAgentShareVolumeName, MountPath: consts.AgentShareDirMount},
 	}
-	if dynakube.FeatureReadOnlyCsiVolume() {
+	if dk.FeatureReadOnlyCsiVolume() {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: oneagentConfVolumeName, MountPath: consts.AgentConfInitDirMount})
 	}
 
@@ -121,11 +121,11 @@ func addInjectionConfigVolumeMount(container *corev1.Container) {
 	)
 }
 
-func addOneAgentVolumes(pod *corev1.Pod, dynakube dynatracev1beta2.DynaKube) {
+func addOneAgentVolumes(pod *corev1.Pod, dk dynakube.DynaKube) {
 	pod.Spec.Volumes = append(pod.Spec.Volumes,
 		corev1.Volume{
 			Name:         OneAgentBinVolumeName,
-			VolumeSource: getInstallerVolumeSource(dynakube),
+			VolumeSource: getInstallerVolumeSource(dk),
 		},
 		corev1.Volume{
 			Name: oneAgentShareVolumeName,
@@ -159,7 +159,7 @@ func addVolumesForReadOnlyCSI(pod *corev1.Pod) {
 	)
 }
 
-func getInstallerVolumeSource(dynakube dynatracev1beta2.DynaKube) corev1.VolumeSource {
+func getInstallerVolumeSource(dynakube dynakube.DynaKube) corev1.VolumeSource {
 	volumeSource := corev1.VolumeSource{}
 	if dynakube.NeedsCSIDriver() {
 		volumeSource.CSI = &corev1.CSIVolumeSource{

--- a/pkg/webhook/mutation/pod/oneagent/volumes.go
+++ b/pkg/webhook/mutation/pod/oneagent/volumes.go
@@ -159,15 +159,15 @@ func addVolumesForReadOnlyCSI(pod *corev1.Pod) {
 	)
 }
 
-func getInstallerVolumeSource(dynakube dynakube.DynaKube) corev1.VolumeSource {
+func getInstallerVolumeSource(dk dynakube.DynaKube) corev1.VolumeSource {
 	volumeSource := corev1.VolumeSource{}
-	if dynakube.NeedsCSIDriver() {
+	if dk.NeedsCSIDriver() {
 		volumeSource.CSI = &corev1.CSIVolumeSource{
 			Driver:   dtcsi.DriverName,
-			ReadOnly: address.Of(dynakube.FeatureReadOnlyCsiVolume()),
+			ReadOnly: address.Of(dk.FeatureReadOnlyCsiVolume()),
 			VolumeAttributes: map[string]string{
 				csivolumes.CSIVolumeAttributeModeField:     appvolumes.Mode,
-				csivolumes.CSIVolumeAttributeDynakubeField: dynakube.Name,
+				csivolumes.CSIVolumeAttributeDynakubeField: dk.Name,
 			},
 		}
 	} else {

--- a/pkg/webhook/mutation/pod/oneagent/volumes_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/volumes_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/volumes"
 	"github.com/pkg/errors"
@@ -47,15 +47,15 @@ func TestAddReadOnlyCSIVolumeMounts(t *testing.T) {
 
 func TestAddCertVolumeMounts(t *testing.T) {
 	t.Run("shouldn't add any cert volume mounts", func(t *testing.T) {
-		dynakube := dynatracev1beta2.DynaKube{}
+		dynakube := dynakube.DynaKube{}
 		container := &corev1.Container{}
 
 		addCertVolumeMounts(container, dynakube)
 		require.Empty(t, container.VolumeMounts)
 	})
 	t.Run("should add both cert volume mounts", func(t *testing.T) {
-		dynakube := dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
+		dynakube := dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
 				TrustedCAs: "test",
 			},
 		}
@@ -67,10 +67,10 @@ func TestAddCertVolumeMounts(t *testing.T) {
 		assert.Equal(t, consts.CustomProxyCertsFileName, container.VolumeMounts[1].SubPath)
 	})
 	t.Run("shouldn't add proxy cert volume mounts", func(t *testing.T) {
-		dynakube := dynatracev1beta2.DynaKube{
-			Spec: dynatracev1beta2.DynaKubeSpec{
-				ActiveGate: dynatracev1beta2.ActiveGateSpec{
-					Capabilities: []dynatracev1beta2.CapabilityDisplayName{
+		dynakube := dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: dynakube.ActiveGateSpec{
+					Capabilities: []dynakube.CapabilityDisplayName{
 						"routing",
 					},
 					TlsSecretName: "test",

--- a/pkg/webhook/mutation/pod/oneagent/volumes_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/volumes_test.go
@@ -47,27 +47,27 @@ func TestAddReadOnlyCSIVolumeMounts(t *testing.T) {
 
 func TestAddCertVolumeMounts(t *testing.T) {
 	t.Run("shouldn't add any cert volume mounts", func(t *testing.T) {
-		dynakube := dynakube.DynaKube{}
+		dk := dynakube.DynaKube{}
 		container := &corev1.Container{}
 
-		addCertVolumeMounts(container, dynakube)
+		addCertVolumeMounts(container, dk)
 		require.Empty(t, container.VolumeMounts)
 	})
 	t.Run("should add both cert volume mounts", func(t *testing.T) {
-		dynakube := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				TrustedCAs: "test",
 			},
 		}
 		container := &corev1.Container{}
 
-		addCertVolumeMounts(container, dynakube)
+		addCertVolumeMounts(container, dk)
 		require.Len(t, container.VolumeMounts, 2) // custom.pem, custom_proxy.pem
 		assert.Equal(t, consts.CustomCertsFileName, container.VolumeMounts[0].SubPath)
 		assert.Equal(t, consts.CustomProxyCertsFileName, container.VolumeMounts[1].SubPath)
 	})
 	t.Run("shouldn't add proxy cert volume mounts", func(t *testing.T) {
-		dynakube := dynakube.DynaKube{
+		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				ActiveGate: dynakube.ActiveGateSpec{
 					Capabilities: []dynakube.CapabilityDisplayName{
@@ -79,7 +79,7 @@ func TestAddCertVolumeMounts(t *testing.T) {
 		}
 		container := &corev1.Container{}
 
-		addCertVolumeMounts(container, dynakube)
+		addCertVolumeMounts(container, dk)
 		require.Len(t, container.VolumeMounts, 1)
 		assert.Equal(t, consts.CustomCertsFileName, container.VolumeMounts[0].SubPath)
 	})
@@ -118,9 +118,9 @@ func TestAddInitVolumeMounts(t *testing.T) {
 func TestAddOneAgentVolumes(t *testing.T) {
 	t.Run("should add oneagent volumes, with csi", func(t *testing.T) {
 		pod := &corev1.Pod{}
-		dynakube := getTestCSIDynakube()
+		dk := getTestCSIDynakube()
 
-		addOneAgentVolumes(pod, *dynakube)
+		addOneAgentVolumes(pod, *dk)
 		require.Len(t, pod.Spec.Volumes, 2)
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.CSI)
 		assert.False(t, *pod.Spec.Volumes[0].VolumeSource.CSI.ReadOnly)
@@ -128,9 +128,9 @@ func TestAddOneAgentVolumes(t *testing.T) {
 
 	t.Run("should add oneagent volumes, with readonly csi", func(t *testing.T) {
 		pod := &corev1.Pod{}
-		dynakube := getTestReadOnlyCSIDynakube()
+		dk := getTestReadOnlyCSIDynakube()
 
-		addOneAgentVolumes(pod, *dynakube)
+		addOneAgentVolumes(pod, *dk)
 		require.Len(t, pod.Spec.Volumes, 2)
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.CSI)
 		assert.True(t, *pod.Spec.Volumes[0].VolumeSource.CSI.ReadOnly)
@@ -138,9 +138,9 @@ func TestAddOneAgentVolumes(t *testing.T) {
 
 	t.Run("should add oneagent volumes, without csi", func(t *testing.T) {
 		pod := &corev1.Pod{}
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 
-		addOneAgentVolumes(pod, *dynakube)
+		addOneAgentVolumes(pod, *dk)
 		require.Len(t, pod.Spec.Volumes, 2)
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.EmptyDir)
 	})

--- a/pkg/webhook/mutation/pod/request.go
+++ b/pkg/webhook/mutation/pod/request.go
@@ -3,7 +3,7 @@ package pod
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtotel"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	webhookotel "github.com/Dynatrace/dynatrace-operator/pkg/webhook/internal/otel"
@@ -93,8 +93,8 @@ func getDynakubeName(namespace corev1.Namespace) (string, error) {
 	return dynakubeName, nil
 }
 
-func (wh *webhook) getDynakube(ctx context.Context, dynakubeName string) (*dynatracev1beta2.DynaKube, error) {
-	var dk dynatracev1beta2.DynaKube
+func (wh *webhook) getDynakube(ctx context.Context, dynakubeName string) (*dynakube.DynaKube, error) {
+	var dk dynakube.DynaKube
 
 	err := wh.apiReader.Get(ctx, client.ObjectKey{Name: dynakubeName, Namespace: wh.webhookNamespace}, &dk)
 	if k8serrors.IsNotFound(err) {

--- a/pkg/webhook/mutation/pod/request_test.go
+++ b/pkg/webhook/mutation/pod/request_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/stretchr/testify/assert"
@@ -102,7 +102,7 @@ func TestGetDynakube(t *testing.T) {
 	})
 }
 
-func createTestMutationRequest(dynakube *dynatracev1beta2.DynaKube) *dtwebhook.MutationRequest {
+func createTestMutationRequest(dynakube *dynakube.DynaKube) *dtwebhook.MutationRequest {
 	return dtwebhook.NewMutationRequest(context.Background(), *getTestNamespace(), nil, getTestPod(), *dynakube)
 }
 

--- a/pkg/webhook/mutation/pod/request_test.go
+++ b/pkg/webhook/mutation/pod/request_test.go
@@ -29,19 +29,19 @@ func getTestSecurityContext() *corev1.SecurityContext {
 
 func TestCreateMutationRequestBase(t *testing.T) {
 	t.Run("should create a mutation request", func(t *testing.T) {
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		podWebhook := createTestWebhook(
 			[]dtwebhook.PodMutator{},
 			[]client.Object{
 				getTestNamespace(),
 				getTestPod(),
-				dynakube,
+				dk,
 			})
 		mutationRequest, err := podWebhook.createMutationRequestBase(context.Background(), *createTestAdmissionRequest(getTestPod()))
 		require.NoError(t, err)
 		require.NotNil(t, mutationRequest)
 
-		expected := createTestMutationRequest(dynakube)
+		expected := createTestMutationRequest(dk)
 		assert.Equal(t, expected.Pod.ObjectMeta, mutationRequest.Pod.ObjectMeta)
 		assert.Equal(t, expected.Pod.Spec.Containers, mutationRequest.Pod.Spec.Containers)
 		assert.Equal(t, expected.Pod.Spec.InitContainers, mutationRequest.Pod.Spec.InitContainers)
@@ -102,8 +102,8 @@ func TestGetDynakube(t *testing.T) {
 	})
 }
 
-func createTestMutationRequest(dynakube *dynakube.DynaKube) *dtwebhook.MutationRequest {
-	return dtwebhook.NewMutationRequest(context.Background(), *getTestNamespace(), nil, getTestPod(), *dynakube)
+func createTestMutationRequest(dk *dynakube.DynaKube) *dtwebhook.MutationRequest {
+	return dtwebhook.NewMutationRequest(context.Background(), *getTestNamespace(), nil, getTestPod(), *dk)
 }
 
 func createTestAdmissionRequest(pod *corev1.Pod) *admission.Request {

--- a/pkg/webhook/mutation/pod/webhook_test.go
+++ b/pkg/webhook/mutation/pod/webhook_test.go
@@ -135,9 +135,9 @@ func TestHandlePodMutation(t *testing.T) {
 	t.Run("should call both mutators, initContainer and annotation added, no error", func(t *testing.T) {
 		mutator1 := createSimplePodMutatorMock(t)
 		mutator2 := createSimplePodMutatorMock(t)
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		podWebhook := createTestWebhook([]dtwebhook.PodMutator{mutator1, mutator2}, nil)
-		mutationRequest := createTestMutationRequest(dynakube)
+		mutationRequest := createTestMutationRequest(dk)
 
 		err := podWebhook.handlePodMutation(context.Background(), mutationRequest)
 		require.NoError(t, err)
@@ -169,9 +169,9 @@ func TestHandlePodMutation(t *testing.T) {
 	t.Run("should call 1 webhook, 1 error, no initContainer and annotation", func(t *testing.T) {
 		sadMutator := createFailPodMutatorMock(t)
 		happyMutator := createSimplePodMutatorMock(t)
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		podWebhook := createTestWebhook([]dtwebhook.PodMutator{sadMutator, happyMutator}, nil)
-		mutationRequest := createTestMutationRequest(dynakube)
+		mutationRequest := createTestMutationRequest(dk)
 
 		err := podWebhook.handlePodMutation(context.Background(), mutationRequest)
 		require.Error(t, err)
@@ -189,9 +189,9 @@ func TestHandlePodReinvocation(t *testing.T) {
 	t.Run("should call both mutators, updated == true", func(t *testing.T) {
 		mutator1 := createAlreadyInjectedPodMutatorMock(t)
 		mutator2 := createAlreadyInjectedPodMutatorMock(t)
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		podWebhook := createTestWebhook([]dtwebhook.PodMutator{mutator1, mutator2}, nil)
-		mutationRequest := createTestMutationRequest(dynakube)
+		mutationRequest := createTestMutationRequest(dk)
 
 		updated := podWebhook.handlePodReinvocation(context.Background(), mutationRequest)
 		require.True(t, updated)
@@ -203,9 +203,9 @@ func TestHandlePodReinvocation(t *testing.T) {
 	t.Run("should call both webhook, only 1 update, updated == true", func(t *testing.T) {
 		failingMutator := createFailPodMutatorMock(t)
 		workingMutator := createAlreadyInjectedPodMutatorMock(t)
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		podWebhook := createTestWebhook([]dtwebhook.PodMutator{failingMutator, workingMutator}, nil)
-		mutationRequest := createTestMutationRequest(dynakube)
+		mutationRequest := createTestMutationRequest(dk)
 
 		updated := podWebhook.handlePodReinvocation(context.Background(), mutationRequest)
 		require.True(t, updated)
@@ -216,9 +216,9 @@ func TestHandlePodReinvocation(t *testing.T) {
 	})
 	t.Run("should call webhook, no update", func(t *testing.T) {
 		failingMutator := createFailPodMutatorMock(t)
-		dynakube := getTestDynakube()
+		dk := getTestDynakube()
 		podWebhook := createTestWebhook([]dtwebhook.PodMutator{failingMutator}, nil)
-		mutationRequest := createTestMutationRequest(dynakube)
+		mutationRequest := createTestMutationRequest(dk)
 
 		updated := podWebhook.handlePodReinvocation(context.Background(), mutationRequest)
 		require.False(t, updated)

--- a/pkg/webhook/mutation/pod/webhook_test.go
+++ b/pkg/webhook/mutation/pod/webhook_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	webhookmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/webhook"
 	"github.com/stretchr/testify/assert"
@@ -303,30 +303,30 @@ func createFailPodMutatorMock(t *testing.T) *webhookmock.PodMutator {
 	return mutator
 }
 
-func getTestDynakube() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func getTestDynakube() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: getTestDynakubeMeta(),
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			OneAgent: getCloudNativeSpec(&testResourceRequirements),
 		},
 	}
 }
 
-func getTestDynakubeNoInitLimits() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func getTestDynakubeNoInitLimits() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: getTestDynakubeMeta(),
-		Spec: dynatracev1beta2.DynaKubeSpec{
+		Spec: dynakube.DynaKubeSpec{
 			OneAgent: getCloudNativeSpec(nil),
 		},
 	}
 }
 
-func getTestDynakubeDefaultAppMon() *dynatracev1beta2.DynaKube {
-	return &dynatracev1beta2.DynaKube{
+func getTestDynakubeDefaultAppMon() *dynakube.DynaKube {
+	return &dynakube.DynaKube{
 		ObjectMeta: getTestDynakubeMeta(),
-		Spec: dynatracev1beta2.DynaKubeSpec{
-			OneAgent: dynatracev1beta2.OneAgentSpec{
-				ApplicationMonitoring: &dynatracev1beta2.ApplicationMonitoringSpec{},
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: dynakube.OneAgentSpec{
+				ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
 			},
 		},
 	}
@@ -339,10 +339,10 @@ func getTestDynakubeMeta() metav1.ObjectMeta {
 	}
 }
 
-func getCloudNativeSpec(initResources *corev1.ResourceRequirements) dynatracev1beta2.OneAgentSpec {
-	return dynatracev1beta2.OneAgentSpec{
-		CloudNativeFullStack: &dynatracev1beta2.CloudNativeFullStackSpec{
-			AppInjectionSpec: dynatracev1beta2.AppInjectionSpec{
+func getCloudNativeSpec(initResources *corev1.ResourceRequirements) dynakube.OneAgentSpec {
+	return dynakube.OneAgentSpec{
+		CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+			AppInjectionSpec: dynakube.AppInjectionSpec{
 				InitResources: initResources,
 			},
 		},

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -56,17 +56,17 @@ type ReinvocationRequest struct {
 	*BaseRequest
 }
 
-func newBaseRequest(pod *corev1.Pod, namespace corev1.Namespace, dynakube dynakube.DynaKube) *BaseRequest {
+func newBaseRequest(pod *corev1.Pod, namespace corev1.Namespace, dk dynakube.DynaKube) *BaseRequest {
 	return &BaseRequest{
 		Pod:       pod,
-		DynaKube:  dynakube,
+		DynaKube:  dk,
 		Namespace: namespace,
 	}
 }
 
-func NewMutationRequest(ctx context.Context, namespace corev1.Namespace, installContainer *corev1.Container, pod *corev1.Pod, dynakube dynakube.DynaKube) *MutationRequest {
+func NewMutationRequest(ctx context.Context, namespace corev1.Namespace, installContainer *corev1.Container, pod *corev1.Pod, dk dynakube.DynaKube) *MutationRequest {
 	return &MutationRequest{
-		BaseRequest:      newBaseRequest(pod, namespace, dynakube),
+		BaseRequest:      newBaseRequest(pod, namespace, dk),
 		Context:          ctx,
 		InstallContainer: installContainer,
 	}

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -3,7 +3,7 @@ package webhook
 import (
 	"context"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/pod"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -29,7 +29,7 @@ type PodMutator interface {
 type BaseRequest struct {
 	Pod       *corev1.Pod
 	Namespace corev1.Namespace
-	DynaKube  dynatracev1beta2.DynaKube
+	DynaKube  dynakube.DynaKube
 }
 
 func (req BaseRequest) PodName() string {
@@ -56,7 +56,7 @@ type ReinvocationRequest struct {
 	*BaseRequest
 }
 
-func newBaseRequest(pod *corev1.Pod, namespace corev1.Namespace, dynakube dynatracev1beta2.DynaKube) *BaseRequest {
+func newBaseRequest(pod *corev1.Pod, namespace corev1.Namespace, dynakube dynakube.DynaKube) *BaseRequest {
 	return &BaseRequest{
 		Pod:       pod,
 		DynaKube:  dynakube,
@@ -64,7 +64,7 @@ func newBaseRequest(pod *corev1.Pod, namespace corev1.Namespace, dynakube dynatr
 	}
 }
 
-func NewMutationRequest(ctx context.Context, namespace corev1.Namespace, installContainer *corev1.Container, pod *corev1.Pod, dynakube dynatracev1beta2.DynaKube) *MutationRequest {
+func NewMutationRequest(ctx context.Context, namespace corev1.Namespace, installContainer *corev1.Container, pod *corev1.Pod, dynakube dynakube.DynaKube) *MutationRequest {
 	return &MutationRequest{
 		BaseRequest:      newBaseRequest(pod, namespace, dynakube),
 		Context:          ctx,

--- a/pkg/webhook/validation/edgeconnect/api_server.go
+++ b/pkg/webhook/validation/edgeconnect/api_server.go
@@ -21,14 +21,14 @@ var (
 	}
 )
 
-func isInvalidApiServer(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
+func isInvalidApiServer(_ context.Context, _ *edgeconnectValidator, ec *edgeconnect.EdgeConnect) string {
 	for _, suffix := range allowedSuffix {
-		if strings.HasSuffix(edgeConnect.Spec.ApiServer, suffix) {
+		if strings.HasSuffix(ec.Spec.ApiServer, suffix) {
 			hostnameWithDomains := strings.FieldsFunc(suffix,
 				func(r rune) bool { return r == '.' },
 			)
 
-			hostnameWithTenant := strings.FieldsFunc(edgeConnect.Spec.ApiServer,
+			hostnameWithTenant := strings.FieldsFunc(ec.Spec.ApiServer,
 				func(r rune) bool { return r == '.' },
 			)
 
@@ -36,7 +36,7 @@ func isInvalidApiServer(_ context.Context, _ *edgeconnectValidator, edgeConnect 
 				return ""
 			}
 
-			log.Info("apiServer is not a valid hostname", "apiServer", edgeConnect.Spec.ApiServer)
+			log.Info("apiServer is not a valid hostname", "apiServer", ec.Spec.ApiServer)
 
 			break
 		}

--- a/pkg/webhook/validation/edgeconnect/api_server_test.go
+++ b/pkg/webhook/validation/edgeconnect/api_server_test.go
@@ -25,7 +25,7 @@ const (
 func TestApiServer(t *testing.T) {
 	t.Run(`happy apiServer`, func(t *testing.T) {
 		for _, suffix := range allowedSuffix {
-			edgeConnect := &edgeconnect.EdgeConnect{
+			ec := &edgeconnect.EdgeConnect{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testName,
 					Namespace: testNamespace,
@@ -40,7 +40,7 @@ func TestApiServer(t *testing.T) {
 					ServiceAccountName: testServiceAccountName,
 				},
 			}
-			assertAllowedResponse(t, edgeConnect, prepareTestServiceAccount(testServiceAccountName, testNamespace))
+			assertAllowedResponse(t, ec, prepareTestServiceAccount(testServiceAccountName, testNamespace))
 		}
 	})
 
@@ -71,14 +71,14 @@ func TestApiServer(t *testing.T) {
 	})
 }
 
-func assertAllowedResponse(t *testing.T, edgeConnect *edgeconnect.EdgeConnect, other ...client.Object) {
-	response := handleRequest(t, edgeConnect, other...)
+func assertAllowedResponse(t *testing.T, ec *edgeconnect.EdgeConnect, other ...client.Object) {
+	response := handleRequest(t, ec, other...)
 	assert.True(t, response.Allowed, response.Result.Message)
 	assert.Empty(t, response.Warnings)
 }
 
-func assertDeniedResponse(t *testing.T, errMessages []string, edgeConnect *edgeconnect.EdgeConnect, other ...client.Object) {
-	response := handleRequest(t, edgeConnect, other...)
+func assertDeniedResponse(t *testing.T, errMessages []string, ec *edgeconnect.EdgeConnect, other ...client.Object) {
+	response := handleRequest(t, ec, other...)
 	assert.False(t, response.Allowed)
 
 	for _, errMsg := range errMessages {
@@ -86,7 +86,7 @@ func assertDeniedResponse(t *testing.T, errMessages []string, edgeConnect *edgec
 	}
 }
 
-func handleRequest(t *testing.T, edgeConnect *edgeconnect.EdgeConnect, other ...client.Object) admission.Response {
+func handleRequest(t *testing.T, ec *edgeconnect.EdgeConnect, other ...client.Object) admission.Response {
 	clt := fake.NewClient()
 	if other != nil {
 		clt = fake.NewClient(other...)
@@ -98,7 +98,7 @@ func handleRequest(t *testing.T, edgeConnect *edgeconnect.EdgeConnect, other ...
 		cfg:       &rest.Config{},
 	}
 
-	data, err := json.Marshal(*edgeConnect)
+	data, err := json.Marshal(*ec)
 	require.NoError(t, err)
 
 	return validator.Handle(context.Background(), admission.Request{

--- a/pkg/webhook/validation/edgeconnect/automation_validation.go
+++ b/pkg/webhook/validation/edgeconnect/automation_validation.go
@@ -10,8 +10,8 @@ const (
 	errorAutomationRequiresProvisioner = `When enabling Kubernetes automation using provisioner mode is mandatory! Please enable spec.oauth.provisioner and provide a resp. OAuth client configuration.`
 )
 
-func automationRequiresProvisionerValidation(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
-	if edgeConnect.Spec.KubernetesAutomation != nil && edgeConnect.Spec.KubernetesAutomation.Enabled && !edgeConnect.Spec.OAuth.Provisioner {
+func automationRequiresProvisionerValidation(_ context.Context, _ *edgeconnectValidator, ec *edgeconnect.EdgeConnect) string {
+	if ec.Spec.KubernetesAutomation != nil && ec.Spec.KubernetesAutomation.Enabled && !ec.Spec.OAuth.Provisioner {
 		return errorAutomationRequiresProvisioner
 	}
 

--- a/pkg/webhook/validation/edgeconnect/automation_validation_test.go
+++ b/pkg/webhook/validation/edgeconnect/automation_validation_test.go
@@ -11,13 +11,13 @@ import (
 
 func TestAutomationValidator(t *testing.T) {
 	t.Run("accept edgeconnect config without automation or oauth configs set", func(t *testing.T) {
-		edgeConnect := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			Spec: edgeconnect.EdgeConnectSpec{},
 		}
-		require.Empty(t, automationRequiresProvisionerValidation(context.Background(), nil, edgeConnect))
+		require.Empty(t, automationRequiresProvisionerValidation(context.Background(), nil, ec))
 	})
 	t.Run("reject automation without provisioning", func(t *testing.T) {
-		edgeConnect := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 
 			Spec: edgeconnect.EdgeConnectSpec{
 				KubernetesAutomation: &edgeconnect.KubernetesAutomationSpec{Enabled: true},
@@ -27,10 +27,10 @@ func TestAutomationValidator(t *testing.T) {
 				Resources: corev1.ResourceRequirements{},
 			},
 		}
-		require.Equal(t, errorAutomationRequiresProvisioner, automationRequiresProvisionerValidation(context.Background(), nil, edgeConnect))
+		require.Equal(t, errorAutomationRequiresProvisioner, automationRequiresProvisionerValidation(context.Background(), nil, ec))
 	})
 	t.Run("accept automation with provisioning enabled", func(t *testing.T) {
-		edgeConnect := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 
 			Spec: edgeconnect.EdgeConnectSpec{
 				KubernetesAutomation: &edgeconnect.KubernetesAutomationSpec{Enabled: true},
@@ -39,15 +39,15 @@ func TestAutomationValidator(t *testing.T) {
 				},
 			},
 		}
-		require.Empty(t, automationRequiresProvisionerValidation(context.Background(), nil, edgeConnect))
+		require.Empty(t, automationRequiresProvisionerValidation(context.Background(), nil, ec))
 	})
 	t.Run("reject automation with no oauth config", func(t *testing.T) {
-		edgeConnect := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 
 			Spec: edgeconnect.EdgeConnectSpec{
 				KubernetesAutomation: &edgeconnect.KubernetesAutomationSpec{Enabled: true},
 			},
 		}
-		require.Equal(t, errorAutomationRequiresProvisioner, automationRequiresProvisionerValidation(context.Background(), nil, edgeConnect))
+		require.Equal(t, errorAutomationRequiresProvisioner, automationRequiresProvisionerValidation(context.Background(), nil, ec))
 	})
 }

--- a/pkg/webhook/validation/edgeconnect/config.go
+++ b/pkg/webhook/validation/edgeconnect/config.go
@@ -13,7 +13,7 @@ const (
 
 var log = logd.Get().WithName("edgeconnect-validation")
 
-type validator func(ctx context.Context, dv *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string
+type validator func(ctx context.Context, dv *edgeconnectValidator, ec *edgeconnect.EdgeConnect) string
 
 var validators = []validator{
 	isInvalidApiServer,

--- a/pkg/webhook/validation/edgeconnect/host_patterns.go
+++ b/pkg/webhook/validation/edgeconnect/host_patterns.go
@@ -10,8 +10,8 @@ const (
 	errorHostPattersIsRequired = `hostPatterns is required when using provisioner mode`
 )
 
-func checkHostPatternsValue(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
-	if edgeConnect.IsProvisionerModeEnabled() && len(edgeConnect.Spec.HostPatterns) == 0 && !edgeConnect.IsK8SAutomationEnabled() {
+func checkHostPatternsValue(_ context.Context, _ *edgeconnectValidator, ec *edgeconnect.EdgeConnect) string {
+	if ec.IsProvisionerModeEnabled() && len(ec.Spec.HostPatterns) == 0 && !ec.IsK8SAutomationEnabled() {
 		return errorHostPattersIsRequired
 	}
 

--- a/pkg/webhook/validation/edgeconnect/host_patterns_test.go
+++ b/pkg/webhook/validation/edgeconnect/host_patterns_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestHostPatternsRequired(t *testing.T) {
 	t.Run(`hostPatters optional - no error when provisioner false`, func(t *testing.T) {
-		edgeConnect := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
@@ -25,13 +25,13 @@ func TestHostPatternsRequired(t *testing.T) {
 				ServiceAccountName: testServiceAccountName,
 			},
 		}
-		response := handleRequest(t, edgeConnect, prepareTestServiceAccount(testServiceAccountName, testNamespace))
+		response := handleRequest(t, ec, prepareTestServiceAccount(testServiceAccountName, testNamespace))
 		assert.True(t, response.Allowed)
 		assert.Empty(t, response.Warnings)
 	})
 
 	t.Run(`hostPatters is required - error when provisioner true`, func(t *testing.T) {
-		edgeConnect := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			Spec: edgeconnect.EdgeConnectSpec{
 				ApiServer: "tenantid-test.dev.apps.dynatracelabs.com",
 				OAuth: edgeconnect.OAuthSpec{
@@ -42,6 +42,6 @@ func TestHostPatternsRequired(t *testing.T) {
 				},
 			},
 		}
-		assertDeniedResponse(t, []string{errorHostPattersIsRequired}, edgeConnect)
+		assertDeniedResponse(t, []string{errorHostPattersIsRequired}, ec)
 	})
 }

--- a/pkg/webhook/validation/edgeconnect/name.go
+++ b/pkg/webhook/validation/edgeconnect/name.go
@@ -12,8 +12,8 @@ const (
 	The limit is necessary because kubernetes uses the name of some resources for the label value, which has a limit of 63 characters. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)`
 )
 
-func nameTooLong(_ context.Context, _ *edgeconnectValidator, edgeConnect *edgeconnect.EdgeConnect) string {
-	edgeConnectName := edgeConnect.Name
+func nameTooLong(_ context.Context, _ *edgeconnectValidator, ec *edgeconnect.EdgeConnect) string {
+	edgeConnectName := ec.Name
 	if edgeConnectName != "" && len(edgeConnectName) > edgeconnect.MaxNameLength {
 		return fmt.Sprintf(errorNameTooLong, edgeconnect.MaxNameLength)
 	}

--- a/pkg/webhook/validation/edgeconnect/service_account_test.go
+++ b/pkg/webhook/validation/edgeconnect/service_account_test.go
@@ -10,12 +10,12 @@ import (
 
 func TestServiceAccountName(t *testing.T) {
 	t.Run("empty name", func(t *testing.T) {
-		edgeConnect := &edgeconnect.EdgeConnect{
+		ec := &edgeconnect.EdgeConnect{
 			Spec: edgeconnect.EdgeConnectSpec{
 				ServiceAccountName: "",
 			},
 		}
-		assertDeniedResponse(t, []string{errorInvalidServiceName}, edgeConnect)
+		assertDeniedResponse(t, []string{errorInvalidServiceName}, ec)
 	})
 }
 

--- a/pkg/webhook/validation/edgeconnect/validation.go
+++ b/pkg/webhook/validation/edgeconnect/validation.go
@@ -40,14 +40,14 @@ func AddEdgeConnectValidationWebhookToManager(manager ctrl.Manager) error {
 func (validator *edgeconnectValidator) Handle(ctx context.Context, request admission.Request) admission.Response {
 	log.Info("validating edgeconnect request", "name", request.Name, "namespace", request.Namespace)
 
-	edgeConnect := &edgeconnect.EdgeConnect{}
+	ec := &edgeconnect.EdgeConnect{}
 
-	err := decodeRequestToEdgeConnect(request, edgeConnect)
+	err := decodeRequestToEdgeConnect(request, ec)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, errors.WithStack(err))
 	}
 
-	validationErrors := validator.runValidators(ctx, validators, edgeConnect)
+	validationErrors := validator.runValidators(ctx, validators, ec)
 	response := admission.Allowed("")
 
 	if len(validationErrors) > 0 {
@@ -57,11 +57,11 @@ func (validator *edgeconnectValidator) Handle(ctx context.Context, request admis
 	return response
 }
 
-func (validator *edgeconnectValidator) runValidators(ctx context.Context, validators []validator, edgeConnect *edgeconnect.EdgeConnect) []string {
+func (validator *edgeconnectValidator) runValidators(ctx context.Context, validators []validator, ec *edgeconnect.EdgeConnect) []string {
 	results := []string{}
 
 	for _, validate := range validators {
-		if errMsg := validate(ctx, validator, edgeConnect); errMsg != "" {
+		if errMsg := validate(ctx, validator, ec); errMsg != "" {
 			results = append(results, errMsg)
 		}
 	}
@@ -69,10 +69,10 @@ func (validator *edgeconnectValidator) runValidators(ctx context.Context, valida
 	return results
 }
 
-func decodeRequestToEdgeConnect(request admission.Request, edgeConnect *edgeconnect.EdgeConnect) error {
+func decodeRequestToEdgeConnect(request admission.Request, ec *edgeconnect.EdgeConnect) error {
 	decoder := admission.NewDecoder(scheme.Scheme)
 
-	err := decoder.Decode(request, edgeConnect)
+	err := decoder.Decode(request, ec)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/test/features/activegate/curl.go
+++ b/test/features/activegate/curl.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/curl"
@@ -24,7 +24,7 @@ const (
 	proxyNamespaceName = "proxy"
 )
 
-func curlActiveGateHttps(builder *features.FeatureBuilder, dynakube dynatracev1beta2.DynaKube) {
+func curlActiveGateHttps(builder *features.FeatureBuilder, dynakube dynakube.DynaKube) {
 	podname := "curl-activegate-https"
 	serviceUrl := getActiveGateHttpsServiceUrl(dynakube)
 	builder.Assess("creating https curl pod for activeGate", installActiveGateCurlPod(podname, serviceUrl, dynakube))
@@ -33,7 +33,7 @@ func curlActiveGateHttps(builder *features.FeatureBuilder, dynakube dynatracev1b
 	builder.Teardown(removeActiveGateCurlPod(podname, serviceUrl, dynakube))
 }
 
-func curlActiveGateHttp(builder *features.FeatureBuilder, dynakube dynatracev1beta2.DynaKube) {
+func curlActiveGateHttp(builder *features.FeatureBuilder, dynakube dynakube.DynaKube) {
 	podname := "curl-activegate-http"
 	serviceUrl := getActiveGateHttpServiceUrl(dynakube)
 	builder.Assess("creating http curl pod for activeGate", installActiveGateCurlPod(podname, serviceUrl, dynakube))
@@ -42,7 +42,7 @@ func curlActiveGateHttp(builder *features.FeatureBuilder, dynakube dynatracev1be
 	builder.Teardown(removeActiveGateCurlPod(podname, serviceUrl, dynakube))
 }
 
-func installActiveGateCurlPod(podName, serviceUrl string, dynakube dynatracev1beta2.DynaKube) features.Func {
+func installActiveGateCurlPod(podName, serviceUrl string, dynakube dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		curlTarget := fmt.Sprintf("%s/%s", serviceUrl, activeGateEndpoint)
 
@@ -53,7 +53,7 @@ func installActiveGateCurlPod(podName, serviceUrl string, dynakube dynatracev1be
 	}
 }
 
-func removeActiveGateCurlPod(podName, serviceUrl string, dynakube dynatracev1beta2.DynaKube) features.Func {
+func removeActiveGateCurlPod(podName, serviceUrl string, dynakube dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		curlTarget := fmt.Sprintf("%s/%s", serviceUrl, activeGateEndpoint)
 
@@ -67,11 +67,11 @@ func removeActiveGateCurlPod(podName, serviceUrl string, dynakube dynatracev1bet
 	}
 }
 
-func waitForActiveGateCurlPod(podName string, dynakube dynatracev1beta2.DynaKube) features.Func {
+func waitForActiveGateCurlPod(podName string, dynakube dynakube.DynaKube) features.Func {
 	return pod.WaitFor(podName, curlNamespace(dynakube))
 }
 
-func checkActiveGateCurlResult(podName string, dynakube dynatracev1beta2.DynaKube) features.Func {
+func checkActiveGateCurlResult(podName string, dynakube dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 
@@ -82,7 +82,7 @@ func checkActiveGateCurlResult(podName string, dynakube dynatracev1beta2.DynaKub
 	}
 }
 
-func curlNamespace(dynakube dynatracev1beta2.DynaKube) string {
+func curlNamespace(dynakube dynakube.DynaKube) string {
 	if dynakube.HasProxy() {
 		return proxyNamespaceName
 	}
@@ -90,13 +90,13 @@ func curlNamespace(dynakube dynatracev1beta2.DynaKube) string {
 	return dynakube.Namespace
 }
 
-func getActiveGateHttpsServiceUrl(dynakube dynatracev1beta2.DynaKube) string {
+func getActiveGateHttpsServiceUrl(dynakube dynakube.DynaKube) string {
 	serviceName := capability.BuildServiceName(dynakube.Name, consts.MultiActiveGateName)
 
 	return fmt.Sprintf("https://%s.%s.svc.cluster.local", serviceName, dynakube.Namespace)
 }
 
-func getActiveGateHttpServiceUrl(dynakube dynatracev1beta2.DynaKube) string {
+func getActiveGateHttpServiceUrl(dynakube dynakube.DynaKube) string {
 	serviceName := capability.BuildServiceName(dynakube.Name, consts.MultiActiveGateName)
 
 	return fmt.Sprintf("http://%s.%s.svc.cluster.local", serviceName, dynakube.Namespace)

--- a/test/features/applicationmonitoring/label_version_detection.go
+++ b/test/features/applicationmonitoring/label_version_detection.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
@@ -100,21 +100,21 @@ func LabelVersionDetection(t *testing.T) features.Feature {
 	builder.WithLabel("name", "app-label-version")
 
 	secretConfig := tenant.GetSingleTenantSecret(t)
-	defaultDynakube := *dynakube.New(
-		dynakube.WithName("dynakube-default"),
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
-		dynakube.WithNameBasedOneAgentNamespaceSelector(),
-		dynakube.WithApplicationMonitoringSpec(&dynatracev1beta2.ApplicationMonitoringSpec{
+	defaultDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithName("dynakubeComponents-default"),
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
+		dynakubeComponents.WithNameBasedOneAgentNamespaceSelector(),
+		dynakubeComponents.WithApplicationMonitoringSpec(&dynakube.ApplicationMonitoringSpec{
 			UseCSIDriver: false,
 		}),
 	)
 
-	labelVersionDynakube := *dynakube.New(
-		dynakube.WithName("dynakube-labels"),
-		dynakube.WithAnnotations(map[string]string{dynatracev1beta2.AnnotationFeatureLabelVersionDetection: "true"}),
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
-		dynakube.WithNameBasedOneAgentNamespaceSelector(),
-		dynakube.WithApplicationMonitoringSpec(&dynatracev1beta2.ApplicationMonitoringSpec{
+	labelVersionDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithName("dynakubeComponents-labels"),
+		dynakubeComponents.WithAnnotations(map[string]string{dynakube.AnnotationFeatureLabelVersionDetection: "true"}),
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
+		dynakubeComponents.WithNameBasedOneAgentNamespaceSelector(),
+		dynakubeComponents.WithApplicationMonitoringSpec(&dynakube.ApplicationMonitoringSpec{
 			UseCSIDriver: false,
 		}),
 	)
@@ -126,16 +126,16 @@ func LabelVersionDetection(t *testing.T) features.Feature {
 		buildPreservedBuildLabelSampleApp(t, labelVersionDynakube),
 		buildInvalidBuildLabelSampleApp(t, labelVersionDynakube),
 	}
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, defaultDynakube)
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, labelVersionDynakube)
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, defaultDynakube)
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, labelVersionDynakube)
 
 	// Register actual test (+sample cleanup)
 	installSampleApplications(builder, sampleApps)
 	checkBuildLabels(builder, sampleApps)
 	teardownSampleApplications(builder, sampleApps)
 
-	dynakube.Delete(builder, helpers.LevelTeardown, defaultDynakube)
-	dynakube.Delete(builder, helpers.LevelTeardown, labelVersionDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, defaultDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, labelVersionDynakube)
 
 	return builder.Feature()
 }
@@ -225,19 +225,19 @@ func assertValue(ctx context.Context, t *testing.T, resource *resources.Resource
 	assert.Equal(t, expectedValue, stdOut, "%s:%s pod - %s variable has invalid value", podItem.Namespace, podItem.Name, variableName)
 }
 
-func buildDisabledBuildLabelNamespace(testDynakube dynatracev1beta2.DynaKube) corev1.Namespace {
+func buildDisabledBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Namespace {
 	return *namespace.New(disabledBuildLabelsNamespace, namespace.WithLabels(testDynakube.OneAgentNamespaceSelector().MatchLabels))
 }
 
-func buildDisabledBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta2.DynaKube) *sample.App {
+func buildDisabledBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube) *sample.App {
 	return sample.NewApp(t, &testDynakube, sample.AsDeployment(), sample.WithNamespace(buildDisabledBuildLabelNamespace(testDynakube)))
 }
 
-func buildDefaultBuildLabelNamespace(testDynakube dynatracev1beta2.DynaKube) corev1.Namespace {
+func buildDefaultBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Namespace {
 	return *namespace.New(defaultBuildLabelsNamespace, namespace.WithLabels(testDynakube.OneAgentNamespaceSelector().MatchLabels))
 }
 
-func buildDefaultBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta2.DynaKube) *sample.App {
+func buildDefaultBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube) *sample.App {
 	sampleApp := sample.NewApp(t, &testDynakube,
 		sample.AsDeployment(),
 		sample.WithNamespace(buildDefaultBuildLabelNamespace(testDynakube)),
@@ -254,7 +254,7 @@ func buildDefaultBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta2
 	return sampleApp
 }
 
-func buildCustomBuildLabelNamespace(testDynakube dynatracev1beta2.DynaKube) corev1.Namespace {
+func buildCustomBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Namespace {
 	return *namespace.New(
 		customBuildLabelsNamespace,
 		namespace.WithLabels(testDynakube.OneAgentNamespaceSelector().MatchLabels),
@@ -267,7 +267,7 @@ func buildCustomBuildLabelNamespace(testDynakube dynatracev1beta2.DynaKube) core
 	)
 }
 
-func buildCustomBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta2.DynaKube) *sample.App {
+func buildCustomBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube) *sample.App {
 	sampleApp := sample.NewApp(t, &testDynakube,
 		sample.AsDeployment(),
 		sample.WithNamespace(buildCustomBuildLabelNamespace(testDynakube)),
@@ -284,7 +284,7 @@ func buildCustomBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta2.
 	return sampleApp
 }
 
-func buildPreservedBuildLabelNamespace(testDynakube dynatracev1beta2.DynaKube) corev1.Namespace {
+func buildPreservedBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Namespace {
 	return *namespace.New(
 		preservedBuildLabelsNamespace,
 		namespace.WithLabels(testDynakube.OneAgentNamespaceSelector().MatchLabels),
@@ -297,7 +297,7 @@ func buildPreservedBuildLabelNamespace(testDynakube dynatracev1beta2.DynaKube) c
 	)
 }
 
-func buildPreservedBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta2.DynaKube) *sample.App {
+func buildPreservedBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube) *sample.App {
 	sampleApp := sample.NewApp(t, &testDynakube,
 		sample.AsDeployment(),
 		sample.WithNamespace(buildPreservedBuildLabelNamespace(testDynakube)),
@@ -352,7 +352,7 @@ func buildPreservedBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1bet
 	return sampleApp
 }
 
-func buildInvalidBuildLabelNamespace(testDynakube dynatracev1beta2.DynaKube) corev1.Namespace {
+func buildInvalidBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Namespace {
 	return *namespace.New(
 		invalidBuildLabelsNamespace,
 		namespace.WithLabels(testDynakube.OneAgentNamespaceSelector().MatchLabels),
@@ -363,7 +363,7 @@ func buildInvalidBuildLabelNamespace(testDynakube dynatracev1beta2.DynaKube) cor
 	)
 }
 
-func buildInvalidBuildLabelSampleApp(t *testing.T, testDynakube dynatracev1beta2.DynaKube) *sample.App {
+func buildInvalidBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube) *sample.App {
 	sampleApp := sample.NewApp(t, &testDynakube,
 		sample.AsDeployment(),
 		sample.WithNamespace(buildInvalidBuildLabelNamespace(testDynakube)),

--- a/test/features/applicationmonitoring/label_version_detection.go
+++ b/test/features/applicationmonitoring/label_version_detection.go
@@ -225,22 +225,22 @@ func assertValue(ctx context.Context, t *testing.T, resource *resources.Resource
 	assert.Equal(t, expectedValue, stdOut, "%s:%s pod - %s variable has invalid value", podItem.Namespace, podItem.Name, variableName)
 }
 
-func buildDisabledBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Namespace {
-	return *namespace.New(disabledBuildLabelsNamespace, namespace.WithLabels(testDynakube.OneAgentNamespaceSelector().MatchLabels))
+func buildDisabledBuildLabelNamespace(dk dynakube.DynaKube) corev1.Namespace {
+	return *namespace.New(disabledBuildLabelsNamespace, namespace.WithLabels(dk.OneAgentNamespaceSelector().MatchLabels))
 }
 
-func buildDisabledBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube) *sample.App {
-	return sample.NewApp(t, &testDynakube, sample.AsDeployment(), sample.WithNamespace(buildDisabledBuildLabelNamespace(testDynakube)))
+func buildDisabledBuildLabelSampleApp(t *testing.T, dk dynakube.DynaKube) *sample.App {
+	return sample.NewApp(t, &dk, sample.AsDeployment(), sample.WithNamespace(buildDisabledBuildLabelNamespace(dk)))
 }
 
-func buildDefaultBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Namespace {
-	return *namespace.New(defaultBuildLabelsNamespace, namespace.WithLabels(testDynakube.OneAgentNamespaceSelector().MatchLabels))
+func buildDefaultBuildLabelNamespace(dk dynakube.DynaKube) corev1.Namespace {
+	return *namespace.New(defaultBuildLabelsNamespace, namespace.WithLabels(dk.OneAgentNamespaceSelector().MatchLabels))
 }
 
-func buildDefaultBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube) *sample.App {
-	sampleApp := sample.NewApp(t, &testDynakube,
+func buildDefaultBuildLabelSampleApp(t *testing.T, dk dynakube.DynaKube) *sample.App {
+	sampleApp := sample.NewApp(t, &dk,
 		sample.AsDeployment(),
-		sample.WithNamespace(buildDefaultBuildLabelNamespace(testDynakube)),
+		sample.WithNamespace(buildDefaultBuildLabelNamespace(dk)),
 		sample.WithLabels(map[string]string{
 			"app.kubernetes.io/version": "app-kubernetes-io-version",
 			"app.kubernetes.io/part-of": "app-kubernetes-io-part-of",
@@ -254,10 +254,10 @@ func buildDefaultBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKub
 	return sampleApp
 }
 
-func buildCustomBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Namespace {
+func buildCustomBuildLabelNamespace(dk dynakube.DynaKube) corev1.Namespace {
 	return *namespace.New(
 		customBuildLabelsNamespace,
-		namespace.WithLabels(testDynakube.OneAgentNamespaceSelector().MatchLabels),
+		namespace.WithLabels(dk.OneAgentNamespaceSelector().MatchLabels),
 		namespace.WithAnnotation(map[string]string{
 			"mapping.release.dynatrace.com/version":       "metadata.labels['my.domain/version']",
 			"mapping.release.dynatrace.com/product":       "metadata.labels['my.domain/product']",
@@ -267,10 +267,10 @@ func buildCustomBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Names
 	)
 }
 
-func buildCustomBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube) *sample.App {
-	sampleApp := sample.NewApp(t, &testDynakube,
+func buildCustomBuildLabelSampleApp(t *testing.T, dk dynakube.DynaKube) *sample.App {
+	sampleApp := sample.NewApp(t, &dk,
 		sample.AsDeployment(),
-		sample.WithNamespace(buildCustomBuildLabelNamespace(testDynakube)),
+		sample.WithNamespace(buildCustomBuildLabelNamespace(dk)),
 		sample.WithLabels(map[string]string{
 			"app.kubernetes.io/version": "app-kubernetes-io-version",
 			"app.kubernetes.io/part-of": "app-kubernetes-io-part-of",
@@ -284,10 +284,10 @@ func buildCustomBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube
 	return sampleApp
 }
 
-func buildPreservedBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Namespace {
+func buildPreservedBuildLabelNamespace(dk dynakube.DynaKube) corev1.Namespace {
 	return *namespace.New(
 		preservedBuildLabelsNamespace,
-		namespace.WithLabels(testDynakube.OneAgentNamespaceSelector().MatchLabels),
+		namespace.WithLabels(dk.OneAgentNamespaceSelector().MatchLabels),
 		namespace.WithAnnotation(map[string]string{
 			"mapping.release.dynatrace.com/version":       "metadata.labels['my.domain/version']",
 			"mapping.release.dynatrace.com/product":       "metadata.labels['my.domain/product']",
@@ -297,10 +297,10 @@ func buildPreservedBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Na
 	)
 }
 
-func buildPreservedBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube) *sample.App {
-	sampleApp := sample.NewApp(t, &testDynakube,
+func buildPreservedBuildLabelSampleApp(t *testing.T, dk dynakube.DynaKube) *sample.App {
+	sampleApp := sample.NewApp(t, &dk,
 		sample.AsDeployment(),
-		sample.WithNamespace(buildPreservedBuildLabelNamespace(testDynakube)),
+		sample.WithNamespace(buildPreservedBuildLabelNamespace(dk)),
 		sample.WithLabels(map[string]string{
 			"app.kubernetes.io/version": "app-kubernetes-io-version",
 			"app.kubernetes.io/part-of": "app-kubernetes-io-part-of",
@@ -352,10 +352,10 @@ func buildPreservedBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaK
 	return sampleApp
 }
 
-func buildInvalidBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Namespace {
+func buildInvalidBuildLabelNamespace(dk dynakube.DynaKube) corev1.Namespace {
 	return *namespace.New(
 		invalidBuildLabelsNamespace,
-		namespace.WithLabels(testDynakube.OneAgentNamespaceSelector().MatchLabels),
+		namespace.WithLabels(dk.OneAgentNamespaceSelector().MatchLabels),
 		namespace.WithAnnotation(map[string]string{
 			"mapping.release.dynatrace.com/stage":         "metadata.labels['my.domain/invalid-stage']",
 			"mapping.release.dynatrace.com/build-version": "metadata.labels['my.domain/invalid-build-version']",
@@ -363,10 +363,10 @@ func buildInvalidBuildLabelNamespace(testDynakube dynakube.DynaKube) corev1.Name
 	)
 }
 
-func buildInvalidBuildLabelSampleApp(t *testing.T, testDynakube dynakube.DynaKube) *sample.App {
-	sampleApp := sample.NewApp(t, &testDynakube,
+func buildInvalidBuildLabelSampleApp(t *testing.T, dk dynakube.DynaKube) *sample.App {
+	sampleApp := sample.NewApp(t, &dk,
 		sample.AsDeployment(),
-		sample.WithNamespace(buildInvalidBuildLabelNamespace(testDynakube)),
+		sample.WithNamespace(buildInvalidBuildLabelNamespace(dk)),
 		sample.WithLabels(map[string]string{
 			"app.kubernetes.io/version": "app-kubernetes-io-version",
 			"app.kubernetes.io/part-of": "app-kubernetes-io-part-of",

--- a/test/features/applicationmonitoring/metadata_enrichment.go
+++ b/test/features/applicationmonitoring/metadata_enrichment.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/map"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
@@ -45,14 +45,14 @@ func MetadataEnrichment(t *testing.T) features.Feature {
 	builder := features.New("metadata-enrichment")
 	builder.WithLabel("name", "app-metadata-enrichment")
 	secretConfig := tenant.GetSingleTenantSecret(t)
-	testDynakube := *dynakube.New(
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
-		dynakube.WithMetadataEnrichment(),
-		dynakube.WithApplicationMonitoringSpec(&dynatracev1beta2.ApplicationMonitoringSpec{
+	testDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
+		dynakubeComponents.WithMetadataEnrichment(),
+		dynakubeComponents.WithApplicationMonitoringSpec(&dynakube.ApplicationMonitoringSpec{
 			UseCSIDriver: false,
 		}),
-		dynakube.WithNameBasedMetadataEnrichmentNamespaceSelector(),
-		dynakube.WithNameBasedOneAgentNamespaceSelector(),
+		dynakubeComponents.WithNameBasedMetadataEnrichmentNamespaceSelector(),
+		dynakubeComponents.WithNameBasedOneAgentNamespaceSelector(),
 	)
 
 	type testCase struct {
@@ -136,8 +136,8 @@ func MetadataEnrichment(t *testing.T) features.Feature {
 		},
 	}
 
-	// dynakube install
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+	// dynakubeComponents install
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
 
 	// Register actual test
 	for _, test := range testCases {
@@ -146,7 +146,7 @@ func MetadataEnrichment(t *testing.T) features.Feature {
 		builder.WithTeardown(fmt.Sprintf("%s: Uninstalling sample app", test.name), test.app.Uninstall())
 	}
 
-	dynakube.Delete(builder, helpers.LevelTeardown, testDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, testDynakube)
 
 	return builder.Feature()
 }

--- a/test/features/applicationmonitoring/metadata_enrichment.go
+++ b/test/features/applicationmonitoring/metadata_enrichment.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/map"
+	maputil "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"

--- a/test/features/applicationmonitoring/read_only_csi_volume.go
+++ b/test/features/applicationmonitoring/read_only_csi_volume.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	oamutation "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/codemodules"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/deployment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
@@ -25,23 +25,23 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-var readOnlyInjection = map[string]string{dynatracev1beta2.AnnotationFeatureReadOnlyCsiVolume: "true"}
+var readOnlyInjection = map[string]string{dynakube.AnnotationFeatureReadOnlyCsiVolume: "true"}
 
 func ReadOnlyCSIVolume(t *testing.T) features.Feature {
 	builder := features.New("read only csi volume")
 	builder.WithLabel("name", "app-read-only-csi-volume")
 	secretConfig := tenant.GetSingleTenantSecret(t)
-	testDynakube := *dynakube.New(
-		dynakube.WithAnnotations(readOnlyInjection),
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
-		dynakube.WithApplicationMonitoringSpec(&dynatracev1beta2.ApplicationMonitoringSpec{
+	testDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithAnnotations(readOnlyInjection),
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
+		dynakubeComponents.WithApplicationMonitoringSpec(&dynakube.ApplicationMonitoringSpec{
 			UseCSIDriver: true,
 		}),
 	)
 	sampleDeployment := sample.NewApp(t, &testDynakube, sample.AsDeployment())
 	builder.Assess("install sample deployment namespace", sampleDeployment.InstallNamespace())
 
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
 
 	builder.Assess("install sample deployment and wait till ready", sampleDeployment.Install())
 	builder.Assess("check mounted volumes", checkMountedVolumes(sampleDeployment))
@@ -49,7 +49,7 @@ func ReadOnlyCSIVolume(t *testing.T) features.Feature {
 
 	builder.WithTeardown("removing sample namespace", sampleDeployment.Uninstall())
 
-	dynakube.Delete(builder, helpers.LevelTeardown, testDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, testDynakube)
 
 	return builder.Feature()
 }

--- a/test/features/applicationmonitoring/without_csi.go
+++ b/test/features/applicationmonitoring/without_csi.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/address"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
 	"github.com/stretchr/testify/require"
@@ -23,14 +23,14 @@ func WithoutCSI(t *testing.T) features.Feature {
 	builder := features.New("application monitoring without csi driver enabled")
 	builder.WithLabel("name", "app-without-csi")
 	secretConfig := tenant.GetSingleTenantSecret(t)
-	appOnlyDynakube := *dynakube.New(
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
-		dynakube.WithApplicationMonitoringSpec(&dynatracev1beta2.ApplicationMonitoringSpec{
+	appOnlyDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
+		dynakubeComponents.WithApplicationMonitoringSpec(&dynakube.ApplicationMonitoringSpec{
 			UseCSIDriver: false,
 		}),
 	)
 
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, appOnlyDynakube)
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, appOnlyDynakube)
 
 	sampleApp := sample.NewApp(t, &appOnlyDynakube, sample.AsDeployment())
 	builder.Assess("install sample app", sampleApp.Install())
@@ -65,7 +65,7 @@ func WithoutCSI(t *testing.T) features.Feature {
 	builder.Teardown(podSample.Uninstall())
 	builder.Teardown(alreadyInjectedSample.Uninstall())
 	builder.Teardown(randomUserSample.Uninstall())
-	dynakube.Delete(builder, helpers.LevelTeardown, appOnlyDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, appOnlyDynakube)
 
 	return builder.Feature()
 }

--- a/test/features/classic/classic.go
+++ b/test/features/classic/classic.go
@@ -5,9 +5,9 @@ package classic
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
@@ -21,14 +21,14 @@ func Feature(t *testing.T) features.Feature {
 	builder := features.New("install classic fullstack")
 	builder.WithLabel("name", "classic")
 	secretConfig := tenant.GetSingleTenantSecret(t)
-	testDynakube := *dynakube.New(
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
-		dynakube.WithClassicFullstackSpec(&dynatracev1beta2.HostInjectSpec{}),
+	testDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
+		dynakubeComponents.WithClassicFullstackSpec(&dynakube.HostInjectSpec{}),
 	)
 
 	// check if oneAgent pods startup and report as ready
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
-	dynakube.Delete(builder, helpers.LevelTeardown, testDynakube)
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, testDynakube)
 
 	return builder.Feature()
 }

--- a/test/features/classic/switch_modes/switch_modes.go
+++ b/test/features/classic/switch_modes/switch_modes.go
@@ -5,11 +5,11 @@ package switch_modes
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
@@ -28,27 +28,27 @@ func Feature(t *testing.T) features.Feature {
 	// build classic full stack dynakube
 	secretConfig := tenant.GetSingleTenantSecret(t)
 
-	commonOptions := []dynakube.Option{
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
+	commonOptions := []dynakubeComponents.Option{
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
 	}
 
-	dynakubeClassicFullStack := *dynakube.New(
-		append(commonOptions, dynakube.WithClassicFullstackSpec(&dynatracev1beta2.HostInjectSpec{}))...,
+	dynakubeClassicFullStack := *dynakubeComponents.New(
+		append(commonOptions, dynakubeComponents.WithClassicFullstackSpec(&dynakube.HostInjectSpec{}))...,
 	)
 
 	sampleAppClassic := sample.NewApp(t, &dynakubeClassicFullStack,
 		sample.AsDeployment(),
 		sample.WithName(sampleAppsClassicName),
 	)
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, dynakubeClassicFullStack)
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, dynakubeClassicFullStack)
 	builder.Assess("install sample app", sampleAppClassic.Install())
 
 	// change dynakube to cloud native
-	dynakubeCloudNative := *dynakube.New(
-		append(commonOptions, dynakube.WithCloudNativeSpec(cloudnative.DefaultCloudNativeSpec()))...,
+	dynakubeCloudNative := *dynakubeComponents.New(
+		append(commonOptions, dynakubeComponents.WithCloudNativeSpec(cloudnative.DefaultCloudNativeSpec()))...,
 	)
 
-	dynakube.Delete(builder, helpers.LevelAssess, dynakubeClassicFullStack)
+	dynakubeComponents.Delete(builder, helpers.LevelAssess, dynakubeClassicFullStack)
 	oneagent.RunClassicUninstall(builder, helpers.LevelAssess, dynakubeClassicFullStack)
 	sampleAppCloudNative := sample.NewApp(t, &dynakubeCloudNative,
 		sample.AsDeployment(),
@@ -57,7 +57,7 @@ func Feature(t *testing.T) features.Feature {
 	)
 	builder.Assess("create sample app namespace", sampleAppCloudNative.InstallNamespace())
 
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, dynakubeCloudNative)
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, dynakubeCloudNative)
 
 	// apply sample apps
 	builder.Assess("install sample app", sampleAppCloudNative.Install())
@@ -68,7 +68,7 @@ func Feature(t *testing.T) features.Feature {
 	// teardown
 	builder.Teardown(sampleAppCloudNative.Uninstall())
 	builder.Teardown(sampleAppClassic.Uninstall())
-	dynakube.Delete(builder, helpers.LevelTeardown, dynakubeClassicFullStack)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, dynakubeClassicFullStack)
 
 	return builder.Feature()
 }

--- a/test/features/cloudnative/codemodules/codemodules.go
+++ b/test/features/cloudnative/codemodules/codemodules.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook"
@@ -21,7 +21,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/csi"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/configmap"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
@@ -69,18 +69,18 @@ func InstallFromImage(t *testing.T) features.Feature {
 	secretConfigs := tenant.GetMultiTenantSecret(t)
 	require.Len(t, secretConfigs, 2)
 
-	cloudNativeDynakube := *dynakube.New(
-		dynakube.WithName("cloudnative-codemodules"),
-		dynakube.WithNameBasedOneAgentNamespaceSelector(),
-		dynakube.WithApiUrl(secretConfigs[0].ApiUrl),
-		dynakube.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
+	cloudNativeDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithName("cloudnative-codemodules"),
+		dynakubeComponents.WithNameBasedOneAgentNamespaceSelector(),
+		dynakubeComponents.WithApiUrl(secretConfigs[0].ApiUrl),
+		dynakubeComponents.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
 	)
 
-	appDynakube := *dynakube.New(
-		dynakube.WithName("app-codemodules"),
-		dynakube.WithNameBasedOneAgentNamespaceSelector(),
-		dynakube.WithApiUrl(secretConfigs[1].ApiUrl),
-		dynakube.WithApplicationMonitoringSpec(&dynatracev1beta2.ApplicationMonitoringSpec{
+	appDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithName("app-codemodules"),
+		dynakubeComponents.WithNameBasedOneAgentNamespaceSelector(),
+		dynakubeComponents.WithApiUrl(secretConfigs[1].ApiUrl),
+		dynakubeComponents.WithApplicationMonitoringSpec(&dynakube.ApplicationMonitoringSpec{
 			AppInjectionSpec: *codeModulesAppInjectSpec(t),
 			UseCSIDriver:     true,
 		}),
@@ -96,8 +96,8 @@ func InstallFromImage(t *testing.T) features.Feature {
 
 	builder.Assess("create sample namespace", sampleApp.InstallNamespace())
 
-	// Register dynakube install
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfigs[0], cloudNativeDynakube)
+	// Register dynakubeComponents install
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfigs[0], cloudNativeDynakube)
 
 	// Register sample app install
 	builder.Assess("install sample app", sampleApp.Install())
@@ -107,14 +107,14 @@ func InstallFromImage(t *testing.T) features.Feature {
 
 	builder.Assess("codemodules have been downloaded", imageHasBeenDownloaded(cloudNativeDynakube))
 	builder.Assess("checking storage used", measureDiskUsage(appDynakube.Namespace, storageMap))
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfigs[1], appDynakube)
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfigs[1], appDynakube)
 	builder.Assess("storage size has not increased", diskUsageDoesNotIncrease(appDynakube.Namespace, storageMap))
 	builder.Assess("volumes are mounted correctly", volumesAreMountedCorrectly(*sampleApp))
 
-	// Register sample, dynakube and operator uninstall
+	// Register sample, dynakubeComponents and operator uninstall
 	builder.Teardown(sampleApp.Uninstall())
-	dynakube.Delete(builder, helpers.LevelTeardown, cloudNativeDynakube)
-	dynakube.Delete(builder, helpers.LevelTeardown, appDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, cloudNativeDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, appDynakube)
 
 	return builder.Feature()
 }
@@ -132,20 +132,20 @@ const (
 //
 // Connectivity in the dynatrace namespace and sample application namespace is restricted to
 // the local cluster. Sample application is installed. The test checks if DT_PROXY environment
-// variable is defined in the *dynakube-oneagent* container and the *application container*.
-func WithProxy(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy) features.Feature {
+// variable is defined in the *dynakubeComponents-oneagent* container and the *application container*.
+func WithProxy(t *testing.T, proxySpec *dynakube.DynaKubeProxy) features.Feature {
 	builder := features.New("codemodules injection with proxy")
 	builder.WithLabel("name", "codemodules-with-proxy")
 	secretConfigs := tenant.GetMultiTenantSecret(t)
 	require.Len(t, secretConfigs, 2)
 
-	cloudNativeDynakube := *dynakube.New(
-		dynakube.WithName("codemodules-with-proxy"),
-		dynakube.WithApiUrl(secretConfigs[0].ApiUrl),
-		dynakube.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
-		dynakube.WithActiveGate(),
-		dynakube.WithIstioIntegration(),
-		dynakube.WithProxy(proxySpec),
+	cloudNativeDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithName("codemodules-with-proxy"),
+		dynakubeComponents.WithApiUrl(secretConfigs[0].ApiUrl),
+		dynakubeComponents.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
+		dynakubeComponents.WithActiveGate(),
+		dynakubeComponents.WithIstioIntegration(),
+		dynakubeComponents.WithProxy(proxySpec),
 	)
 
 	sampleNamespace := *namespace.New("codemodules-sample-with-proxy", namespace.WithIstio())
@@ -161,8 +161,8 @@ func WithProxy(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy) features
 	proxy.CutOffDynatraceNamespace(builder, proxySpec)
 	proxy.IsDynatraceNamespaceCutOff(builder, cloudNativeDynakube)
 
-	// Register dynakube install
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfigs[0], cloudNativeDynakube)
+	// Register dynakubeComponents install
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfigs[0], cloudNativeDynakube)
 
 	// Register sample app install
 	builder.Assess("install sample app", sampleApp.Install())
@@ -179,30 +179,30 @@ func WithProxy(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy) features
 	cloudnative.AssessOneAgentContainer(builder, nil, nil)
 	cloudnative.AssessActiveGateContainer(builder, &cloudNativeDynakube, nil)
 
-	// Register sample, dynakube and operator uninstall
+	// Register sample, dynakubeComponents and operator uninstall
 	builder.Teardown(sampleApp.Uninstall())
-	dynakube.Delete(builder, helpers.LevelTeardown, cloudNativeDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, cloudNativeDynakube)
 
 	builder.WithTeardown("deleted tenant secret", tenant.DeleteTenantSecret(cloudNativeDynakube.Name, cloudNativeDynakube.Namespace))
 
 	return builder.Feature()
 }
 
-func WithProxyCA(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy) features.Feature {
+func WithProxyCA(t *testing.T, proxySpec *dynakube.DynaKubeProxy) features.Feature {
 	const configMapName = "proxy-ca"
 	builder := features.New("codemodules injection with proxy and custom CA")
 	builder.WithLabel("name", "codemodules-with-proxy-custom-ca")
 	secretConfigs := tenant.GetMultiTenantSecret(t)
 	require.Len(t, secretConfigs, 2)
 
-	cloudNativeDynakube := *dynakube.New(
-		dynakube.WithName("codemodules-with-proxy-custom-ca"),
-		dynakube.WithApiUrl(secretConfigs[0].ApiUrl),
-		dynakube.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
-		dynakube.WithCustomCAs(configMapName),
-		dynakube.WithActiveGate(),
-		dynakube.WithIstioIntegration(),
-		dynakube.WithProxy(proxySpec),
+	cloudNativeDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithName("codemodules-with-proxy-custom-ca"),
+		dynakubeComponents.WithApiUrl(secretConfigs[0].ApiUrl),
+		dynakubeComponents.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
+		dynakubeComponents.WithCustomCAs(configMapName),
+		dynakubeComponents.WithActiveGate(),
+		dynakubeComponents.WithIstioIntegration(),
+		dynakubeComponents.WithProxy(proxySpec),
 	)
 
 	sampleNamespace := *namespace.New("codemodules-sample-with-proxy-custom-ca", namespace.WithIstio())
@@ -216,7 +216,7 @@ func WithProxyCA(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy) featur
 	// Add customCA config map
 	trustedCa, _ := os.ReadFile(path.Join(project.TestDataDir(), proxyCertificate))
 	caConfigMap := configmap.New(configMapName, cloudNativeDynakube.Namespace,
-		map[string]string{dynatracev1beta2.TrustedCAKey: string(trustedCa)})
+		map[string]string{dynakube.TrustedCAKey: string(trustedCa)})
 	builder.Assess("create trusted CAs config map", configmap.Create(caConfigMap))
 
 	// Register proxy create and delete
@@ -224,8 +224,8 @@ func WithProxyCA(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy) featur
 	proxy.CutOffDynatraceNamespace(builder, proxySpec)
 	proxy.IsDynatraceNamespaceCutOff(builder, cloudNativeDynakube)
 
-	// Register dynakube install
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfigs[0], cloudNativeDynakube)
+	// Register dynakubeComponents install
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfigs[0], cloudNativeDynakube)
 
 	// Register sample app install
 	builder.Assess("install sample app", sampleApp.Install())
@@ -240,9 +240,9 @@ func WithProxyCA(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy) featur
 	cloudnative.AssessOneAgentContainer(builder, nil, trustedCa)
 	cloudnative.AssessActiveGateContainer(builder, &cloudNativeDynakube, trustedCa)
 
-	// Register sample, dynakube and operator uninstall
+	// Register sample, dynakubeComponents and operator uninstall
 	builder.Teardown(sampleApp.Uninstall())
-	dynakube.Delete(builder, helpers.LevelTeardown, cloudNativeDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, cloudNativeDynakube)
 
 	builder.WithTeardown("deleted tenant secret", tenant.DeleteTenantSecret(cloudNativeDynakube.Name, cloudNativeDynakube.Namespace))
 	builder.WithTeardown("deleted trusted CAs config map", configmap.Delete(caConfigMap))
@@ -250,20 +250,20 @@ func WithProxyCA(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy) featur
 	return builder.Feature()
 }
 
-func WithProxyAndAGCert(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy) features.Feature {
+func WithProxyAndAGCert(t *testing.T, proxySpec *dynakube.DynaKubeProxy) features.Feature {
 	builder := features.New("codemodules injection with proxy and AG certificate")
 	builder.WithLabel("name", "codemodules-with-proxy-and-ag-cert")
 	secretConfigs := tenant.GetMultiTenantSecret(t)
 	require.Len(t, secretConfigs, 2)
 
-	cloudNativeDynakube := *dynakube.New(
-		dynakube.WithName("codemodules-with-proxy-and-ag-cert"),
-		dynakube.WithApiUrl(secretConfigs[0].ApiUrl),
-		dynakube.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
-		dynakube.WithActiveGate(),
-		dynakube.WithActiveGateTlsSecret(agSecretName),
-		dynakube.WithIstioIntegration(),
-		dynakube.WithProxy(proxySpec),
+	cloudNativeDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithName("codemodules-with-proxy-and-ag-cert"),
+		dynakubeComponents.WithApiUrl(secretConfigs[0].ApiUrl),
+		dynakubeComponents.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
+		dynakubeComponents.WithActiveGate(),
+		dynakubeComponents.WithActiveGateTlsSecret(agSecretName),
+		dynakubeComponents.WithIstioIntegration(),
+		dynakubeComponents.WithProxy(proxySpec),
 	)
 
 	sampleNamespace := *namespace.New("codemodules-sample-with-proxy-custom-ca", namespace.WithIstio())
@@ -281,7 +281,7 @@ func WithProxyAndAGCert(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy)
 	agP12, _ := os.ReadFile(path.Join(project.TestDataDir(), agCertificateAndPrivateKey))
 	agSecret := secret.New(agSecretName, cloudNativeDynakube.Namespace,
 		map[string][]byte{
-			dynatracev1beta2.TlsCertKey:     agCrt,
+			dynakube.TlsCertKey:             agCrt,
 			agCertificateAndPrivateKeyField: agP12,
 		})
 	builder.Assess("create AG TLS secret", secret.Create(agSecret))
@@ -291,8 +291,8 @@ func WithProxyAndAGCert(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy)
 	proxy.CutOffDynatraceNamespace(builder, proxySpec)
 	proxy.IsDynatraceNamespaceCutOff(builder, cloudNativeDynakube)
 
-	// Register dynakube install
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfigs[0], cloudNativeDynakube)
+	// Register dynakubeComponents install
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfigs[0], cloudNativeDynakube)
 
 	// Register sample app install
 	builder.Assess("install sample app", sampleApp.Install())
@@ -307,30 +307,30 @@ func WithProxyAndAGCert(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy)
 	cloudnative.AssessOneAgentContainer(builder, agCrt, nil)
 	cloudnative.AssessActiveGateContainer(builder, &cloudNativeDynakube, nil)
 
-	// Register sample, dynakube and operator uninstall
+	// Register sample, dynakubeComponents and operator uninstall
 	builder.Teardown(sampleApp.Uninstall())
-	dynakube.Delete(builder, helpers.LevelTeardown, cloudNativeDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, cloudNativeDynakube)
 
 	builder.WithTeardown("deleted tenant secret", tenant.DeleteTenantSecret(cloudNativeDynakube.Name, cloudNativeDynakube.Namespace))
 
 	return builder.Feature()
 }
 
-func WithProxyCAAndAGCert(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProxy) features.Feature {
+func WithProxyCAAndAGCert(t *testing.T, proxySpec *dynakube.DynaKubeProxy) features.Feature {
 	builder := features.New("codemodules injection with proxy and custom CA and AG certificate")
 	builder.WithLabel("name", "codemodules-with-proxy-custom-ca-ag-cert")
 	secretConfigs := tenant.GetMultiTenantSecret(t)
 	require.Len(t, secretConfigs, 2)
 
-	cloudNativeDynakube := *dynakube.New(
-		dynakube.WithName("codemodules-with-proxy-custom-ca-ag-cert"),
-		dynakube.WithApiUrl(secretConfigs[0].ApiUrl),
-		dynakube.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
-		dynakube.WithCustomCAs(configMapName),
-		dynakube.WithActiveGate(),
-		dynakube.WithActiveGateTlsSecret(agSecretName),
-		dynakube.WithIstioIntegration(),
-		dynakube.WithProxy(proxySpec),
+	cloudNativeDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithName("codemodules-with-proxy-custom-ca-ag-cert"),
+		dynakubeComponents.WithApiUrl(secretConfigs[0].ApiUrl),
+		dynakubeComponents.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
+		dynakubeComponents.WithCustomCAs(configMapName),
+		dynakubeComponents.WithActiveGate(),
+		dynakubeComponents.WithActiveGateTlsSecret(agSecretName),
+		dynakubeComponents.WithIstioIntegration(),
+		dynakubeComponents.WithProxy(proxySpec),
 	)
 
 	sampleNamespace := *namespace.New("codemodules-sample-with-proxy-custom-ca", namespace.WithIstio())
@@ -348,7 +348,7 @@ func WithProxyCAAndAGCert(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProx
 	agP12, _ := os.ReadFile(path.Join(project.TestDataDir(), agCertificateAndPrivateKey))
 	agSecret := secret.New(agSecretName, cloudNativeDynakube.Namespace,
 		map[string][]byte{
-			dynatracev1beta2.TlsCertKey:     agCrt,
+			dynakube.TlsCertKey:             agCrt,
 			agCertificateAndPrivateKeyField: agP12,
 		})
 	builder.Assess("create AG TLS secret", secret.Create(agSecret))
@@ -356,7 +356,7 @@ func WithProxyCAAndAGCert(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProx
 	// Add customCA config map
 	trustedCa, _ := os.ReadFile(path.Join(project.TestDataDir(), proxyCertificate))
 	caConfigMap := configmap.New(configMapName, cloudNativeDynakube.Namespace,
-		map[string]string{dynatracev1beta2.TrustedCAKey: string(trustedCa)})
+		map[string]string{dynakube.TrustedCAKey: string(trustedCa)})
 	builder.Assess("create trusted CAs config map", configmap.Create(caConfigMap))
 
 	// Register proxy create and delete
@@ -364,8 +364,8 @@ func WithProxyCAAndAGCert(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProx
 	proxy.CutOffDynatraceNamespace(builder, proxySpec)
 	proxy.IsDynatraceNamespaceCutOff(builder, cloudNativeDynakube)
 
-	// Register dynakube install
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfigs[0], cloudNativeDynakube)
+	// Register dynakubeComponents install
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfigs[0], cloudNativeDynakube)
 
 	// Register sample app install
 	builder.Assess("install sample app", sampleApp.Install())
@@ -380,9 +380,9 @@ func WithProxyCAAndAGCert(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProx
 	cloudnative.AssessOneAgentContainer(builder, agCrt, trustedCa)
 	cloudnative.AssessActiveGateContainer(builder, &cloudNativeDynakube, trustedCa)
 
-	// Register sample, dynakube and operator uninstall
+	// Register sample, dynakubeComponents and operator uninstall
 	builder.Teardown(sampleApp.Uninstall())
-	dynakube.Delete(builder, helpers.LevelTeardown, cloudNativeDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, cloudNativeDynakube)
 
 	builder.WithTeardown("deleted tenant secret", tenant.DeleteTenantSecret(cloudNativeDynakube.Name, cloudNativeDynakube.Namespace))
 	builder.WithTeardown("deleted trusted CAs config map", configmap.Delete(caConfigMap))
@@ -390,19 +390,19 @@ func WithProxyCAAndAGCert(t *testing.T, proxySpec *dynatracev1beta2.DynaKubeProx
 	return builder.Feature()
 }
 
-func codeModulesCloudNativeSpec(t *testing.T) *dynatracev1beta2.CloudNativeFullStackSpec {
-	return &dynatracev1beta2.CloudNativeFullStackSpec{
+func codeModulesCloudNativeSpec(t *testing.T) *dynakube.CloudNativeFullStackSpec {
+	return &dynakube.CloudNativeFullStackSpec{
 		AppInjectionSpec: *codeModulesAppInjectSpec(t),
 	}
 }
 
-func codeModulesAppInjectSpec(t *testing.T) *dynatracev1beta2.AppInjectionSpec {
-	return &dynatracev1beta2.AppInjectionSpec{
+func codeModulesAppInjectSpec(t *testing.T) *dynakube.AppInjectionSpec {
+	return &dynakube.AppInjectionSpec{
 		CodeModulesImage: registry.GetLatestCodeModulesImageURI(t),
 	}
 }
 
-func imageHasBeenDownloaded(dynakube dynatracev1beta2.DynaKube) features.Func {
+func imageHasBeenDownloaded(dynakube dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resource := envConfig.Client().Resources()
 		clientset, err := kubernetes.NewForConfig(resource.GetConfig())
@@ -549,7 +549,7 @@ func isVolumeAttached(t *testing.T, volumes []corev1.Volume, volumeName string) 
 	return result
 }
 
-func checkOneAgentEnvVars(dynakube dynatracev1beta2.DynaKube) features.Func {
+func checkOneAgentEnvVars(dynakube dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 		err := daemonset.NewQuery(ctx, resources, client.ObjectKey{

--- a/test/features/cloudnative/container.go
+++ b/test/features/cloudnative/container.go
@@ -5,7 +5,7 @@ package cloudnative
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/activegate"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
@@ -75,11 +75,11 @@ func checkOneAgentContainer(agCrt []byte, trustedCAs []byte) features.Func {
 	}
 }
 
-func AssessActiveGateContainer(builder *features.FeatureBuilder, dynakube *dynatracev1beta2.DynaKube, trustedCAs []byte) {
+func AssessActiveGateContainer(builder *features.FeatureBuilder, dynakube *dynakube.DynaKube, trustedCAs []byte) {
 	builder.Assess("certificates are propagated to ActiveGate container", checkActiveGateContainer(dynakube, trustedCAs))
 }
 
-func checkActiveGateContainer(dynakube *dynatracev1beta2.DynaKube, trustedCAs []byte) features.Func {
+func checkActiveGateContainer(dynakube *dynakube.DynaKube, trustedCAs []byte) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 

--- a/test/features/cloudnative/container.go
+++ b/test/features/cloudnative/container.go
@@ -75,8 +75,8 @@ func checkOneAgentContainer(agCrt []byte, trustedCAs []byte) features.Func {
 	}
 }
 
-func AssessActiveGateContainer(builder *features.FeatureBuilder, dynakube *dynakube.DynaKube, trustedCAs []byte) {
-	builder.Assess("certificates are propagated to ActiveGate container", checkActiveGateContainer(dynakube, trustedCAs))
+func AssessActiveGateContainer(builder *features.FeatureBuilder, dk *dynakube.DynaKube, trustedCAs []byte) {
+	builder.Assess("certificates are propagated to ActiveGate container", checkActiveGateContainer(dk, trustedCAs))
 }
 
 func checkActiveGateContainer(dk *dynakube.DynaKube, trustedCAs []byte) features.Func {

--- a/test/features/cloudnative/container.go
+++ b/test/features/cloudnative/container.go
@@ -79,12 +79,12 @@ func AssessActiveGateContainer(builder *features.FeatureBuilder, dynakube *dynak
 	builder.Assess("certificates are propagated to ActiveGate container", checkActiveGateContainer(dynakube, trustedCAs))
 }
 
-func checkActiveGateContainer(dynakube *dynakube.DynaKube, trustedCAs []byte) features.Func {
+func checkActiveGateContainer(dk *dynakube.DynaKube, trustedCAs []byte) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 
 		var activeGatePod corev1.Pod
-		require.NoError(t, resources.WithNamespace(dynakube.Namespace).Get(ctx, activegate.GetActiveGatePodName(dynakube, "activegate"), dynakube.Namespace, &activeGatePod))
+		require.NoError(t, resources.WithNamespace(dk.Namespace).Get(ctx, activegate.GetActiveGatePodName(dk, "activegate"), dk.Namespace, &activeGatePod))
 
 		require.NotNil(t, activeGatePod.Spec)
 		require.NotEmpty(t, activeGatePod.Spec.Containers)

--- a/test/features/cloudnative/disabled_auto_injection/disabled_auto_injection.go
+++ b/test/features/cloudnative/disabled_auto_injection/disabled_auto_injection.go
@@ -5,10 +5,10 @@ package disabled_auto_injection
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
@@ -23,12 +23,12 @@ func Feature(t *testing.T) features.Feature {
 	builder.WithLabel("name", "cloudnative-disabled-auto-inject")
 
 	secretConfig := tenant.GetSingleTenantSecret(t)
-	testDynakube := *dynakube.New(
-		dynakube.WithAnnotations(map[string]string{
-			dynatracev1beta2.AnnotationFeatureAutomaticInjection: "false",
+	testDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithAnnotations(map[string]string{
+			dynakube.AnnotationFeatureAutomaticInjection: "false",
 		}),
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
-		dynakube.WithCloudNativeSpec(cloudnative.DefaultCloudNativeSpec()),
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
+		dynakubeComponents.WithCloudNativeSpec(cloudnative.DefaultCloudNativeSpec()),
 	)
 
 	// Register sample app install
@@ -40,7 +40,7 @@ func Feature(t *testing.T) features.Feature {
 	builder.Assess("create sample namespace", sampleApp.InstallNamespace())
 
 	// Register dynakube install
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
 
 	// Register sample app install
 	builder.Assess("install sample app", sampleApp.Install())
@@ -48,9 +48,9 @@ func Feature(t *testing.T) features.Feature {
 	// Register actual test
 	assessSampleInitContainersDisabled(builder, sampleApp)
 
-	// Register sample, dynakube and operator uninstall
+	// Register sample, dynakubeComponents and operator uninstall
 	builder.Teardown(sampleApp.Uninstall())
-	dynakube.Delete(builder, helpers.LevelTeardown, testDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, testDynakube)
 
 	return builder.Feature()
 }

--- a/test/features/cloudnative/init_containers.go
+++ b/test/features/cloudnative/init_containers.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/logs"
@@ -79,8 +79,8 @@ func checkInitContainers(sampleApp *sample.App) features.Func {
 	}
 }
 
-func DefaultCloudNativeSpec() *dynatracev1beta2.CloudNativeFullStackSpec {
-	return &dynatracev1beta2.CloudNativeFullStackSpec{
-		HostInjectSpec: dynatracev1beta2.HostInjectSpec{},
+func DefaultCloudNativeSpec() *dynakube.CloudNativeFullStackSpec {
+	return &dynakube.CloudNativeFullStackSpec{
+		HostInjectSpec: dynakube.HostInjectSpec{},
 	}
 }

--- a/test/features/cloudnative/network_zones/network_zones.go
+++ b/test/features/cloudnative/network_zones/network_zones.go
@@ -135,13 +135,13 @@ func checkInjectionAnnotations(sampleApp *sample.App, injected string, reason st
 	}
 }
 
-func checkOneAgentPodsDoNotStart(testDynakube dynakube.DynaKube, timeout time.Duration) features.Func {
+func checkOneAgentPodsDoNotStart(dk dynakube.DynaKube, timeout time.Duration) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 		err := wait.For(conditions.New(resources).ResourceMatch(&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      testDynakube.OneAgentDaemonsetName(),
-				Namespace: testDynakube.Namespace,
+				Name:      dk.OneAgentDaemonsetName(),
+				Namespace: dk.Namespace,
 			},
 		}, func(object k8s.Object) bool {
 			daemonset, isDaemonset := object.(*appsv1.DaemonSet)

--- a/test/features/cloudnative/network_zones/network_zones.go
+++ b/test/features/cloudnative/network_zones/network_zones.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynakubev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/activegate"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/rand"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
@@ -65,13 +65,13 @@ func Feature(t *testing.T) features.Feature {
 		tenant.WaitForNetworkZone(secretConfig, networkZone, tenant.FallbackNone))
 
 	// intentionally no ActiveGate, to block OA rollout and codemodules injection
-	options := []dynakube.Option{
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
-		dynakube.WithNetworkZone(networkZone),
-		dynakube.WithCloudNativeSpec(cloudnative.DefaultCloudNativeSpec()),
+	options := []dynakubeComponents.Option{
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
+		dynakubeComponents.WithNetworkZone(networkZone),
+		dynakubeComponents.WithCloudNativeSpec(cloudnative.DefaultCloudNativeSpec()),
 	}
 
-	testDynakube := *dynakube.New(options...)
+	testDynakube := *dynakubeComponents.New(options...)
 
 	// Register sample app install
 	sampleNamespace := *namespace.New("cloudnative-network-zone")
@@ -82,11 +82,11 @@ func Feature(t *testing.T) features.Feature {
 
 	builder.Assess("create sample namespace", sampleApp.InstallNamespace())
 
-	// Register dynakube install, do not wait for OneAgents to start up, because them not to is expected in this scenario
-	dynakube.Create(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+	// Register dynakubeComponents install, do not wait for OneAgents to start up, because them not to is expected in this scenario
+	dynakubeComponents.Create(builder, helpers.LevelAssess, &secretConfig, testDynakube)
 	builder.Assess(
-		fmt.Sprintf("'%s' dynakube phase changes to 'Running'", testDynakube.Name),
-		dynakube.WaitForPhase(testDynakube, status.Deploying))
+		fmt.Sprintf("'%s' dynakubeComponents phase changes to 'Running'", testDynakube.Name),
+		dynakubeComponents.WaitForPhase(testDynakube, status.Deploying))
 	builder.Assess("install sample app", sampleApp.Install())
 
 	// Register actual tests
@@ -94,17 +94,17 @@ func Feature(t *testing.T) features.Feature {
 	builder.Assess("make sure that OneAgent pods do not yet start up", checkOneAgentPodsDoNotStart(testDynakube, timeout))
 
 	// update DynaKube to start AG, which should than enable OA rollout
-	options = append(options, dynakube.WithActiveGate())
-	testDynaKubeWithAG := *dynakube.New(options...)
-	dynakube.Update(builder, helpers.LevelAssess, testDynaKubeWithAG)
-	dynakube.VerifyStartup(builder, helpers.LevelAssess, testDynaKubeWithAG)
+	options = append(options, dynakubeComponents.WithActiveGate())
+	testDynaKubeWithAG := *dynakubeComponents.New(options...)
+	dynakubeComponents.Update(builder, helpers.LevelAssess, testDynaKubeWithAG)
+	dynakubeComponents.VerifyStartup(builder, helpers.LevelAssess, testDynaKubeWithAG)
 
 	builder.Assess("Restart sample app pods", sampleApp.Restart())
 	builder.Assess("check injection annotations on sample app pods", checkInjectionAnnotations(sampleApp, "true", ""))
 
 	// Register sample, DynaKube and operator uninstall
 	builder.Teardown(sampleApp.Uninstall())
-	dynakube.Delete(builder, helpers.LevelTeardown, testDynakube)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, testDynakube)
 
 	builder.Teardown(activegate.WaitForStatefulSetPodsDeletion(&testDynakube, "activegate"))
 	builder.Teardown(tenant.WaitForNetworkZoneDeletion(secretConfig, networkZone))
@@ -135,7 +135,7 @@ func checkInjectionAnnotations(sampleApp *sample.App, injected string, reason st
 	}
 }
 
-func checkOneAgentPodsDoNotStart(testDynakube dynakubev1beta2.DynaKube, timeout time.Duration) features.Func {
+func checkOneAgentPodsDoNotStart(testDynakube dynakube.DynaKube, timeout time.Duration) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 		err := wait.For(conditions.New(resources).ResourceMatch(&appsv1.DaemonSet{

--- a/test/features/cloudnative/switch_modes/switch_modes.go
+++ b/test/features/cloudnative/switch_modes/switch_modes.go
@@ -5,10 +5,10 @@ package switch_modes
 import (
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/sample"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
 	"sigs.k8s.io/e2e-framework/pkg/features"
@@ -23,12 +23,12 @@ func Feature(t *testing.T) features.Feature {
 	builder := features.New("switch from cloudnative to classic")
 	builder.WithLabel("name", "cloudnative-to-classic")
 
-	// build cloud native full stack dynakube
+	// build cloud native full stack dynakubeComponents
 	secretConfig := tenant.GetSingleTenantSecret(t)
-	commonOptions := []dynakube.Option{
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
+	commonOptions := []dynakubeComponents.Option{
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
 	}
-	dynakubeCloudNative := *dynakube.New(append(commonOptions, dynakube.WithCloudNativeSpec(&dynatracev1beta2.CloudNativeFullStackSpec{}))...)
+	dynakubeCloudNative := *dynakubeComponents.New(append(commonOptions, dynakubeComponents.WithCloudNativeSpec(&dynakube.CloudNativeFullStackSpec{}))...)
 	sampleAppCloudNative := sample.NewApp(t, &dynakubeCloudNative,
 		sample.AsDeployment(),
 		sample.WithName(sampleAppsCloudNativeName),
@@ -36,8 +36,8 @@ func Feature(t *testing.T) features.Feature {
 	builder.Assess("(cloudnative) create sample app namespace", sampleAppCloudNative.InstallNamespace())
 	builder.Teardown(sampleAppCloudNative.Uninstall())
 
-	// install operator and dynakube
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, dynakubeCloudNative)
+	// install operator and dynakubeComponents
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, dynakubeCloudNative)
 
 	// apply sample apps
 	builder.Assess("(cloudnative) install sample app", sampleAppCloudNative.Install())
@@ -46,19 +46,19 @@ func Feature(t *testing.T) features.Feature {
 	cloudnative.AssessSampleInitContainers(builder, sampleAppCloudNative)
 
 	// switch to classic full stack
-	dynakubeClassicFullStack := *dynakube.New(append(commonOptions, dynakube.WithClassicFullstackSpec(&dynatracev1beta2.HostInjectSpec{}))...)
+	dynakubeClassicFullStack := *dynakubeComponents.New(append(commonOptions, dynakubeComponents.WithClassicFullstackSpec(&dynakube.HostInjectSpec{}))...)
 	sampleAppClassicFullStack := sample.NewApp(t, &dynakubeClassicFullStack,
 		sample.AsDeployment(),
 		sample.WithName(sampleAppsClassicName),
 	)
 
-	dynakube.Update(builder, helpers.LevelAssess, dynakubeClassicFullStack)
+	dynakubeComponents.Update(builder, helpers.LevelAssess, dynakubeClassicFullStack)
 
 	// deploy sample apps
 	builder.Assess("(classic) install sample app", sampleAppClassicFullStack.Install())
 	builder.Teardown(sampleAppClassicFullStack.Uninstall())
 	// tear down
-	dynakube.Delete(builder, helpers.LevelTeardown, dynakubeCloudNative)
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, dynakubeCloudNative)
 
 	return builder.Feature()
 }

--- a/test/features/edgeconnect/edgeconnect.go
+++ b/test/features/edgeconnect/edgeconnect.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	edgeconnectv1alpha "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
-	ecclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/edgeconnect"
+	edgeconnectClient "github.com/Dynatrace/dynatrace-operator/pkg/clients/edgeconnect"
 	controller "github.com/Dynatrace/dynatrace-operator/pkg/controllers/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/edgeconnect"
@@ -158,7 +158,7 @@ func createTenantConfig(clientSecret tenant.EdgeConnectSecret, edgeConnectTenant
 		ecClt, err := buildEcClient(ctx, clientSecret)
 		require.NoError(t, err)
 
-		edgeConnectRequest := ecclient.NewRequest(clientSecret.Name, []string{testHostPattern}, []edgeconnectv1alpha.HostMapping{}, "")
+		edgeConnectRequest := edgeconnectClient.NewRequest(clientSecret.Name, []string{testHostPattern}, []edgeconnectv1alpha.HostMapping{}, "")
 		edgeConnectRequest.ManagedByDynatraceOperator = false
 
 		res, err := ecClt.CreateEdgeConnect(edgeConnectRequest)
@@ -279,19 +279,19 @@ func checkSettingsNotExistsOnTheTenant(clientSecret tenant.EdgeConnectSecret, te
 
 		se, err := controller.GetConnectionSetting(ecClt, testEdgeConnect.Name, testEdgeConnect.Namespace, testEdgeConnect.Status.KubeSystemUID)
 		require.NoError(t, err)
-		assert.Equal(t, ecclient.EnvironmentSetting{}, se)
+		assert.Equal(t, edgeconnectClient.EnvironmentSetting{}, se)
 
 		return ctx
 	}
 }
 
-func buildEcClient(ctx context.Context, secret tenant.EdgeConnectSecret) (ecclient.Client, error) {
-	clt, err := ecclient.NewClient(
+func buildEcClient(ctx context.Context, secret tenant.EdgeConnectSecret) (edgeconnectClient.Client, error) {
+	clt, err := edgeconnectClient.NewClient(
 		secret.OauthClientId,
 		secret.OauthClientSecret,
-		ecclient.WithBaseURL("https://"+secret.ApiServer),
-		ecclient.WithTokenURL("https://sso-dev.dynatracelabs.com/sso/oauth2/token"),
-		ecclient.WithOauthScopes([]string{
+		edgeconnectClient.WithBaseURL("https://"+secret.ApiServer),
+		edgeconnectClient.WithTokenURL("https://sso-dev.dynatracelabs.com/sso/oauth2/token"),
+		edgeconnectClient.WithOauthScopes([]string{
 			"app-engine:edge-connects:read",
 			"app-engine:edge-connects:write",
 			"app-engine:edge-connects:delete",
@@ -299,7 +299,7 @@ func buildEcClient(ctx context.Context, secret tenant.EdgeConnectSecret) (ecclie
 			"settings:objects:read",
 			"settings:objects:write",
 		}),
-		ecclient.WithContext(ctx),
+		edgeconnectClient.WithContext(ctx),
 	)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/test/features/support_archive/files.go
+++ b/test/features/support_archive/files.go
@@ -31,8 +31,8 @@ type requiredFiles struct {
 	t              *testing.T
 	ctx            context.Context
 	resources      *resources.Resources
-	dynakube       dynakube.DynaKube
-	edgeconnect    edgeconnect.EdgeConnect
+	dk             dynakube.DynaKube
+	ec             edgeconnect.EdgeConnect
 	collectManaged bool
 }
 
@@ -41,8 +41,8 @@ func newRequiredFiles(t *testing.T, ctx context.Context, resources *resources.Re
 		t:              t,
 		ctx:            ctx,
 		resources:      resources,
-		dynakube:       customResources.dynakube,
-		edgeconnect:    customResources.edgeconnect,
+		dk:             customResources.dk,
+		ec:             customResources.ec,
 		collectManaged: collectManaged,
 	}
 }
@@ -70,7 +70,7 @@ func (r requiredFiles) collectRequiredFiles() []string {
 }
 
 func (r requiredFiles) getRequiredPodFiles(labelKey string, collectManaged bool) []string {
-	pods := pod.List(r.t, r.ctx, r.resources, r.dynakube.Namespace)
+	pods := pod.List(r.t, r.ctx, r.resources, r.dk.Namespace)
 	requiredFiles := make([]string, 0)
 
 	podList := functional.Filter(pods.Items, func(podItem corev1.Pod) bool {
@@ -97,7 +97,7 @@ func (r requiredFiles) getRequiredPodFiles(labelKey string, collectManaged bool)
 }
 
 func (r requiredFiles) getRequiredReplicaSetFiles() []string {
-	replicaSets := replicaset.List(r.t, r.ctx, r.resources, r.dynakube.Namespace)
+	replicaSets := replicaset.List(r.t, r.ctx, r.resources, r.dk.Namespace)
 	requiredFiles := make([]string, 0)
 	for _, replicaSet := range replicaSets.Items {
 		requiredFiles = append(requiredFiles,
@@ -112,7 +112,7 @@ func (r requiredFiles) getRequiredReplicaSetFiles() []string {
 
 func (r requiredFiles) getRequiredStatefulSetFiles() []string {
 	statefulSet, err := statefulset.NewQuery(r.ctx, r.resources, client.ObjectKey{
-		Namespace: r.dynakube.Namespace,
+		Namespace: r.dk.Namespace,
 		Name:      "dynakube-activegate"}).Get()
 	require.NoError(r.t, err)
 	requiredFiles := make([]string, 0)
@@ -126,7 +126,7 @@ func (r requiredFiles) getRequiredStatefulSetFiles() []string {
 }
 
 func (r requiredFiles) getRequiredDaemonSetFiles() []string {
-	oneagentDaemonSet, err := oneagent.Get(r.ctx, r.resources, r.dynakube)
+	oneagentDaemonSet, err := oneagent.Get(r.ctx, r.resources, r.dk)
 	require.NoError(r.t, err)
 	requiredFiles := make([]string, 0)
 	requiredFiles = append(requiredFiles,
@@ -140,7 +140,7 @@ func (r requiredFiles) getRequiredDaemonSetFiles() []string {
 }
 
 func (r requiredFiles) getRequiredServiceFiles() []string {
-	services := service.List(r.t, r.ctx, r.resources, r.dynakube.Namespace)
+	services := service.List(r.t, r.ctx, r.resources, r.dk.Namespace)
 	requiredFiles := make([]string, 0)
 	for _, requiredService := range services.Items {
 		requiredFiles = append(requiredFiles,
@@ -159,30 +159,30 @@ func (r requiredFiles) getRequiredWorkloadFiles() []string {
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.dynakube.Namespace,
+			r.dk.Namespace,
 			"deployment",
 			operator.DeploymentName,
 			support_archive.ManifestsFileExtension))
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.dynakube.Namespace,
+			r.dk.Namespace,
 			"deployment",
 			e2ewebhook.DeploymentName,
 			support_archive.ManifestsFileExtension))
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.dynakube.Namespace,
+			r.dk.Namespace,
 			"daemonset",
 			csi.DaemonSetName,
 			support_archive.ManifestsFileExtension))
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.edgeconnect.Namespace,
+			r.ec.Namespace,
 			"deployment",
-			r.edgeconnect.Name,
+			r.ec.Name,
 			support_archive.ManifestsFileExtension))
 
 	return requiredFiles
@@ -193,8 +193,8 @@ func (r requiredFiles) getRequiredNamespaceFiles() []string {
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/namespace-%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.dynakube.Namespace,
-			r.dynakube.Namespace,
+			r.dk.Namespace,
+			r.dk.Namespace,
 			support_archive.ManifestsFileExtension))
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/namespace-%s%s",
@@ -211,9 +211,9 @@ func (r requiredFiles) getRequiredDynaKubeFiles() []string {
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.dynakube.Namespace,
+			r.dk.Namespace,
 			"dynakube",
-			r.dynakube.Name,
+			r.dk.Name,
 			support_archive.ManifestsFileExtension))
 
 	return requiredFiles
@@ -224,9 +224,9 @@ func (r requiredFiles) getRequiredEdgeConnectFiles() []string {
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.edgeconnect.Namespace,
+			r.ec.Namespace,
 			"edgeconnect",
-			r.edgeconnect.Name,
+			r.ec.Name,
 			support_archive.ManifestsFileExtension))
 
 	return requiredFiles
@@ -276,7 +276,7 @@ func (r requiredFiles) getRequiredConfigMapFiles() []string {
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.dynakube.Namespace,
+			r.dk.Namespace,
 			"configmap",
 			"dynatrace-node-cache",
 			support_archive.ManifestsFileExtension))
@@ -284,7 +284,7 @@ func (r requiredFiles) getRequiredConfigMapFiles() []string {
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.dynakube.Namespace,
+			r.dk.Namespace,
 			"configmap",
 			"kube-root-ca.crt",
 			support_archive.ManifestsFileExtension))
@@ -292,27 +292,27 @@ func (r requiredFiles) getRequiredConfigMapFiles() []string {
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s-%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.dynakube.Namespace,
+			r.dk.Namespace,
 			"configmap",
-			r.dynakube.Name,
+			r.dk.Name,
 			"deployment-metadata",
 			support_archive.ManifestsFileExtension))
 
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s-%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.dynakube.Namespace,
+			r.dk.Namespace,
 			"configmap",
-			r.dynakube.Name,
+			r.dk.Name,
 			"oneagent-connection-info",
 			support_archive.ManifestsFileExtension))
 
 	requiredFiles = append(requiredFiles,
 		fmt.Sprintf("%s/%s/%s/%s-%s%s",
 			support_archive.ManifestsDirectoryName,
-			r.dynakube.Namespace,
+			r.dk.Namespace,
 			"configmap",
-			r.dynakube.Name,
+			r.dk.Name,
 			"activegate-connection-info",
 			support_archive.ManifestsFileExtension))
 

--- a/test/features/support_archive/files.go
+++ b/test/features/support_archive/files.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/cmd/support_archive"
-	edgeconnectv1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/functional"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/csi"
@@ -31,8 +31,8 @@ type requiredFiles struct {
 	t              *testing.T
 	ctx            context.Context
 	resources      *resources.Resources
-	dynakube       dynatracev1beta2.DynaKube
-	edgeconnect    edgeconnectv1beta1.EdgeConnect
+	dynakube       dynakube.DynaKube
+	edgeconnect    edgeconnect.EdgeConnect
 	collectManaged bool
 }
 

--- a/test/features/support_archive/support_archive.go
+++ b/test/features/support_archive/support_archive.go
@@ -33,8 +33,8 @@ const testAppNameNotInjected = "application1"
 const testAppNameInjected = "application2"
 
 type CustomResources struct {
-	dynakube    dynakube.DynaKube
-	edgeconnect edgeconnect.EdgeConnect
+	dk dynakube.DynaKube
+	ec edgeconnect.EdgeConnect
 }
 
 // Setup: DTO with CSI driver
@@ -102,8 +102,8 @@ func testSupportArchiveCommand(testDynakube dynakube.DynaKube, testEdgeConnect e
 		require.NoError(t, err)
 
 		customResources := CustomResources{
-			dynakube:    testDynakube,
-			edgeconnect: testEdgeConnect,
+			dk: testDynakube,
+			ec: testEdgeConnect,
 		}
 		requiredFiles := newRequiredFiles(t, ctx, envConfig.Client().Resources(), customResources, collectManaged).
 			collectRequiredFiles()

--- a/test/features/support_archive/support_archive.go
+++ b/test/features/support_archive/support_archive.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"testing"
 
-	edgeconnectv1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/functional"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/edgeconnect"
+	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	edgeconnectComponents "github.com/Dynatrace/dynatrace-operator/test/helpers/components/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/namespace"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
@@ -33,8 +33,8 @@ const testAppNameNotInjected = "application1"
 const testAppNameInjected = "application2"
 
 type CustomResources struct {
-	dynakube    dynatracev1beta2.DynaKube
-	edgeconnect edgeconnectv1beta1.EdgeConnect
+	dynakube    dynakube.DynaKube
+	edgeconnect edgeconnect.EdgeConnect
 }
 
 // Setup: DTO with CSI driver
@@ -52,28 +52,28 @@ func Feature(t *testing.T) features.Feature {
 		"inject": "me",
 	}
 
-	testDynakube := *dynakube.New(
-		dynakube.WithOneAgentNamespaceSelector(metav1.LabelSelector{
+	testDynakube := *dynakubeComponents.New(
+		dynakubeComponents.WithOneAgentNamespaceSelector(metav1.LabelSelector{
 			MatchLabels: injectLabels,
 		}),
-		dynakube.WithApiUrl(secretConfig.ApiUrl),
-		dynakube.WithCloudNativeSpec(&dynatracev1beta2.CloudNativeFullStackSpec{}),
-		dynakube.WithActiveGate(),
+		dynakubeComponents.WithApiUrl(secretConfig.ApiUrl),
+		dynakubeComponents.WithCloudNativeSpec(&dynakube.CloudNativeFullStackSpec{}),
+		dynakubeComponents.WithActiveGate(),
 	)
 
-	testEdgeConnect := *edgeconnect.New(
+	testEdgeConnect := *edgeconnectComponents.New(
 		// this name should match with tenant edge connect name
-		edgeconnect.WithName(edgeconnectSecretConfig.Name),
-		edgeconnect.WithApiServer(edgeconnectSecretConfig.ApiServer),
-		edgeconnect.WithOAuthClientSecret(fmt.Sprintf("%s-client-secret", edgeconnectSecretConfig.Name)),
-		edgeconnect.WithOAuthEndpoint("https://sso-dev.dynatracelabs.com/sso/oauth2/token"),
-		edgeconnect.WithOAuthResource(fmt.Sprintf("urn:dtenvironment:%s", edgeconnectSecretConfig.TenantUid)),
+		edgeconnectComponents.WithName(edgeconnectSecretConfig.Name),
+		edgeconnectComponents.WithApiServer(edgeconnectSecretConfig.ApiServer),
+		edgeconnectComponents.WithOAuthClientSecret(fmt.Sprintf("%s-client-secret", edgeconnectSecretConfig.Name)),
+		edgeconnectComponents.WithOAuthEndpoint("https://sso-dev.dynatracelabs.com/sso/oauth2/token"),
+		edgeconnectComponents.WithOAuthResource(fmt.Sprintf("urn:dtenvironment:%s", edgeconnectSecretConfig.TenantUid)),
 	)
 
 	builder.Assess("deploy injected namespace", namespace.Create(*namespace.New(testAppNameInjected, namespace.WithLabels(injectLabels))))
 	builder.Assess("deploy NOT injected namespace", namespace.Create(*namespace.New(testAppNameNotInjected)))
-	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
-	edgeconnect.Install(builder, helpers.LevelAssess, &edgeconnectSecretConfig, testEdgeConnect)
+	dynakubeComponents.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+	edgeconnectComponents.Install(builder, helpers.LevelAssess, &edgeconnectSecretConfig, testEdgeConnect)
 
 	// Register actual test
 	builder.Assess("support archive subcommand can be executed correctly with managed logs", testSupportArchiveCommand(testDynakube, testEdgeConnect, true))
@@ -81,13 +81,13 @@ func Feature(t *testing.T) features.Feature {
 
 	builder.WithTeardown("remove injected namespace", namespace.Delete(testAppNameInjected))
 	builder.WithTeardown("remove NOT injected namespace", namespace.Delete(testAppNameNotInjected))
-	dynakube.Delete(builder, helpers.LevelTeardown, testDynakube)
-	builder.WithTeardown("remove edgeconnect CR", edgeconnect.Delete(testEdgeConnect))
+	dynakubeComponents.Delete(builder, helpers.LevelTeardown, testDynakube)
+	builder.WithTeardown("remove edgeconnect CR", edgeconnectComponents.Delete(testEdgeConnect))
 
 	return builder.Feature()
 }
 
-func testSupportArchiveCommand(testDynakube dynatracev1beta2.DynaKube, testEdgeConnect edgeconnectv1beta1.EdgeConnect, collectManaged bool) features.Func {
+func testSupportArchiveCommand(testDynakube dynakube.DynaKube, testEdgeConnect edgeconnect.EdgeConnect, collectManaged bool) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		commandLineArguments := []string{"--stdout"}
 		if !collectManaged {

--- a/test/helpers/components/activegate/installation.go
+++ b/test/helpers/components/activegate/installation.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/statefulset"
@@ -19,29 +19,29 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-func WaitForStatefulSet(testDynakube *dynatracev1beta2.DynaKube, component string) features.Func {
-	return statefulset.WaitFor(GetActiveGateStateFulSetName(testDynakube, component), testDynakube.Namespace)
+func WaitForStatefulSet(dk *dynakube.DynaKube, component string) features.Func {
+	return statefulset.WaitFor(GetActiveGateStateFulSetName(dk, component), dk.Namespace)
 }
 
-func GetActiveGateStateFulSetName(testDynakube *dynatracev1beta2.DynaKube, component string) string {
-	return fmt.Sprintf("%s-%s", testDynakube.Name, component)
+func GetActiveGateStateFulSetName(dk *dynakube.DynaKube, component string) string {
+	return fmt.Sprintf("%s-%s", dk.Name, component)
 }
 
-func GetActiveGatePodName(testDynakube *dynatracev1beta2.DynaKube, component string) string {
-	return fmt.Sprintf("%s-0", GetActiveGateStateFulSetName(testDynakube, component))
+func GetActiveGatePodName(dk *dynakube.DynaKube, component string) string {
+	return fmt.Sprintf("%s-0", GetActiveGateStateFulSetName(dk, component))
 }
 
-func ReadActiveGateLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, testDynakube *dynatracev1beta2.DynaKube, component string) string {
-	return logs.ReadLog(ctx, t, envConfig, testDynakube.Namespace, GetActiveGatePodName(testDynakube, component), consts.ActiveGateContainerName)
+func ReadActiveGateLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, dk *dynakube.DynaKube, component string) string {
+	return logs.ReadLog(ctx, t, envConfig, dk.Namespace, GetActiveGatePodName(dk, component), consts.ActiveGateContainerName)
 }
 
-func Get(ctx context.Context, resource *resources.Resources, dynakube dynatracev1beta2.DynaKube) (appsv1.StatefulSet, error) {
+func Get(ctx context.Context, resource *resources.Resources, dk dynakube.DynaKube) (appsv1.StatefulSet, error) {
 	return statefulset.NewQuery(ctx, resource, client.ObjectKey{
-		Name:      GetActiveGateStateFulSetName(&dynakube, "activegate"),
-		Namespace: dynakube.Namespace,
+		Name:      GetActiveGateStateFulSetName(&dk, "activegate"),
+		Namespace: dk.Namespace,
 	}).Get()
 }
 
-func WaitForStatefulSetPodsDeletion(testDynakube *dynatracev1beta2.DynaKube, component string) features.Func {
-	return pod.WaitForPodsDeletionWithOwner(GetActiveGateStateFulSetName(testDynakube, component), testDynakube.Namespace)
+func WaitForStatefulSetPodsDeletion(dk *dynakube.DynaKube, component string) features.Func {
+	return pod.WaitForPodsDeletionWithOwner(GetActiveGateStateFulSetName(dk, component), dk.Namespace)
 }

--- a/test/helpers/components/codemodules/codemodules.go
+++ b/test/helpers/components/codemodules/codemodules.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/csi"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
@@ -24,11 +24,11 @@ const (
 	RuxitAgentProcFile = "ruxitagentproc.conf"
 )
 
-func CheckRuxitAgentProcFileHasNoConnInfo(testDynakube dynatracev1beta2.DynaKube) features.Func {
+func CheckRuxitAgentProcFileHasNoConnInfo(testDynakube dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, e *envconf.Config) context.Context {
 		resources := e.Client().Resources()
 
-		var dk dynatracev1beta2.DynaKube
+		var dk dynakube.DynaKube
 		require.NoError(t, e.Client().Resources().Get(ctx, testDynakube.Name, testDynakube.Namespace, &dk))
 
 		err := daemonset.NewQuery(ctx, resources, client.ObjectKey{

--- a/test/helpers/components/dynakube/dynakube.go
+++ b/test/helpers/components/dynakube/dynakube.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1"
 	dynakubev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2"
 	dynakubev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
@@ -129,7 +129,7 @@ func WaitForPhasePreviousVersion(dynakube dynakubev1beta1.DynaKube, phase status
 
 func create(dynakube dynakubev1beta2.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		require.NoError(t, dynatracev1beta2.AddToScheme(envConfig.Client().Resources().GetScheme()))
+		require.NoError(t, v1beta2.AddToScheme(envConfig.Client().Resources().GetScheme()))
 		require.NoError(t, envConfig.Client().Resources().Create(ctx, &dynakube))
 
 		return ctx
@@ -138,7 +138,7 @@ func create(dynakube dynakubev1beta2.DynaKube) features.Func {
 
 func createPreviousVersion(dynakube dynakubev1beta1.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		require.NoError(t, dynatracev1beta1.AddToScheme(envConfig.Client().Resources().GetScheme()))
+		require.NoError(t, v1beta1.AddToScheme(envConfig.Client().Resources().GetScheme()))
 		require.NoError(t, envConfig.Client().Resources().Create(ctx, &dynakube))
 
 		return ctx
@@ -147,7 +147,7 @@ func createPreviousVersion(dynakube dynakubev1beta1.DynaKube) features.Func {
 
 func update(dynakube dynakubev1beta2.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		require.NoError(t, dynatracev1beta2.AddToScheme(envConfig.Client().Resources().GetScheme()))
+		require.NoError(t, v1beta2.AddToScheme(envConfig.Client().Resources().GetScheme()))
 		var dk dynakubev1beta2.DynaKube
 		require.NoError(t, envConfig.Client().Resources().Get(ctx, dynakube.Name, dynakube.Namespace, &dk))
 		dynakube.ResourceVersion = dk.ResourceVersion
@@ -161,7 +161,7 @@ func remove(dynakube dynakubev1beta2.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 
-		err := dynatracev1beta2.AddToScheme(resources.GetScheme())
+		err := v1beta2.AddToScheme(resources.GetScheme())
 		require.NoError(t, err)
 
 		err = resources.Delete(ctx, &dynakube)

--- a/test/helpers/components/dynakube/options.go
+++ b/test/helpers/components/dynakube/options.go
@@ -3,168 +3,168 @@
 package dynakube
 
 import (
-	dynakubev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type Option func(dynakube *dynakubev1beta2.DynaKube)
+type Option func(dk *dynakube.DynaKube)
 
-func New(opts ...Option) *dynakubev1beta2.DynaKube {
-	dynakube := &dynakubev1beta2.DynaKube{
+func New(opts ...Option) *dynakube.DynaKube {
+	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        defaultName,
 			Namespace:   operator.DefaultNamespace,
 			Annotations: map[string]string{},
 		},
-		Spec: dynakubev1beta2.DynaKubeSpec{},
+		Spec: dynakube.DynaKubeSpec{},
 	}
 	for _, opt := range opts {
-		opt(dynakube)
+		opt(dk)
 	}
 
-	return dynakube
+	return dk
 }
 
 func WithName(name string) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Name = name
+	return func(dk *dynakube.DynaKube) {
+		dk.Name = name
 	}
 }
 
 func WithCustomPullSecret(secretName string) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.CustomPullSecret = secretName
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.CustomPullSecret = secretName
 	}
 }
 
 func WithCustomCAs(configMapName string) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.TrustedCAs = configMapName
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.TrustedCAs = configMapName
 	}
 }
 
 func WithAnnotations(annotations map[string]string) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
+	return func(dk *dynakube.DynaKube) {
 		for key, value := range annotations {
-			dynakube.ObjectMeta.Annotations[key] = value
+			dk.ObjectMeta.Annotations[key] = value
 		}
 	}
 }
 
 func WithApiUrl(apiUrl string) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.APIURL = apiUrl
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.APIURL = apiUrl
 	}
 }
 
 func WithActiveGate() Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.ActiveGate = dynakubev1beta2.ActiveGateSpec{
-			Capabilities: []dynakubev1beta2.CapabilityDisplayName{
-				dynakubev1beta2.KubeMonCapability.DisplayName,
-				dynakubev1beta2.DynatraceApiCapability.DisplayName,
-				dynakubev1beta2.RoutingCapability.DisplayName,
-				dynakubev1beta2.MetricsIngestCapability.DisplayName,
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.ActiveGate = dynakube.ActiveGateSpec{
+			Capabilities: []dynakube.CapabilityDisplayName{
+				dynakube.KubeMonCapability.DisplayName,
+				dynakube.DynatraceApiCapability.DisplayName,
+				dynakube.RoutingCapability.DisplayName,
+				dynakube.MetricsIngestCapability.DisplayName,
 			},
 		}
 	}
 }
 
 func WithMetadataEnrichment() Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.MetadataEnrichment.Enabled = true
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.MetadataEnrichment.Enabled = true
 	}
 }
 
 func WithActiveGateTlsSecret(tlsSecretName string) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.ActiveGate.TlsSecretName = tlsSecretName
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.ActiveGate.TlsSecretName = tlsSecretName
 	}
 }
 
 func WithCustomActiveGateImage(imageURI string) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.ActiveGate.Image = imageURI
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.ActiveGate.Image = imageURI
 	}
 }
 
 func WithNameBasedOneAgentNamespaceSelector() Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
+	return func(dk *dynakube.DynaKube) {
 		namespaceSelector := metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"oa-inject": dynakube.Name,
+				"oa-inject": dk.Name,
 			},
 		}
 		switch {
-		case dynakube.CloudNativeFullstackMode():
-			dynakube.Spec.OneAgent.CloudNativeFullStack.NamespaceSelector = namespaceSelector
-		case dynakube.ApplicationMonitoringMode():
-			dynakube.Spec.OneAgent.ApplicationMonitoring.NamespaceSelector = namespaceSelector
+		case dk.CloudNativeFullstackMode():
+			dk.Spec.OneAgent.CloudNativeFullStack.NamespaceSelector = namespaceSelector
+		case dk.ApplicationMonitoringMode():
+			dk.Spec.OneAgent.ApplicationMonitoring.NamespaceSelector = namespaceSelector
 		}
 	}
 }
 
 func WithNameBasedMetadataEnrichmentNamespaceSelector() Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
+	return func(dk *dynakube.DynaKube) {
 		namespaceSelector := metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"me-inject": dynakube.Name,
+				"me-inject": dk.Name,
 			},
 		}
-		dynakube.Spec.MetadataEnrichment.NamespaceSelector = namespaceSelector
+		dk.Spec.MetadataEnrichment.NamespaceSelector = namespaceSelector
 	}
 }
 
 func WithOneAgentNamespaceSelector(selector metav1.LabelSelector) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
+	return func(dk *dynakube.DynaKube) {
 		switch {
-		case dynakube.CloudNativeFullstackMode():
-			dynakube.Spec.OneAgent.CloudNativeFullStack.NamespaceSelector = selector
-		case dynakube.ApplicationMonitoringMode():
-			dynakube.Spec.OneAgent.ApplicationMonitoring.NamespaceSelector = selector
+		case dk.CloudNativeFullstackMode():
+			dk.Spec.OneAgent.CloudNativeFullStack.NamespaceSelector = selector
+		case dk.ApplicationMonitoringMode():
+			dk.Spec.OneAgent.ApplicationMonitoring.NamespaceSelector = selector
 		}
 	}
 }
 
 func WithMetadataEnrichmentNamespaceSelector(selector metav1.LabelSelector) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.MetadataEnrichment.NamespaceSelector = selector
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.MetadataEnrichment.NamespaceSelector = selector
 	}
 }
 
-func WithProxy(proxy *dynakubev1beta2.DynaKubeProxy) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.Proxy = proxy
+func WithProxy(proxy *dynakube.DynaKubeProxy) Option {
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.Proxy = proxy
 	}
 }
 
 func WithIstioIntegration() Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.EnableIstio = true
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.EnableIstio = true
 	}
 }
 
-func WithClassicFullstackSpec(classicFullStackSpec *dynakubev1beta2.HostInjectSpec) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.OneAgent.ClassicFullStack = classicFullStackSpec
+func WithClassicFullstackSpec(classicFullStackSpec *dynakube.HostInjectSpec) Option {
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.OneAgent.ClassicFullStack = classicFullStackSpec
 	}
 }
 
-func WithCloudNativeSpec(cloudNativeFullStackSpec *dynakubev1beta2.CloudNativeFullStackSpec) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.OneAgent.CloudNativeFullStack = cloudNativeFullStackSpec
+func WithCloudNativeSpec(cloudNativeFullStackSpec *dynakube.CloudNativeFullStackSpec) Option {
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.OneAgent.CloudNativeFullStack = cloudNativeFullStackSpec
 	}
 }
 
-func WithApplicationMonitoringSpec(applicationMonitoringSpec *dynakubev1beta2.ApplicationMonitoringSpec) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.OneAgent.ApplicationMonitoring = applicationMonitoringSpec
+func WithApplicationMonitoringSpec(applicationMonitoringSpec *dynakube.ApplicationMonitoringSpec) Option {
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.OneAgent.ApplicationMonitoring = applicationMonitoringSpec
 	}
 }
 
 func WithNetworkZone(networkZone string) Option {
-	return func(dynakube *dynakubev1beta2.DynaKube) {
-		dynakube.Spec.NetworkZone = networkZone
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.NetworkZone = networkZone
 	}
 }

--- a/test/helpers/components/edgeconnect/edgeconnect.go
+++ b/test/helpers/components/edgeconnect/edgeconnect.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
 	"github.com/stretchr/testify/require"
@@ -42,17 +42,17 @@ func VerifyStartup(builder *features.FeatureBuilder, level features.Level, testE
 
 func Create(edgeConnect edgeconnect.EdgeConnect) features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		require.NoError(t, dynatracev1alpha1.AddToScheme(environmentConfig.Client().Resources().GetScheme()))
+		require.NoError(t, v1alpha1.AddToScheme(environmentConfig.Client().Resources().GetScheme()))
 		require.NoError(t, environmentConfig.Client().Resources().Create(ctx, &edgeConnect))
 
 		return ctx
 	}
 }
 
-func Get(edgeConnect *edgeconnect.EdgeConnect) features.Func {
+func Get(ec *edgeconnect.EdgeConnect) features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		require.NoError(t, dynatracev1alpha1.AddToScheme(environmentConfig.Client().Resources().GetScheme()))
-		require.NoError(t, environmentConfig.Client().Resources().Get(ctx, edgeConnect.Name, edgeConnect.Namespace, edgeConnect))
+		require.NoError(t, v1alpha1.AddToScheme(environmentConfig.Client().Resources().GetScheme()))
+		require.NoError(t, environmentConfig.Client().Resources().Get(ctx, ec.Name, ec.Namespace, ec))
 
 		return ctx
 	}
@@ -62,7 +62,7 @@ func Delete(edgeConnect edgeconnect.EdgeConnect) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 
-		err := dynatracev1alpha1.AddToScheme(resources.GetScheme())
+		err := v1alpha1.AddToScheme(resources.GetScheme())
 		require.NoError(t, err)
 
 		err = resources.Delete(ctx, &edgeConnect)

--- a/test/helpers/components/edgeconnect/edgeconnect.go
+++ b/test/helpers/components/edgeconnect/edgeconnect.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-func Install(builder *features.FeatureBuilder, level features.Level, secretConfig *tenant.EdgeConnectSecret, testEdgeConnect edgeconnectv1alpha1.EdgeConnect) {
+func Install(builder *features.FeatureBuilder, level features.Level, secretConfig *tenant.EdgeConnectSecret, testEdgeConnect edgeconnect.EdgeConnect) {
 	if secretConfig != nil {
 		builder.WithStep("create edgeconnect client secret", level, tenant.CreateClientSecret(*secretConfig, fmt.Sprintf("%s-client-secret", testEdgeConnect.Name), testEdgeConnect.Namespace))
 	}
@@ -33,14 +33,14 @@ func Install(builder *features.FeatureBuilder, level features.Level, secretConfi
 	VerifyStartup(builder, level, testEdgeConnect)
 }
 
-func VerifyStartup(builder *features.FeatureBuilder, level features.Level, testEdgeConnect edgeconnectv1alpha1.EdgeConnect) {
+func VerifyStartup(builder *features.FeatureBuilder, level features.Level, testEdgeConnect edgeconnect.EdgeConnect) {
 	builder.WithStep(
 		fmt.Sprintf("'%s' edgeconnect phase changes to 'Running'", testEdgeConnect.Name),
 		level,
 		WaitForPhase(testEdgeConnect, status.Running))
 }
 
-func Create(edgeConnect edgeconnectv1alpha1.EdgeConnect) features.Func {
+func Create(edgeConnect edgeconnect.EdgeConnect) features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
 		require.NoError(t, dynatracev1alpha1.AddToScheme(environmentConfig.Client().Resources().GetScheme()))
 		require.NoError(t, environmentConfig.Client().Resources().Create(ctx, &edgeConnect))
@@ -49,7 +49,7 @@ func Create(edgeConnect edgeconnectv1alpha1.EdgeConnect) features.Func {
 	}
 }
 
-func Get(edgeConnect *edgeconnectv1alpha1.EdgeConnect) features.Func {
+func Get(edgeConnect *edgeconnect.EdgeConnect) features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
 		require.NoError(t, dynatracev1alpha1.AddToScheme(environmentConfig.Client().Resources().GetScheme()))
 		require.NoError(t, environmentConfig.Client().Resources().Get(ctx, edgeConnect.Name, edgeConnect.Namespace, edgeConnect))
@@ -58,7 +58,7 @@ func Get(edgeConnect *edgeconnectv1alpha1.EdgeConnect) features.Func {
 	}
 }
 
-func Delete(edgeConnect edgeconnectv1alpha1.EdgeConnect) features.Func {
+func Delete(edgeConnect edgeconnect.EdgeConnect) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 
@@ -83,12 +83,12 @@ func Delete(edgeConnect edgeconnectv1alpha1.EdgeConnect) features.Func {
 	}
 }
 
-func WaitForPhase(edgeConnect edgeconnectv1alpha1.EdgeConnect, phase status.DeploymentPhase) features.Func {
+func WaitForPhase(edgeConnect edgeconnect.EdgeConnect, phase status.DeploymentPhase) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 
 		err := wait.For(conditions.New(resources).ResourceMatch(&edgeConnect, func(object k8s.Object) bool {
-			ec, isEdgeConnect := object.(*edgeconnectv1alpha1.EdgeConnect)
+			ec, isEdgeConnect := object.(*edgeconnect.EdgeConnect)
 
 			return isEdgeConnect && ec.Status.DeploymentPhase == phase
 		}), wait.WithTimeout(5*time.Minute))

--- a/test/helpers/components/edgeconnect/options.go
+++ b/test/helpers/components/edgeconnect/options.go
@@ -3,7 +3,7 @@
 package edgeconnect
 
 import (
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -12,79 +12,79 @@ const (
 	defaultNamespace = "dynatrace"
 )
 
-type Option func(edgeconnect *edgeconnectv1alpha1.EdgeConnect)
+type Option func(ec *edgeconnect.EdgeConnect)
 
-func New(opts ...Option) *edgeconnectv1alpha1.EdgeConnect {
-	edgeconnect := &edgeconnectv1alpha1.EdgeConnect{
+func New(opts ...Option) *edgeconnect.EdgeConnect {
+	ec := &edgeconnect.EdgeConnect{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      defaultName,
 			Namespace: defaultNamespace,
 		},
-		Spec:   edgeconnectv1alpha1.EdgeConnectSpec{},
-		Status: edgeconnectv1alpha1.EdgeConnectStatus{},
+		Spec:   edgeconnect.EdgeConnectSpec{},
+		Status: edgeconnect.EdgeConnectStatus{},
 	}
 	for _, opt := range opts {
-		opt(edgeconnect)
+		opt(ec)
 	}
 
-	return edgeconnect
+	return ec
 }
 
 func WithName(name string) Option {
-	return func(edgeconnect *edgeconnectv1alpha1.EdgeConnect) {
-		edgeconnect.ObjectMeta.Name = name
+	return func(ec *edgeconnect.EdgeConnect) {
+		ec.ObjectMeta.Name = name
 	}
 }
 
 func WithApiServer(apiURL string) Option {
-	return func(edgeconnect *edgeconnectv1alpha1.EdgeConnect) {
-		edgeconnect.Spec.ApiServer = apiURL
+	return func(ec *edgeconnect.EdgeConnect) {
+		ec.Spec.ApiServer = apiURL
 	}
 }
 
 func WithOAuthClientSecret(clientSecretName string) Option {
-	return func(edgeconnect *edgeconnectv1alpha1.EdgeConnect) {
-		edgeconnect.Spec.OAuth.ClientSecret = clientSecretName
+	return func(ec *edgeconnect.EdgeConnect) {
+		ec.Spec.OAuth.ClientSecret = clientSecretName
 	}
 }
 
 func WithOAuthResource(resource string) Option {
-	return func(edgeconnect *edgeconnectv1alpha1.EdgeConnect) {
-		edgeconnect.Spec.OAuth.Resource = resource
+	return func(ec *edgeconnect.EdgeConnect) {
+		ec.Spec.OAuth.Resource = resource
 	}
 }
 
 func WithOAuthEndpoint(endpoint string) Option {
-	return func(edgeconnect *edgeconnectv1alpha1.EdgeConnect) {
-		edgeconnect.Spec.OAuth.Endpoint = endpoint
+	return func(ec *edgeconnect.EdgeConnect) {
+		ec.Spec.OAuth.Endpoint = endpoint
 	}
 }
 
 func WithProvisionerMode(enabled bool) Option {
-	return func(edgeconnect *edgeconnectv1alpha1.EdgeConnect) {
+	return func(edgeconnect *edgeconnect.EdgeConnect) {
 		edgeconnect.Spec.OAuth.Provisioner = enabled
 	}
 }
 
 func WithK8SAutomationMode(enabled bool) Option {
-	return func(edgeconnect *edgeconnectv1alpha1.EdgeConnect) {
-		edgeconnect.Spec.KubernetesAutomation = &edgeconnectv1alpha1.KubernetesAutomationSpec{
+	return func(ec *edgeconnect.EdgeConnect) {
+		ec.Spec.KubernetesAutomation = &edgeconnect.KubernetesAutomationSpec{
 			Enabled: enabled,
 		}
 	}
 }
 
 func WithHostPattern(hostPattern string) Option {
-	return func(edgeconnect *edgeconnectv1alpha1.EdgeConnect) {
-		if edgeconnect.Spec.HostPatterns == nil {
-			edgeconnect.Spec.HostPatterns = make([]string, 0)
+	return func(ec *edgeconnect.EdgeConnect) {
+		if ec.Spec.HostPatterns == nil {
+			ec.Spec.HostPatterns = make([]string, 0)
 		}
-		edgeconnect.Spec.HostPatterns = append(edgeconnect.Spec.HostPatterns, hostPattern)
+		ec.Spec.HostPatterns = append(ec.Spec.HostPatterns, hostPattern)
 	}
 }
 
 func WithServiceAccount(serviceAccountName string) Option {
-	return func(edgeconnect *edgeconnectv1alpha1.EdgeConnect) {
-		edgeconnect.Spec.ServiceAccountName = serviceAccountName
+	return func(ec *edgeconnect.EdgeConnect) {
+		ec.Spec.ServiceAccountName = serviceAccountName
 	}
 }

--- a/test/helpers/components/edgeconnect/options.go
+++ b/test/helpers/components/edgeconnect/options.go
@@ -61,8 +61,8 @@ func WithOAuthEndpoint(endpoint string) Option {
 }
 
 func WithProvisionerMode(enabled bool) Option {
-	return func(edgeconnect *edgeconnect.EdgeConnect) {
-		edgeconnect.Spec.OAuth.Provisioner = enabled
+	return func(ec *edgeconnect.EdgeConnect) {
+		ec.Spec.OAuth.Provisioner = enabled
 	}
 }
 

--- a/test/helpers/components/oneagent/daemonset.go
+++ b/test/helpers/components/oneagent/daemonset.go
@@ -5,8 +5,8 @@ package oneagent
 import (
 	"context"
 
-	dynatracev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	dynakubev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	dynakubev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/pod"
@@ -16,19 +16,19 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-func WaitForDaemonset(dynakube dynatracev1beta2.DynaKube) features.Func {
+func WaitForDaemonset(dynakube dynakubev1beta2.DynaKube) features.Func {
 	return helpers.ToFeatureFunc(daemonset.WaitFor(dynakube.OneAgentDaemonsetName(), dynakube.Namespace), true)
 }
 
-func WaitForDaemonsetV1Beta1(dynakube dynatracev1beta1.DynaKube) features.Func {
+func WaitForDaemonsetV1Beta1(dynakube dynakubev1beta1.DynaKube) features.Func {
 	return helpers.ToFeatureFunc(daemonset.WaitFor(dynakube.OneAgentDaemonsetName(), dynakube.Namespace), true)
 }
 
-func WaitForDaemonSetPodsDeletion(dynakube dynatracev1beta2.DynaKube) features.Func {
+func WaitForDaemonSetPodsDeletion(dynakube dynakubev1beta2.DynaKube) features.Func {
 	return pod.WaitForPodsDeletionWithOwner(dynakube.OneAgentDaemonsetName(), dynakube.Namespace)
 }
 
-func Get(ctx context.Context, resource *resources.Resources, dynakube dynatracev1beta2.DynaKube) (appsv1.DaemonSet, error) {
+func Get(ctx context.Context, resource *resources.Resources, dynakube dynakubev1beta2.DynaKube) (appsv1.DaemonSet, error) {
 	return daemonset.NewQuery(ctx, resource, client.ObjectKey{
 		Name:      dynakube.OneAgentDaemonsetName(),
 		Namespace: dynakube.Namespace,

--- a/test/helpers/components/oneagent/daemonset.go
+++ b/test/helpers/components/oneagent/daemonset.go
@@ -16,21 +16,21 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-func WaitForDaemonset(dynakube dynakubev1beta2.DynaKube) features.Func {
-	return helpers.ToFeatureFunc(daemonset.WaitFor(dynakube.OneAgentDaemonsetName(), dynakube.Namespace), true)
+func WaitForDaemonset(dk dynakubev1beta2.DynaKube) features.Func {
+	return helpers.ToFeatureFunc(daemonset.WaitFor(dk.OneAgentDaemonsetName(), dk.Namespace), true)
 }
 
-func WaitForDaemonsetV1Beta1(dynakube dynakubev1beta1.DynaKube) features.Func {
-	return helpers.ToFeatureFunc(daemonset.WaitFor(dynakube.OneAgentDaemonsetName(), dynakube.Namespace), true)
+func WaitForDaemonsetV1Beta1(dk dynakubev1beta1.DynaKube) features.Func {
+	return helpers.ToFeatureFunc(daemonset.WaitFor(dk.OneAgentDaemonsetName(), dk.Namespace), true)
 }
 
-func WaitForDaemonSetPodsDeletion(dynakube dynakubev1beta2.DynaKube) features.Func {
-	return pod.WaitForPodsDeletionWithOwner(dynakube.OneAgentDaemonsetName(), dynakube.Namespace)
+func WaitForDaemonSetPodsDeletion(dk dynakubev1beta2.DynaKube) features.Func {
+	return pod.WaitForPodsDeletionWithOwner(dk.OneAgentDaemonsetName(), dk.Namespace)
 }
 
-func Get(ctx context.Context, resource *resources.Resources, dynakube dynakubev1beta2.DynaKube) (appsv1.DaemonSet, error) {
+func Get(ctx context.Context, resource *resources.Resources, dk dynakubev1beta2.DynaKube) (appsv1.DaemonSet, error) {
 	return daemonset.NewQuery(ctx, resource, client.ObjectKey{
-		Name:      dynakube.OneAgentDaemonsetName(),
-		Namespace: dynakube.Namespace,
+		Name:      dk.OneAgentDaemonsetName(),
+		Namespace: dk.Namespace,
 	}).Get()
 }

--- a/test/helpers/components/oneagent/uninstall.go
+++ b/test/helpers/components/oneagent/uninstall.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/manifests"
@@ -30,14 +30,14 @@ var (
 	uninstallOneAgentDaemonSetPath = path.Join(project.TestDataDir(), "oneagent/uninstall-oneagent.yaml")
 )
 
-func RunClassicUninstall(builder *features.FeatureBuilder, level features.Level, testDynakube dynatracev1beta2.DynaKube) {
+func RunClassicUninstall(builder *features.FeatureBuilder, level features.Level, testDynakube dynakube.DynaKube) {
 	builder.WithStep("clean up OneAgent files from nodes", level, createUninstallDaemonSet(testDynakube))
 	builder.WithStep("wait for daemonset", level, waitForUninstallDaemonset(testDynakube.Namespace))
 	builder.WithStep("OneAgent files removed from nodes", level, executeUninstall(testDynakube.Namespace))
 	builder.WithStep("clean up removed", level, removeUninstallDaemonset(testDynakube.Namespace))
 }
 
-func createUninstallDaemonSet(dynakube dynatracev1beta2.DynaKube) features.Func {
+func createUninstallDaemonSet(dynakube dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		uninstallDaemonSet := manifests.ObjectFromFile[*appsv1.DaemonSet](t, uninstallOneAgentDaemonSetPath)
 		uninstallDaemonSet.Namespace = dynakube.Namespace

--- a/test/helpers/components/oneagent/uninstall.go
+++ b/test/helpers/components/oneagent/uninstall.go
@@ -37,11 +37,11 @@ func RunClassicUninstall(builder *features.FeatureBuilder, level features.Level,
 	builder.WithStep("clean up removed", level, removeUninstallDaemonset(testDynakube.Namespace))
 }
 
-func createUninstallDaemonSet(dynakube dynakube.DynaKube) features.Func {
+func createUninstallDaemonSet(dk dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		uninstallDaemonSet := manifests.ObjectFromFile[*appsv1.DaemonSet](t, uninstallOneAgentDaemonSetPath)
-		uninstallDaemonSet.Namespace = dynakube.Namespace
-		uninstallDaemonSet.Spec.Template.Spec.Tolerations = dynakube.Spec.OneAgent.ClassicFullStack.Tolerations
+		uninstallDaemonSet.Namespace = dk.Namespace
+		uninstallDaemonSet.Spec.Template.Spec.Tolerations = dk.Spec.OneAgent.ClassicFullStack.Tolerations
 		resource := envConfig.Client().Resources()
 		require.NoError(t, resource.Create(ctx, uninstallDaemonSet))
 

--- a/test/helpers/curl/curl.go
+++ b/test/helpers/curl/curl.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,7 +84,7 @@ func WithReadinessProbe(probe *corev1.Probe) Option {
 	}
 }
 
-func WithProxy(dynakube dynatracev1beta2.DynaKube) Option {
+func WithProxy(dynakube dynakube.DynaKube) Option {
 	return func(curlPod *corev1.Pod) {
 		if dynakube.HasProxy() {
 			proxyEnv := corev1.EnvVar{

--- a/test/helpers/curl/curl.go
+++ b/test/helpers/curl/curl.go
@@ -84,12 +84,12 @@ func WithReadinessProbe(probe *corev1.Probe) Option {
 	}
 }
 
-func WithProxy(dynakube dynakube.DynaKube) Option {
+func WithProxy(dk dynakube.DynaKube) Option {
 	return func(curlPod *corev1.Pod) {
-		if dynakube.HasProxy() {
+		if dk.HasProxy() {
 			proxyEnv := corev1.EnvVar{
 				Name:  "https_proxy",
-				Value: dynakube.Spec.Proxy.Value,
+				Value: dk.Spec.Proxy.Value,
 			}
 			curlPod.Spec.Containers[0].Env = append(curlPod.Spec.Containers[0].Env, proxyEnv)
 		}

--- a/test/helpers/istio/install.go
+++ b/test/helpers/istio/install.go
@@ -134,16 +134,16 @@ func determineIstioInitContainerName(t *testing.T) string {
 	return istioInitName
 }
 
-func checkVirtualServiceForApiUrl(dynakube dynakube.DynaKube) features.Func { //nolint: dupl
+func checkVirtualServiceForApiUrl(dk dynakube.DynaKube) features.Func { //nolint: dupl
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		apiHost := apiUrlCommunicationHost(t, dynakube)
-		serviceName := istio.BuildNameForFQDNServiceEntry(dynakube.Name, istio.OperatorComponent)
+		apiHost := apiUrlCommunicationHost(t, dk)
+		serviceName := istio.BuildNameForFQDNServiceEntry(dk.Name, istio.OperatorComponent)
 
-		virtualService, err := istioClient(t, envConfig.Client().RESTConfig()).NetworkingV1beta1().VirtualServices(dynakube.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		virtualService, err := istioClient(t, envConfig.Client().RESTConfig()).NetworkingV1beta1().VirtualServices(dk.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
 		require.NoError(t, err, "istio: failed to get '%s' virtual service object", serviceName)
 
 		require.NotEmpty(t, virtualService.ObjectMeta.OwnerReferences)
-		assert.Equal(t, dynakube.Name, virtualService.ObjectMeta.OwnerReferences[0].Name)
+		assert.Equal(t, dk.Name, virtualService.ObjectMeta.OwnerReferences[0].Name)
 
 		require.NotEmpty(t, virtualService.Spec.GetHosts())
 		assert.Equal(t, apiHost.Host, virtualService.Spec.GetHosts()[0])
@@ -152,16 +152,16 @@ func checkVirtualServiceForApiUrl(dynakube dynakube.DynaKube) features.Func { //
 	}
 }
 
-func checkServiceEntryForApiUrl(dynakube dynakube.DynaKube) features.Func { //nolint: dupl
+func checkServiceEntryForApiUrl(dk dynakube.DynaKube) features.Func { //nolint: dupl
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		apiHost := apiUrlCommunicationHost(t, dynakube)
-		serviceName := istio.BuildNameForFQDNServiceEntry(dynakube.Name, istio.OperatorComponent)
+		apiHost := apiUrlCommunicationHost(t, dk)
+		serviceName := istio.BuildNameForFQDNServiceEntry(dk.Name, istio.OperatorComponent)
 
-		serviceEntry, err := istioClient(t, envConfig.Client().RESTConfig()).NetworkingV1beta1().ServiceEntries(dynakube.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		serviceEntry, err := istioClient(t, envConfig.Client().RESTConfig()).NetworkingV1beta1().ServiceEntries(dk.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
 		require.NoError(t, err, "istio: failed to get '%s' service entry object", serviceName)
 
 		require.NotEmpty(t, serviceEntry.ObjectMeta.OwnerReferences)
-		assert.Equal(t, dynakube.Name, serviceEntry.ObjectMeta.OwnerReferences[0].Name)
+		assert.Equal(t, dk.Name, serviceEntry.ObjectMeta.OwnerReferences[0].Name)
 
 		require.NotEmpty(t, serviceEntry.Spec.GetHosts())
 		assert.Equal(t, apiHost.Host, serviceEntry.Spec.GetHosts()[0])
@@ -177,8 +177,8 @@ func istioClient(t *testing.T, restConfig *rest.Config) *istioclientset.Clientse
 	return client
 }
 
-func apiUrlCommunicationHost(t *testing.T, dynakube dynakube.DynaKube) dtclient.CommunicationHost {
-	apiHost, err := dtclient.ParseEndpoint(dynakube.ApiUrl())
+func apiUrlCommunicationHost(t *testing.T, dk dynakube.DynaKube) dtclient.CommunicationHost {
+	apiHost, err := dtclient.ParseEndpoint(dk.ApiUrl())
 	require.NoError(t, err)
 
 	return apiHost

--- a/test/helpers/istio/install.go
+++ b/test/helpers/istio/install.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/platform"
@@ -64,14 +64,14 @@ func AssertIstiodDeployment() func(ctx context.Context, envConfig *envconf.Confi
 	}
 }
 
-func AssessIstio(builder *features.FeatureBuilder, testDynakube dynatracev1beta2.DynaKube, sampleApp sample.App) {
+func AssessIstio(builder *features.FeatureBuilder, testDynakube dynakube.DynaKube, sampleApp sample.App) {
 	builder.Assess("sample apps have working istio init container", checkSampleAppIstioInitContainers(sampleApp, testDynakube))
 	builder.Assess("operator pods have working istio init container", checkOperatorIstioInitContainers(testDynakube))
 	builder.Assess("istio virtual service for ApiUrl created", checkVirtualServiceForApiUrl(testDynakube))
 	builder.Assess("istio service entry for ApiUrl created", checkServiceEntryForApiUrl(testDynakube))
 }
 
-func checkSampleAppIstioInitContainers(sampleApp sample.App, testDynakube dynatracev1beta2.DynaKube) features.Func {
+func checkSampleAppIstioInitContainers(sampleApp sample.App, testDynakube dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 		pods := sampleApp.GetPods(ctx, t, resources)
@@ -81,7 +81,7 @@ func checkSampleAppIstioInitContainers(sampleApp sample.App, testDynakube dynatr
 	}
 }
 
-func checkOperatorIstioInitContainers(testDynakube dynatracev1beta2.DynaKube) features.Func {
+func checkOperatorIstioInitContainers(testDynakube dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 		var pods corev1.PodList
@@ -93,7 +93,7 @@ func checkOperatorIstioInitContainers(testDynakube dynatracev1beta2.DynaKube) fe
 	}
 }
 
-func assertIstioInitContainer(t *testing.T, pods corev1.PodList, testDynakube dynatracev1beta2.DynaKube) {
+func assertIstioInitContainer(t *testing.T, pods corev1.PodList, testDynakube dynakube.DynaKube) {
 	istioInitName := determineIstioInitContainerName(t)
 
 	for _, podItem := range pods.Items {
@@ -134,7 +134,7 @@ func determineIstioInitContainerName(t *testing.T) string {
 	return istioInitName
 }
 
-func checkVirtualServiceForApiUrl(dynakube dynatracev1beta2.DynaKube) features.Func { //nolint: dupl
+func checkVirtualServiceForApiUrl(dynakube dynakube.DynaKube) features.Func { //nolint: dupl
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		apiHost := apiUrlCommunicationHost(t, dynakube)
 		serviceName := istio.BuildNameForFQDNServiceEntry(dynakube.Name, istio.OperatorComponent)
@@ -152,7 +152,7 @@ func checkVirtualServiceForApiUrl(dynakube dynatracev1beta2.DynaKube) features.F
 	}
 }
 
-func checkServiceEntryForApiUrl(dynakube dynatracev1beta2.DynaKube) features.Func { //nolint: dupl
+func checkServiceEntryForApiUrl(dynakube dynakube.DynaKube) features.Func { //nolint: dupl
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		apiHost := apiUrlCommunicationHost(t, dynakube)
 		serviceName := istio.BuildNameForFQDNServiceEntry(dynakube.Name, istio.OperatorComponent)
@@ -177,7 +177,7 @@ func istioClient(t *testing.T, restConfig *rest.Config) *istioclientset.Clientse
 	return client
 }
 
-func apiUrlCommunicationHost(t *testing.T, dynakube dynatracev1beta2.DynaKube) dtclient.CommunicationHost {
+func apiUrlCommunicationHost(t *testing.T, dynakube dynakube.DynaKube) dtclient.CommunicationHost {
 	apiHost, err := dtclient.ParseEndpoint(dynakube.ApiUrl())
 	require.NoError(t, err)
 

--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -137,6 +137,6 @@ func CheckRuxitAgentProcFileHasProxySetting(sampleApp sample.App, proxySpec *dyn
 	}
 }
 
-func getWebhookServiceUrl(dynakube dynakube.DynaKube) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", webhook.DeploymentName, dynakube.Namespace)
+func getWebhookServiceUrl(dk dynakube.DynaKube) string {
+	return fmt.Sprintf("%s.%s.svc.cluster.local", webhook.DeploymentName, dk.Namespace)
 }

--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	dynatracev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/common"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	oamutation "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/oneagent"
@@ -48,15 +48,15 @@ var (
 	proxyWithCustomCADeploymentPath = path.Join(project.TestDataDir(), "network/proxy-ssl.yaml")
 	proxySCCPath                    = path.Join(project.TestDataDir(), "network/proxy-scc.yaml")
 
-	ProxySpec = &dynatracev1beta2.DynaKubeProxy{
+	ProxySpec = &dynakube.DynaKubeProxy{
 		Value: "http://squid.proxy.svc.cluster.local:3128",
 	}
-	HttpsProxySpec = &dynatracev1beta2.DynaKubeProxy{
+	HttpsProxySpec = &dynakube.DynaKubeProxy{
 		Value: "https://squid.proxy.svc.cluster.local:3128",
 	}
 )
 
-func SetupProxyWithTeardown(t *testing.T, builder *features.FeatureBuilder, testDynakube dynatracev1beta2.DynaKube) {
+func SetupProxyWithTeardown(t *testing.T, builder *features.FeatureBuilder, testDynakube dynakube.DynaKube) {
 	if testDynakube.Spec.Proxy != nil {
 		installProxySCC(builder, t)
 		builder.Assess("install proxy", helpers.ToFeatureFunc(manifests.InstallFromFile(proxyDeploymentPath), true))
@@ -66,7 +66,7 @@ func SetupProxyWithTeardown(t *testing.T, builder *features.FeatureBuilder, test
 	}
 }
 
-func SetupProxyWithCustomCAandTeardown(t *testing.T, builder *features.FeatureBuilder, testDynakube dynatracev1beta2.DynaKube) {
+func SetupProxyWithCustomCAandTeardown(t *testing.T, builder *features.FeatureBuilder, testDynakube dynakube.DynaKube) {
 	if testDynakube.Spec.Proxy != nil {
 		installProxySCC(builder, t)
 		builder.Assess("install proxy", helpers.ToFeatureFunc(manifests.InstallFromFile(proxyWithCustomCADeploymentPath), true))
@@ -96,14 +96,14 @@ func checkProxyReady() features.Func {
 	}
 }
 
-func CutOffDynatraceNamespace(builder *features.FeatureBuilder, proxySpec *dynatracev1beta2.DynaKubeProxy) {
+func CutOffDynatraceNamespace(builder *features.FeatureBuilder, proxySpec *dynakube.DynaKubeProxy) {
 	if proxySpec != nil {
 		builder.Assess("cut off dynatrace namespace", helpers.ToFeatureFunc(manifests.InstallFromFile(dynatraceNetworkPolicy), true))
 		builder.Teardown(helpers.ToFeatureFunc(manifests.UninstallFromFile(dynatraceNetworkPolicy), false))
 	}
 }
 
-func IsDynatraceNamespaceCutOff(builder *features.FeatureBuilder, testDynakube dynatracev1beta2.DynaKube) {
+func IsDynatraceNamespaceCutOff(builder *features.FeatureBuilder, testDynakube dynakube.DynaKube) {
 	if testDynakube.HasProxy() {
 		isNetworkTrafficCutOff(builder, "ingress", curlPodNameDynatraceInboundTraffic, proxyNamespaceName, getWebhookServiceUrl(testDynakube))
 		isNetworkTrafficCutOff(builder, "egress", curlPodNameDynatraceOutboundTraffic, testDynakube.Namespace, internetUrl)
@@ -116,7 +116,7 @@ func isNetworkTrafficCutOff(builder *features.FeatureBuilder, directionName, pod
 	builder.Teardown(curl.DeleteCutOffCurlPod(podName, podNamespaceName, targetUrl))
 }
 
-func CheckRuxitAgentProcFileHasProxySetting(sampleApp sample.App, proxySpec *dynatracev1beta2.DynaKubeProxy) features.Func {
+func CheckRuxitAgentProcFileHasProxySetting(sampleApp sample.App, proxySpec *dynakube.DynaKubeProxy) features.Func {
 	return func(ctx context.Context, t *testing.T, e *envconf.Config) context.Context {
 		resources := e.Client().Resources()
 
@@ -137,6 +137,6 @@ func CheckRuxitAgentProcFileHasProxySetting(sampleApp sample.App, proxySpec *dyn
 	}
 }
 
-func getWebhookServiceUrl(dynakube dynatracev1beta2.DynaKube) string {
+func getWebhookServiceUrl(dynakube dynakube.DynaKube) string {
 	return fmt.Sprintf("%s.%s.svc.cluster.local", webhook.DeploymentName, dynakube.Namespace)
 }


### PR DESCRIPTION
## Description

This PR implements groundwork for a consistent way of importing the API-packages of our CRs in a way that if we bump the version, there will be a minimal amount of changes necessary.

## How can this be tested?

make go/test
run some basic e2e tests to install dynakube/edgeconnect.