### PR TITLE
Do not reconcile extensions self-signed TLS secret when `spec.extensions.enabled: false`

### DIFF
--- a/pkg/controllers/dynakube/extension/tls/reconciler.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler.go
@@ -36,11 +36,11 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dk *dynakube.Dyna
 }
 
 func (r *reconciler) Reconcile(ctx context.Context) error {
-	if !r.dk.IsExtensionsEnabled() || !r.dk.ExtensionsNeedsSelfSignedTLS() {
-		return r.deleteSelfSignedTLSSecret(ctx)
+	if r.dk.IsExtensionsEnabled() && r.dk.ExtensionsNeedsSelfSignedTLS() {
+		return r.reconcileSelfSignedTLSSecret(ctx)
 	}
 
-	return r.reconcileSelfSignedTLSSecret(ctx)
+	return r.deleteSelfSignedTLSSecret(ctx)
 }
 
 func (r *reconciler) reconcileSelfSignedTLSSecret(ctx context.Context) error {

--- a/pkg/controllers/dynakube/extension/tls/reconciler.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler.go
@@ -36,14 +36,14 @@ func NewReconciler(clt client.Client, apiReader client.Reader, dk *dynakube.Dyna
 }
 
 func (r *reconciler) Reconcile(ctx context.Context) error {
-	if r.dk.ExtensionsNeedsSelfSignedTLS() {
-		return r.reconcileSelfSigned(ctx)
+	if !r.dk.IsExtensionsEnabled() || !r.dk.ExtensionsNeedsSelfSignedTLS() {
+		return r.deleteSelfSignedTLSSecret(ctx)
 	}
 
-	return r.reconcileTLSRefName(ctx)
+	return r.reconcileSelfSignedTLSSecret(ctx)
 }
 
-func (r *reconciler) reconcileSelfSigned(ctx context.Context) error {
+func (r *reconciler) reconcileSelfSignedTLSSecret(ctx context.Context) error {
 	query := k8ssecret.Query(r.client, r.client, log)
 
 	_, err := query.Get(ctx, types.NamespacedName{
@@ -58,7 +58,7 @@ func (r *reconciler) reconcileSelfSigned(ctx context.Context) error {
 	return err
 }
 
-func (r *reconciler) reconcileTLSRefName(ctx context.Context) error {
+func (r *reconciler) deleteSelfSignedTLSSecret(ctx context.Context) error {
 	query := k8ssecret.Query(r.client, r.client, log)
 
 	return query.Delete(ctx, &corev1.Secret{

--- a/pkg/controllers/dynakube/extension/tls/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler_test.go
@@ -40,13 +40,14 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := NewReconciler(fakeClient, fakeClient, dk)
 
-		reconciler.Reconcile(context.Background())
+		err := reconciler.Reconcile(context.Background())
+		require.NoError(t, err)
 
 		var secret corev1.Secret
-		err := fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
+		err = fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
 
 		require.True(t, k8serrors.IsNotFound(err))
-		require.Equal(t, corev1.Secret{}, secret)
+		assert.Equal(t, corev1.Secret{}, secret)
 	})
 	t.Run("self-signed tls secret is generated", func(t *testing.T) {
 		dk := getTestDynakube()
@@ -55,13 +56,14 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := NewReconciler(fakeClient, fakeClient, dk)
 
-		reconciler.Reconcile(context.Background())
+		err := reconciler.Reconcile(context.Background())
+		require.NoError(t, err)
 
 		var secret corev1.Secret
-		err := fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
+		fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
 
 		require.NoError(t, err)
-		require.NotEmpty(t, secret)
+		assert.NotEmpty(t, secret)
 	})
 	t.Run("do not renew self-signed tls secret if it exists", func(t *testing.T) {
 		dk := getTestDynakube()
@@ -72,10 +74,11 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := NewReconciler(fakeClient, fakeClient, dk)
 
-		reconciler.Reconcile(context.Background())
+		err := reconciler.Reconcile(context.Background())
+		require.NoError(t, err)
 
 		var secret corev1.Secret
-		err := fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
+		err = fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
 
 		require.NoError(t, err)
 		require.NotEmpty(t, secret)
@@ -89,13 +92,32 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := NewReconciler(fakeClient, fakeClient, dk)
 
-		reconciler.Reconcile(context.Background())
+		err := reconciler.Reconcile(context.Background())
+		require.NoError(t, err)
 
 		var secret corev1.Secret
-		err := fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
+		err = fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
 
 		require.True(t, k8serrors.IsNotFound(err))
-		require.Empty(t, secret)
+		assert.Empty(t, secret)
+	})
+	t.Run("self-signed tls secret is deleted if spec.extensions.enabled is false", func(t *testing.T) {
+		dk := getTestDynakube()
+		dk.Spec.Extensions.Enabled = false
+
+		fakeClient := fake.NewClient()
+		fakeClient = mockSelfSignedTLSSecret(t, fakeClient, dk)
+
+		reconciler := NewReconciler(fakeClient, fakeClient, dk)
+
+		err := reconciler.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		var secret corev1.Secret
+		err = fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
+
+		require.True(t, k8serrors.IsNotFound(err))
+		require.Equal(t, corev1.Secret{}, secret)
 	})
 }
 

--- a/pkg/controllers/dynakube/extension/tls/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler_test.go
@@ -60,7 +60,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		var secret corev1.Secret
-		fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
+		err = fakeClient.Get(context.Background(), SelfSignedTLSSecretObjectKey, &secret)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, secret)


### PR DESCRIPTION
## Description

[DAQ-1680](https://dt-rnd.atlassian.net/browse/DAQ-1680)

Extensions self-signed TLS Secret was getting reconciled when `spec.extensions.enabled: false`, which is wrong.

Now we check `r.dk.IsExtensionsEnabled()`, like in the rest of extension reconcilers.

I also renamed the functions for clarity.

## How can this be tested?

- I added a new unit test with this case. It fails to execute it on main, and passes on this branch :heavy_check_mark: 
- To test manually, apply dynakube with `spec.extensions.enabled: false` and check that the secret `<namespace>-extensions-controller-tls` doesn't exist.

[DAQ-1680]: https://dt-rnd.atlassian.net/browse/DAQ-1680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ