### PR TITLE
Rename fields of EnrichmentRules

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -4410,9 +4410,9 @@ spec:
                       properties:
                         enabled:
                           type: boolean
-                        key:
+                        source:
                           type: string
-                        mapping:
+                        target:
                           type: string
                         type:
                           type: string
@@ -7044,9 +7044,9 @@ spec:
                       properties:
                         enabled:
                           type: boolean
-                        key:
+                        source:
                           type: string
-                        mapping:
+                        target:
                           type: string
                         type:
                           type: string

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -4422,9 +4422,9 @@ spec:
                       properties:
                         enabled:
                           type: boolean
-                        key:
+                        source:
                           type: string
-                        mapping:
+                        target:
                           type: string
                         type:
                           type: string
@@ -7056,9 +7056,9 @@ spec:
                       properties:
                         enabled:
                           type: boolean
-                        key:
+                        source:
                           type: string
-                        mapping:
+                        target:
                           type: string
                         type:
                           type: string

--- a/pkg/api/v1beta2/dynakube/dynakube_status.go
+++ b/pkg/api/v1beta2/dynakube/dynakube_status.go
@@ -145,13 +145,13 @@ type MetadataEnrichmentStatus struct {
 
 type EnrichmentRule struct {
 	Type    EnrichmentRuleType `json:"type,omitempty"`
-	Key     string             `json:"key,omitempty"`
-	Mapping string             `json:"mapping,omitempty"`
+	Source  string             `json:"source,omitempty"`
+	Target  string             `json:"target,omitempty"`
 	Enabled bool               `json:"enabled,omitempty"`
 }
 
 func (rule EnrichmentRule) ToAnnotationKey() string {
-	return MetadataPrefix + "/" + rule.Mapping
+	return MetadataPrefix + "/" + rule.Target
 }
 
 // SetPhase sets the status phase on the DynaKube object.

--- a/pkg/api/v1beta3/dynakube/dynakube_status.go
+++ b/pkg/api/v1beta3/dynakube/dynakube_status.go
@@ -156,17 +156,17 @@ type MetadataEnrichmentStatus struct {
 
 type EnrichmentRule struct {
 	Type    EnrichmentRuleType `json:"type,omitempty"`
-	Key     string             `json:"key,omitempty"`
-	Mapping string             `json:"mapping,omitempty"`
+	Source  string             `json:"source,omitempty"`
+	Target  string             `json:"target,omitempty"`
 	Enabled bool               `json:"enabled,omitempty"`
 }
 
 func (rule EnrichmentRule) ToAnnotationKey() string {
-	if rule.Mapping == "" {
+	if rule.Target == "" {
 		return ""
 	}
 
-	return MetadataPrefix + "/" + rule.Mapping
+	return MetadataPrefix + "/" + rule.Target
 }
 
 // SetPhase sets the status phase on the DynaKube object.

--- a/pkg/clients/dynatrace/settings_enrichment_test.go
+++ b/pkg/clients/dynatrace/settings_enrichment_test.go
@@ -98,10 +98,10 @@ func mockGetRulesSettingsAPI(writer http.ResponseWriter, totalCount int) {
 func createRulesResponse(totalCount int) GetRulesSettingsResponse {
 	rules := []dynakube.EnrichmentRule{
 		{
-			Key: "rule-1",
+			Source: "rule-1",
 		},
 		{
-			Key: "rule-2",
+			Source: "rule-2",
 		},
 	}
 	rulesGetResponse := GetRulesSettingsResponse{

--- a/pkg/controllers/dynakube/metadata/rules/reconciler_test.go
+++ b/pkg/controllers/dynakube/metadata/rules/reconciler_test.go
@@ -150,7 +150,7 @@ func createRulesResponse() dtclient.GetRulesSettingsResponse {
 
 func createRules() []dynakube.EnrichmentRule {
 	return []dynakube.EnrichmentRule{
-		{Key: "test1"},
-		{Key: "test2"},
+		{Source: "test1"},
+		{Source: "test2"},
 	}
 }

--- a/pkg/webhook/mutation/pod/metadata/mutator.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator.go
@@ -158,8 +158,8 @@ func copyMetadataAccordingToPrefix(pod *corev1.Pod, namespace corev1.Namespace) 
 
 func copyMetadataAccordingToCustomRules(pod *corev1.Pod, namespace corev1.Namespace, dk dynakube.DynaKube) {
 	for _, rule := range dk.Status.MetadataEnrichment.Rules {
-		if rule.Mapping == "" {
-			log.Info("rule without mapping set found, ignoring", "key", rule.Key, "type", rule.Type)
+		if rule.Target == "" {
+			log.Info("rule without target set found, ignoring", "source", rule.Source, "type", rule.Type)
 
 			continue
 		}
@@ -170,9 +170,9 @@ func copyMetadataAccordingToCustomRules(pod *corev1.Pod, namespace corev1.Namesp
 
 		switch rule.Type {
 		case dynakube.EnrichmentLabelRule:
-			valueFromNamespace, exists = namespace.Labels[rule.Key]
+			valueFromNamespace, exists = namespace.Labels[rule.Source]
 		case dynakube.EnrichmentAnnotationRule:
-			valueFromNamespace, exists = namespace.Annotations[rule.Key]
+			valueFromNamespace, exists = namespace.Annotations[rule.Source]
 		}
 
 		if exists {

--- a/pkg/webhook/mutation/pod/metadata/mutator_test.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator_test.go
@@ -243,24 +243,24 @@ func TestCopyMetadataFromNamespace(t *testing.T) {
 
 		request.DynaKube.Status.MetadataEnrichment.Rules = []dynakube.EnrichmentRule{
 			{
-				Type:    dynakube.EnrichmentAnnotationRule,
-				Key:     "test-annotation",
-				Mapping: "dt.test-annotation",
+				Type:   dynakube.EnrichmentAnnotationRule,
+				Source: "test-annotation",
+				Target: "dt.test-annotation",
 			},
 			{
-				Type:    dynakube.EnrichmentLabelRule,
-				Key:     "test-label",
-				Mapping: "test-label",
+				Type:   dynakube.EnrichmentLabelRule,
+				Source: "test-label",
+				Target: "test-label",
 			},
 			{
-				Type:    dynakube.EnrichmentLabelRule,
-				Key:     dynakube.MetadataPrefix + "/copyifruleexists",
-				Mapping: "dt.copyifruleexists",
+				Type:   dynakube.EnrichmentLabelRule,
+				Source: dynakube.MetadataPrefix + "/copyifruleexists",
+				Target: "dt.copyifruleexists",
 			},
 			{
-				Type:    dynakube.EnrichmentLabelRule,
-				Key:     "does-not-exist-in-namespace",
-				Mapping: "dt.does-not-exist-in-namespace",
+				Type:   dynakube.EnrichmentLabelRule,
+				Source: "does-not-exist-in-namespace",
+				Target: "dt.does-not-exist-in-namespace",
 			},
 		}
 		request.Pod.Annotations = map[string]string{
@@ -295,19 +295,19 @@ func TestCopyMetadataFromNamespace(t *testing.T) {
 
 		request.DynaKube.Status.MetadataEnrichment.Rules = []dynakube.EnrichmentRule{
 			{
-				Type:    dynakube.EnrichmentLabelRule,
-				Key:     "test",
-				Mapping: "dt.test-label",
+				Type:   dynakube.EnrichmentLabelRule,
+				Source: "test",
+				Target: "dt.test-label",
 			},
 			{
-				Type:    dynakube.EnrichmentAnnotationRule,
-				Key:     "test2",
-				Mapping: "dt.test-annotation",
+				Type:   dynakube.EnrichmentAnnotationRule,
+				Source: "test2",
+				Target: "dt.test-annotation",
 			},
 			{
-				Type:    dynakube.EnrichmentAnnotationRule,
-				Key:     "test3",
-				Mapping: "", // mapping missing => rule ignored
+				Type:   dynakube.EnrichmentAnnotationRule,
+				Source: "test3",
+				Target: "", // mapping missing => rule ignored
 			},
 		}
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[K8S-10946](https://dt-rnd.atlassian.net/browse/K8S-10946)

In the `EnrichmentRule` struct `key` was renamed to `source` and `mapping` to `target`. (because the API changed)

## How can this be tested?

same as https://github.com/Dynatrace/dynatrace-operator/pull/3327, but the fields should be different(renamed) in the Status:
```
  metadataEnrichment:
    rules:
    - enabled: true
      source: cost-center
      target: dt.cost.costcenter
      type: LABEL
    - enabled: true
      source: security-context
      target: dt.security_context
      type: ANNOTATION
```