### PR TITLE
Add additional permissions to prometheus-service-detector ClusterRole.

### DIFF
--- a/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
@@ -20,8 +20,11 @@ metadata:
     {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "namepsaces"]
   verbs: ["get", "watch", "list"]
+- apiGroups: [ "apps" ]
+  resources: [ "replicasets" ]
+  verbs: [ "list", "get", "watch" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
@@ -19,12 +19,23 @@ metadata:
   labels:
     {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
 rules:
-- apiGroups: [""]
-  resources: ["pods", "namepsaces"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: [ "apps" ]
-  resources: [ "replicasets" ]
-  verbs: [ "list", "get", "watch" ]
+- apiGroups:
+    - ""
+  resources:
+    - pods
+    - namespaces
+  verbs:
+    - list
+    - get
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - replicasets
+  verbs:
+    - list
+    - get
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector_test.yaml
@@ -2,7 +2,54 @@ suite: test clusterrole for the extensions OpenTelemetry collector
 templates:
   - Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
 tests:
-  - it: should exist
+  - it: ClusterRole and ClusterRoleBinding exists
     asserts:
-      - hasDocuments:
-          count: 2
+    - hasDocuments:
+        count: 2
+
+  - it: ClusterRole has correct permissions for Prometheus scraping
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: prometheus-service-detector
+      - isNotEmpty:
+          path: metadata.labels
+      - isNotEmpty:
+          path: rules
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - pods
+              - namespaces
+            verbs:
+              - list
+              - get
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - replicasets
+            verbs:
+              - list
+              - get
+              - watch
+
+  - it: ClusterRoleBinding exists
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: prometheus-service-detector
+      - isNotEmpty:
+          path: metadata.labels


### PR DESCRIPTION
## Description

Prometheus extensions need more RBAC permissions.

## How can this be tested?

Deploy operator and observe `prometheus-service-detector` ClusterRole. It shall look like this
```
  Resources         Non-Resource URLs  Resource Names  Verbs
  ---------         -----------------  --------------  -----
  namepsaces        []                 []              [get watch list]
  pods              []                 []              [get watch list]
  replicasets.apps  []                 []              [list get watch]
```