### PR TITLE
Use SubPath in eec-modifier

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec_test.go
@@ -42,7 +42,7 @@ func TestEecModify(t *testing.T) {
 		isSubset(t, mod.getVolumes(), sts.Spec.Template.Spec.Volumes)
 		isSubset(t, mod.getVolumeMounts(), sts.Spec.Template.Spec.Containers[0].VolumeMounts)
 		require.Equal(t, extension.EecTokenSecretKey, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
-		require.Equal(t, eecMountPath, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath)
+		require.Equal(t, eecSecretsMountPoint, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath)
 		require.True(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].ReadOnly)
 	})
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Related to [my comment](https://github.com/Dynatrace/dynatrace-operator/pull/3497#discussion_r1686255478) on the original PR.

Dunno how to explain it so I just did a quick test of it.

This is how the filesystem of the ActiveGate looks like after my change. (no hacky `args`)
```
<<K9s-Shell>> Pod: dynatrace/zib50933-activegate-0 | Container: activegate

bash-5.1$ ls -la /var/lib/dynatrace/secrets/eec/token/
total 12
drwxr-xr-x 2 root root 4096 Jul 23 09:08 .
drwxr-xr-x 3 root root 4096 Jul 23 09:08 ..
-rw-r--r-- 1 root root  100 Jul 23 09:08 eec.token

bash-5.1$ cat /var/lib/dynatrace/secrets/eec/token/eec.token
EEC dt0x01.**************

bash-5.1$ ls -la /var/lib/dynatrace/gateway/config
total 104
drwxrwxrwx 2 root root  4096 Jul 23 09:08 .
drwxrwx--- 1 1001 root  4096 Jul 23 09:08 ..
-rw-r--r-- 1 1001 1001   153 Jul 23 09:08 authorization.properties
-rw-r--r-- 1 1001 1001  1777 Jul 23 09:08 cluster.properties
-rw-rw---- 1 1001 1001  7543 Jul 23 09:08 config.properties
-rw-rw---- 1 1001 1001 40975 Jul 22 21:20 config.txt
-rw-r--r-- 1 1001 1001   318 Jul 23 09:08 connectivity.history
-rw-rw---- 1 1001 1001     1 Jul 23 09:08 custom.properties
-rw-r--r-- 1 root root   100 Jul 23 09:08 eec.token
-rw-r--r-- 1 1001 1001    16 Jul 23 09:08 id.properties
-rw-r--r-- 1 1001 1001   539 Jul 23 09:08 keystore.jks
-rw-r--r-- 1 1001 1001  2090 Jul 23 09:08 keystore.jks_rsa
-rw-r--r-- 1 1001 1001    44 Jul 23 09:08 lsa.token
-rw-rw---- 1 1001 1001    88 Jul 22 21:20 secure.config.properties
-rw-rw---- 1 1001 1001    31 Jul 22 21:20 version.properties

bash-5.1$ cat /var/lib/dynatrace/gateway/config/eec.token
EEC dt0x01.*******************
```

@aorcholski @albertogdd 
I used `SubPath` for both volumes, dunno if both volumes are needed or not.

## How can this be tested?
deploy DK with extensions enabled