### PR TITLE
Change default value of metadata enrichment

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -3066,8 +3066,8 @@ spec:
                 description: Configuration for Metadata Enrichment.
                 properties:
                   enabled:
-                    default: true
-                    description: Enables MetadataEnrichment, `true` by default.
+                    default: false
+                    description: Enables MetadataEnrichment, `false` by default.
                     type: boolean
                   namespaceSelector:
                     description: The namespaces where you want Dynatrace Operator

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -3078,8 +3078,8 @@ spec:
                 description: Configuration for Metadata Enrichment.
                 properties:
                   enabled:
-                    default: true
-                    description: Enables MetadataEnrichment, `true` by default.
+                    default: false
+                    description: Enables MetadataEnrichment, `false` by default.
                     type: boolean
                   namespaceSelector:
                     description: The namespaces where you want Dynatrace Operator

--- a/pkg/api/v1beta2/dynakube/metada_enrichment.go
+++ b/pkg/api/v1beta2/dynakube/metada_enrichment.go
@@ -7,8 +7,8 @@ type MetadataEnrichment struct {
 	// The namespaces where you want Dynatrace Operator to inject enrichment.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Namespace Selector",xDescriptors="urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Namespace"
 	NamespaceSelector metav1.LabelSelector `json:"namespaceSelector,omitempty"`
-	// Enables MetadataEnrichment, `true` by default.
-	// +kubebuilder:default:=true
+	// Enables MetadataEnrichment, `false` by default.
+	// +kubebuilder:default:=false
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="MetaDataEnrichment",xDescriptors="urn:alm:descriptor:com.tectonic.ui:selector:booleanSwitch"
 	Enabled bool `json:"enabled"`
 }


### PR DESCRIPTION
https://dt-rnd.atlassian.net/browse/K8S-10945

## Description

Change default value of metadata enrichment to false

## How can this be tested?

Deploy a dynakube with metaDataEnrichment section but without the enabled flag -> metadataEnrichment should be not enabled and not working