### PR TITLE
Change slack notification target for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -74,7 +74,10 @@ jobs:
       - name: Notify failure in Slack
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
-          channel-id: 'int-cp-operator'
-          slack-message: ":x: E2E tests failed on ${{ github.event.inputs.target || 'main' }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          payload: |
+            {
+              "message": ":x: E2E tests failed on ${{ github.event.inputs.target || 'main' }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})",
+              "run_id": "${{ github.run_id }}"
+            }
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

In order to have a proper workflow for the e2e tests, we need to change the target for the notification if the tests are failing. This will allow us to run custom things, like creating jira issues etc.

## How can this be tested?

Run e2e test and let the fail