### PR TITLE
Add missing permissions to fix edgeconnect e2e tests

### DIFF
--- a/config/helm/chart/default/templates/Common/operator/role-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/role-operator.yaml
@@ -28,12 +28,12 @@ rules:
       - get
       - list
       - watch
+      - update
   - apiGroups:
       - dynatrace.com
     resources:
       - dynakubes/finalizers
       - dynakubes/status
-      - edgeconnects/finalizers
       - edgeconnects/status
     verbs:
       - update

--- a/config/helm/chart/default/templates/Common/operator/role-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/role-operator.yaml
@@ -32,7 +32,6 @@ rules:
   - apiGroups:
       - dynatrace.com
     resources:
-      - dynakubes/finalizers
       - dynakubes/status
       - edgeconnects/status
     verbs:

--- a/config/helm/chart/default/tests/Common/operator/role-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/role-operator_test.yaml
@@ -25,12 +25,12 @@ tests:
                 - get
                 - list
                 - watch
+                - update
             - apiGroups:
                 - dynatrace.com
               resources:
                 - dynakubes/finalizers
                 - dynakubes/status
-                - edgeconnects/finalizers
                 - edgeconnects/status
               verbs:
                 - update

--- a/config/helm/chart/default/tests/Common/operator/role-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/role-operator_test.yaml
@@ -29,7 +29,6 @@ tests:
             - apiGroups:
                 - dynatrace.com
               resources:
-                - dynakubes/finalizers
                 - dynakubes/status
                 - edgeconnects/status
               verbs:


### PR DESCRIPTION
This PR reverts permissions to fix EdgeConnect deployment introduced in https://github.com/Dynatrace/dynatrace-operator/pull/3934: 

```
│ -01a80b9ffd27\" is forbidden: User \"system:serviceaccount:dynatrace:dynatrace-operator\" cannot update resource \"edgeconnects\" in API g │
│ roup \"dynatrace.com\" in the namespace \"dynatrace\"  
```

## How to test:

Deploy Edgeconnect/DK make sure no permission errors