### PR TITLE
Use the secret.Query in the AuthToken reconciler 

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -67,7 +67,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 }
 
 func (r *Reconciler) reconcileAuthTokenSecret(ctx context.Context) error {
-	secret, err := r.query().Get(ctx, client.ObjectKey{Name: r.dk.ActiveGate().GetAuthTokenSecretName(), Namespace: r.dk.Namespace})
+	secret, err := r.secretQuery().Get(ctx, client.ObjectKey{Name: r.dk.ActiveGate().GetAuthTokenSecretName(), Namespace: r.dk.Namespace})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			log.Info("creating activeGateAuthToken secret")
@@ -131,7 +131,7 @@ func (r *Reconciler) createSecret(ctx context.Context, secretData map[string][]b
 		return errors.WithStack(err)
 	}
 
-	err = r.query().WithOwner(r.dk).Create(ctx, secret)
+	err = r.secretQuery().WithOwner(r.dk).Create(ctx, secret)
 	if err != nil {
 		conditions.SetKubeApiError(r.dk.Conditions(), ActiveGateAuthTokenSecretConditionType, err)
 
@@ -144,7 +144,7 @@ func (r *Reconciler) createSecret(ctx context.Context, secretData map[string][]b
 }
 
 func (r *Reconciler) deleteSecret(ctx context.Context, secret *corev1.Secret) error {
-	if err := r.query().Delete(ctx, secret); err != nil {
+	if err := r.secretQuery().Delete(ctx, secret); err != nil {
 		conditions.SetKubeApiError(r.dk.Conditions(), ActiveGateAuthTokenSecretConditionType, err)
 
 		return err
@@ -166,6 +166,6 @@ func (r *Reconciler) conditionSetSecretCreated(secret *corev1.Secret) {
 	setAuthSecretCreated(r.dk.Conditions(), ActiveGateAuthTokenSecretConditionType, "secret created "+days+" day(s) ago, token:"+tokenPublicPart)
 }
 
-func (r *Reconciler) query() k8ssecret.QueryObject {
+func (r *Reconciler) secretQuery() k8ssecret.QueryObject {
 	return k8ssecret.Query(r.client, r.apiReader, log)
 }

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -50,9 +50,10 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 			return nil
 		}
 
+		defer meta.RemoveStatusCondition(r.dk.Conditions(), ActiveGateAuthTokenSecretConditionType)
+
 		secret, _ := k8ssecret.Build(r.dk, r.dk.ActiveGate().GetAuthTokenSecretName(), nil)
 		_ = r.deleteSecret(ctx, secret)
-		_ = meta.RemoveStatusCondition(r.dk.Conditions(), ActiveGateAuthTokenSecretConditionType)
 
 		return nil
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
[DAQ-1456](https://dt-rnd.atlassian.net/browse/DAQ-1456)

Not much has changed, as this secret is rather unique in the codebase, so only small adjustments made sense,

## How can this be tested?

no big noticeable (biggest one would be that the Auth-token secret now has an ownerReference)