### PR TITLE
Add OTLP Endpoint Settings to Pods using OTelExportersFeature

### DIFF
--- a/pkg/injection/namespace/ingestendpoint/secret.go
+++ b/pkg/injection/namespace/ingestendpoint/secret.go
@@ -169,7 +169,7 @@ func (g *SecretGenerator) PrepareFields(ctx context.Context, dk *dynakube.DynaKu
 		if token, ok := tokens.Data[dtclient.DataIngestToken]; ok {
 			fields[MetricsTokenSecretField] = string(token)
 			// TODO: always add OTLP field or only when exporter is enabled?
-			// TODO: which token to use here?
+			// TODO: which token to use here? what to do if no token is defined?
 			fields[OTLPTokensSecretField] = string(token)
 		}
 		// TODO: always add OTLP fields or only when exporter is enabled?


### PR DESCRIPTION
[K8S-10697](https://dt-rnd.atlassian.net/browse/K8S-10697)

## Description

Automatically configure customer application pods that match the exporter configuration from [pull 3611](https://github.com/Dynatrace/dynatrace-operator/pull/3611) by adding the endpoint settings to `endpoint.properties` file.

## How can this be tested?

TBD