### PR TITLE
Improve how we wait for status when we create/destroy clusters

### DIFF
--- a/.github/scripts/create-cluster.sh
+++ b/.github/scripts/create-cluster.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-DEFAULT_TIMEOUT="60m" # K8s takes <10min, Openshift >40min
+DEFAULT_TIMEOUT="80m" # K8s takes <10min, Openshift >40min
 DESIRED_STATE="environment-deployed"
 
 kubectl version
@@ -15,20 +15,4 @@ echo "Patching environment '$FLC_ENVIRONMENT' to 'deployed'"
 kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch '{"spec": {"desiredState": "environment-deployed"}}' flcenvironment "$FLC_ENVIRONMENT"
 
 echo "Waiting up to '$DEFAULT_TIMEOUT' for successful deployment of environment '$FLC_ENVIRONMENT'"
-kubectl wait --namespace "$FLC_NAMESPACE" --timeout="$DEFAULT_TIMEOUT" --for=condition=InTransition=false flcenvironment "$FLC_ENVIRONMENT"
-
-if [[ "$FLC_ENVIRONMENT" == *"ocp"* ]]; then
-  echo "PLATFORM is set to 'ocp'. Waiting for 5 minutes..."
-  sleep 300  # Wait for 5 minutes (300 seconds)
-  echo "done"
-fi
-
-echo "Checking currentState='$DESIRED_STATE' for '$FLC_ENVIRONMENT'..."
-flc_state=$(kubectl get flcenvironment "$FLC_ENVIRONMENT" --namespace "$FLC_NAMESPACE" -ojsonpath="{.status.currentState}")
-if [[ "$flc_state" != "$DESIRED_STATE" ]]; then
-  echo "Pipeline deployment did not reach expected state '$DESIRED_STATE', currentState: ${flc_state}..."
-  exit 1
-  else
-    echo "successful..."
-fi
-echo "done"
+kubectl wait --namespace "$FLC_NAMESPACE" --timeout="$DEFAULT_TIMEOUT" --for jsonpath='{.status.currentState}'="$DESIRED_STATE" flcenvironment "$FLC_ENVIRONMENT"

--- a/.github/scripts/destroy-cluster.sh
+++ b/.github/scripts/destroy-cluster.sh
@@ -8,3 +8,5 @@ kubectl get flcenvironments --namespace "$FLC_NAMESPACE"
 
 echo "Patching environment '$FLC_ENVIRONMENT' to 'not-deployed'"
 kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch '{"spec": {"desiredState": "environment-not-deployed"}}' flcenvironment "$FLC_ENVIRONMENT"
+
+kubectl wait --namespace "$FLC_NAMESPACE" --timeout="$DEFAULT_TIMEOUT" --for jsonpath='{.status.currentState}'=environment-not-deployed flcenvironment "$FLC_ENVIRONMENT"


### PR DESCRIPTION
## Description

Improve how we wait for after creating/desctroying test clusters.

Notes:
1. `kubectl wait` already can do what we want:

```
kubectl --namespace dto-ocp-ondemand wait --for jsonpath='{.status.currentState}'=enviro
nment-deployed flcenvironments dto-ocp-4-12 --timeout=10s
error: timed out waiting for the condition on flcenvironments/dto-ocp-4-12
➜  dynatrace-operator git:(revert/x-validation-flags) ✗ echo $?
1
```

2. We should wait for proper status after we destroying cluster.

3. Increased default timeout because OCP clusters not always quick as we want, and extra 5 mins doesn't help much in some cases.

## How can this be tested?

n/a