### PR TITLE
Fix ondemand E2E slack message

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -81,6 +81,6 @@ jobs:
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           channel-id: 'int-cp-operator'
-          slack-message: ":x: E2E ondemand tests failed on ${{ github.event.inputs.target }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          slack-message: ":x: E2E ondemand tests failed on ${{ github.event.inputs.target || 'main' }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Description

Default mode (main branch) prints an empty branch value. This fixes it.

![image](https://github.com/user-attachments/assets/564d3810-c8ff-492b-bcea-5862ff92c907)

## How can this be tested?

There is no need; it's exactly the same in the working workflow `e2e-tests.yaml`.