### PR TITLE
Implement rate limiter for GRPC server

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: dynakubes.dynatrace.com
 spec:
   group: dynatrace.com

--- a/config/crd/bases/dynatrace.com_edgeconnects.yaml
+++ b/config/crd/bases/dynatrace.com_edgeconnects.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: edgeconnects.dynatrace.com
 spec:
   group: dynatrace.com

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: dynakubes.dynatrace.com
 spec:
   conversion:
@@ -4528,7 +4528,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: edgeconnects.dynatrace.com
 spec:
   conversion:

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -95,7 +95,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
         livenessProbe:
-          failureThreshold: 3
+          failureThreshold: 5
           httpGet:
             path: /healthz
             port: healthz
@@ -103,7 +103,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 4
         ports:
         - containerPort: 9808
           name: healthz
@@ -213,6 +213,7 @@ spec:
         args:
         - --csi-address=/csi/csi.sock
         - --health-port=9808
+        - --probe-timeout=4s
         command:
         - livenessprobe
         resources:

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -182,7 +182,7 @@ tests:
                 image: image-name
                 imagePullPolicy: Always
                 livenessProbe:
-                  failureThreshold: 3
+                  failureThreshold: 5
                   httpGet:
                     path: "/healthz"
                     port: healthz
@@ -190,7 +190,7 @@ tests:
                   initialDelaySeconds: 5
                   periodSeconds: 5
                   successThreshold: 1
-                  timeoutSeconds: 1
+                  timeoutSeconds: 4
                 name: server
                 ports:
                   - containerPort: 9808
@@ -321,6 +321,7 @@ tests:
               - args:
                   - "--csi-address=/csi/csi.sock"
                   - "--health-port=9808"
+                  - "--probe-timeout=4s"
                 command:
                   - livenessprobe
                 image: image-name

--- a/pkg/controllers/csi/config.go
+++ b/pkg/controllers/csi/config.go
@@ -37,7 +37,7 @@ const (
 	UnixUmask = 0000
 )
 
-var MetadataAccessPath = filepath.Join(DataPath, "csi.db")
+var MetadataAccessPath = filepath.Join(DataPath, "csi.db?_journal=WAL")
 
 type CSIOptions struct {
 	NodeId   string

--- a/pkg/controllers/csi/driver/server.go
+++ b/pkg/controllers/csi/driver/server.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
@@ -39,6 +40,10 @@ import (
 	mount "k8s.io/mount-utils"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
+
+const MaxGrpcRequests = 20
+
+var counter atomic.Int32
 
 type Server struct {
 	csi.UnimplementedIdentityServer
@@ -96,7 +101,7 @@ func (svr *Server) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start server: %w", err)
 	}
 
-	server := grpc.NewServer(grpc.UnaryInterceptor(logGRPC()))
+	server := grpc.NewServer(grpc.UnaryInterceptor(grpcLimiter()))
 
 	go func() {
 		ticker := time.NewTicker(memoryMetricTick)
@@ -231,27 +236,39 @@ func (svr *Server) NodeExpandVolume(context.Context, *csi.NodeExpandVolumeReques
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-func logGRPC() grpc.UnaryServerInterceptor {
+func grpcLimiter() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if info.FullMethod == "/csi.v1.Identity/Probe" || info.FullMethod == "/csi.v1.Node/NodeGetCapabilities" {
-			return handler(ctx, req)
-		}
+		var methodName string
 
-		methodName := ""
-
-		if info.FullMethod == "/csi.v1.Node/NodePublishVolume" {
+		switch {
+		case info.FullMethod == "/csi.v1.Node/NodePublishVolume":
 			req := req.(*csi.NodePublishVolumeRequest)
 			methodName = "NodePublishVolume"
 			log.Info("GRPC call", "method", methodName, "volume-id", req.GetVolumeId())
-		} else if info.FullMethod == "/csi.v1.Node/NodeUnpublishVolume" {
+		case info.FullMethod == "/csi.v1.Node/NodeUnpublishVolume":
 			req := req.(*csi.NodeUnpublishVolumeRequest)
 			methodName = "NodeUnpublishVolume"
 			log.Info("GRPC call", "method", methodName, "volume-id", req.GetVolumeId())
+		default:
+			resp, err := handler(ctx, req)
+			if err != nil {
+				log.Error(err, "GRPC failed", "full_method", info.FullMethod)
+			}
+
+			return resp, err
+		}
+
+		counter.Add(1)
+		defer counter.Add(-1)
+
+		if counter.Load() > MaxGrpcRequests {
+			return nil, status.Error(codes.ResourceExhausted, fmt.Sprintf("rate limit exceeded, current value %d more than max %d", counter.Load(), MaxGrpcRequests))
 		}
 
 		resp, err := handler(ctx, req)
+
 		if err != nil {
-			log.Error(err, "GRPC call failed", "method", methodName)
+			log.Error(err, "GRPC call failed", "method", methodName, "full_method", info.FullMethod)
 		}
 
 		return resp, err


### PR DESCRIPTION
## Description

This PR introduce:

and fixes https://dt-rnd.atlassian.net/browse/DAQ-2252

- switch journal=WAL for SQLite connection string (to avoid lock database error)
- implement rate limiter for Publish/Unpublish grpc server methods
- increase liveness probe to up-to `4s` https://github.com/Dynatrace/dynatrace-operator/pull/4018/files#diff-7e50509ea7a8d1b31acdb20b0d93c4dbb51cb3e5940a654756793cf3b4485462R216 (because under heavy load performance and small limit of CPU usage, response time increases from GRPC server).


## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

1. Deploy Operator release-1.3 version without patch and deploy dk:
```
apiVersion: dynatrace.com/v1beta2
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://<tenant>.dev.dynatracelabs.com/api
  activeGate:
    capabilities:
      - routing
  oneAgent:
    applicationMonitoring:
      useCSIDriver: true
```
2. Create sample-app namespace and deploy sample apps to inject oneAgent:
```
apiVersion: apps/v1
kind: ReplicaSet
metadata:
  name: sample-app
  namespace: sample-app
spec:
  replicas: 200
  selector:
    matchLabels:
      tier: sample-app
  template:
    metadata:
      labels:
        tier: sample-app
    spec:
      containers:
        - name: pause
          image: gcr.io/google_containers/pause-amd64:3.0
```
3. It's easy to run 100 pods using regular dev GKE cluster.
4. Monitor csi driver logs, and expose metrics endpoint and monitor for example number of `gorotines` per pod:
```
kubectl port-forward -n dynatrace dynatrace-oneagent-csi-driver-fh8gx 8080:8080
```

```
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 26
```

If you start collecting metric and visualise you we get something like it, but keep in mind ( we tested using bigger cluster and ~ 450-460 pods per node.)
<img width="1688" alt="Screenshot 2024-11-08 at 07 51 18" src="https://github.com/user-attachments/assets/7ca6b89b-1a6d-49b1-be78-0e99ff21e986">
