### PR TITLE
Fix empty ME case by not throwing an error

### DIFF
--- a/pkg/controllers/dynakube/apimonitoring/reconciler.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler.go
@@ -45,13 +45,11 @@ func (r *Reconciler) createObjectIdIfNotExists(ctx context.Context) (string, err
 		return "", errors.New("no kube-system namespace UUID given")
 	}
 
-	if r.dk.Status.KubernetesClusterMEID == "" {
-		monitoredEntitiesreconciler := monitoredentities.NewReconciler(r.dtc, r.dk)
+	monitoredEntitiesreconciler := monitoredentities.NewReconciler(r.dtc, r.dk)
 
-		err := monitoredEntitiesreconciler.Reconcile(ctx)
-		if err != nil {
-			return "", err
-		}
+	err := monitoredEntitiesreconciler.Reconcile(ctx)
+	if err != nil {
+		return "", err
 	}
 
 	monitoredEntity := []dtclient.MonitoredEntity{

--- a/pkg/controllers/dynakube/monitoredentities/reconciler.go
+++ b/pkg/controllers/dynakube/monitoredentities/reconciler.go
@@ -2,7 +2,6 @@ package monitoredentities
 
 import (
 	"context"
-	"errors"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
@@ -41,7 +40,9 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		}
 
 		if len(monitoredEntities) == 0 {
-			return errors.New("MEs are empty, at this point this should not be the case")
+			log.Info("no MEs found, no monitoredentityID will be set in the dynakube status")
+
+			return nil
 		}
 
 		r.dk.Status.KubernetesClusterMEID = findLatestEntity(monitoredEntities).EntityId

--- a/pkg/controllers/dynakube/monitoredentities/reconciler.go
+++ b/pkg/controllers/dynakube/monitoredentities/reconciler.go
@@ -40,7 +40,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		}
 
 		if len(monitoredEntities) == 0 {
-			log.Info("no MEs found, no monitoredentityID will be set in the dynakube status")
+			log.Info("no MEs found, no kubernetesClusterMEID will be set in the dynakube status")
 
 			return nil
 		}

--- a/pkg/controllers/dynakube/monitoredentities/reconciler_test.go
+++ b/pkg/controllers/dynakube/monitoredentities/reconciler_test.go
@@ -42,7 +42,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, dk.Status.KubernetesClusterMEID)
 	})
-	t.Run("error if no MEs are found", func(t *testing.T) {
+	t.Run("no error if no MEs are found", func(t *testing.T) {
 		clt := dtclientmock.NewClient(t)
 		clt.On("GetMonitoredEntitiesForKubeSystemUUID",
 			mock.AnythingOfType("context.backgroundCtx"), "kube-system-uuid").Return([]dtclient.MonitoredEntity{}, nil)
@@ -53,7 +53,7 @@ func TestReconcile(t *testing.T) {
 
 		err := reconciler.Reconcile(ctx)
 
-		require.Error(t, err)
+		require.NoError(t, err)
 		require.Empty(t, dk.Status.KubernetesClusterMEID)
 	})
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Follow up to: https://github.com/Dynatrace/dynatrace-operator/pull/3447

Because the case of classicFullStack or applicationMonitoring without kubernetes monitoring were not covered correctly we get spammed by errors when there are no monitoredEntitiy during reconcile. Now we do not error but simply log that there are not MEs and return nil.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Apply dynakubes with:
- classicFullStack
- applicationMonitoring without k8s monitoring
- and other possible configurations (the more the better to cover more cases)

See if kubernetesClusterMEID is properly set in the dk status and if something breaks.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->