### PR TITLE
Add OneAgent version validator

### DIFF
--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -29,7 +29,7 @@ Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 
 	versionRegex = `^\d+.\d+.\d+.\d{8}-\d{6}$`
 
-	versionInvalidMessage = "Only versions in the form of major.minor.patch.timestamp (e.g. 1.0.0.20240101-000000) are allowed"
+	versionInvalidMessage = "The OneAgent's version is only valid in the format 'major.minor.patch.timestamp', e.g. 1.0.0.20240101-000000"
 )
 
 func conflictingOneAgentConfiguration(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {

--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -3,9 +3,11 @@ package validation
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +26,10 @@ Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 	warningOneAgentInstallerEnvVars = `The environment variables ONEAGENT_INSTALLER_SCRIPT_URL and ONEAGENT_INSTALLER_TOKEN are only relevant for an unsupported image type. Please ensure you are using a supported image.`
 
 	warningHostGroupConflict = `The DynaKube specification sets the host group using the --set-host-group parameter. Instead, specify the new spec.oneagent.hostGroup field. If both settings are used, the new field takes precedence over the parameter.`
+
+	versionRegex = `^\d+.\d+.\d+.\d{8}-\d{6}$`
+
+	versionInvalidMessage = "Only versions in the form of major.minor.patch.timestamp (e.g. 1.0.0.20240101-000000) are allowed"
 )
 
 func conflictingOneAgentConfiguration(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
@@ -158,6 +164,25 @@ func conflictingOneAgentVolumeStorageSettings(_ context.Context, _ *Validator, d
 func conflictingHostGroupSettings(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	if dk.HostGroupAsParam() != "" {
 		return warningHostGroupConflict
+	}
+
+	return ""
+}
+
+func isOneAgentVersionValid(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	agentVersion := dk.CustomOneAgentVersion()
+	if agentVersion == "" {
+		return ""
+	}
+
+	_, err := dtversion.ToSemver(agentVersion)
+	if err != nil {
+		return versionInvalidMessage
+	}
+
+	match, err := regexp.MatchString(versionRegex, agentVersion)
+	if err != nil || !match {
+		return versionInvalidMessage
 	}
 
 	return ""

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -477,3 +477,49 @@ func createDynakubeWithHostGroup(args []string, hostGroup string) *dynakube.Dyna
 		},
 	}
 }
+
+func TestIsOneAgentVersionValid(t *testing.T) {
+	dk := dynakube.DynaKube{
+		ObjectMeta: defaultDynakubeObjectMeta,
+		Spec: dynakube.DynaKubeSpec{
+			APIURL: testApiUrl,
+			OneAgent: dynakube.OneAgentSpec{
+				ClassicFullStack: &dynakube.HostInjectSpec{},
+			},
+		},
+	}
+
+	t.Run("valid OneAgent custom versions are allowed", func(t *testing.T) {
+		versions := []string{"", "1.0.0.20240101-000000"}
+		for _, version := range versions {
+			dk.Spec.OneAgent.ClassicFullStack.Version = version
+			assertAllowed(t, &dk)
+		}
+	})
+	t.Run("invalid OneAgent custom versions are denied", func(t *testing.T) {
+		versions := []string{
+			"latest",
+			"raw",
+			"1.200.1-raw",
+			"v1.200.1-raw",
+			"1.200.1+build",
+			"v1.200.1+build",
+			"1.200.1-raw+build",
+			"v1.200.1-raw+build",
+			"1.200",
+			"1.200.0",
+			"1.200.0.0",
+			"1.200.0.0-0",
+			"v1.200",
+			"1",
+			"v1",
+			"1.0",
+			"v1.0",
+			"v1.200.0",
+		}
+		for _, version := range versions {
+			dk.Spec.OneAgent.ClassicFullStack.Version = version
+			assertDenied(t, []string{versionInvalidMessage}, &dk)
+		}
+	})
+}

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -517,6 +517,7 @@ func TestIsOneAgentVersionValid(t *testing.T) {
 			assertAllowed(t, &dk)
 		})
 	}
+
 	for _, invalidVersion := range invalidVersions {
 		dk.Spec.OneAgent.ClassicFullStack.Version = invalidVersion
 		t.Run(fmt.Sprintf("OneAgent custom version %s is not allowed", invalidVersion), func(t *testing.T) {

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -489,37 +489,38 @@ func TestIsOneAgentVersionValid(t *testing.T) {
 		},
 	}
 
-	t.Run("valid OneAgent custom versions are allowed", func(t *testing.T) {
-		versions := []string{"", "1.0.0.20240101-000000"}
-		for _, version := range versions {
-			dk.Spec.OneAgent.ClassicFullStack.Version = version
+	validVersions := []string{"", "1.0.0.20240101-000000"}
+	invalidVersions := []string{
+		"latest",
+		"raw",
+		"1.200.1-raw",
+		"v1.200.1-raw",
+		"1.200.1+build",
+		"v1.200.1+build",
+		"1.200.1-raw+build",
+		"v1.200.1-raw+build",
+		"1.200",
+		"1.200.0",
+		"1.200.0.0",
+		"1.200.0.0-0",
+		"v1.200",
+		"1",
+		"v1",
+		"1.0",
+		"v1.0",
+		"v1.200.0",
+	}
+
+	for _, validVersion := range validVersions {
+		dk.Spec.OneAgent.ClassicFullStack.Version = validVersion
+		t.Run(fmt.Sprintf("OneAgent custom version %s is allowed", validVersion), func(t *testing.T) {
 			assertAllowed(t, &dk)
-		}
-	})
-	t.Run("invalid OneAgent custom versions are denied", func(t *testing.T) {
-		versions := []string{
-			"latest",
-			"raw",
-			"1.200.1-raw",
-			"v1.200.1-raw",
-			"1.200.1+build",
-			"v1.200.1+build",
-			"1.200.1-raw+build",
-			"v1.200.1-raw+build",
-			"1.200",
-			"1.200.0",
-			"1.200.0.0",
-			"1.200.0.0-0",
-			"v1.200",
-			"1",
-			"v1",
-			"1.0",
-			"v1.0",
-			"v1.200.0",
-		}
-		for _, version := range versions {
-			dk.Spec.OneAgent.ClassicFullStack.Version = version
+		})
+	}
+	for _, invalidVersion := range invalidVersions {
+		dk.Spec.OneAgent.ClassicFullStack.Version = invalidVersion
+		t.Run(fmt.Sprintf("OneAgent custom version %s is not allowed", invalidVersion), func(t *testing.T) {
 			assertDenied(t, []string{versionInvalidMessage}, &dk)
-		}
-	})
+		})
+	}
 }

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -27,6 +27,7 @@ var (
 		isExtensionsModuleDisabled,
 		isLogMonitoringModuleDisabled,
 		isOneAgentModuleDisabled,
+		isOneAgentVersionValid,
 		NoApiUrl,
 		IsInvalidApiUrl,
 		IsThirdGenAPIUrl,

--- a/pkg/controllers/nodes/nodes_controller.go
+++ b/pkg/controllers/nodes/nodes_controller.go
@@ -303,7 +303,7 @@ func (controller *Controller) sendMarkedForTermination(ctx context.Context, dk *
 		return err
 	}
 
-	ts := uint64(cachedNode.LastSeen.Add(-10*time.Minute).UnixNano()) / uint64(time.Millisecond)
+	ts := uint64(cachedNode.LastSeen.Add(-10*time.Minute).UnixNano()) / uint64(time.Millisecond) //nolint:gosec
 
 	return dynatraceClient.SendEvent(ctx, &dtclient.EventData{
 		EventType:     dtclient.MarkedForTerminationEvent,

--- a/pkg/controllers/nodes/nodes_controller.go
+++ b/pkg/controllers/nodes/nodes_controller.go
@@ -303,7 +303,7 @@ func (controller *Controller) sendMarkedForTermination(ctx context.Context, dk *
 		return err
 	}
 
-	ts := uint64(cachedNode.LastSeen.Add(-10*time.Minute).UnixNano()) / uint64(time.Millisecond) //nolint:gosec
+	ts := uint64(cachedNode.LastSeen.Add(-10*time.Minute).UnixNano()) / uint64(time.Millisecond)
 
 	return dynatraceClient.SendEvent(ctx, &dtclient.EventData{
 		EventType:     dtclient.MarkedForTerminationEvent,


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/DAQ-1817

Add validator for OA version. Now it works only for timestamped versions.

We removed it on a previous PR but got the requirement to have it in place for 1.3.2.

## How can this be tested?

Only DynaKubes with versions like this should pass the CR validation when applying:
```yaml
spec:
  oneAgent:
    cloudNativeFullStack:
      version: 1.304.0.20240826-070516
```
