### PR TITLE
Adds immutability attribute to apiUrl field

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -4981,7 +4981,11 @@ spec:
                 description: |-
                   Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
                   For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.com/support/help/get-started/monitoring-environment/environment-id).
+                maxLength: 128
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable, delete the CR and apply new one
+                  rule: self == oldSelf
               customPullSecret:
                 description: |-
                   Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -4994,7 +4994,11 @@ spec:
                 description: |-
                   Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
                   For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.com/support/help/get-started/monitoring-environment/environment-id).
+                maxLength: 128
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable, delete the CR and apply new one
+                  rule: self == oldSelf
               customPullSecret:
                 description: |-
                   Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.

--- a/pkg/api/v1beta3/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta3/dynakube/dynakube_types.go
@@ -100,6 +100,8 @@ type DynaKubeSpec struct { //nolint:revive
 	// Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
 	// For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.com/support/help/get-started/monitoring-environment/environment-id).
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable, delete the CR and apply new one"
+	// +kubebuilder:validation:MaxLength=128
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="API URL",order=1,xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	APIURL string `json:"apiUrl"`
 

--- a/pkg/api/v1beta3/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta3/dynakube/dynakube_types.go
@@ -100,7 +100,7 @@ type DynaKubeSpec struct { //nolint:revive
 	// Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
 	// For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.com/support/help/get-started/monitoring-environment/environment-id).
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable, delete the CR and apply new one"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="APIURL is immutable, please delete the CR and then apply new one"
 	// +kubebuilder:validation:MaxLength=128
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="API URL",order=1,xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	APIURL string `json:"apiUrl"`


### PR DESCRIPTION
## Description

Value of dynakube.spec.ApiUrl can't be changed.

```
# * spec.apiUrl: Invalid value: "string": Value is immutable, delete the CR and apply new one  
```

## How can this be tested?

Apply a dynakube. Try to change `apiUrl`.
