### PR TITLE
Add modifier to ActiveGate StatefulSet mounting EEC token volume

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
@@ -38,5 +38,6 @@ func GenerateAllModifiers(dk dynakube.DynaKube, capability capability.Capability
 		NewReadOnlyModifier(dk),
 		NewServicePortModifier(dk, capability, agBaseContainerEnvMap),
 		NewKubernetesMonitoringModifier(dk, capability),
+		NewEecVolumeModifier(dk),
 	}
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -42,7 +42,7 @@ func (mod EecModifier) Modify(sts *appsv1.StatefulSet) error {
 	baseContainer.Command = []string{"/bin/sh"}
 	baseContainer.Args = []string{
 		"-c",
-		"echo abc ; cp -v " + eecMountPath + "/" + eecFile + " /var/lib/dynatrace/gateway/config/ ; /opt/dynatrace/gateway/entrypoint.sh",
+		"cp -v " + eecMountPath + "/" + eecFile + " /var/lib/dynatrace/gateway/config/ ; /opt/dynatrace/gateway/entrypoint.sh",
 	}
 
 	return nil

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -16,7 +16,7 @@ var _ builder.Modifier = EecModifier{}
 
 const (
 	eecVolumeName = "eec-token"
-	eecMountPath  = "/var/lib/dynatrace/secrets/eec"
+	eecMountPath  = "/var/lib/dynatrace/secrets/eec/token"
 	eecFile       = "eec.token"
 )
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -40,10 +40,10 @@ func (mod EecModifier) Modify(sts *appsv1.StatefulSet) error {
 	baseContainer.VolumeMounts = append(baseContainer.VolumeMounts, mod.getVolumeMounts()...)
 
 	baseContainer.Command = []string{"/bin/sh"}
-	baseContainer.Args = []string{
-		"-c",
-		"cp -v " + eecMountPath + "/" + eecFile + " /var/lib/dynatrace/gateway/config/ ; /opt/dynatrace/gateway/entrypoint.sh",
-	}
+
+	baseContainer.Args = append(baseContainer.Args,
+		"cp -v "+eecMountPath+"/"+eecFile+" /var/lib/dynatrace/gateway/config/ ; /opt/dynatrace/gateway/entrypoint.sh",
+	)
 
 	return nil
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -39,12 +39,6 @@ func (mod EecModifier) Modify(sts *appsv1.StatefulSet) error {
 	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, mod.getVolumes()...)
 	baseContainer.VolumeMounts = append(baseContainer.VolumeMounts, mod.getVolumeMounts()...)
 
-	baseContainer.Command = []string{"/bin/sh"}
-
-	baseContainer.Args = append(baseContainer.Args,
-		"cp -v "+eecMountPath+"/"+eecFile+" /var/lib/dynatrace/gateway/config/ ; /opt/dynatrace/gateway/entrypoint.sh",
-	)
-
 	return nil
 }
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -17,7 +17,7 @@ var _ builder.Modifier = EecModifier{}
 const (
 	eecVolumeName = "eec-token"
 	eecMountPath  = "/var/lib/dynatrace/secrets/eec"
-	eecFile       = "token/eec.token"
+	eecFile       = "eec.token"
 )
 
 func NewEecVolumeModifier(dk dynakube.DynaKube) EecModifier {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -1,0 +1,82 @@
+package modifiers
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/container"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ volumeModifier = EecModifier{}
+var _ volumeMountModifier = EecModifier{}
+var _ builder.Modifier = EecModifier{}
+
+const (
+	eecVolumeName = "eec-token"
+	eecMountPath  = "/var/lib/dynatrace/secrets/eec"
+	eecFile       = "token/eec.token"
+)
+
+func NewEecVolumeModifier(dk dynakube.DynaKube) EecModifier {
+	return EecModifier{
+		dk: dk,
+	}
+}
+
+type EecModifier struct {
+	dk dynakube.DynaKube
+}
+
+func (mod EecModifier) Enabled() bool {
+	return mod.dk.PrometheusEnabled()
+}
+
+func (mod EecModifier) Modify(sts *appsv1.StatefulSet) error {
+	baseContainer := container.FindContainerInPodSpec(&sts.Spec.Template.Spec, consts.ActiveGateContainerName)
+	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, mod.getVolumes()...)
+	baseContainer.VolumeMounts = append(baseContainer.VolumeMounts, mod.getVolumeMounts()...)
+
+	baseContainer.Command = []string{"/bin/sh"}
+	baseContainer.Args = []string{
+		"-c",
+		"echo abc ; cp -v " + eecMountPath + "/" + eecFile + " /var/lib/dynatrace/gateway/config/ ; /opt/dynatrace/gateway/entrypoint.sh",
+	}
+
+	return nil
+}
+
+func (mod EecModifier) getVolumes() []corev1.Volume {
+	mode := int32(420)
+
+	return []corev1.Volume{
+		{
+			Name: eecVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  extension.GetSecretName(mod.dk.Name),
+					DefaultMode: &mode,
+					Items: []corev1.KeyToPath{
+						{
+							Key:  extension.EecTokenSecretKey,
+							Path: eecFile,
+							Mode: &mode,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (mod EecModifier) getVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			ReadOnly:  true,
+			Name:      eecVolumeName,
+			MountPath: eecMountPath,
+		},
+	}
+}

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec_test.go
@@ -1,0 +1,48 @@
+package modifiers
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEecEnabled(t *testing.T) {
+	t.Run("Prometheus extension is enabled", func(t *testing.T) {
+		dk := getBaseDynakube()
+		dk.Spec.Extensions.Prometheus.Enabled = true
+
+		mod := NewEecVolumeModifier(dk)
+
+		assert.True(t, mod.Enabled())
+	})
+
+	t.Run("Prometheus extension is disabled", func(t *testing.T) {
+		dk := getBaseDynakube()
+		dk.Spec.Extensions.Prometheus.Enabled = false
+
+		mod := NewEecVolumeModifier(dk)
+
+		assert.False(t, mod.Enabled())
+	})
+}
+
+func TestEecModify(t *testing.T) {
+	t.Run("Statefulset is successfully modified with eec volume", func(t *testing.T) {
+		dk := getBaseDynakube()
+		dk.Spec.Extensions.Prometheus.Enabled = true
+
+		mod := NewEecVolumeModifier(dk)
+		builder := createBuilderForTesting()
+
+		sts, _ := builder.AddModifier(mod).Build()
+
+		require.NotEmpty(t, sts)
+		isSubset(t, mod.getVolumes(), sts.Spec.Template.Spec.Volumes)
+		isSubset(t, mod.getVolumeMounts(), sts.Spec.Template.Spec.Containers[0].VolumeMounts)
+		require.Equal(t, extension.EecTokenSecretKey, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
+		require.Equal(t, eecMountPath, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath)
+		require.True(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].ReadOnly)
+	})
+}

--- a/pkg/controllers/dynakube/extension/consts.go
+++ b/pkg/controllers/dynakube/extension/consts.go
@@ -1,7 +1,8 @@
 package extension
 
 const (
-	eecTokenSecretKey         = "eec-token"
+	// secret
+	EecTokenSecretKey         = "eec-token"
 	eecTokenSecretValuePrefix = "EEC dt0x01"
 	secretSuffix              = "-extensions-token"
 

--- a/pkg/controllers/dynakube/extension/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/reconciler_test.go
@@ -50,7 +50,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		// mock secret
 		secretToken, _ := dttoken.New(eecTokenSecretValuePrefix)
 		secretData := map[string][]byte{
-			eecTokenSecretKey: []byte(secretToken.String()),
+			EecTokenSecretKey: []byte(secretToken.String()),
 		}
 		secretMock, _ := k8ssecret.Build(dk, testName+"-extensions-token", secretData)
 

--- a/pkg/controllers/dynakube/extension/secret.go
+++ b/pkg/controllers/dynakube/extension/secret.go
@@ -77,12 +77,16 @@ func (r *reconciler) reconcileSecret(ctx context.Context) error {
 
 func (r *reconciler) buildSecret(token dttoken.Token) (*corev1.Secret, error) {
 	secretData := map[string][]byte{
-		eecTokenSecretKey: []byte(token.String()),
+		EecTokenSecretKey: []byte(token.String()),
 	}
 
 	return k8ssecret.Build(r.dk, r.getSecretName(), secretData)
 }
 
 func (r *reconciler) getSecretName() string {
-	return r.dk.Name + secretSuffix
+	return GetSecretName(r.dk.Name)
+}
+
+func GetSecretName(dynakubeName string) string {
+	return dynakubeName + secretSuffix
 }


### PR DESCRIPTION
## Description

[K8S-10131](https://dt-rnd.atlassian.net/browse/K8S-10131)

Now, when Prometheus extension is enabled, we mount the EEC token value from the extensions secret to the ActiveGate StatefulSet.

## How can this be tested?

- Apply a dynakube with Prometheus enabled
- Check volume is mounted in ActiveGate pod and that the file with its content exist (via shell, path `/var/lib/dynatrace/secrets/eec/token/eec.token`)
- Apply a dynakube with Prometheus disabled and there shouldn't be any mounts