### PR TITLE
Revert kubebuilder minimal length tag and go back to custom validation

### DIFF
--- a/config/crd/bases/dynatrace.com_edgeconnects.yaml
+++ b/config/crd/bases/dynatrace.com_edgeconnects.yaml
@@ -963,7 +963,6 @@ spec:
                 default: dynatrace-edgeconnect
                 description: ServiceAccountName that allows EdgeConnect to access
                   the Kubernetes API
-                minLength: 1
                 type: string
               tolerations:
                 description: Sets tolerations for the EdgeConnect pods

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -8312,7 +8312,6 @@ spec:
                 default: dynatrace-edgeconnect
                 description: ServiceAccountName that allows EdgeConnect to access
                   the Kubernetes API
-                minLength: 1
                 type: string
               tolerations:
                 description: Sets tolerations for the EdgeConnect pods

--- a/pkg/api/v1alpha2/edgeconnect/edgeconnect_types.go
+++ b/pkg/api/v1alpha2/edgeconnect/edgeconnect_types.go
@@ -57,8 +57,7 @@ type EdgeConnectSpec struct { //nolint:revive
 
 	// ServiceAccountName that allows EdgeConnect to access the Kubernetes API
 	// +kubebuilder:default:=dynatrace-edgeconnect
-	// +kubebuilder:validation:MinLength=1
-	ServiceAccountName string `json:"serviceAccountName"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// EdgeConnect uses the OAuth client to authenticate itself with the Dynatrace platform.
 	// +kubebuilder:validation:Required

--- a/pkg/api/v1alpha2/edgeconnect/validation/api_server_test.go
+++ b/pkg/api/v1alpha2/edgeconnect/validation/api_server_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -12,15 +11,6 @@ const (
 	testName      = "test-name"
 	testNamespace = "test-namespace"
 )
-
-func prepareTestServiceAccount(name string, namespace string) *corev1.ServiceAccount {
-	return &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-}
 
 func TestApiServer(t *testing.T) {
 	t.Run(`happy apiServer`, func(t *testing.T) {

--- a/pkg/api/v1alpha2/edgeconnect/validation/service_account.go
+++ b/pkg/api/v1alpha2/edgeconnect/validation/service_account.go
@@ -1,0 +1,19 @@
+package validation
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+	"golang.org/x/net/context"
+)
+
+const (
+	errorInvalidServiceName = `The EdgeConnect's specification has an invalid serviceAccountName.
+`
+)
+
+func isInvalidServiceName(_ context.Context, _ *Validator, edgeConnectCR *edgeconnect.EdgeConnect) string {
+	if edgeConnectCR.Spec.ServiceAccountName == "" {
+		return errorInvalidServiceName
+	}
+
+	return ""
+}

--- a/pkg/api/v1alpha2/edgeconnect/validation/service_account_test.go
+++ b/pkg/api/v1alpha2/edgeconnect/validation/service_account_test.go
@@ -1,0 +1,29 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestServiceAccountName(t *testing.T) {
+	t.Run("empty name", func(t *testing.T) {
+		ec := &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				ServiceAccountName: "",
+			},
+		}
+		assertDenied(t, []string{errorInvalidServiceName}, ec)
+	})
+}
+
+func prepareTestServiceAccount(name string, namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}

--- a/pkg/api/v1alpha2/edgeconnect/validation/validation.go
+++ b/pkg/api/v1alpha2/edgeconnect/validation/validation.go
@@ -23,6 +23,7 @@ var validatorErrorFuncs = []validatorFunc{
 	isInvalidApiServer,
 	nameTooLong,
 	checkHostPatternsValue,
+	isInvalidServiceName,
 	automationRequiresProvisionerValidation,
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

As the kubebuilder tags do not work as we hoped they would, we decided to remove this one again.

Reverts: https://github.com/Dynatrace/dynatrace-operator/pull/3763

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- run `make test/e2e/supportarchive`

- apply an `edgeconnect` with an empty `serviceAccount` name

- unit tests

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->