### PR TITLE
Adds customConfig field to dynakube.templates.ExtensionController spec

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -6197,6 +6197,10 @@ spec:
                         description: Adds additional annotations to the ExtensionExecutionController
                           pods
                         type: object
+                      customConfig:
+                        description: Defines name of ConfigMap containing custom configuration
+                          file
+                        type: string
                       imageRef:
                         description: Overrides the default image
                         properties:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -6210,6 +6210,10 @@ spec:
                         description: Adds additional annotations to the ExtensionExecutionController
                           pods
                         type: object
+                      customConfig:
+                        description: Defines name of ConfigMap containing custom configuration
+                          file
+                        type: string
                       imageRef:
                         description: Overrides the default image
                         properties:

--- a/doc/api/dynakube-api-ref.md
+++ b/doc/api/dynakube-api-ref.md
@@ -164,6 +164,7 @@
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
 |`annotations`|Adds additional annotations to the ExtensionExecutionController pods|-|object|
+|`customConfig`|Defines name of ConfigMap containing custom configuration file|-|string|
 |`labels`|Adds additional labels for the ExtensionExecutionController pods|-|object|
 |`persistentVolumeClaimRetentionPolicy`|Determines retention policy|-|string|
 |`resources`|Define resources' requests and limits for single ExtensionExecutionController pod|-|object|

--- a/pkg/api/v1beta3/dynakube/extensions.go
+++ b/pkg/api/v1beta3/dynakube/extensions.go
@@ -27,6 +27,10 @@ type ExtensionExecutionControllerSpec struct {
 	// Adds additional annotations to the ExtensionExecutionController pods
 	Annotations map[string]string `json:"annotations,omitempty"`
 
+	// Determines retention policy
+	// +kubebuilder:validation:Optional
+	PersistentVolumeClaimRetentionPolicy *appsv1.PersistentVolumeClaimRetentionPolicyType `json:"persistentVolumeClaimRetentionPolicy,omitempty"`
+
 	// Overrides the default image
 	// +kubebuilder:validation:Optional
 	ImageRef ImageRefSpec `json:"imageRef,omitempty"`
@@ -34,13 +38,13 @@ type ExtensionExecutionControllerSpec struct {
 	// +kubebuilder:validation:Optional
 	TlsRefName string `json:"tlsRefName,omitempty"`
 
+	// Defines name of ConfigMap containing custom configuration file
+	// +kubebuilder:validation:Optional
+	CustomConfig string `json:"customConfig,omitempty"`
+
 	// Define resources' requests and limits for single ExtensionExecutionController pod
 	// +kubebuilder:validation:Optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-
-	// Determines retention policy
-	// +kubebuilder:validation:Optional
-	PersistentVolumeClaimRetentionPolicy *appsv1.PersistentVolumeClaimRetentionPolicyType `json:"persistentVolumeClaimRetentionPolicy,omitempty"`
 
 	// Set tolerations for the ExtensionExecutionController pods
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
[K8S-10801](https://dt-rnd.atlassian.net/browse/K8S-10801)

## Description

Adds `customConfig` field to dynakube.templates.ExtensionController spec.
Specified configmap is mounted to Extension Execution Controller pod.

## How can this be tested?
1) Apply dynakube without EEC custom configuration:
```
  extensions:
    prometheus:
      enabled: true
  templates:
    extensionExecutionController:
      imageRef:
        repository: ...
        tag: ...
```
`dynatrace-extensions-controller-0` POD is running
```
kubectl -n dynatrace describe pod/dynatrace-extensions-controller-0
```
2) Create configmap
```
kubectl -n dynatrace create configmap eec-custom-config --from-literal=runtimeConfig=aaa --from-literal=other.txt=bbb 
```
3) Apply dynakube:
```
  extensions:
    prometheus:
      enabled: true
  templates:
    extensionExecutionController:
      imageRef:
        repository: ...
        tag: ...
      customConfig: eec-custom-config  
```
4) Check Volumes and VolumesMounts (`custom-config`):
```
kubectl -n dynatrace describe pod/dynatrace-extensions-controller-0
```
5) Check files:
```
$ kubectl -n dynatrace exec -it pod/dynatrace-extensions-controller-0 -- /bin/sh
sh-4.4# ls -l /var/lib/dynatrace/remotepluginmodule/secrets/config/
```
expected 2 files:
```
lrwxrwxrwx 1 root root 16 Aug  7 16:05 other.txt -> ..data/other.txt
lrwxrwxrwx 1 root root 20 Aug  7 16:05 runtimeConfig -> ..data/runtimeConfig
```