### PR TITLE
Instrument the CSI Server with OTel Traces

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -87,6 +87,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -137,6 +142,11 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
           {{- if .Values.csidriver.maxUnmountedVolumeAge }}
           - name: MAX_UNMOUNTED_VOLUME_AGE
             value: "{{ .Values.csidriver.maxUnmountedVolumeAge}}"

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -87,11 +87,6 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -142,11 +137,6 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.name
           {{- if .Values.csidriver.maxUnmountedVolumeAge }}
           - name: MAX_UNMOUNTED_VOLUME_AGE
             value: "{{ .Values.csidriver.maxUnmountedVolumeAge}}"

--- a/doc/otel.md
+++ b/doc/otel.md
@@ -24,7 +24,7 @@ metadata:
   name: dynatrace-operator-otel-config
   namespace: dynatrace
 data:
-  endpoint: base64(<uuid>.dev.dyntracelabs.com)
+  endpoint: base64(<uuid>.dev.dynatracelabs.com)
   apiToken: base64(<apiToken>)
 EOF
 ```

--- a/pkg/controllers/csi/driver/server.go
+++ b/pkg/controllers/csi/driver/server.go
@@ -147,7 +147,7 @@ func (svr *Server) GetPluginCapabilities(context.Context, *csi.GetPluginCapabili
 }
 
 func (svr *Server) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	volumeCfg, err := csivolumes.ParseNodePublishVolumeRequest(req)
@@ -176,7 +176,7 @@ func (svr *Server) NodePublishVolume(ctx context.Context, req *csi.NodePublishVo
 }
 
 func (svr *Server) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (response *csi.NodeUnpublishVolumeResponse, err error) {
-	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	volumeInfo, err := csivolumes.ParseNodeUnpublishVolumeRequest(req)

--- a/pkg/controllers/csi/driver/volumes/app/publisher.go
+++ b/pkg/controllers/csi/driver/volumes/app/publisher.go
@@ -57,7 +57,7 @@ type AppVolumePublisher struct {
 }
 
 func (publisher *AppVolumePublisher) PublishVolume(ctx context.Context, volumeCfg csivolumes.VolumeConfig) (*csi.NodePublishVolumeResponse, error) {
-	_, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	_, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	tenantConfig, err := publisher.db.ReadTenantConfig(metadata.TenantConfig{Name: volumeCfg.DynakubeName})
@@ -97,7 +97,7 @@ func IsArchiveAvailable(tenantConfig *metadata.TenantConfig) bool {
 }
 
 func (publisher *AppVolumePublisher) UnpublishVolume(ctx context.Context, volumeInfo csivolumes.VolumeInfo) (*csi.NodeUnpublishVolumeResponse, error) {
-	_, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	_, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	appMount, err := publisher.db.ReadAppMount(metadata.AppMount{VolumeMetaID: volumeInfo.VolumeID})
@@ -139,7 +139,7 @@ func (publisher *AppVolumePublisher) UnpublishVolume(ctx context.Context, volume
 }
 
 func (publisher *AppVolumePublisher) CanUnpublishVolume(ctx context.Context, volumeInfo csivolumes.VolumeInfo) (bool, error) {
-	_, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	_, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	appMount, err := publisher.db.ReadAppMount(metadata.AppMount{VolumeMetaID: volumeInfo.VolumeID})

--- a/pkg/controllers/csi/driver/volumes/host/publisher.go
+++ b/pkg/controllers/csi/driver/volumes/host/publisher.go
@@ -59,7 +59,7 @@ type HostVolumePublisher struct {
 }
 
 func (publisher *HostVolumePublisher) PublishVolume(ctx context.Context, volumeCfg csivolumes.VolumeConfig) (*csi.NodePublishVolumeResponse, error) {
-	_, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	_, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	tenantConfig, err := publisher.db.ReadTenantConfig(metadata.TenantConfig{Name: volumeCfg.DynakubeName})
@@ -127,7 +127,7 @@ func (publisher *HostVolumePublisher) PublishVolume(ctx context.Context, volumeC
 }
 
 func (publisher *HostVolumePublisher) UnpublishVolume(ctx context.Context, volumeInfo csivolumes.VolumeInfo) (*csi.NodeUnpublishVolumeResponse, error) {
-	_, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	_, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	osMount, err := publisher.db.ReadOSMount(metadata.OSMount{VolumeMetaID: volumeInfo.VolumeID})
@@ -159,7 +159,7 @@ func (publisher *HostVolumePublisher) UnpublishVolume(ctx context.Context, volum
 }
 
 func (publisher *HostVolumePublisher) CanUnpublishVolume(ctx context.Context, volumeInfo csivolumes.VolumeInfo) (bool, error) {
-	_, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	_, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	volume, err := publisher.db.ReadOSMount(metadata.OSMount{VolumeMetaID: volumeInfo.VolumeID})

--- a/pkg/controllers/csi/internal/otel/config.go
+++ b/pkg/controllers/csi/internal/otel/config.go
@@ -1,8 +1,6 @@
 package otel
 
 import (
-	"sync"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
@@ -13,25 +11,10 @@ const (
 	CsiPodNameKey            = "k8s.pod.name"
 )
 
-var tracer trace.Tracer
-var meter metric.Meter
+var Meter metric.Meter
+var Tracer trace.Tracer
 
-var once = sync.Once{}
-
-func Meter() metric.Meter {
-	once.Do(func() {
-		tracer = otel.Tracer(otelInstrumentationScope)
-		meter = otel.Meter(otelInstrumentationScope)
-	})
-
-	return meter
-}
-
-func Tracer() trace.Tracer {
-	once.Do(func() {
-		tracer = otel.Tracer(otelInstrumentationScope)
-		meter = otel.Meter(otelInstrumentationScope)
-	})
-
-	return tracer
+func init() {
+	Tracer = otel.Tracer(otelInstrumentationScope)
+	Meter = otel.Meter(otelInstrumentationScope)
 }

--- a/pkg/controllers/csi/internal/otel/otel.go
+++ b/pkg/controllers/csi/internal/otel/otel.go
@@ -2,28 +2,22 @@ package otel
 
 import (
 	"os"
-	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
 var envPodName string
-var oncePodName = sync.Once{}
 
-func GetCSIPodName() string {
-	oncePodName.Do(func() {
-		envPodName = os.Getenv("POD_NAME")
-	})
-
-	return envPodName
+func init() {
+	envPodName = os.Getenv("POD_NAME")
 }
 
 func SpanOptions(opts ...trace.SpanStartOption) []trace.SpanStartOption {
 	options := make([]trace.SpanStartOption, 0)
 	options = append(options, opts...)
 	options = append(options, trace.WithAttributes(
-		attribute.String(CsiPodNameKey, GetCSIPodName())))
+		attribute.String(CsiPodNameKey, envPodName)))
 
 	return options
 }

--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -90,7 +90,7 @@ func (provisioner *OneAgentProvisioner) SetupWithManager(mgr ctrl.Manager) error
 func (provisioner *OneAgentProvisioner) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log.Info("reconciling DynaKube", "namespace", request.Namespace, "dynakube", request.Name)
 
-	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	dk, err := provisioner.needsReconcile(ctx, request)
@@ -216,7 +216,7 @@ func (provisioner *OneAgentProvisioner) setupTenantConfig(dk *dynakube.DynaKube)
 }
 
 func (provisioner *OneAgentProvisioner) collectGarbage(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	result, err := provisioner.gc.Reconcile(ctx, request)
@@ -259,7 +259,7 @@ func (provisioner *OneAgentProvisioner) updateAgentInstallation(
 	requeue bool,
 	err error,
 ) {
-	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	latestProcessModuleConfig, err := processmoduleconfigsecret.GetSecretData(ctx, provisioner.apiReader, dk.Name, dk.Namespace)
@@ -334,7 +334,7 @@ func buildDtc(provisioner *OneAgentProvisioner, ctx context.Context, dk *dynakub
 }
 
 func (provisioner *OneAgentProvisioner) getDynaKube(ctx context.Context, name types.NamespacedName) (*dynakube.DynaKube, error) {
-	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	var dk dynakube.DynaKube

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -62,7 +62,7 @@ func (provisioner *OneAgentProvisioner) installAgentImage(
 		return "", err
 	}
 
-	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	err = provisioner.installAgent(ctx, imageInstaller, dk, targetDir, targetImage, tenantUUID)
@@ -108,7 +108,7 @@ func (provisioner *OneAgentProvisioner) installAgentZip(ctx context.Context, dk 
 		return targetVersion, nil
 	}
 
-	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer(), csiotel.SpanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, csiotel.Tracer, csiotel.SpanOptions()...)
 	defer span.End()
 
 	err = provisioner.installAgent(ctx, urlInstaller, dk, targetDir, targetVersion, tenantUUID)

--- a/pkg/injection/internal/otel/otel.go
+++ b/pkg/injection/internal/otel/otel.go
@@ -1,8 +1,6 @@
 package otel
 
 import (
-	"sync"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -11,14 +9,8 @@ const (
 	otelInstrumentationScope = "injection"
 )
 
-var tracer trace.Tracer
+var Tracer trace.Tracer
 
-var once = sync.Once{}
-
-func Tracer() trace.Tracer {
-	once.Do(func() {
-		tracer = otel.Tracer(otelInstrumentationScope)
-	})
-
-	return tracer
+func init() {
+	Tracer = otel.Tracer(otelInstrumentationScope)
 }

--- a/pkg/injection/namespace/mapper/namespaces.go
+++ b/pkg/injection/namespace/mapper/namespaces.go
@@ -26,7 +26,7 @@ func NewNamespaceMapper(clt client.Client, apiReader client.Reader, operatorNs s
 
 // MapFromNamespace adds the labels to the targetNs if there is a matching Dynakube
 func (nm NamespaceMapper) MapFromNamespace(ctx context.Context) (bool, error) {
-	ctx, span := dtotel.StartSpan(ctx, injectionotel.Tracer())
+	ctx, span := dtotel.StartSpan(ctx, injectionotel.Tracer)
 	defer span.End()
 
 	updatedNamespace, err := nm.updateNamespace(ctx)
@@ -40,7 +40,7 @@ func (nm NamespaceMapper) MapFromNamespace(ctx context.Context) (bool, error) {
 }
 
 func (nm NamespaceMapper) updateNamespace(ctx context.Context) (bool, error) {
-	ctx, span := dtotel.StartSpan(ctx, injectionotel.Tracer())
+	ctx, span := dtotel.StartSpan(ctx, injectionotel.Tracer)
 	defer span.End()
 
 	deployedDynakubes := &dynakube.DynaKubeList{}

--- a/pkg/util/dtotel/controller_runtime/otel.go
+++ b/pkg/util/dtotel/controller_runtime/otel.go
@@ -1,21 +1,14 @@
 package controller_runtime
 
 import (
-	"sync"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
 
 const otelInstrumentationScope = "controller_runtime"
 
-var tracer trace.Tracer
-var once = sync.Once{}
+var ControllerRuntimeTracer trace.Tracer
 
-func controllerRuntimeTracer() trace.Tracer {
-	once.Do(func() {
-		tracer = otel.Tracer(otelInstrumentationScope)
-	})
-
-	return tracer
+func init() {
+	ControllerRuntimeTracer = otel.Tracer(otelInstrumentationScope)
 }

--- a/pkg/util/dtotel/controller_runtime/reader.go
+++ b/pkg/util/dtotel/controller_runtime/reader.go
@@ -23,7 +23,7 @@ func NewReader(wrapped client.Reader) client.Reader {
 // obj must be a struct pointer so that obj can be updated with the response
 // returned by the Server.
 func (r wrappedReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	ctx, span := dtotel.StartSpan(ctx, controllerRuntimeTracer())
+	ctx, span := dtotel.StartSpan(ctx, ControllerRuntimeTracer)
 	defer span.End()
 
 	err := r.wrapped.Get(ctx, key, obj, opts...)
@@ -36,7 +36,7 @@ func (r wrappedReader) Get(ctx context.Context, key client.ObjectKey, obj client
 // successful call, Items field in the list will be populated with the
 // result returned from the server.
 func (r wrappedReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-	ctx, span := dtotel.StartSpan(ctx, controllerRuntimeTracer())
+	ctx, span := dtotel.StartSpan(ctx, ControllerRuntimeTracer)
 	defer span.End()
 
 	err := r.wrapped.List(ctx, list, opts...)

--- a/pkg/util/dtotel/controller_runtime/writer.go
+++ b/pkg/util/dtotel/controller_runtime/writer.go
@@ -13,7 +13,7 @@ type wrappedWriter struct {
 }
 
 func (w wrappedWriter) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	ctx, span := dtotel.StartSpan(ctx, controllerRuntimeTracer())
+	ctx, span := dtotel.StartSpan(ctx, ControllerRuntimeTracer)
 	defer span.End()
 
 	err := w.wrapped.Create(ctx, obj, opts...)
@@ -24,7 +24,7 @@ func (w wrappedWriter) Create(ctx context.Context, obj client.Object, opts ...cl
 
 // Delete deletes the given obj from Kubernetes cluster.
 func (w wrappedWriter) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-	ctx, span := dtotel.StartSpan(ctx, controllerRuntimeTracer())
+	ctx, span := dtotel.StartSpan(ctx, ControllerRuntimeTracer)
 	defer span.End()
 
 	err := w.wrapped.Delete(ctx, obj, opts...)
@@ -36,7 +36,7 @@ func (w wrappedWriter) Delete(ctx context.Context, obj client.Object, opts ...cl
 // Update updates the given obj in the Kubernetes cluster. obj must be a
 // struct pointer so that obj can be updated with the content returned by the Server.
 func (w wrappedWriter) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	ctx, span := dtotel.StartSpan(ctx, controllerRuntimeTracer())
+	ctx, span := dtotel.StartSpan(ctx, ControllerRuntimeTracer)
 	defer span.End()
 
 	err := w.wrapped.Update(ctx, obj, opts...)
@@ -48,7 +48,7 @@ func (w wrappedWriter) Update(ctx context.Context, obj client.Object, opts ...cl
 // Patch patches the given obj in the Kubernetes cluster. obj must be a
 // struct pointer so that obj can be updated with the content returned by the Server.
 func (w wrappedWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-	ctx, span := dtotel.StartSpan(ctx, controllerRuntimeTracer())
+	ctx, span := dtotel.StartSpan(ctx, ControllerRuntimeTracer)
 	defer span.End()
 
 	err := w.wrapped.Patch(ctx, obj, patch, opts...)
@@ -59,7 +59,7 @@ func (w wrappedWriter) Patch(ctx context.Context, obj client.Object, patch clien
 
 // DeleteAllOf deletes all objects of the given type matching the given options.
 func (w wrappedWriter) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
-	ctx, span := dtotel.StartSpan(ctx, controllerRuntimeTracer())
+	ctx, span := dtotel.StartSpan(ctx, ControllerRuntimeTracer)
 	defer span.End()
 
 	err := w.wrapped.DeleteAllOf(ctx, obj, opts...)

--- a/pkg/util/dtotel/traces.go
+++ b/pkg/util/dtotel/traces.go
@@ -29,6 +29,18 @@ func StartSpan[T any](ctx context.Context, tracer T, opts ...trace.SpanStartOpti
 	return realTracer.Start(ctx, spanTitle, opts...)
 }
 
+func RecordError(span trace.Span, err error) error {
+	if err != nil {
+		span.RecordError(err)
+	}
+
+	return err
+}
+
+func IsEnabled(spanContext trace.SpanContext) bool {
+	return spanContext.SpanID() != trace.SpanContext{}.SpanID() || spanContext.TraceID() != trace.SpanContext{}.TraceID()
+}
+
 func setupTracesWithOtlp(ctx context.Context, resource *resource.Resource, endpoint string, apiToken string) (trace.TracerProvider, shutdownFn, error) {
 	tracerExporter, err := newOtlpTraceExporter(ctx, endpoint, apiToken)
 	if err != nil {

--- a/pkg/util/dtotel/traces_test.go
+++ b/pkg/util/dtotel/traces_test.go
@@ -46,6 +46,22 @@ func TestStartSpan(t *testing.T) {
 	})
 }
 
+func TestIsEnabled(t *testing.T) {
+	t.Run("span context is empty", func(t *testing.T) {
+		spanContext := trace.SpanContext{}
+
+		assert.False(t, IsEnabled(spanContext))
+	})
+	t.Run("span context is not empty", func(t *testing.T) {
+		spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: trace.TraceID{1, 2, 3},
+			SpanID:  trace.SpanID{4, 5, 6},
+		})
+
+		assert.True(t, IsEnabled(spanContext))
+	})
+}
+
 func TestGetCaller(t *testing.T) {
 	// Call getCaller with stack depth of 1
 	caller := getCaller(1)

--- a/pkg/util/kubesystem/kubesystem.go
+++ b/pkg/util/kubesystem/kubesystem.go
@@ -16,7 +16,7 @@ const (
 )
 
 func GetUID(ctx context.Context, clt client.Reader) (types.UID, error) {
-	ctx, span := dtotel.StartSpan(ctx, tracer())
+	ctx, span := dtotel.StartSpan(ctx, Tracer)
 	defer span.End()
 
 	kubeSystemNamespace := &corev1.Namespace{}

--- a/pkg/util/kubesystem/otel.go
+++ b/pkg/util/kubesystem/otel.go
@@ -1,8 +1,6 @@
 package kubesystem
 
 import (
-	"sync"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -11,13 +9,8 @@ const (
 	otelInstrumentationScope = "kubesystem"
 )
 
-var kubeSystemTracer trace.Tracer
-var once = sync.Once{}
+var Tracer trace.Tracer
 
-func tracer() trace.Tracer {
-	once.Do(func() {
-		kubeSystemTracer = otel.Tracer(otelInstrumentationScope)
-	})
-
-	return kubeSystemTracer
+func init() {
+	Tracer = otel.Tracer(otelInstrumentationScope)
 }

--- a/pkg/webhook/internal/otel/config.go
+++ b/pkg/webhook/internal/otel/config.go
@@ -1,8 +1,6 @@
 package otel
 
 import (
-	"sync"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
@@ -13,25 +11,10 @@ const (
 	WebhookPodNameKey        = "k8s.pod.name"
 )
 
-var tracer trace.Tracer
-var meter metric.Meter
+var Meter metric.Meter
+var Tracer trace.Tracer
 
-var once = sync.Once{}
-
-func Meter() metric.Meter {
-	once.Do(func() {
-		tracer = otel.Tracer(otelInstrumentationScope)
-		meter = otel.Meter(otelInstrumentationScope)
-	})
-
-	return meter
-}
-
-func Tracer() trace.Tracer {
-	once.Do(func() {
-		tracer = otel.Tracer(otelInstrumentationScope)
-		meter = otel.Meter(otelInstrumentationScope)
-	})
-
-	return tracer
+func init() {
+	Tracer = otel.Tracer(otelInstrumentationScope)
+	Meter = otel.Meter(otelInstrumentationScope)
 }

--- a/pkg/webhook/internal/otel/otel.go
+++ b/pkg/webhook/internal/otel/otel.go
@@ -2,16 +2,10 @@ package otel
 
 import (
 	"os"
-	"sync"
 )
 
-var envPodName string
-var oncePodName = sync.Once{}
+var WebhookPodName string
 
-func GetWebhookPodName() string {
-	oncePodName.Do(func() {
-		envPodName = os.Getenv("POD_NAME")
-	})
-
-	return envPodName
+func init() {
+	WebhookPodName = os.Getenv("POD_NAME")
 }

--- a/pkg/webhook/mutation/namespace/otel.go
+++ b/pkg/webhook/mutation/namespace/otel.go
@@ -16,8 +16,8 @@ const (
 )
 
 func countHandleMutationRequest(ctx context.Context, namespace string) {
-	dtotel.Count(ctx, webhookotel.Meter(), namespaceMutationHandledMetricName, int64(1),
-		attribute.String(webhookotel.WebhookPodNameKey, webhookotel.GetWebhookPodName()),
+	dtotel.Count(ctx, webhookotel.Meter, namespaceMutationHandledMetricName, int64(1),
+		attribute.String(webhookotel.WebhookPodNameKey, webhookotel.WebhookPodName),
 		attribute.String(mutatedNamespaceNameKey, namespace))
 }
 
@@ -25,7 +25,7 @@ func spanOptions(opts ...trace.SpanStartOption) []trace.SpanStartOption {
 	options := make([]trace.SpanStartOption, 0)
 	options = append(options, opts...)
 	options = append(options, trace.WithAttributes(
-		attribute.String(webhookotel.WebhookPodNameKey, webhookotel.GetWebhookPodName())))
+		attribute.String(webhookotel.WebhookPodNameKey, webhookotel.WebhookPodName)))
 
 	return options
 }

--- a/pkg/webhook/mutation/namespace/webhook.go
+++ b/pkg/webhook/mutation/namespace/webhook.go
@@ -40,7 +40,7 @@ type webhook struct {
 //  2. if the namespace was updated by the operator => don't do the mapping: we detect this using an annotation, we do this because the operator also does the mapping
 //     but from the dynakube's side (during dynakube reconcile) and we don't want to repeat ourselves. So we just remove the annotation.
 func (wh *webhook) Handle(ctx context.Context, request admission.Request) admission.Response {
-	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer(), spanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer, spanOptions()...)
 	defer span.End()
 	countHandleMutationRequest(ctx, request.Namespace)
 

--- a/pkg/webhook/mutation/pod/metadata/mutator.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator.go
@@ -55,7 +55,7 @@ func (mut *Mutator) Injected(request *dtwebhook.BaseRequest) bool {
 }
 
 func (mut *Mutator) Mutate(ctx context.Context, request *dtwebhook.MutationRequest) error {
-	_, span := dtotel.StartSpan(ctx, webhookotel.Tracer())
+	_, span := dtotel.StartSpan(ctx, webhookotel.Tracer)
 	defer span.End()
 
 	log.Info("injecting metadata-enrichment into pod", "podName", request.PodName())

--- a/pkg/webhook/mutation/pod/oneagent/mutator.go
+++ b/pkg/webhook/mutation/pod/oneagent/mutator.go
@@ -57,7 +57,7 @@ func (mut *Mutator) Injected(request *dtwebhook.BaseRequest) bool {
 }
 
 func (mut *Mutator) Mutate(ctx context.Context, request *dtwebhook.MutationRequest) error {
-	_, span := dtotel.StartSpan(ctx, webhookotel.Tracer())
+	_, span := dtotel.StartSpan(ctx, webhookotel.Tracer)
 	defer span.End()
 
 	if !request.DynaKube.IsOneAgentCommunicationRouteClear() {

--- a/pkg/webhook/mutation/pod/oneagent/mutator.go
+++ b/pkg/webhook/mutation/pod/oneagent/mutator.go
@@ -76,7 +76,7 @@ func (mut *Mutator) Mutate(ctx context.Context, request *dtwebhook.MutationReque
 	}
 
 	installerInfo := getInstallerInfo(request.Pod, request.DynaKube)
-	mut.addVolumes(request.Pod, request.DynaKube)
+	mut.addVolumes(request.Pod, request.DynaKube, span.SpanContext())
 	mut.configureInitContainer(request, installerInfo)
 	injectedContainers := mut.mutateUserContainers(request)
 	mut.setContainerCount(request.InstallContainer, injectedContainers)

--- a/pkg/webhook/mutation/pod/oneagent/volumes_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/volumes_test.go
@@ -1,12 +1,12 @@
 package oneagent
 
 import (
-	csivolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver/volumes"
 	"path/filepath"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	csivolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver/volumes"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/volumes"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -126,7 +126,7 @@ func TestAddOneAgentVolumes(t *testing.T) {
 		require.Len(t, pod.Spec.Volumes, 2)
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.CSI)
 		assert.False(t, *pod.Spec.Volumes[0].VolumeSource.CSI.ReadOnly)
-		assert.Equal(t, len(pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes), 2)
+		assert.Len(t, pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes, 2)
 	})
 
 	t.Run("should add oneagent volumes, with readonly csi", func(t *testing.T) {
@@ -161,7 +161,7 @@ func TestAddOneAgentVolumes(t *testing.T) {
 		require.Len(t, pod.Spec.Volumes, 2)
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.CSI)
 		assert.False(t, *pod.Spec.Volumes[0].VolumeSource.CSI.ReadOnly)
-		assert.Equal(t, 4, len(pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes))
+		assert.Len(t, pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes, 4)
 		assert.Contains(t, pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes, csivolumes.CSIOtelSpanId)
 		assert.Contains(t, pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes, csivolumes.CSIOtelTraceId)
 	})

--- a/pkg/webhook/mutation/pod/oneagent/volumes_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/volumes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -120,7 +121,7 @@ func TestAddOneAgentVolumes(t *testing.T) {
 		pod := &corev1.Pod{}
 		dk := getTestCSIDynakube()
 
-		addOneAgentVolumes(pod, *dk)
+		addOneAgentVolumes(pod, *dk, trace.SpanContext{})
 		require.Len(t, pod.Spec.Volumes, 2)
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.CSI)
 		assert.False(t, *pod.Spec.Volumes[0].VolumeSource.CSI.ReadOnly)
@@ -130,7 +131,7 @@ func TestAddOneAgentVolumes(t *testing.T) {
 		pod := &corev1.Pod{}
 		dk := getTestReadOnlyCSIDynakube()
 
-		addOneAgentVolumes(pod, *dk)
+		addOneAgentVolumes(pod, *dk, trace.SpanContext{})
 		require.Len(t, pod.Spec.Volumes, 2)
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.CSI)
 		assert.True(t, *pod.Spec.Volumes[0].VolumeSource.CSI.ReadOnly)
@@ -140,7 +141,7 @@ func TestAddOneAgentVolumes(t *testing.T) {
 		pod := &corev1.Pod{}
 		dk := getTestDynakube()
 
-		addOneAgentVolumes(pod, *dk)
+		addOneAgentVolumes(pod, *dk, trace.SpanContext{})
 		require.Len(t, pod.Spec.Volumes, 2)
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.EmptyDir)
 	})

--- a/pkg/webhook/mutation/pod/oneagent/volumes_test.go
+++ b/pkg/webhook/mutation/pod/oneagent/volumes_test.go
@@ -1,6 +1,7 @@
 package oneagent
 
 import (
+	csivolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver/volumes"
 	"path/filepath"
 	"testing"
 
@@ -117,7 +118,7 @@ func TestAddInitVolumeMounts(t *testing.T) {
 }
 
 func TestAddOneAgentVolumes(t *testing.T) {
-	t.Run("should add oneagent volumes, with csi", func(t *testing.T) {
+	t.Run("should add oneagent volumes, with csi and without Otel attributes", func(t *testing.T) {
 		pod := &corev1.Pod{}
 		dk := getTestCSIDynakube()
 
@@ -125,6 +126,7 @@ func TestAddOneAgentVolumes(t *testing.T) {
 		require.Len(t, pod.Spec.Volumes, 2)
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.CSI)
 		assert.False(t, *pod.Spec.Volumes[0].VolumeSource.CSI.ReadOnly)
+		assert.Equal(t, len(pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes), 2)
 	})
 
 	t.Run("should add oneagent volumes, with readonly csi", func(t *testing.T) {
@@ -144,6 +146,24 @@ func TestAddOneAgentVolumes(t *testing.T) {
 		addOneAgentVolumes(pod, *dk, trace.SpanContext{})
 		require.Len(t, pod.Spec.Volumes, 2)
 		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.EmptyDir)
+	})
+
+	t.Run("should add oneagent volumes, with csi and Otel attributes", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		dk := getTestCSIDynakube()
+
+		spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: trace.TraceID{1, 2, 3},
+			SpanID:  trace.SpanID{4, 5, 6},
+		})
+
+		addOneAgentVolumes(pod, *dk, spanContext)
+		require.Len(t, pod.Spec.Volumes, 2)
+		assert.NotNil(t, pod.Spec.Volumes[0].VolumeSource.CSI)
+		assert.False(t, *pod.Spec.Volumes[0].VolumeSource.CSI.ReadOnly)
+		assert.Equal(t, 4, len(pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes))
+		assert.Contains(t, pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes, csivolumes.CSIOtelSpanId)
+		assert.Contains(t, pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes, csivolumes.CSIOtelTraceId)
 	})
 }
 

--- a/pkg/webhook/mutation/pod/register.go
+++ b/pkg/webhook/mutation/pod/register.go
@@ -25,7 +25,7 @@ import (
 )
 
 func registerInjectEndpoint(mgr manager.Manager, webhookNamespace string, webhookPodName string) error {
-	ctx, span := dtotel.StartSpan(context.Background(), webhookotel.Tracer())
+	ctx, span := dtotel.StartSpan(context.Background(), webhookotel.Tracer)
 	defer span.End()
 
 	// Don't use mgr.GetClient() on this function, or other cache-dependent functions from the manager. The cache may
@@ -70,7 +70,7 @@ func registerInjectEndpoint(mgr manager.Manager, webhookNamespace string, webhoo
 		return err
 	}
 
-	requestCounter, err := webhookotel.Meter().Int64Counter("handledPodMutationRequests")
+	requestCounter, err := webhookotel.Meter.Int64Counter("handledPodMutationRequests")
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -125,7 +125,7 @@ func getWebhookContainerImage(webhookPod corev1.Pod) (string, error) {
 }
 
 func getClusterID(ctx context.Context, apiReader client.Reader) (string, error) {
-	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer())
+	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer)
 	defer span.End()
 
 	if clusterUID, err := kubesystem.GetUID(ctx, apiReader); err != nil {

--- a/pkg/webhook/mutation/pod/request.go
+++ b/pkg/webhook/mutation/pod/request.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (wh *webhook) createMutationRequestBase(ctx context.Context, request admission.Request) (*dtwebhook.MutationRequest, error) {
-	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer())
+	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer)
 	defer span.End()
 
 	pod, err := getPodFromRequest(request, wh.decoder)

--- a/pkg/webhook/mutation/pod/webhook.go
+++ b/pkg/webhook/mutation/pod/webhook.go
@@ -61,7 +61,7 @@ type webhook struct {
 }
 
 func (wh *webhook) Handle(ctx context.Context, request admission.Request) admission.Response {
-	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer(), spanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer, spanOptions()...)
 	defer span.End()
 
 	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
@@ -126,7 +126,7 @@ func mutationRequired(mutationRequest *dtwebhook.MutationRequest) bool {
 }
 
 func (wh *webhook) setupEventRecorder(ctx context.Context, mutationRequest *dtwebhook.MutationRequest) {
-	_, span := dtotel.StartSpan(ctx, webhookotel.Tracer(), spanOptions()...)
+	_, span := dtotel.StartSpan(ctx, webhookotel.Tracer, spanOptions()...)
 	defer span.End()
 
 	wh.recorder.dk = &mutationRequest.DynaKube
@@ -134,7 +134,7 @@ func (wh *webhook) setupEventRecorder(ctx context.Context, mutationRequest *dtwe
 }
 
 func (wh *webhook) isInjected(ctx context.Context, mutationRequest *dtwebhook.MutationRequest) bool {
-	_, span := dtotel.StartSpan(ctx, webhookotel.Tracer(), spanOptions()...)
+	_, span := dtotel.StartSpan(ctx, webhookotel.Tracer, spanOptions()...)
 	defer span.End()
 
 	for _, mutator := range wh.mutators {
@@ -168,7 +168,7 @@ func podNeedsInjection(mutationRequest *dtwebhook.MutationRequest) bool {
 }
 
 func (wh *webhook) handlePodMutation(ctx context.Context, mutationRequest *dtwebhook.MutationRequest) error {
-	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer(), spanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer, spanOptions()...)
 	defer span.End()
 
 	if !podNeedsInjection(mutationRequest) {
@@ -207,7 +207,7 @@ func (wh *webhook) handlePodMutation(ctx context.Context, mutationRequest *dtweb
 }
 
 func (wh *webhook) handlePodReinvocation(ctx context.Context, mutationRequest *dtwebhook.MutationRequest) bool {
-	_, span := dtotel.StartSpan(ctx, webhookotel.Tracer(), spanOptions()...)
+	_, span := dtotel.StartSpan(ctx, webhookotel.Tracer, spanOptions()...)
 	defer span.End()
 
 	var needsUpdate bool
@@ -235,7 +235,7 @@ func setDynatraceInjectedAnnotation(mutationRequest *dtwebhook.MutationRequest) 
 
 // createResponseForPod tries to format pod as json
 func createResponseForPod(ctx context.Context, pod *corev1.Pod, req admission.Request) admission.Response {
-	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer(), spanOptions()...)
+	ctx, span := dtotel.StartSpan(ctx, webhookotel.Tracer, spanOptions()...)
 	defer span.End()
 
 	marshaledPod, err := json.MarshalIndent(pod, "", "  ")


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Adds OTel instrumentation to the csidriver containers and links them to the webhook created span. 
In addition, the singletons were replaced with init functions.

[Jira](https://dt-rnd.atlassian.net/browse/K8S-9452)

## How can this be tested?

- Apply the otel secret as described in `doc/otel.md`.
- Apply a dynakube with cloud native and create some pods. 
- Check the otel traces in your tenant.
<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->