### PR TITLE
Fix incorrect comparison of MEID lastSeenTimestamp

### DIFF
--- a/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
@@ -118,8 +118,8 @@ func createReconcilerWithError(t *testing.T, dk *dynakube.DynaKube, monitoredEnt
 
 func createMonitoredEntities() []dtclient.MonitoredEntity {
 	return []dtclient.MonitoredEntity{
-		{EntityId: "KUBERNETES_CLUSTER-0E30FE4BF2007587", DisplayName: "operator test entity 1", LastSeenTms: 1639483869085},
-		{EntityId: "KUBERNETES_CLUSTER-119C75CCDA94799F", DisplayName: "operator test entity 2", LastSeenTms: 1639034988126},
+		{EntityId: "KUBERNETES_CLUSTER-0E30FE4BF2007587", DisplayName: "operator test entity 1", LastSeenTms: 1639034988126},
+		{EntityId: "KUBERNETES_CLUSTER-119C75CCDA94799F", DisplayName: "operator test entity 2", LastSeenTms: 1639483869085},
 	}
 }
 

--- a/pkg/controllers/dynakube/monitoredentities/reconciler.go
+++ b/pkg/controllers/dynakube/monitoredentities/reconciler.go
@@ -68,7 +68,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 func findLatestEntity(monitoredEntities []dynatrace.MonitoredEntity) dynatrace.MonitoredEntity {
 	latest := monitoredEntities[0]
 	for _, entity := range monitoredEntities {
-		if entity.LastSeenTms < latest.LastSeenTms {
+		if entity.LastSeenTms > latest.LastSeenTms {
 			latest = entity
 		}
 	}

--- a/pkg/controllers/dynakube/monitoredentities/reconciler_test.go
+++ b/pkg/controllers/dynakube/monitoredentities/reconciler_test.go
@@ -28,10 +28,10 @@ func TestReconcile(t *testing.T) {
 
 		require.NoError(t, err)
 	})
-	t.Run("no error if enabled and has valid kube system uuid", func(t *testing.T) {
+	t.Run("no error if enabled and has two different entity IDs", func(t *testing.T) {
 		clt := dtclientmock.NewClient(t)
 		clt.On("GetMonitoredEntitiesForKubeSystemUUID",
-			mock.AnythingOfType("context.backgroundCtx"), "kube-system-uuid").Return([]dtclient.MonitoredEntity{{EntityId: "KUBERNETES_CLUSTER-0E30FE4BF2007587", DisplayName: "operator test entity 1", LastSeenTms: 1639483869085}}, nil)
+			mock.AnythingOfType("context.backgroundCtx"), "kube-system-uuid").Return([]dtclient.MonitoredEntity{{EntityId: "KUBERNETES_CLUSTER-OUTDATED", DisplayName: "operator test entity 1", LastSeenTms: 1}, {EntityId: "KUBERNETES_CLUSTER-ACTIVE", DisplayName: "operator test entity 2", LastSeenTms: 10}}, nil)
 
 		dk := createDynaKube()
 
@@ -41,6 +41,7 @@ func TestReconcile(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotEmpty(t, dk.Status.KubernetesClusterMEID)
+		require.Equal(t, "KUBERNETES_CLUSTER-ACTIVE", dk.Status.KubernetesClusterMEID)
 	})
 	t.Run("no error if no MEs are found", func(t *testing.T) {
 		clt := dtclientmock.NewClient(t)


### PR DESCRIPTION
Ticket: https://dt-rnd.atlassian.net/browse/DAQ-2355

## Description

Currently instead of using the newest and more up-to-date MEID we use the most outdated one as we compare the timestamps (the bigger the more up-to-date it is) incorrectly

## How can this be tested?

Have two MEs for the same clusterID -> check if the one with the bigger timestamp is used for metadata enrichment