### PR TITLE
Delete extensions self-signed TLS Secret when `spec.extensions.enabled: false`

### DIFF
--- a/pkg/controllers/dynakube/extension/tls/reconciler.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler.go
@@ -36,14 +36,14 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dk *dynakube.Dyna
 }
 
 func (r *reconciler) Reconcile(ctx context.Context) error {
-	if r.dk.ExtensionsNeedsSelfSignedTLS() {
-		return r.reconcileSelfSigned(ctx)
+	if !r.dk.IsExtensionsEnabled() || !r.dk.ExtensionsNeedsSelfSignedTLS() {
+		return r.deleteSelfSignedTLSSecret(ctx)
 	}
 
-	return r.reconcileTLSRefName(ctx)
+	return r.reconcileSelfSignedTLSSecret(ctx)
 }
 
-func (r *reconciler) reconcileSelfSigned(ctx context.Context) error {
+func (r *reconciler) reconcileSelfSignedTLSSecret(ctx context.Context) error {
 	query := k8ssecret.Query(r.client, r.client, log)
 
 	_, err := query.Get(ctx, types.NamespacedName{
@@ -58,7 +58,7 @@ func (r *reconciler) reconcileSelfSigned(ctx context.Context) error {
 	return err
 }
 
-func (r *reconciler) reconcileTLSRefName(ctx context.Context) error {
+func (r *reconciler) deleteSelfSignedTLSSecret(ctx context.Context) error {
 	query := k8ssecret.Query(r.client, r.client, log)
 
 	return query.Delete(ctx, &corev1.Secret{


### PR DESCRIPTION
## Description

[DAQ-1680](https://dt-rnd.atlassian.net/browse/K8S-11326)

Extensions self-signed TLS Secret was getting reconciled when `spec.extensions.enabled: false`, which is wrong.

Now we check `r.dk.IsExtensionsEnabled()`, like in the rest of extension reconcilers.

I also renamed the functions for clarity.

## How can this be tested?

- I added a new unit test with this case. It fails if run on main, and passes on this branch :heavy_check_mark: 
- To test manually, apply dynakube with `spec.extensions.enabled: false` and check that the secret `<namespace>-extensions-controller-tls` doesn't exist.