### PR TITLE
Removes vulnerability from the update-e2e-ondemand-pipeline.py script

### DIFF
--- a/.github/workflows/self-update-on-new-release-version.yaml
+++ b/.github/workflows/self-update-on-new-release-version.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Update e2e-tests-ondemand.yaml file
         run: |
           source local/.venv/bin/activate
-          python3 hack/build/ci/update-e2e-ondemand-pipeline.py release-branches.txt .github/workflows/e2e-tests-ondemand.yaml
+          python3 hack/build/ci/update-e2e-ondemand-pipeline.py
       - name: Create pull request for updating all files
         uses: peter-evans/create-pull-request@v7
         with:

--- a/hack/build/ci/update-e2e-ondemand-pipeline.py
+++ b/hack/build/ci/update-e2e-ondemand-pipeline.py
@@ -3,8 +3,8 @@ import sys
 from ruamel.yaml import YAML
 
 # version file contains a list of strings
-version_file = sys.argv[1]
-ondemand_file = sys.argv[2]
+version_file = "release-branches.txt"
+ondemand_file = ".github/workflows/e2e-tests-ondemand.yaml"
 
 version = ""
 # read versions to list


### PR DESCRIPTION
## Description

The script can't be used to read specific file in any directory. Still can be called in any CurrentWorkingDirectory but the filename is hardcoded.

## How can this be tested?

I have tested it using my forked repo.
