### PR TITLE
Adapt EEC statefulset to new version of the image

### DIFF
--- a/pkg/controllers/dynakube/extension/eec/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler_test.go
@@ -1,7 +1,6 @@
 package eec
 
 import (
-	"path"
 	"strconv"
 	"testing"
 
@@ -198,8 +197,8 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Equal(t, corev1.EnvVar{Name: envDsInstallDirName, Value: envDsInstallDir}, statefulSet.Spec.Template.Spec.Containers[0].Env[5])
 		assert.Equal(t, corev1.EnvVar{Name: envK8sClusterId, Value: dk.Status.KubeSystemUUID}, statefulSet.Spec.Template.Spec.Containers[0].Env[6])
 		assert.Equal(t, corev1.EnvVar{Name: envK8sExtServiceUrl, Value: serviceAccountName}, statefulSet.Spec.Template.Spec.Containers[0].Env[7])
-		assert.Equal(t, corev1.EnvVar{Name: envHttpsCertPathPem, Value: path.Join(httpsCertMountPath, httpsCertFile)}, statefulSet.Spec.Template.Spec.Containers[0].Env[8])
-		assert.Equal(t, corev1.EnvVar{Name: envHttpsPrivKeyPathPem, Value: path.Join(httpsCertMountPath, httpsPrivKeyFile)}, statefulSet.Spec.Template.Spec.Containers[0].Env[9])
+		assert.Equal(t, corev1.EnvVar{Name: envHttpsCertPathPem, Value: httpsCertMountPath + "/" + httpsCertFile}, statefulSet.Spec.Template.Spec.Containers[0].Env[8])
+		assert.Equal(t, corev1.EnvVar{Name: envHttpsPrivKeyPathPem, Value: httpsCertMountPath + "/" + httpsPrivKeyFile}, statefulSet.Spec.Template.Spec.Containers[0].Env[9])
 		assert.Equal(t, corev1.EnvVar{Name: envDSTokenPath, Value: dsTokenPath}, statefulSet.Spec.Template.Spec.Containers[0].Env[10])
 	})
 }

--- a/pkg/controllers/dynakube/extension/eec/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler_test.go
@@ -1,6 +1,7 @@
 package eec
 
 import (
+	"path"
 	"strconv"
 	"testing"
 
@@ -193,10 +194,13 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Equal(t, corev1.EnvVar{Name: envServerUrl, Value: buildActiveGateServiceName(dk) + "." + dk.Namespace + ".svc.cluster.local:443"}, statefulSet.Spec.Template.Spec.Containers[0].Env[1])
 		assert.Equal(t, corev1.EnvVar{Name: envEecTokenPath, Value: eecTokenMountPath + "/" + eecFile}, statefulSet.Spec.Template.Spec.Containers[0].Env[2])
 		assert.Equal(t, corev1.EnvVar{Name: envEecIngestPort, Value: strconv.Itoa(int(collectorPort))}, statefulSet.Spec.Template.Spec.Containers[0].Env[3])
-		assert.Equal(t, corev1.EnvVar{Name: envExtensionsConfPathName, Value: envExtensionsConfPath}, statefulSet.Spec.Template.Spec.Containers[0].Env[4])
-		assert.Equal(t, corev1.EnvVar{Name: envExtensionsModuleExecPathName, Value: envExtensionsModuleExecPath}, statefulSet.Spec.Template.Spec.Containers[0].Env[5])
-		assert.Equal(t, corev1.EnvVar{Name: envDsInstallDirName, Value: envDsInstallDir}, statefulSet.Spec.Template.Spec.Containers[0].Env[6])
-		assert.Equal(t, corev1.EnvVar{Name: envK8sClusterId, Value: dk.Status.KubeSystemUUID}, statefulSet.Spec.Template.Spec.Containers[0].Env[7])
+		assert.Equal(t, corev1.EnvVar{Name: envExtensionsModuleExecPathName, Value: envExtensionsModuleExecPath}, statefulSet.Spec.Template.Spec.Containers[0].Env[4])
+		assert.Equal(t, corev1.EnvVar{Name: envDsInstallDirName, Value: envDsInstallDir}, statefulSet.Spec.Template.Spec.Containers[0].Env[5])
+		assert.Equal(t, corev1.EnvVar{Name: envK8sClusterId, Value: dk.Status.KubeSystemUUID}, statefulSet.Spec.Template.Spec.Containers[0].Env[6])
+		assert.Equal(t, corev1.EnvVar{Name: envK8sExtServiceUrl, Value: serviceAccountName}, statefulSet.Spec.Template.Spec.Containers[0].Env[7])
+		assert.Equal(t, corev1.EnvVar{Name: envHttpsCertPathPem, Value: path.Join(httpsCertMountPath, httpsCertFile)}, statefulSet.Spec.Template.Spec.Containers[0].Env[8])
+		assert.Equal(t, corev1.EnvVar{Name: envHttpsPrivKeyPathPem, Value: path.Join(httpsCertMountPath, httpsPrivKeyFile)}, statefulSet.Spec.Template.Spec.Containers[0].Env[9])
+		assert.Equal(t, corev1.EnvVar{Name: envDSTokenPath, Value: dsTokenPath}, statefulSet.Spec.Template.Spec.Containers[0].Env[10])
 	})
 }
 
@@ -223,6 +227,11 @@ func TestVolumes(t *testing.T) {
 			{
 				Name:      configurationVolumeName,
 				MountPath: configurationMountPath,
+				ReadOnly:  false,
+			},
+			{
+				Name:      httpsCertVolumeName,
+				MountPath: httpsCertMountPath,
 				ReadOnly:  true,
 			},
 		}
@@ -254,6 +263,11 @@ func TestVolumes(t *testing.T) {
 			{
 				Name:      configurationVolumeName,
 				MountPath: configurationMountPath,
+				ReadOnly:  false,
+			},
+			{
+				Name:      httpsCertVolumeName,
+				MountPath: httpsCertMountPath,
 				ReadOnly:  true,
 			},
 			{
@@ -291,6 +305,24 @@ func TestVolumes(t *testing.T) {
 				Name: configurationVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: httpsCertVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: extensionsControllerTlsSecretName,
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "tls.crt",
+								Path: "cert.pem",
+							},
+							{
+								Key:  "tls.key",
+								Path: "key.pem",
+							},
+						},
+					},
 				},
 			},
 			{
@@ -340,6 +372,24 @@ func TestVolumes(t *testing.T) {
 				},
 			},
 			{
+				Name: httpsCertVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: extensionsControllerTlsSecretName,
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "tls.crt",
+								Path: "cert.pem",
+							},
+							{
+								Key:  "tls.key",
+								Path: "key.pem",
+							},
+						},
+					},
+				},
+			},
+			{
 				Name: runtimeVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
@@ -379,6 +429,24 @@ func TestVolumes(t *testing.T) {
 				Name: configurationVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: httpsCertVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: extensionsControllerTlsSecretName,
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "tls.crt",
+								Path: "cert.pem",
+							},
+							{
+								Key:  "tls.key",
+								Path: "key.pem",
+							},
+						},
+					},
 				},
 			},
 			{
@@ -577,11 +645,22 @@ func TestServiceAccountName(t *testing.T) {
 }
 
 func TestSecurityContext(t *testing.T) {
-	t.Run("the default securityContext is set", func(t *testing.T) {
+	t.Run("securityContext is set", func(t *testing.T) {
 		statefulSet := getStatefulset(t, getTestDynakube())
 
-		assert.NotNil(t, statefulSet.Spec.Template.Spec.SecurityContext)
-		assert.NotNil(t, statefulSet.Spec.Template.Spec.Containers[0].SecurityContext)
+		require.NotNil(t, statefulSet.Spec.Template.Spec.SecurityContext)
+		assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, statefulSet.Spec.Template.Spec.SecurityContext.SeccompProfile.Type)
+
+		require.NotNil(t, statefulSet.Spec.Template.Spec.Containers[0].SecurityContext)
+		assert.Equal(t, int64(1001), *statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser)
+		assert.Equal(t, int64(1001), *statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup)
+		assert.False(t, *statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
+		assert.True(t, *statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot)
+		assert.True(t, *statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem)
+		assert.False(t, *statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation)
+
+		require.Len(t, statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Drop, 1)
+		assert.Equal(t, corev1.Capability("ALL"), statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Drop[0])
 	})
 }
 

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -1,7 +1,6 @@
 package eec
 
 import (
-	"path"
 	"strconv"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
@@ -211,8 +210,8 @@ func buildContainerEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 		{Name: envDsInstallDirName, Value: envDsInstallDir},
 		{Name: envK8sClusterId, Value: dk.Status.KubeSystemUUID},
 		{Name: envK8sExtServiceUrl, Value: serviceAccountName},
-		{Name: envHttpsCertPathPem, Value: path.Join(httpsCertMountPath, httpsCertFile)},
-		{Name: envHttpsPrivKeyPathPem, Value: path.Join(httpsCertMountPath, httpsPrivKeyFile)},
+		{Name: envHttpsCertPathPem, Value: httpsCertMountPath + "/" + httpsCertFile},
+		{Name: envHttpsPrivKeyPathPem, Value: httpsCertMountPath + "/" + httpsPrivKeyFile},
 		{Name: envDSTokenPath, Value: dsTokenPath},
 	}
 


### PR DESCRIPTION
[K8S-10973](https://dt-rnd.atlassian.net/browse/K8S-10973)

## Description

New EEC image requires some changes in the EEC statefulset.


## How can this be tested?

1) Create `extensions-controller-tls` secret
```
openssl req -nodes -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -subj "/CN=dynakube-extensions-controller.dynatrace"
kubectl create secret tls extensions-controller-tls --cert=cert.pem --key=key.pem
```
2) Create AG `tlsSecretName` secret (use the same export password when asked for)
```
openssl req -nodes -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -subj "/CN=dynakube-activegate.dynatrace"
openssl pkcs12 -export -inkey key.pem -in cert.pem -out cert.p12
kubectl -n dynatrace create secret generic dynakube-ag-tls --from-file=server.p12=cert.p12 --from-file=server.crt=cert.pem --from-literal=password=<an export password>
```
3) Apply a dynakube with prometheus feature enabled.
```
spec:
  activeGate:
    tlsSecretName: dynakube-ag-tls
  customPullSecret: <name>
  extensions:
    prometheus:
      enabled: true
  templates:
    extensionExecutionController:
      imageRef:
        repository: extk8sregistry.azurecr.io/eec/dynatrace-eec
        tag: 1.300.0.20240814-073129
```
4) EEC is running
```
NAME                                      READY   STATUS             RESTARTS         AGE
pod/dynatrace-extensions-controller-0     1/1     Running            0                13m
```

Logs:
```
kubectl -n dynatrace logs statefulset.apps/dynatrace-extensions-controller
```
```
2024-08-19 16:03:58.334 UTC [0000000b] info    [native] Extension Agent has been started
...
2024-08-19 16:03:58.449 UTC [0000000d] info    [native] Logs ingest limits configuration arrived:
 	-MaxContentLength: 65536
 	-MaxAttributeLength: 250
...
2024-08-19 16:04:04.335 UTC [0000000b] info    [native] EEC AG runtime configuration file: /var/lib/dynatrace/remotepluginmodule/agent/conf/runtime/runtimeConfiguration does not exist
2024-08-19 16:04:27.037 UTC [00000012] info    [native] ... last message repeated 7 times ...
2024-08-19 16:04:27.037 UTC [00000012] warning [native] restserver error shutdown: Success
```