### PR TITLE
Add wait for secret is created, before getting it

### DIFF
--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -8,6 +8,9 @@ cd target
 FLC_ENVIRONMENT_KUBECONFIG="$RUNNER_TEMP/environment-kubeconfig"
 FLC_ENVIRONMENT_SECRET_NAME="$FLC_ENVIRONMENT-kubeconfig"
 
+echo "Wait 30s for secret is created '$FLC_ENVIRONMENT_SECRET_NAME'"
+kubectl wait --timeout=30s --for=create secret --namespace "$FLC_NAMESPACE" "$FLC_ENVIRONMENT_SECRET_NAME"
+
 echo "Loading kubeconfig from secret for environment '$FLC_ENVIRONMENT' from namespace '$FLC_NAMESPACE'"
 kubectl get secret --namespace "$FLC_NAMESPACE" "$FLC_ENVIRONMENT_SECRET_NAME" -o jsonpath='{.data.kubeconfig}' | base64 --decode > "$FLC_ENVIRONMENT_KUBECONFIG"
 


### PR DESCRIPTION
## Description
Add wait for secret is created, before getting it for running e2e tests
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

you can test concept seperatly, or we can trigger e2e test from branch.
```
kubectl wait --for=create secret andrii-test-client-secret
secret/andrii-test-client-secret condition met
```