### PR TITLE
Cherry-pick of K8S-11404 for EdgeConnect empty hostPatterns v1alpha1 to v1alpha2

### DIFF
--- a/pkg/api/v1alpha1/edgeconnect/convert_to.go
+++ b/pkg/api/v1alpha1/edgeconnect/convert_to.go
@@ -45,7 +45,12 @@ func (src *EdgeConnect) toSpec(dst *edgeconnect.EdgeConnect) {
 	dst.Spec.ImageRef.Tag = src.Spec.ImageRef.Tag
 	dst.Spec.ImageRef.Repository = src.Spec.ImageRef.Repository
 	dst.Spec.ApiServer = src.Spec.ApiServer
-	dst.Spec.HostRestrictions = strings.Split(src.Spec.HostRestrictions, ",")
+
+	// Note: strings.Split returns [""] if we apply it to empty "" string
+	if src.Spec.HostRestrictions != "" {
+		dst.Spec.HostRestrictions = strings.Split(src.Spec.HostRestrictions, ",")
+	}
+
 	dst.Spec.CustomPullSecret = src.Spec.CustomPullSecret
 	dst.Spec.CaCertsRef = src.Spec.CaCertsRef
 	dst.Spec.ServiceAccountName = src.Spec.ServiceAccountName

--- a/pkg/api/v1alpha1/edgeconnect/convert_to_test.go
+++ b/pkg/api/v1alpha1/edgeconnect/convert_to_test.go
@@ -29,6 +29,15 @@ func TestConvertTo(t *testing.T) {
 		toAreSpecsEqual(t, &from.Spec, &to.Spec)
 		toAreStatusesEqual(t, &from.Status, &to.Status)
 	})
+	t.Run("migrate from edgeconnect v1alpha1 to v1alpha2 .spec.hostRestrictions is not provided", func(t *testing.T) {
+		from := EdgeConnect{
+			Spec: EdgeConnectSpec{},
+		}
+		to := edgeconnect.EdgeConnect{}
+
+		from.ConvertTo(&to)
+		assert.Nil(t, to.Spec.HostRestrictions)
+	})
 }
 
 func getV1alpha1Base() metav1.ObjectMeta {


### PR DESCRIPTION
Cherry-pick of bugfix [K8S-11404](https://dt-rnd.atlassian.net/browse/K8S-11404) https://github.com/Dynatrace/dynatrace-operator/commit/a919cae4d5680fba156e8a799e300b5e3e8d2a05

Same as https://github.com/Dynatrace/dynatrace-operator/pull/3852