### PR TITLE
Rename the existing ClusterRole prometheus-service-detector and update permissions

### DIFF
--- a/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
@@ -15,40 +15,52 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus-service-detector
+  name: dynatrace-extensions-prometheus
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
 rules:
-- apiGroups:
-    - ""
-  resources:
-    - pods
-    - namespaces
-  verbs:
-    - list
-    - get
-    - watch
-- apiGroups:
-    - apps
-  resources:
-    - replicasets
-  verbs:
-    - list
-    - get
-    - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+      - endpoints
+      - services
+      - nodes
+      - nodes/metrics
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/cadvisor
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-service-detector
+  name: dynatrace-extensions-prometheus
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-service-detector
+  name: dynatrace-extensions-prometheus
 subjects:
   - kind: ServiceAccount
     name: dynatrace-extensions-collector

--- a/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: ClusterRole
       - equal:
           path: metadata.name
-          value: prometheus-service-detector
+          value: dynatrace-extensions-prometheus
       - isNotEmpty:
           path: metadata.labels
       - isNotEmpty:
@@ -27,21 +27,36 @@ tests:
             resources:
               - pods
               - namespaces
+              - endpoints
+              - services
+              - nodes
+              - nodes/metrics
             verbs:
-              - list
               - get
               - watch
+              - list
       - contains:
           path: rules
           content:
             apiGroups:
               - apps
             resources:
+              - deployments
+              - daemonsets
               - replicasets
+              - statefulsets
             verbs:
-              - list
               - get
+              - list
               - watch
+      - contains:
+          path: rules
+          content:
+            nonResourceURLs:
+              - /metrics
+              - /metrics/cadvisor
+            verbs:
+              - get
 
   - it: ClusterRoleBinding exists
     documentIndex: 1
@@ -50,7 +65,7 @@ tests:
           of: ClusterRoleBinding
       - equal:
           path: metadata.name
-          value: prometheus-service-detector
+          value: dynatrace-extensions-prometheus
       - isNotEmpty:
           path: metadata.labels
 


### PR DESCRIPTION
[DAQ-1459](https://dt-rnd.atlassian.net/browse/DAQ-1459)

## Description

Renames the existing ClusterRole `prometheus-service-detector` to `dynatrace-extensions-prometheus`.

Renames the existing ClusterRoleBinding `prometheus-service-detector` to `dynatrace-extensions-prometheus`.

Updates the permissions as shown in the ticket.

## How can this be tested?

1) `make test/helm`
2) deploy dynakube with extensions