### PR TITLE
Fix dynakube always being set to error phase

### DIFF
--- a/pkg/controllers/dynakube/logmodule/daemonset/reconciler_test.go
+++ b/pkg/controllers/dynakube/logmodule/daemonset/reconciler_test.go
@@ -99,6 +99,20 @@ func TestReconcile(t *testing.T) {
 		assert.Equal(t, conditions.KubeApiErrorReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	})
+
+	t.Run("returns an error if no clusterMEID set", func(t *testing.T) {
+		dk := createDynakube(true)
+		dk.Status.KubernetesClusterMEID = ""
+
+		mockK8sClient := fake.NewClient()
+
+		reconciler := NewReconciler(mockK8sClient,
+			mockK8sClient, dk)
+
+		err := reconciler.Reconcile(context.Background())
+
+		require.Error(t, err)
+	})
 }
 
 func TestGenerateDaemonSet(t *testing.T) {
@@ -251,6 +265,8 @@ func createDynakube(isEnabled bool) *dynakube.DynaKube {
 					},
 				},
 			},
+			KubernetesClusterMEID: "test-cluster-me-id",
+			KubernetesClusterName: "test-cluster-name",
 		},
 	}
 }

--- a/pkg/controllers/dynakube/logmodule/reconciler.go
+++ b/pkg/controllers/dynakube/logmodule/reconciler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmodule/configsecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmodule/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/monitoredentities"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -51,10 +50,6 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		return err
 	}
 
-	if !r.isMEConfigured() {
-		return errors.New("the status of the DynaKube is missing information about the kubernetes monitored-entity, skipping logmodule deployment")
-	}
-
 	err = r.oneAgentConnectionInfoReconciler.Reconcile(ctx)
 	if err != nil {
 		return err
@@ -71,8 +66,4 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (r *Reconciler) isMEConfigured() bool {
-	return r.dk.Status.KubernetesClusterMEID != "" && r.dk.Status.KubernetesClusterName != ""
 }

--- a/pkg/controllers/dynakube/logmodule/reconciler_test.go
+++ b/pkg/controllers/dynakube/logmodule/reconciler_test.go
@@ -14,20 +14,6 @@ import (
 func TestReconcile(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("monitored-entity not available => error", func(t *testing.T) {
-		dk := &dynakube.DynaKube{}
-		notEffectiveMonitoredEntity := createIneffectiveMonitoredEntityReconciler(t, dk)
-		r := Reconciler{
-			dk:                          dk,
-			monitoredEntitiesReconciler: notEffectiveMonitoredEntity,
-		}
-
-		err := r.Reconcile(ctx)
-		require.Error(t, err)
-
-		notEffectiveMonitoredEntity.AssertCalled(t, "Reconcile", ctx)
-	})
-
 	t.Run("connection-info fail => error", func(t *testing.T) {
 		failOAConnectionInfo := createFailingReconciler(t)
 		dk := &dynakube.DynaKube{}
@@ -108,16 +94,6 @@ func createPassingMonitoredEntityReconciler(t *testing.T, dk *dynakube.DynaKube)
 	passMock.On("Reconcile", mock.Anything).Run(func(args mock.Arguments) {
 		dk.Status.KubernetesClusterMEID = "meid"
 		dk.Status.KubernetesClusterName = "cluster-name"
-	}).Return(nil)
-
-	return passMock
-}
-
-func createIneffectiveMonitoredEntityReconciler(t *testing.T, dk *dynakube.DynaKube) *controllermock.Reconciler {
-	passMock := controllermock.NewReconciler(t)
-	passMock.On("Reconcile", mock.Anything).Run(func(args mock.Arguments) {
-		dk.Status.KubernetesClusterMEID = ""
-		dk.Status.KubernetesClusterName = ""
 	}).Return(nil)
 
 	return passMock


### PR DESCRIPTION
## Description
https://dt-rnd.atlassian.net/browse/DAQ-1842

Currently the Dynakube is always set to error phase if there is no kubernetesMEID (e.g because no automatic api monitoring) since the logModule Reconciler always returned an error in this case

## How can this be tested?

Create a cloudNative Dynakube without `kubernetes-monitoring` and without `automatic-api-monitoring` -> check if the phase is correctly set to Runninng