### PR TITLE
Add Dynakube condition for Extensions TLS reconciler

### DIFF
--- a/pkg/controllers/dynakube/extension/tls/conditions.go
+++ b/pkg/controllers/dynakube/extension/tls/conditions.go
@@ -1,0 +1,3 @@
+package tls
+
+const extensionsTLSSecretConditionType string = "ExtensionsTLSSecret"

--- a/pkg/controllers/dynakube/extension/tls/conditions.go
+++ b/pkg/controllers/dynakube/extension/tls/conditions.go
@@ -1,3 +1,3 @@
 package tls
 
-const extensionsTLSSecretConditionType string = "ExtensionsTLSSecret"
+const conditionType string = "ExtensionsTLSSecret"

--- a/pkg/controllers/dynakube/extension/tls/reconciler.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler.go
@@ -130,6 +130,8 @@ func (r *reconciler) createSelfSignedTLSSecret(ctx context.Context) error {
 		return err
 	}
 
+	conditions.SetSecretCreated(r.dk.Conditions(), extensionsTLSSecretConditionType, secret.Name)
+
 	return nil
 }
 

--- a/pkg/controllers/dynakube/extension/tls/reconciler.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler.go
@@ -8,11 +8,13 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/certificates"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	k8slabels "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,6 +42,11 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		return r.reconcileSelfSignedTLSSecret(ctx)
 	}
 
+	if meta.FindStatusCondition(*r.dk.Conditions(), extensionsTLSSecretConditionType) == nil {
+		return nil
+	}
+	defer meta.RemoveStatusCondition(r.dk.Conditions(), extensionsTLSSecretConditionType)
+
 	return r.deleteSelfSignedTLSSecret(ctx)
 }
 
@@ -55,7 +62,13 @@ func (r *reconciler) reconcileSelfSignedTLSSecret(ctx context.Context) error {
 		return r.createSelfSignedTLSSecret(ctx)
 	}
 
-	return err
+	if err != nil {
+		conditions.SetKubeApiError(r.dk.Conditions(), extensionsTLSSecretConditionType, err)
+
+		return err
+	}
+
+	return nil
 }
 
 func (r *reconciler) deleteSelfSignedTLSSecret(ctx context.Context) error {
@@ -72,6 +85,8 @@ func (r *reconciler) deleteSelfSignedTLSSecret(ctx context.Context) error {
 func (r *reconciler) createSelfSignedTLSSecret(ctx context.Context) error {
 	cert, err := certificates.New(r.timeProvider)
 	if err != nil {
+		conditions.SetSecretGenFailed(r.dk.Conditions(), extensionsTLSSecretConditionType, err)
+
 		return err
 	}
 
@@ -82,11 +97,15 @@ func (r *reconciler) createSelfSignedTLSSecret(ctx context.Context) error {
 
 	err = cert.SelfSign()
 	if err != nil {
+		conditions.SetSecretGenFailed(r.dk.Conditions(), extensionsTLSSecretConditionType, err)
+
 		return err
 	}
 
 	pemCert, pemPk, err := cert.ToPEM()
 	if err != nil {
+		conditions.SetSecretGenFailed(r.dk.Conditions(), extensionsTLSSecretConditionType, err)
+
 		return err
 	}
 
@@ -95,6 +114,8 @@ func (r *reconciler) createSelfSignedTLSSecret(ctx context.Context) error {
 
 	secret, err := k8ssecret.Build(r.dk, getSelfSignedTLSSecretName(r.dk.Name), secretData, k8ssecret.SetLabels(coreLabels.BuildLabels()))
 	if err != nil {
+		conditions.SetSecretGenFailed(r.dk.Conditions(), extensionsTLSSecretConditionType, err)
+
 		return err
 	}
 
@@ -104,6 +125,8 @@ func (r *reconciler) createSelfSignedTLSSecret(ctx context.Context) error {
 
 	err = query.Create(ctx, secret)
 	if err != nil {
+		conditions.SetKubeApiError(r.dk.Conditions(), extensionsTLSSecretConditionType, err)
+
 		return err
 	}
 

--- a/pkg/controllers/dynakube/extension/tls/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler_test.go
@@ -66,7 +66,7 @@ func TestReconcile(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, secret)
-		assert.NotEmpty(t, dk.Conditions())
+		require.NotEmpty(t, dk.Conditions())
 		assert.Equal(t, extensionsTLSSecretConditionType, (*dk.Conditions())[0].Type)
 		assert.Equal(t, metav1.ConditionTrue, (*dk.Conditions())[0].Status)
 		assert.Equal(t, conditions.SecretCreatedReason, (*dk.Conditions())[0].Reason)

--- a/pkg/controllers/dynakube/extension/tls/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler_test.go
@@ -67,7 +67,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, secret)
 		require.NotEmpty(t, dk.Conditions())
-		assert.Equal(t, extensionsTLSSecretConditionType, (*dk.Conditions())[0].Type)
+		assert.Equal(t, conditionType, (*dk.Conditions())[0].Type)
 		assert.Equal(t, metav1.ConditionTrue, (*dk.Conditions())[0].Status)
 		assert.Equal(t, conditions.SecretCreatedReason, (*dk.Conditions())[0].Reason)
 		assert.Equal(t, "dynakube-extensions-controller-tls created", (*dk.Conditions())[0].Message)
@@ -75,7 +75,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("do not renew self-signed tls secret if it exists", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Spec.Templates.ExtensionExecutionController.TlsRefName = ""
-		conditions.SetSecretCreated(dk.Conditions(), extensionsTLSSecretConditionType, "dynakube-extensions-controller-tls")
+		conditions.SetSecretCreated(dk.Conditions(), conditionType, "dynakube-extensions-controller-tls")
 
 		fakeClient := fake.NewClient()
 		fakeClient = mockSelfSignedTLSSecret(t, fakeClient, dk)
@@ -95,7 +95,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("self-signed tls secret is deleted", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Spec.Templates.ExtensionExecutionController.TlsRefName = "dummy-value"
-		conditions.SetSecretCreated(dk.Conditions(), extensionsTLSSecretConditionType, "dynakube-extensions-controller-tls")
+		conditions.SetSecretCreated(dk.Conditions(), conditionType, "dynakube-extensions-controller-tls")
 
 		fakeClient := fake.NewClient()
 		fakeClient = mockSelfSignedTLSSecret(t, fakeClient, dk)
@@ -115,7 +115,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("self-signed tls secret is deleted if spec.extensions.enabled is false", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Spec.Extensions.Enabled = false
-		conditions.SetSecretCreated(dk.Conditions(), extensionsTLSSecretConditionType, "dynakube-extensions-controller-tls")
+		conditions.SetSecretCreated(dk.Conditions(), conditionType, "dynakube-extensions-controller-tls")
 
 		fakeClient := fake.NewClient()
 		fakeClient = mockSelfSignedTLSSecret(t, fakeClient, dk)


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/DAQ-1717

Add new condition `ExtensionsTLSSecret` when Extensions TLS reconciler generates a self-signed TLS secret

## How can this be tested?

- Deploy Dynakube with extensions enabled and without `tlsRefName`, so the Operator generates the secret and adds the condition.
```yaml
spec:
  apiUrl: https://dib18963.dev.dynatracelabs.com/api
  extensions:
    enabled: true
  templates:
    extensionExecutionController:
      imageRef:
        repository: extk8sregistry.azurecr.io/eec/dynatrace-eec
        tag: 1.301.0.20240826-070516
  customPullSecret: azurecr
  tokens: dynakube
```