### PR TITLE
Add OTLP Exporter configuration options to CRD

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -5005,70 +5005,6 @@ spec:
                 type: boolean
               extensions:
                 properties:
-                  otlpexporter:
-                    properties:
-                      enableLogs:
-                        description: |-
-                          Enable OpenTelemetry Protocol Exporters logs endpoint
-                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
-                        type: boolean
-                      enableMetrics:
-                        description: |-
-                          Enable OpenTelemetry Protocol Exporters metrics endpoint
-                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
-                        type: boolean
-                      enableTraces:
-                        description: |-
-                          Enable OpenTelemetry Protocol Exporters traces endpoint
-                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
-                        type: boolean
-                      namespaceSelector:
-                        description: Namespaces where the operator should enable OTLP-Exporters
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
-                    type: object
                   prometheus:
                     properties:
                       enabled:
@@ -6231,6 +6167,71 @@ spec:
                         description: The OneAgent version to be used.
                         type: string
                     type: object
+                type: object
+              otlpExporterConfiguration:
+                description: Configuration of OpenTelemetry-Protocol Exporters
+                properties:
+                  enableLogs:
+                    description: |-
+                      Enable OpenTelemetry Protocol Exporters logs endpoint
+                      see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                    type: boolean
+                  enableMetrics:
+                    description: |-
+                      Enable OpenTelemetry Protocol Exporters metrics endpoint
+                      see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                    type: boolean
+                  enableTraces:
+                    description: |-
+                      Enable OpenTelemetry Protocol Exporters traces endpoint
+                      see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                    type: boolean
+                  namespaceSelector:
+                    description: Namespaces where the operator should enable OTLP-Exporters
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               proxy:
                 description: |-

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -5005,6 +5005,70 @@ spec:
                 type: boolean
               extensions:
                 properties:
+                  otlpexporter:
+                    properties:
+                      enableLogs:
+                        description: |-
+                          Enable OpenTelemetry Protocol Exporters logs endpoint
+                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                        type: boolean
+                      enableMetrics:
+                        description: |-
+                          Enable OpenTelemetry Protocol Exporters metrics endpoint
+                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                        type: boolean
+                      enableTraces:
+                        description: |-
+                          Enable OpenTelemetry Protocol Exporters traces endpoint
+                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                        type: boolean
+                      namespaceSelector:
+                        description: Namespaces where the operator should enable OTLP-Exporters
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
                   prometheus:
                     properties:
                       enabled:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -5018,70 +5018,6 @@ spec:
                 type: boolean
               extensions:
                 properties:
-                  otlpexporter:
-                    properties:
-                      enableLogs:
-                        description: |-
-                          Enable OpenTelemetry Protocol Exporters logs endpoint
-                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
-                        type: boolean
-                      enableMetrics:
-                        description: |-
-                          Enable OpenTelemetry Protocol Exporters metrics endpoint
-                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
-                        type: boolean
-                      enableTraces:
-                        description: |-
-                          Enable OpenTelemetry Protocol Exporters traces endpoint
-                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
-                        type: boolean
-                      namespaceSelector:
-                        description: Namespaces where the operator should enable OTLP-Exporters
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
-                    type: object
                   prometheus:
                     properties:
                       enabled:
@@ -6244,6 +6180,71 @@ spec:
                         description: The OneAgent version to be used.
                         type: string
                     type: object
+                type: object
+              otlpExporterConfiguration:
+                description: Configuration of OpenTelemetry-Protocol Exporters
+                properties:
+                  enableLogs:
+                    description: |-
+                      Enable OpenTelemetry Protocol Exporters logs endpoint
+                      see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                    type: boolean
+                  enableMetrics:
+                    description: |-
+                      Enable OpenTelemetry Protocol Exporters metrics endpoint
+                      see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                    type: boolean
+                  enableTraces:
+                    description: |-
+                      Enable OpenTelemetry Protocol Exporters traces endpoint
+                      see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                    type: boolean
+                  namespaceSelector:
+                    description: Namespaces where the operator should enable OTLP-Exporters
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               proxy:
                 description: |-

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -5018,6 +5018,70 @@ spec:
                 type: boolean
               extensions:
                 properties:
+                  otlpexporter:
+                    properties:
+                      enableLogs:
+                        description: |-
+                          Enable OpenTelemetry Protocol Exporters logs endpoint
+                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                        type: boolean
+                      enableMetrics:
+                        description: |-
+                          Enable OpenTelemetry Protocol Exporters metrics endpoint
+                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                        type: boolean
+                      enableTraces:
+                        description: |-
+                          Enable OpenTelemetry Protocol Exporters traces endpoint
+                          see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+                        type: boolean
+                      namespaceSelector:
+                        description: Namespaces where the operator should enable OTLP-Exporters
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
                   prometheus:
                     properties:
                       enabled:

--- a/doc/api/dynakube-api-ref.md
+++ b/doc/api/dynakube-api-ref.md
@@ -73,15 +73,6 @@
 |:-|:-|:-|:-|
 |`enabled`||-|boolean|
 
-### .spec.extensions.otlpexporter
-
-|Parameter|Description|Default value|Data type|
-|:-|:-|:-|:-|
-|`enableLogs`|Enable OpenTelemetry Protocol Exporters logs endpoint<br/>see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp|-|boolean|
-|`enableMetrics`|Enable OpenTelemetry Protocol Exporters metrics endpoint<br/>see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp|-|boolean|
-|`enableTraces`|Enable OpenTelemetry Protocol Exporters traces endpoint<br/>see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp|-|boolean|
-|`namespaceSelector`|Namespaces where the operator should enable OTLP-Exporters|-|object|
-
 ### .spec.oneAgent.hostMonitoring
 
 |Parameter|Description|Default value|Data type|
@@ -117,6 +108,15 @@
 |`secCompProfile`|The SecComp Profile that will be configured in order to run in secure computing mode.|-|string|
 |`tolerations`|Tolerations to include with the OneAgent DaemonSet. For details, see Taints and Tolerations (<https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>).|-|array|
 |`version`|The OneAgent version to be used.|-|string|
+
+### .spec.otlpExporterConfiguration
+
+|Parameter|Description|Default value|Data type|
+|:-|:-|:-|:-|
+|`enableLogs`|Enable OpenTelemetry Protocol Exporters logs endpoint<br/>see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp|-|boolean|
+|`enableMetrics`|Enable OpenTelemetry Protocol Exporters metrics endpoint<br/>see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp|-|boolean|
+|`enableTraces`|Enable OpenTelemetry Protocol Exporters traces endpoint<br/>see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp|-|boolean|
+|`namespaceSelector`|Namespaces where the operator should enable OTLP-Exporters|-|object|
 
 ### .spec.templates.logAgent.imageRef
 

--- a/doc/api/dynakube-api-ref.md
+++ b/doc/api/dynakube-api-ref.md
@@ -73,6 +73,15 @@
 |:-|:-|:-|:-|
 |`enabled`||-|boolean|
 
+### .spec.extensions.otlpexporter
+
+|Parameter|Description|Default value|Data type|
+|:-|:-|:-|:-|
+|`enableLogs`|Enable OpenTelemetry Protocol Exporters logs endpoint<br/>see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp|-|boolean|
+|`enableMetrics`|Enable OpenTelemetry Protocol Exporters metrics endpoint<br/>see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp|-|boolean|
+|`enableTraces`|Enable OpenTelemetry Protocol Exporters traces endpoint<br/>see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp|-|boolean|
+|`namespaceSelector`|Namespaces where the operator should enable OTLP-Exporters|-|object|
+
 ### .spec.oneAgent.hostMonitoring
 
 |Parameter|Description|Default value|Data type|

--- a/pkg/api/v1beta3/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta3/dynakube/dynakube_types.go
@@ -89,9 +89,6 @@ type DynaKubeSpec struct { //nolint:revive
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Proxy",order=3,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Proxy *DynaKubeProxy `json:"proxy,omitempty"`
 
-	// +kubebuilder:validation:Optional
-	Templates TemplatesSpec `json:"templates,omitempty"`
-
 	// General configuration about OneAgent instances.
 	// You can't enable more than one module (classicFullStack, cloudNativeFullStack, hostMonitoring, or applicationMonitoring).
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OneAgent",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
@@ -128,6 +125,9 @@ type DynaKubeSpec struct { //nolint:revive
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Custom PullSecret",order=8,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:io.kubernetes:Secret"}
 	CustomPullSecret string `json:"customPullSecret,omitempty"`
 
+	// +kubebuilder:validation:Optional
+	Templates TemplatesSpec `json:"templates,omitempty"`
+
 	// General configuration about ActiveGate instances.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ActiveGate",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	ActiveGate ActiveGateSpec `json:"activeGate,omitempty"`
@@ -136,6 +136,9 @@ type DynaKubeSpec struct { //nolint:revive
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Metadata Enrichment",order=9,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	MetadataEnrichment MetadataEnrichment `json:"metadataEnrichment,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	Extensions ExtensionsSpec `json:"extensions,omitempty"`
 
 	// Configuration for thresholding Dynatrace API requests.
 	// +kubebuilder:validation:Optional
@@ -155,9 +158,6 @@ type DynaKubeSpec struct { //nolint:revive
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Istio automatic management",order=9,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	EnableIstio bool `json:"enableIstio,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	Extensions ExtensionsSpec `json:"extensions,omitempty"`
 
 	// General configuration about LogMonitoring instances.
 	// +kubebuilder:validation:Optional

--- a/pkg/api/v1beta3/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta3/dynakube/dynakube_types.go
@@ -137,14 +137,18 @@ type DynaKubeSpec struct { //nolint:revive
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Metadata Enrichment",order=9,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	MetadataEnrichment MetadataEnrichment `json:"metadataEnrichment,omitempty"`
 
+	// Configuration of OpenTelemetry-Protocol Exporters
 	// +kubebuilder:validation:Optional
-	Extensions ExtensionsSpec `json:"extensions,omitempty"`
+	OTLPExporterConfiguration OTLPExporterConfigurationSpec `json:"otlpExporterConfiguration,omitempty"`
 
 	// Configuration for thresholding Dynatrace API requests.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=15
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Dynatrace API Request Threshold",order=9,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	DynatraceApiRequestThreshold int `json:"dynatraceApiRequestThreshold,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	Extensions ExtensionsSpec `json:"extensions,omitempty"`
 
 	// Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.
 	// Set to true if you want to skip certification validation checks.
@@ -172,6 +176,24 @@ type TemplatesSpec struct {
 	ExtensionExecutionController ExtensionExecutionControllerSpec `json:"extensionExecutionController,omitempty"`
 	// +kubebuilder:validation:Optional
 	LogAgent LogAgentSpec `json:"logAgent,omitempty"`
+}
+
+type OTLPExporterConfigurationSpec struct {
+	// Namespaces where the operator should enable OTLP-Exporters
+	// +kubebuilder:validation:Optional
+	NamespaceSelector metav1.LabelSelector `json:"namespaceSelector,omitempty"`
+	// Enable OpenTelemetry Protocol Exporters traces endpoint
+	// see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+	// +kubebuilder:validation:Optional
+	EnableTraces bool `json:"enableTraces,omitempty"`
+	// Enable OpenTelemetry Protocol Exporters metrics endpoint
+	// see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+	// +kubebuilder:validation:Optional
+	EnableMetrics bool `json:"enableMetrics,omitempty"`
+	// Enable OpenTelemetry Protocol Exporters logs endpoint
+	// see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+	// +kubebuilder:validation:Optional
+	EnableLogs bool `json:"enableLogs,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/api/v1beta3/dynakube/extensions.go
+++ b/pkg/api/v1beta3/dynakube/extensions.go
@@ -3,9 +3,30 @@ package dynakube
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type OTLPExporterSpec struct {
+	// Namespaces where the operator should enable OTLP-Exporters
+	// +kubebuilder:validation:Optional
+	NamespaceSelector metav1.LabelSelector `json:"namespaceSelector,omitempty"`
+	// Enable OpenTelemetry Protocol Exporters traces endpoint
+	// see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+	// +kubebuilder:validation:Optional
+	EnableTraces bool `json:"enableTraces,omitempty"`
+	// Enable OpenTelemetry Protocol Exporters metrics endpoint
+	// see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+	// +kubebuilder:validation:Optional
+	EnableMetrics bool `json:"enableMetrics,omitempty"`
+	// Enable OpenTelemetry Protocol Exporters logs endpoint
+	// see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+	// +kubebuilder:validation:Optional
+	EnableLogs bool `json:"enableLogs,omitempty"`
+}
+
 type ExtensionsSpec struct {
+	// +kubebuilder:validation:Optional
+	OTLPExporter OTLPExporterSpec `json:"otlpexporter,omitempty"`
 	// +kubebuilder:validation:Optional
 	Prometheus PrometheusSpec `json:"prometheus,omitempty"`
 }

--- a/pkg/api/v1beta3/dynakube/extensions.go
+++ b/pkg/api/v1beta3/dynakube/extensions.go
@@ -3,30 +3,9 @@ package dynakube
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type OTLPExporterSpec struct {
-	// Namespaces where the operator should enable OTLP-Exporters
-	// +kubebuilder:validation:Optional
-	NamespaceSelector metav1.LabelSelector `json:"namespaceSelector,omitempty"`
-	// Enable OpenTelemetry Protocol Exporters traces endpoint
-	// see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
-	// +kubebuilder:validation:Optional
-	EnableTraces bool `json:"enableTraces,omitempty"`
-	// Enable OpenTelemetry Protocol Exporters metrics endpoint
-	// see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
-	// +kubebuilder:validation:Optional
-	EnableMetrics bool `json:"enableMetrics,omitempty"`
-	// Enable OpenTelemetry Protocol Exporters logs endpoint
-	// see https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
-	// +kubebuilder:validation:Optional
-	EnableLogs bool `json:"enableLogs,omitempty"`
-}
-
 type ExtensionsSpec struct {
-	// +kubebuilder:validation:Optional
-	OTLPExporter OTLPExporterSpec `json:"otlpexporter,omitempty"`
 	// +kubebuilder:validation:Optional
 	Prometheus PrometheusSpec `json:"prometheus,omitempty"`
 }


### PR DESCRIPTION
## Description

[K8S-10698](https://dt-rnd.atlassian.net/browse/K8S-10698)

Adds OTLP Exporter configuration options to the extensions section of the DynaKube.

Test by
1. Deploy using `make deploy/helm` 
2. Apply a Dk with the following config added:
   ```...
    spec:
      otlpExporter:
        enableLogs: true
        enableTraces: true
        enableMetrics: true
        namespaceSelector:
          matchLabels:
            otlpe: "true"
    ```