### PR TITLE
Standardize scheme usage in e2e-tests

### DIFF
--- a/test/helpers/components/dynakube/dynakube.go
+++ b/test/helpers/components/dynakube/dynakube.go
@@ -9,9 +9,7 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	prevVersion "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1"
 	prevDynakube "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube" //nolint:staticcheck
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
@@ -129,7 +127,6 @@ func WaitForPhasePreviousVersion(dk prevDynakube.DynaKube, phase status.Deployme
 
 func create(dk dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		require.NoError(t, v1beta3.AddToScheme(envConfig.Client().Resources().GetScheme()))
 		require.NoError(t, envConfig.Client().Resources().Create(ctx, &dk))
 
 		return ctx
@@ -138,7 +135,6 @@ func create(dk dynakube.DynaKube) features.Func {
 
 func createPreviousVersion(dk prevDynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		require.NoError(t, prevVersion.AddToScheme(envConfig.Client().Resources().GetScheme()))
 		require.NoError(t, envConfig.Client().Resources().Create(ctx, &dk))
 
 		return ctx
@@ -147,7 +143,6 @@ func createPreviousVersion(dk prevDynakube.DynaKube) features.Func {
 
 func update(dk dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		require.NoError(t, v1beta3.AddToScheme(envConfig.Client().Resources().GetScheme()))
 		var oldDK dynakube.DynaKube
 		require.NoError(t, envConfig.Client().Resources().Get(ctx, oldDK.Name, oldDK.Namespace, &oldDK))
 		oldDK.ResourceVersion = dk.ResourceVersion
@@ -161,10 +156,7 @@ func remove(dk dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 
-		err := v1beta3.AddToScheme(resources.GetScheme())
-		require.NoError(t, err)
-
-		err = resources.Delete(ctx, &dk)
+		err := resources.Delete(ctx, &dk)
 		isNoKindMatchErr := meta.IsNoMatchError(err)
 
 		if err != nil {

--- a/test/helpers/components/dynakube/dynakube.go
+++ b/test/helpers/components/dynakube/dynakube.go
@@ -144,9 +144,9 @@ func createPreviousVersion(dk prevDynakube.DynaKube) features.Func {
 func update(dk dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		var oldDK dynakube.DynaKube
-		require.NoError(t, envConfig.Client().Resources().Get(ctx, oldDK.Name, oldDK.Namespace, &oldDK))
-		oldDK.ResourceVersion = dk.ResourceVersion
-		require.NoError(t, envConfig.Client().Resources().Update(ctx, &oldDK))
+		require.NoError(t, envConfig.Client().Resources().Get(ctx, dk.Name, dk.Namespace, &oldDK))
+		dk.ResourceVersion = oldDK.ResourceVersion
+		require.NoError(t, envConfig.Client().Resources().Update(ctx, &dk))
 
 		return ctx
 	}

--- a/test/helpers/components/edgeconnect/edgeconnect.go
+++ b/test/helpers/components/edgeconnect/edgeconnect.go
@@ -42,7 +42,6 @@ func VerifyStartup(builder *features.FeatureBuilder, level features.Level, testE
 
 func Create(edgeConnect edgeconnect.EdgeConnect) features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		require.NoError(t, v1alpha1.AddToScheme(environmentConfig.Client().Resources().GetScheme()))
 		require.NoError(t, environmentConfig.Client().Resources().Create(ctx, &edgeConnect))
 
 		return ctx
@@ -51,7 +50,6 @@ func Create(edgeConnect edgeconnect.EdgeConnect) features.Func {
 
 func Get(ec *edgeconnect.EdgeConnect) features.Func {
 	return func(ctx context.Context, t *testing.T, environmentConfig *envconf.Config) context.Context {
-		require.NoError(t, v1alpha1.AddToScheme(environmentConfig.Client().Resources().GetScheme()))
 		require.NoError(t, environmentConfig.Client().Resources().Get(ctx, ec.Name, ec.Namespace, ec))
 
 		return ctx

--- a/test/helpers/scheme.go
+++ b/test/helpers/scheme.go
@@ -1,11 +1,10 @@
 //go:build e2e
-package helpers
 
+package helpers
 
 import (
 	"context"
 
-	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
 	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1"
@@ -14,8 +13,8 @@ import (
 	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube" //nolint:staticcheck
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3"
 	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
-
 
 func SetScheme(ctx context.Context, envConfig *envconf.Config) (context.Context, error) {
 	err := v1beta3.AddToScheme(envConfig.Client().Resources().GetScheme())
@@ -34,6 +33,6 @@ func SetScheme(ctx context.Context, envConfig *envconf.Config) (context.Context,
 	if err != nil {
 		return ctx, err
 	}
+
 	return ctx, nil
 }
-

--- a/test/helpers/scheme.go
+++ b/test/helpers/scheme.go
@@ -1,0 +1,39 @@
+//go:build e2e
+package helpers
+
+
+import (
+	"context"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
+	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1"
+	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube" //nolint:staticcheck
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2"
+	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube" //nolint:staticcheck
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3"
+	_ "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+)
+
+
+func SetScheme(ctx context.Context, envConfig *envconf.Config) (context.Context, error) {
+	err := v1beta3.AddToScheme(envConfig.Client().Resources().GetScheme())
+	if err != nil {
+		return ctx, err
+	}
+	err = v1beta2.AddToScheme(envConfig.Client().Resources().GetScheme())
+	if err != nil {
+		return ctx, err
+	}
+	err = v1beta1.AddToScheme(envConfig.Client().Resources().GetScheme())
+	if err != nil {
+		return ctx, err
+	}
+	err = v1alpha1.AddToScheme(envConfig.Client().Resources().GetScheme())
+	if err != nil {
+		return ctx, err
+	}
+	return ctx, nil
+}
+

--- a/test/scenarios/istio/istio_test.go
+++ b/test/scenarios/istio/istio_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative/codemodules"
 	cloudnativeDefault "github.com/Dynatrace/dynatrace-operator/test/features/cloudnative/default"
 	networkProblems "github.com/Dynatrace/dynatrace-operator/test/features/cloudnative/network_problems"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
@@ -30,6 +31,7 @@ func TestMain(m *testing.M) {
 	testEnv.BeforeEachTest(istio.AssertIstioNamespace())
 	testEnv.BeforeEachTest(istio.AssertIstiodDeployment())
 	testEnv.Setup(
+		helpers.SetScheme,
 		namespace.CreateForEnv(nsWithIstio),
 		tenant.CreateOtelSecret(nsWithIstio.Name),
 		operator.InstallViaMake(true),

--- a/test/scenarios/release/release_test.go
+++ b/test/scenarios/release/release_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative/upgrade"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
@@ -21,6 +22,7 @@ func TestMain(m *testing.M) {
 	cfg := environment.GetStandardKubeClusterEnvConfig()
 	testEnv = env.NewWithConfig(cfg)
 	testEnv.Setup(
+		helpers.SetScheme,
 		tenant.CreateOtelSecret(operator.DefaultNamespace),
 		operator.InstallViaHelm(releaseTag, true, operator.DefaultNamespace), // TODO: add logic to get releaseTag in a dynamic way instead of hard coding it
 	)

--- a/test/scenarios/standard/standard_test.go
+++ b/test/scenarios/standard/standard_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/features/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/test/features/publicregistry"
 	supportArchive "github.com/Dynatrace/dynatrace-operator/test/features/support_archive"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
@@ -30,6 +31,7 @@ func TestMain(m *testing.M) {
 	cfg := environment.GetStandardKubeClusterEnvConfig()
 	testEnv = env.NewWithConfig(cfg)
 	testEnv.Setup(
+		helpers.SetScheme,
 		tenant.CreateOtelSecret(operator.DefaultNamespace),
 		operator.InstallViaMake(true),
 	)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Instead of randomly saying `<some-group-version>.AddToScheme(envConfig.Client().Resources().GetScheme())` in a function, I added a `Setup` func that does this with all our versions, similar to `pkg/api/scheme/scheme.go`, but setting it for the `envConfig` in a given test-scenario

## How can this be tested?

run `make test/e2e/cloudnative/upgrade`

Sidenote:
- I had to remove my `dynatrace` repo from Helm for some reason because I got the error:
```
E0722 17:15:48.322546   84599 env.go:384] Setup failure: Error: repository name (dynatrace) already exists, please specify a different name: exit status 1
```
(repeated runs worked after)