### PR TITLE
Fix ondemand pipeline using wrong branch for setup scripts

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -52,8 +52,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          ref: ${{ env.branch }}
       - name: Run e2e test
         uses: ./.github/actions/run-e2e
         with:


### PR DESCRIPTION
## Description

on demand action is using release branch scripts to run e2e tests, wich is wrong

## How can this be tested?

Run ondemand piplines and check if they use the correct branch