### PR TITLE
Propagate both cluster-name and entity-id to enrichment files 

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -4402,6 +4402,11 @@ spec:
                 description: KubernetesClusterMEID contains the ID of the monitored
                   entity that points to the Kubernetes cluster
                 type: string
+              kubernetesClusterName:
+                description: KubernetesClusterName contains the display name (also
+                  know as label) of the monitored entity that points to the Kubernetes
+                  cluster
+                type: string
               metadataEnrichment:
                 description: Observed state of Metadata-Enrichment
                 properties:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -4414,6 +4414,11 @@ spec:
                 description: KubernetesClusterMEID contains the ID of the monitored
                   entity that points to the Kubernetes cluster
                 type: string
+              kubernetesClusterName:
+                description: KubernetesClusterName contains the display name (also
+                  know as label) of the monitored entity that points to the Kubernetes
+                  cluster
+                type: string
               metadataEnrichment:
                 description: Observed state of Metadata-Enrichment
                 properties:

--- a/doc/api/dynakube-api-ref.md
+++ b/doc/api/dynakube-api-ref.md
@@ -44,7 +44,7 @@
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`enabled`|Enables MetadataEnrichment, `true` by default.|True|boolean|
+|`enabled`|Enables MetadataEnrichment, `false` by default.|False|boolean|
 |`namespaceSelector`|The namespaces where you want Dynatrace Operator to inject enrichment.|-|object|
 
 ### .spec.oneAgent.hostMonitoring

--- a/pkg/api/v1beta2/dynakube/dynakube_status.go
+++ b/pkg/api/v1beta2/dynakube/dynakube_status.go
@@ -47,6 +47,9 @@ type DynaKubeStatus struct { //nolint:revive
 	// KubernetesClusterMEID contains the ID of the monitored entity that points to the Kubernetes cluster
 	KubernetesClusterMEID string `json:"kubernetesClusterMEID,omitempty"`
 
+	// KubernetesClusterName contains the display name (also know as label) of the monitored entity that points to the Kubernetes cluster
+	KubernetesClusterName string `json:"kubernetesClusterName,omitempty"`
+
 	// Conditions includes status about the current state of the instance
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/pkg/consts/enrichment_injection.go
+++ b/pkg/consts/enrichment_injection.go
@@ -6,6 +6,7 @@ const (
 	EnrichmentWorkloadKindEnv        = "DT_WORKLOAD_KIND"
 	EnrichmentWorkloadNameEnv        = "DT_WORKLOAD_NAME"
 	EnrichmentWorkloadAnnotationsEnv = "DT_WORKLOAD_ANNOTATIONS"
+	EnrichmentClusterEntityIDEnv     = "DT_ENTITY_ID"
 	EnrichmentClusterNameEnv         = "DT_CLUSTER_NAME"
 
 	EnrichmentMountPath          = "/var/lib/dynatrace/enrichment"

--- a/pkg/controllers/dynakube/monitoredentities/reconciler.go
+++ b/pkg/controllers/dynakube/monitoredentities/reconciler.go
@@ -57,6 +57,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	}
 
 	r.dk.Status.KubernetesClusterMEID = findLatestEntity(monitoredEntities).EntityId
+	r.dk.Status.KubernetesClusterName = findLatestEntity(monitoredEntities).DisplayName
 	conditions.SetStatusUpdated(r.dk.Conditions(), MEIDConditionType, "Kubernetes Cluster MEID is up to date")
 
 	log.Info("kubernetesClusterMEID set in dynakube status, done reconciling", "kubernetesClusterMEID", r.dk.Status.KubernetesClusterMEID)

--- a/pkg/injection/startup/enrichment.go
+++ b/pkg/injection/startup/enrichment.go
@@ -10,18 +10,17 @@ import (
 )
 
 type enrichmentJson struct {
-	ContainerName string `json:"k8s.container.name"`
-	PodUid        string `json:"k8s.pod.uid"`
-	PodName       string `json:"k8s.pod.name"`
-	NodeName      string `json:"k8s.node.name"`
-	NamespaceName string `json:"k8s.namespace.name"`
-	ClusterName   string `json:"k8s.cluster.name,omitempty"`
-	ClusterUID    string `json:"k8s.cluster.uid"`
-	WorkloadKind  string `json:"k8s.workload.kind"`
-	WorkloadName  string `json:"k8s.workload.name"`
-
-	// Deprecated
+	ContainerName   string `json:"k8s.container.name"`
+	PodUid          string `json:"k8s.pod.uid"`
+	PodName         string `json:"k8s.pod.name"`
+	NodeName        string `json:"k8s.node.name"`
+	NamespaceName   string `json:"k8s.namespace.name"`
+	ClusterName     string `json:"k8s.cluster.name,omitempty"`
+	ClusterUID      string `json:"k8s.cluster.uid"`
+	WorkloadKind    string `json:"k8s.workload.kind"`
+	WorkloadName    string `json:"k8s.workload.name"`
 	DTClusterEntity string `json:"dt.entity.kubernetes_cluster,omitempty"`
+
 	// Deprecated
 	DTClusterID string `json:"dt.kubernetes.cluster.id"`
 	// Deprecated
@@ -48,7 +47,7 @@ func (runner *Runner) createEnrichmentFiles() error {
 			WorkloadKind:  runner.env.WorkloadKind,
 			WorkloadName:  runner.env.WorkloadName,
 
-			DTClusterEntity: runner.env.K8ClusterName,
+			DTClusterEntity: runner.env.K8ClusterEntityID,
 			DTClusterID:     runner.env.K8ClusterID,
 			DTWorkloadKind:  runner.env.WorkloadKind,
 			DTWorkloadName:  runner.env.WorkloadName,

--- a/pkg/injection/startup/enrichment_test.go
+++ b/pkg/injection/startup/enrichment_test.go
@@ -17,14 +17,15 @@ func TestCreateEnrichmentFiles(t *testing.T) {
 		runner := Runner{
 			fs: fs,
 			env: &environment{
-				K8PodUID:      "K8PodUID",
-				K8PodName:     "K8PodName",
-				K8NodeName:    "K8NodeName",
-				K8Namespace:   "K8Namespace",
-				K8ClusterName: "K8ClusterName",
-				K8ClusterID:   "K8ClusterID",
-				WorkloadKind:  "WorkloadKind",
-				WorkloadName:  "WorkloadName",
+				K8PodUID:          "K8PodUID",
+				K8PodName:         "K8PodName",
+				K8NodeName:        "K8NodeName",
+				K8Namespace:       "K8Namespace",
+				K8ClusterName:     "K8ClusterName",
+				K8ClusterEntityID: "K8EntityID",
+				K8ClusterID:       "K8ClusterID",
+				WorkloadKind:      "WorkloadKind",
+				WorkloadName:      "WorkloadName",
 				Containers: []ContainerInfo{
 					{
 						Name: "Container-1",
@@ -40,7 +41,7 @@ func TestCreateEnrichmentFiles(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, container := range runner.env.Containers {
-			expectedJson := fmt.Sprintf("{\"dt.entity.kubernetes_cluster\":\"K8ClusterName\",\"dt.kubernetes.cluster.id\":\"K8ClusterID\",\"dt.kubernetes.workload.kind\":\"WorkloadKind\",\"dt.kubernetes.workload.name\":\"WorkloadName\",\"k8s.cluster.name\":\"K8ClusterName\",\"k8s.cluster.uid\":\"K8ClusterID\",\"k8s.container.name\":\"%s\",\"k8s.namespace.name\":\"K8Namespace\",\"k8s.node.name\":\"K8NodeName\",\"k8s.pod.name\":\"K8PodName\",\"k8s.pod.uid\":\"K8PodUID\",\"k8s.workload.kind\":\"WorkloadKind\",\"k8s.workload.name\":\"WorkloadName\"}", container.Name)
+			expectedJson := fmt.Sprintf("{\"dt.entity.kubernetes_cluster\":\"K8EntityID\",\"dt.kubernetes.cluster.id\":\"K8ClusterID\",\"dt.kubernetes.workload.kind\":\"WorkloadKind\",\"dt.kubernetes.workload.name\":\"WorkloadName\",\"k8s.cluster.name\":\"K8ClusterName\",\"k8s.cluster.uid\":\"K8ClusterID\",\"k8s.container.name\":\"%s\",\"k8s.namespace.name\":\"K8Namespace\",\"k8s.node.name\":\"K8NodeName\",\"k8s.pod.name\":\"K8PodName\",\"k8s.pod.uid\":\"K8PodUID\",\"k8s.workload.kind\":\"WorkloadKind\",\"k8s.workload.name\":\"WorkloadName\"}", container.Name)
 
 			jsonFile, err := fs.Open(fmt.Sprintf(enrichmentJsonPathTemplate, container.Name))
 			require.NoError(t, err)
@@ -110,14 +111,15 @@ func TestCreateEnrichmentFiles(t *testing.T) {
 		runner := Runner{
 			fs: fs,
 			env: &environment{
-				K8PodUID:      "K8PodUID",
-				K8PodName:     "K8PodName",
-				K8NodeName:    "K8NodeName",
-				K8Namespace:   "K8Namespace",
-				K8ClusterName: "K8ClusterName",
-				K8ClusterID:   "K8ClusterID",
-				WorkloadKind:  "WorkloadKind",
-				WorkloadName:  "WorkloadName",
+				K8PodUID:          "K8PodUID",
+				K8PodName:         "K8PodName",
+				K8NodeName:        "K8NodeName",
+				K8Namespace:       "K8Namespace",
+				K8ClusterName:     "K8ClusterName",
+				K8ClusterEntityID: "K8EntityID",
+				K8ClusterID:       "K8ClusterID",
+				WorkloadKind:      "WorkloadKind",
+				WorkloadName:      "WorkloadName",
 				WorkloadAnnotations: map[string]string{
 					"key1": "value1",
 					"key2": "value2",
@@ -137,7 +139,7 @@ func TestCreateEnrichmentFiles(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, container := range runner.env.Containers {
-			expectedJson := fmt.Sprintf("{\"dt.entity.kubernetes_cluster\":\"K8ClusterName\",\"dt.kubernetes.cluster.id\":\"K8ClusterID\",\"dt.kubernetes.workload.kind\":\"WorkloadKind\",\"dt.kubernetes.workload.name\":\"WorkloadName\",\"k8s.cluster.name\":\"K8ClusterName\",\"k8s.cluster.uid\":\"K8ClusterID\",\"k8s.container.name\":\"%s\",\"k8s.namespace.name\":\"K8Namespace\",\"k8s.node.name\":\"K8NodeName\",\"k8s.pod.name\":\"K8PodName\",\"k8s.pod.uid\":\"K8PodUID\",\"k8s.workload.kind\":\"WorkloadKind\",\"k8s.workload.name\":\"WorkloadName\",\"key1\":\"value1\",\"key2\":\"value2\"}", container.Name)
+			expectedJson := fmt.Sprintf("{\"dt.entity.kubernetes_cluster\":\"K8EntityID\",\"dt.kubernetes.cluster.id\":\"K8ClusterID\",\"dt.kubernetes.workload.kind\":\"WorkloadKind\",\"dt.kubernetes.workload.name\":\"WorkloadName\",\"k8s.cluster.name\":\"K8ClusterName\",\"k8s.cluster.uid\":\"K8ClusterID\",\"k8s.container.name\":\"%s\",\"k8s.namespace.name\":\"K8Namespace\",\"k8s.node.name\":\"K8NodeName\",\"k8s.pod.name\":\"K8PodName\",\"k8s.pod.uid\":\"K8PodUID\",\"k8s.workload.kind\":\"WorkloadKind\",\"k8s.workload.name\":\"WorkloadName\",\"key1\":\"value1\",\"key2\":\"value2\"}", container.Name)
 
 			jsonFile, err := fs.Open(fmt.Sprintf(enrichmentJsonPathTemplate, container.Name))
 			require.NoError(t, err)

--- a/pkg/injection/startup/env.go
+++ b/pkg/injection/startup/env.go
@@ -29,13 +29,14 @@ type environment struct {
 	InstallVersion  string `json:"installVersion"`
 	InstallPath     string `json:"installPath"`
 
-	K8NodeName    string `json:"k8NodeName"`
-	K8PodName     string `json:"k8PodName"`
-	K8PodUID      string `json:"k8BasePodUID"`
-	K8BasePodName string `json:"k8BasePodName"`
-	K8Namespace   string `json:"k8Namespace"`
-	K8ClusterID   string `json:"k8ClusterID"`
-	K8ClusterName string `json:"k8sClusterName"`
+	K8NodeName        string `json:"k8NodeName"`
+	K8PodName         string `json:"k8PodName"`
+	K8PodUID          string `json:"k8BasePodUID"`
+	K8BasePodName     string `json:"k8BasePodName"`
+	K8Namespace       string `json:"k8Namespace"`
+	K8ClusterID       string `json:"k8ClusterID"`
+	K8ClusterName     string `json:"k8sClusterName"`
+	K8ClusterEntityID string `json:"k8sClusterEntityID"`
 
 	WorkloadKind        string            `json:"workloadKind"`
 	WorkloadName        string            `json:"workloadName"`
@@ -125,6 +126,7 @@ func (env *environment) setOptionalFields() {
 	env.addInstallerFlavor()
 	env.addInstallVersion()
 	env.addClusterName()
+	env.addEntityID()
 }
 
 func (env *environment) setMutationTypeFields() {
@@ -295,6 +297,11 @@ func (env *environment) addWorkloadAnnotations() error {
 func (env *environment) addClusterName() {
 	clusterName, _ := checkEnvVar(consts.EnrichmentClusterNameEnv)
 	env.K8ClusterName = clusterName
+}
+
+func (env *environment) addEntityID() {
+	entityID, _ := checkEnvVar(consts.EnrichmentClusterEntityIDEnv)
+	env.K8ClusterEntityID = entityID
 }
 
 func (env *environment) addInstallerUrl() {

--- a/pkg/injection/startup/env_test.go
+++ b/pkg/injection/startup/env_test.go
@@ -197,6 +197,7 @@ func prepMetadataEnrichmentTestEnv(t *testing.T, isUnknownWorkload bool) func() 
 		consts.K8sNodeNameEnv,
 		consts.K8sNamespaceEnv,
 		consts.EnrichmentClusterNameEnv,
+		consts.EnrichmentClusterEntityIDEnv,
 	}
 
 	for _, envvar := range envs {

--- a/pkg/webhook/mutation/pod/metadata/containers.go
+++ b/pkg/webhook/mutation/pod/metadata/containers.go
@@ -32,9 +32,9 @@ func reinvokeUserContainers(request *dtwebhook.BaseRequest) bool {
 	return updated
 }
 
-func updateInstallContainer(installContainer *corev1.Container, workload *workloadInfo, clusterName string) {
+func updateInstallContainer(installContainer *corev1.Container, workload *workloadInfo, entityID, clusterName string) {
 	addInjectedEnv(installContainer)
-	addClusterNameEnv(installContainer, clusterName)
+	addDTClusterEnvs(installContainer, entityID, clusterName)
 	addWorkloadInfoEnvs(installContainer, workload)
 	addWorkloadEnrichmentInstallVolumeMount(installContainer)
 }

--- a/pkg/webhook/mutation/pod/metadata/containers_test.go
+++ b/pkg/webhook/mutation/pod/metadata/containers_test.go
@@ -85,10 +85,11 @@ func TestUpdateInstallContainer(t *testing.T) {
 	t.Run("Add volume mounts and envs", func(t *testing.T) {
 		container := &corev1.Container{}
 		clusterName := "test-cluster"
+		entityID := "test-entity"
 
-		updateInstallContainer(container, createTestWorkloadInfo(t), clusterName)
+		updateInstallContainer(container, createTestWorkloadInfo(t), entityID, clusterName)
 
 		require.Len(t, container.VolumeMounts, 1)
-		require.Len(t, container.Env, 4)
+		require.Len(t, container.Env, 5)
 	})
 }

--- a/pkg/webhook/mutation/pod/metadata/env.go
+++ b/pkg/webhook/mutation/pod/metadata/env.go
@@ -18,8 +18,9 @@ func addWorkloadInfoEnvs(container *corev1.Container, workload *workloadInfo) {
 	)
 }
 
-func addClusterNameEnv(container *corev1.Container, clusterName string) {
+func addDTClusterEnvs(container *corev1.Container, clusterName, entityID string) {
 	container.Env = append(container.Env,
 		corev1.EnvVar{Name: consts.EnrichmentClusterNameEnv, Value: clusterName},
+		corev1.EnvVar{Name: consts.EnrichmentClusterEntityIDEnv, Value: entityID},
 	)
 }

--- a/pkg/webhook/mutation/pod/metadata/env_test.go
+++ b/pkg/webhook/mutation/pod/metadata/env_test.go
@@ -29,8 +29,8 @@ func TestAddInjectedEnv(t *testing.T) {
 func TestAddClusterNameEnv(t *testing.T) {
 	t.Run("Add workload info envs", func(t *testing.T) {
 		container := &corev1.Container{}
-		addClusterNameEnv(container, "test")
+		addDTClusterEnvs(container, "entityID", "clusterName")
 
-		require.Len(t, container.Env, 1)
+		require.Len(t, container.Env, 2)
 	})
 }

--- a/pkg/webhook/mutation/pod/metadata/mutator.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator.go
@@ -66,7 +66,7 @@ func (mut *Mutator) Mutate(ctx context.Context, request *dtwebhook.MutationReque
 
 	setupVolumes(request.Pod)
 	mutateUserContainers(request.BaseRequest)
-	updateInstallContainer(request.InstallContainer, workload, request.DynaKube.Status.KubernetesClusterMEID)
+	updateInstallContainer(request.InstallContainer, workload, request.DynaKube.Status.KubernetesClusterName, request.DynaKube.Status.KubernetesClusterMEID)
 	propagateMetadataAnnotations(request)
 	setInjectedAnnotation(request.Pod)
 	setWorkloadAnnotations(request.Pod, workload)

--- a/pkg/webhook/mutation/pod/metadata/mutator_test.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator_test.go
@@ -140,7 +140,7 @@ func TestMutate(t *testing.T) {
 		assert.Len(t, request.Pod.Spec.Containers[0].VolumeMounts, initialContainerVolumeMountsLen+3)
 		assert.Len(t, request.Pod.Annotations, initialAnnotationsLen+3)
 
-		assert.Len(t, request.InstallContainer.Env, 5)
+		assert.Len(t, request.InstallContainer.Env, 6)
 		assert.Len(t, request.InstallContainer.VolumeMounts, 1)
 	})
 }


### PR DESCRIPTION
## Description

We previously considered that the "cluster-name" is the same as the `entity-id`. This is incorrect the "cluster-name" is the display name of the related entity

## How can this be tested?

Check that both the cluster-name and entity-id are in the enrichment files
```
root@php-glibc-meta-c97978dcf-7rkw6:/var/www/html# cat /var/lib/dynatrace/enrichment/dt_metadata.properties
k8s.container.name=app
k8s.pod.name=php-glibc-meta-c97978dcf-7rkw6
k8s.node.name=gke-marcell-test-default-pool-934ffcd9-qz3m
dt.kubernetes.workload.kind=Deployment
prop=hello
test=test
k8s.namespace.name=php-zib50933-meta
k8s.workload.name=php-glibc-meta
dt.kubernetes.cluster.id=63599eca-d0d4-4c49-803e-c9a251b91033
boop=beep
k8s.pod.uid=abe1e0c2-d139-413d-9346-4ad409cf98ab
k8s.cluster.name=zib50933zib50933zib50933zib50933zib50933  << THIS
k8s.cluster.uid=63599eca-d0d4-4c49-803e-c9a251b91033
k8s.workload.kind=Deployment
dt.entity.kubernetes_cluster=KUBERNETES_CLUSTER-DF21B23EF84C5C2F  << THIS
dt.kubernetes.workload.name=php-glibc-meta
```