### PR TITLE
Allow to configure the annotations of service accounts within helm values

### DIFF
--- a/config/helm/chart/default/templates/Common/activegate/serviceaccount-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/serviceaccount-activegate.yaml
@@ -16,5 +16,9 @@ kind: ServiceAccount
 metadata:
   name: dynatrace-activegate
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.rbac.activeGate.annotations }}
+  annotations:
+    {{- toYaml .Values.rbac.activeGate.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "dynatrace-operator.activegateLabels" . | nindent 4 }}

--- a/config/helm/chart/default/templates/Common/edge-connect/serviceaccount-edgeconnect.yaml
+++ b/config/helm/chart/default/templates/Common/edge-connect/serviceaccount-edgeconnect.yaml
@@ -16,5 +16,9 @@ kind: ServiceAccount
 metadata:
   name: dynatrace-edgeconnect
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.rbac.edgeConnect.annotations }}
+  annotations:
+    {{- toYaml .Values.rbac.edgeConnect.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}

--- a/config/helm/chart/default/templates/Common/extensions-controller/serviceaccount-extensions-controller.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-controller/serviceaccount-extensions-controller.yaml
@@ -16,6 +16,10 @@ kind: ServiceAccount
 metadata:
   name: dynatrace-extensions-controller
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.rbac.extensions.annotations }}
+  annotations:
+    {{- toYaml .Values.rbac.extensions.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "dynatrace-operator.extensionsControllerLabels" . | nindent 4 }}
 

--- a/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector.yaml
@@ -16,6 +16,10 @@ kind: ServiceAccount
 metadata:
   name: dynatrace-extensions-collector
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.rbac.extensions.annotations }}
+  annotations:
+    {{- toYaml .Values.rbac.extensions.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
 

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
@@ -16,9 +16,9 @@ kind: ServiceAccount
 metadata:
   name: dynatrace-kubernetes-monitoring
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.rbac.activeGate.kubernetesMonitoring.annotations }}
+  {{- if .Values.rbac.activeGate.annotations }}
   annotations:
-    {{- toYaml .Values.rbac.activeGate.kubernetesMonitoring.annotations | nindent 4 }}
+    {{- toYaml .Values.rbac.activeGate.annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "dynatrace-operator.activegateLabels" . | nindent 4 }}

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
@@ -16,5 +16,9 @@ kind: ServiceAccount
 metadata:
   name: dynatrace-kubernetes-monitoring
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.rbac.activeGate.kubernetesMonitoring.annotations }}
+  annotations:
+    {{- toYaml .Values.rbac.activeGate.kubernetesMonitoring.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "dynatrace-operator.activegateLabels" . | nindent 4 }}

--- a/config/helm/chart/default/templates/Common/logmodule/serviceaccount-logmodule.yaml
+++ b/config/helm/chart/default/templates/Common/logmodule/serviceaccount-logmodule.yaml
@@ -16,5 +16,9 @@ kind: ServiceAccount
 metadata:
   name: dynatrace-logmodule
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.rbac.logModule.annotations }}
+  annotations:
+    {{- toYaml .Values.rbac.logModule.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "dynatrace-operator.logModuleLabels" . | nindent 4 }}

--- a/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent.yaml
@@ -16,6 +16,10 @@ kind: ServiceAccount
 metadata:
   name: dynatrace-dynakube-oneagent
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.rbac.oneAgent.annotations }}
+  annotations:
+    {{- toYaml .Values.rbac.oneAgent.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
 automountServiceAccountToken: false

--- a/config/helm/chart/default/tests/Common/activegate/serviceaccount-activegate_test.yaml
+++ b/config/helm/chart/default/tests/Common/activegate/serviceaccount-activegate_test.yaml
@@ -1,0 +1,15 @@
+suite: test serviceaccount for activegate
+templates:
+  - Common/activegate/serviceaccount-activegate.yaml
+tests:
+  - it: should exist
+    set:
+      rbac.activeGate.annotations:
+        test: test
+    asserts:
+        - isKind:
+            of: ServiceAccount
+        - equal:
+            path: metadata.annotations
+            value:
+              test: test

--- a/config/helm/chart/default/tests/Common/edgeconnect/serviceaccount-edgeconnect_test.yaml
+++ b/config/helm/chart/default/tests/Common/edgeconnect/serviceaccount-edgeconnect_test.yaml
@@ -1,0 +1,15 @@
+suite: test serviceaccount for edgeconnect
+templates:
+  - Common/edge-connect/serviceaccount-edgeconnect.yaml
+tests:
+  - it: should exist
+    set:
+      rbac.edgeConnect.annotations:
+        test: test
+    asserts:
+        - isKind:
+            of: ServiceAccount
+        - equal:
+            path: metadata.annotations
+            value:
+              test: test

--- a/config/helm/chart/default/tests/Common/extensions-controller/serviceaccount-extensions-controller_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-controller/serviceaccount-extensions-controller_test.yaml
@@ -16,3 +16,15 @@ tests:
           value: NAMESPACE
       - isNotEmpty:
           path: metadata.labels
+
+  - it: should exist
+    set:
+      rbac.extensions.annotations:
+        test: test
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.annotations
+          value:
+            test: test

--- a/config/helm/chart/default/tests/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring_test.yaml
@@ -16,3 +16,15 @@ tests:
           value: NAMESPACE
       - isNotEmpty:
           path: metadata.labels
+
+  - it: should exist
+    set:
+      rbac.activeGate.annotations:
+        test: test
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.annotations
+          value:
+            test: test

--- a/config/helm/chart/default/tests/Common/logmodule/serviceaccount-logmodule_test.yaml
+++ b/config/helm/chart/default/tests/Common/logmodule/serviceaccount-logmodule_test.yaml
@@ -14,3 +14,15 @@ tests:
           value: NAMESPACE
       - isNull:
           path: imagePullSecrets
+
+  - it: should exist
+    set:
+      rbac.logModule.annotations:
+        test: test
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.annotations
+          value:
+            test: test

--- a/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent_test.yaml
+++ b/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent_test.yaml
@@ -27,4 +27,15 @@ tests:
           path: metadata.name
           value: dynatrace-dynakube-oneagent
 
+  - it: should exist
+    set:
+      rbac.oneAgent.annotations:
+        test: test
+    asserts:
+        - isKind:
+            of: ServiceAccount
+        - equal:
+            path: metadata.annotations
+            value:
+              test: test
 

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -194,3 +194,16 @@ csidriver:
         cpu: 20m
         memory: 30Mi
 
+rbac:
+  activeGate:
+    annotations:
+    kubernetesMonitoring:
+      annotations:
+  edgeConnect:
+    annotations:
+  extensions:
+    annotations:
+  logModule:
+    annotations:
+  oneAgent:
+    annotations:

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -197,8 +197,6 @@ csidriver:
 rbac:
   activeGate:
     annotations:
-    kubernetesMonitoring:
-      annotations:
   edgeConnect:
     annotations:
   extensions:

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -196,12 +196,12 @@ csidriver:
 
 rbac:
   activeGate:
-    annotations:
+    annotations: {}
   edgeConnect:
-    annotations:
+    annotations: {}
   extensions:
-    annotations:
+    annotations: {}
   logModule:
-    annotations:
+    annotations: {}
   oneAgent:
-    annotations:
+    annotations: {}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

The operator deploys service accounts for all components deployed in the cluster. 
This PR enables adding labels to these service accounts.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Set the rbac values in the values.yaml and check if the labels are there in the service accounts.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->