### PR TITLE
Do not inject into ignored namespaces after adding a namespace to the annotation

### DIFF
--- a/pkg/injection/namespace/mapper/mapper.go
+++ b/pkg/injection/namespace/mapper/mapper.go
@@ -62,6 +62,10 @@ func setUpdatedViaDynakubeAnnotation(ns *corev1.Namespace) {
 }
 
 func match(dk *dynakube.DynaKube, namespace *corev1.Namespace) (bool, error) {
+	if isIgnoredNamespace(dk, namespace.Name) {
+		return false, nil
+	}
+
 	matchesOneAgent, err := matchOneAgent(dk, namespace)
 	if err != nil {
 		return false, err
@@ -116,9 +120,6 @@ func updateNamespace(namespace *corev1.Namespace, deployedDynakubes *dynakube.Dy
 
 	for i := range deployedDynakubes.Items {
 		dk := &deployedDynakubes.Items[i]
-		if isIgnoredNamespace(dk, namespace.Name) {
-			continue
-		}
 
 		matches, err := match(dk, namespace)
 		if err != nil {


### PR DESCRIPTION
cherrypick of #3809

[K8S-11291](https://dt-rnd.atlassian.net/browse/K8S-11291)

## Description

Problem: When updating a DK with the annotation `feature.dynatrace.com/ignored-namespaces` to include a namespace that should NOT be injected we still inject if it was injected before.

This PR corrects this behaviour.

## How can this be tested?

1. Apply a DK.
2. Deploy a sample application into a namespace `sample-ns` and make sure it get's injected.
3. Update the DK:
   ```
   metadata:
     annotations:
       feature.dynatrace.com/ignored-namespaces: '["sample-ns.*", "^kube-.*", "^gke-.*", "^gmp-.*",  "dynatrace"]'
   ```
4. Restart the pod of the sample application.
   Make sure the sample application is not injected.
