### PR TITLE
Enable ExtensionController in ActiveGate

### DIFF
--- a/pkg/api/v1beta3/dynakube/properties.go
+++ b/pkg/api/v1beta3/dynakube/properties.go
@@ -102,7 +102,11 @@ func (dk *DynaKube) OneAgentDaemonsetName() string {
 }
 
 func (dk *DynaKube) ActiveGateMode() bool {
-	return len(dk.Spec.ActiveGate.Capabilities) > 0
+	return len(dk.Spec.ActiveGate.Capabilities) > 0 || dk.HasExtensionsEnabled()
+}
+
+func (dk *DynaKube) HasExtensionsEnabled() bool {
+	return dk.Spec.Extensions.Prometheus.Enabled
 }
 
 func (dk *DynaKube) IsActiveGateMode(mode CapabilityDisplayName) bool {
@@ -143,14 +147,11 @@ func (dk *DynaKube) IsMetricsIngestActiveGateEnabled() bool {
 	return dk.IsActiveGateMode(MetricsIngestCapability.DisplayName)
 }
 
-func (dk *DynaKube) NeedsActiveGateServicePorts() bool {
+func (dk *DynaKube) NeedsActiveGateService() bool {
 	return dk.IsRoutingActiveGateEnabled() ||
 		dk.IsApiActiveGateEnabled() ||
-		dk.IsMetricsIngestActiveGateEnabled()
-}
-
-func (dk *DynaKube) NeedsActiveGateService() bool {
-	return dk.NeedsActiveGateServicePorts()
+		dk.IsMetricsIngestActiveGateEnabled() ||
+		dk.HasExtensionsEnabled()
 }
 
 func (dk *DynaKube) HasActiveGateCaCert() bool {

--- a/pkg/api/v1beta3/dynakube/properties.go
+++ b/pkg/api/v1beta3/dynakube/properties.go
@@ -102,10 +102,10 @@ func (dk *DynaKube) OneAgentDaemonsetName() string {
 }
 
 func (dk *DynaKube) ActiveGateMode() bool {
-	return len(dk.Spec.ActiveGate.Capabilities) > 0 || dk.HasExtensionsEnabled()
+	return len(dk.Spec.ActiveGate.Capabilities) > 0 || dk.IsExtensionsEnabled()
 }
 
-func (dk *DynaKube) HasExtensionsEnabled() bool {
+func (dk *DynaKube) IsExtensionsEnabled() bool {
 	return dk.Spec.Extensions.Prometheus.Enabled
 }
 
@@ -151,7 +151,7 @@ func (dk *DynaKube) NeedsActiveGateService() bool {
 	return dk.IsRoutingActiveGateEnabled() ||
 		dk.IsApiActiveGateEnabled() ||
 		dk.IsMetricsIngestActiveGateEnabled() ||
-		dk.HasExtensionsEnabled()
+		dk.IsExtensionsEnabled()
 }
 
 func (dk *DynaKube) HasActiveGateCaCert() bool {

--- a/pkg/controllers/dynakube/activegate/capability/capability.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability.go
@@ -77,7 +77,7 @@ func NewMultiCapability(dk *dynakube.DynaKube) Capability {
 	mc.enabled = true
 	mc.properties = &dk.Spec.ActiveGate.CapabilityProperties
 
-	if len(dk.Spec.ActiveGate.Capabilities) == 0 && dk.HasExtensionsEnabled() {
+	if len(dk.Spec.ActiveGate.Capabilities) == 0 && dk.IsExtensionsEnabled() {
 		mc.properties.Replicas = 1
 	}
 
@@ -95,7 +95,7 @@ func NewMultiCapability(dk *dynakube.DynaKube) Capability {
 		capabilityDisplayNames = append(capabilityDisplayNames, capGen.displayName)
 	}
 
-	if dk.HasExtensionsEnabled() {
+	if dk.IsExtensionsEnabled() {
 		capabilityNames = append(capabilityNames, "extension_controller")
 		capabilityDisplayNames = append(capabilityDisplayNames, "extension_controller")
 	}

--- a/pkg/controllers/dynakube/activegate/capability/capability.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability.go
@@ -76,10 +76,15 @@ func NewMultiCapability(dk *dynakube.DynaKube) Capability {
 
 	mc.enabled = true
 	mc.properties = &dk.Spec.ActiveGate.CapabilityProperties
-	capabilityNames := []string{}
-	capabilityDisplayNames := make([]string, len(dk.Spec.ActiveGate.Capabilities))
 
-	for i, capName := range dk.Spec.ActiveGate.Capabilities {
+	if len(dk.Spec.ActiveGate.Capabilities) == 0 && dk.HasExtensionsEnabled() {
+		mc.properties.Replicas = 1
+	}
+
+	capabilityNames := []string{}
+	capabilityDisplayNames := []string{}
+
+	for _, capName := range dk.Spec.ActiveGate.Capabilities {
 		capabilityGenerator, ok := activeGateCapabilities[capName]
 		if !ok {
 			continue
@@ -87,7 +92,12 @@ func NewMultiCapability(dk *dynakube.DynaKube) Capability {
 
 		capGen := capabilityGenerator()
 		capabilityNames = append(capabilityNames, capGen.argName)
-		capabilityDisplayNames[i] = capGen.displayName
+		capabilityDisplayNames = append(capabilityDisplayNames, capGen.displayName)
+	}
+
+	if dk.HasExtensionsEnabled() {
+		capabilityNames = append(capabilityNames, "extension_controller")
+		capabilityDisplayNames = append(capabilityDisplayNames, "extension_controller")
 	}
 
 	mc.argName = strings.Join(capabilityNames, ",")

--- a/pkg/controllers/dynakube/activegate/capability/capability_test.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability_test.go
@@ -11,11 +11,13 @@ import (
 )
 
 const (
-	testNamespace     = "test-namespace"
-	testName          = "test-name"
-	testApiUrl        = "https://demo.dev.dynatracelabs.com/api"
-	expectedShortName = "activegate"
-	expectedArgName   = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface"
+	testNamespace                     = "test-namespace"
+	testName                          = "test-name"
+	testApiUrl                        = "https://demo.dev.dynatracelabs.com/api"
+	expectedShortName                 = "activegate"
+	expectedArgName                   = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface"
+	expectedArgNameWithExtensions     = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface,extension_controller"
+	expectedArgNameWithExtensionsOnly = "extension_controller"
 )
 
 var capabilities = []dynakube.CapabilityDisplayName{
@@ -25,7 +27,7 @@ var capabilities = []dynakube.CapabilityDisplayName{
 	dynakube.DynatraceApiCapability.DisplayName,
 }
 
-func buildDynakube(capabilities []dynakube.CapabilityDisplayName) *dynakube.DynaKube {
+func buildDynakube(capabilities []dynakube.CapabilityDisplayName, enableExtensions bool) *dynakube.DynaKube {
 	return &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace, Name: testName,
@@ -34,6 +36,11 @@ func buildDynakube(capabilities []dynakube.CapabilityDisplayName) *dynakube.Dyna
 			APIURL: testApiUrl,
 			ActiveGate: dynakube.ActiveGateSpec{
 				Capabilities: capabilities,
+			},
+			Extensions: dynakube.ExtensionsSpec{
+				Prometheus: dynakube.PrometheusSpec{
+					Enabled: enableExtensions,
+				},
 			},
 		},
 	}
@@ -59,7 +66,7 @@ func TestBuildServiceName(t *testing.T) {
 
 func TestNewMultiCapability(t *testing.T) {
 	t.Run(`creates new multicapability`, func(t *testing.T) {
-		dk := buildDynakube(capabilities)
+		dk := buildDynakube(capabilities, false)
 		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.True(t, mc.Enabled())
@@ -68,12 +75,32 @@ func TestNewMultiCapability(t *testing.T) {
 	})
 	t.Run(`creates new multicapability without capabilities set in dynakube`, func(t *testing.T) {
 		var emptyCapabilites []dynakube.CapabilityDisplayName
-		dk := buildDynakube(emptyCapabilites)
+		dk := buildDynakube(emptyCapabilites, false)
 		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.False(t, mc.Enabled())
 		assert.Equal(t, expectedShortName, mc.ShortName())
 		assert.Equal(t, "", mc.ArgName())
+	})
+}
+
+func TestNewMultiCapabilityWithExtensions(t *testing.T) {
+	t.Run(`creates new multicapability with Extensions enabled`, func(t *testing.T) {
+		dk := buildDynakube(capabilities, true)
+		mc := NewMultiCapability(dk)
+		require.NotNil(t, mc)
+		assert.True(t, mc.Enabled())
+		assert.Equal(t, expectedShortName, mc.ShortName())
+		assert.Equal(t, expectedArgNameWithExtensions, mc.ArgName())
+	})
+	t.Run(`creates new multicapability without capabilities set in dynakube and Extensions enabled`, func(t *testing.T) {
+		var emptyCapabilites []dynakube.CapabilityDisplayName
+		dk := buildDynakube(emptyCapabilites, true)
+		mc := NewMultiCapability(dk)
+		require.NotNil(t, mc)
+		assert.True(t, mc.Enabled())
+		assert.Equal(t, expectedShortName, mc.ShortName())
+		assert.Equal(t, expectedArgNameWithExtensionsOnly, mc.ArgName())
 	})
 }
 

--- a/pkg/controllers/dynakube/activegate/internal/capability/service.go
+++ b/pkg/controllers/dynakube/activegate/internal/capability/service.go
@@ -13,7 +13,7 @@ import (
 func CreateService(dk *dynakube.DynaKube, feature string) *corev1.Service {
 	var ports []corev1.ServicePort
 
-	if dk.NeedsActiveGateServicePorts() {
+	if dk.NeedsActiveGateService() {
 		ports = append(ports,
 			corev1.ServicePort{
 				Name:       consts.HttpsServicePortName,

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
@@ -30,7 +30,7 @@ type ServicePortModifier struct {
 }
 
 func (mod ServicePortModifier) Enabled() bool {
-	return mod.dk.NeedsActiveGateServicePorts()
+	return mod.dk.NeedsActiveGateService()
 }
 
 func (mod ServicePortModifier) Modify(sts *appsv1.StatefulSet) error {

--- a/pkg/controllers/dynakube/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/reconciler_test.go
@@ -232,6 +232,212 @@ func TestReconciler_Reconcile(t *testing.T) {
 	})
 }
 
+func TestExtensionControllerRequiresActiveGate(t *testing.T) {
+	t.Run("no activegate is created when extensions are disabled in dk, and no capability is configured", func(t *testing.T) {
+		instance := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      testName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{}},
+				Extensions: dynakube.ExtensionsSpec{
+					Prometheus: dynakube.PrometheusSpec{
+						Enabled: false,
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClient(testKubeSystemNamespace)
+
+		r := NewReconciler(fakeClient, fakeClient, instance, createMockDtClient(t, false), nil, nil).(*Reconciler)
+		r.connectionReconciler = createGenericReconcilerMock(t)
+		r.versionReconciler = createVersionReconcilerMock(t)
+		r.pullSecretReconciler = createGenericReconcilerMock(t)
+
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var service corev1.Service
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
+		assert.True(t, k8serrors.IsNotFound(err))
+
+		var statefulset appsv1.StatefulSet
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: instance.Name + "-activegate", Namespace: testNamespace}, &statefulset)
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
+	t.Run("activegate is created when extensions are enabled in dk, but no activegate is configured", func(t *testing.T) {
+		instance := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      testName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				Extensions: dynakube.ExtensionsSpec{
+					Prometheus: dynakube.PrometheusSpec{
+						Enabled: true,
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClient(testKubeSystemNamespace)
+
+		r := NewReconciler(fakeClient, fakeClient, instance, createMockDtClient(t, true), nil, nil).(*Reconciler)
+		r.connectionReconciler = createGenericReconcilerMock(t)
+		r.versionReconciler = createVersionReconcilerMock(t)
+		r.pullSecretReconciler = createGenericReconcilerMock(t)
+
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var service corev1.Service
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
+		require.NoError(t, err)
+		require.Equal(t, testServiceName, service.Name)
+
+		var statefulset appsv1.StatefulSet
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: instance.Name + "-activegate", Namespace: testNamespace}, &statefulset)
+		require.NoError(t, err)
+	})
+	t.Run("activegate is created when extensions are enabled in dk, but no activegate capability is configured", func(t *testing.T) {
+		instance := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      testName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{}},
+				Extensions: dynakube.ExtensionsSpec{
+					Prometheus: dynakube.PrometheusSpec{
+						Enabled: true,
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClient(testKubeSystemNamespace)
+
+		r := NewReconciler(fakeClient, fakeClient, instance, createMockDtClient(t, true), nil, nil).(*Reconciler)
+		r.connectionReconciler = createGenericReconcilerMock(t)
+		r.versionReconciler = createVersionReconcilerMock(t)
+		r.pullSecretReconciler = createGenericReconcilerMock(t)
+
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var service corev1.Service
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
+		require.NoError(t, err)
+		require.Equal(t, testServiceName, service.Name)
+
+		var statefulset appsv1.StatefulSet
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: instance.Name + "-activegate", Namespace: testNamespace}, &statefulset)
+		require.NoError(t, err)
+	})
+	t.Run("activegate is created when extensions are enabled in dk, and activegate kubernetes is configured", func(t *testing.T) {
+		instance := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      testName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}},
+				Extensions: dynakube.ExtensionsSpec{
+					Prometheus: dynakube.PrometheusSpec{
+						Enabled: true,
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClient(testKubeSystemNamespace)
+
+		r := NewReconciler(fakeClient, fakeClient, instance, createMockDtClient(t, true), nil, nil).(*Reconciler)
+		r.connectionReconciler = createGenericReconcilerMock(t)
+		r.versionReconciler = createVersionReconcilerMock(t)
+		r.pullSecretReconciler = createGenericReconcilerMock(t)
+
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var service corev1.Service
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
+		require.NoError(t, err)
+		require.Equal(t, testServiceName, service.Name)
+
+		var statefulset appsv1.StatefulSet
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: instance.Name + "-activegate", Namespace: testNamespace}, &statefulset)
+		require.NoError(t, err)
+	})
+	t.Run("activegate is created when extensions are enabled in dk, but activegate capabilities are removed", func(t *testing.T) {
+		instance := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      testName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}},
+				Extensions: dynakube.ExtensionsSpec{
+					Prometheus: dynakube.PrometheusSpec{
+						Enabled: true,
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClient(testKubeSystemNamespace)
+
+		r := NewReconciler(fakeClient, fakeClient, instance, createMockDtClient(t, true), nil, nil).(*Reconciler)
+		r.connectionReconciler = createGenericReconcilerMock(t)
+		r.versionReconciler = createVersionReconcilerMock(t)
+		r.pullSecretReconciler = createGenericReconcilerMock(t)
+
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var service corev1.Service
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
+		require.NoError(t, err)
+		require.Equal(t, testServiceName, service.Name)
+
+		var statefulset appsv1.StatefulSet
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: instance.Name + "-activegate", Namespace: testNamespace}, &statefulset)
+		require.NoError(t, err)
+
+		// remove AG from spec
+		r.dk.Spec.ActiveGate = dynakube.ActiveGateSpec{}
+		r.connectionReconciler = createGenericReconcilerMock(t)
+		r.versionReconciler = createVersionReconcilerMock(t)
+		r.pullSecretReconciler = createGenericReconcilerMock(t)
+		err = r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var service1 corev1.Service
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service1)
+		require.NoError(t, err)
+		require.Equal(t, testServiceName, service1.Name)
+
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: instance.Name + "-activegate", Namespace: testNamespace}, &statefulset)
+		require.NoError(t, err)
+
+		// disable extensions
+		r.dk.Spec.Extensions.Prometheus.Enabled = false
+		r.connectionReconciler = createGenericReconcilerMock(t)
+		r.versionReconciler = createVersionReconcilerMock(t)
+		r.pullSecretReconciler = createGenericReconcilerMock(t)
+		err = r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
+		assert.True(t, k8serrors.IsNotFound(err))
+
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: instance.Name + "-activegate", Namespace: testNamespace}, &statefulset)
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
+}
+
 func TestServiceCreation(t *testing.T) {
 	dynatraceClient := dtclientmock.NewClient(t)
 	dynatraceClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenId: "test", Token: "dt.some.valuegoeshere"}, nil)


### PR DESCRIPTION
## Description

see [K8S-10118](https://dt-rnd.atlassian.net/browse/K8S-10118)

ActiveGate is also created when Extensions are enabled in the DynaKube. No other AG capabilities are needed.


## How can this be tested?

1) Unittests.
2) Apply dynakubes below. ActiveGate pod should be always created.
Check enabled capabilities on the AG pod using:
```
kubectl -n dynatrace get -o yaml pod/dynakube-activegate-0 -o jsonpath="{.spec.containers[0].env[0]}"
```

a)
dynakube:
```
spec:
  activeGate:
    capabilities:
      - routing
    replicas: 1
  extensions:
    prometheus:
      enabled: true
  oneAgent:
    cloudNativeFullStack: {}
```
capabilities:
```
{"name":"DT_CAPABILITIES","value":"MSGrouter,extension_controller"}
```

b)
dynakube:
```
spec:
  activeGate:
    replicas: 1
  extensions:
    prometheus:
      enabled: true
  oneAgent:
    cloudNativeFullStack: {}
```
capabilities:
```
{"name":"DT_CAPABILITIES","value":"extension_controller"}
```

c)
dynakube:
```
spec:
  extensions:
    prometheus:
      enabled: true
  oneAgent:
    cloudNativeFullStack: {}
```
capabilities:
```
{"name":"DT_CAPABILITIES","value":"extension_controller"}
```