### PR TITLE
fixup: set SA name for ec test

### DIFF
--- a/test/features/support_archive/support_archive.go
+++ b/test/features/support_archive/support_archive.go
@@ -63,11 +63,13 @@ func Feature(t *testing.T) features.Feature {
 	testEdgeConnect := *edgeconnectComponents.New(
 		// this name should match with tenant edge connect name
 		edgeconnectComponents.WithName(edgeconnectSecretConfig.Name),
+		edgeconnectComponents.WithServiceAccountName("ec-service-account"),
 		edgeconnectComponents.WithApiServer(edgeconnectSecretConfig.ApiServer),
 		edgeconnectComponents.WithOAuthClientSecret(fmt.Sprintf("%s-client-secret", edgeconnectSecretConfig.Name)),
 		edgeconnectComponents.WithOAuthEndpoint("https://sso-dev.dynatracelabs.com/sso/oauth2/token"),
 		edgeconnectComponents.WithOAuthResource(fmt.Sprintf("urn:dtenvironment:%s", edgeconnectSecretConfig.TenantUid)),
 	)
+	testEdgeConnect.Spec.ServiceAccountName = "test"
 
 	builder.Assess("deploy injected namespace", namespace.Create(*namespace.New(testAppNameInjected, namespace.WithLabels(injectLabels))))
 	builder.Assess("deploy NOT injected namespace", namespace.Create(*namespace.New(testAppNameNotInjected)))

--- a/test/helpers/components/edgeconnect/options.go
+++ b/test/helpers/components/edgeconnect/options.go
@@ -36,6 +36,12 @@ func WithName(name string) Option {
 	}
 }
 
+func WithServiceAccountName(name string) Option {
+	return func(ec *edgeconnect.EdgeConnect) {
+		ec.Spec.ServiceAccountName = name
+	}
+}
+
 func WithApiServer(apiURL string) Option {
 	return func(ec *edgeconnect.EdgeConnect) {
 		ec.Spec.ApiServer = apiURL


### PR DESCRIPTION

## Description

Problem:

```
=== Failed
=== FAIL: test/scenarios/standard TestStandard/support-archive/'e2e-test'_edgeconnect_created (0.01s)
    edgeconnect.go:45: 
        	Error Trace:	/runner/_work/dynatrace-operator/dynatrace-operator/target/test/helpers/components/edgeconnect/edgeconnect.go:45
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.4.0/pkg/env/env.go:444
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.4.0/pkg/env/env.go:483
        	Error:      	Received unexpected error:
        	            	EdgeConnect.dynatrace.com "e2e-test" is invalid: spec.serviceAccountName: Invalid value: "": spec.serviceAccountName in body should be at least 1 chars long
        	Test:       	TestStandard/support-archive/'e2e-test'_edgeconnect_created
        --- FAIL: TestStandard/support-archive/'e2e-test'_edgeconnect_created (0.01s)
```

related to https://github.com/Dynatrace/dynatrace-operator/pull/3763

## How can this be tested?

```make test/e2e/supportarchive```