### PR TITLE
Revert "Move CR name length validation to kubebuilder markers (#3665)"

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: dynakubes.dynatrace.com
 spec:
   group: dynatrace.com
@@ -4507,15 +4507,6 @@ spec:
                 type: string
             type: object
         type: object
-        x-kubernetes-validations:
-        - fieldPath: .metadata
-          message: 'The length limit for the name of a DynaKube is 40, because it
-            is the base for the name of resources related to the DynaKube. (example:
-            dkName-activegate-<some-hash>) The limit is necessary because kubernetes
-            uses the name of some resources (example: StatefulSet) for the label value,
-            which has a limit of 63 characters. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)'
-          reason: FieldValueInvalid
-          rule: size(self.metadata.name) <= 40
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/dynatrace.com_edgeconnects.yaml
+++ b/config/crd/bases/dynatrace.com_edgeconnects.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: edgeconnects.dynatrace.com
 spec:
   group: dynatrace.com
@@ -1239,14 +1239,6 @@ spec:
                 type: object
             type: object
         type: object
-        x-kubernetes-validations:
-        - fieldPath: .metadata
-          message: The length limit for the name of a EdgeConnect is 40, because it
-            is the base for the name of resources related to the EdgeConnect. The
-            limit is necessary because kubernetes uses the name of some resources
-            for the label value, which has a limit of 63 characters.
-          reason: FieldValueInvalid
-          rule: size(self.metadata.name) <= 40
     served: true
     storage: true
     subresources:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -4519,15 +4519,6 @@ spec:
                 type: string
             type: object
         type: object
-        x-kubernetes-validations:
-        - fieldPath: .metadata
-          message: 'The length limit for the name of a DynaKube is 40, because it
-            is the base for the name of resources related to the DynaKube. (example:
-            dkName-activegate-<some-hash>) The limit is necessary because kubernetes
-            uses the name of some resources (example: StatefulSet) for the label value,
-            which has a limit of 63 characters. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)'
-          reason: FieldValueInvalid
-          rule: size(self.metadata.name) <= 40
     served: true
     storage: true
     subresources:
@@ -4537,7 +4528,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: edgeconnects.dynatrace.com
 spec:
   conversion:
@@ -5785,14 +5776,6 @@ spec:
                 type: object
             type: object
         type: object
-        x-kubernetes-validations:
-        - fieldPath: .metadata
-          message: The length limit for the name of a EdgeConnect is 40, because it
-            is the base for the name of resources related to the EdgeConnect. The
-            limit is necessary because kubernetes uses the name of some resources
-            for the label value, which has a limit of 63 characters.
-          reason: FieldValueInvalid
-          rule: size(self.metadata.name) <= 40
     served: true
     storage: true
     subresources:

--- a/pkg/api/v1alpha2/edgeconnect/edgeconnect_types.go
+++ b/pkg/api/v1alpha2/edgeconnect/edgeconnect_types.go
@@ -167,7 +167,6 @@ func (dk *EdgeConnectStatus) SetPhase(phase status.DeploymentPhase) bool {
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:storageversion
-// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 40",reason="FieldValueInvalid",fieldPath=".metadata",message="The length limit for the name of a EdgeConnect is 40, because it is the base for the name of resources related to the EdgeConnect. The limit is necessary because kubernetes uses the name of some resources for the label value, which has a limit of 63 characters."
 type EdgeConnect struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha2/edgeconnect/properties.go
+++ b/pkg/api/v1alpha2/edgeconnect/properties.go
@@ -9,6 +9,10 @@ import (
 )
 
 const (
+	// MaxNameLength is the maximum length of a EdgeConnect's name, we tend to add suffixes to the name to avoid name collisions for resources related to the EdgeConnect.
+	// The limit is necessary because kubernetes uses the name of some resources for the label value, which has a limit of 63 characters. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
+	MaxNameLength = 40
+
 	defaultEdgeConnectRepository = "docker.io/dynatrace/edgeconnect"
 )
 

--- a/pkg/api/v1alpha2/edgeconnect/validation/name.go
+++ b/pkg/api/v1alpha2/edgeconnect/validation/name.go
@@ -1,0 +1,22 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+)
+
+const (
+	errorNameTooLong = `The length limit for the name of a EdgeConnect is %d, because it is the base for the name of resources related to the EdgeConnect.
+	The limit is necessary because kubernetes uses the name of some resources for the label value, which has a limit of 63 characters. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)`
+)
+
+func nameTooLong(_ context.Context, _ *Validator, ec *edgeconnect.EdgeConnect) string {
+	edgeConnectName := ec.Name
+	if edgeConnectName != "" && len(edgeConnectName) > edgeconnect.MaxNameLength {
+		return fmt.Sprintf(errorNameTooLong, edgeconnect.MaxNameLength)
+	}
+
+	return ""
+}

--- a/pkg/api/v1alpha2/edgeconnect/validation/name_test.go
+++ b/pkg/api/v1alpha2/edgeconnect/validation/name_test.go
@@ -1,0 +1,62 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNameTooLong(t *testing.T) {
+	type testCase struct {
+		name         string
+		crNameLength int
+		allow        bool
+	}
+
+	testCases := []testCase{
+		{
+			name:         "normal length",
+			crNameLength: 10,
+			allow:        true,
+		},
+		{
+			name:         "max - 1 ",
+			crNameLength: edgeconnect.MaxNameLength - 1,
+			allow:        true,
+		},
+		{
+			name:         "max",
+			crNameLength: edgeconnect.MaxNameLength,
+			allow:        true,
+		},
+		{
+			name:         "max + 1 ",
+			crNameLength: edgeconnect.MaxNameLength + 1,
+			allow:        false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			ec := &edgeconnect.EdgeConnect{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      strings.Repeat("a", test.crNameLength),
+					Namespace: testNamespace,
+				},
+				Spec: edgeconnect.EdgeConnectSpec{
+					ApiServer:          "id." + allowedSuffix[0],
+					ServiceAccountName: testServiceAccountName,
+				},
+			}
+			if test.allow {
+				assertAllowed(t, ec, prepareTestServiceAccount(testServiceAccountName, testNamespace))
+			} else {
+				errorMessage := fmt.Sprintf(errorNameTooLong, edgeconnect.MaxNameLength)
+				assertDenied(t, []string{errorMessage}, ec)
+			}
+		})
+	}
+}

--- a/pkg/api/v1alpha2/edgeconnect/validation/validation.go
+++ b/pkg/api/v1alpha2/edgeconnect/validation/validation.go
@@ -21,6 +21,7 @@ type validatorFunc func(ctx context.Context, dv *Validator, ec *edgeconnect.Edge
 
 var validatorErrorFuncs = []validatorFunc{
 	isInvalidApiServer,
+	nameTooLong,
 	checkHostPatternsValue,
 	isInvalidServiceName,
 	automationRequiresProvisionerValidation,

--- a/pkg/api/v1beta2/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta2/dynakube/dynakube_types.go
@@ -69,7 +69,6 @@ type DynaKubeValueSource struct { //nolint:revive
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +operator-sdk:csv:customresourcedefinitions:displayName="Dynatrace DynaKube"
 // +operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,},{DaemonSet,v1,},{Pod,v1,}}
-// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 40",reason="FieldValueInvalid",fieldPath=".metadata",message="The length limit for the name of a DynaKube is 40, because it is the base for the name of resources related to the DynaKube. (example: dkName-activegate-<some-hash>) The limit is necessary because kubernetes uses the name of some resources (example: StatefulSet) for the label value, which has a limit of 63 characters. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)"
 type DynaKube struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/pkg/api/v1beta2/dynakube/properties.go
+++ b/pkg/api/v1beta2/dynakube/properties.go
@@ -31,6 +31,10 @@ import (
 )
 
 const (
+	// MaxNameLength is the maximum length of a DynaKube's name, we tend to add suffixes to the name to avoid name collisions for resources related to the DynaKube. (example: dkName-activegate-<some-hash>)
+	// The limit is necessary because kubernetes uses the name of some resources (ActiveGate StatefulSet) for the label value, which has a limit of 63 characters. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
+	MaxNameLength = 40
+
 	// PullSecretSuffix is the suffix appended to the DynaKube name to n.
 	PullSecretSuffix                        = "-pull-secret"
 	ActiveGateTenantSecretSuffix            = "-activegate-tenant-secret"

--- a/pkg/api/v1beta2/dynakube/validation/dynakube_name.go
+++ b/pkg/api/v1beta2/dynakube/validation/dynakube_name.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -11,6 +12,9 @@ const (
 	errorNoDNS1053Label = `The DynaKube's specification violates DNS-1035.
     [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]
 	`
+
+	errorNameTooLong = `The length limit for the name of a DynaKube is %d, because it is the base for the name of resources related to the DynaKube. (example: dkName-activegate-<some-hash>)
+	The limit is necessary because kubernetes uses the name of some resources (example: StatefulSet) for the label value, which has a limit of 63 characters. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)`
 )
 
 func nameViolatesDNS1035(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
@@ -27,4 +31,13 @@ func nameViolatesDNS1035(_ context.Context, _ *Validator, dk *dynakube.DynaKube)
 	}
 
 	return errorNoDNS1053Label
+}
+
+func nameTooLong(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	dynakubeName := dk.Name
+	if dynakubeName != "" && len(dynakubeName) > dynakube.MaxNameLength {
+		return fmt.Sprintf(errorNameTooLong, dynakube.MaxNameLength)
+	}
+
+	return ""
 }

--- a/pkg/api/v1beta2/dynakube/validation/dynakube_name_test.go
+++ b/pkg/api/v1beta2/dynakube/validation/dynakube_name_test.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube"
@@ -23,4 +25,54 @@ func TestNameStartsWithDigit(t *testing.T) {
 			},
 		})
 	})
+}
+
+func TestNameTooLong(t *testing.T) {
+	type testCase struct {
+		name         string
+		crNameLength int
+		allow        bool
+	}
+
+	testCases := []testCase{
+		{
+			name:         "normal length",
+			crNameLength: 10,
+			allow:        true,
+		},
+		{
+			name:         "max - 1 ",
+			crNameLength: dynakube.MaxNameLength - 1,
+			allow:        true,
+		},
+		{
+			name:         "max",
+			crNameLength: dynakube.MaxNameLength,
+			allow:        true,
+		},
+		{
+			name:         "max + 1 ",
+			crNameLength: dynakube.MaxNameLength + 1,
+			allow:        false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			dk := &dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: strings.Repeat("a", test.crNameLength),
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: "https://tenantid.doma.in/api",
+				},
+			}
+			if test.allow {
+				assertAllowed(t, dk)
+			} else {
+				errorMessage := fmt.Sprintf(errorNameTooLong, dynakube.MaxNameLength)
+				assertDenied(t, []string{errorMessage}, dk)
+			}
+		})
+	}
 }

--- a/pkg/api/v1beta2/dynakube/validation/validation.go
+++ b/pkg/api/v1beta2/dynakube/validation/validation.go
@@ -34,6 +34,7 @@ var (
 		imageFieldSetWithoutCSIFlag,
 		conflictingOneAgentVolumeStorageSettings,
 		nameViolatesDNS1035,
+		nameTooLong,
 		namespaceSelectorViolateLabelSpec,
 		imageFieldHasTenantImage,
 		validateOneAgentVersionIsSemVerCompliant,


### PR DESCRIPTION
This reverts commit cc4809062d8933060c6ae8547111cea7ec66dbf7.

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Unfortunately, the x-validation properties in the CRD is not supported in OCP 4.10 and 4.11, but the operator does support these versions. So we have to go back to checking the length by hand.

## How can this be tested?

On OCP 4.10 or 4.11 cluster you can successfully apply the CRD
And on every version the name length limit is enforced by the validation