### PR TITLE
Add feature flag to disable CSI volume

### DIFF
--- a/pkg/api/v1beta2/dynakube/feature_flags.go
+++ b/pkg/api/v1beta2/dynakube/feature_flags.go
@@ -62,6 +62,7 @@ const (
 	AnnotationInjectionFailurePolicy       = AnnotationFeaturePrefix + "injection-failure-policy"
 	AnnotationFeatureInitContainerSeccomp  = AnnotationFeaturePrefix + "init-container-seccomp-profile"
 	AnnotationFeatureEnforcementMode       = AnnotationFeaturePrefix + "enforcement-mode"
+	AnnotationFeatureReadOnlyOneAgent      = AnnotationFeaturePrefix + "oneagent-readonly-host-fs"
 
 	// CSI.
 	AnnotationFeatureMaxFailedCsiMountAttempts = AnnotationFeaturePrefix + "max-csi-mount-attempts"
@@ -183,6 +184,13 @@ func (dk *DynaKube) FeatureEnableK8sAppEnabled() bool {
 // or if pods need to be opted-in one by one ("automatic-injection=false").
 func (dk *DynaKube) FeatureAutomaticInjection() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureAutomaticInjection) != falsePhrase
+}
+
+// FeatureReadOnlyOneAgent controls whether the host agent is run in readonly mode.
+// In Host Monitoring disabling readonly mode, also disables the use of a CSI volume.
+// Not compatible with Classic Fullstack.
+func (dk *DynaKube) FeatureReadOnlyOneAgent() bool {
+	return dk.getFeatureFlagRaw(AnnotationFeatureReadOnlyOneAgent) != falsePhrase
 }
 
 // FeatureEnableMultipleOsAgentsOnNode is a feature flag to enable multiple osagents running on the same host.

--- a/pkg/api/v1beta2/dynakube/properties.go
+++ b/pkg/api/v1beta2/dynakube/properties.go
@@ -222,14 +222,17 @@ func (dk *DynaKube) PullSecretWithoutData() corev1.Secret {
 }
 
 func (dk *DynaKube) NeedsReadOnlyOneAgents() bool {
-	return dk.HostMonitoringMode() || dk.CloudNativeFullstackMode()
+	return (dk.HostMonitoringMode() || dk.CloudNativeFullstackMode()) &&
+		dk.FeatureReadOnlyOneAgent()
 }
 
 func (dk *DynaKube) NeedsCSIDriver() bool {
 	isAppMonitoringWithCSI := dk.ApplicationMonitoringMode() &&
 		dk.Spec.OneAgent.ApplicationMonitoring.UseCSIDriver
 
-	return dk.CloudNativeFullstackMode() || isAppMonitoringWithCSI || dk.HostMonitoringMode()
+	isHostMonitoringWithCSI := dk.HostMonitoringMode() && dk.FeatureReadOnlyOneAgent()
+
+	return dk.CloudNativeFullstackMode() || isAppMonitoringWithCSI || isHostMonitoringWithCSI
 }
 
 func (dk *DynaKube) NeedAppInjection() bool {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Readd feature flag to disable CSI volume for host agent in host monitoring (and cloud native fullstack)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?
Oneagent does not use a CSI volume and is not configured for read only mode.

Host Monitoring does not require CSI driver to be installed (oneagent volume storage required in case of readonly host filesystem):
```yaml
metadata:
  annotations:
    feature.dynatrace.com/oneagent-readonly-host-fs: "false"
spec:
  oneAgent:
    hostMonitoring:
      env:
        - name: "ONEAGENT_ENABLE_VOLUME_STORAGE"
          value: "true"
```

Cloud native Fullstack still requires CSI driver for code module injection:
```yaml
metadata:
  annotations:
    feature.dynatrace.com/oneagent-readonly-host-fs: "false"
spec:
  oneAgent:
    cloudNativeFullStack:
      env:
        - name: "ONEAGENT_ENABLE_VOLUME_STORAGE"
          value: "true"
```

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->