### PR TITLE
Add DEFAULT_TIMEOUT to destro_cluster to avoid error

### DIFF
--- a/.github/scripts/destroy-cluster.sh
+++ b/.github/scripts/destroy-cluster.sh
@@ -2,6 +2,8 @@
 
 set -x
 
+DEFAULT_TIMEOUT="20m"
+
 echo "Destroying environment '$FLC_ENVIRONMENT' in namespace '$FLC_NAMESPACE'"
 
 kubectl get flcenvironments --namespace "$FLC_NAMESPACE"


### PR DESCRIPTION
## Description

Problem:

```
Patching environment 'dto-k8s-latest-flc' to 'not-deployed'
flcenvironment.asperitas.dynatrace.com/dto-k8s-latest-flc patched
+ kubectl wait --namespace dto-daily --timeout= --for 'jsonpath={.status.currentState}=environment-not-deployed' flcenvironment dto-k8s-latest-flc
error: invalid argument "" for "--timeout" flag: time: invalid duration ""
```
