### PR TITLE
Add versioned validation logic to v1beta1

### DIFF
--- a/cmd/webhook/builder.go
+++ b/cmd/webhook/builder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/cmd/config"
 	cmdManager "github.com/Dynatrace/dynatrace-operator/cmd/manager"
 	dynakubev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	dynakubev1beta1validation "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube/validation"
 	dynakubev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	dynakubev1beta2validation "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube/validation"
 	dynakubev1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
@@ -157,7 +158,9 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 			return err
 		}
 
-		err = (&dynakubev1beta1.DynaKube{}).SetupWebhookWithManager(webhookManager)
+		dkv1beta1Validator := dynakubev1beta1validation.New(webhookManager.GetAPIReader(), webhookManager.GetConfig())
+
+		err = dynakubev1beta1.SetupWebhookWithManager(webhookManager, dkv1beta1Validator)
 		if err != nil {
 			return err
 		}

--- a/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
@@ -25,6 +25,27 @@ webhooks:
       service:
         name: dynatrace-webhook
         namespace: {{ .Release.Namespace }}
+        path: /validate-dynatrace-com-v1beta1-dynakube
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - dynatrace.com
+        apiVersions:
+          - v1beta1
+        resources:
+          - dynakubes
+    name: v1beta1.dynakube.webhook.dynatrace.com
+    timeoutSeconds: {{.Values.webhook.validatingWebhook.timeoutSeconds}}
+    sideEffects: None
+    matchPolicy: Exact
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: dynatrace-webhook
+        namespace: {{ .Release.Namespace }}
         path: /validate-dynatrace-com-v1beta2-dynakube
     rules:
       - operations:

--- a/config/helm/chart/default/tests/Common/webhook/validatingwebhookconfiguration_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/validatingwebhookconfiguration_test.yaml
@@ -22,6 +22,27 @@ tests:
                 service:
                   name: dynatrace-webhook
                   namespace: NAMESPACE
+                  path: /validate-dynatrace-com-v1beta1-dynakube
+              rules:
+                - operations:
+                    - CREATE
+                    - UPDATE
+                  apiGroups:
+                    - dynatrace.com
+                  apiVersions:
+                    - v1beta1
+                  resources:
+                    - dynakubes
+              name: v1beta1.dynakube.webhook.dynatrace.com
+              timeoutSeconds: 10
+              sideEffects: None
+              matchPolicy: Exact
+            - admissionReviewVersions:
+                - v1
+              clientConfig:
+                service:
+                  name: dynatrace-webhook
+                  namespace: NAMESPACE
                   path: /validate-dynatrace-com-v1beta2-dynakube
               rules:
                 - operations:
@@ -65,7 +86,7 @@ tests:
                   name: dynatrace-webhook
                   namespace: NAMESPACE
                   path: /validate/edgeconnect
-              rules:
+              rules: # todo gakr do something in this file
                 - operations:
                     - CREATE
                     - UPDATE

--- a/config/helm/chart/default/tests/Common/webhook/validatingwebhookconfiguration_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/validatingwebhookconfiguration_test.yaml
@@ -86,7 +86,7 @@ tests:
                   name: dynatrace-webhook
                   namespace: NAMESPACE
                   path: /validate/edgeconnect
-              rules: # todo gakr do something in this file
+              rules:
                 - operations:
                     - CREATE
                     - UPDATE

--- a/pkg/api/v1beta1/dynakube/dynakube_webhook.go
+++ b/pkg/api/v1beta1/dynakube/dynakube_webhook.go
@@ -1,9 +1,13 @@
 package dynakube
 
-import ctrl "sigs.k8s.io/controller-runtime"
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
 
-func (r *DynaKube) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func SetupWebhookWithManager(mgr ctrl.Manager, validator admission.CustomValidator) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&DynaKube{}).
+		WithValidator(validator). // will create an endpoint at /validate-dynatrace-com-v1beta1-dynakube
 		Complete()
 }

--- a/pkg/api/v1beta1/dynakube/validation/activegate.go
+++ b/pkg/api/v1beta1/dynakube/validation/activegate.go
@@ -1,0 +1,67 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	errorInvalidActiveGateCapability = `The DynaKube's specification tries to use an invalid capability in ActiveGate section, invalid capability=%s.
+Make sure you correctly specify the ActiveGate capabilities in your custom resource.
+`
+
+	errorDuplicateActiveGateCapability = `The DynaKube's specification tries to specify duplicate capabilities in the ActiveGate section, duplicate capability=%s.
+Make sure you don't duplicate an Activegate capability in your custom resource.
+`
+	warningMissingActiveGateMemoryLimit = `ActiveGate specification missing memory limits. Can cause excess memory usage.`
+)
+
+func duplicateActiveGateCapabilities(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if dk.ActiveGateMode() {
+		capabilities := dk.Spec.ActiveGate.Capabilities
+		duplicateChecker := map[dynakube.CapabilityDisplayName]bool{}
+
+		for _, capability := range capabilities {
+			if duplicateChecker[capability] {
+				log.Info("requested dynakube has duplicates in the active gate capabilities section", "name", dk.Name, "namespace", dk.Namespace)
+
+				return fmt.Sprintf(errorDuplicateActiveGateCapability, capability)
+			}
+
+			duplicateChecker[capability] = true
+		}
+	}
+
+	return ""
+}
+
+func invalidActiveGateCapabilities(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if dk.ActiveGateMode() {
+		capabilities := dk.Spec.ActiveGate.Capabilities
+		for _, capability := range capabilities {
+			if _, ok := dynakube.ActiveGateDisplayNames[capability]; !ok {
+				log.Info("requested dynakube has invalid active gate capability", "name", dk.Name, "namespace", dk.Namespace)
+
+				return fmt.Sprintf(errorInvalidActiveGateCapability, capability)
+			}
+		}
+	}
+
+	return ""
+}
+
+func missingActiveGateMemoryLimit(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if dk.ActiveGateMode() &&
+		!memoryLimitSet(dk.Spec.ActiveGate.Resources) {
+		return warningMissingActiveGateMemoryLimit
+	}
+
+	return ""
+}
+
+func memoryLimitSet(resources corev1.ResourceRequirements) bool {
+	return resources.Limits != nil && resources.Limits.Memory() != nil
+}

--- a/pkg/api/v1beta1/dynakube/validation/activegate_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/activegate_test.go
@@ -1,0 +1,88 @@
+package validation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestDuplicateActiveGateCapabilities(t *testing.T) {
+	t.Run(`conflicting dynakube specs`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{fmt.Sprintf(errorDuplicateActiveGateCapability, dynakube.RoutingCapability.DisplayName)},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					ActiveGate: dynakube.ActiveGateSpec{
+						Capabilities: []dynakube.CapabilityDisplayName{
+							dynakube.RoutingCapability.DisplayName,
+							dynakube.RoutingCapability.DisplayName,
+						},
+					},
+				},
+			})
+	})
+}
+
+func TestInvalidActiveGateCapabilities(t *testing.T) {
+	t.Run(`conflicting dynakube specs`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{fmt.Sprintf(errorInvalidActiveGateCapability, "invalid-capability")},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					ActiveGate: dynakube.ActiveGateSpec{
+						Capabilities: []dynakube.CapabilityDisplayName{
+							"invalid-capability",
+						},
+					},
+				},
+			})
+	})
+}
+
+func TestMissingActiveGateMemoryLimit(t *testing.T) {
+	t.Run(`memory warning in activeGate mode`, func(t *testing.T) {
+		assertAllowedWithWarnings(t, 1,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					ActiveGate: dynakube.ActiveGateSpec{
+						Capabilities: []dynakube.CapabilityDisplayName{
+							dynakube.RoutingCapability.DisplayName,
+						},
+						CapabilityProperties: dynakube.CapabilityProperties{
+							Resources: corev1.ResourceRequirements{},
+						},
+					},
+				},
+			})
+	})
+	t.Run(`no memory warning in activeGate mode with memory limit`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					ActiveGate: dynakube.ActiveGateSpec{
+						Capabilities: []dynakube.CapabilityDisplayName{
+							dynakube.RoutingCapability.DisplayName,
+						},
+						CapabilityProperties: dynakube.CapabilityProperties{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceLimitsMemory: *resource.NewMilliQuantity(1, ""),
+								},
+							},
+						},
+					},
+				},
+			})
+	})
+}

--- a/pkg/api/v1beta1/dynakube/validation/api_url.go
+++ b/pkg/api/v1beta1/dynakube/validation/api_url.go
@@ -1,0 +1,79 @@
+package validation
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+)
+
+const (
+	ExampleApiUrl = "https://ENVIRONMENTID.live.dynatrace.com/api"
+	errorNoApiUrl = `The DynaKube's specification is missing the API URL or still has the example value set.
+	Make sure you correctly specify the URL in your custom resource.
+	`
+
+	errorInvalidApiUrl = `The DynaKube's specification has an invalid API URL value set.
+	Make sure you correctly specify the URL in your custom resource (including the /api postfix).
+	`
+
+	errorThirdGenApiUrl = `The DynaKube's specification has an 3rd gen API URL. Make sure to remove the 'apps' part
+	out of it. Example: ` + ExampleApiUrl
+)
+
+func NoApiUrl(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	apiUrl := dk.Spec.APIURL
+
+	if apiUrl == ExampleApiUrl {
+		log.Info("api url is an example url", "apiUrl", apiUrl)
+
+		return errorNoApiUrl
+	}
+
+	if apiUrl == "" {
+		log.Info("requested dynakube has no api url", "name", dk.Name, "namespace", dk.Namespace)
+
+		return errorNoApiUrl
+	}
+
+	return ""
+}
+
+func IsInvalidApiUrl(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	apiUrl := dk.Spec.APIURL
+
+	if !strings.HasSuffix(apiUrl, "/api") {
+		log.Info("api url does not end with /api", "apiUrl", apiUrl)
+
+		return errorInvalidApiUrl
+	}
+
+	parsedUrl, err := url.Parse(apiUrl)
+	if err != nil {
+		log.Info("API URL is not a valid URL", "err", err.Error())
+
+		return errorInvalidApiUrl
+	}
+
+	hostname := parsedUrl.Hostname()
+	hostnameWithDomains := strings.FieldsFunc(hostname,
+		func(r rune) bool { return r == '.' },
+	)
+
+	if len(hostnameWithDomains) < 1 || len(hostnameWithDomains[0]) == 0 {
+		log.Info("invalid hostname in the api url", "hostname", hostname)
+
+		return errorInvalidApiUrl
+	}
+
+	return ""
+}
+
+func IsThirdGenAPIUrl(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if strings.Contains(dk.ApiUrl(), ".apps.") {
+		return errorThirdGenApiUrl
+	}
+
+	return ""
+}

--- a/pkg/api/v1beta1/dynakube/validation/api_url_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/api_url_test.go
@@ -1,0 +1,80 @@
+package validation
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasApiUrl(t *testing.T) {
+	dk := &dynakube.DynaKube{}
+	assert.Equal(t, errorNoApiUrl, NoApiUrl(context.Background(), nil, dk))
+
+	dk.Spec.APIURL = testApiUrl
+	assert.Empty(t, NoApiUrl(context.Background(), nil, dk))
+
+	t.Run(`happy path`, func(t *testing.T) {
+		assertAllowed(t, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: "https://tenantid.doma.in/api",
+			},
+		})
+	})
+	t.Run(`valid API URL (no domain)`, func(t *testing.T) {
+		assertAllowed(t, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: "https://...tenantid/api",
+			},
+		})
+		assertAllowed(t, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: "https://my-in-cluster-activegate/e/<tenant>/api",
+			},
+		})
+	})
+	t.Run(`missing API URL`, func(t *testing.T) {
+		assertDenied(t, []string{errorNoApiUrl}, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: "",
+			},
+		})
+	})
+	t.Run(`example API URL`, func(t *testing.T) {
+		assertDenied(t, []string{errorNoApiUrl}, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: ExampleApiUrl,
+			},
+		})
+	})
+	t.Run(`invalid API URL (without /api suffix)`, func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidApiUrl}, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: strings.TrimSuffix(ExampleApiUrl, "/api"),
+			},
+		})
+	})
+	t.Run(`invalid API URL (not a Dynatrace environment)`, func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidApiUrl}, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: "https://www.google.com",
+			},
+		})
+	})
+	t.Run(`invalid API URL (empty tenant ID)`, func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidApiUrl}, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: "/api",
+			},
+		})
+	})
+	t.Run(`third gen API URL`, func(t *testing.T) {
+		assertDenied(t, []string{errorThirdGenApiUrl}, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: "https://tenantid.doma.apps.in/api",
+			},
+		})
+	})
+}

--- a/pkg/api/v1beta1/dynakube/validation/config.go
+++ b/pkg/api/v1beta1/dynakube/validation/config.go
@@ -1,0 +1,11 @@
+package validation
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+)
+
+const oneagentEnableVolumeStorageEnvVarName = "ONEAGENT_ENABLE_VOLUME_STORAGE"
+const oneagentInstallerScriptUrlEnvVarName = "ONEAGENT_INSTALLER_SCRIPT_URL"
+const oneagentInstallerTokenEnvVarName = "ONEAGENT_INSTALLER_TOKEN"
+
+var log = logd.Get().WithName("dynakube-validation")

--- a/pkg/api/v1beta1/dynakube/validation/csi_daemonset.go
+++ b/pkg/api/v1beta1/dynakube/validation/csi_daemonset.go
@@ -1,0 +1,47 @@
+package validation
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
+	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	errorCSIRequired = `The Dynakube's specification requires the CSI driver to work. Make sure you deployed the correct manifests.
+`
+	errorCSIEnabledRequired = `The Dynakube's specification specifies readonly-CSI volume, but the CSI driver is not enabled.
+`
+)
+
+func missingCSIDaemonSet(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	if !dk.NeedsCSIDriver() {
+		return ""
+	}
+
+	csiDaemonSet := appsv1.DaemonSet{}
+
+	err := dv.apiReader.Get(ctx, types.NamespacedName{Name: dtcsi.DaemonSetName, Namespace: dk.Namespace}, &csiDaemonSet)
+	if k8serrors.IsNotFound(err) {
+		log.Info("requested dynakube uses csi driver, but csi driver is missing in the cluster", "name", dk.Name, "namespace", dk.Namespace)
+
+		return errorCSIRequired
+	} else if err != nil {
+		log.Info("error occurred while listing dynakubes", "err", err.Error())
+	}
+
+	return ""
+}
+
+func disabledCSIForReadonlyCSIVolume(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if !dk.NeedsCSIDriver() && dk.FeatureReadOnlyCsiVolume() {
+		log.Info("requested dynakube uses readonly csi volume, but csi driver is not enabled", "name", dk.Name, "namespace", dk.Namespace)
+
+		return errorCSIEnabledRequired
+	}
+
+	return ""
+}

--- a/pkg/api/v1beta1/dynakube/validation/csi_daemonset_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/csi_daemonset_test.go
@@ -1,0 +1,158 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+)
+
+func TestMissingCSIDaemonSet(t *testing.T) {
+	t.Run(`valid cloud-native dynakube specs`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
+				},
+			},
+		}, &defaultCSIDaemonSet)
+	})
+
+	t.Run(`valid default application-monitoring dynakube specs`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
+				},
+			},
+		})
+	})
+
+	t.Run(`valid application-monitoring via csi dynakube specs`, func(t *testing.T) {
+		useCSIDriver := true
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+						UseCSIDriver: &useCSIDriver,
+					},
+				},
+			},
+		}, &defaultCSIDaemonSet)
+	})
+
+	t.Run(`valid default host-monitoring dynakube specs`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					HostMonitoring: &dynakube.HostInjectSpec{},
+				},
+			},
+		}, &defaultCSIDaemonSet)
+	})
+
+	t.Run(`invalid cloud-native dynakube specs`, func(t *testing.T) {
+		// no daemonset ==> fail
+		assertDenied(t,
+			[]string{errorCSIRequired},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
+					},
+				},
+			})
+	})
+
+	t.Run(`invalid default host-monitoring dynakube specs`, func(t *testing.T) {
+		// no daemonset ==> fail
+		assertDenied(t,
+			[]string{errorCSIRequired},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{},
+					},
+				},
+			})
+	})
+
+	t.Run(`invalid application-monitoring via csi dynakube specs`, func(t *testing.T) {
+		// no daemonset ==> fail
+		useCSIDriver := true
+		assertDenied(t,
+			[]string{errorCSIRequired},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+							UseCSIDriver: &useCSIDriver,
+						},
+					},
+				},
+			})
+	})
+}
+
+func TestDisabledCSIForReadonlyCSIVolume(t *testing.T) {
+	objectMeta := defaultDynakubeObjectMeta.DeepCopy()
+	objectMeta.Annotations = map[string]string{
+		dynakube.AnnotationFeatureReadOnlyCsiVolume: "true",
+	}
+
+	t.Run(`valid cloud-native dynakube specs`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: *objectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
+				},
+			},
+		}, &defaultCSIDaemonSet)
+	})
+
+	t.Run(`invalid dynakube specs, as csi is disabled`, func(t *testing.T) {
+		useCSIDriver := false
+		assertDenied(t,
+			[]string{errorCSIEnabledRequired},
+			&dynakube.DynaKube{
+				ObjectMeta: *objectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+							UseCSIDriver: &useCSIDriver,
+						},
+					},
+				},
+			}, &defaultCSIDaemonSet)
+	})
+
+	t.Run(`invalid dynakube specs, as csi is not supported for feature`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorCSIEnabledRequired},
+			&dynakube.DynaKube{
+				ObjectMeta: *objectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						ClassicFullStack: &dynakube.HostInjectSpec{},
+					},
+				},
+			})
+	})
+}

--- a/pkg/api/v1beta1/dynakube/validation/dynakube_name.go
+++ b/pkg/api/v1beta1/dynakube/validation/dynakube_name.go
@@ -1,0 +1,43 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	errorNoDNS1053Label = `The DynaKube's specification violates DNS-1035.
+    [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]
+	`
+
+	errorNameTooLong = `The length limit for the name of a DynaKube is %d, because it is the base for the name of resources related to the DynaKube. (example: dkName-activegate-<some-hash>)
+	The limit is necessary because kubernetes uses the name of some resources (example: StatefulSet) for the label value, which has a limit of 63 characters. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)`
+)
+
+func nameViolatesDNS1035(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	dynakubeName := dk.Name
+
+	var errs []string
+
+	if dynakubeName != "" {
+		errs = validation.IsDNS1035Label(dynakubeName)
+	}
+
+	if len(errs) == 0 {
+		return ""
+	}
+
+	return errorNoDNS1053Label
+}
+
+func nameTooLong(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	dynakubeName := dk.Name
+	if dynakubeName != "" && len(dynakubeName) > dynakube.MaxNameLength {
+		return fmt.Sprintf(errorNameTooLong, dynakube.MaxNameLength)
+	}
+
+	return ""
+}

--- a/pkg/api/v1beta1/dynakube/validation/dynakube_name_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/dynakube_name_test.go
@@ -1,0 +1,78 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNameStartsWithDigit(t *testing.T) {
+	t.Run(`dynakube name starts with digit`, func(t *testing.T) {
+		assertDenied(t, []string{errorNoDNS1053Label}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "1dynakube",
+			},
+		})
+		assertAllowed(t, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dynakube",
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: "https://tenantid.doma.in/api",
+			},
+		})
+	})
+}
+
+func TestNameTooLong(t *testing.T) {
+	type testCase struct {
+		name         string
+		crNameLength int
+		allow        bool
+	}
+
+	testCases := []testCase{
+		{
+			name:         "normal length",
+			crNameLength: 10,
+			allow:        true,
+		},
+		{
+			name:         "max - 1 ",
+			crNameLength: dynakube.MaxNameLength - 1,
+			allow:        true,
+		},
+		{
+			name:         "max",
+			crNameLength: dynakube.MaxNameLength,
+			allow:        true,
+		},
+		{
+			name:         "max + 1 ",
+			crNameLength: dynakube.MaxNameLength + 1,
+			allow:        false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			dk := &dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: strings.Repeat("a", test.crNameLength),
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: "https://tenantid.doma.in/api",
+				},
+			}
+			if test.allow {
+				assertAllowed(t, dk)
+			} else {
+				errorMessage := fmt.Sprintf(errorNameTooLong, dynakube.MaxNameLength)
+				assertDenied(t, []string{errorMessage}, dk)
+			}
+		})
+	}
+}

--- a/pkg/api/v1beta1/dynakube/validation/image.go
+++ b/pkg/api/v1beta1/dynakube/validation/image.go
@@ -1,0 +1,65 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+const (
+	errorUsingTenantImageAsCustom = `Custom %s image must not reference the Dynatrace Environment directly.`
+
+	errorUnparsableImageRef = `Custom %s image can't be parsed, make sure it's a valid image reference.`
+)
+
+func imageFieldHasTenantImage(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	tenantHost := dk.ApiUrlHost()
+
+	type imageField struct {
+		value   string
+		section string
+	}
+
+	imageFields := []imageField{
+		{
+			section: "ActiveGate",
+			value:   dk.CustomActiveGateImage(),
+		},
+		{
+			section: "OneAgent",
+			value:   dk.CustomOneAgentImage(),
+		},
+	}
+
+	messages := []string{}
+
+	for _, field := range imageFields {
+		message := checkImageField(field.value, field.section, tenantHost)
+		if message != "" {
+			messages = append(messages, message)
+		}
+	}
+
+	return strings.Join(messages, ";")
+}
+
+func checkImageField(image, section, disallowedHost string) (errorMsg string) {
+	if image != "" {
+		ref, err := name.ParseReference(image)
+		if err != nil {
+			return fmt.Sprintf(errorUnparsableImageRef, section)
+		}
+
+		refUrl, _ := url.Parse(ref.Name())
+
+		if refUrl.Host == disallowedHost {
+			return fmt.Sprintf(errorUsingTenantImageAsCustom, section)
+		}
+	}
+
+	return ""
+}

--- a/pkg/api/v1beta1/dynakube/validation/image_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/image_test.go
@@ -1,0 +1,87 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestImageFieldHasTenantImage(t *testing.T) {
+	testTenantUrl := "https://beepboop.dev.dynatracelabs.com"
+
+	t.Run("image fields are a malformed ref", func(t *testing.T) {
+		expectedMessage := strings.Join([]string{
+			fmt.Sprintf(errorUnparsableImageRef, "ActiveGate"),
+			fmt.Sprintf(errorUnparsableImageRef, "OneAgent"),
+		}, ";")
+
+		assertDenied(t, []string{expectedMessage}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dynakube",
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testTenantUrl + "/api",
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: &dynakube.HostInjectSpec{
+						Image: "BOOM",
+					},
+				},
+				ActiveGate: dynakube.ActiveGateSpec{
+					CapabilityProperties: dynakube.CapabilityProperties{
+						Image: "BOOM",
+					},
+				},
+			},
+		})
+	})
+	t.Run("image fields are using tenant repos", func(t *testing.T) {
+		expectedMessage := strings.Join([]string{
+			fmt.Sprintf(errorUsingTenantImageAsCustom, "ActiveGate"),
+			fmt.Sprintf(errorUsingTenantImageAsCustom, "OneAgent"),
+		}, ";")
+
+		assertDenied(t, []string{expectedMessage}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dynakube",
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testTenantUrl + "/api",
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: &dynakube.HostInjectSpec{
+						Image: testTenantUrl + "/linux/oneagent:latest",
+					},
+				},
+				ActiveGate: dynakube.ActiveGateSpec{
+					CapabilityProperties: dynakube.CapabilityProperties{
+						Image: testTenantUrl + "/linux/activegate:latest",
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("valid image fields", func(t *testing.T) {
+		testRegistryUrl := "my.images.com"
+		assertAllowed(t, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dynakube",
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testTenantUrl + "/api",
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: &dynakube.HostInjectSpec{
+						Image: testRegistryUrl + "/linux/oneagent:latest",
+					},
+				},
+				ActiveGate: dynakube.ActiveGateSpec{
+					CapabilityProperties: dynakube.CapabilityProperties{
+						Image: testRegistryUrl + "/linux/activegate:latest",
+					},
+				},
+			},
+		})
+	})
+}

--- a/pkg/api/v1beta1/dynakube/validation/istio.go
+++ b/pkg/api/v1beta1/dynakube/validation/istio.go
@@ -1,0 +1,29 @@
+package validation
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
+)
+
+const (
+	errorNoResources           = `No resources for istio available`
+	errorFailToInitIstioClient = `Failed to initialize istio client`
+)
+
+func noResourcesAvailable(_ context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	if dk.Spec.EnableIstio {
+		istioClient, err := istio.NewClient(dv.cfg, dk)
+		if err != nil {
+			return errorFailToInitIstioClient
+		}
+
+		enabled, err := istioClient.CheckIstioInstalled()
+		if !enabled || err != nil {
+			return errorNoResources
+		}
+	}
+
+	return ""
+}

--- a/pkg/api/v1beta1/dynakube/validation/istio_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/istio_test.go
@@ -1,0 +1,18 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+)
+
+func TestNoResourcesAvailable(t *testing.T) {
+	t.Run(`no resources`, func(t *testing.T) {
+		assertDenied(t, []string{errorNoResources}, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL:      testApiUrl,
+				EnableIstio: true,
+			},
+		})
+	})
+}

--- a/pkg/api/v1beta1/dynakube/validation/namespace_selector.go
+++ b/pkg/api/v1beta1/dynakube/validation/namespace_selector.go
@@ -1,0 +1,52 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	v1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/mapper"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+const (
+	errorConflictingNamespaceSelector = `The DynaKube's specification tries to inject into namespaces where another Dynakube already injects into, which is not supported.
+Make sure the namespaceSelector doesn't conflict with other Dynakubes namespaceSelector`
+
+	errorNamespaceSelectorMatchLabelsViolateLabelSpec = "The DynaKube's namespaceSelector contains matchLabels that are not conform to spec."
+)
+
+func conflictingNamespaceSelector(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	if !dk.NeedAppInjection() && dk.FeatureDisableMetadataEnrichment() {
+		return ""
+	}
+
+	dst := &v1beta3.DynaKube{}
+
+	err := dk.ConvertTo(dst)
+	if err != nil {
+		return err.Error()
+	}
+
+	dkMapper := mapper.NewDynakubeMapper(ctx, nil, dv.apiReader, dst.Namespace, dst)
+
+	_, err = dkMapper.MatchingNamespaces()
+	if err != nil && err.Error() == mapper.ErrorConflictingNamespace {
+		log.Info("requested dynakube has conflicting namespaceSelector", "name", dk.Name, "namespace", dk.Namespace)
+
+		return errorConflictingNamespaceSelector
+	}
+
+	return ""
+}
+
+func namespaceSelectorViolateLabelSpec(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	errs := validation.ValidateLabelSelector(dk.NamespaceSelector(), validation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: false}, field.NewPath("spec", "namespaceSelector"))
+	if len(errs) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("%s (%s)", errorNamespaceSelectorMatchLabelsViolateLabelSpec, errs)
+}

--- a/pkg/api/v1beta1/dynakube/validation/namespace_selector_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/namespace_selector_test.go
@@ -1,0 +1,193 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	v1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConflictingNamespaceSelector(t *testing.T) {
+	t.Run(`valid dynakube specs`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				NamespaceSelector: metav1.LabelSelector{
+					MatchLabels: dummyLabels,
+				},
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+						AppInjectionSpec: dynakube.AppInjectionSpec{},
+					},
+				},
+			},
+		},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					NamespaceSelector: metav1.LabelSelector{
+						MatchLabels: dummyLabels,
+					},
+					OneAgent: dynakube.OneAgentSpec{
+						ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+							AppInjectionSpec: dynakube.AppInjectionSpec{},
+						},
+					},
+				},
+			}, &dummyNamespace, &dummyNamespace2)
+	})
+	t.Run(`invalid dynakube specs`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorConflictingNamespaceSelector},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					NamespaceSelector: metav1.LabelSelector{
+						MatchLabels: dummyLabels,
+					},
+					OneAgent: dynakube.OneAgentSpec{
+						ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+							AppInjectionSpec: dynakube.AppInjectionSpec{},
+						},
+					},
+				},
+			},
+			&v1beta3.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflicting-dk",
+					Namespace: testNamespace,
+				},
+				Spec: v1beta3.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: v1beta3.OneAgentSpec{
+						ApplicationMonitoring: &v1beta3.ApplicationMonitoringSpec{
+							AppInjectionSpec: v1beta3.AppInjectionSpec{
+								NamespaceSelector: metav1.LabelSelector{
+									MatchLabels: dummyLabels,
+								},
+							},
+						},
+					},
+				},
+			}, &defaultCSIDaemonSet, &dummyNamespace)
+	})
+	t.Run("validate namespaceSelector to be a valid label according to spec", func(t *testing.T) {
+		testsValidLabels := []string{
+			"",
+			"a",
+			"short",
+			"WithUpperCase",
+			"contains123",
+			"label-with-Dash",
+			"label_with_underscore",
+			"label.with.dotttses",
+			"label.with.dotttses-567567",
+		}
+		// MatchLabels
+		for _, label := range testsValidLabels {
+			assertAllowed(t, &dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-namespace-selector",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					NamespaceSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"dummy": label,
+						},
+					},
+					OneAgent: dynakube.OneAgentSpec{
+						ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+							AppInjectionSpec: dynakube.AppInjectionSpec{},
+						},
+					},
+				},
+			}, &dummyNamespace, &dummyNamespace2)
+		}
+		// MatchExpressions
+		assertAllowed(t, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "invalid-namespace-selector",
+				Namespace: testNamespace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				NamespaceSelector: metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "dummy",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   testsValidLabels,
+						},
+					},
+				},
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+						AppInjectionSpec: dynakube.AppInjectionSpec{},
+					},
+				},
+			},
+		}, &dummyNamespace, &dummyNamespace2)
+
+		testsInvalidLabels := []string{
+			"name%",
+			"name/",
+			"AMuchTooLongLabelThatGoesOverSixtyThreeCharactersAndSoIsInvalidAccordingToSpec",
+		}
+		for _, label := range testsInvalidLabels {
+			// MatchLabels
+			assertDenied(t,
+				[]string{errorNamespaceSelectorMatchLabelsViolateLabelSpec},
+				&dynakube.DynaKube{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "invalid-namespace-selector",
+						Namespace: testNamespace,
+					},
+					Spec: dynakube.DynaKubeSpec{
+						APIURL: testApiUrl,
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"dummy": label,
+							},
+						},
+						OneAgent: dynakube.OneAgentSpec{
+							ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+								AppInjectionSpec: dynakube.AppInjectionSpec{},
+							},
+						},
+					},
+				}, &dummyNamespace, &dummyNamespace2)
+		}
+		// MatchExpressions
+		assertDenied(t,
+			[]string{errorNamespaceSelectorMatchLabelsViolateLabelSpec},
+			&dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-namespace-selector",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					NamespaceSelector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "dummy",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   testsInvalidLabels,
+							},
+						},
+					},
+					OneAgent: dynakube.OneAgentSpec{
+						ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+							AppInjectionSpec: dynakube.AppInjectionSpec{},
+						},
+					},
+				},
+			}, &dummyNamespace, &dummyNamespace2)
+	})
+}

--- a/pkg/api/v1beta1/dynakube/validation/oneagent.go
+++ b/pkg/api/v1beta1/dynakube/validation/oneagent.go
@@ -1,0 +1,158 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
+	"golang.org/x/mod/semver"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	errorConflictingOneagentMode = `The DynaKube's specification tries to use multiple oneagent modes at the same time, which is not supported.
+`
+	errorImageFieldSetWithoutCSIFlag = `The DynaKube's specification tries to enable ApplicationMonitoring mode and get the respective image, but the CSI driver is not enabled.`
+
+	errorNodeSelectorConflict = `The DynaKube's specification tries to specify a nodeSelector conflicts with an another Dynakube's nodeSelector, which is not supported.
+The conflicting Dynakube: %s
+`
+	errorVolumeStorageReadOnlyModeConflict = `The DynaKube's specification specifies a read-only host file system and OneAgent has volume storage enabled.`
+
+	warningOneAgentInstallerEnvVars = `Environment variables ONEAGENT_INSTALLER_SCRIPT_URL and ONEAGENT_INSTALLER_TOKEN are only relevant for an unsupported image type. Please make sure you are using a supported image.`
+
+	warningHostGroupConflict = `DynaKube's specification sets the host group using --set-host-group parameter. Instead, specify the new spec.oneagent.hostGroup field. If you use both settings, the new field precedes the parameter.`
+)
+
+func conflictingOneAgentConfiguration(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	counter := 0
+	if dk.ApplicationMonitoringMode() {
+		counter += 1
+	}
+
+	if dk.CloudNativeFullstackMode() {
+		counter += 1
+	}
+
+	if dk.ClassicFullStackMode() {
+		counter += 1
+	}
+
+	if dk.HostMonitoringMode() {
+		counter += 1
+	}
+
+	if counter > 1 {
+		log.Info("requested dynakube has conflicting one agent configuration", "name", dk.Name, "namespace", dk.Namespace)
+
+		return errorConflictingOneagentMode
+	}
+
+	return ""
+}
+
+func conflictingNodeSelector(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	if !dk.NeedsOneAgent() || dk.FeatureEnableMultipleOsAgentsOnNode() {
+		return ""
+	}
+
+	validDynakubes := &dynakube.DynaKubeList{}
+	if err := dv.apiReader.List(ctx, validDynakubes, &client.ListOptions{Namespace: dk.Namespace}); err != nil {
+		log.Info("error occurred while listing dynakubes", "err", err.Error())
+
+		return ""
+	}
+
+	for _, item := range validDynakubes.Items {
+		if !item.NeedsOneAgent() {
+			continue
+		}
+
+		nodeSelectorMap := dk.NodeSelector()
+		validNodeSelectorMap := item.NodeSelector()
+
+		if item.Name != dk.Name {
+			if hasConflictingMatchLabels(nodeSelectorMap, validNodeSelectorMap) {
+				log.Info("requested dynakube has conflicting nodeSelector", "name", dk.Name, "namespace", dk.Namespace)
+
+				return fmt.Sprintf(errorNodeSelectorConflict, item.Name)
+			}
+		}
+	}
+
+	return ""
+}
+
+func imageFieldSetWithoutCSIFlag(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if dk.ApplicationMonitoringMode() {
+		if !dk.NeedsCSIDriver() && len(dk.Spec.OneAgent.ApplicationMonitoring.CodeModulesImage) > 0 {
+			return errorImageFieldSetWithoutCSIFlag
+		}
+	}
+
+	return ""
+}
+
+func hasConflictingMatchLabels(labelMap, otherLabelMap map[string]string) bool {
+	if labelMap == nil || otherLabelMap == nil {
+		return true
+	}
+
+	labelSelector := labels.SelectorFromSet(labelMap)
+	otherLabelSelector := labels.SelectorFromSet(otherLabelMap)
+	labelSelectorLabels := labels.Set(labelMap)
+	otherLabelSelectorLabels := labels.Set(otherLabelMap)
+
+	return labelSelector.Matches(otherLabelSelectorLabels) || otherLabelSelector.Matches(labelSelectorLabels)
+}
+
+func hasOneAgentVolumeStorageEnabled(dk *dynakube.DynaKube) (isEnabled bool, isSet bool) {
+	envVar := env.FindEnvVar(dk.GetOneAgentEnvironment(), oneagentEnableVolumeStorageEnvVarName)
+	isSet = envVar != nil
+	isEnabled = isSet && envVar.Value == "true"
+
+	return
+}
+
+func unsupportedOneAgentImage(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if env.FindEnvVar(dk.GetOneAgentEnvironment(), oneagentInstallerScriptUrlEnvVarName) != nil ||
+		env.FindEnvVar(dk.GetOneAgentEnvironment(), oneagentInstallerTokenEnvVarName) != nil {
+		return warningOneAgentInstallerEnvVars
+	}
+
+	return ""
+}
+
+func conflictingOneAgentVolumeStorageSettings(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	volumeStorageEnabled, volumeStorageSet := hasOneAgentVolumeStorageEnabled(dk)
+	if dk.NeedsReadOnlyOneAgents() && volumeStorageSet && !volumeStorageEnabled {
+		return errorVolumeStorageReadOnlyModeConflict
+	}
+
+	return ""
+}
+
+func conflictingHostGroupSettings(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if dk.HostGroupAsParam() != "" {
+		return warningHostGroupConflict
+	}
+
+	return ""
+}
+
+func validateOneAgentVersionIsSemVerCompliant(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	agentVersion := dk.CustomOneAgentVersion()
+	if agentVersion == "" {
+		return ""
+	}
+
+	version := "v" + agentVersion
+	if !(semver.IsValid(version) && semver.Prerelease(version) == "" && semver.Build(version) == "" && len(strings.Split(version, ".")) == 3) {
+		return "Only semantic versions in the form of major.minor.patch (e.g. 1.0.0) are allowed!"
+	}
+
+	return ""
+}

--- a/pkg/api/v1beta1/dynakube/validation/oneagent_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/oneagent_test.go
@@ -1,0 +1,464 @@
+package validation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConflictingOneAgentConfiguration(t *testing.T) {
+	t.Run(`valid dynakube specs`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: nil,
+					HostMonitoring:   nil,
+				},
+			},
+		})
+
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: &dynakube.HostInjectSpec{},
+					HostMonitoring:   nil,
+				},
+			},
+		})
+
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					ClassicFullStack: nil,
+					HostMonitoring:   &dynakube.HostInjectSpec{},
+				},
+			},
+		}, &defaultCSIDaemonSet)
+	})
+	t.Run(`conflicting dynakube specs`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorConflictingOneagentMode},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						ClassicFullStack: &dynakube.HostInjectSpec{},
+						HostMonitoring:   &dynakube.HostInjectSpec{},
+					},
+				},
+			}, &defaultCSIDaemonSet)
+
+		assertDenied(t,
+			[]string{errorConflictingOneagentMode},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
+						HostMonitoring:        &dynakube.HostInjectSpec{},
+					},
+				},
+			}, &defaultCSIDaemonSet)
+	})
+}
+
+func TestConflictingNodeSelector(t *testing.T) {
+	newCloudNativeDynakube := func(name string, annotations map[string]string, nodeSelectorValue string) *dynakube.DynaKube {
+		return &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   testNamespace,
+				Annotations: annotations,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+						HostInjectSpec: dynakube.HostInjectSpec{
+							NodeSelector: map[string]string{
+								"node": nodeSelectorValue,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run(`valid dynakube specs`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{
+							NodeSelector: map[string]string{
+								"node": "1",
+							},
+						},
+					},
+				},
+			},
+			&dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict1",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{
+							NodeSelector: map[string]string{
+								"node": "2",
+							},
+						},
+					},
+				},
+			}, &defaultCSIDaemonSet)
+
+		assertAllowedWithoutWarnings(t,
+			&dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict2",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+							HostInjectSpec: dynakube.HostInjectSpec{
+								NodeSelector: map[string]string{
+									"node": "1",
+								},
+							},
+						},
+					},
+				},
+			},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{
+							NodeSelector: map[string]string{
+								"node": "2",
+							},
+						},
+					},
+				},
+			}, &defaultCSIDaemonSet)
+	})
+	t.Run(`valid dynakube specs with multitenant hostMonitoring`, func(t *testing.T) {
+		assertAllowedWithWarnings(t, 0,
+			newCloudNativeDynakube("dk1", map[string]string{
+				dynakube.AnnotationFeatureMultipleOsAgentsOnNode: "true",
+			}, "1"),
+			newCloudNativeDynakube("dk2", map[string]string{
+				dynakube.AnnotationFeatureMultipleOsAgentsOnNode: "true",
+			}, "2"),
+			&defaultCSIDaemonSet)
+
+		assertAllowedWithWarnings(t, 0,
+			newCloudNativeDynakube("dk1", map[string]string{
+				dynakube.AnnotationFeatureMultipleOsAgentsOnNode: "true",
+			}, "1"),
+			newCloudNativeDynakube("dk2", map[string]string{
+				dynakube.AnnotationFeatureMultipleOsAgentsOnNode: "true",
+			}, "1"),
+			&defaultCSIDaemonSet)
+	})
+	t.Run(`invalid dynakube specs`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{fmt.Sprintf(errorNodeSelectorConflict, "conflicting-dk")},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+							HostInjectSpec: dynakube.HostInjectSpec{
+								NodeSelector: map[string]string{
+									"node": "1",
+								},
+							},
+						},
+					},
+				},
+			},
+			&dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflicting-dk",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{
+							NodeSelector: map[string]string{
+								"node": "1",
+							},
+						},
+					},
+				},
+			}, &defaultCSIDaemonSet)
+	})
+	t.Run(`invalid dynakube specs with multitenant hostMonitoring`, func(t *testing.T) {
+		assertDenied(t, nil,
+			newCloudNativeDynakube("dk1", map[string]string{
+				dynakube.AnnotationFeatureMultipleOsAgentsOnNode: "false",
+			}, "1"),
+			newCloudNativeDynakube("dk2", map[string]string{
+				dynakube.AnnotationFeatureMultipleOsAgentsOnNode: "true",
+			}, "1"),
+			&defaultCSIDaemonSet)
+
+		assertDenied(t, nil,
+			newCloudNativeDynakube("dk1", map[string]string{
+				dynakube.AnnotationFeatureMultipleOsAgentsOnNode: "false",
+			}, "1"),
+			newCloudNativeDynakube("dk2", map[string]string{
+				dynakube.AnnotationFeatureMultipleOsAgentsOnNode: "false",
+			}, "1"),
+			&defaultCSIDaemonSet)
+
+		assertDenied(t, nil,
+			newCloudNativeDynakube("dk1", map[string]string{}, "1"),
+			newCloudNativeDynakube("dk2", map[string]string{}, "1"),
+			&defaultCSIDaemonSet)
+	})
+}
+
+func TestImageFieldSetWithoutCSIFlag(t *testing.T) {
+	t.Run(`spec with appMon enabled and image name`, func(t *testing.T) {
+		useCSIDriver := true
+		testImage := "testImage"
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+						AppInjectionSpec: dynakube.AppInjectionSpec{
+							CodeModulesImage: testImage,
+						},
+						UseCSIDriver: &useCSIDriver,
+					},
+				},
+			},
+		}, &defaultCSIDaemonSet)
+	})
+
+	t.Run(`spec with appMon enabled, useCSIDriver not enabled but image set`, func(t *testing.T) {
+		useCSIDriver := false
+		testImage := "testImage"
+		assertDenied(t, []string{errorImageFieldSetWithoutCSIFlag}, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{
+						AppInjectionSpec: dynakube.AppInjectionSpec{
+							CodeModulesImage: testImage,
+						},
+						UseCSIDriver: &useCSIDriver,
+					},
+				},
+			},
+		}, &defaultCSIDaemonSet)
+	})
+}
+
+func createDynakube(oaEnvVar ...string) *dynakube.DynaKube {
+	envVars := make([]corev1.EnvVar, 0)
+	for i := 0; i < len(oaEnvVar); i += 2 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  oaEnvVar[i],
+			Value: oaEnvVar[i+1],
+		})
+	}
+
+	return &dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dynakube",
+			Namespace: testNamespace,
+		},
+		Spec: dynakube.DynaKubeSpec{
+			APIURL: testApiUrl,
+			OneAgent: dynakube.OneAgentSpec{
+				CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+					HostInjectSpec: dynakube.HostInjectSpec{
+						Env: envVars,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestUnsupportedOneAgentImage(t *testing.T) {
+	type unsupportedOneAgentImageTests struct {
+		testName        string
+		envVars         []string
+		allowedWarnings int
+	}
+
+	testcases := []unsupportedOneAgentImageTests{
+		{
+			testName:        "ONEAGENT_INSTALLER_SCRIPT_URL",
+			envVars:         []string{"ONEAGENT_INSTALLER_SCRIPT_URL", "foobar"},
+			allowedWarnings: 1,
+		},
+		{
+			testName:        "ONEAGENT_INSTALLER_TOKEN",
+			envVars:         []string{"ONEAGENT_INSTALLER_TOKEN", "foobar"},
+			allowedWarnings: 1,
+		},
+		{
+			testName:        "ONEAGENT_INSTALLER_SCRIPT_URL",
+			envVars:         []string{"ONEAGENT_INSTALLER_SCRIPT_URL", "foobar", "ONEAGENT_INSTALLER_TOKEN", "foobar"},
+			allowedWarnings: 1,
+		},
+		{
+			testName:        "no env vars",
+			envVars:         []string{},
+			allowedWarnings: 0,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.testName, func(t *testing.T) {
+			assertAllowedWithWarnings(t,
+				tc.allowedWarnings,
+				createDynakube(tc.envVars...),
+				&defaultCSIDaemonSet)
+		})
+	}
+}
+
+func TestOneAgentHostGroup(t *testing.T) {
+	t.Run(`valid dynakube specs`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t,
+			createDynakubeWithHostGroup([]string{}, ""),
+			&defaultCSIDaemonSet)
+
+		assertAllowedWithoutWarnings(t,
+			createDynakubeWithHostGroup([]string{"--other-param=1"}, ""),
+			&defaultCSIDaemonSet)
+
+		assertAllowedWithoutWarnings(t,
+			createDynakubeWithHostGroup([]string{}, "field"),
+			&defaultCSIDaemonSet)
+	})
+
+	t.Run(`obsolete settings`, func(t *testing.T) {
+		assertAllowedWithWarnings(t,
+			1,
+			createDynakubeWithHostGroup([]string{"--set-host-group=arg"}, ""),
+			&defaultCSIDaemonSet)
+
+		assertAllowedWithWarnings(t,
+			1,
+			createDynakubeWithHostGroup([]string{"--set-host-group=arg"}, "field"),
+			&defaultCSIDaemonSet)
+
+		assertAllowedWithWarnings(t,
+			1,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						ClassicFullStack: &dynakube.HostInjectSpec{
+							Args: []string{"--set-host-group=arg"},
+						},
+						HostGroup: "",
+					},
+				},
+			},
+			&defaultCSIDaemonSet)
+
+		assertAllowedWithWarnings(t,
+			1,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{
+							Args: []string{"--set-host-group=arg"},
+						},
+						HostGroup: "",
+					},
+				},
+			},
+			&defaultCSIDaemonSet)
+	})
+}
+
+func createDynakubeWithHostGroup(args []string, hostGroup string) *dynakube.DynaKube {
+	return &dynakube.DynaKube{
+		ObjectMeta: defaultDynakubeObjectMeta,
+		Spec: dynakube.DynaKubeSpec{
+			APIURL: testApiUrl,
+			OneAgent: dynakube.OneAgentSpec{
+				CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+					HostInjectSpec: dynakube.HostInjectSpec{
+						Args: args,
+					},
+				},
+				HostGroup: hostGroup,
+			},
+		},
+	}
+}
+
+func TestValidateOneAgentVersionIsSemVer(t *testing.T) {
+	testCasesAcceptedVersions := []string{"", "1.0.0", "1.200.1"}
+
+	testCasesNotAcceptedVersions := []string{"latest", "raw", "1.200.1-raw", "v1.200.1-raw", "1.200.1+build", "v1.200.1+build", "1.200.1-raw+build", "v1.200.1-raw+build", "1.200", "v1.200", "1", "v1", "1.0", "v1.0", "v1.200.0"}
+
+	for _, tc := range testCasesAcceptedVersions {
+		t.Run("should accept version "+tc, func(t *testing.T) {
+			assertAllowed(t, &dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						ClassicFullStack: &dynakube.HostInjectSpec{
+							Version: tc,
+						},
+					},
+				},
+			})
+		})
+	}
+
+	for _, tc := range testCasesNotAcceptedVersions {
+		t.Run("should accept version "+tc, func(t *testing.T) {
+			assertDenied(t, []string{"Only semantic versions in the form of major.minor.patch (e.g. 1.0.0) are allowed!"}, &dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						ClassicFullStack: &dynakube.HostInjectSpec{
+							Version: tc,
+						},
+					},
+				},
+			})
+		})
+	}
+}

--- a/pkg/api/v1beta1/dynakube/validation/preview.go
+++ b/pkg/api/v1beta1/dynakube/validation/preview.go
@@ -1,0 +1,8 @@
+package validation
+
+const (
+	featurePreviewWarningMessage = `%s feature is in PREVIEW.`                                            //nolint: unused
+	basePreviewWarning           = "PREVIEW features are NOT production ready and you may run into bugs." //nolint: unused
+)
+
+// Logics related to preview warnings go here.

--- a/pkg/api/v1beta1/dynakube/validation/preview_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/preview_test.go
@@ -1,0 +1,21 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+)
+
+func TestPreviewWarning(t *testing.T) {
+	t.Run(`no warning`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: &dynakube.ApplicationMonitoringSpec{},
+				},
+			},
+		})
+	})
+}

--- a/pkg/api/v1beta1/dynakube/validation/proxy_url.go
+++ b/pkg/api/v1beta1/dynakube/validation/proxy_url.go
@@ -1,0 +1,61 @@
+package validation
+
+import (
+	"context"
+	"net/url"
+	"regexp"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/pkg/errors"
+)
+
+const (
+	errorInvalidProxyUrl      = `The DynaKube's specification has an invalid Proxy URL value set. Make sure you correctly specify the URL in your custom resource or in the provided secret.`
+	errorInvalidEvalCharacter = `The DynaKube's specification has an invalid Proxy password value set. Make sure you don't use forbidden characters: space, apostrophe, backtick, comma, ampersand, equals sign, plus sign, percent sign, backslash.`
+
+	errorMissingProxySecret = `Error occurred while reading PROXY secret indicated in the Dynakube specification`
+)
+
+func invalidActiveGateProxyUrl(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	if dk.Spec.Proxy != nil {
+		proxyUrl, err := dk.Proxy(ctx, dv.apiReader)
+		if err != nil {
+			return errors.Wrap(err, errorMissingProxySecret).Error()
+		}
+
+		return validateProxyUrl(proxyUrl, errorInvalidProxyUrl, errorInvalidEvalCharacter)
+	}
+
+	return ""
+}
+
+// proxyUrl is valid if
+// 1) encoded
+// 2) password does not contain '` characters.
+func validateProxyUrl(proxyUrl string, parseErrorMessage string, evalErrorMessage string) string {
+	if parsedUrl, err := url.Parse(proxyUrl); err != nil {
+		return parseErrorMessage
+	} else {
+		password, _ := parsedUrl.User.Password()
+		if !isStringValidForAG(password) {
+			return evalErrorMessage
+		}
+	}
+
+	return ""
+}
+
+func isStringValidForAG(str string) bool {
+	// SP   !	"	#	$	%	&	'	(	)	*	+	,	-	.	/
+	// 0	1	2	3	4	5	6	7	8	9	:	;	<	=	>	?
+	// @	A	B	C	D	E	F	G	H	I	J	K	L	M	N	O
+	// P	Q	R	S	T	U	V	W	X	Y	Z	[	\	]	^	_
+	// `	a	b	c	d	e	f	g	h	i	j	k	l	m	n	o
+	// p	q	r	s	t	u	v	w	x	y	z	{	|	}	~
+	// '\'' '`'            exceptions due to entrypoint.sh:readSecret:eval
+	// ','                 exceptions due to Gateway reader of config files
+	// '&' '=' '+' '%' '\' exceptions due to entrypoint.sh:saveProxyConfiguration
+	regex := regexp.MustCompile(`^[!"#$()*\-./0-9:;<>?@A-Z\[\]^_a-z{|}~]*$`)
+
+	return regex.MatchString(str)
+}

--- a/pkg/api/v1beta1/dynakube/validation/proxy_url_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/proxy_url_test.go
@@ -1,0 +1,185 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testProxySecret = "proxysecret"
+
+	// invalidPlainTextProxyUrl contains forbidden apostrophe character.
+	invalidPlainTextProxyUrl = "http://test:password'!\"#$()*-./:;<>?@[]^_{|}~@proxy-service.dynatrace:3128"
+
+	// validEncodedProxyUrl contains no forbidden characters "http://test:password!"#$()*-./:;<>?@[]^_{|}~@proxy-service.dynatrace:3128"
+	validEncodedProxyUrl = "http://test:password!%22%23%24()*-.%2F%3A%3B%3C%3E%3F%40%5B%5D%5E_%7B%7C%7D~@proxy-service.dynatrace:3128"
+
+	// validEncodedProxyUrlNoPassword contains empty password.
+	validEncodedProxyUrlNoPassword = "http://test@proxy-service.dynatrace:3128"
+)
+
+func TestInvalidActiveGateProxy(t *testing.T) {
+	t.Run(`valid proxy url`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					Proxy: &dynakube.DynaKubeProxy{
+						Value:     validEncodedProxyUrl,
+						ValueFrom: "",
+					},
+				},
+			})
+	})
+
+	t.Run(`valid proxy url, no password`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					Proxy: &dynakube.DynaKubeProxy{
+						Value:     validEncodedProxyUrlNoPassword,
+						ValueFrom: "",
+					},
+				},
+			})
+	})
+
+	t.Run(`invalid proxy url`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorInvalidProxyUrl},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					Proxy: &dynakube.DynaKubeProxy{
+						Value:     invalidPlainTextProxyUrl,
+						ValueFrom: "",
+					},
+				},
+			})
+	})
+
+	t.Run(`valid proxy secret url`, func(t *testing.T) {
+		assertAllowedWithoutWarnings(t,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					Proxy: &dynakube.DynaKubeProxy{
+						Value:     "",
+						ValueFrom: testProxySecret,
+					},
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testProxySecret,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"proxy": []byte(validEncodedProxyUrl),
+				},
+			})
+	})
+
+	t.Run(`missing proxy secret`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorMissingProxySecret},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					Proxy: &dynakube.DynaKubeProxy{
+						Value:     "",
+						ValueFrom: testProxySecret,
+					},
+				},
+			})
+	})
+
+	t.Run(`invalid format of proxy secret`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorMissingProxySecret},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					Proxy: &dynakube.DynaKubeProxy{
+						Value:     "",
+						ValueFrom: testProxySecret,
+					},
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testProxySecret,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"invalid-name": []byte(validEncodedProxyUrl),
+				},
+			})
+	})
+
+	t.Run(`invalid proxy secret url`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorInvalidProxyUrl},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					Proxy: &dynakube.DynaKubeProxy{
+						Value:     "",
+						ValueFrom: testProxySecret,
+					},
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testProxySecret,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"proxy": []byte(invalidPlainTextProxyUrl),
+				},
+			})
+	})
+
+	t.Run(`invalid proxy secret url - entrypoint.sh`, func(t *testing.T) {
+		assert.True(t, isStringValidForAG("password"))
+		assert.True(t, isStringValidForAG("test~!@#^*()_-|}{[]\":;?><./pass"))
+
+		// -[] have to be escaped in the regex
+		assert.True(t, isStringValidForAG("pass-word"))
+		assert.True(t, isStringValidForAG("pass[word"))
+		assert.True(t, isStringValidForAG("pass]word"))
+		assert.True(t, isStringValidForAG("pass$word"))
+
+		// apostrophe
+		assert.False(t, isStringValidForAG("pass'word"))
+		// backtick
+		assert.False(t, isStringValidForAG("pass`word"))
+		// comma
+		assert.False(t, isStringValidForAG("pass,word"))
+		// ampersand
+		assert.False(t, isStringValidForAG("pass&word"))
+		// equals sign
+		assert.False(t, isStringValidForAG("pass=word"))
+		// plus sign
+		assert.False(t, isStringValidForAG("pass+word"))
+		// percent sign
+		assert.False(t, isStringValidForAG("pass%word"))
+		// backslash
+		assert.False(t, isStringValidForAG("pass\\word"))
+
+		// UTF-8 single character - U+1F600 grinning face
+		assert.False(t, isStringValidForAG("\xF0\x9F\x98\x80"))
+	})
+}

--- a/pkg/api/v1beta1/dynakube/validation/validation.go
+++ b/pkg/api/v1beta1/dynakube/validation/validation.go
@@ -1,0 +1,96 @@
+package validation
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type Validator struct {
+	apiReader client.Reader
+	cfg       *rest.Config
+}
+
+var (
+	validatorErrorFuncs = []validatorFunc{
+		NoApiUrl,
+		IsInvalidApiUrl,
+		IsThirdGenAPIUrl,
+		missingCSIDaemonSet,
+		disabledCSIForReadonlyCSIVolume,
+		invalidActiveGateCapabilities,
+		duplicateActiveGateCapabilities,
+		invalidActiveGateProxyUrl,
+		conflictingOneAgentConfiguration,
+		conflictingNodeSelector,
+		conflictingNamespaceSelector,
+		noResourcesAvailable,
+		imageFieldSetWithoutCSIFlag,
+		conflictingOneAgentVolumeStorageSettings,
+		nameViolatesDNS1035,
+		nameTooLong,
+		namespaceSelectorViolateLabelSpec,
+		imageFieldHasTenantImage,
+		validateOneAgentVersionIsSemVerCompliant,
+	}
+	validatorWarningFuncs = []validatorFunc{
+		missingActiveGateMemoryLimit,
+		unsupportedOneAgentImage,
+		conflictingHostGroupSettings,
+	}
+)
+
+type validatorFunc func(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string
+
+func New(apiReader client.Reader, cfg *rest.Config) admission.CustomValidator {
+	return &Validator{
+		apiReader: apiReader,
+		cfg:       cfg,
+	}
+}
+
+func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	dk := obj.(*dynakube.DynaKube)
+	errMessages := v.runValidators(ctx, validatorErrorFuncs, dk)
+	warnings = v.runValidators(ctx, validatorWarningFuncs, dk)
+
+	if len(errMessages) != 0 {
+		err = errors.New(validation.SumErrors(errMessages, "DynaKube"))
+	}
+
+	return
+}
+
+func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	dk := newObj.(*dynakube.DynaKube)
+	errMessages := v.runValidators(ctx, validatorErrorFuncs, dk)
+	warnings = v.runValidators(ctx, validatorWarningFuncs, dk)
+
+	if len(errMessages) != 0 {
+		err = errors.New(validation.SumErrors(errMessages, "DynaKube"))
+	}
+
+	return
+}
+
+func (v *Validator) ValidateDelete(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	return nil, nil
+}
+
+func (v *Validator) runValidators(ctx context.Context, validators []validatorFunc, dk *dynakube.DynaKube) []string {
+	results := []string{}
+
+	for _, validate := range validators {
+		if errMsg := validate(ctx, v, dk); errMsg != "" {
+			results = append(results, errMsg)
+		}
+	}
+
+	return results
+}

--- a/pkg/api/v1beta1/dynakube/validation/validation_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/validation_test.go
@@ -1,0 +1,212 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube"
+	v1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	testName      = "test-name"
+	testNamespace = "test-namespace"
+	testApiUrl    = "https://f.q.d.n/api"
+)
+
+var defaultDynakubeObjectMeta = metav1.ObjectMeta{
+	Name:      testName,
+	Namespace: testNamespace,
+}
+
+var defaultCSIDaemonSet = appsv1.DaemonSet{
+	ObjectMeta: metav1.ObjectMeta{Name: dtcsi.DaemonSetName, Namespace: testNamespace},
+}
+
+var dummyLabels = map[string]string{
+	"dummy": "label",
+}
+
+var dummyNamespace = corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:   "dummy",
+		Labels: dummyLabels,
+	},
+}
+
+var dummyLabels2 = map[string]string{
+	"dummy": "label",
+}
+
+var dummyNamespace2 = corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:   "dummy2",
+		Labels: dummyLabels2,
+	},
+}
+
+func TestDynakubeValidator_Handle(t *testing.T) {
+	t.Run(`valid dynakube specs`, func(t *testing.T) {
+		assertAllowedWithWarnings(t, 1, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				NamespaceSelector: metav1.LabelSelector{
+					MatchLabels: dummyLabels,
+				},
+				OneAgent: dynakube.OneAgentSpec{
+					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+						HostInjectSpec: dynakube.HostInjectSpec{
+							NodeSelector: map[string]string{
+								"node": "1",
+							},
+						},
+						AppInjectionSpec: dynakube.AppInjectionSpec{},
+					},
+				},
+				ActiveGate: dynakube.ActiveGateSpec{
+					Capabilities: []dynakube.CapabilityDisplayName{
+						dynakube.RoutingCapability.DisplayName,
+						dynakube.KubeMonCapability.DisplayName,
+						dynakube.MetricsIngestCapability.DisplayName,
+					},
+				},
+			},
+		},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					NamespaceSelector: metav1.LabelSelector{
+						MatchLabels: dummyLabels2,
+					},
+					OneAgent: dynakube.OneAgentSpec{
+						CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+							HostInjectSpec: dynakube.HostInjectSpec{
+								NodeSelector: map[string]string{
+									"node": "2",
+								},
+							},
+							AppInjectionSpec: dynakube.AppInjectionSpec{},
+						},
+					},
+				},
+			}, &dummyNamespace, &dummyNamespace2, &defaultCSIDaemonSet)
+	})
+	t.Run(`conflicting dynakube specs`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{
+				errorCSIRequired,
+				errorNoApiUrl,
+				errorConflictingNamespaceSelector,
+				fmt.Sprintf(errorDuplicateActiveGateCapability, dynakube.KubeMonCapability.DisplayName),
+				fmt.Sprintf(errorInvalidActiveGateCapability, "me dumb"),
+				fmt.Sprintf(errorNodeSelectorConflict, "conflict2")},
+			&dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: "",
+					NamespaceSelector: metav1.LabelSelector{
+						MatchLabels: dummyLabels,
+					},
+					OneAgent: dynakube.OneAgentSpec{
+						CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+							AppInjectionSpec: dynakube.AppInjectionSpec{},
+						},
+					},
+					ActiveGate: dynakube.ActiveGateSpec{
+						Capabilities: []dynakube.CapabilityDisplayName{
+							dynakube.KubeMonCapability.DisplayName,
+							dynakube.KubeMonCapability.DisplayName,
+							"me dumb",
+						},
+					},
+				},
+			},
+			&v1beta3.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict1",
+					Namespace: testNamespace,
+				},
+				Spec: v1beta3.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: v1beta3.OneAgentSpec{
+						ApplicationMonitoring: &v1beta3.ApplicationMonitoringSpec{
+							AppInjectionSpec: v1beta3.AppInjectionSpec{
+								NamespaceSelector: metav1.LabelSelector{
+									MatchLabels: dummyLabels,
+								},
+							},
+						},
+					},
+				},
+			},
+			&dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict2",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{},
+					},
+				},
+			}, &dummyNamespace, &dummyNamespace2)
+	})
+}
+
+func assertDenied(t *testing.T, errMessages []string, dk *dynakube.DynaKube, other ...client.Object) {
+	_, err := runValidators(dk, other...)
+	require.Error(t, err)
+
+	for _, errMsg := range errMessages {
+		assert.Contains(t, err.Error(), errMsg)
+	}
+}
+
+func assertAllowedWithoutWarnings(t *testing.T, dk *dynakube.DynaKube, other ...client.Object) {
+	warnings, _ := assertAllowed(t, dk, other...)
+	assert.Empty(t, warnings)
+}
+
+func assertAllowedWithWarnings(t *testing.T, warningAmount int, dk *dynakube.DynaKube, other ...client.Object) {
+	warnings, _ := assertAllowed(t, dk, other...)
+	assert.Len(t, warnings, warningAmount)
+}
+
+func assertAllowed(t *testing.T, dk *dynakube.DynaKube, other ...client.Object) (admission.Warnings, error) {
+	warnings, err := runValidators(dk, other...)
+	assert.NoError(t, err)
+
+	return warnings, err
+}
+
+func runValidators(dk *dynakube.DynaKube, other ...client.Object) (admission.Warnings, error) {
+	clt := fake.NewClient()
+	if other != nil {
+		clt = fake.NewClient(other...)
+	}
+
+	validator := &Validator{
+		apiReader: clt,
+		cfg:       &rest.Config{},
+	}
+
+	return validator.ValidateCreate(context.Background(), dk)
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

With the introduction of versioned validation logic, every DynaKube version should have it's own validation logic. 

This PR adds validation logic for v1beta1.

[Jira](https://dt-rnd.atlassian.net/browse/K8S-10056)
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- Apply a v1beta1 dynakube and check if it is validated on creation or update

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->