### PR TITLE
Revert back the tenantUUID change in the CSI driver

### DIFF
--- a/pkg/controllers/csi/gc/binaries_test.go
+++ b/pkg/controllers/csi/gc/binaries_test.go
@@ -118,6 +118,7 @@ func (gc *CSIGarbageCollector) mockUnusedVersions(versions ...string) {
 		gc.db.(metadata.Access).DeleteCodeModule(&metadata.CodeModule{Version: version})
 	}
 }
+
 func (gc *CSIGarbageCollector) mockUsedVersions(t *testing.T, versions ...string) {
 	_ = gc.fs.Mkdir(testBinaryDir, 0770)
 	for i, version := range versions {

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -24,7 +24,7 @@ func (provisioner *OneAgentProvisioner) installAgentImage(
 	targetImage string,
 	err error,
 ) {
-	tenantUUID, err := dk.TenantUUIDFromConnectionInfoStatus()
+	tenantUUID, err := dk.TenantUUIDFromApiUrl()
 	if err != nil {
 		return "", err
 	}
@@ -84,7 +84,7 @@ func (provisioner *OneAgentProvisioner) installAgentImage(
 }
 
 func (provisioner *OneAgentProvisioner) installAgentZip(ctx context.Context, dk dynakube.DynaKube, dtc dtclient.Client, latestProcessModuleConfig *dtclient.ProcessModuleConfig) (string, error) {
-	tenantUUID, err := dk.TenantUUIDFromConnectionInfoStatus()
+	tenantUUID, err := dk.TenantUUIDFromApiUrl()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Since #3124 the CSI driver provisioner already uses the new tennantUUID from the status, which was planned to be changed later. This leads to issues like #3533 and breaks CSI driver mounts.

This PR reverts the change. 

[Bug Ticket](https://dt-rnd.atlassian.net/browse/K8S-10808)

## How can this be tested?

- Run cloudnativefs
- Create some pods that are injected
- Pods should start up again and be monitored

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->