### PR TITLE
fix e2e: after rename injected init-container

### DIFF
--- a/test/features/cloudnative/init_containers.go
+++ b/test/features/cloudnative/init_containers.go
@@ -47,23 +47,19 @@ func checkInitContainers(sampleApp *sample.App) features.Func {
 			require.NotNil(t, podItem.Spec)
 			require.NotEmpty(t, podItem.Spec.InitContainers)
 
-			var oneAgentInstallContainer *corev1.Container
+			var oneAgentInstallInitContainer *corev1.Container
 
-			var initContainerName string
 			for _, initContainer := range podItem.Spec.InitContainers {
 				if initContainer.Name == oldInstallContainerName || initContainer.Name == webhook.InstallContainerName {
-					oneAgentInstallContainer = &initContainer // loop breaks after assignment, memory aliasing is not a problem
-					initContainerName = initContainer.Name
+					oneAgentInstallInitContainer = &initContainer // loop breaks after assignment, memory aliasing is not a problem
 
 					break
 				}
 			}
-			require.NotNil(t, oneAgentInstallContainer, "'%s' pod - '%s' container not found", podItem.Name, initContainerName)
-
-			assert.Equal(t, initContainerName, oneAgentInstallContainer.Name)
+			require.NotNil(t, oneAgentInstallInitContainer, "init container not found in '%s' pod", podItem.Name)
 
 			logStream, err := clientset.CoreV1().Pods(podItem.Namespace).GetLogs(podItem.Name, &corev1.PodLogOptions{
-				Container: initContainerName,
+				Container: oneAgentInstallInitContainer.Name,
 			}).Stream(ctx)
 
 			require.NoError(t, err)

--- a/test/features/cloudnative/init_containers.go
+++ b/test/features/cloudnative/init_containers.go
@@ -58,7 +58,7 @@ func checkInitContainers(sampleApp *sample.App) features.Func {
 					break
 				}
 			}
-			require.NotNil(t, oneAgentInstallContainer, "'%s' pod - '%s' container not found", podItem.Name)
+			require.NotNil(t, oneAgentInstallContainer, "'%s' pod - '%s' container not found", podItem.Name, initContainerName)
 
 			assert.Equal(t, initContainerName, oneAgentInstallContainer.Name)
 

--- a/test/features/cloudnative/upgrade/upgrade.go
+++ b/test/features/cloudnative/upgrade/upgrade.go
@@ -37,7 +37,7 @@ func Feature(t *testing.T) features.Feature {
 
 	// Register sample app install
 	builder.Assess("install sample app", sampleApp.Install())
-	cloudnative.AssessSampleInitContainersOldDk(builder, sampleApp)
+	cloudnative.AssessSampleInitContainers(builder, sampleApp)
 
 	// update to snapshot
 	builder.Assess("upgrade operator", helpers.ToFeatureFunc(operator.InstallViaMake(testDynakube.NeedsCSIDriver()), true))

--- a/test/features/cloudnative/upgrade/upgrade.go
+++ b/test/features/cloudnative/upgrade/upgrade.go
@@ -37,7 +37,7 @@ func Feature(t *testing.T) features.Feature {
 
 	// Register sample app install
 	builder.Assess("install sample app", sampleApp.Install())
-	cloudnative.AssessSampleInitContainers(builder, sampleApp)
+	cloudnative.AssessSampleInitContainersOldDk(builder, sampleApp)
 
 	// update to snapshot
 	builder.Assess("upgrade operator", helpers.ToFeatureFunc(operator.InstallViaMake(testDynakube.NeedsCSIDriver()), true))


### PR DESCRIPTION
## Description

This PR adds `AssessSampleInitContainersOldDk` func to check old init container name, we need it for an upgrade e2e test scenario.


related to https://github.com/Dynatrace/dynatrace-operator/pull/4025
issue: https://dt-rnd.atlassian.net/browse/DAQ-2310


## How can this be tested?

```
make test/e2e/release
```

<details>

    <summary>test results</summary>
	```
	➜  dynatrace-operator git:(main) ✗ make test/e2e/release
	go install "sigs.k8s.io/kustomize/kustomize/v5@v5.5.0"
	go install "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5"
	/Users/andrii.soldatenko/go/bin/controller-gen "crd:crdVersions=v1,maxDescLen=350,ignoreUnexportedFields=true" paths="./..." output:crd:artifacts:config=config/crd/bases
	./hack/helm/generate-crd.sh /Users/andrii.soldatenko/go/bin/kustomize config/helm/chart/default//templates//Common/crd/ config/deploy/
	go test -v -tags "osusergo,netgo,sqlite_omit_load_extension,e2e," -timeout 20m -count=1 ./test/scenarios/release -args
	=== RUN   TestRelease
	=== RUN   TestRelease/cloudnative-upgrade
	=== RUN   TestRelease/cloudnative-upgrade/create_sample_namespace
	=== RUN   TestRelease/cloudnative-upgrade/created_tenant_secret
	=== RUN   TestRelease/cloudnative-upgrade/'dynakube'_dynakube_created
	=== RUN   TestRelease/cloudnative-upgrade/oneagent_started
	=== RUN   TestRelease/cloudnative-upgrade/'dynakube'_dynakube_phase_changes_to_'Running'
	=== RUN   TestRelease/cloudnative-upgrade/install_sample_app
	=== RUN   TestRelease/cloudnative-upgrade/sample_apps_have_working_init_containers
	=== RUN   TestRelease/cloudnative-upgrade/upgrade_operator
	out: go install "sigs.k8s.io/kustomize/kustomize/v5@v5.5.0"
	go install "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5"
	/Users/andrii.soldatenko/go/bin/controller-gen "crd:crdVersions=v1,maxDescLen=350,ignoreUnexportedFields=true" paths="./..." output:crd:artifacts:config=config/crd/bases
	./hack/helm/generate-crd.sh /Users/andrii.soldatenko/go/bin/kustomize config/helm/chart/default//templates//Common/crd/ config/deploy/
	helm upgrade dynatrace-operator config/helm/chart/default \
	                        --install \
	                        --namespace dynatrace \
	                        --create-namespace \
	                        --atomic \
	                        --set installCRD=true \
	                        --set csidriver.enabled=true \
	                        --set manifests=true \
	                        --set image=""quay.io/dynatrace/dynatrace-operator:snapshot"" \
	                        --set debug=false
	Release "dynatrace-operator" has been upgraded. Happy Helming!
	NAME: dynatrace-operator
	LAST DEPLOYED: Tue Nov 12 11:02:56 2024
	NAMESPACE: dynatrace
	STATUS: deployed
	REVISION: 2
	TEST SUITE: None
	NOTES:
	Thank you for installing dynatrace-operator.
	
	Your release is named dynatrace-operator.
	
	To find more information about the Dynatrace Operator, try:
	https://github.com/Dynatrace/dynatrace-operator
	
	To verify the current state of the deployments, try:
	  $ kubectl get pods -n dynatrace
	  $ kubectl logs -f deployment/dynatrace-operator -n dynatrace
	
	=== RUN   TestRelease/cloudnative-upgrade/restart_half_of_sample_apps
	=== RUN   TestRelease/cloudnative-upgrade/sample_apps_have_working_init_containers#01
	--- PASS: TestRelease (285.47s)
	    --- PASS: TestRelease/cloudnative-upgrade (285.47s)
	        --- PASS: TestRelease/cloudnative-upgrade/create_sample_namespace (0.70s)
	        --- PASS: TestRelease/cloudnative-upgrade/created_tenant_secret (0.34s)
	        --- PASS: TestRelease/cloudnative-upgrade/'dynakube'_dynakube_created (0.48s)
	        --- PASS: TestRelease/cloudnative-upgrade/oneagent_started (115.16s)
	        --- PASS: TestRelease/cloudnative-upgrade/'dynakube'_dynakube_phase_changes_to_'Running' (5.18s)
	        --- PASS: TestRelease/cloudnative-upgrade/install_sample_app (5.71s)
	        --- PASS: TestRelease/cloudnative-upgrade/sample_apps_have_working_init_containers (2.75s)
	        --- PASS: TestRelease/cloudnative-upgrade/upgrade_operator (98.47s)
	        --- PASS: TestRelease/cloudnative-upgrade/restart_half_of_sample_apps (16.55s)
	        --- PASS: TestRelease/cloudnative-upgrade/sample_apps_have_working_init_containers#01 (3.04s)
	PASS
	
	
	
	
	out: helm uninstall dynatrace-operator \
	                        --namespace dynatrace
	release "dynatrace-operator" uninstalled
	
	ok      github.com/Dynatrace/dynatrace-operator/test/scenarios/release  385.119s
	```
</details>