### PR TITLE
Add logAgent configuration options for Operator

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -5013,6 +5013,14 @@ spec:
                     - enabled
                     type: object
                 type: object
+              logMonitoring:
+                description: General configuration about LogMonitoring instances.
+                properties:
+                  enabled:
+                    type: boolean
+                required:
+                - enabled
+                type: object
               metadataEnrichment:
                 description: Configuration for Metadata Enrichment.
                 properties:
@@ -6613,6 +6621,147 @@ spec:
                           - maxSkew
                           - topologyKey
                           - whenUnsatisfiable
+                          type: object
+                        type: array
+                    type: object
+                  logAgentDaemonSet:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Add custom LogAgent annotations
+                        type: object
+                      args:
+                        description: Set additional arguments to the LogAgent pods
+                        items:
+                          type: string
+                        type: array
+                      dnsPolicy:
+                        description: Sets DNS Policy for the ActiveGate pods
+                        type: string
+                      imageRef:
+                        description: Overrides the default image
+                        properties:
+                          repository:
+                            description: Custom image repository
+                            example: docker.io/dynatrace/image-name
+                            type: string
+                          tag:
+                            description: Indicates a tag of the image to use
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Add custom LogAgent labels
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Node selector to control the selection of nodes
+                          for the LogAgent pods
+                        type: object
+                      priorityClassName:
+                        description: Assign a priority class to the LogAgent pods.
+                          By default, no class is set
+                        type: string
+                      resources:
+                        description: Define resources' requests and limits for single
+                          LogAgent pod
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      secCompProfile:
+                        description: The SecComp Profile that will be configured in
+                          order to run in secure computing mode
+                        type: string
+                      tolerations:
+                        description: Set tolerations for the LogAgent pods
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
                           type: object
                         type: array
                     type: object

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -6624,7 +6624,7 @@ spec:
                           type: object
                         type: array
                     type: object
-                  logAgentDaemonSet:
+                  logAgent:
                     properties:
                       annotations:
                         additionalProperties:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -5026,6 +5026,14 @@ spec:
                     - enabled
                     type: object
                 type: object
+              logMonitoring:
+                description: General configuration about LogMonitoring instances.
+                properties:
+                  enabled:
+                    type: boolean
+                required:
+                - enabled
+                type: object
               metadataEnrichment:
                 description: Configuration for Metadata Enrichment.
                 properties:
@@ -6626,6 +6634,147 @@ spec:
                           - maxSkew
                           - topologyKey
                           - whenUnsatisfiable
+                          type: object
+                        type: array
+                    type: object
+                  logAgentDaemonSet:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Add custom LogAgent annotations
+                        type: object
+                      args:
+                        description: Set additional arguments to the LogAgent pods
+                        items:
+                          type: string
+                        type: array
+                      dnsPolicy:
+                        description: Sets DNS Policy for the ActiveGate pods
+                        type: string
+                      imageRef:
+                        description: Overrides the default image
+                        properties:
+                          repository:
+                            description: Custom image repository
+                            example: docker.io/dynatrace/image-name
+                            type: string
+                          tag:
+                            description: Indicates a tag of the image to use
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Add custom LogAgent labels
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Node selector to control the selection of nodes
+                          for the LogAgent pods
+                        type: object
+                      priorityClassName:
+                        description: Assign a priority class to the LogAgent pods.
+                          By default, no class is set
+                        type: string
+                      resources:
+                        description: Define resources' requests and limits for single
+                          LogAgent pod
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      secCompProfile:
+                        description: The SecComp Profile that will be configured in
+                          order to run in secure computing mode
+                        type: string
+                      tolerations:
+                        description: Set tolerations for the LogAgent pods
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
                           type: object
                         type: array
                     type: object

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -6637,7 +6637,7 @@ spec:
                           type: object
                         type: array
                     type: object
-                  logAgentDaemonSet:
+                  logAgent:
                     properties:
                       annotations:
                         additionalProperties:

--- a/doc/api/dynakube-api-ref.md
+++ b/doc/api/dynakube-api-ref.md
@@ -40,12 +40,32 @@
 |`tolerations`|Set tolerations for the ActiveGate pods|-|array|
 |`topologySpreadConstraints`|Adds TopologySpreadConstraints for the ActiveGate pods|-|array|
 
+### .spec.logMonitoring
+
+|Parameter|Description|Default value|Data type|
+|:-|:-|:-|:-|
+|`enabled`||-|boolean|
+
 ### .spec.metadataEnrichment
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
 |`enabled`|Enables MetadataEnrichment, `true` by default.|True|boolean|
 |`namespaceSelector`|The namespaces where you want Dynatrace Operator to inject enrichment.|-|object|
+
+### .spec.templates.logAgent
+
+|Parameter|Description|Default value|Data type|
+|:-|:-|:-|:-|
+|`annotations`|Add custom LogAgent annotations|-|object|
+|`args`|Set additional arguments to the LogAgent pods|-|array|
+|`dnsPolicy`|Sets DNS Policy for the ActiveGate pods|-|string|
+|`labels`|Add custom LogAgent labels|-|object|
+|`nodeSelector`|Node selector to control the selection of nodes for the LogAgent pods|-|object|
+|`priorityClassName`|Assign a priority class to the LogAgent pods. By default, no class is set|-|string|
+|`resources`|Define resources' requests and limits for single LogAgent pod|-|object|
+|`secCompProfile`|The SecComp Profile that will be configured in order to run in secure computing mode|-|string|
+|`tolerations`|Set tolerations for the LogAgent pods|-|array|
 
 ### .spec.extensions.prometheus
 
@@ -88,6 +108,13 @@
 |`secCompProfile`|The SecComp Profile that will be configured in order to run in secure computing mode.|-|string|
 |`tolerations`|Tolerations to include with the OneAgent DaemonSet. For details, see Taints and Tolerations (<https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>).|-|array|
 |`version`|The OneAgent version to be used.|-|string|
+
+### .spec.templates.logAgent.imageRef
+
+|Parameter|Description|Default value|Data type|
+|:-|:-|:-|:-|
+|`repository`|Custom image repository|-|string|
+|`tag`|Indicates a tag of the image to use|-|string|
 
 ### .spec.oneAgent.cloudNativeFullStack
 

--- a/pkg/api/v1beta3/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta3/dynakube/dynakube_types.go
@@ -164,6 +164,16 @@ type DynaKubeSpec struct { //nolint:revive
 	LogMonitoring LogMonitoringSpec `json:"logMonitoring,omitempty"`
 }
 
+type TemplatesSpec struct {
+
+	// +kubebuilder:validation:Optional
+	OpenTelemetryCollector OpenTelemetryCollectorSpec `json:"openTelemetryCollector,omitempty"`
+	// +kubebuilder:validation:Optional
+	ExtensionExecutionController ExtensionExecutionControllerSpec `json:"extensionExecutionController,omitempty"`
+	// +kubebuilder:validation:Optional
+	LogAgent LogAgentSpec `json:"logAgent,omitempty"`
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DynaKubeList contains a list of DynaKube

--- a/pkg/api/v1beta3/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta3/dynakube/dynakube_types.go
@@ -158,6 +158,10 @@ type DynaKubeSpec struct { //nolint:revive
 
 	// +kubebuilder:validation:Optional
 	Extensions ExtensionsSpec `json:"extensions,omitempty"`
+
+	// General configuration about LogMonitoring instances.
+	// +kubebuilder:validation:Optional
+	LogMonitoring LogMonitoringSpec `json:"logMonitoring,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/api/v1beta3/dynakube/extensions.go
+++ b/pkg/api/v1beta3/dynakube/extensions.go
@@ -17,7 +17,7 @@ type TemplatesSpec struct {
 	// +kubebuilder:validation:Optional
 	ExtensionExecutionController ExtensionExecutionControllerSpec `json:"extensionExecutionController,omitempty"`
 	// +kubebuilder:validation:Optional
-	LogAgent LogAgentDaemonSetSpec `json:"logAgent,omitempty"`
+	LogAgent LogAgentSpec `json:"logAgent,omitempty"`
 }
 
 type PrometheusSpec struct {
@@ -105,7 +105,7 @@ type ImageRefSpec struct {
 	Tag string `json:"tag,omitempty"`
 }
 
-type LogAgentDaemonSetSpec struct {
+type LogAgentSpec struct {
 	// Add custom LogAgent annotations
 	// +kubebuilder:validation:Optional
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/pkg/api/v1beta3/dynakube/extensions.go
+++ b/pkg/api/v1beta3/dynakube/extensions.go
@@ -17,7 +17,7 @@ type TemplatesSpec struct {
 	// +kubebuilder:validation:Optional
 	ExtensionExecutionController ExtensionExecutionControllerSpec `json:"extensionExecutionController,omitempty"`
 	// +kubebuilder:validation:Optional
-	LogAgentDaemonSet LogAgentDaemonSetSpec `json:"logAgentDaemonSet,omitempty"`
+	LogAgent LogAgentDaemonSetSpec `json:"logAgent,omitempty"`
 }
 
 type PrometheusSpec struct {

--- a/pkg/api/v1beta3/dynakube/extensions.go
+++ b/pkg/api/v1beta3/dynakube/extensions.go
@@ -10,16 +10,6 @@ type ExtensionsSpec struct {
 	Prometheus PrometheusSpec `json:"prometheus,omitempty"`
 }
 
-type TemplatesSpec struct {
-
-	// +kubebuilder:validation:Optional
-	OpenTelemetryCollector OpenTelemetryCollectorSpec `json:"openTelemetryCollector,omitempty"`
-	// +kubebuilder:validation:Optional
-	ExtensionExecutionController ExtensionExecutionControllerSpec `json:"extensionExecutionController,omitempty"`
-	// +kubebuilder:validation:Optional
-	LogAgent LogAgentSpec `json:"logAgent,omitempty"`
-}
-
 type PrometheusSpec struct {
 	Enabled bool `json:"enabled"`
 }
@@ -103,46 +93,4 @@ type ImageRefSpec struct {
 
 	// Indicates a tag of the image to use
 	Tag string `json:"tag,omitempty"`
-}
-
-type LogAgentSpec struct {
-	// Add custom LogAgent annotations
-	// +kubebuilder:validation:Optional
-	Annotations map[string]string `json:"annotations,omitempty"`
-
-	// Add custom LogAgent labels
-	// +kubebuilder:validation:Optional
-	Labels map[string]string `json:"labels,omitempty"`
-
-	// Node selector to control the selection of nodes for the LogAgent pods
-	// +kubebuilder:validation:Optional
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
-
-	// Overrides the default image
-	// +kubebuilder:validation:Optional
-	ImageRef ImageRefSpec `json:"imageRef,omitempty"`
-
-	// Sets DNS Policy for the ActiveGate pods
-	// +kubebuilder:validation:Optional
-	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
-
-	// Assign a priority class to the LogAgent pods. By default, no class is set
-	// +kubebuilder:validation:Optional
-	PriorityClassName string `json:"priorityClassName,omitempty"`
-
-	// The SecComp Profile that will be configured in order to run in secure computing mode
-	// +kubebuilder:validation:Optional
-	SecCompProfile string `json:"secCompProfile,omitempty"`
-
-	// Define resources' requests and limits for single LogAgent pod
-	// +kubebuilder:validation:Optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-
-	// Set tolerations for the LogAgent pods
-	// +kubebuilder:validation:Optional
-	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-
-	// Set additional arguments to the LogAgent pods
-	// +kubebuilder:validation:Optional
-	Args []string `json:"args,omitempty"`
 }

--- a/pkg/api/v1beta3/dynakube/extensions.go
+++ b/pkg/api/v1beta3/dynakube/extensions.go
@@ -16,6 +16,8 @@ type TemplatesSpec struct {
 	OpenTelemetryCollector OpenTelemetryCollectorSpec `json:"openTelemetryCollector,omitempty"`
 	// +kubebuilder:validation:Optional
 	ExtensionExecutionController ExtensionExecutionControllerSpec `json:"extensionExecutionController,omitempty"`
+	// +kubebuilder:validation:Optional
+	LogAgentDaemonSet LogAgentDaemonSetSpec `json:"logAgentDaemonSet,omitempty"`
 }
 
 type PrometheusSpec struct {
@@ -101,4 +103,46 @@ type ImageRefSpec struct {
 
 	// Indicates a tag of the image to use
 	Tag string `json:"tag,omitempty"`
+}
+
+type LogAgentDaemonSetSpec struct {
+	// Add custom LogAgent annotations
+	// +kubebuilder:validation:Optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Add custom LogAgent labels
+	// +kubebuilder:validation:Optional
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Node selector to control the selection of nodes for the LogAgent pods
+	// +kubebuilder:validation:Optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Overrides the default image
+	// +kubebuilder:validation:Optional
+	ImageRef ImageRefSpec `json:"imageRef,omitempty"`
+
+	// Sets DNS Policy for the ActiveGate pods
+	// +kubebuilder:validation:Optional
+	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
+
+	// Assign a priority class to the LogAgent pods. By default, no class is set
+	// +kubebuilder:validation:Optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// The SecComp Profile that will be configured in order to run in secure computing mode
+	// +kubebuilder:validation:Optional
+	SecCompProfile string `json:"secCompProfile,omitempty"`
+
+	// Define resources' requests and limits for single LogAgent pod
+	// +kubebuilder:validation:Optional
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// Set tolerations for the LogAgent pods
+	// +kubebuilder:validation:Optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// Set additional arguments to the LogAgent pods
+	// +kubebuilder:validation:Optional
+	Args []string `json:"args,omitempty"`
 }

--- a/pkg/api/v1beta3/dynakube/log_monitoring_types.go
+++ b/pkg/api/v1beta3/dynakube/log_monitoring_types.go
@@ -1,0 +1,5 @@
+package dynakube
+
+type LogMonitoringSpec struct {
+	Enabled bool `json:"enabled"`
+}

--- a/pkg/api/v1beta3/dynakube/log_monitoring_types.go
+++ b/pkg/api/v1beta3/dynakube/log_monitoring_types.go
@@ -1,5 +1,49 @@
 package dynakube
 
+import corev1 "k8s.io/api/core/v1"
+
 type LogMonitoringSpec struct {
 	Enabled bool `json:"enabled"`
+}
+
+type LogAgentSpec struct {
+	// Add custom LogAgent annotations
+	// +kubebuilder:validation:Optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Add custom LogAgent labels
+	// +kubebuilder:validation:Optional
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Node selector to control the selection of nodes for the LogAgent pods
+	// +kubebuilder:validation:Optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Overrides the default image
+	// +kubebuilder:validation:Optional
+	ImageRef ImageRefSpec `json:"imageRef,omitempty"`
+
+	// Sets DNS Policy for the ActiveGate pods
+	// +kubebuilder:validation:Optional
+	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
+
+	// Assign a priority class to the LogAgent pods. By default, no class is set
+	// +kubebuilder:validation:Optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// The SecComp Profile that will be configured in order to run in secure computing mode
+	// +kubebuilder:validation:Optional
+	SecCompProfile string `json:"secCompProfile,omitempty"`
+
+	// Define resources' requests and limits for single LogAgent pod
+	// +kubebuilder:validation:Optional
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// Set tolerations for the LogAgent pods
+	// +kubebuilder:validation:Optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// Set additional arguments to the LogAgent pods
+	// +kubebuilder:validation:Optional
+	Args []string `json:"args,omitempty"`
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

Jira: https://dt-rnd.atlassian.net/browse/K8S-10533

With this PR the LogAgent is introduced in the CR. It can be configured and applied. It is only added to v1beta3 and no conversion logic is needed. Further logic will be added in follow ups.

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

Apply dynakubes that use the newly introduced field, check if the fields are correctly set, see if everything works as before. Also read through my comments and correct if necessary.