### PR TITLE
Adds EEC and OtelC statefulsets to status.DeploymentPhase equation

### DIFF
--- a/pkg/api/v1beta3/dynakube/properties.go
+++ b/pkg/api/v1beta3/dynakube/properties.go
@@ -46,6 +46,9 @@ const (
 
 	DefaultActiveGateImageRegistrySubPath = "/linux/activegate"
 	DefaultOneAgentImageRegistrySubPath   = "/linux/oneagent"
+
+	ExtensionsExecutionControllerStatefulsetName = "dynatrace-extensions-controller"
+	ExtensionsCollectorStatefulsetName           = "dynatrace-extensions-collector"
 )
 
 // ApiUrl is a getter for dk.Spec.APIURL.

--- a/pkg/controllers/dynakube/extension/eec/reconciler.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler.go
@@ -38,9 +38,9 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		}
 		defer meta.RemoveStatusCondition(r.dk.Conditions(), extensionsControllerStatefulSetConditionType)
 
-		sts, err := statefulset.Build(r.dk, statefulsetName, corev1.Container{})
+		sts, err := statefulset.Build(r.dk, dynakube.ExtensionsExecutionControllerStatefulsetName, corev1.Container{})
 		if err != nil {
-			log.Error(err, "could not build "+statefulsetName+" during cleanup")
+			log.Error(err, "could not build "+dynakube.ExtensionsExecutionControllerStatefulsetName+" during cleanup")
 
 			return err
 		}
@@ -48,7 +48,7 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		err = statefulset.Query(r.client, r.apiReader, log).Delete(ctx, sts)
 
 		if err != nil {
-			log.Error(err, "failed to clean up "+statefulsetName+" statufulset")
+			log.Error(err, "failed to clean up "+dynakube.ExtensionsExecutionControllerStatefulsetName+" statufulset")
 
 			return nil
 		}
@@ -57,13 +57,13 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 	}
 
 	if r.dk.Status.ActiveGate.ConnectionInfoStatus.TenantUUID == "" {
-		conditions.SetStatefulSetOutdated(r.dk.Conditions(), extensionsControllerStatefulSetConditionType, statefulsetName)
+		conditions.SetStatefulSetOutdated(r.dk.Conditions(), extensionsControllerStatefulSetConditionType, dynakube.ExtensionsExecutionControllerStatefulsetName)
 
 		return errors.New("tenantUUID unknown")
 	}
 
 	if r.dk.Status.KubeSystemUUID == "" {
-		conditions.SetStatefulSetOutdated(r.dk.Conditions(), extensionsControllerStatefulSetConditionType, statefulsetName)
+		conditions.SetStatefulSetOutdated(r.dk.Conditions(), extensionsControllerStatefulSetConditionType, dynakube.ExtensionsExecutionControllerStatefulsetName)
 
 		return errors.New("kubeSystemUUID unknown")
 	}

--- a/pkg/controllers/dynakube/extension/eec/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler_test.go
@@ -78,7 +78,7 @@ func getStatefulset(t *testing.T, dk *dynakube.DynaKube) *appsv1.StatefulSet {
 	require.NoError(t, err)
 
 	statefulSet := &appsv1.StatefulSet{}
-	err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
+	err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dynakube.ExtensionsExecutionControllerStatefulsetName, Namespace: dk.Namespace}, statefulSet)
 	require.NoError(t, err)
 
 	return statefulSet
@@ -95,7 +95,7 @@ func TestConditions(t *testing.T) {
 		require.Error(t, err)
 
 		statefulSet := &appsv1.StatefulSet{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dynakube.ExtensionsExecutionControllerStatefulsetName, Namespace: dk.Namespace}, statefulSet)
 		require.Error(t, err)
 
 		assert.True(t, errors.IsNotFound(err))
@@ -111,7 +111,7 @@ func TestConditions(t *testing.T) {
 		require.Error(t, err)
 
 		statefulSet := &appsv1.StatefulSet{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dynakube.ExtensionsExecutionControllerStatefulsetName, Namespace: dk.Namespace}, statefulSet)
 		require.Error(t, err)
 
 		assert.True(t, errors.IsNotFound(err))
@@ -120,7 +120,7 @@ func TestConditions(t *testing.T) {
 	t.Run("prometheus is disabled", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Spec.Extensions.Prometheus.Enabled = false
-		conditions.SetStatefulSetCreated(dk.Conditions(), extensionsControllerStatefulSetConditionType, statefulsetName)
+		conditions.SetStatefulSetCreated(dk.Conditions(), extensionsControllerStatefulSetConditionType, dynakube.ExtensionsExecutionControllerStatefulsetName)
 
 		mockK8sClient := fake.NewClient(dk)
 
@@ -128,7 +128,7 @@ func TestConditions(t *testing.T) {
 		require.NoError(t, err)
 
 		statefulSet := &appsv1.StatefulSet{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dynakube.ExtensionsExecutionControllerStatefulsetName, Namespace: dk.Namespace}, statefulSet)
 		require.Error(t, err)
 
 		assert.True(t, errors.IsNotFound(err))

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -19,8 +19,7 @@ import (
 )
 
 const (
-	statefulsetName                  = "dynatrace-extensions-controller"
-	runtimePersistentVolumeClaimName = statefulsetName + "-runtime"
+	runtimePersistentVolumeClaimName = dynakube.ExtensionsExecutionControllerStatefulsetName + "-runtime"
 	containerName                    = "extensions-controller"
 	collectorPort                    = int32(14599)
 	serviceAccountName               = "dynatrace-extensions-controller"
@@ -52,7 +51,7 @@ const (
 
 func (r *reconciler) createOrUpdateStatefulset(ctx context.Context) error {
 	appLabels := buildAppLabels(r.dk.Name)
-	desiredSts, err := statefulset.Build(r.dk, statefulsetName, buildContainer(r.dk),
+	desiredSts, err := statefulset.Build(r.dk, dynakube.ExtensionsExecutionControllerStatefulsetName, buildContainer(r.dk),
 		statefulset.SetReplicas(1),
 		statefulset.SetPodManagementPolicy(appsv1.ParallelPodManagement),
 		statefulset.SetAllLabels(appLabels.BuildLabels(), appLabels.BuildMatchLabels(), appLabels.BuildLabels(), r.dk.Spec.Templates.ExtensionExecutionController.Labels),
@@ -82,7 +81,7 @@ func (r *reconciler) createOrUpdateStatefulset(ctx context.Context) error {
 
 	_, err = statefulset.Query(r.client, r.apiReader, log).WithOwner(r.dk).CreateOrUpdate(ctx, desiredSts)
 	if err != nil {
-		log.Info("failed to create/update " + statefulsetName + " statefulset")
+		log.Info("failed to create/update " + dynakube.ExtensionsExecutionControllerStatefulsetName + " statefulset")
 		conditions.SetKubeApiError(r.dk.Conditions(), extensionsControllerStatefulSetConditionType, err)
 
 		return err

--- a/pkg/controllers/dynakube/extension/otel/reconciler.go
+++ b/pkg/controllers/dynakube/extension/otel/reconciler.go
@@ -37,9 +37,9 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		}
 		defer meta.RemoveStatusCondition(r.dk.Conditions(), otelControllerStatefulSetConditionType)
 
-		sts, err := statefulset.Build(r.dk, statefulsetName, corev1.Container{})
+		sts, err := statefulset.Build(r.dk, dynakube.ExtensionsCollectorStatefulsetName, corev1.Container{})
 		if err != nil {
-			log.Error(err, "could not build "+statefulsetName+" during cleanup")
+			log.Error(err, "could not build "+dynakube.ExtensionsCollectorStatefulsetName+" during cleanup")
 
 			return err
 		}
@@ -47,7 +47,7 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		err = statefulset.Query(r.client, r.apiReader, log).Delete(ctx, sts)
 
 		if err != nil {
-			log.Error(err, "failed to clean up "+statefulsetName+" statufulset")
+			log.Error(err, "failed to clean up "+dynakube.ExtensionsCollectorStatefulsetName+" statufulset")
 
 			return nil
 		}

--- a/pkg/controllers/dynakube/extension/otel/statefulset.go
+++ b/pkg/controllers/dynakube/extension/otel/statefulset.go
@@ -18,7 +18,6 @@ import (
 )
 
 const (
-	statefulsetName      = "dynatrace-extensions-collector"
 	serviceAccountName   = "dynatrace-extensions-collector"
 	containerName        = "collector"
 	tokenSecretKey       = "otelc.token"
@@ -39,7 +38,7 @@ const (
 
 func (r *reconciler) createOrUpdateStatefulset(ctx context.Context) error {
 	appLabels := buildAppLabels(r.dk.Name)
-	sts, err := statefulset.Build(r.dk, statefulsetName, buildContainer(r.dk),
+	sts, err := statefulset.Build(r.dk, dynakube.ExtensionsCollectorStatefulsetName, buildContainer(r.dk),
 		statefulset.SetReplicas(getReplicas(r.dk)),
 		statefulset.SetPodManagementPolicy(appsv1.ParallelPodManagement),
 		statefulset.SetAllLabels(appLabels.BuildLabels(), appLabels.BuildMatchLabels(), appLabels.BuildLabels(), r.dk.Spec.Templates.OpenTelemetryCollector.Labels),
@@ -68,7 +67,7 @@ func (r *reconciler) createOrUpdateStatefulset(ctx context.Context) error {
 
 	_, err = statefulset.Query(r.client, r.apiReader, log).WithOwner(r.dk).CreateOrUpdate(ctx, sts)
 	if err != nil {
-		log.Info("failed to create/update " + statefulsetName + " statefulset")
+		log.Info("failed to create/update " + dynakube.ExtensionsCollectorStatefulsetName + " statefulset")
 		conditions.SetKubeApiError(r.dk.Conditions(), otelControllerStatefulSetConditionType, err)
 
 		return err

--- a/pkg/controllers/dynakube/extension/otel/statefulset_test.go
+++ b/pkg/controllers/dynakube/extension/otel/statefulset_test.go
@@ -53,7 +53,7 @@ func getStatefulset(t *testing.T, dk *dynakube.DynaKube) *appsv1.StatefulSet {
 	require.NoError(t, err)
 
 	statefulSet := &appsv1.StatefulSet{}
-	err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
+	err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dynakube.ExtensionsCollectorStatefulsetName, Namespace: dk.Namespace}, statefulSet)
 	require.NoError(t, err)
 
 	return statefulSet
@@ -63,7 +63,7 @@ func TestConditions(t *testing.T) {
 	t.Run("prometheus is disabled", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Spec.Extensions.Prometheus.Enabled = false
-		conditions.SetStatefulSetCreated(dk.Conditions(), otelControllerStatefulSetConditionType, statefulsetName)
+		conditions.SetStatefulSetCreated(dk.Conditions(), otelControllerStatefulSetConditionType, dynakube.ExtensionsCollectorStatefulsetName)
 
 		mockK8sClient := fake.NewClient(dk)
 
@@ -71,7 +71,7 @@ func TestConditions(t *testing.T) {
 		require.NoError(t, err)
 
 		statefulSet := &appsv1.StatefulSet{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dynakube.ExtensionsCollectorStatefulsetName, Namespace: dk.Namespace}, statefulSet)
 		require.Error(t, err)
 
 		assert.True(t, errors.IsNotFound(err))

--- a/pkg/controllers/dynakube/phase.go
+++ b/pkg/controllers/dynakube/phase.go
@@ -64,7 +64,7 @@ func (controller *Controller) determinePrometheusStatefulsetPhase(dk *dynakube.D
 	if dk.PrometheusEnabled() {
 		statefulSet := &appsv1.StatefulSet{}
 
-		err := controller.client.Get(context.TODO(), types.NamespacedName{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
+		err := controller.client.Get(context.Background(), types.NamespacedName{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
 		if k8serrors.IsNotFound(err) {
 			log.Info("statefulset to be deployed", "dynakube", dk.Name, "statefulset", statefulsetName)
 
@@ -121,7 +121,7 @@ func (controller *Controller) numberOfMissingOneagentPods(dk *dynakube.DynaKube)
 	oneAgentDaemonSet := &appsv1.DaemonSet{}
 	instanceName := dk.OneAgentDaemonsetName()
 
-	err := controller.client.Get(context.TODO(), types.NamespacedName{Name: instanceName, Namespace: dk.Namespace}, oneAgentDaemonSet)
+	err := controller.client.Get(context.Background(), types.NamespacedName{Name: instanceName, Namespace: dk.Namespace}, oneAgentDaemonSet)
 	if err != nil {
 		return 0, err
 	}
@@ -139,7 +139,7 @@ func (controller *Controller) numberOfMissingActiveGatePods(dk *dynakube.DynaKub
 		activeGateStatefulSet := &appsv1.StatefulSet{}
 		instanceName := capability.CalculateStatefulSetName(activeGateCapability, dk.Name)
 
-		err := controller.client.Get(context.TODO(), types.NamespacedName{Name: instanceName, Namespace: dk.Namespace}, activeGateStatefulSet)
+		err := controller.client.Get(context.Background(), types.NamespacedName{Name: instanceName, Namespace: dk.Namespace}, activeGateStatefulSet)
 		if k8serrors.IsNotFound(err) {
 			continue
 		}

--- a/pkg/controllers/dynakube/phase.go
+++ b/pkg/controllers/dynakube/phase.go
@@ -12,6 +12,22 @@ import (
 )
 
 func (controller *Controller) determineDynaKubePhase(dk *dynakube.DynaKube) status.DeploymentPhase {
+	components := []func(dk *dynakube.DynaKube) status.DeploymentPhase{
+		controller.determineActiveGatePhase,
+		controller.determineExtensionsExecutionControllerPhase,
+		controller.determineExtensionsCollectorPhase,
+		controller.determineOneAgentPhase,
+	}
+	for _, component := range components {
+		if phase := component(dk); phase != status.Running {
+			return phase
+		}
+	}
+
+	return status.Running
+}
+
+func (controller *Controller) determineActiveGatePhase(dk *dynakube.DynaKube) status.DeploymentPhase {
 	if dk.NeedsActiveGate() {
 		activeGatePods, err := controller.numberOfMissingActiveGatePods(dk)
 		if err != nil {
@@ -33,6 +49,50 @@ func (controller *Controller) determineDynaKubePhase(dk *dynakube.DynaKube) stat
 		}
 	}
 
+	return status.Running
+}
+
+func (controller *Controller) determineExtensionsExecutionControllerPhase(dk *dynakube.DynaKube) status.DeploymentPhase {
+	return controller.determinePrometheusStatefulsetPhase(dk, dynakube.ExtensionsExecutionControllerStatefulsetName)
+}
+
+func (controller *Controller) determineExtensionsCollectorPhase(dk *dynakube.DynaKube) status.DeploymentPhase {
+	return controller.determinePrometheusStatefulsetPhase(dk, dynakube.ExtensionsCollectorStatefulsetName)
+}
+
+func (controller *Controller) determinePrometheusStatefulsetPhase(dk *dynakube.DynaKube, statefulsetName string) status.DeploymentPhase {
+	if dk.PrometheusEnabled() {
+		statefulSet := &appsv1.StatefulSet{}
+
+		err := controller.client.Get(context.TODO(), types.NamespacedName{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
+		if k8serrors.IsNotFound(err) {
+			log.Info("statefulset to be deployed", "dynakube", dk.Name, "statefulset", statefulsetName)
+
+			return status.Deploying
+		}
+
+		if err != nil {
+			log.Error(err, "statefulset could not be accessed", "dynakube", dk.Name, "statefulset", statefulsetName)
+
+			return status.Error
+		}
+
+		scheduledReplicas := int32(0)
+		if statefulSet.Spec.Replicas != nil {
+			scheduledReplicas = *statefulSet.Spec.Replicas
+		}
+
+		if scheduledReplicas != statefulSet.Status.ReadyReplicas {
+			log.Info("statefulset is still deploying", "dynakube", dk.Name, "statefulset", statefulsetName)
+
+			return status.Deploying
+		}
+	}
+
+	return status.Running
+}
+
+func (controller *Controller) determineOneAgentPhase(dk *dynakube.DynaKube) status.DeploymentPhase {
 	if dk.CloudNativeFullstackMode() || dk.ClassicFullStackMode() || dk.HostMonitoringMode() {
 		oneAgentPods, err := controller.numberOfMissingOneagentPods(dk)
 		if k8serrors.IsNotFound(err) {


### PR DESCRIPTION
[K8S-10856](https://dt-rnd.atlassian.net/browse/K8S-10856)

## Description

Dynakube deployment status (Error/Deploying/Running) depends also on state of EEC/OtelC statefulsets.

## How can this be tested?

Enable Prometheus mode.
```
spec:
  customPullSecret: ...
  extensions:
    prometheus:
      enabled: true
  templates:
    extensionExecutionController:
      imageRef:
        repository: ...
        tag: ...  
```
Deployment status is `Deploying` forever because OtelC POD is in `CrashLoopBackOff` state.