### PR TITLE
Adds RuntimeConfigMountPath env var if custom runtimeConfig is defined

### DIFF
--- a/pkg/controllers/dynakube/extension/eec/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler_test.go
@@ -200,6 +200,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Equal(t, corev1.EnvVar{Name: envDSTokenPath, Value: dsTokenPath}, statefulSet.Spec.Template.Spec.Containers[0].Env[8])
 		assert.Equal(t, corev1.EnvVar{Name: envHttpsCertPathPem, Value: envEecHttpsCertPathPem}, statefulSet.Spec.Template.Spec.Containers[0].Env[9])
 		assert.Equal(t, corev1.EnvVar{Name: envHttpsPrivKeyPathPem, Value: envEecHttpsPrivKeyPathPem}, statefulSet.Spec.Template.Spec.Containers[0].Env[10])
+		assert.NotContains(t, statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envRuntimeConfigMountPath, Value: customConfigMountPath + "/" + runtimeConfigurationFilename})
 	})
 
 	t.Run("environment variables with custom EEC tls certificate", func(t *testing.T) {
@@ -210,6 +211,15 @@ func TestEnvironmentVariables(t *testing.T) {
 
 		assert.Contains(t, statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envHttpsCertPathPem, Value: envEecHttpsCertPathPem})
 		assert.Contains(t, statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envHttpsPrivKeyPathPem, Value: envEecHttpsPrivKeyPathPem})
+	})
+
+	t.Run("environment variables with custom EEC config", func(t *testing.T) {
+		dk := getTestDynakube()
+		dk.Spec.Templates.ExtensionExecutionController.CustomConfig = "abc"
+
+		statefulSet := getStatefulset(t, dk)
+
+		assert.Contains(t, statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envRuntimeConfigMountPath, Value: customConfigMountPath + "/" + runtimeConfigurationFilename})
 	})
 }
 

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -38,10 +38,11 @@ const (
 	envHttpsCertPathPem             = "HttpsCertPathPem"
 	envHttpsPrivKeyPathPem          = "HttpsPrivKeyPathPem"
 	envDSTokenPath                  = "DSTokenPath"
+	envRuntimeConfigMountPath       = "RuntimeConfigMountPath"
 	// Env variable values
 	envExtensionsModuleExecPath = "/opt/dynatrace/remotepluginmodule/agent/lib64/extensionsmodule"
 	envDsInstallDir             = "/opt/dynatrace/remotepluginmodule/agent/datasources"
-	envActiveGateTrustedCert    = "/var/lib/dynatrace/secrets/ag/" + activeGateTrustedCertSecretKeyPath
+	envActiveGateTrustedCert    = activeGateTrustedCertMountPath + "/" + activeGateTrustedCertSecretKeyPath
 	envEecHttpsCertPathPem      = httpsCertMountPath + "/" + consts.TLSCrtDataName
 	envEecHttpsPrivKeyPathPem   = httpsCertMountPath + "/" + consts.TLSKeyDataName
 	// Volume names and paths
@@ -54,12 +55,13 @@ const (
 	customConfigVolumeName             = "custom-config"
 	customConfigMountPath              = "/var/lib/dynatrace/remotepluginmodule/secrets/config"
 	activeGateTrustedCertVolumeName    = "server-certs"
-	activeGateTrustedCertMountPath     = "/var/lib/dynatrace/secrets/ag"
+	activeGateTrustedCertMountPath     = "/var/lib/dynatrace/remotepluginmodule/secrets/ag"
 	activeGateTrustedCertSecretKeyPath = "server.crt"
 	httpsCertVolumeName                = "https-certs"
 	httpsCertMountPath                 = "/var/lib/dynatrace/remotepluginmodule/secrets/https"
 	extensionsControllerTlsSecretName  = "extensions-controller-tls"
 	dsTokenPath                        = "/var/lib/dynatrace/remotepluginmodule/secrets/dsauthtoken"
+	runtimeConfigurationFilename       = "runtimeConfiguration"
 
 	// misc
 	tokensVolumeName = "tokens"
@@ -214,6 +216,10 @@ func buildContainerEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 
 	if dk.Spec.ActiveGate.TlsSecretName != "" {
 		containerEnvs = append(containerEnvs, corev1.EnvVar{Name: envActiveGateTrustedCertName, Value: envActiveGateTrustedCert})
+	}
+
+	if dk.Spec.Templates.ExtensionExecutionController.CustomConfig != "" {
+		containerEnvs = append(containerEnvs, corev1.EnvVar{Name: envRuntimeConfigMountPath, Value: customConfigMountPath + "/" + runtimeConfigurationFilename})
 	}
 
 	return containerEnvs


### PR DESCRIPTION
[K8S-11020](https://dt-rnd.atlassian.net/browse/K8S-11020)

## Description

Adds `RuntimeConfigMountPath` environment variable to EEC pod definition if custom `runtimeConfig` file is used.

Changes `ActiveGateTrustedCert` path from `/var/lib/dynatrace/secrets/ag/server.crt` to   `/var/lib/dynatrace/remotepluginmodule/secrets/ag/server.crt`.

## How can this be tested?
Create extensions-controller-tls secret :
```
openssl req -nodes -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -subj "/CN=dynakube-extensions-controller.dynatrace"
kubectl -n dynatrace create secret tls extensions-controller-tls --cert=cert.pem --key=key.pem
```
Create AG tlsSecretName secret (use the same export password when asked for) :
```
openssl req -nodes -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -subj "/CN=dynakube-activegate.dynatrace"
openssl pkcs12 -export -inkey key.pem -in cert.pem -out cert.p12
kubectl -n dynatrace create secret generic dynakube-ag-tls --from-file=server.p12=cert.p12 --from-file=server.crt=cert.pem --from-literal=password=<an export password>
```
Create custom EEC runtimeConfig :
```
cat > eec-custom-runtimeconfig.json <<EOF
{
    "revision": 1705562762188,
    "booleanMap": {
        "debugPluginAgentExtendedLogNative": false,
        "debugPluginAgentFirewallLogNative": true,
    },
    "stringMap": {},
    "longMap": {}
}
EOF
kubectl -n dynatrace create configmap eec-custom-runtimeconfig --from-file=runtimeConfig=eec-custom-runtimeconfig.json 
```
(*) Always make sure EEC app is running after dynakube is applied/changed :
```
$ kubectl -n dynatrace logs statefulset.apps/dynatrace-extensions-controller

...
2024-08-23 15:59:11.996 UTC [0000000f] info    [native] Logs ingest limits configuration arrived:
 	-MaxContentLength: 65536
 	-MaxAttributeLength: 250
... 	
```

Apply dynakube :
```
spec:
  apiUrl: https://.../api  
  activeGate:
    tlsSecretName: dynakube-ag-tls
  customPullSecret: azurecr
  extensions:
    prometheus:
      enabled: true
  templates:
    extensionExecutionController:
      imageRef:
        repository: extk8sregistry.azurecr.io/eec/dynatrace-eec
        tag: 1.301.0.20240823-092629
      tlsRefName: extensions-controller-tls
```
Expected Environment and Mounts :
```
$ kubectl -n dynatrace describe statefulset.apps/dynatrace-extensions-controller

    Environment:
      ...
      EecTokenPath:              /var/lib/dynatrace/remotepluginmodule/secrets/tokens/eec.token
      HttpsCertPathPem:          /var/lib/dynatrace/remotepluginmodule/secrets/https/tls.crt
      HttpsPrivKeyPathPem:       /var/lib/dynatrace/remotepluginmodule/secrets/https/tls.key
      ActiveGateTrustedCert:     /var/lib/dynatrace/remotepluginmodule/secrets/ag/server.crt
    Mounts:
      ...
      /var/lib/dynatrace/remotepluginmodule/secrets/ag from server-certs (ro)  <-- ActiveGateTrustedCert
      /var/lib/dynatrace/remotepluginmodule/secrets/https from https-certs (ro) <-- HttpsCertPathPem , HttpsPrivKeyPathPem
      /var/lib/dynatrace/remotepluginmodule/secrets/tokens from tokens (ro)  <-- EecTokenPath
```
Add customConfig field :
```
  templates:
    extensionExecutionController:
      ...
      customConfig: eec-custom-config
```
Expected Environment and Mounts :
```
$ kubectl -n dynatrace describe statefulset.apps/dynatrace-extensions-controller

    Environment:
      ...
      EecTokenPath:              /var/lib/dynatrace/remotepluginmodule/secrets/tokens/eec.token
      HttpsCertPathPem:          /var/lib/dynatrace/remotepluginmodule/secrets/https/tls.crt
      HttpsPrivKeyPathPem:       /var/lib/dynatrace/remotepluginmodule/secrets/https/tls.key
      ActiveGateTrustedCert:     /var/lib/dynatrace/remotepluginmodule/secrets/ag/server.crt
*     RuntimeConfigMountPath:    /var/lib/dynatrace/remotepluginmodule/secrets/config/runtimeConfiguration
    Mounts:
      ...
      /var/lib/dynatrace/remotepluginmodule/secrets/ag from server-certs (ro)  <-- ActiveGateTrustedCert
*     /var/lib/dynatrace/remotepluginmodule/secrets/config from custom-config (ro) <-- RuntimeConfigMountPath
      /var/lib/dynatrace/remotepluginmodule/secrets/https from https-certs (ro) <-- HttpsCertPathPem , HttpsPrivKeyPathPem
      /var/lib/dynatrace/remotepluginmodule/secrets/tokens from tokens (ro)  <-- EecTokenPath
```

