### PR TITLE
Set owner during update

### DIFF
--- a/pkg/util/kubeobjects/internal/query/query.go
+++ b/pkg/util/kubeobjects/internal/query/query.go
@@ -56,6 +56,13 @@ func (c Generic[T, L]) Create(ctx context.Context, object T) error {
 func (c Generic[T, L]) Update(ctx context.Context, object T) error {
 	c.log(object).Info("updating")
 
+	if c.Owner != nil {
+		err := controllerutil.SetControllerReference(c.Owner, object, scheme.Scheme)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
 	return errors.WithStack(c.KubeClient.Update(ctx, object))
 }
 


### PR DESCRIPTION

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
Set owner during update otherwise after an update the owner reference disappears

## How can this be tested?

Wait, or make a small change (add an env) to make an update happen, and see that the owner reference is still present and if you delete the dynakube the related resource is deleted