### PR TITLE
Exclude e2e curl pod from injection

### DIFF
--- a/test/helpers/curl/curl.go
+++ b/test/helpers/curl/curl.go
@@ -40,6 +40,9 @@ func NewPod(podName, namespaceName, targetUrl string, options ...Option) *corev1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
 			Namespace: namespaceName,
+			Annotations: map[string]string{
+				dynakube.AnnotationFeatureAutomaticInjection: "false",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

The e2e curl helper pod shouldn't be injected. It's only meant to check network traffic, and we shouldn't interfere with it at all.

## How can this be tested?

Run e2e tests (ones that test the network, like the `istio` scenario). Check that the curl pod doesn't get injected.