### PR TITLE
Remove obsolete OTEL secret e2e struct

### DIFF
--- a/test/helpers/tenant/secrets.go
+++ b/test/helpers/tenant/secrets.go
@@ -44,11 +44,6 @@ type EdgeConnectSecret struct {
 	Resource          string `yaml:"resource"`
 }
 
-type OtelSecret struct {
-	Endpoint string `yaml:"endpoint"`
-	ApiToken string `yaml:"apiToken"`
-}
-
 func manyFromConfig(fs afero.Fs, path string) ([]Secret, error) {
 	secretConfigFile, err := afero.ReadFile(fs, path)
 


### PR DESCRIPTION
something is left from big removal https://github.com/Dynatrace/dynatrace-operator/pull/3653 and i found accidentally. 