### PR TITLE
Remove vulnerability from the update-renovate-json5.py script

### DIFF
--- a/.github/workflows/self-update-on-new-release-version.yaml
+++ b/.github/workflows/self-update-on-new-release-version.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Update renovate file
         run: |
           source local/.venv/bin/activate
-          python3 hack/build/ci/update-renovate-json5.py release-branches.txt .github/renovate.json5
+          python3 hack/build/ci/update-renovate-json5.py
       - name: Update e2e-tests-ondemand.yaml file
         run: |
           source local/.venv/bin/activate

--- a/hack/build/ci/update-renovate-json5.py
+++ b/hack/build/ci/update-renovate-json5.py
@@ -2,8 +2,8 @@ import json5
 import sys
 
 # version file contains a list of strings
-versionFile = sys.argv[1]
-renovateFile = sys.argv[2]
+versionFile = "release-branches.txt"
+renovateFile = ".github/renovate.json5"
 
 # read versions to list
 versions = ["$default"]


### PR DESCRIPTION
[DAQ-1716](https://dt-rnd.atlassian.net/browse/DAQ-1716)

## Description

The script can't be used to read specific file in any directory. Still can be called in any CurrentWorkingDirectory but the filename is hardcoded.

## How can this be tested?

I tested the `self-update-on-new-release-version.yaml` workflow using my forked repo (`release-1.0` branch exists, I am pushing `release-1.1`)  and it works as expected :

```
 baseBranches: [       =>      baseBranches: [
    "$default",                   "$default",
    "release-1.1",                "release-1.0",
    "release-1.2",                "release-1.1",
    "release-1.3",             ],
  ],
  
      matchBaseBranches: [    =>    matchBaseBranches: [
        "$default",                   "$default",
        "release-1.1",                "release-1.0",
        "release-1.2",                "release-1.1",
        "release-1.3",              ],
      ],
```

[DAQ-1716]: https://dt-rnd.atlassian.net/browse/DAQ-1716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ