### PR TITLE
Configure Activegate for node collector communication

### DIFF
--- a/pkg/api/v1beta3/dynakube/kspm/kspm.go
+++ b/pkg/api/v1beta3/dynakube/kspm/kspm.go
@@ -6,6 +6,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	TokenSecretKey = "kspm-token"
+)
+
+type Kspm struct {
+	*Spec
+	*NodeConfigurationCollectorSpec
+
+	name string
+}
+
 // +kubebuilder:object:generate=true
 
 type Spec struct {

--- a/pkg/api/v1beta3/dynakube/kspm/props.go
+++ b/pkg/api/v1beta3/dynakube/kspm/props.go
@@ -1,0 +1,13 @@
+package kspm
+
+func (kspm *Kspm) SetName(name string) {
+	kspm.name = name
+}
+
+func (kspm *Kspm) IsEnabled() bool {
+	return kspm.Enabled
+}
+
+func (kspm *Kspm) GetTokenSecretName() string {
+	return kspm.name + "-" + TokenSecretKey
+}

--- a/pkg/api/v1beta3/dynakube/kspm_props.go
+++ b/pkg/api/v1beta3/dynakube/kspm_props.go
@@ -1,13 +1,13 @@
 package dynakube
 
-const (
-	KSPMSecretKey = "kspm-token"
-)
+import "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/kspm"
 
-func (dk *DynaKube) IsKSPMEnabled() bool {
-	return dk.Spec.Kspm.Enabled
-}
+func (dk *DynaKube) KSPM() *kspm.Kspm {
+	_kspm := &kspm.Kspm{
+		Spec:                           &dk.Spec.Kspm,
+		NodeConfigurationCollectorSpec: &dk.Spec.Templates.KspmNodeConfigurationCollector,
+	}
+	_kspm.SetName(dk.GetName())
 
-func (dk *DynaKube) GetKSPMSecretName() string {
-	return dk.Name + "-" + KSPMSecretKey
+	return _kspm
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
@@ -39,5 +39,6 @@ func GenerateAllModifiers(dk dynakube.DynaKube, capability capability.Capability
 		NewServicePortModifier(dk, capability, agBaseContainerEnvMap),
 		NewKubernetesMonitoringModifier(dk, capability),
 		NewEecVolumeModifier(dk),
+		NewKspmModifier(dk),
 	}
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kspm.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kspm.go
@@ -1,0 +1,66 @@
+package modifiers
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/kspm"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/container"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ volumeModifier = KspmModifier{}
+var _ volumeMountModifier = KspmModifier{}
+var _ builder.Modifier = KspmModifier{}
+
+const (
+	kspmTokenVolumeName = "kspm-token"
+	kspmTokenMountPath  = "/var/lib/dynatrace/secrets/tokens/kspm/node-configuration-collector"
+)
+
+func NewKspmModifier(dk dynakube.DynaKube) KspmModifier {
+	return KspmModifier{
+		dk: dk,
+	}
+}
+
+type KspmModifier struct {
+	dk dynakube.DynaKube
+}
+
+func (mod KspmModifier) Enabled() bool {
+	return mod.dk.KSPM().IsEnabled() && mod.dk.ActiveGate().IsKubernetesMonitoringEnabled()
+}
+
+func (mod KspmModifier) Modify(sts *appsv1.StatefulSet) error {
+	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, mod.getVolumes()...)
+	baseContainer := container.FindContainerInPodSpec(&sts.Spec.Template.Spec, consts.ActiveGateContainerName)
+	baseContainer.VolumeMounts = append(baseContainer.VolumeMounts, mod.getVolumeMounts()...)
+
+	return nil
+}
+
+func (mod KspmModifier) getVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: kspmTokenVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: mod.dk.KSPM().GetTokenSecretName(),
+				},
+			},
+		},
+	}
+}
+
+func (mod KspmModifier) getVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			ReadOnly:  true,
+			Name:      kspmTokenVolumeName,
+			MountPath: kspmTokenMountPath,
+			SubPath:   kspm.TokenSecretKey,
+		},
+	}
+}

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kspm_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kspm_test.go
@@ -1,0 +1,60 @@
+package modifiers
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setKSPMUsage(dk *dynakube.DynaKube, isUsed bool) {
+	dk.Spec.Kspm.Enabled = isUsed
+}
+
+func TestKspmEnabled(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		setKSPMUsage(&dk, true)
+
+		mod := NewKspmModifier(dk)
+
+		assert.True(t, mod.Enabled())
+	})
+
+	t.Run("false - directly disabled", func(t *testing.T) {
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		setKSPMUsage(&dk, false)
+
+		mod := NewKspmModifier(dk)
+
+		assert.False(t, mod.Enabled())
+	})
+
+	t.Run("false - dependency(kubemon) not enabled", func(t *testing.T) {
+		dk := getBaseDynakube()
+		setKSPMUsage(&dk, true)
+
+		mod := NewKspmModifier(dk)
+
+		assert.False(t, mod.Enabled())
+	})
+}
+
+func TestKspmModify(t *testing.T) {
+	t.Run("successfully modified", func(t *testing.T) {
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+		setKSPMUsage(&dk, true)
+		mod := NewKspmModifier(dk)
+		builder := createBuilderForTesting()
+
+		sts, _ := builder.AddModifier(mod).Build()
+
+		require.NotEmpty(t, sts)
+		isSubset(t, mod.getVolumes(), sts.Spec.Template.Spec.Volumes)
+		isSubset(t, mod.getVolumeMounts(), sts.Spec.Template.Spec.Containers[0].VolumeMounts)
+	})
+}

--- a/pkg/controllers/dynakube/kspm/token/reconciler_test.go
+++ b/pkg/controllers/dynakube/kspm/token/reconciler_test.go
@@ -29,7 +29,7 @@ func TestTokenCreation(t *testing.T) {
 		require.NoError(t, err)
 
 		var secret corev1.Secret
-		err = clt.Get(ctx, types.NamespacedName{Name: dk.GetKSPMSecretName(), Namespace: dk.Namespace}, &secret)
+		err = clt.Get(ctx, types.NamespacedName{Name: dk.KSPM().GetTokenSecretName(), Namespace: dk.Namespace}, &secret)
 
 		require.NotNil(t, meta.FindStatusCondition(*dk.Conditions(), kspmConditionType))
 		require.Equal(t, conditions.SecretCreatedReason, meta.FindStatusCondition(*dk.Conditions(), kspmConditionType).Reason)
@@ -39,12 +39,12 @@ func TestTokenCreation(t *testing.T) {
 
 	t.Run("removes secret if exists", func(t *testing.T) {
 		dk := createDynaKube(false)
-		conditions.SetSecretCreated(dk.Conditions(), kspmConditionType, dk.GetKSPMSecretName())
+		conditions.SetSecretCreated(dk.Conditions(), kspmConditionType, dk.KSPM().GetTokenSecretName())
 
 		objs := []client.Object{
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      dk.GetKSPMSecretName(),
+					Name:      dk.KSPM().GetTokenSecretName(),
 					Namespace: dk.Namespace,
 				},
 			},
@@ -61,7 +61,7 @@ func TestTokenCreation(t *testing.T) {
 		require.NoError(t, err)
 
 		var secret corev1.Secret
-		err = clt.Get(ctx, types.NamespacedName{Name: dk.GetKSPMSecretName(), Namespace: dk.Namespace}, &secret)
+		err = clt.Get(ctx, types.NamespacedName{Name: dk.KSPM().GetTokenSecretName(), Namespace: dk.Namespace}, &secret)
 
 		require.Empty(t, secret)
 		require.Error(t, err)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-1343](https://dt-rnd.atlassian.net/browse/DAQ-1343)

- [Brings the kspm api package in line](https://github.com/Dynatrace/dynatrace-operator/commit/63d6cc78cda08cc6211f90787c4a880cea0139c8)
- [Add KSPM modifier to activeGate reconciler](https://github.com/Dynatrace/dynatrace-operator/commit/e35acbb92c8b63ec473b1d00436daf7b21c4858d)
  - Just adds a simple volume that contains the token generated  by the Operator, so the ActiveGate and node-configuration-collector can safely communicate

## How can this be tested?

1. Deploy `DynaKube` to test:
```
# This is the minimal config,  if any of the following settings is missing, it will not work, otherwise, you can go crazy with it
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: dk
  namespace: dynatrace
spec:
  apiUrl: https://<tenant>.dev.dynatracelabs.com/api
  kspm:
    enabled: true
  activeGate:
    capabilities:
      - kubernetes-monitoring
```
2. You see the `kspm-token` Volume/Mount on the `StatefulSet` of the ActiveGate
3. When shelling into the ActiveGate container, run:
```
bash-5.1$ cat /var/lib/dynatrace/secrets/tokens/kspm/node-configuration-collector
dt0n01.<super-secret-stuff>
```

[DAQ-1343]: https://dt-rnd.atlassian.net/browse/DAQ-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ