### PR TITLE
Add simple KSPM dependency validation

### DIFF
--- a/pkg/api/validation/dynakube/kspm.go
+++ b/pkg/api/validation/dynakube/kspm.go
@@ -1,0 +1,23 @@
+package validation
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+)
+
+const (
+	errorKSPMMissingKubemon = `For the KSPM feature, the "kubernetes-monitoring" capability also needs to be enabled on the ActiveGate. `
+)
+
+func missingKSPMDependecy(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if !dk.KSPM().IsEnabled() {
+		return ""
+	}
+
+	if dk.ActiveGate().IsKubernetesMonitoringEnabled() {
+		return ""
+	}
+
+	return errorKSPMMissingKubemon
+}

--- a/pkg/api/validation/dynakube/kspm.go
+++ b/pkg/api/validation/dynakube/kspm.go
@@ -10,7 +10,7 @@ const (
 	errorKSPMMissingKubemon = `For the KSPM feature, the "kubernetes-monitoring" capability also needs to be enabled on the ActiveGate. `
 )
 
-func missingKSPMDependecy(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+func missingKSPMDependency(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	if dk.KSPM().IsEnabled() &&
 		!dk.ActiveGate().IsKubernetesMonitoringEnabled() {
 		return errorKSPMMissingKubemon

--- a/pkg/api/validation/dynakube/kspm.go
+++ b/pkg/api/validation/dynakube/kspm.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	errorKSPMMissingKubemon = `For the KSPM feature, the "kubernetes-monitoring" capability also needs to be enabled on the ActiveGate. `
+	errorKSPMMissingKubemon = `The Dynakube's specification specifies KSPM, but "kubernetes-monitoring" is not enabled on the Activegate.`
 )
 
 func missingKSPMDependency(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {

--- a/pkg/api/validation/dynakube/kspm.go
+++ b/pkg/api/validation/dynakube/kspm.go
@@ -11,13 +11,10 @@ const (
 )
 
 func missingKSPMDependecy(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	if !dk.KSPM().IsEnabled() {
-		return ""
+	if dk.KSPM().IsEnabled() &&
+		!dk.ActiveGate().IsKubernetesMonitoringEnabled() {
+		return errorKSPMMissingKubemon
 	}
 
-	if dk.ActiveGate().IsKubernetesMonitoringEnabled() {
-		return ""
-	}
-
-	return errorKSPMMissingKubemon
+	return ""
 }

--- a/pkg/api/validation/dynakube/kspm_test.go
+++ b/pkg/api/validation/dynakube/kspm_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/kspm"
 )
 
-func TestMissingKSPMDependecy(t *testing.T) {
+func TestMissingKSPMDependency(t *testing.T) {
 	t.Run("both kspm and kubemon enabled", func(t *testing.T) {
 		assertAllowed(t,
 			&dynakube.DynaKube{
@@ -27,7 +27,7 @@ func TestMissingKSPMDependecy(t *testing.T) {
 			})
 	})
 
-	t.Run(`missing kubemon but kspm enabled`, func(t *testing.T) {
+	t.Run("missing kubemon but kspm enabled", func(t *testing.T) {
 		assertDenied(t,
 			[]string{errorKSPMMissingKubemon},
 			&dynakube.DynaKube{

--- a/pkg/api/validation/dynakube/kspm_test.go
+++ b/pkg/api/validation/dynakube/kspm_test.go
@@ -1,0 +1,44 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/activegate"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/kspm"
+)
+
+func TestMissingKSPMDependecy(t *testing.T) {
+	t.Run("both kspm and kubemon enabled", func(t *testing.T) {
+		assertAllowed(t,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					Kspm: kspm.Spec{
+						Enabled: true,
+					},
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
+				},
+			})
+	})
+
+	t.Run(`missing kubemon but kspm enabled`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorKSPMMissingKubemon},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					Kspm: kspm.Spec{
+						Enabled: true,
+					},
+					ActiveGate: activegate.Spec{},
+				},
+			})
+	})
+}

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -47,6 +47,7 @@ var (
 		namespaceSelectorViolateLabelSpec,
 		imageFieldHasTenantImage,
 		extensionControllerImage,
+		missingKSPMDependecy,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -47,7 +47,7 @@ var (
 		namespaceSelectorViolateLabelSpec,
 		imageFieldHasTenantImage,
 		extensionControllerImage,
-		missingKSPMDependecy,
+		missingKSPMDependency,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-1352](https://dt-rnd.atlassian.net/browse/DAQ-1352)

For the `KSPM` feature to work, an ActiveGate with the`kubernetes-monitoring` capability also needs to be deployed and configured. This can be simply validated in the webhook

## How can this be tested?

- Should be allowed:
```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: dk
  namespace: dynatrace
spec:
  apiUrl: https://<tenant>.dev.dynatracelabs.com/api
  kspm:
    enabled: true
  activeGate:
    capabilities:
      - kubernetes-monitoring
```
- Should be rejected:
```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: dk
  namespace: dynatrace
spec:
  apiUrl: https://<tenant>.dev.dynatracelabs.com/api
  kspm:
    enabled: true
  activeGate: {}
```

[DAQ-1352]: https://dt-rnd.atlassian.net/browse/DAQ-1352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ