### PR TITLE
Set ondemand E2E tests at 3AM

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -3,7 +3,7 @@ name: E2E tests ondemand
 on:
   schedule:
     # every Mon/Wed/Fri at 08:00 UTC
-    - cron: 0 8 * * 1,3,5
+    - cron: 0 3 * * 1,3,5
 
 env:
   branch: 'release-1.3'

--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -2,7 +2,7 @@ name: E2E tests ondemand
 
 on:
   schedule:
-    # every Mon/Wed/Fri at 08:00 UTC
+    # At 03:00 UTC on Monday, Wednesday, and Friday.
     - cron: 0 3 * * 1,3,5
 
 env:


### PR DESCRIPTION
## Description

[DAQ-1351](https://dt-rnd.atlassian.net/browse/DAQ-1351)

Change ondemand E2E execution to 3:00 AM.

Daily E2E are executed at 12:00 PM, and usually take 2-3 hours, so they shouldn't collide.

## How can this be tested?

---

[DAQ-1351]: https://dt-rnd.atlassian.net/browse/DAQ-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ