### PR TITLE
[release-1.3] Add OneAgent version validator

### DIFF
--- a/pkg/api/v1beta1/dynakube/validation/oneagent_test.go
+++ b/pkg/api/v1beta1/dynakube/validation/oneagent_test.go
@@ -425,40 +425,50 @@ func createDynakubeWithHostGroup(args []string, hostGroup string) *dynakube.Dyna
 	}
 }
 
-func TestValidateOneAgentVersionIsSemVer(t *testing.T) {
-	testCasesAcceptedVersions := []string{"", "1.0.0", "1.200.1"}
+func TestIsOneAgentVersionValid(t *testing.T) {
+	dk := dynakube.DynaKube{
+		ObjectMeta: defaultDynakubeObjectMeta,
+		Spec: dynakube.DynaKubeSpec{
+			APIURL: testApiUrl,
+			OneAgent: dynakube.OneAgentSpec{
+				ClassicFullStack: &dynakube.HostInjectSpec{},
+			},
+		},
+	}
 
-	testCasesNotAcceptedVersions := []string{"latest", "raw", "1.200.1-raw", "v1.200.1-raw", "1.200.1+build", "v1.200.1+build", "1.200.1-raw+build", "v1.200.1-raw+build", "1.200", "v1.200", "1", "v1", "1.0", "v1.0", "v1.200.0"}
+	validVersions := []string{"", "1.0.0.20240101-000000"}
+	invalidVersions := []string{
+		"latest",
+		"raw",
+		"1.200.1-raw",
+		"v1.200.1-raw",
+		"1.200.1+build",
+		"v1.200.1+build",
+		"1.200.1-raw+build",
+		"v1.200.1-raw+build",
+		"1.200",
+		"1.200.0",
+		"1.200.0.0",
+		"1.200.0.0-0",
+		"v1.200",
+		"1",
+		"v1",
+		"1.0",
+		"v1.0",
+		"v1.200.0",
+	}
 
-	for _, tc := range testCasesAcceptedVersions {
-		t.Run("should accept version "+tc, func(t *testing.T) {
-			assertAllowed(t, &dynakube.DynaKube{
-				ObjectMeta: defaultDynakubeObjectMeta,
-				Spec: dynakube.DynaKubeSpec{
-					APIURL: testApiUrl,
-					OneAgent: dynakube.OneAgentSpec{
-						ClassicFullStack: &dynakube.HostInjectSpec{
-							Version: tc,
-						},
-					},
-				},
-			})
+	for _, validVersion := range validVersions {
+		dk.Spec.OneAgent.ClassicFullStack.Version = validVersion
+		t.Run(fmt.Sprintf("OneAgent custom version %s is allowed", validVersion), func(t *testing.T) {
+			assertAllowed(t, &dk)
 		})
 	}
 
-	for _, tc := range testCasesNotAcceptedVersions {
-		t.Run("should accept version "+tc, func(t *testing.T) {
-			assertDenied(t, []string{"Only semantic versions in the form of major.minor.patch (e.g. 1.0.0) are allowed!"}, &dynakube.DynaKube{
-				ObjectMeta: defaultDynakubeObjectMeta,
-				Spec: dynakube.DynaKubeSpec{
-					APIURL: testApiUrl,
-					OneAgent: dynakube.OneAgentSpec{
-						ClassicFullStack: &dynakube.HostInjectSpec{
-							Version: tc,
-						},
-					},
-				},
-			})
+	for _, invalidVersion := range invalidVersions {
+		dk.Spec.OneAgent.ClassicFullStack.Version = invalidVersion
+		t.Run(fmt.Sprintf("OneAgent custom version %s is not allowed", invalidVersion), func(t *testing.T) {
+			assertDenied(t, []string{versionInvalidMessage}, &dk)
 		})
 	}
 }

--- a/pkg/api/v1beta1/dynakube/validation/validation.go
+++ b/pkg/api/v1beta1/dynakube/validation/validation.go
@@ -22,6 +22,7 @@ var (
 		NoApiUrl,
 		IsInvalidApiUrl,
 		IsThirdGenAPIUrl,
+		isOneAgentVersionValid,
 		missingCSIDaemonSet,
 		disabledCSIForReadonlyCSIVolume,
 		invalidActiveGateCapabilities,
@@ -37,7 +38,6 @@ var (
 		nameTooLong,
 		namespaceSelectorViolateLabelSpec,
 		imageFieldHasTenantImage,
-		validateOneAgentVersionIsSemVerCompliant,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,

--- a/pkg/api/v1beta2/dynakube/validation/oneagent_test.go
+++ b/pkg/api/v1beta2/dynakube/validation/oneagent_test.go
@@ -424,3 +424,51 @@ func createDynakubeWithHostGroup(args []string, hostGroup string) *dynakube.Dyna
 		},
 	}
 }
+
+func TestIsOneAgentVersionValid(t *testing.T) {
+	dk := dynakube.DynaKube{
+		ObjectMeta: defaultDynakubeObjectMeta,
+		Spec: dynakube.DynaKubeSpec{
+			APIURL: testApiUrl,
+			OneAgent: dynakube.OneAgentSpec{
+				ClassicFullStack: &dynakube.HostInjectSpec{},
+			},
+		},
+	}
+
+	validVersions := []string{"", "1.0.0.20240101-000000"}
+	invalidVersions := []string{
+		"latest",
+		"raw",
+		"1.200.1-raw",
+		"v1.200.1-raw",
+		"1.200.1+build",
+		"v1.200.1+build",
+		"1.200.1-raw+build",
+		"v1.200.1-raw+build",
+		"1.200",
+		"1.200.0",
+		"1.200.0.0",
+		"1.200.0.0-0",
+		"v1.200",
+		"1",
+		"v1",
+		"1.0",
+		"v1.0",
+		"v1.200.0",
+	}
+
+	for _, validVersion := range validVersions {
+		dk.Spec.OneAgent.ClassicFullStack.Version = validVersion
+		t.Run(fmt.Sprintf("OneAgent custom version %s is allowed", validVersion), func(t *testing.T) {
+			assertAllowed(t, &dk)
+		})
+	}
+
+	for _, invalidVersion := range invalidVersions {
+		dk.Spec.OneAgent.ClassicFullStack.Version = invalidVersion
+		t.Run(fmt.Sprintf("OneAgent custom version %s is not allowed", invalidVersion), func(t *testing.T) {
+			assertDenied(t, []string{versionInvalidMessage}, &dk)
+		})
+	}
+}

--- a/pkg/api/v1beta2/dynakube/validation/validation.go
+++ b/pkg/api/v1beta2/dynakube/validation/validation.go
@@ -19,6 +19,7 @@ type Validator struct {
 
 var (
 	validatorErrorFuncs = []validatorFunc{
+		isOneAgentVersionValid,
 		NoApiUrl,
 		IsInvalidApiUrl,
 		IsThirdGenAPIUrl,

--- a/pkg/controllers/nodes/nodes_controller.go
+++ b/pkg/controllers/nodes/nodes_controller.go
@@ -303,7 +303,7 @@ func (controller *Controller) sendMarkedForTermination(ctx context.Context, dk *
 		return err
 	}
 
-	ts := uint64(cachedNode.LastSeen.Add(-10*time.Minute).UnixNano()) / uint64(time.Millisecond)
+	ts := uint64(cachedNode.LastSeen.Add(-10*time.Minute).UnixNano()) / uint64(time.Millisecond) //nolint:gosec
 
 	return dynatraceClient.SendEvent(ctx, &dtclient.EventData{
 		EventType:     dtclient.MarkedForTerminationEvent,


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/DAQ-1817

Same as https://github.com/Dynatrace/dynatrace-operator/pull/3966

But adding the validator also for beta1 (because different apiVersion validators are only merged on main)

## How can this be tested?

Only DynaKubes with versions like this should pass the CR validation when applying:
```yaml
spec:
  oneAgent:
    cloudNativeFullStack:
      version: 1.304.0.20240826-070516
```
:warning:  Test on v1beta1 and v1beta2