### PR TITLE
Add check for deepcopy files to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,14 @@ jobs:
         id: deadcode
         run: |
           make go/deadcode
+      - name: Deepcopy generation
+        id: deepcopy
+        run: |
+          make manifests/deepcopy
+      - name: Check if deepcopy generation changed files
+        id: check-deepcopy
+        run: |
+          git diff --exit-code
 
   security:
     name: Code security scanning alerts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,13 +103,20 @@ jobs:
         id: deadcode
         run: |
           make go/deadcode
-      - name: Deepcopy generation
+
+  generated-files:
+    name: Check generated files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: "${{ github.workspace }}/go.mod"
+      - name: Check deepcopy files
         id: deepcopy
         run: |
           make manifests/deepcopy
-      - name: Check if deepcopy generation changed files
-        id: check-deepcopy
-        run: |
           git diff --exit-code
 
   security:
@@ -194,7 +201,7 @@ jobs:
   build:
     name: Build images
     runs-on: ubuntu-latest
-    needs: [prepare, tests, linting]
+    needs: [prepare, tests, linting, generated-files]
     strategy:
       matrix:
         platform: [amd64, arm64, ppc64le, s390x]

--- a/hack/make/manifests/manifests.mk
+++ b/hack/make/manifests/manifests.mk
@@ -2,8 +2,8 @@ manifests/prepare-directory:
 	find $(MANIFESTS_DIR) -type f -not -name 'kustomization.yaml' -delete
 
 ## Generates manifests e.g. CRD, RBAC etc, for Kubernetes and OpenShift
-manifests: manifests/prepare-directory manifests/kubernetes manifests/openshift
+manifests: manifests/prepare-directory manifests/kubernetes manifests/openshift manifests/deepcopy
 
 ## Generate deep copy files
-manifests/deepcopy:
-	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
+manifests/deepcopy: prerequisites/controller-gen
+	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./pkg/api/..."


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR does 2 things: 
- It speeds up the deepcopy command and adds it to the manifest. This speed improvement is achieved by only searching in the relevant folders
- It adds a check to the CI to verify that the deepcopy files were updated if needed 

[Jira](https://dt-rnd.atlassian.net/browse/K8S-10776)
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- change file in the api folder that generates a deepcopy file
- run `make manifests` and check if deepcopy file was updated

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->