### PR TITLE
Updates crd yaml files after apiUrl immutable attribute was added

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -4984,7 +4984,8 @@ spec:
                 maxLength: 128
                 type: string
                 x-kubernetes-validations:
-                - message: Value is immutable, delete the CR and apply new one
+                - message: APIURL is immutable, please delete the CR and then apply
+                    new one
                   rule: self == oldSelf
               customPullSecret:
                 description: |-

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -4997,7 +4997,8 @@ spec:
                 maxLength: 128
                 type: string
                 x-kubernetes-validations:
-                - message: Value is immutable, delete the CR and apply new one
+                - message: APIURL is immutable, please delete the CR and then apply
+                    new one
                   rule: self == oldSelf
               customPullSecret:
                 description: |-


### PR DESCRIPTION
## Description
I used github commit suggestion to change the warning message in my previous [PR](https://github.com/Dynatrace/dynatrace-operator/pull/3570) and forgot to update crd yaml files. Sorry!

## How can this be tested?

