### PR TITLE
Change release workflow to release all architectures to rhcc

### DIFF
--- a/.github/actions/preflight/action.yaml
+++ b/.github/actions/preflight/action.yaml
@@ -28,7 +28,7 @@ runs:
     env:
       RHCC_APITOKEN: ${{ inputs.pyxis-api-token }}
       RHCC_PROJECT_ID: ${{ inputs.redhat-project-id }}
-      PREFLIGHT_VERSION: "1.9.1"
+      PREFLIGHT_VERSION: "1.9.9"
       IMAGE_URI: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.version }}
     run: |
       hack/build/ci/preflight.sh "${{ env.PREFLIGHT_VERSION }}" "${{ env.IMAGE_URI}}" "${{ inputs.report-name }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         platform: [amd64, arm64, ppc64le, s390x]
-        registry: [gcr, dockerhub, amazon-ecr]
+        registry: [gcr, dockerhub, amazon-ecr, rhcc]
         include:
         - registry: gcr
           url: gcr.io
@@ -76,6 +76,11 @@ jobs:
         - registry: amazon-ecr
           url: public.ecr.aws
           repository: ECR_REPOSITORY
+        - registry: rhcc
+          url: quay.io
+          username: RHCC_USERNAME
+          password: RHCC_PASSWORD
+          repository: RHCC_REPOSITORY
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -113,42 +118,6 @@ jobs:
           signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
 
-  push-rhcc:
-    name: Push amd64 image to RHCC
-    if: ${{ !contains(github.ref, '-rc') }}
-    environment: Release
-    needs: [prepare, build]
-    runs-on: ubuntu-latest
-    env:
-      SCAN_REGISTRY: "quay.io"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Login to Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ${{ env.SCAN_REGISTRY }}
-          username: ${{ secrets.RHCC_USERNAME }}
-          password: ${{ secrets.RHCC_PASSWORD }}
-      - name: Push amd64 image to scan registry
-        uses: ./.github/actions/upload-image
-        with:
-          platform: "amd64"
-          labels: ${{ needs.prepare.outputs.labels }}
-          version: ${{ needs.prepare.outputs.version }}
-          registry: ${{ env.SCAN_REGISTRY }}
-          repository: ${{ secrets.RHCC_REPOSITORY }}
-          skip-platform-suffix: true
-      - name: Run preflight
-        uses: ./.github/actions/preflight
-        with:
-          version: ${{ needs.prepare.outputs.version }}
-          registry: ${{ env.SCAN_REGISTRY }}
-          repository: ${{ secrets.RHCC_REPOSITORY }}
-          report-name: "preflight.json"
-          redhat-project-id: ${{ secrets.REDHAT_PROJECT_ID }}
-          pyxis-api-token: ${{ secrets.PYXIS_API_TOKEN }}
-
   manifest:
     name: Create Docker manifests
     environment: Release
@@ -160,7 +129,7 @@ jobs:
       digest: ${{ steps.create-manifests.outputs.digest }}
     strategy:
       matrix:
-        registry: [gcr, dockerhub, amazon-ecr]
+        registry: [gcr, dockerhub, amazon-ecr, rhcc]
         include:
           - registry: gcr
             url: gcr.io
@@ -175,6 +144,11 @@ jobs:
           - registry: amazon-ecr
             url: public.ecr.aws
             repository: ECR_REPOSITORY
+          - registry: rhcc
+            url: quay.io
+            username: RHCC_USERNAME
+            password: RHCC_PASSWORD
+            repository: RHCC_REPOSITORY
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -272,9 +246,35 @@ jobs:
           signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
 
+  run-preflight-rhcc:
+    name: Run preflight for rhcc
+    environment: Release
+    needs: [ prepare, push, manifest]
+    runs-on: ubuntu-latest
+    env:
+      SCAN_REGISTRY: "quay.io"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Login to Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.SCAN_REGISTRY }}
+          username: ${{ secrets.RHCC_USERNAME }}
+          password: ${{ secrets.RHCC_PASSWORD }}
+      - name: Run preflight
+        uses: ./.github/actions/preflight
+        with:
+          version: ${{ needs.prepare.outputs.version }}
+          registry: ${{ env.SCAN_REGISTRY }}
+          repository: ${{ secrets.RHCC_REPOSITORY }}
+          report-name: "preflight.json"
+          redhat-project-id: ${{ secrets.REDHAT_PROJECT_ID }}
+          pyxis-api-token: ${{ secrets.PYXIS_API_TOKEN }}
+
   release:
     name: Create release
-    needs: [prepare, build, attach-sbom, manifest]
+    needs: [prepare, build, attach-sbom, manifest, run-preflight-rhcc]
     environment: Release
     permissions:
       contents: write
@@ -309,7 +309,7 @@ jobs:
           make manifests/kubernetes/olm IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
           make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
           make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
-          make manifests/openshift IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
+          make manifests/openshift IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
           cp config/deploy/kubernetes/kubernetes.yaml config/deploy/kubernetes/gke-autopilot.yaml
       - name: Build helm packages
         uses: ./.github/actions/build-helm


### PR DESCRIPTION
## Description

Ticket: https://dt-rnd.atlassian.net/browse/K8S-10606

Currently we only push the -amd64 image to rhcc, but instead we should now push all architectures to rhcc and also create a manifest (with all architectures) like we do it for all other platforms. 

## How can this be tested?

Do a prerelease or a release (😄 ) and check if the manifest is correctly pushed to rhcc, aswell as the openshift.yaml and openshift-csi.yaml have the correct image (registry.connect.redhat) set