### PR TITLE
Fix proxy content logged in init-container logs

### DIFF
--- a/pkg/injection/startup/secret.go
+++ b/pkg/injection/startup/secret.go
@@ -46,6 +46,10 @@ func (secret SecretConfig) logContent() {
 		secret.PaasToken = asterisks
 	}
 
+	if secret.Proxy != "" {
+		secret.Proxy = asterisks
+	}
+
 	log.Info("contents of secret config", "content", secret)
 }
 


### PR DESCRIPTION
## Description
https://dt-rnd.atlassian.net/browse/DAQ-1677

When using a proxy with auths, the content of username and password is logged in the initContainer logs

## How can this be tested?

1. Deploy Dynatrace the Operator
2. Create Dynakube with a proxy which contains username+password
4. Apply Dynakube
5. Restart monitored application
6. Check the oneagent-init container logs and see that both username and password is logged