### PR TITLE
Return early if owner is not well-known

### DIFF
--- a/pkg/webhook/mutation/pod/metadata/workload.go
+++ b/pkg/webhook/mutation/pod/metadata/workload.go
@@ -65,6 +65,10 @@ func findRootOwner(ctx context.Context, clt client.Client, childObjectMetadata *
 				},
 			}
 
+			if !isWellKnownWorkload(parentObjectMetadata) {
+				return childObjectMetadata, nil
+			}
+
 			err = clt.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: objectMetadata.Namespace}, parentObjectMetadata)
 			if err != nil {
 				log.Error(err, "failed to query the object",
@@ -82,11 +86,7 @@ func findRootOwner(ctx context.Context, clt client.Client, childObjectMetadata *
 				return childObjectMetadata, err
 			}
 
-			if isWellKnownWorkload(parentObjectMetadata) {
-				return parentObjectMetadata, nil
-			}
-
-			return childObjectMetadata, nil
+			return parentObjectMetadata, nil
 		}
 	}
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

If we don't return early, when the owner is NOT well-known, then we will have a permission error when trying to get it with the client.

## How can this be tested?

tbd 😅 