### PR TITLE
Fix workload Owner lookup in case of not well-known Owner type (#3783)

### DIFF
--- a/pkg/webhook/mutation/pod/metadata/containers_test.go
+++ b/pkg/webhook/mutation/pod/metadata/containers_test.go
@@ -86,7 +86,7 @@ func TestUpdateInstallContainer(t *testing.T) {
 		container := &corev1.Container{}
 		clusterName := "test-cluster"
 
-		updateInstallContainer(container, createTestWorkloadInfo(), clusterName)
+		updateInstallContainer(container, createTestWorkloadInfo(t), clusterName)
 
 		require.Len(t, container.VolumeMounts, 1)
 		require.Len(t, container.Env, 4)

--- a/pkg/webhook/mutation/pod/metadata/env_test.go
+++ b/pkg/webhook/mutation/pod/metadata/env_test.go
@@ -10,7 +10,7 @@ import (
 func TestAddWorkloadInfoEnvs(t *testing.T) {
 	t.Run("Add workload info envs", func(t *testing.T) {
 		container := &corev1.Container{}
-		workloadInfo := createTestWorkloadInfo()
+		workloadInfo := createTestWorkloadInfo(t)
 		addWorkloadInfoEnvs(container, workloadInfo)
 
 		require.Len(t, container.Env, 2)

--- a/pkg/webhook/mutation/pod/metadata/workload.go
+++ b/pkg/webhook/mutation/pod/metadata/workload.go
@@ -65,6 +65,10 @@ func findRootOwner(ctx context.Context, clt client.Client, childObjectMetadata *
 				},
 			}
 
+			if !isWellKnownWorkload(parentObjectMetadata) {
+				return childObjectMetadata, nil
+			}
+
 			err = clt.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: objectMetadata.Namespace}, parentObjectMetadata)
 			if err != nil {
 				log.Error(err, "failed to query the object",
@@ -82,11 +86,7 @@ func findRootOwner(ctx context.Context, clt client.Client, childObjectMetadata *
 				return childObjectMetadata, err
 			}
 
-			if isWellKnownWorkload(parentObjectMetadata) {
-				return parentObjectMetadata, nil
-			}
-
-			return childObjectMetadata, nil
+			return parentObjectMetadata, nil
 		}
 	}
 

--- a/pkg/webhook/mutation/pod/metadata/workload_test.go
+++ b/pkg/webhook/mutation/pod/metadata/workload_test.go
@@ -6,11 +6,14 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/address"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestFindRootOwnerOfPod(t *testing.T) {
@@ -203,11 +206,47 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 		assert.Equal(t, resourceName, workloadInfo.name)
 		assert.Equal(t, "Deployment", workloadInfo.kind)
 	})
+	t.Run("should not make an api-call if workload is not well known", func(t *testing.T) {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "some.unknown.kind.com/v1alpha1",
+						Kind:       "SomeUnknownKind",
+						Name:       "some-owner",
+						Controller: address.Of(true),
+					},
+				},
+				Name:      resourceName,
+				Namespace: namespaceName,
+			},
+		}
+
+		client := createFailK8sClient(t)
+
+		workloadInfo, err := findRootOwnerOfPod(ctx, client, &pod, namespaceName)
+		require.NoError(t, err)
+		assert.Equal(t, resourceName, workloadInfo.name)
+	})
 }
 
-func createTestWorkloadInfo() *workloadInfo {
+func createTestWorkloadInfo(t *testing.T) *workloadInfo {
+	t.Helper()
+
 	return &workloadInfo{
 		kind: "test",
 		name: "test",
 	}
+}
+
+func createFailK8sClient(t *testing.T) client.Client {
+	t.Helper()
+
+	boomClient := fake.NewClientWithInterceptors(interceptor.Funcs{
+		Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			return errors.New("BOOM")
+		},
+	})
+
+	return boomClient
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

cherry pick of https://github.com/Dynatrace/dynatrace-operator/pull/3783

## How can this be tested?

same as https://github.com/Dynatrace/dynatrace-operator/pull/3783