### PR TITLE
Run unit tests only once on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,12 +61,12 @@ jobs:
         id: depdownload
         run: |
           hack/build/ci/install-cgo-dependencies.sh
-      - name: Run Unit tests and Integration tests
+      - name: Run unit tests and integration tests
         id: unittest
         run: |
           make go/test
           make go/integration_test
-      - name: check test coverage
+      - name: Check test coverage
         id: check-code-coverage
         run: |
           make go/check-coverage
@@ -93,7 +93,7 @@ jobs:
         id: depdownload
         run: |
           hack/build/ci/install-cgo-dependencies.sh
-      - name: golangci-lint
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
           # renovate depName=github.com/golangci/golangci-lint

--- a/hack/make/go.mk
+++ b/hack/make/go.mk
@@ -56,5 +56,6 @@ go/deadcode: prerequisites/go-deadcode
 	# we add `tee` in the end to make it fail if it finds dead code, by default deadcode always return exit code 0
 	deadcode -test -tags="$(shell ./hack/build/create_go_build_tags.sh true)" $(LINT_TARGET) | tee deadcode.out && [ ! -s deadcode.out ]
 
-go/check-coverage: prerequisites/go-test-coverage go/test
+## Runs go-test-coverage tool
+go/check-coverage: prerequisites/go-test-coverage
 	go-test-coverage --config=./.testcoverage.yml


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/DAQ-1918

Unit tests are currently executed two times on CI, once on `Run unit tests - Run Unit tests and Integration tests` step and another time on `Run unit tests - check code coverage` step.

This PR removes the second execution (which was in `make go/check-coverage`)

## How can this be tested?

Compare CI action executions and see that unit tests are not executed twice on this branch.
  New CI -> https://github.com/Dynatrace/dynatrace-operator/actions/runs/11496876194/job/31999373500?pr=3972
  Old CI  -> https://github.com/Dynatrace/dynatrace-operator/actions/runs/11495532388/job/31995247239
Code coverage should still be working fine.