### PR TITLE
Do not inject into ignored namespaces after adding a namespace to the annotation

### DIFF
--- a/pkg/injection/namespace/mapper/mapper.go
+++ b/pkg/injection/namespace/mapper/mapper.go
@@ -62,6 +62,10 @@ func setUpdatedViaDynakubeAnnotation(ns *corev1.Namespace) {
 }
 
 func match(dk *dynakube.DynaKube, namespace *corev1.Namespace) (bool, error) {
+	if isIgnoredNamespace(dk, namespace.Name) {
+		return false, nil
+	}
+
 	matchesOneAgent, err := matchOneAgent(dk, namespace)
 	if err != nil {
 		return false, err
@@ -116,9 +120,6 @@ func updateNamespace(namespace *corev1.Namespace, deployedDynakubes *dynakube.Dy
 
 	for i := range deployedDynakubes.Items {
 		dk := &deployedDynakubes.Items[i]
-		if isIgnoredNamespace(dk, namespace.Name) {
-			continue
-		}
 
 		matches, err := match(dk, namespace)
 		if err != nil {

--- a/pkg/injection/namespace/mapper/mapper_test.go
+++ b/pkg/injection/namespace/mapper/mapper_test.go
@@ -211,7 +211,7 @@ func TestUpdateNamespace(t *testing.T) {
 		require.True(t, updated)
 		assert.Empty(t, namespace.Labels)
 	})
-	t.Run("Do not inject into pods when adding namespace to ignored namespaces", func(t *testing.T) {
+	t.Run("Remove injection label from ignored-namespaces if present from previous setup", func(t *testing.T) {
 		labels := map[string]string{"test": "selector"}
 		dk := createDynakubeWithAppInject("dk-test", convertToLabelSelector(labels))
 		namespace := createNamespace("test-namespace", labels)

--- a/pkg/injection/namespace/mapper/mapper_test.go
+++ b/pkg/injection/namespace/mapper/mapper_test.go
@@ -211,4 +211,22 @@ func TestUpdateNamespace(t *testing.T) {
 		require.True(t, updated)
 		assert.Empty(t, namespace.Labels)
 	})
+	t.Run("Do not inject into pods when adding namespace to ignored namespaces", func(t *testing.T) {
+		labels := map[string]string{"test": "selector"}
+		dk := createDynakubeWithAppInject("dk-test", convertToLabelSelector(labels))
+		namespace := createNamespace("test-namespace", labels)
+
+		updated, err := updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*dk}})
+
+		require.NoError(t, err)
+		require.True(t, updated)
+		assert.Len(t, namespace.Labels, 2)
+		require.Equal(t, namespace.Labels[dtwebhook.InjectionInstanceLabel], dk.Name)
+		dk.SetAnnotations(map[string]string{dynakube.AnnotationFeatureIgnoredNamespaces: "[\"" + namespace.Name + "\"]"})
+		updated, err = updateNamespace(namespace, &dynakube.DynaKubeList{Items: []dynakube.DynaKube{*dk}})
+
+		require.NoError(t, err)
+		require.True(t, updated)
+		assert.Len(t, namespace.Labels, 1)
+	})
 }


### PR DESCRIPTION
[K8S-11291](https://dt-rnd.atlassian.net/browse/K8S-11291)

## Description

Problem: When updating a DK with the annotation `feature.dynatrace.com/ignored-namespaces` to include a namespace that should NOT be injected we still inject if it was injected before.

This PR corrects this behaviour.

## How can this be tested?

1. Apply a DK.
2. Deploy a sample application into a namespace `sample-ns` and make sure it get's injected.
3. Update the DK:
   ```
   metadata:
     annotations:
       feature.dynatrace.com/ignored-namespaces: '["sample-ns.*", "^kube-.*", "^gke-.*", "^gmp-.*",  "dynatrace"]'
   ```
4. Restart the pod of the sample application.
   Make sure the sample application is not injected.
