### PR TITLE
Add EEC_DS_TOKEN env var to OTelC StatefulSet.

### DIFF
--- a/pkg/api/v1beta3/dynakube/extensions_props.go
+++ b/pkg/api/v1beta3/dynakube/extensions_props.go
@@ -29,3 +29,7 @@ func (dk *DynaKube) ExtensionsExecutionControllerStatefulsetName() string {
 func (dk *DynaKube) ExtensionsCollectorStatefulsetName() string {
 	return dk.Name + "-extensions-collector"
 }
+
+func (dk *DynaKube) ExtensionsTokenSecretName() string {
+	return dk.Name + "-extensions-token"
+}

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -4,7 +4,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension"
 	eecconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/container"
 	appsv1 "k8s.io/api/apps/v1"
@@ -51,7 +50,7 @@ func (mod EecModifier) getVolumes() []corev1.Volume {
 			Name: eecVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  extension.GetSecretName(mod.dk.Name),
+					SecretName:  mod.dk.ExtensionsTokenSecretName(),
 					DefaultMode: &mode,
 					Items: []corev1.KeyToPath{
 						{

--- a/pkg/controllers/dynakube/extension/consts/consts.go
+++ b/pkg/controllers/dynakube/extension/consts/consts.go
@@ -12,8 +12,6 @@ const (
 	OtelcTokenSecretKey         = "otelc.token"
 	OtelcTokenSecretValuePrefix = "dt0x01"
 
-	SecretSuffix = "-extensions-token"
-
 	// shared volume name between eec and OtelC
 	ExtensionsTokensVolumeName = "tokens"
 

--- a/pkg/controllers/dynakube/extension/eec/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler_test.go
@@ -713,7 +713,7 @@ func TestVolumes(t *testing.T) {
 				Name: consts.ExtensionsTokensVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName:  dk.Name + consts.SecretSuffix,
+						SecretName:  dk.ExtensionsTokenSecretName(),
 						DefaultMode: &mode,
 					},
 				},
@@ -767,7 +767,7 @@ func TestVolumes(t *testing.T) {
 				Name: consts.ExtensionsTokensVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName:  dk.Name + consts.SecretSuffix,
+						SecretName:  dk.ExtensionsTokenSecretName(),
 						DefaultMode: &mode,
 					},
 				},
@@ -809,7 +809,7 @@ func TestVolumes(t *testing.T) {
 				Name: consts.ExtensionsTokensVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName:  dk.Name + consts.SecretSuffix,
+						SecretName:  dk.ExtensionsTokenSecretName(),
 						DefaultMode: &mode,
 					},
 				},

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -338,7 +338,7 @@ func setVolumes(dk *dynakube.DynaKube) func(o *appsv1.StatefulSet) {
 				Name: consts.ExtensionsTokensVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName:  dk.Name + consts.SecretSuffix,
+						SecretName:  dk.ExtensionsTokenSecretName(),
 						DefaultMode: &mode,
 					},
 				},

--- a/pkg/controllers/dynakube/extension/otel/statefulset.go
+++ b/pkg/controllers/dynakube/extension/otel/statefulset.go
@@ -42,6 +42,7 @@ const (
 	envOTLPgrpcPort       = "OTLP_GRPC_PORT"
 	envOTLPhttpPort       = "OTLP_HTTP_PORT"
 	envOTLPtoken          = "OTLP_TOKEN"
+	envEECDStoken         = "EEC_DS_TOKEN"
 	envTrustedCAs         = "TRUSTED_CAS"
 	envK8sClusterName     = "K8S_CLUSTER_NAME"
 	envK8sClusterUuid     = "K8S_CLUSTER_UID"
@@ -208,6 +209,13 @@ func buildContainerEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 		{Name: envOTLPgrpcPort, Value: defaultOLTPgrpcPort},
 		{Name: envOTLPhttpPort, Value: defaultOLTPhttpPort},
 		{Name: envOTLPtoken, ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: dk.Name + consts.SecretSuffix},
+				Key:                  consts.OtelcTokenSecretKey,
+			},
+		},
+		},
+		{Name: envEECDStoken, ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: dk.Name + consts.SecretSuffix},
 				Key:                  consts.OtelcTokenSecretKey,

--- a/pkg/controllers/dynakube/extension/otel/statefulset.go
+++ b/pkg/controllers/dynakube/extension/otel/statefulset.go
@@ -210,14 +210,14 @@ func buildContainerEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 		{Name: envOTLPhttpPort, Value: defaultOLTPhttpPort},
 		{Name: envOTLPtoken, ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: dk.Name + consts.SecretSuffix},
+				LocalObjectReference: corev1.LocalObjectReference{Name: dk.ExtensionsTokenSecretName()},
 				Key:                  consts.OtelcTokenSecretKey,
 			},
 		},
 		},
 		{Name: envEECDStoken, ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: dk.Name + consts.SecretSuffix},
+				LocalObjectReference: corev1.LocalObjectReference{Name: dk.ExtensionsTokenSecretName()},
 				Key:                  consts.OtelcTokenSecretKey,
 			},
 		},
@@ -272,7 +272,7 @@ func setVolumes(dk *dynakube.DynaKube) func(o *appsv1.StatefulSet) {
 				Name: consts.ExtensionsTokensVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: dk.Name + consts.SecretSuffix,
+						SecretName: dk.ExtensionsTokenSecretName(),
 						Items: []corev1.KeyToPath{
 							{
 								Key:  consts.OtelcTokenSecretKey,

--- a/pkg/controllers/dynakube/extension/otel/statefulset_test.go
+++ b/pkg/controllers/dynakube/extension/otel/statefulset_test.go
@@ -231,13 +231,13 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Equal(t, corev1.EnvVar{Name: envOTLPhttpPort, Value: defaultOLTPhttpPort}, statefulSet.Spec.Template.Spec.Containers[0].Env[5])
 		assert.Equal(t, corev1.EnvVar{Name: envOTLPtoken, ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: dk.Name + consts.SecretSuffix},
+				LocalObjectReference: corev1.LocalObjectReference{Name: dk.ExtensionsTokenSecretName()},
 				Key:                  consts.OtelcTokenSecretKey,
 			},
 		}}, statefulSet.Spec.Template.Spec.Containers[0].Env[6])
 		assert.Equal(t, corev1.EnvVar{Name: envEECDStoken, ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: dk.Name + consts.SecretSuffix},
+				LocalObjectReference: corev1.LocalObjectReference{Name: dk.ExtensionsTokenSecretName()},
 				Key:                  consts.OtelcTokenSecretKey,
 			},
 		}}, statefulSet.Spec.Template.Spec.Containers[0].Env[7])
@@ -511,7 +511,7 @@ func TestVolumes(t *testing.T) {
 			Name: consts.ExtensionsTokensVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: dk.Name + consts.SecretSuffix,
+					SecretName: dk.ExtensionsTokenSecretName(),
 					Items: []corev1.KeyToPath{
 						{
 							Key:  consts.OtelcTokenSecretKey,

--- a/pkg/controllers/dynakube/extension/otel/statefulset_test.go
+++ b/pkg/controllers/dynakube/extension/otel/statefulset_test.go
@@ -235,10 +235,16 @@ func TestEnvironmentVariables(t *testing.T) {
 				Key:                  consts.OtelcTokenSecretKey,
 			},
 		}}, statefulSet.Spec.Template.Spec.Containers[0].Env[6])
-		assert.Equal(t, corev1.EnvVar{Name: envCertDir, Value: customEecTLSCertificatePath}, statefulSet.Spec.Template.Spec.Containers[0].Env[7])
-		assert.Equal(t, corev1.EnvVar{Name: envK8sClusterName, Value: dk.Name}, statefulSet.Spec.Template.Spec.Containers[0].Env[8])
-		assert.Equal(t, corev1.EnvVar{Name: envK8sClusterUuid, Value: dk.Status.KubeSystemUUID}, statefulSet.Spec.Template.Spec.Containers[0].Env[9])
-		assert.Equal(t, corev1.EnvVar{Name: envDTentityK8sCluster, Value: dk.Status.KubernetesClusterMEID}, statefulSet.Spec.Template.Spec.Containers[0].Env[10])
+		assert.Equal(t, corev1.EnvVar{Name: envEECDStoken, ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: dk.Name + consts.SecretSuffix},
+				Key:                  consts.OtelcTokenSecretKey,
+			},
+		}}, statefulSet.Spec.Template.Spec.Containers[0].Env[7])
+		assert.Equal(t, corev1.EnvVar{Name: envCertDir, Value: customEecTLSCertificatePath}, statefulSet.Spec.Template.Spec.Containers[0].Env[8])
+		assert.Equal(t, corev1.EnvVar{Name: envK8sClusterName, Value: dk.Name}, statefulSet.Spec.Template.Spec.Containers[0].Env[9])
+		assert.Equal(t, corev1.EnvVar{Name: envK8sClusterUuid, Value: dk.Status.KubeSystemUUID}, statefulSet.Spec.Template.Spec.Containers[0].Env[10])
+		assert.Equal(t, corev1.EnvVar{Name: envDTentityK8sCluster, Value: dk.Status.KubernetesClusterMEID}, statefulSet.Spec.Template.Spec.Containers[0].Env[11])
 	})
 	t.Run("environment variables with trustedCA", func(t *testing.T) {
 		dk := getTestDynakube()

--- a/pkg/controllers/dynakube/extension/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/reconciler_test.go
@@ -48,7 +48,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		dk := createDynakube()
 
 		// mock SecretCreated condition
-		conditions.SetSecretCreated(dk.Conditions(), consts.ExtensionsSecretConditionType, dk.Name+consts.SecretSuffix)
+		conditions.SetSecretCreated(dk.Conditions(), consts.ExtensionsSecretConditionType, dk.ExtensionsTokenSecretName())
 
 		// mock secret
 		secretToken, _ := dttoken.New(consts.EecTokenSecretValuePrefix)
@@ -102,7 +102,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		condition := meta.FindStatusCondition(*dk.Conditions(), consts.ExtensionsSecretConditionType)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
-		assert.Equal(t, dk.Name+consts.SecretSuffix+" created", condition.Message)
+		assert.Equal(t, dk.ExtensionsTokenSecretName()+" created", condition.Message)
 	})
 	t.Run(`Extension SecretCreated failure condition is set when error`, func(t *testing.T) {
 		dk := createDynakube()

--- a/pkg/controllers/dynakube/extension/secret.go
+++ b/pkg/controllers/dynakube/extension/secret.go
@@ -95,9 +95,5 @@ func (r *reconciler) buildSecret(eecToken dttoken.Token, otelcToken dttoken.Toke
 }
 
 func (r *reconciler) getSecretName() string {
-	return GetSecretName(r.dk.Name)
-}
-
-func GetSecretName(dynakubeName string) string {
-	return dynakubeName + consts.SecretSuffix
+	return r.dk.ExtensionsTokenSecretName()
 }


### PR DESCRIPTION
## Description

Add env var `EEC_DS_TOKEN` to OTelC StatefulSet.

## How can this be tested?

1. Deploy Dynakube with extensions
2. check that env var is set on OTelC pods
  ```
  EEC_DS_TOKEN: <set to the key 'otelc.token' in secret 'ext-dk-extensions-token'>  Optional: false 
  ```