### PR TITLE
Create AG service if KSPM is enabled

### DIFF
--- a/pkg/api/v1beta3/dynakube/activegate/props.go
+++ b/pkg/api/v1beta3/dynakube/activegate/props.go
@@ -31,7 +31,6 @@ func (ag *Spec) SetKSPMDependency(isEnabled bool) {
 	ag.enabledDependencies.kspm = isEnabled
 }
 
-
 func (ag *Spec) apiUrlHost() string {
 	parsedUrl, err := url.Parse(ag.apiUrl)
 	if err != nil {

--- a/pkg/api/v1beta3/dynakube/activegate/props.go
+++ b/pkg/api/v1beta3/dynakube/activegate/props.go
@@ -27,6 +27,11 @@ func (ag *Spec) SetExtensionsDependency(isEnabled bool) {
 	ag.enabledDependencies.extensions = isEnabled
 }
 
+func (ag *Spec) SetKSPMDependency(isEnabled bool) {
+	ag.enabledDependencies.kspm = isEnabled
+}
+
+
 func (ag *Spec) apiUrlHost() string {
 	parsedUrl, err := url.Parse(ag.apiUrl)
 	if err != nil {
@@ -83,7 +88,8 @@ func (ag *Spec) NeedsService() bool {
 	return ag.IsRoutingEnabled() ||
 		ag.IsApiEnabled() ||
 		ag.IsMetricsIngestEnabled() ||
-		ag.enabledDependencies.extensions
+		ag.enabledDependencies.extensions ||
+		ag.enabledDependencies.kspm
 }
 
 func (ag *Spec) HasCaCert() bool {

--- a/pkg/api/v1beta3/dynakube/activegate/spec.go
+++ b/pkg/api/v1beta3/dynakube/activegate/spec.go
@@ -60,6 +60,7 @@ type ActiveGate struct {
 // dependencies is a collection of possible other feature/components that need an ActiveGate, but is not directly configured in the ActiveGate section.
 type dependencies struct {
 	extensions bool
+	kspm       bool
 }
 
 func (d dependencies) Any() bool {

--- a/pkg/api/v1beta3/dynakube/activegate_props.go
+++ b/pkg/api/v1beta3/dynakube/activegate_props.go
@@ -8,6 +8,7 @@ func (dk *DynaKube) ActiveGate() *activegate.ActiveGate {
 	dk.Spec.ActiveGate.SetApiUrl(dk.ApiUrl())
 	dk.Spec.ActiveGate.SetName(dk.Name)
 	dk.Spec.ActiveGate.SetExtensionsDependency(dk.IsExtensionsEnabled())
+	dk.Spec.ActiveGate.SetKSPMDependency(dk.KSPM().IsEnabled())
 
 	return &activegate.ActiveGate{
 		Spec:   &dk.Spec.ActiveGate,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

related to [DAQ-1448](https://dt-rnd.atlassian.net/browse/DAQ-1448)

In the [KSPM DaemonSet PR](https://github.com/Dynatrace/dynatrace-operator/pull/3997) there was an issue, that if no ActiveGate capability was configured that would result in the creation of a `Service` then the node-collector DaemonSet couldn't communicate with the ActiveGate

## How can this be tested?
This should work: (be sure to ONLY set the `kubernetes-monitoring` capability)
```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: dk
  namespace: dynatrace
spec:
  apiUrl: https://<tenant>.dev.dynatracelabs.com/api
  kspm:
    enabled: true
  activeGate:
    tlsSecretName: my-secret
    capabilities:
      - kubernetes-monitoring
    customProperties:
      value: |
        [kubernetes_monitoring]
        kubernetes_configuration_dataset_pipeline_enabled = true
        kubernetes_configuration_dataset_pipeline_include_node_config = true
  templates:
     kspmNodeConfigurationCollector:
       imageRef:
         repository: us-central1-docker.pkg.dev/cloud-platform-207208/chmu/k8s-node-config-collector
         tag: latest
```

[DAQ-1448]: https://dt-rnd.atlassian.net/browse/DAQ-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ