### PR TITLE
Integrate new coverage tool

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,10 @@ jobs:
         run: |
           make go/test
           make go/integration_test
+      - name: check test coverage
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          config: ./.testcoverage.yml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         with:

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,51 @@
+# (mandatory)
+# Path to coverprofile file (output of `go test -coverprofile` command).
+#
+# For cases where there are many coverage profiles, such as when running
+# unit tests and integration tests separately, you can combine all those
+# profiles into one. In this case, the profile should have a comma-separated list
+# of profile files, e.g., 'cover_unit.out,cover_integration.out'.
+profile: coverage.txt
+
+# (optional; but recommended to set)
+# When specified reported file paths will not contain local prefix in the output
+local-prefix: "github.com/dynatrace/dynatrace-operator"
+
+# Holds coverage thresholds percentages, values should be in range [0-100]
+threshold:
+  # (optional; default 0)
+  # The minimum coverage that each file should have
+  # we can add it later
+  # file: 70
+
+  # (optional; default 0)
+  # The minimum coverage that each package should have
+  #  package: 80
+
+  # (optional; default 0)
+  # The minimum total coverage project should have
+  total: 71
+
+# Holds regexp rules which will override thresholds for matched files or packages
+# using their paths.
+#
+# The First rule from this list that matches file or package is going to apply
+# a new threshold to it. If a project has multiple rules that match the same path,
+# override rules should be listed in order from specific to more general rules.
+override:
+  # Increase the coverage threshold to 100% for `foo` package
+  # (default is 80, as configured above in this example)
+  - threshold: 100
+    path: ^pkg/lib/foo$
+
+# Holds regexp rules which will exclude matched files or packages
+# from coverage statistics
+exclude:
+  # Exclude files or packages matching their paths
+  paths:
+    - \.pb\.go$    # excludes all protobuf generated files
+    - ^test/mocks     # exclude package `pkg/bar`
+
+# NOTES:
+# - symbol `/` in all paths regexps will be replaced by current OS file path separator
+#   to properly work on Windows

--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -37,7 +37,7 @@ go/lint: prerequisites/go-linting go/format go/vet go/wsl go/betteralign go/gola
 
 ## Runs all go unit tests and writes the coverprofile to coverage.txt
 go/test:
-	go test ./... -coverprofile=coverage.txt -covermode=atomic -tags "$(shell ./hack/build/create_go_build_tags.sh false)"
+	go test ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... -tags "$(shell ./hack/build/create_go_build_tags.sh false)"
 
 ## Runs all go unit tests and opens coverage report in a browser
 go/coverage: go/test
@@ -55,3 +55,6 @@ go/gen_mocks: prerequisites/mockery
 go/deadcode: prerequisites/go-deadcode
 	# we add `tee` in the end to make it fail if it finds dead code, by default deadcode always return exit code 0
 	deadcode -test -tags="$(shell ./hack/build/create_go_build_tags.sh true)" $(LINT_TARGET) | tee deadcode.out && [ ! -s deadcode.out ]
+
+go/check-coverage: prerequisites/go-test-coverage go/test
+	go-test-coverage --config=./.testcoverage.yml

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -47,6 +47,10 @@ prerequisites/go-linting: prerequisites/go-deadcode
 prerequisites/go-deadcode:
 	go install golang.org/x/tools/cmd/deadcode@$(golang_tools_version)
 
+## Install go test coverage
+prerequisites/go-test-coverage:
+	go install github.com/vladopajic/go-test-coverage/v2@latest
+
 ## Install 'helm' if it is missing
 ## TODO: Have version accessible by renovate?
 prerequisites/helm-unittest:


### PR DESCRIPTION
## Description

This PR adds a new tool for calculating total code coverage and making sure it's above the specific threshold (current coverage 71%)

## How can this be tested?

CI must be green.

Also locally, change threshold to 95% and run new command `make go/check-coverage` it should fail.
```

Total coverage threshold (95%) satisfied:       FAIL
Total test coverage: 71%
make: *** [go/check-coverage] Error 1
```
and success message is:

```
go-test-coverage --config=./.testcoverage.yml
File coverage threshold (0%) satisfied:         PASS
Package coverage threshold (0%) satisfied:      PASS
Total coverage threshold (71%) satisfied:       PASS
Total test coverage: 71%
```