### PR TITLE
Reconcile AG connection-info before creating configmap from it

### DIFF
--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -86,12 +86,12 @@ func NewReconciler(clt client.Client, //nolint
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	err := r.createActiveGateTenantConnectionInfoConfigMap(ctx)
+	err := r.connectionReconciler.Reconcile(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = r.connectionReconciler.Reconcile(ctx)
+	err = r.createActiveGateTenantConnectionInfoConfigMap(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

We create an empty configMap on first reconcile, and second reconcile we actually create it with data.

This didn't really cause any issue, as we reconcile multiple times in the initial creation, but still 😅  

## How can this be tested?

Hard to properly, as the original "issue" is hard to catch (for a split second the ag connection-info configmap is empty).
Just checking that the ag connection-info configmap is created properly.