### PR TITLE
Add rbac turn-off option in Helm values.yaml

### DIFF
--- a/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
@@ -1,5 +1,4 @@
-{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
-{{- if .Values.rbac.activeGate.create }}
+{{- if and .Values.rbac.activeGate.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,5 +43,4 @@ roleRef:
   kind: ClusterRole
   name: dynatrace-activegate
   apiGroup: rbac.authorization.k8s.io
-{{ end }}
 {{ end }}

--- a/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
@@ -1,5 +1,5 @@
 {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
-
+{{- if .Values.rbac.activeGate.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,4 +44,5 @@ roleRef:
   kind: ClusterRole
   name: dynatrace-activegate
   apiGroup: rbac.authorization.k8s.io
-{{- end -}}
+{{ end }}
+{{ end }}

--- a/config/helm/chart/default/templates/Common/activegate/serviceaccount-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/serviceaccount-activegate.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.activeGate.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,3 +23,4 @@ metadata:
   {{- end }}
   labels:
     {{- include "dynatrace-operator.activegateLabels" . | nindent 4 }}
+{{ end }}

--- a/config/helm/chart/default/templates/Common/edge-connect/serviceaccount-edgeconnect.yaml
+++ b/config/helm/chart/default/templates/Common/edge-connect/serviceaccount-edgeconnect.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.edgeConnect.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,3 +23,4 @@ metadata:
   {{- end }}
   labels:
     {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
+{{ end }}

--- a/config/helm/chart/default/templates/Common/extensions-controller/role-extensions-controller.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-controller/role-extensions-controller.yaml
@@ -1,5 +1,4 @@
-{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
-{{- if .Values.rbac.extensions.create }}
+{{- if and .Values.rbac.extensions.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,5 +39,4 @@ roleRef:
   kind: Role
   name: dynatrace-extensions-controller
   apiGroup: rbac.authorization.k8s.io
-{{ end }}
 {{ end }}

--- a/config/helm/chart/default/templates/Common/extensions-controller/role-extensions-controller.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-controller/role-extensions-controller.yaml
@@ -1,4 +1,5 @@
 {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if .Values.rbac.extensions.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,4 +40,5 @@ roleRef:
   kind: Role
   name: dynatrace-extensions-controller
   apiGroup: rbac.authorization.k8s.io
+{{ end }}
 {{ end }}

--- a/config/helm/chart/default/templates/Common/extensions-controller/serviceaccount-extensions-controller.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-controller/serviceaccount-extensions-controller.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.extensions.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,4 +23,4 @@ metadata:
   {{- end }}
   labels:
     {{- include "dynatrace-operator.extensionsControllerLabels" . | nindent 4 }}
-
+{{ end }}

--- a/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.extensions.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,3 +53,4 @@ subjects:
   - kind: ServiceAccount
     name: dynatrace-extensions-collector
     namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.extensions.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,4 +23,4 @@ metadata:
   {{- end }}
   labels:
     {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
-
+{{ end }}

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.activeGate.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -112,3 +113,4 @@ subjects:
   - kind: ServiceAccount
     name: dynatrace-kubernetes-monitoring
     namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.activeGate.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,3 +23,4 @@ metadata:
   {{- end }}
   labels:
     {{- include "dynatrace-operator.activegateLabels" . | nindent 4 }}
+{{ end }}

--- a/config/helm/chart/default/templates/Common/logmodule/clusterrole-logmodule.yaml
+++ b/config/helm/chart/default/templates/Common/logmodule/clusterrole-logmodule.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.logModule.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,3 +48,4 @@ subjects:
 - kind: ServiceAccount
   name: dynatrace-logmodule
   namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/config/helm/chart/default/templates/Common/logmodule/clusterrole-logmodule.yaml
+++ b/config/helm/chart/default/templates/Common/logmodule/clusterrole-logmodule.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.logModule.create }}
+{{- if and .Values.rbac.logModule.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/logmodule/serviceaccount-logmodule.yaml
+++ b/config/helm/chart/default/templates/Common/logmodule/serviceaccount-logmodule.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.logModule.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,3 +23,4 @@ metadata:
   {{- end }}
   labels:
     {{- include "dynatrace-operator.logModuleLabels" . | nindent 4 }}
+{{ end }}

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent.yaml
@@ -1,4 +1,5 @@
 {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if .Values.rbac.oneAgent.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,4 +43,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: dynatrace-dynakube-oneagent
+{{ end }}
 {{ end }}

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent.yaml
@@ -1,5 +1,4 @@
-{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
-{{- if .Values.rbac.oneAgent.create }}
+{{- if and .Values.rbac.oneAgent.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,5 +42,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: dynatrace-dynakube-oneagent
-{{ end }}
 {{ end }}

--- a/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.oneAgent.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,3 +24,4 @@ metadata:
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
 automountServiceAccountToken: false
+{{ end }}

--- a/config/helm/chart/default/templates/Common/operator/install-config.yaml
+++ b/config/helm/chart/default/templates/Common/operator/install-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: operator-config
+  name: install-config
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}

--- a/config/helm/chart/default/templates/Common/operator/operator-config.yaml
+++ b/config/helm/chart/default/templates/Common/operator/operator-config.yaml
@@ -3,16 +3,14 @@ kind: ConfigMap
 metadata:
   name: operator-config
   namespace: {{ .Release.Namespace }}
-  annotations:
-  {{- if .Values.operator.annotations }}
-    {{- toYaml .Values.operator.annotations | nindent 4 }}
-  {{- end }}
+  labels:
+    {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
 data:
   modules.json: |
     {
-      "activeGate": {{ .Values.rbac.activeGate.create | default true }},
-      "oneAgent": {{ .Values.rbac.oneAgent.create | default true }},
-      "extensions": {{ .Values.rbac.extensions.create | default true }},
-      "logModule": {{ .Values.rbac.logModule.create | default true }},
-      "edgeConnect": {{ .Values.rbac.edgeConnect.create | default true }}
+      "activeGate": {{ .Values.rbac.activeGate.create }},
+      "oneAgent": {{ .Values.rbac.oneAgent.create }},
+      "extensions": {{ .Values.rbac.extensions.create }},
+      "logModule": {{ .Values.rbac.logModule.create }},
+      "edgeConnect": {{ .Values.rbac.edgeConnect.create }}
     }

--- a/config/helm/chart/default/templates/Common/operator/operator-config.yaml
+++ b/config/helm/chart/default/templates/Common/operator/operator-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-config
+  namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- if .Values.operator.annotations }}
+    {{- toYaml .Values.operator.annotations | nindent 4 }}
+  {{- end }}
+data:
+  modules.json: |
+    {
+      "activeGate": {{ .Values.rbac.activeGate.create | default true }},
+      "oneAgent": {{ .Values.rbac.oneAgent.create | default true }},
+      "extensions": {{ .Values.rbac.extensions.create | default true }},
+      "logModule": {{ .Values.rbac.logModule.create | default true }},
+      "edgeConnect": {{ .Values.rbac.edgeConnect.create | default true }}
+    }

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -87,6 +87,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          envFrom:
+            - configMapRef:
+                name: operator-config
           readinessProbe:
             httpGet:
               path: /readyz

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -89,7 +89,7 @@ spec:
                   fieldPath: metadata.name
           envFrom:
             - configMapRef:
-                name: operator-config
+                name: install-config
           readinessProbe:
             httpGet:
               path: /readyz

--- a/config/helm/chart/default/tests/Common/activegate/serviceaccount-activegate_test.yaml
+++ b/config/helm/chart/default/tests/Common/activegate/serviceaccount-activegate_test.yaml
@@ -13,3 +13,9 @@ tests:
             path: metadata.annotations
             value:
               test: test
+  - it: shouldn't exist if turned off
+    set:
+      rbac.activeGate.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/edgeconnect/serviceaccount-edgeconnect_test.yaml
+++ b/config/helm/chart/default/tests/Common/edgeconnect/serviceaccount-edgeconnect_test.yaml
@@ -13,3 +13,9 @@ tests:
             path: metadata.annotations
             value:
               test: test
+  - it: shouldn't exist if turned off
+    set:
+      rbac.edgeConnect.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/extensions-controller/role-extensions-controller_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-controller/role-extensions-controller_test.yaml
@@ -44,6 +44,7 @@ tests:
           path: metadata.labels
   - it: shouldn't exist if turned off
     set:
+      platform: openshift
       rbac.extensions.create: false
     asserts:
       - hasDocuments:

--- a/config/helm/chart/default/tests/Common/extensions-controller/role-extensions-controller_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-controller/role-extensions-controller_test.yaml
@@ -42,3 +42,9 @@ tests:
           value: dynatrace-extensions-controller
       - isNotEmpty:
           path: metadata.labels
+  - it: shouldn't exist if turned off
+    set:
+      rbac.extensions.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/extensions-controller/serviceaccount-extensions-controller_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-controller/serviceaccount-extensions-controller_test.yaml
@@ -28,3 +28,9 @@ tests:
           path: metadata.annotations
           value:
             test: test
+  - it: shouldn't exist if turned off
+    set:
+      rbac.extensions.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector_test.yaml
@@ -53,3 +53,10 @@ tests:
           value: prometheus-service-detector
       - isNotEmpty:
           path: metadata.labels
+
+  - it: shouldn't exist if turned off
+    set:
+      rbac.extensions.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/serviceaccount-extensions-opentelemetry-collector_test.yaml
@@ -16,3 +16,10 @@ tests:
           value: NAMESPACE
       - isNotEmpty:
           path: metadata.labels
+
+  - it: shouldn't exist if turned off
+    set:
+      rbac.extensions.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
@@ -149,3 +149,9 @@ tests:
             kind: ServiceAccount
             name: dynatrace-kubernetes-monitoring
             namespace: NAMESPACE
+  - it: shouldn't exist if turned off
+    set:
+      rbac.activeGate.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring_test.yaml
@@ -28,3 +28,9 @@ tests:
           path: metadata.annotations
           value:
             test: test
+  - it: shouldn't exist if turned off
+    set:
+      rbac.activeGate.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/logmodule/clusterrole-logmodule_test.yaml
+++ b/config/helm/chart/default/tests/Common/logmodule/clusterrole-logmodule_test.yaml
@@ -33,3 +33,9 @@ tests:
           value: dynatrace-logmodule
       - isNotEmpty:
           path: metadata.labels
+  - it: shouldn't exist if turned off
+    set:
+      rbac.logModule.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/logmodule/clusterrole-logmodule_test.yaml
+++ b/config/helm/chart/default/tests/Common/logmodule/clusterrole-logmodule_test.yaml
@@ -3,6 +3,8 @@ templates:
   - Common/logmodule/clusterrole-logmodule.yaml
 tests:
   - it: logmodule ClusterRole should exist
+    set:
+      platform: openshift
     documentIndex: 0
     asserts:
       - isKind:
@@ -25,6 +27,8 @@ tests:
               - use
   - it: logmodule ClusterRoleBinding should exist
     documentIndex: 1
+    set:
+      platform: openshift
     asserts:
       - isKind:
           of: ClusterRoleBinding
@@ -33,6 +37,13 @@ tests:
           value: dynatrace-logmodule
       - isNotEmpty:
           path: metadata.labels
+  - it: shouldn't exist if not openshift
+    set:
+      rbac.logModule.create: true
+      platform: NOT-openshift
+    asserts:
+      - hasDocuments:
+        count: 0
   - it: shouldn't exist if turned off
     set:
       rbac.logModule.create: false

--- a/config/helm/chart/default/tests/Common/logmodule/serviceaccount-logmodule_test.yaml
+++ b/config/helm/chart/default/tests/Common/logmodule/serviceaccount-logmodule_test.yaml
@@ -26,3 +26,9 @@ tests:
           path: metadata.annotations
           value:
             test: test
+  - it: shouldn't exist if turned off
+    set:
+      rbac.logModule.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/oneagent/clusterrole-oneagent_test.yaml
+++ b/config/helm/chart/default/tests/Common/oneagent/clusterrole-oneagent_test.yaml
@@ -42,3 +42,9 @@ tests:
           value: dynatrace-dynakube-oneagent
       - isNotEmpty:
           path: metadata.labels
+  - it: shouldn't exist if turned off
+    set:
+      rbac.oneAgent.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent_test.yaml
+++ b/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent_test.yaml
@@ -38,4 +38,9 @@ tests:
             path: metadata.annotations
             value:
               test: test
-
+  - it: shouldn't exist if turned off
+    set:
+      rbac.oneAgent.create: false
+    asserts:
+      - hasDocuments:
+        count: 0

--- a/config/helm/chart/default/tests/Common/operator/install-config_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/install-config_test.yaml
@@ -1,12 +1,12 @@
 suite: test role for oneagent on kubernetes
 templates:
-  - Common/operator/operator-config.yaml
+  - Common/operator/install-config.yaml
 tests:
   - it: ConfigMap should exist
     asserts:
       - equal:
           path: metadata.name
-          value: operator-config
+          value: install-config
       - equal:
           path: metadata.namespace
           value: NAMESPACE
@@ -33,7 +33,7 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: operator-config
+          value: install-config
       - equal:
           path: metadata.namespace
           value: NAMESPACE

--- a/config/helm/chart/default/tests/Common/operator/operator-config_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/operator-config_test.yaml
@@ -1,0 +1,52 @@
+suite: test role for oneagent on kubernetes
+templates:
+  - Common/operator/operator-config.yaml
+tests:
+  - it: ConfigMap should exist
+    asserts:
+      - equal:
+          path: metadata.name
+          value: operator-config
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - isNotEmpty:
+          path: metadata.labels
+      - equal:
+          path: data
+          value:
+            modules.json: |
+                {
+                  "activeGate": true,
+                  "oneAgent": true,
+                  "extensions": true,
+                  "logModule": true,
+                  "edgeConnect": true
+                }
+  - it: ConfigMap should respect the set values
+    set:
+      rbac.oneAgent.create: false
+      rbac.logModule.create: false
+      rbac.edgeConnect.create: false
+      rbac.activeGate.create: false
+      rbac.extensions.create: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: operator-config
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - isNotEmpty:
+          path: metadata.labels
+      - equal:
+          path: data
+          value:
+            modules.json: |
+                {
+                  "activeGate": false,
+                  "oneAgent": false,
+                  "extensions": false,
+                  "logModule": false,
+                  "edgeConnect": false
+                }

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -69,7 +69,7 @@ tests:
                     internal.dynatrace.com/app: webhook
                     internal.dynatrace.com/component: webhook
             volumes:
-              - emptyDir: { }
+              - emptyDir: {}
                 name: certs-dir
             affinity:
               nodeAffinity:
@@ -116,6 +116,9 @@ tests:
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.name
+                envFrom:
+                  - configMapRef:
+                      name: operator-config
                 livenessProbe:
                   httpGet:
                     path: /livez
@@ -172,24 +175,24 @@ tests:
           key: a-special-taint
           value: a-special-value
     asserts:
-    - equal:
-        path: spec.template.spec.tolerations
-        value:
-          - effect: NoSchedule
-            key: a-special-taint
-            value: a-special-value
-          - effect: NoSchedule
-            key: kubernetes.io/arch
-            value: arm64
-          - effect: NoSchedule
-            key: kubernetes.io/arch
-            value: amd64
-          - effect: NoSchedule
-            key: kubernetes.io/arch
-            value: ppc64le
-          - effect: NoSchedule
-            key: kubernetes.io/arch
-            value: s390x
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - effect: NoSchedule
+              key: a-special-taint
+              value: a-special-value
+            - effect: NoSchedule
+              key: kubernetes.io/arch
+              value: arm64
+            - effect: NoSchedule
+              key: kubernetes.io/arch
+              value: amd64
+            - effect: NoSchedule
+              key: kubernetes.io/arch
+              value: ppc64le
+            - effect: NoSchedule
+              key: kubernetes.io/arch
+              value: s390x
 
   - it: should have nodeSelectors if set
     set:
@@ -197,10 +200,10 @@ tests:
       webhook.nodeSelector:
         test-key: test-value
     asserts:
-    - equal:
-        path: spec.template.spec.nodeSelector
-        value:
-          test-key: test-value
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            test-key: test-value
 
   - it: should exist (without highavailabilty mode)
     set:
@@ -294,6 +297,9 @@ tests:
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.name
+                envFrom:
+                  - configMapRef:
+                      name: operator-config
                 livenessProbe:
                   httpGet:
                     path: /livez
@@ -437,6 +443,9 @@ tests:
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.name
+                envFrom:
+                  - configMapRef:
+                      name: operator-config
                 livenessProbe:
                   httpGet:
                     path: /livez

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -118,7 +118,7 @@ tests:
                         fieldPath: metadata.name
                 envFrom:
                   - configMapRef:
-                      name: operator-config
+                      name: install-config
                 livenessProbe:
                   httpGet:
                     path: /livez
@@ -299,7 +299,7 @@ tests:
                         fieldPath: metadata.name
                 envFrom:
                   - configMapRef:
-                      name: operator-config
+                      name: install-config
                 livenessProbe:
                   httpGet:
                     path: /livez
@@ -445,7 +445,7 @@ tests:
                         fieldPath: metadata.name
                 envFrom:
                   - configMapRef:
-                      name: operator-config
+                      name: install-config
                 livenessProbe:
                   httpGet:
                     path: /livez

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -196,12 +196,17 @@ csidriver:
 
 rbac:
   activeGate:
+    create: true
     annotations: {}
   edgeConnect:
+    create: true
     annotations: {}
   extensions:
+    create: true
     annotations: {}
   logModule:
+    create: true
     annotations: {}
   oneAgent:
+    create: true
     annotations: {}

--- a/pkg/api/validation/dynakube/module_test.go
+++ b/pkg/api/validation/dynakube/module_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +15,7 @@ func TestIsModuleDisabled(t *testing.T) {
 	type testCase struct {
 		title           string
 		dk              dynakube.DynaKube
-		modules         operatorconfig.Modules
+		modules         installconfig.Modules
 		moduleFunc      validatorFunc
 		expectedMessage string
 	}
@@ -24,84 +24,84 @@ func TestIsModuleDisabled(t *testing.T) {
 		{
 			title:           "oa module disabled but also configured in dk => error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{OneAgent: dynakube.OneAgentSpec{CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}}}},
-			modules:         operatorconfig.Modules{OneAgent: false},
+			modules:         installconfig.Modules{OneAgent: false},
 			moduleFunc:      isOneAgentModuleDisabled,
 			expectedMessage: errorOneAgentModuleDisabled,
 		},
 		{
 			title:           "oa module disabled but not configured => no error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{OneAgent: dynakube.OneAgentSpec{CloudNativeFullStack: nil}}},
-			modules:         operatorconfig.Modules{OneAgent: false},
+			modules:         installconfig.Modules{OneAgent: false},
 			moduleFunc:      isOneAgentModuleDisabled,
 			expectedMessage: "",
 		},
 		{
 			title:           "oa module enabled and also configured => no error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{OneAgent: dynakube.OneAgentSpec{CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}}}},
-			modules:         operatorconfig.Modules{OneAgent: true},
+			modules:         installconfig.Modules{OneAgent: true},
 			moduleFunc:      isOneAgentModuleDisabled,
 			expectedMessage: "",
 		},
 		{
 			title:           "ag module disabled but also configured in dk => error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}}}},
-			modules:         operatorconfig.Modules{ActiveGate: false},
+			modules:         installconfig.Modules{ActiveGate: false},
 			moduleFunc:      isActiveGateModuleDisabled,
 			expectedMessage: errorActiveGateModuleDisabled,
 		},
 		{
 			title:           "ag module disabled but not configured => no error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{}},
-			modules:         operatorconfig.Modules{ActiveGate: false},
+			modules:         installconfig.Modules{ActiveGate: false},
 			moduleFunc:      isActiveGateModuleDisabled,
 			expectedMessage: "",
 		},
 		{
 			title:           "ag module enabled and also configured => no error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}}}},
-			modules:         operatorconfig.Modules{ActiveGate: true},
+			modules:         installconfig.Modules{ActiveGate: true},
 			moduleFunc:      isActiveGateModuleDisabled,
 			expectedMessage: "",
 		},
 		{
 			title:           "ecc module disabled but also configured in dk => error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{Extensions: dynakube.ExtensionsSpec{Enabled: true}}},
-			modules:         operatorconfig.Modules{Extensions: false},
+			modules:         installconfig.Modules{Extensions: false},
 			moduleFunc:      isExtensionsModuleDisabled,
 			expectedMessage: errorExtensionsModuleDisabled,
 		},
 		{
 			title:           "ecc module disabled but not configured => no error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{}},
-			modules:         operatorconfig.Modules{Extensions: false},
+			modules:         installconfig.Modules{Extensions: false},
 			moduleFunc:      isExtensionsModuleDisabled,
 			expectedMessage: "",
 		},
 		{
 			title:           "ecc module enabled and also configured => no error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{Extensions: dynakube.ExtensionsSpec{Enabled: true}}},
-			modules:         operatorconfig.Modules{Extensions: true},
+			modules:         installconfig.Modules{Extensions: true},
 			moduleFunc:      isExtensionsModuleDisabled,
 			expectedMessage: "",
 		},
 		{
 			title:           "logmodule module disabled but also configured in dk => error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{LogModule: dynakube.LogModuleSpec{Enabled: true}}},
-			modules:         operatorconfig.Modules{LogModule: false},
+			modules:         installconfig.Modules{LogModule: false},
 			moduleFunc:      isLogModuleModuleDisabled,
 			expectedMessage: errorLogModuleModuleDisabled,
 		},
 		{
 			title:           "logmodule module disabled but not configured => no error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{}},
-			modules:         operatorconfig.Modules{LogModule: false},
+			modules:         installconfig.Modules{LogModule: false},
 			moduleFunc:      isLogModuleModuleDisabled,
 			expectedMessage: "",
 		},
 		{
 			title:           "logmodule module enabled and also configured => no error",
 			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{LogModule: dynakube.LogModuleSpec{Enabled: true}}},
-			modules:         operatorconfig.Modules{LogModule: true},
+			modules:         installconfig.Modules{LogModule: true},
 			moduleFunc:      isLogModuleModuleDisabled,
 			expectedMessage: "",
 		},

--- a/pkg/api/validation/dynakube/module_test.go
+++ b/pkg/api/validation/dynakube/module_test.go
@@ -63,6 +63,48 @@ func TestIsModuleDisabled(t *testing.T) {
 			moduleFunc:      isActiveGateModuleDisabled,
 			expectedMessage: "",
 		},
+		{
+			title:           "ecc module disabled but also configured in dk => error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{Extensions: dynakube.ExtensionsSpec{Enabled: true}}},
+			modules:         operatorconfig.Modules{Extensions: false},
+			moduleFunc:      isExtensionsModuleDisabled,
+			expectedMessage: errorExtensionsModuleDisabled,
+		},
+		{
+			title:           "ecc module disabled but not configured => no error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{}},
+			modules:         operatorconfig.Modules{Extensions: false},
+			moduleFunc:      isExtensionsModuleDisabled,
+			expectedMessage: "",
+		},
+		{
+			title:           "ecc module enabled and also configured => no error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{Extensions: dynakube.ExtensionsSpec{Enabled: true}}},
+			modules:         operatorconfig.Modules{Extensions: true},
+			moduleFunc:      isExtensionsModuleDisabled,
+			expectedMessage: "",
+		},
+		{
+			title:           "logmodule module disabled but also configured in dk => error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{LogModule: dynakube.LogModuleSpec{Enabled: true}}},
+			modules:         operatorconfig.Modules{LogModule: false},
+			moduleFunc:      isLogModuleModuleDisabled,
+			expectedMessage: errorLogModuleModuleDisabled,
+		},
+		{
+			title:           "logmodule module disabled but not configured => no error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{}},
+			modules:         operatorconfig.Modules{LogModule: false},
+			moduleFunc:      isLogModuleModuleDisabled,
+			expectedMessage: "",
+		},
+		{
+			title:           "logmodule module enabled and also configured => no error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{LogModule: dynakube.LogModuleSpec{Enabled: true}}},
+			modules:         operatorconfig.Modules{LogModule: true},
+			moduleFunc:      isLogModuleModuleDisabled,
+			expectedMessage: "",
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/api/validation/dynakube/module_test.go
+++ b/pkg/api/validation/dynakube/module_test.go
@@ -1,0 +1,74 @@
+package validation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsModuleDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	type testCase struct {
+		title           string
+		dk              dynakube.DynaKube
+		modules         operatorconfig.Modules
+		moduleFunc      validatorFunc
+		expectedMessage string
+	}
+
+	testCases := []testCase{
+		{
+			title:           "oa module disabled but also configured in dk => error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{OneAgent: dynakube.OneAgentSpec{CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}}}},
+			modules:         operatorconfig.Modules{OneAgent: false},
+			moduleFunc:      isOneAgentModuleDisabled,
+			expectedMessage: errorOneAgentModuleDisabled,
+		},
+		{
+			title:           "oa module disabled but not configured => no error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{OneAgent: dynakube.OneAgentSpec{CloudNativeFullStack: nil}}},
+			modules:         operatorconfig.Modules{OneAgent: false},
+			moduleFunc:      isOneAgentModuleDisabled,
+			expectedMessage: "",
+		},
+		{
+			title:           "oa module enabled and also configured => no error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{OneAgent: dynakube.OneAgentSpec{CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{}}}},
+			modules:         operatorconfig.Modules{OneAgent: true},
+			moduleFunc:      isOneAgentModuleDisabled,
+			expectedMessage: "",
+		},
+		{
+			title:           "ag module disabled but also configured in dk => error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}}}},
+			modules:         operatorconfig.Modules{ActiveGate: false},
+			moduleFunc:      isActiveGateModuleDisabled,
+			expectedMessage: errorActiveGateModuleDisabled,
+		},
+		{
+			title:           "ag module disabled but not configured => no error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{}},
+			modules:         operatorconfig.Modules{ActiveGate: false},
+			moduleFunc:      isActiveGateModuleDisabled,
+			expectedMessage: "",
+		},
+		{
+			title:           "ag module enabled and also configured => no error",
+			dk:              dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{ActiveGate: dynakube.ActiveGateSpec{Capabilities: []dynakube.CapabilityDisplayName{dynakube.KubeMonCapability.DisplayName}}}},
+			modules:         operatorconfig.Modules{ActiveGate: true},
+			moduleFunc:      isActiveGateModuleDisabled,
+			expectedMessage: "",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.title, func(t *testing.T) {
+			errMsg := test.moduleFunc(ctx, &Validator{modules: test.modules}, &test.dk)
+			assert.Equal(t, test.expectedMessage, errMsg)
+		})
+	}
+}

--- a/pkg/api/validation/dynakube/modules.go
+++ b/pkg/api/validation/dynakube/modules.go
@@ -4,13 +4,14 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 )
 
-const (
-	errorOneAgentModuleDisabled   = `OneAgent features has been disabled during Operator install. The necessary resources for deploying a OneAgent DaemonSet to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
-	errorActiveGateModuleDisabled = `ActiveGate features has been disabled during Operator install. The necessary resources for deploying a ActiveGate Statefulset to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
-	errorExtensionsModuleDisabled = `Extensions features has been disabled during Operator install. The necessary resources for deploying components for the Extension feature to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
-	errorLogModuleModuleDisabled  = `LogModule features has been disabled during Operator install. The necessary resources for deploying a LogModule DaemonSet to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
+var (
+	errorOneAgentModuleDisabled   = installconfig.GetModuleValidationErrorMessage("OneAgent")
+	errorActiveGateModuleDisabled = installconfig.GetModuleValidationErrorMessage("ActiveGate")
+	errorExtensionsModuleDisabled = installconfig.GetModuleValidationErrorMessage("Extensions")
+	errorLogModuleModuleDisabled  = installconfig.GetModuleValidationErrorMessage("LogModule")
 )
 
 func isOneAgentModuleDisabled(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {

--- a/pkg/api/validation/dynakube/modules.go
+++ b/pkg/api/validation/dynakube/modules.go
@@ -1,0 +1,28 @@
+package validation
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+)
+
+const (
+	errorOneAgentModuleDisabled   = `OneAgent features has been disabled during Operator install. The necessary resources for deploying a OneAgent DaemonSet to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
+	errorActiveGateModuleDisabled = `ActiveGate features has been disabled during Operator install. The necessary resources for deploying a ActiveGate Statefulset to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
+)
+
+func isOneAgentModuleDisabled(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
+	if dk.NeedsOneAgent() && !v.modules.OneAgent {
+		return errorOneAgentModuleDisabled
+	}
+
+	return ""
+}
+
+func isActiveGateModuleDisabled(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
+	if dk.NeedsActiveGate() && !v.modules.ActiveGate {
+		return errorActiveGateModuleDisabled
+	}
+
+	return ""
+}

--- a/pkg/api/validation/dynakube/modules.go
+++ b/pkg/api/validation/dynakube/modules.go
@@ -9,6 +9,8 @@ import (
 const (
 	errorOneAgentModuleDisabled   = `OneAgent features has been disabled during Operator install. The necessary resources for deploying a OneAgent DaemonSet to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
 	errorActiveGateModuleDisabled = `ActiveGate features has been disabled during Operator install. The necessary resources for deploying a ActiveGate Statefulset to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
+	errorExtensionsModuleDisabled = `Extensions features has been disabled during Operator install. The necessary resources for deploying components for the Extension feature to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
+	errorLogModuleModuleDisabled  = `LogModule features has been disabled during Operator install. The necessary resources for deploying a LogModule DaemonSet to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
 )
 
 func isOneAgentModuleDisabled(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
@@ -22,6 +24,22 @@ func isOneAgentModuleDisabled(_ context.Context, v *Validator, dk *dynakube.Dyna
 func isActiveGateModuleDisabled(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
 	if dk.NeedsActiveGate() && !v.modules.ActiveGate {
 		return errorActiveGateModuleDisabled
+	}
+
+	return ""
+}
+
+func isExtensionsModuleDisabled(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
+	if dk.IsExtensionsEnabled() && !v.modules.Extensions {
+		return errorExtensionsModuleDisabled
+	}
+
+	return ""
+}
+
+func isLogModuleModuleDisabled(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
+	if dk.NeedsLogModule() && !v.modules.LogModule {
+		return errorLogModuleModuleDisabled
 	}
 
 	return ""

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -6,7 +6,7 @@ import (
 
 	v1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube" //nolint:staticcheck
 	v1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube" //nolint:staticcheck
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/validation"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,7 +18,7 @@ import (
 type Validator struct {
 	apiReader client.Reader
 	cfg       *rest.Config
-	modules   operatorconfig.Modules
+	modules   installconfig.Modules
 }
 
 var (
@@ -63,7 +63,7 @@ func New(apiReader client.Reader, cfg *rest.Config) admission.CustomValidator {
 	return &Validator{
 		apiReader: apiReader,
 		cfg:       cfg,
-		modules:   operatorconfig.GetModules(),
+		modules:   installconfig.GetModules(),
 	}
 }
 

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -6,8 +6,8 @@ import (
 
 	v1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube" //nolint:staticcheck
 	v1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube" //nolint:staticcheck
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -6,6 +6,7 @@ import (
 
 	v1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube" //nolint:staticcheck
 	v1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube" //nolint:staticcheck
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/validation"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,10 +18,13 @@ import (
 type Validator struct {
 	apiReader client.Reader
 	cfg       *rest.Config
+	modules   operatorconfig.Modules
 }
 
 var (
 	validatorErrorFuncs = []validatorFunc{
+		isOneAgentModuleDisabled,
+		isActiveGateModuleDisabled,
 		NoApiUrl,
 		IsInvalidApiUrl,
 		IsThirdGenAPIUrl,
@@ -57,6 +61,7 @@ func New(apiReader client.Reader, cfg *rest.Config) admission.CustomValidator {
 	return &Validator{
 		apiReader: apiReader,
 		cfg:       cfg,
+		modules:   operatorconfig.GetModules(),
 	}
 }
 

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -23,8 +23,10 @@ type Validator struct {
 
 var (
 	validatorErrorFuncs = []validatorFunc{
-		isOneAgentModuleDisabled,
 		isActiveGateModuleDisabled,
+		isExtensionsModuleDisabled,
+		isLogModuleModuleDisabled,
+		isOneAgentModuleDisabled,
 		NoApiUrl,
 		IsInvalidApiUrl,
 		IsThirdGenAPIUrl,

--- a/pkg/api/validation/dynakube/validation_test.go
+++ b/pkg/api/validation/dynakube/validation_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -208,7 +208,7 @@ func runValidators(dk *dynakube.DynaKube, other ...client.Object) (admission.War
 	validator := &Validator{
 		apiReader: clt,
 		cfg:       &rest.Config{},
-		modules:   operatorconfig.GetModules(),
+		modules:   installconfig.GetModules(),
 	}
 
 	return validator.ValidateCreate(context.Background(), dk)

--- a/pkg/api/validation/dynakube/validation_test.go
+++ b/pkg/api/validation/dynakube/validation_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -207,6 +208,7 @@ func runValidators(dk *dynakube.DynaKube, other ...client.Object) (admission.War
 	validator := &Validator{
 		apiReader: clt,
 		cfg:       &rest.Config{},
+		modules:   operatorconfig.GetModules(),
 	}
 
 	return validator.ValidateCreate(context.Background(), dk)

--- a/pkg/api/validation/edgeconnect/module.go
+++ b/pkg/api/validation/edgeconnect/module.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 )
 
-const (
-	errorModuleDisabled = `EdgeConnect has been disabled during Operator install. The necessary resources for EdgeConnect to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
+var (
+	errorModuleDisabled = installconfig.GetModuleValidationErrorMessage("EdgeConnect")
 )
 
 func isModuleDisabled(_ context.Context, v *Validator, _ *edgeconnect.EdgeConnect) string {

--- a/pkg/api/validation/edgeconnect/module.go
+++ b/pkg/api/validation/edgeconnect/module.go
@@ -1,0 +1,19 @@
+package validation
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+)
+
+const (
+	errorModuleDisabled = `EdgeConnect has been disabled during Operator install. The necessary resources for EdgeConnect to work are not present on the cluster. Redeploy the Operator with all the necessary resources`
+)
+
+func isModuleDisabled(_ context.Context, v *Validator, _ *edgeconnect.EdgeConnect) string {
+	if v.modules.EdgeConnect {
+		return ""
+	}
+
+	return errorModuleDisabled
+}

--- a/pkg/api/validation/edgeconnect/module_test.go
+++ b/pkg/api/validation/edgeconnect/module_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,12 +12,12 @@ func TestIsModuleDisabled(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("module disabled => error", func(t *testing.T) {
-		errMsg := isModuleDisabled(ctx, &Validator{modules: operatorconfig.Modules{EdgeConnect: false}}, nil)
+		errMsg := isModuleDisabled(ctx, &Validator{modules: installconfig.Modules{EdgeConnect: false}}, nil)
 		assert.Equal(t, errorModuleDisabled, errMsg)
 	})
 
 	t.Run("module enabled => no error", func(t *testing.T) {
-		errMsg := isModuleDisabled(ctx, &Validator{modules: operatorconfig.Modules{EdgeConnect: true}}, nil)
+		errMsg := isModuleDisabled(ctx, &Validator{modules: installconfig.Modules{EdgeConnect: true}}, nil)
 		assert.Empty(t, errMsg)
 	})
 }

--- a/pkg/api/validation/edgeconnect/module_test.go
+++ b/pkg/api/validation/edgeconnect/module_test.go
@@ -1,0 +1,23 @@
+package validation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsModuleDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("module disabled => error", func(t *testing.T) {
+		errMsg := isModuleDisabled(ctx, &Validator{modules: operatorconfig.Modules{EdgeConnect: false}}, nil)
+		assert.Equal(t, errorModuleDisabled, errMsg)
+	})
+
+	t.Run("module enabled => no error", func(t *testing.T) {
+		errMsg := isModuleDisabled(ctx, &Validator{modules: operatorconfig.Modules{EdgeConnect: true}}, nil)
+		assert.Empty(t, errMsg)
+	})
+}

--- a/pkg/api/validation/edgeconnect/validation.go
+++ b/pkg/api/validation/edgeconnect/validation.go
@@ -5,7 +5,7 @@ import (
 
 	v1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/validation"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,7 +17,7 @@ import (
 type Validator struct {
 	apiReader client.Reader
 	cfg       *rest.Config
-	modules   operatorconfig.Modules
+	modules   installconfig.Modules
 }
 
 type validatorFunc func(ctx context.Context, dv *Validator, ec *edgeconnect.EdgeConnect) string
@@ -35,7 +35,7 @@ func New(apiReader client.Reader, cfg *rest.Config) admission.CustomValidator {
 	return &Validator{
 		apiReader: apiReader,
 		cfg:       cfg,
-		modules:   operatorconfig.GetModules(),
+		modules:   installconfig.GetModules(),
 	}
 }
 

--- a/pkg/api/validation/edgeconnect/validation.go
+++ b/pkg/api/validation/edgeconnect/validation.go
@@ -5,6 +5,7 @@ import (
 
 	v1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/validation"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,11 +17,13 @@ import (
 type Validator struct {
 	apiReader client.Reader
 	cfg       *rest.Config
+	modules   operatorconfig.Modules
 }
 
 type validatorFunc func(ctx context.Context, dv *Validator, ec *edgeconnect.EdgeConnect) string
 
 var validatorErrorFuncs = []validatorFunc{
+	isModuleDisabled,
 	isInvalidApiServer,
 	nameTooLong,
 	checkHostPatternsValue,
@@ -32,6 +35,7 @@ func New(apiReader client.Reader, cfg *rest.Config) admission.CustomValidator {
 	return &Validator{
 		apiReader: apiReader,
 		cfg:       cfg,
+		modules:   operatorconfig.GetModules(),
 	}
 }
 

--- a/pkg/api/validation/edgeconnect/validation_test.go
+++ b/pkg/api/validation/edgeconnect/validation_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
@@ -38,7 +38,7 @@ func runValidators(ec *edgeconnect.EdgeConnect, other ...client.Object) (admissi
 	validator := &Validator{
 		apiReader: clt,
 		cfg:       &rest.Config{},
-		modules:   operatorconfig.GetModules(),
+		modules:   installconfig.GetModules(),
 	}
 
 	return validator.ValidateCreate(context.Background(), ec)

--- a/pkg/api/validation/edgeconnect/validation_test.go
+++ b/pkg/api/validation/edgeconnect/validation_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/operatorconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
@@ -37,6 +38,7 @@ func runValidators(ec *edgeconnect.EdgeConnect, other ...client.Object) (admissi
 	validator := &Validator{
 		apiReader: clt,
 		cfg:       &rest.Config{},
+		modules:   operatorconfig.GetModules(),
 	}
 
 	return validator.ValidateCreate(context.Background(), ec)

--- a/pkg/util/installconfig/modules.go
+++ b/pkg/util/installconfig/modules.go
@@ -1,4 +1,4 @@
-package operatorconfig
+package installconfig
 
 import (
 	"encoding/json"
@@ -25,7 +25,7 @@ var (
 		EdgeConnect: true,
 	}
 
-	log = logd.Get().WithName("operator-config")
+	log = logd.Get().WithName("install-config")
 )
 
 type Modules struct {
@@ -40,19 +40,19 @@ func GetModules() Modules {
 	once.Do(func() {
 		modulesJson := os.Getenv(modulesJsonEnv)
 		if modulesJson == "" {
-			log.Info("operator config envvar not set, using default", "envvar", modulesJsonEnv)
+			log.Info("envvar not set, using default", "envvar", modulesJsonEnv)
 
 			modules = fallbackModules
 		}
 
 		err := json.Unmarshal([]byte(modulesJson), &modules)
 		if err != nil {
-			log.Info("problem unmarshalling operator-config, using default", "envvar", modulesJsonEnv, "err", err)
+			log.Info("problem unmarshalling envvar content, using default", "envvar", modulesJsonEnv, "err", err)
 
 			modules = fallbackModules
 		}
 
-		log.Info("operator-config read and set", "envvar", modulesJsonEnv, "value", modulesJson)
+		log.Info("envvar content read and set", "envvar", modulesJsonEnv, "value", modulesJson)
 	})
 
 	return modules

--- a/pkg/util/installconfig/modules.go
+++ b/pkg/util/installconfig/modules.go
@@ -2,6 +2,7 @@ package installconfig
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"sync"
 
@@ -10,6 +11,8 @@ import (
 
 const (
 	modulesJsonEnv = "modules.json"
+
+	validationErrorTemplate = "%s has been disabled during Operator install. The necessary resources for %s to work are not present on the cluster. Redeploy the Operator via Helm with all the necessary resources enabled."
 )
 
 var (
@@ -56,4 +59,8 @@ func GetModules() Modules {
 	})
 
 	return modules
+}
+
+func GetModuleValidationErrorMessage(moduleName string) string {
+	return fmt.Sprintf(validationErrorTemplate, moduleName, moduleName)
 }

--- a/pkg/util/installconfig/modules_test.go
+++ b/pkg/util/installconfig/modules_test.go
@@ -1,4 +1,4 @@
-package operatorconfig
+package installconfig
 
 import (
 	"sync"

--- a/pkg/util/operatorconfig/modules.go
+++ b/pkg/util/operatorconfig/modules.go
@@ -1,0 +1,59 @@
+package operatorconfig
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+)
+
+const (
+	modulesJsonEnv = "modules.json"
+)
+
+var (
+	once sync.Once
+
+	modules Modules
+
+	fallbackModules = Modules{
+		ActiveGate:  true,
+		OneAgent:    true,
+		Extensions:  true,
+		LogModule:   true,
+		EdgeConnect: true,
+	}
+
+	log = logd.Get().WithName("operator-config")
+)
+
+type Modules struct {
+	ActiveGate  bool `json:"activeGate"`
+	OneAgent    bool `json:"oneAgent"`
+	Extensions  bool `json:"extensions"`
+	LogModule   bool `json:"logModule"`
+	EdgeConnect bool `json:"edgeConnect"`
+}
+
+func GetModules() Modules {
+	once.Do(func() {
+		modulesJson := os.Getenv(modulesJsonEnv)
+		if modulesJson == "" {
+			log.Info("operator config envvar not set, using default", "envvar", modulesJsonEnv)
+
+			modules = fallbackModules
+		}
+
+		err := json.Unmarshal([]byte(modulesJson), &modules)
+		if err != nil {
+			log.Info("problem unmarshalling operator-config, using default", "envvar", modulesJsonEnv, "err", err)
+
+			modules = fallbackModules
+		}
+
+		log.Info("operator-config read and set", "envvar", modulesJsonEnv, "value", modulesJson)
+	})
+
+	return modules
+}

--- a/pkg/util/operatorconfig/modules_test.go
+++ b/pkg/util/operatorconfig/modules_test.go
@@ -1,0 +1,83 @@
+package operatorconfig
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGet(t *testing.T) {
+	t.Run("empty env -> use fallback", func(t *testing.T) {
+		t.Setenv(modulesJsonEnv, "")
+
+		m := GetModules()
+		assert.Equal(t, fallbackModules, m)
+
+		once = sync.Once{} // need to reset it
+	})
+
+	t.Run("messy env -> use fallback", func(t *testing.T) {
+		t.Setenv(modulesJsonEnv, "this is not json :(")
+
+		m := GetModules()
+		assert.Equal(t, fallbackModules, m)
+
+		once = sync.Once{} // need to reset it
+	})
+
+	t.Run("correct env -> set correctly", func(t *testing.T) {
+		jsonValue := `
+		{
+			"activeGate": true,
+			"oneAgent": false,
+			"extensions": true,
+			"logModule": false,
+			"edgeConnect": true
+		}`
+		expected := Modules{
+			ActiveGate:  true,
+			OneAgent:    false,
+			Extensions:  true,
+			LogModule:   false,
+			EdgeConnect: true,
+		}
+
+		t.Setenv(modulesJsonEnv, jsonValue)
+
+		m := GetModules()
+		assert.Equal(t, expected, m)
+
+		once = sync.Once{} // need to reset it
+	})
+
+	t.Run("run only once", func(t *testing.T) {
+		jsonValue := `
+		{
+			"activeGate": true,
+			"oneAgent": false,
+			"extensions": true,
+			"logModule": false,
+			"edgeConnect": true
+		}`
+		expected := Modules{
+			ActiveGate:  true,
+			OneAgent:    false,
+			Extensions:  true,
+			LogModule:   false,
+			EdgeConnect: true,
+		}
+
+		t.Setenv(modulesJsonEnv, jsonValue)
+
+		m := GetModules()
+
+		assert.Equal(t, expected, m)
+
+		t.Setenv(modulesJsonEnv, "boom")
+
+		m = GetModules()
+
+		assert.Equal(t, expected, m)
+	})
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

[K8S-10824](https://dt-rnd.atlassian.net/browse/K8S-10824)

The following options have been added to the helm values.yaml:
```
rbac:
  activeGate:
    create: true
  edgeConnect:
    create: true
  extensions:
    create: true
  logModule:
    create: true
  oneAgent:
    create: true
```

Turning any of them to `false` will result in the following:
1. The related RBAC components (`Role`/`ClusterRole`/`ServiceAccount`) will not be deployed
2. The validation webhook will deny any `DynaKube`/`EdgeConnect` CR that tries to configure a feature relying on such RBAC components
   - This is done by creating a `ConfigMap` called `operator-config`, the content's of which is added to the envs of the webhook
     - This env is ONLY checked 1 time at startup

## How can this be tested?

Configure the `rbac.<module>.create` fields to your heart's content.
- Check the `install-config` `ConfigMap` reflect what you configred
- Try to deploy a CR that would use the disabled "module"