### PR TITLE
Add symlink that points to the latest codemodule version

### DIFF
--- a/.github/actions/preflight/action.yaml
+++ b/.github/actions/preflight/action.yaml
@@ -28,7 +28,8 @@ runs:
     env:
       RHCC_APITOKEN: ${{ inputs.pyxis-api-token }}
       RHCC_PROJECT_ID: ${{ inputs.redhat-project-id }}
-      PREFLIGHT_VERSION: "1.9.9"
+      # renovate depName=redhat-openshift-ecosystem/openshift-preflight
+      PREFLIGHT_VERSION: "1.10.1"
       IMAGE_URI: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.version }}
     run: |
       hack/build/ci/preflight.sh "${{ env.PREFLIGHT_VERSION }}" "${{ env.IMAGE_URI}}" "${{ inputs.report-name }}"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,6 +48,15 @@
       ],
       datasourceTemplate: "go",
     },
+    {
+      fileMatch: [
+        "(^|/|\\.)action.yaml$",
+      ],
+      matchStrings: [
+        "depName=(?<depName>.*?)\\s.*?PREFLIGHT_VERSION\\:\\s(?<currentValue>.*)\\s",
+      ],
+      datasourceTemplate: "github-releases",
+    }
   ],
   packageRules: [
     {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -232,7 +232,7 @@ jobs:
           registry-type: public
       - name: Create sbom for ${{matrix.registry}}
         id: sbom
-        uses: aquasecurity/trivy-action@5681af892cd0f4997658e2bacc62bd0a894cf564 # 0.27.0
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # 0.28.0
         with:
           image-ref: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ needs.manifest.outputs.digest }}
           format: 'cyclonedx'

--- a/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
+++ b/config/helm/chart/default/templates/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector.yaml
@@ -15,40 +15,52 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus-service-detector
+  name: dynatrace-extensions-prometheus
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
 rules:
-- apiGroups:
-    - ""
-  resources:
-    - pods
-    - namespaces
-  verbs:
-    - list
-    - get
-    - watch
-- apiGroups:
-    - apps
-  resources:
-    - replicasets
-  verbs:
-    - list
-    - get
-    - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+      - endpoints
+      - services
+      - nodes
+      - nodes/metrics
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/cadvisor
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-service-detector
+  name: dynatrace-extensions-prometheus
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.extensionsOpenTelemetryCollectorLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-service-detector
+  name: dynatrace-extensions-prometheus
 subjects:
   - kind: ServiceAccount
     name: dynatrace-extensions-collector

--- a/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions-opentelemetry-collector/clusterrole-extensions-opentelemetry-collector_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: ClusterRole
       - equal:
           path: metadata.name
-          value: prometheus-service-detector
+          value: dynatrace-extensions-prometheus
       - isNotEmpty:
           path: metadata.labels
       - isNotEmpty:
@@ -27,21 +27,36 @@ tests:
             resources:
               - pods
               - namespaces
+              - endpoints
+              - services
+              - nodes
+              - nodes/metrics
             verbs:
-              - list
               - get
               - watch
+              - list
       - contains:
           path: rules
           content:
             apiGroups:
               - apps
             resources:
+              - deployments
+              - daemonsets
               - replicasets
+              - statefulsets
             verbs:
-              - list
               - get
+              - list
               - watch
+      - contains:
+          path: rules
+          content:
+            nonResourceURLs:
+              - /metrics
+              - /metrics/cadvisor
+            verbs:
+              - get
 
   - it: ClusterRoleBinding exists
     documentIndex: 1
@@ -50,7 +65,7 @@ tests:
           of: ClusterRoleBinding
       - equal:
           path: metadata.name
-          value: prometheus-service-detector
+          value: dynatrace-extensions-prometheus
       - isNotEmpty:
           path: metadata.labels
 

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -311,19 +311,18 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		mockDtcBuilder := dtbuildermock.NewBuilder(t)
 		provisioner := &OneAgentProvisioner{
 			apiReader: fake.NewClient(
-				addFakeTenantUUID(
-					&dynakube.DynaKube{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: dkName,
-						},
-						Spec: dynakube.DynaKubeSpec{
-							APIURL: testAPIURL,
-							OneAgent: dynakube.OneAgentSpec{
-								ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
-							},
+				&dynakube.DynaKube{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: dkName,
+					},
+					Spec: dynakube.DynaKubeSpec{
+						APIURL: testAPIURL,
+						OneAgent: dynakube.OneAgentSpec{
+							ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
 						},
 					},
-				),
+				},
+
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: dkName,
@@ -340,7 +339,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		}
 		result, err := provisioner.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: dkName}})
 
-		require.EqualError(t, err, "failed to create directory "+tenantUUID+": "+errorMsg)
+		require.EqualError(t, err, "failed to create directory "+dkName+": "+errorMsg)
 		require.NotNil(t, result)
 		require.Equal(t, reconcile.Result{}, result)
 
@@ -351,19 +350,17 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		gc := reconcilermock.NewReconciler(t)
 		memFs := afero.NewMemMapFs()
 		mockDtcBuilder := dtbuildermock.NewBuilder(t)
-		dynakube := addFakeTenantUUID(
-			&dynakube.DynaKube{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: dkName,
-				},
-				Spec: dynakube.DynaKubeSpec{
-					APIURL: testAPIURL,
-					OneAgent: dynakube.OneAgentSpec{
-						ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
-					},
+		dynakube := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: dkName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testAPIURL,
+				OneAgent: dynakube.OneAgentSpec{
+					ApplicationMonitoring: buildValidApplicationMonitoringSpec(t),
 				},
 			},
-		)
+		}
 		installerMock := installermock.NewInstaller(t)
 
 		provisioner := &OneAgentProvisioner{
@@ -403,7 +400,7 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, result)
 
-		exists, err := afero.Exists(memFs, tenantUUID)
+		exists, err := afero.Exists(memFs, dkName)
 
 		require.NoError(t, err)
 		require.True(t, exists)
@@ -454,19 +451,17 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		gc := reconcilermock.NewReconciler(t)
 		memFs := afero.NewMemMapFs()
 		memDB := metadata.FakeMemoryDB()
-		dynakube := addFakeTenantUUID(
-			&dynakube.DynaKube{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: dkName,
-				},
-				Spec: dynakube.DynaKubeSpec{
-					APIURL: testAPIURL,
-					OneAgent: dynakube.OneAgentSpec{
-						HostMonitoring: &dynakube.HostInjectSpec{},
-					},
+		dynakube := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: dkName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testAPIURL,
+				OneAgent: dynakube.OneAgentSpec{
+					HostMonitoring: &dynakube.HostInjectSpec{},
 				},
 			},
-		)
+		}
 
 		r := &OneAgentProvisioner{
 			apiReader: fake.NewClient(dynakube),
@@ -480,12 +475,12 @@ func TestOneAgentProvisioner_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
-		exists, err := afero.Exists(memFs, tenantUUID)
+		exists, err := afero.Exists(memFs, dkName)
 
 		require.NoError(t, err)
 		require.True(t, exists)
 
-		fileInfo, err := memFs.Stat(tenantUUID)
+		fileInfo, err := memFs.Stat(dkName)
 
 		require.NoError(t, err)
 		require.True(t, fileInfo.IsDir())

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -94,11 +94,11 @@ func (provisioner *OneAgentProvisioner) installAgent(ctx context.Context, agentI
 	}
 
 	symlinkPath := provisioner.path.LatestAgentBinaryForDynaKube(dk.GetName())
-	if err := symlink.RemoveSymlink(provisioner.fs, symlinkPath); err != nil {
+	if err := symlink.Remove(provisioner.fs, symlinkPath); err != nil {
 		return err
 	}
 
-	err = symlink.CreateSymlinkForLatestVersion(provisioner.fs, dk, targetDir, symlinkPath)
+	err = symlink.CreateForLatestVersion(provisioner.fs, dk, targetDir, symlinkPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -93,12 +93,12 @@ func (provisioner *OneAgentProvisioner) installAgent(ctx context.Context, agentI
 		eventRecorder.sendInstalledAgentVersionEvent(targetVersion, dk.GetName())
 	}
 
-	symLinkPath := provisioner.path.LatestAgentBinaryForDynaKube(dk.GetName())
-	if err := symlink.RemoveSymLink(provisioner.fs, symLinkPath); err != nil {
+	symlinkPath := provisioner.path.LatestAgentBinaryForDynaKube(dk.GetName())
+	if err := symlink.RemoveSymlink(provisioner.fs, symlinkPath); err != nil {
 		return err
 	}
 
-	err = symlink.CreateSymlinkForLatestVersion(provisioner.fs, dk, targetDir, symLinkPath)
+	err = symlink.CreateSymlinkForLatestVersion(provisioner.fs, dk, targetDir, symlinkPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/injection/codemodule/installer/image/installer.go
+++ b/pkg/injection/codemodule/installer/image/installer.go
@@ -85,7 +85,7 @@ func (installer *Installer) InstallAgent(_ context.Context, targetDir string) (b
 		return false, errors.WithStack(err)
 	}
 
-	if err := symlink.CreateSymlinkForCurrentVersionIfNotExists(installer.fs, targetDir); err != nil {
+	if err := symlink.CreateForCurrentVersionIfNotExists(installer.fs, targetDir); err != nil {
 		_ = installer.fs.RemoveAll(targetDir)
 
 		log.Info("failed to create symlink for agent installation", "err", err)

--- a/pkg/injection/codemodule/installer/symlink/symlink.go
+++ b/pkg/injection/codemodule/installer/symlink/symlink.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func CreateSymlinkForCurrentVersionIfNotExists(fs afero.Fs, targetDir string) error {
+func CreateForCurrentVersionIfNotExists(fs afero.Fs, targetDir string) error {
 	var relativeSymlinkPath string
 
 	var err error
@@ -50,7 +50,7 @@ func CreateSymlinkForCurrentVersionIfNotExists(fs afero.Fs, targetDir string) er
 	return nil
 }
 
-func CreateSymlinkForLatestVersion(fs afero.Fs, dk dynakube.DynaKube, latestVersionDir, symlinkDir string) error {
+func CreateForLatestVersion(fs afero.Fs, dk dynakube.DynaKube, latestVersionDir, symlinkDir string) error {
 	// MemMapFs (used for testing) doesn't comply with the Linker interface
 	linker, ok := fs.(afero.Linker)
 	if !ok {
@@ -70,7 +70,7 @@ func CreateSymlinkForLatestVersion(fs afero.Fs, dk dynakube.DynaKube, latestVers
 	return nil
 }
 
-func RemoveSymlink(fs afero.Fs, symlinkPath string) error {
+func Remove(fs afero.Fs, symlinkPath string) error {
 	if info, _ := fs.Stat(symlinkPath); info != nil {
 		log.Info("symlink to codemodule directory exists, removing it due to the possibility of the agent being installed again")
 

--- a/pkg/injection/codemodule/installer/symlink/symlink.go
+++ b/pkg/injection/codemodule/installer/symlink/symlink.go
@@ -70,11 +70,11 @@ func CreateSymlinkForLatestVersion(fs afero.Fs, dk dynakube.DynaKube, latestVers
 	return nil
 }
 
-func RemoveSymLink(fs afero.Fs, symLinkPath string) error {
-	if info, _ := fs.Stat(symLinkPath); info != nil {
+func RemoveSymlink(fs afero.Fs, symlinkPath string) error {
+	if info, _ := fs.Stat(symlinkPath); info != nil {
 		log.Info("symlink to codemodule directory exists, removing it due to the possibility of the agent being installed again")
 
-		if err := fs.RemoveAll(symLinkPath); err != nil {
+		if err := fs.RemoveAll(symlinkPath); err != nil {
 			return err
 		}
 	}

--- a/pkg/injection/codemodule/installer/url/installer.go
+++ b/pkg/injection/codemodule/installer/url/installer.go
@@ -77,7 +77,7 @@ func (installer Installer) InstallAgent(ctx context.Context, targetDir string) (
 		return false, err
 	}
 
-	if err := symlink.CreateSymlinkForCurrentVersionIfNotExists(installer.fs, targetDir); err != nil {
+	if err := symlink.CreateForCurrentVersionIfNotExists(installer.fs, targetDir); err != nil {
 		_ = installer.fs.RemoveAll(targetDir)
 		log.Info("failed to create symlink for agent installation", "targetDir", targetDir)
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[Jira](https://dt-rnd.atlassian.net/browse/DAQ-1361)

**Attention** 
This PR will not be merged into `main` but into `epic/csi-nodb` - our feature branch for the csi no db epic.

With this a symlink is added at the location: `/data/<dk>/latest-codemodule` that points to the codemodule directory (`/data/codemodules/<base64encodedImage/version>`) in the `provisioner` container.

It is maintained in a way that the symlink is always removed and immediatly after created again if:

- agent is being newly installed
- csi driver pod starts but agent is already installed from previous runs

This is done in order to update the codemodule directory and with that also the symlink and to avoid errors because of a mismatch between symlink and codemodule dir (happened to me! I updated the `codeModulesImage` -> the directory got "updated" accordingly, but the symlink still pointed to the old directory). 

I added no unit tests as I do not think the things I introduced are properly unit testable, the other method in `symlink.go` is also not unit tested and `installAgent` also isn't.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Deploy operator with `codeModulesImage` set.

shell into the `provisioner` container and run:

`bash-5.1# ls -lR /data | grep '^l'`

The result should contain this line which indicates that there is a symlink from latest-codemodule to the dir: 

`lrwxrwxrwx 1 root root  114 Oct 16 11:26 latest-codemodule -> /data/codemodules/cHVibGljLmVjci5hd3MvZHluYXRyYWNlL2R5bmF0cmFjZS1jb2RlbW9kdWxlczoxLjMwMS40OC4yMDI0MTAwNy0xMDMzMzY=`

Update the codeModulesImage and when the agent is installed run the command again. The symlink should be updated accordingly.

You can also cd into `latest-codemodule` and look if the linking works. You should see the same directory as under the codemodules directory. You can move into the `/agent/bin/` dir and check the version there.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->