### PR TITLE
Unify construction of EEC service fully qualified domain name

### DIFF
--- a/pkg/controllers/dynakube/extension/eec/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler_test.go
@@ -196,7 +196,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Equal(t, corev1.EnvVar{Name: envExtensionsModuleExecPathName, Value: envExtensionsModuleExecPath}, statefulSet.Spec.Template.Spec.Containers[0].Env[4])
 		assert.Equal(t, corev1.EnvVar{Name: envDsInstallDirName, Value: envDsInstallDir}, statefulSet.Spec.Template.Spec.Containers[0].Env[5])
 		assert.Equal(t, corev1.EnvVar{Name: envK8sClusterId, Value: dk.Status.KubeSystemUUID}, statefulSet.Spec.Template.Spec.Containers[0].Env[6])
-		assert.Equal(t, corev1.EnvVar{Name: envK8sExtServiceUrl, Value: serviceAccountName}, statefulSet.Spec.Template.Spec.Containers[0].Env[7])
+		assert.Equal(t, corev1.EnvVar{Name: envK8sExtServiceUrl, Value: "dynakube-extensions-controller.dynatrace"}, statefulSet.Spec.Template.Spec.Containers[0].Env[7])
 		assert.Equal(t, corev1.EnvVar{Name: envDSTokenPath, Value: eecTokenMountPath + "/" + consts.OtelcTokenSecretKey}, statefulSet.Spec.Template.Spec.Containers[0].Env[8])
 		assert.Equal(t, corev1.EnvVar{Name: envHttpsCertPathPem, Value: envEecHttpsCertPathPem}, statefulSet.Spec.Template.Spec.Containers[0].Env[9])
 		assert.Equal(t, corev1.EnvVar{Name: envHttpsPrivKeyPathPem, Value: envEecHttpsPrivKeyPathPem}, statefulSet.Spec.Template.Spec.Containers[0].Env[10])

--- a/pkg/controllers/dynakube/extension/eec/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler_test.go
@@ -196,7 +196,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Equal(t, corev1.EnvVar{Name: envExtensionsModuleExecPathName, Value: envExtensionsModuleExecPath}, statefulSet.Spec.Template.Spec.Containers[0].Env[4])
 		assert.Equal(t, corev1.EnvVar{Name: envDsInstallDirName, Value: envDsInstallDir}, statefulSet.Spec.Template.Spec.Containers[0].Env[5])
 		assert.Equal(t, corev1.EnvVar{Name: envK8sClusterId, Value: dk.Status.KubeSystemUUID}, statefulSet.Spec.Template.Spec.Containers[0].Env[6])
-		assert.Equal(t, corev1.EnvVar{Name: envK8sExtServiceUrl, Value: "dynakube-extensions-controller.dynatrace"}, statefulSet.Spec.Template.Spec.Containers[0].Env[7])
+		assert.Equal(t, corev1.EnvVar{Name: envK8sExtServiceUrl, Value: dk.Name + consts.ExtensionsControllerSuffix + "." + dk.Namespace}, statefulSet.Spec.Template.Spec.Containers[0].Env[7])
 		assert.Equal(t, corev1.EnvVar{Name: envDSTokenPath, Value: eecTokenMountPath + "/" + consts.OtelcTokenSecretKey}, statefulSet.Spec.Template.Spec.Containers[0].Env[8])
 		assert.Equal(t, corev1.EnvVar{Name: envHttpsCertPathPem, Value: envEecHttpsCertPathPem}, statefulSet.Spec.Template.Spec.Containers[0].Env[9])
 		assert.Equal(t, corev1.EnvVar{Name: envHttpsPrivKeyPathPem, Value: envEecHttpsPrivKeyPathPem}, statefulSet.Spec.Template.Spec.Containers[0].Env[10])

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/hash"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/servicename"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/utils"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/address"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
@@ -209,7 +210,7 @@ func buildContainerEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 		{Name: envExtensionsModuleExecPathName, Value: envExtensionsModuleExecPath},
 		{Name: envDsInstallDirName, Value: envDsInstallDir},
 		{Name: envK8sClusterId, Value: dk.Status.KubeSystemUUID},
-		{Name: envK8sExtServiceUrl, Value: utils.BuildFQDName(dk)},
+		{Name: envK8sExtServiceUrl, Value: servicename.BuildFQDN(dk)},
 		{Name: envDSTokenPath, Value: eecTokenMountPath + "/" + consts.OtelcTokenSecretKey},
 		{Name: envHttpsCertPathPem, Value: envEecHttpsCertPathPem},
 		{Name: envHttpsPrivKeyPathPem, Value: envEecHttpsPrivKeyPathPem},

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -209,7 +209,7 @@ func buildContainerEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 		{Name: envExtensionsModuleExecPathName, Value: envExtensionsModuleExecPath},
 		{Name: envDsInstallDirName, Value: envDsInstallDir},
 		{Name: envK8sClusterId, Value: dk.Status.KubeSystemUUID},
-		{Name: envK8sExtServiceUrl, Value: serviceAccountName},
+		{Name: envK8sExtServiceUrl, Value: utils.BuildFQDName(dk)},
 		{Name: envDSTokenPath, Value: eecTokenMountPath + "/" + consts.OtelcTokenSecretKey},
 		{Name: envHttpsCertPathPem, Value: envEecHttpsCertPathPem},
 		{Name: envHttpsPrivKeyPathPem, Value: envEecHttpsPrivKeyPathPem},

--- a/pkg/controllers/dynakube/extension/otel/statefulset.go
+++ b/pkg/controllers/dynakube/extension/otel/statefulset.go
@@ -131,7 +131,7 @@ func buildContainer(dk *dynakube.DynaKube) corev1.Container {
 		SecurityContext: buildSecurityContext(),
 		Env:             buildContainerEnvs(dk),
 		Resources:       dk.Spec.Templates.OpenTelemetryCollector.Resources,
-		Args:            []string{fmt.Sprintf("--config=eec://%s.%s.svc.cluster.local:%d/otcconfig/prometheusMetrics#refresh-interval=5s&auth-file=%s", dk.Name+consts.ExtensionsControllerSuffix, dk.Namespace, consts.ExtensionsCollectorComPort, otelcSecretTokenFilePath)},
+		Args:            []string{fmt.Sprintf("--config=eec://%s:%d/otcconfig/prometheusMetrics#refresh-interval=5s&auth-file=%s", utils.BuildFQDName(dk), consts.ExtensionsCollectorComPort, otelcSecretTokenFilePath)},
 		VolumeMounts:    buildContainerVolumeMounts(dk),
 	}
 }

--- a/pkg/controllers/dynakube/extension/otel/statefulset.go
+++ b/pkg/controllers/dynakube/extension/otel/statefulset.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/hash"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/servicename"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/utils"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/address"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
@@ -131,7 +132,7 @@ func buildContainer(dk *dynakube.DynaKube) corev1.Container {
 		SecurityContext: buildSecurityContext(),
 		Env:             buildContainerEnvs(dk),
 		Resources:       dk.Spec.Templates.OpenTelemetryCollector.Resources,
-		Args:            []string{fmt.Sprintf("--config=eec://%s:%d/otcconfig/prometheusMetrics#refresh-interval=5s&auth-file=%s", utils.BuildFQDName(dk), consts.ExtensionsCollectorComPort, otelcSecretTokenFilePath)},
+		Args:            []string{fmt.Sprintf("--config=eec://%s:%d/otcconfig/prometheusMetrics#refresh-interval=5s&auth-file=%s", servicename.BuildFQDN(dk), consts.ExtensionsCollectorComPort, otelcSecretTokenFilePath)},
 		VolumeMounts:    buildContainerVolumeMounts(dk),
 	}
 }

--- a/pkg/controllers/dynakube/extension/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/reconciler_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/utils"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/servicename"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
@@ -134,7 +134,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		var svc corev1.Service
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: utils.BuildServiceName(r.dk), Namespace: testNamespace}, &svc)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: servicename.Build(r.dk), Namespace: testNamespace}, &svc)
 		require.NoError(t, err)
 		assert.NotNil(t, svc)
 
@@ -159,7 +159,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		var svc corev1.Service
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: utils.BuildServiceName(r.dk), Namespace: testNamespace}, &svc)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: servicename.Build(r.dk), Namespace: testNamespace}, &svc)
 		require.Error(t, err)
 		assert.True(t, k8serrors.IsNotFound(err))
 	})

--- a/pkg/controllers/dynakube/extension/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/utils"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
@@ -133,7 +134,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		var svc corev1.Service
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: r.buildServiceName(), Namespace: testNamespace}, &svc)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: utils.BuildServiceName(r.dk), Namespace: testNamespace}, &svc)
 		require.NoError(t, err)
 		assert.NotNil(t, svc)
 
@@ -158,7 +159,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		var svc corev1.Service
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: r.buildServiceName(), Namespace: testNamespace}, &svc)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: utils.BuildServiceName(r.dk), Namespace: testNamespace}, &svc)
 		require.Error(t, err)
 		assert.True(t, k8serrors.IsNotFound(err))
 	})

--- a/pkg/controllers/dynakube/extension/service.go
+++ b/pkg/controllers/dynakube/extension/service.go
@@ -68,7 +68,7 @@ func (r *reconciler) buildService() (*corev1.Service, error) {
 	appLabels := labels.NewAppLabels(labels.ExtensionComponentLabel, r.dk.Name, labels.ExtensionComponentLabel, "")
 
 	svcPort := corev1.ServicePort{
-		Name:       utils.BuildPortsName(),
+		Name:       utils.BuildPortName(),
 		Port:       consts.ExtensionsCollectorComPort,
 		Protocol:   corev1.ProtocolTCP,
 		TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: consts.ExtensionsCollectorTargetPortName},

--- a/pkg/controllers/dynakube/extension/service.go
+++ b/pkg/controllers/dynakube/extension/service.go
@@ -68,7 +68,7 @@ func (r *reconciler) buildService() (*corev1.Service, error) {
 	appLabels := labels.NewAppLabels(labels.ExtensionComponentLabel, r.dk.Name, labels.ExtensionComponentLabel, "")
 
 	svcPort := corev1.ServicePort{
-		Name:       servicename.BuildPort(),
+		Name:       servicename.BuildPortName(),
 		Port:       consts.ExtensionsCollectorComPort,
 		Protocol:   corev1.ProtocolTCP,
 		TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: consts.ExtensionsCollectorTargetPortName},

--- a/pkg/controllers/dynakube/extension/service.go
+++ b/pkg/controllers/dynakube/extension/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/utils"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/service"
@@ -56,7 +57,7 @@ func (r *reconciler) createOrUpdateService(ctx context.Context) error {
 		return err
 	}
 
-	conditions.SetServiceCreated(r.dk.Conditions(), consts.ExtensionsServiceConditionType, r.buildServiceName())
+	conditions.SetServiceCreated(r.dk.Conditions(), consts.ExtensionsServiceConditionType, utils.BuildServiceName(r.dk))
 
 	return nil
 }
@@ -67,25 +68,17 @@ func (r *reconciler) buildService() (*corev1.Service, error) {
 	appLabels := labels.NewAppLabels(labels.ExtensionComponentLabel, r.dk.Name, labels.ExtensionComponentLabel, "")
 
 	svcPort := corev1.ServicePort{
-		Name:       r.buildPortsName(),
+		Name:       utils.BuildPortsName(),
 		Port:       consts.ExtensionsCollectorComPort,
 		Protocol:   corev1.ProtocolTCP,
 		TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: consts.ExtensionsCollectorTargetPortName},
 	}
 
 	return service.Build(r.dk,
-		r.buildServiceName(),
+		utils.BuildServiceName(r.dk),
 		appLabels.BuildMatchLabels(),
 		svcPort,
 		service.SetLabels(coreLabels.BuildLabels()),
 		service.SetType(corev1.ServiceTypeClusterIP),
 	)
-}
-
-func (r *reconciler) buildServiceName() string {
-	return r.dk.Name + consts.ExtensionsControllerSuffix
-}
-
-func (r *reconciler) buildPortsName() string {
-	return "dynatrace" + consts.ExtensionsControllerSuffix + "-" + consts.ExtensionsCollectorTargetPortName
 }

--- a/pkg/controllers/dynakube/extension/service.go
+++ b/pkg/controllers/dynakube/extension/service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/utils"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/servicename"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/service"
@@ -57,7 +57,7 @@ func (r *reconciler) createOrUpdateService(ctx context.Context) error {
 		return err
 	}
 
-	conditions.SetServiceCreated(r.dk.Conditions(), consts.ExtensionsServiceConditionType, utils.BuildServiceName(r.dk))
+	conditions.SetServiceCreated(r.dk.Conditions(), consts.ExtensionsServiceConditionType, servicename.Build(r.dk))
 
 	return nil
 }
@@ -68,14 +68,14 @@ func (r *reconciler) buildService() (*corev1.Service, error) {
 	appLabels := labels.NewAppLabels(labels.ExtensionComponentLabel, r.dk.Name, labels.ExtensionComponentLabel, "")
 
 	svcPort := corev1.ServicePort{
-		Name:       utils.BuildPortName(),
+		Name:       servicename.BuildPort(),
 		Port:       consts.ExtensionsCollectorComPort,
 		Protocol:   corev1.ProtocolTCP,
 		TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: consts.ExtensionsCollectorTargetPortName},
 	}
 
 	return service.Build(r.dk,
-		utils.BuildServiceName(r.dk),
+		servicename.Build(r.dk),
 		appLabels.BuildMatchLabels(),
 		svcPort,
 		service.SetLabels(coreLabels.BuildLabels()),

--- a/pkg/controllers/dynakube/extension/service_test.go
+++ b/pkg/controllers/dynakube/extension/service_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/utils"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
@@ -31,5 +32,12 @@ func TestReconciler_prepareService(t *testing.T) {
 			labels.AppCreatedByLabel: dk.Name,
 			labels.AppNameLabel:      labels.ExtensionComponentLabel,
 		}, svc.Spec.Selector)
+	})
+}
+
+func TestFQDNNameGeneration(t *testing.T) {
+	t.Run(`Check FQDN name generation`, func(t *testing.T) {
+		dk := createDynakube()
+		assert.Equal(t, "test-name-extensions-controller.test-namespace", utils.BuildFQDName(dk))
 	})
 }

--- a/pkg/controllers/dynakube/extension/service_test.go
+++ b/pkg/controllers/dynakube/extension/service_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/utils"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/servicename"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
@@ -38,6 +38,6 @@ func TestReconciler_prepareService(t *testing.T) {
 func TestFQDNNameGeneration(t *testing.T) {
 	t.Run(`Check FQDN name generation`, func(t *testing.T) {
 		dk := createDynakube()
-		assert.Equal(t, "test-name-extensions-controller.test-namespace", utils.BuildFQDName(dk))
+		assert.Equal(t, "test-name-extensions-controller.test-namespace", servicename.BuildFQDN(dk))
 	})
 }

--- a/pkg/controllers/dynakube/extension/servicename/naming.go
+++ b/pkg/controllers/dynakube/extension/servicename/naming.go
@@ -1,18 +1,18 @@
-package utils
+package servicename
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
 )
 
-func BuildPortName() string {
+func BuildPort() string {
 	return "dynatrace" + consts.ExtensionsControllerSuffix + "-" + consts.ExtensionsCollectorTargetPortName
 }
 
-func BuildFQDName(dk *dynakube.DynaKube) string {
-	return BuildServiceName(dk) + "." + dk.Namespace
+func BuildFQDN(dk *dynakube.DynaKube) string {
+	return Build(dk) + "." + dk.Namespace
 }
 
-func BuildServiceName(dk *dynakube.DynaKube) string {
+func Build(dk *dynakube.DynaKube) string {
 	return dk.Name + consts.ExtensionsControllerSuffix
 }

--- a/pkg/controllers/dynakube/extension/servicename/naming.go
+++ b/pkg/controllers/dynakube/extension/servicename/naming.go
@@ -5,7 +5,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
 )
 
-func BuildPort() string {
+func BuildPortName() string {
 	return "dynatrace" + consts.ExtensionsControllerSuffix + "-" + consts.ExtensionsCollectorTargetPortName
 }
 

--- a/pkg/controllers/dynakube/extension/utils/naming.go
+++ b/pkg/controllers/dynakube/extension/utils/naming.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
+)
+
+func BuildPortsName() string {
+	return "dynatrace" + consts.ExtensionsControllerSuffix + "-" + consts.ExtensionsCollectorTargetPortName
+}
+
+func BuildFQDName(dk *dynakube.DynaKube) string {
+	return BuildServiceName(dk) + "." + dk.Namespace
+}
+
+func BuildServiceName(dk *dynakube.DynaKube) string {
+	return dk.Name + consts.ExtensionsControllerSuffix
+}

--- a/pkg/controllers/dynakube/extension/utils/naming.go
+++ b/pkg/controllers/dynakube/extension/utils/naming.go
@@ -5,7 +5,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
 )
 
-func BuildPortsName() string {
+func BuildPortName() string {
 	return "dynatrace" + consts.ExtensionsControllerSuffix + "-" + consts.ExtensionsCollectorTargetPortName
 }
 


### PR DESCRIPTION
[K8S-11079](https://dt-rnd.atlassian.net/browse/K8S-11079)

## Description

We have two locations where we need the FQDName of the EEC service:

* EEC env var, where it is currently set incorrectly and fixed in this PR
* OTelC

## How can this be tested?

Deploy the operator with extensions and OTelC according to [Stefans PoC docs](https://bitbucket.lab.dynatrace.org/users/stefan.hauth/repos/extensions-demo/browse):

* deploy this branch with `make deploy/helm`
* Create ActiveGate secret like in PoC
* Create TLS secret for communication between EEC and OTelC
* Create DK with Extensions and OTelC enabled like in PoC

### Expected results:

_assuming your DK name is dynakube_

* `dynatrace/dynatrace-extensions-controller-0` Env Var `K8sExtServiceUrl` should have FQDName `dynakube-extensions-controller.dynatrace`
* `dynatrace-extensions-collector-0` container args should have `--config=eec://dynakube-extensions-controller.dynatrace:14599/otcconfig/prometheusMetrics...`

mind that `dynatrace-extensions-collector-0` will go into Error/CrashLoopBackOff if you do not have a config for it.
