### PR TITLE
Create reconciler for LogModule deployment.conf

### DIFF
--- a/pkg/api/v1beta3/dynakube/properties.go
+++ b/pkg/api/v1beta3/dynakube/properties.go
@@ -96,6 +96,10 @@ func (dk *DynaKube) NeedsOneAgent() bool {
 	return dk.ClassicFullStackMode() || dk.CloudNativeFullstackMode() || dk.HostMonitoringMode()
 }
 
+func (dk *DynaKube) NeedsLogModule() bool {
+	return dk.Spec.LogModule.Enabled
+}
+
 func (dk *DynaKube) OneAgentDaemonsetName() string {
 	return fmt.Sprintf("%s-%s", dk.Name, PodNameOsAgent)
 }

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
@@ -43,7 +43,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dtc dtclient.Clie
 var NoOneAgentCommunicationHostsError = errors.New("no communication hosts for OneAgent are available")
 
 func (r *reconciler) Reconcile(ctx context.Context) error {
-	if !r.dk.NeedAppInjection() && !r.dk.NeedsOneAgent() {
+	if !r.dk.NeedAppInjection() && !r.dk.NeedsOneAgent() && !r.dk.Spec.LogModule.Enabled {
 		if meta.FindStatusCondition(*r.dk.Conditions(), oaConnectionInfoConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
@@ -43,7 +43,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dtc dtclient.Clie
 var NoOneAgentCommunicationHostsError = errors.New("no communication hosts for OneAgent are available")
 
 func (r *reconciler) Reconcile(ctx context.Context) error {
-	if !r.dk.NeedAppInjection() && !r.dk.NeedsOneAgent() && !r.dk.Spec.LogModule.Enabled {
+	if !r.dk.NeedAppInjection() && !r.dk.NeedsOneAgent() && !r.dk.NeedsLogModule() {
 		if meta.FindStatusCondition(*r.dk.Conditions(), oaConnectionInfoConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}

--- a/pkg/controllers/dynakube/controller.go
+++ b/pkg/controllers/dynakube/controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/injection"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmodule"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
@@ -75,6 +76,7 @@ func NewDynaKubeController(kubeClient client.Client, apiReader client.Reader, co
 		injectionReconcilerBuilder:          injection.NewReconciler,
 		istioReconcilerBuilder:              istio.NewReconciler,
 		extensionBuilder:                    extension.NewReconciler,
+		logModuleReconcilerBuilder:          logmodule.NewReconciler,
 	}
 }
 
@@ -108,6 +110,7 @@ type Controller struct {
 	injectionReconcilerBuilder          injection.ReconcilerBuilder
 	istioReconcilerBuilder              istio.ReconcilerBuilder
 	extensionBuilder                    extension.ReconcilerBuilder
+	logModuleReconcilerBuilder          logmodule.ReconcilerBuilder
 
 	tokens            token.Tokens
 	operatorNamespace string
@@ -342,6 +345,17 @@ func (controller *Controller) reconcileComponents(ctx context.Context, dynatrace
 		}
 
 		log.Info("could not reconcile app injection")
+
+		componentErrors = append(componentErrors, err)
+	}
+
+	log.Info("start reconciling LogModule")
+
+	logModuleReconciler := controller.logModuleReconcilerBuilder(controller.client, controller.apiReader, dynatraceClient, dk)
+
+	err = logModuleReconciler.Reconcile(ctx)
+	if err != nil {
+		log.Info("could not reconcile LogModule")
 
 		componentErrors = append(componentErrors, err)
 	}

--- a/pkg/controllers/dynakube/controller_system_test.go
+++ b/pkg/controllers/dynakube/controller_system_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/apimonitoring"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/injection"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmodule"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
@@ -417,6 +418,7 @@ func createFakeClientAndReconciler(t *testing.T, mockClient dtclient.Client, dk 
 		apiMonitoringReconcilerBuilder:      apimonitoring.NewReconciler,
 		injectionReconcilerBuilder:          injection.NewReconciler,
 		oneAgentReconcilerBuilder:           oneagent.NewReconciler,
+		logModuleReconcilerBuilder:          logmodule.NewReconciler,
 		clusterID:                           testUID,
 	}
 

--- a/pkg/controllers/dynakube/logmodule/configsecret/conditions.go
+++ b/pkg/controllers/dynakube/logmodule/configsecret/conditions.go
@@ -1,0 +1,5 @@
+package configsecret
+
+const (
+	lmcConditionType = "LogModuleConfig"
+)

--- a/pkg/controllers/dynakube/logmodule/configsecret/config.go
+++ b/pkg/controllers/dynakube/logmodule/configsecret/config.go
@@ -1,0 +1,9 @@
+package configsecret
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+)
+
+var (
+	log = logd.Get().WithName("logmodule-config-secret")
+)

--- a/pkg/controllers/dynakube/logmodule/configsecret/reconciler.go
+++ b/pkg/controllers/dynakube/logmodule/configsecret/reconciler.go
@@ -1,0 +1,148 @@
+package configsecret
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	k8slabels "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
+	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	logModuleSecretSuffix    = "-logmodule-config"
+	deploymentConfigFilename = "deployment.conf"
+
+	tenantKey       = "Tenant"
+	tenantTokenKey  = "TenantToken"
+	hostIdSourceKey = "HostIdSource"
+	serverKey       = "Server"
+)
+
+type Reconciler struct {
+	client    client.Client
+	apiReader client.Reader
+	dk        *dynakube.DynaKube
+}
+
+func NewReconciler(clt client.Client,
+	apiReader client.Reader,
+	dk *dynakube.DynaKube) *Reconciler {
+	return &Reconciler{
+		client:    clt,
+		apiReader: apiReader,
+		dk:        dk,
+	}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context) error {
+	if !r.dk.Spec.LogModule.Enabled {
+		if meta.FindStatusCondition(*r.dk.Conditions(), lmcConditionType) == nil {
+			return nil // no condition == nothing is there to clean up
+		}
+
+		query := k8ssecret.Query(r.client, r.apiReader, log)
+		err := query.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: getSecretName(r.dk.Name), Namespace: r.dk.Namespace}})
+
+		if err != nil {
+			log.Error(err, "failed to clean-up LogModule config-secret")
+		}
+
+		meta.RemoveStatusCondition(r.dk.Conditions(), lmcConditionType)
+
+		return nil // clean-up shouldn't cause a failure
+	}
+
+	return r.reconcileSecret(ctx)
+}
+
+func (r *Reconciler) reconcileSecret(ctx context.Context) error {
+	query := k8ssecret.Query(r.client, r.apiReader, log)
+
+	newSecret, err := r.prepareSecret(ctx)
+	if err != nil {
+		return err
+	}
+
+	changed, err := query.CreateOrUpdate(ctx, newSecret)
+	if err != nil {
+		conditions.SetKubeApiError(r.dk.Conditions(), lmcConditionType, err)
+
+		return err
+	} else if changed {
+		conditions.SetSecretOutdated(r.dk.Conditions(), lmcConditionType, newSecret.Name) // needed so the timestamp updates, will never actually show up in the status
+	}
+
+	conditions.SetSecretCreated(r.dk.Conditions(), lmcConditionType, newSecret.Name)
+
+	return nil
+}
+
+func (r *Reconciler) prepareSecret(ctx context.Context) (*corev1.Secret, error) {
+	data, err := r.getSecretData(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	coreLabels := k8slabels.NewCoreLabels(r.dk.Name, k8slabels.LogModuleComponentLabel).BuildLabels()
+
+	newSecret, err := k8ssecret.Build(r.dk,
+		getSecretName(r.dk.Name),
+		data,
+		k8ssecret.SetLabels(coreLabels),
+	)
+	if err != nil {
+		conditions.SetSecretGenFailed(r.dk.Conditions(), lmcConditionType, err)
+
+		return nil, err
+	}
+
+	return newSecret, err
+}
+
+func (r *Reconciler) getSecretData(ctx context.Context) (map[string][]byte, error) {
+	tenantToken, err := k8ssecret.GetDataFromSecretName(ctx, r.apiReader, types.NamespacedName{
+		Name:      r.dk.OneagentTenantSecret(),
+		Namespace: r.dk.Namespace,
+	}, connectioninfo.TenantTokenKey, log)
+	if err != nil {
+		conditions.SetKubeApiError(r.dk.Conditions(), lmcConditionType, err)
+
+		return nil, err
+	}
+
+	tenantUUID, err := r.dk.TenantUUIDFromConnectionInfoStatus()
+	if err != nil {
+		conditions.SetSecretGenFailed(r.dk.Conditions(), lmcConditionType, err)
+
+		return nil, err
+	}
+
+	deploymentConfigContent := map[string]string{
+		serverKey:       r.dk.ApiUrl(),
+		tenantKey:       tenantUUID,
+		tenantTokenKey:  tenantToken,
+		hostIdSourceKey: "k8s-node-name",
+	}
+
+	var content strings.Builder
+	for key, value := range deploymentConfigContent {
+		content.WriteString(key)
+		content.WriteString("=")
+		content.WriteString(value)
+		content.WriteString("\n")
+	}
+
+	return map[string][]byte{deploymentConfigFilename: []byte(content.String())}, nil
+}
+
+func getSecretName(dkName string) string {
+	return dkName + logModuleSecretSuffix
+}

--- a/pkg/controllers/dynakube/logmodule/configsecret/reconciler.go
+++ b/pkg/controllers/dynakube/logmodule/configsecret/reconciler.go
@@ -43,7 +43,7 @@ func NewReconciler(clt client.Client,
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	if !r.dk.Spec.LogModule.Enabled {
+	if !r.dk.NeedsLogModule() {
 		if meta.FindStatusCondition(*r.dk.Conditions(), lmcConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}

--- a/pkg/controllers/dynakube/logmodule/configsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/logmodule/configsecret/reconciler_test.go
@@ -1,0 +1,177 @@
+package configsecret
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+const (
+	dkName      = "test-name"
+	dkNamespace = "test-namespace"
+	tokenValue  = "test-token"
+)
+
+func TestReconcile(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Create and update works with minimal setup", func(t *testing.T) {
+		dk := createDynakube(true)
+
+		mockK8sClient := createK8sClientWithOneAgentTenantSecret(dk, tokenValue)
+
+		reconciler := NewReconciler(mockK8sClient,
+			mockK8sClient, dk)
+		err := reconciler.Reconcile(ctx)
+		require.NoError(t, err)
+
+		checkSecretForValue(t, mockK8sClient, dk)
+
+		condition := meta.FindStatusCondition(*dk.Conditions(), lmcConditionType)
+		oldTransitionTime := condition.LastTransitionTime
+		require.NotNil(t, condition)
+		require.NotEmpty(t, oldTransitionTime)
+		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+
+		err = reconciler.Reconcile(context.Background())
+
+		require.NoError(t, err)
+		checkSecretForValue(t, mockK8sClient, dk)
+	})
+	t.Run("Only runs when required, and cleans up condition + secret", func(t *testing.T) {
+		dk := createDynakube(false)
+
+		mockK8sClient := createK8sClientWithOneAgentTenantSecret(dk, tokenValue)
+		conditions.SetSecretCreated(dk.Conditions(), lmcConditionType, "this is a test")
+
+		reconciler := NewReconciler(mockK8sClient, mockK8sClient, dk)
+		err := reconciler.Reconcile(ctx)
+
+		require.NoError(t, err)
+		assert.Empty(t, *dk.Conditions())
+
+		var secretConfig corev1.Secret
+		err = mockK8sClient.Get(ctx, types.NamespacedName{
+			Name:      getSecretName(dk.Name),
+			Namespace: dk.Namespace,
+		}, &secretConfig)
+		require.True(t, k8serrors.IsNotFound(err))
+	})
+
+	t.Run("problem with k8s request => visible in conditions", func(t *testing.T) {
+		dk := createDynakube(true)
+
+		boomClient := createBOOMK8sClient()
+
+		reconciler := NewReconciler(boomClient,
+			boomClient, dk)
+
+		err := reconciler.Reconcile(context.Background())
+
+		require.Error(t, err)
+		require.Len(t, *dk.Conditions(), 1)
+		condition := meta.FindStatusCondition(*dk.Conditions(), lmcConditionType)
+		assert.Equal(t, conditions.KubeApiErrorReason, condition.Reason)
+		assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	})
+}
+
+func checkSecretForValue(t *testing.T, k8sClient client.Client, dk *dynakube.DynaKube) {
+	var secret corev1.Secret
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: getSecretName((dk.Name)), Namespace: dk.Namespace}, &secret)
+	require.NoError(t, err)
+
+	deploymentConfig, ok := secret.Data[deploymentConfigFilename]
+	require.True(t, ok)
+
+	tenantUUID, err := dk.TenantUUIDFromConnectionInfoStatus()
+	require.NoError(t, err)
+
+	expectedLines := []string{
+		serverKey + "=" + dk.ApiUrl(),
+		tenantKey + "=" + tenantUUID,
+		tenantTokenKey + "=" + tokenValue,
+		hostIdSourceKey + "=k8s-node-name",
+	}
+
+	split := strings.Split(strings.Trim(string(deploymentConfig), "\n"), "\n")
+	require.Len(t, split, len(expectedLines))
+
+	for _, line := range split {
+		assert.Contains(t, expectedLines, line)
+	}
+}
+
+func createDynakube(isEnabled bool) *dynakube.DynaKube {
+	return &dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: dkNamespace,
+			Name:      dkName,
+		},
+		Spec: dynakube.DynaKubeSpec{
+			APIURL: "test-url",
+			LogModule: dynakube.LogModuleSpec{
+				Enabled: isEnabled,
+			},
+		},
+		Status: dynakube.DynaKubeStatus{
+			OneAgent: dynakube.OneAgentStatus{
+				ConnectionInfoStatus: dynakube.OneAgentConnectionInfoStatus{
+					ConnectionInfoStatus: dynakube.ConnectionInfoStatus{
+						TenantUUID: "test-uuid",
+					},
+				},
+			},
+		},
+	}
+}
+
+func createBOOMK8sClient() client.Client {
+	boomClient := fake.NewClientWithInterceptors(interceptor.Funcs{
+		Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			return errors.New("BOOM")
+		},
+		Delete: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			return errors.New("BOOM")
+		},
+		Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			return errors.New("BOOM")
+		},
+		Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			return errors.New("BOOM")
+		},
+	})
+
+	return boomClient
+}
+
+func createK8sClientWithOneAgentTenantSecret(dk *dynakube.DynaKube, token string) client.Client {
+	mockK8sClient := fake.NewClient()
+	_ = mockK8sClient.Create(context.Background(),
+		&corev1.Secret{
+			Data: map[string][]byte{connectioninfo.TenantTokenKey: []byte(token)},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dk.OneagentTenantSecret(),
+				Namespace: dkNamespace,
+			},
+		},
+	)
+
+	return mockK8sClient
+}

--- a/pkg/controllers/dynakube/logmodule/reconciler.go
+++ b/pkg/controllers/dynakube/logmodule/reconciler.go
@@ -1,0 +1,53 @@
+package logmodule
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
+	oaconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmodule/configsecret"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Reconciler struct {
+	client    client.Client
+	apiReader client.Reader
+	dk        *dynakube.DynaKube
+	dtc       dtclient.Client
+
+	configSecretReconciler           controllers.Reconciler
+	oneAgentConnectionInfoReconciler controllers.Reconciler
+}
+
+type ReconcilerBuilder func(clt client.Client, apiReader client.Reader, dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Reconciler
+
+func NewReconciler(clt client.Client,
+	apiReader client.Reader,
+	dtc dtclient.Client,
+	dk *dynakube.DynaKube) controllers.Reconciler {
+	return &Reconciler{
+		client:    clt,
+		apiReader: apiReader,
+		dk:        dk,
+		dtc:       dtc,
+
+		configSecretReconciler:           configsecret.NewReconciler(clt, apiReader, dk),
+		oneAgentConnectionInfoReconciler: oaconnectioninfo.NewReconciler(clt, apiReader, dtc, dk),
+	}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context) error {
+	err := r.oneAgentConnectionInfoReconciler.Reconcile(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = r.configSecretReconciler.Reconcile(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controllers/dynakube/logmodule/reconciler_test.go
+++ b/pkg/controllers/dynakube/logmodule/reconciler_test.go
@@ -1,0 +1,71 @@
+package logmodule
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	controllermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/controllers"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcile(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("connection-info fail => error", func(t *testing.T) {
+		failOAConnectionInfo := createFailingReconciler(t)
+		r := Reconciler{
+			oneAgentConnectionInfoReconciler: failOAConnectionInfo,
+		}
+
+		err := r.Reconcile(ctx)
+		require.Error(t, err)
+
+		failOAConnectionInfo.AssertCalled(t, "Reconcile", ctx)
+	})
+
+	t.Run("config-secret fail => error", func(t *testing.T) {
+		failConfigSecret := createFailingReconciler(t)
+		passOAConnectionInfo := createPassingReconciler(t)
+		r := Reconciler{
+			oneAgentConnectionInfoReconciler: passOAConnectionInfo,
+			configSecretReconciler:           failConfigSecret,
+		}
+
+		err := r.Reconcile(ctx)
+		require.Error(t, err)
+
+		failConfigSecret.AssertCalled(t, "Reconcile", ctx)
+		passOAConnectionInfo.AssertCalled(t, "Reconcile", ctx)
+	})
+
+	t.Run("all reconcilers pass", func(t *testing.T) {
+		passOAConnectionInfo := createPassingReconciler(t)
+		passConfigSecret := createPassingReconciler(t)
+		r := Reconciler{
+			oneAgentConnectionInfoReconciler: passOAConnectionInfo,
+			configSecretReconciler:           passConfigSecret,
+		}
+
+		err := r.Reconcile(ctx)
+		require.NoError(t, err)
+
+		passConfigSecret.AssertCalled(t, "Reconcile", ctx)
+		passOAConnectionInfo.AssertCalled(t, "Reconcile", ctx)
+	})
+}
+
+func createFailingReconciler(t *testing.T) *controllermock.Reconciler {
+	failMock := controllermock.NewReconciler(t)
+	failMock.On("Reconcile", mock.Anything).Return(errors.New("BOOM"))
+
+	return failMock
+}
+
+func createPassingReconciler(t *testing.T) *controllermock.Reconciler {
+	passMock := controllermock.NewReconciler(t)
+	passMock.On("Reconcile", mock.Anything).Return(nil)
+
+	return passMock
+}

--- a/pkg/util/kubeobjects/labels/labels.go
+++ b/pkg/util/kubeobjects/labels/labels.go
@@ -15,6 +15,7 @@ const (
 	AppVersionLabel   = "app.kubernetes.io/version"
 
 	OneAgentComponentLabel    = "oneagent"
+	LogModuleComponentLabel   = "logmodule"
 	ActiveGateComponentLabel  = "activegate"
 	WebhookComponentLabel     = "webhook"
 	EdgeConnectComponentLabel = "edgeconnect"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[K8S-10615](https://dt-rnd.atlassian.net/browse/K8S-10615)

1. Adds a base reconciler for the LogModule section
2. Adds a small secret reconciler for the `deployment.conf` of the LogModule


## How can this be tested?

Deploy a dk with `logModule.enabled=true`:
- check the conditions on the dk
- check the secret was created (`<dk>-logmodule-config`)