### PR TITLE
Activate AG capabilities required by OtlpIngest feature

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -996,7 +996,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -1269,7 +1269,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -1609,7 +1609,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -3175,7 +3175,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -3456,7 +3456,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -3855,7 +3855,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -5078,7 +5078,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -5356,7 +5356,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -5749,7 +5749,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -1008,7 +1008,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -1281,7 +1281,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -1621,7 +1621,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -3187,7 +3187,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -3468,7 +3468,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -3867,7 +3867,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -5090,7 +5090,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -5368,7 +5368,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array
@@ -5761,7 +5761,7 @@ spec:
                         description: |-
                           Set additional arguments to the OneAgent installer.
                           For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
+                          For the list of limitations, see Limitations (https://www.
                         items:
                           type: string
                         type: array

--- a/hack/make/manifests/config.mk
+++ b/hack/make/manifests/config.mk
@@ -1,4 +1,4 @@
-CRD_OPTIONS ?= "crd:crdVersions=v1,maxDescLen=350,ignoreUnexportedFields=true"
+CRD_OPTIONS ?= "crd:crdVersions=v1,maxDescLen=340,ignoreUnexportedFields=true"
 
 OLM ?= false
 

--- a/pkg/api/v1beta3/dynakube/activegate/props.go
+++ b/pkg/api/v1beta3/dynakube/activegate/props.go
@@ -27,6 +27,10 @@ func (ag *Spec) SetExtensionsDependency(isEnabled bool) {
 	ag.enabledDependencies.extensions = isEnabled
 }
 
+func (ag *Spec) SetOTLPIngestDependency(isEnabled bool) {
+	ag.enabledDependencies.otlpIngest = isEnabled
+}
+
 func (ag *Spec) SetKSPMDependency(isEnabled bool) {
 	ag.enabledDependencies.kspm = isEnabled
 }
@@ -97,7 +101,8 @@ func (ag *Spec) NeedsService() bool {
 		ag.IsApiEnabled() ||
 		ag.IsMetricsIngestEnabled() ||
 		ag.enabledDependencies.extensions ||
-		ag.enabledDependencies.kspm
+		ag.enabledDependencies.kspm ||
+		ag.enabledDependencies.otlpIngest
 }
 
 func (ag *Spec) HasCaCert() bool {

--- a/pkg/api/v1beta3/dynakube/activegate/props.go
+++ b/pkg/api/v1beta3/dynakube/activegate/props.go
@@ -27,7 +27,7 @@ func (ag *Spec) SetExtensionsDependency(isEnabled bool) {
 	ag.enabledDependencies.extensions = isEnabled
 }
 
-func (ag *Spec) SetOTLPIngestDependency(isEnabled bool) {
+func (ag *Spec) SetOTLPingestDependency(isEnabled bool) {
 	ag.enabledDependencies.otlpIngest = isEnabled
 }
 

--- a/pkg/api/v1beta3/dynakube/activegate/spec.go
+++ b/pkg/api/v1beta3/dynakube/activegate/spec.go
@@ -61,10 +61,11 @@ type ActiveGate struct {
 type dependencies struct {
 	extensions bool
 	kspm       bool
+	otlpIngest bool
 }
 
 func (d dependencies) Any() bool {
-	return d.extensions
+	return d.extensions || d.otlpIngest
 }
 
 // +kubebuilder:object:generate=true

--- a/pkg/api/v1beta3/dynakube/activegate_props.go
+++ b/pkg/api/v1beta3/dynakube/activegate_props.go
@@ -9,7 +9,7 @@ func (dk *DynaKube) ActiveGate() *activegate.ActiveGate {
 	dk.Spec.ActiveGate.SetName(dk.Name)
 	dk.Spec.ActiveGate.SetExtensionsDependency(dk.IsExtensionsEnabled())
 	dk.Spec.ActiveGate.SetKSPMDependency(dk.KSPM().IsEnabled())
-	dk.Spec.ActiveGate.SetOTLPIngestDependency(dk.IsOtlpIngestEnabled())
+	dk.Spec.ActiveGate.SetOTLPingestDependency(dk.IsOTLPingestEnabled())
 
 	return &activegate.ActiveGate{
 		Spec:   &dk.Spec.ActiveGate,

--- a/pkg/api/v1beta3/dynakube/activegate_props.go
+++ b/pkg/api/v1beta3/dynakube/activegate_props.go
@@ -9,6 +9,7 @@ func (dk *DynaKube) ActiveGate() *activegate.ActiveGate {
 	dk.Spec.ActiveGate.SetName(dk.Name)
 	dk.Spec.ActiveGate.SetExtensionsDependency(dk.IsExtensionsEnabled())
 	dk.Spec.ActiveGate.SetKSPMDependency(dk.KSPM().IsEnabled())
+	dk.Spec.ActiveGate.SetOTLPIngestDependency(dk.IsOtlpIngestEnabled())
 
 	return &activegate.ActiveGate{
 		Spec:   &dk.Spec.ActiveGate,

--- a/pkg/api/v1beta3/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta3/dynakube/dynakube_types.go
@@ -146,6 +146,8 @@ type DynaKubeSpec struct { //nolint:revive
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Istio automatic management",order=9,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	EnableIstio bool `json:"enableIstio,omitempty"`
+
+	EnableOtlpIngest bool `json:"-"`
 }
 
 type TemplatesSpec struct {

--- a/pkg/api/v1beta3/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta3/dynakube/dynakube_types.go
@@ -147,7 +147,7 @@ type DynaKubeSpec struct { //nolint:revive
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Istio automatic management",order=9,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	EnableIstio bool `json:"enableIstio,omitempty"`
 
-	EnableOtlpIngest bool `json:"-"`
+	EnableOTLPingest bool `json:"-"`
 }
 
 type TemplatesSpec struct {

--- a/pkg/api/v1beta3/dynakube/otlp_props.go
+++ b/pkg/api/v1beta3/dynakube/otlp_props.go
@@ -1,5 +1,5 @@
 package dynakube
 
-func (dk *DynaKube) IsOtlpIngestEnabled() bool {
-	return dk.Spec.EnableOtlpIngest
+func (dk *DynaKube) IsOTLPingestEnabled() bool {
+	return dk.Spec.EnableOTLPingest
 }

--- a/pkg/api/v1beta3/dynakube/otlp_props.go
+++ b/pkg/api/v1beta3/dynakube/otlp_props.go
@@ -1,0 +1,5 @@
+package dynakube
+
+func (dk *DynaKube) IsOtlpIngestEnabled() bool {
+	return dk.Spec.EnableOtlpIngest
+}

--- a/pkg/controllers/dynakube/activegate/capability/capability.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability.go
@@ -79,7 +79,7 @@ func NewMultiCapability(dk *dynakube.DynaKube) Capability {
 	mc.enabled = true
 	mc.properties = &dk.Spec.ActiveGate.CapabilityProperties
 
-	if len(dk.Spec.ActiveGate.Capabilities) == 0 && dk.IsExtensionsEnabled() {
+	if len(dk.Spec.ActiveGate.Capabilities) == 0 && (dk.IsExtensionsEnabled() || dk.IsOtlpIngestEnabled()) {
 		mc.properties.Replicas = address.Of(int32(1))
 	}
 
@@ -100,6 +100,11 @@ func NewMultiCapability(dk *dynakube.DynaKube) Capability {
 	if dk.IsExtensionsEnabled() {
 		capabilityNames = append(capabilityNames, "extension_controller")
 		capabilityDisplayNames = append(capabilityDisplayNames, "extension_controller")
+	}
+
+	if dk.IsOtlpIngestEnabled() {
+		capabilityNames = append(capabilityNames, "log_analytics_collector", "generic_ingest_enabled", "otlp_ingest")
+		capabilityDisplayNames = append(capabilityDisplayNames, "log_analytics_collector", "generic_ingest_enabled", "otlp_ingest")
 	}
 
 	mc.argName = strings.Join(capabilityNames, ",")

--- a/pkg/controllers/dynakube/activegate/capability/capability.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability.go
@@ -79,7 +79,7 @@ func NewMultiCapability(dk *dynakube.DynaKube) Capability {
 	mc.enabled = true
 	mc.properties = &dk.Spec.ActiveGate.CapabilityProperties
 
-	if len(dk.Spec.ActiveGate.Capabilities) == 0 && (dk.IsExtensionsEnabled() || dk.IsOtlpIngestEnabled()) {
+	if len(dk.Spec.ActiveGate.Capabilities) == 0 && (dk.IsExtensionsEnabled() || dk.IsOTLPingestEnabled()) {
 		mc.properties.Replicas = address.Of(int32(1))
 	}
 
@@ -102,7 +102,7 @@ func NewMultiCapability(dk *dynakube.DynaKube) Capability {
 		capabilityDisplayNames = append(capabilityDisplayNames, "extension_controller")
 	}
 
-	if dk.IsOtlpIngestEnabled() {
+	if dk.IsOTLPingestEnabled() {
 		capabilityNames = append(capabilityNames, "log_analytics_collector", "generic_ingest_enabled", "otlp_ingest")
 		capabilityDisplayNames = append(capabilityDisplayNames, "log_analytics_collector", "generic_ingest_enabled", "otlp_ingest")
 	}

--- a/pkg/controllers/dynakube/activegate/capability/capability_test.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability_test.go
@@ -20,9 +20,9 @@ const (
 	expectedArgName                            = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface"
 	expectedArgNameWithExtensions              = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface,extension_controller"
 	expectedArgNameWithExtensionsOnly          = "extension_controller"
-	expectedArgNameWithOtlpIngest              = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface,log_analytics_collector,generic_ingest_enabled,otlp_ingest"
-	expectedArgNameWithOtlpIngestOnly          = "log_analytics_collector,generic_ingest_enabled,otlp_ingest"
-	expectedArgNameWithExtensionsAndOtlpIngest = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface,extension_controller,log_analytics_collector,generic_ingest_enabled,otlp_ingest"
+	expectedArgNameWithOTLPingest              = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface,log_analytics_collector,generic_ingest_enabled,otlp_ingest"
+	expectedArgNameWithOTLPingestOnly          = "log_analytics_collector,generic_ingest_enabled,otlp_ingest"
+	expectedArgNameWithExtensionsAndOTLPingest = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface,extension_controller,log_analytics_collector,generic_ingest_enabled,otlp_ingest"
 )
 
 var capabilities = []activegate.CapabilityDisplayName{
@@ -32,7 +32,7 @@ var capabilities = []activegate.CapabilityDisplayName{
 	activegate.DynatraceApiCapability.DisplayName,
 }
 
-func buildDynakube(capabilities []activegate.CapabilityDisplayName, enableExtensions bool, enableOtlpIngest bool) *dynakube.DynaKube {
+func buildDynakube(capabilities []activegate.CapabilityDisplayName, enableExtensions bool, enableOTLPingest bool) *dynakube.DynaKube {
 	extensionsSpec := &dynakube.ExtensionsSpec{}
 	if !enableExtensions {
 		extensionsSpec = nil
@@ -48,7 +48,7 @@ func buildDynakube(capabilities []activegate.CapabilityDisplayName, enableExtens
 				Capabilities: capabilities,
 			},
 			Extensions:       extensionsSpec,
-			EnableOtlpIngest: enableOtlpIngest,
+			EnableOTLPingest: enableOTLPingest,
 		},
 	}
 }
@@ -121,34 +121,34 @@ func TestNewMultiCapabilityWithExtensions(t *testing.T) {
 	})
 }
 
-func TestNewMultiCapabilityWithOtlpIngest(t *testing.T) {
-	t.Run(`creates new multicapability with OtlpIngest enabled`, func(t *testing.T) {
+func TestNewMultiCapabilityWithOTLPingest(t *testing.T) {
+	t.Run(`creates new multicapability with OTLPingest enabled`, func(t *testing.T) {
 		dk := buildDynakube(capabilities, false, true)
 		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.True(t, mc.Enabled())
 		assert.Equal(t, expectedShortName, mc.ShortName())
-		assert.Equal(t, expectedArgNameWithOtlpIngest, mc.ArgName())
+		assert.Equal(t, expectedArgNameWithOTLPingest, mc.ArgName())
 	})
-	t.Run(`creates new multicapability without capabilities set in dynakube and OtlpIngest enabled`, func(t *testing.T) {
+	t.Run(`creates new multicapability without capabilities set in dynakube and OTLPingest enabled`, func(t *testing.T) {
 		var emptyCapabilites []activegate.CapabilityDisplayName
 		dk := buildDynakube(emptyCapabilites, false, true)
 		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.True(t, mc.Enabled())
 		assert.Equal(t, expectedShortName, mc.ShortName())
-		assert.Equal(t, expectedArgNameWithOtlpIngestOnly, mc.ArgName())
+		assert.Equal(t, expectedArgNameWithOTLPingestOnly, mc.ArgName())
 	})
 }
 
-func TestNewMultiCapabilityWithExtensionsAndOtlpIngest(t *testing.T) {
-	t.Run(`creates new multicapability with Extensions and OtlpIngest enabled`, func(t *testing.T) {
+func TestNewMultiCapabilityWithExtensionsAndOTLPingest(t *testing.T) {
+	t.Run(`creates new multicapability with Extensions and OTLPingest enabled`, func(t *testing.T) {
 		dk := buildDynakube(capabilities, true, true)
 		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.True(t, mc.Enabled())
 		assert.Equal(t, expectedShortName, mc.ShortName())
-		assert.Equal(t, expectedArgNameWithExtensionsAndOtlpIngest, mc.ArgName())
+		assert.Equal(t, expectedArgNameWithExtensionsAndOTLPingest, mc.ArgName())
 	})
 }
 
@@ -365,10 +365,10 @@ func TestActiveGateService(t *testing.T) {
 		}
 		assert.True(t, dk.ActiveGate().NeedsService())
 	})
-	t.Run(`creates dynakube with OtlpIngest enabled`, func(t *testing.T) {
+	t.Run(`creates dynakube with OTLPingest enabled`, func(t *testing.T) {
 		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
-				EnableOtlpIngest: true,
+				EnableOTLPingest: true,
 			},
 		}
 		assert.True(t, dk.ActiveGate().NeedsService())

--- a/pkg/controllers/dynakube/activegate/capability/capability_test.go
+++ b/pkg/controllers/dynakube/activegate/capability/capability_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/activegate"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/kspm"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,13 +13,16 @@ import (
 )
 
 const (
-	testNamespace                     = "test-namespace"
-	testName                          = "test-name"
-	testApiUrl                        = "https://demo.dev.dynatracelabs.com/api"
-	expectedShortName                 = "activegate"
-	expectedArgName                   = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface"
-	expectedArgNameWithExtensions     = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface,extension_controller"
-	expectedArgNameWithExtensionsOnly = "extension_controller"
+	testNamespace                              = "test-namespace"
+	testName                                   = "test-name"
+	testApiUrl                                 = "https://demo.dev.dynatracelabs.com/api"
+	expectedShortName                          = "activegate"
+	expectedArgName                            = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface"
+	expectedArgNameWithExtensions              = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface,extension_controller"
+	expectedArgNameWithExtensionsOnly          = "extension_controller"
+	expectedArgNameWithOtlpIngest              = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface,log_analytics_collector,generic_ingest_enabled,otlp_ingest"
+	expectedArgNameWithOtlpIngestOnly          = "log_analytics_collector,generic_ingest_enabled,otlp_ingest"
+	expectedArgNameWithExtensionsAndOtlpIngest = "MSGrouter,kubernetes_monitoring,metrics_ingest,restInterface,extension_controller,log_analytics_collector,generic_ingest_enabled,otlp_ingest"
 )
 
 var capabilities = []activegate.CapabilityDisplayName{
@@ -28,7 +32,7 @@ var capabilities = []activegate.CapabilityDisplayName{
 	activegate.DynatraceApiCapability.DisplayName,
 }
 
-func buildDynakube(capabilities []activegate.CapabilityDisplayName, enableExtensions bool) *dynakube.DynaKube {
+func buildDynakube(capabilities []activegate.CapabilityDisplayName, enableExtensions bool, enableOtlpIngest bool) *dynakube.DynaKube {
 	extensionsSpec := &dynakube.ExtensionsSpec{}
 	if !enableExtensions {
 		extensionsSpec = nil
@@ -43,7 +47,8 @@ func buildDynakube(capabilities []activegate.CapabilityDisplayName, enableExtens
 			ActiveGate: activegate.Spec{
 				Capabilities: capabilities,
 			},
-			Extensions: extensionsSpec,
+			Extensions:       extensionsSpec,
+			EnableOtlpIngest: enableOtlpIngest,
 		},
 	}
 }
@@ -68,7 +73,7 @@ func TestBuildServiceName(t *testing.T) {
 
 func TestNewMultiCapability(t *testing.T) {
 	t.Run(`creates new multicapability`, func(t *testing.T) {
-		dk := buildDynakube(capabilities, false)
+		dk := buildDynakube(capabilities, false, false)
 		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.True(t, mc.Enabled())
@@ -77,18 +82,28 @@ func TestNewMultiCapability(t *testing.T) {
 	})
 	t.Run(`creates new multicapability without capabilities set in dynakube`, func(t *testing.T) {
 		var emptyCapabilites []activegate.CapabilityDisplayName
-		dk := buildDynakube(emptyCapabilites, false)
+		dk := buildDynakube(emptyCapabilites, false, false)
 		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.False(t, mc.Enabled())
 		assert.Equal(t, expectedShortName, mc.ShortName())
 		assert.Equal(t, "", mc.ArgName())
 	})
+	t.Run(`creates new multicapability with KSPM enabled`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				Kspm: &kspm.Spec{},
+			},
+		}
+		mc := NewMultiCapability(dk)
+		require.NotNil(t, mc)
+		assert.False(t, mc.Enabled())
+	})
 }
 
 func TestNewMultiCapabilityWithExtensions(t *testing.T) {
 	t.Run(`creates new multicapability with Extensions enabled`, func(t *testing.T) {
-		dk := buildDynakube(capabilities, true)
+		dk := buildDynakube(capabilities, true, false)
 		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.True(t, mc.Enabled())
@@ -97,12 +112,43 @@ func TestNewMultiCapabilityWithExtensions(t *testing.T) {
 	})
 	t.Run(`creates new multicapability without capabilities set in dynakube and Extensions enabled`, func(t *testing.T) {
 		var emptyCapabilites []activegate.CapabilityDisplayName
-		dk := buildDynakube(emptyCapabilites, true)
+		dk := buildDynakube(emptyCapabilites, true, false)
 		mc := NewMultiCapability(dk)
 		require.NotNil(t, mc)
 		assert.True(t, mc.Enabled())
 		assert.Equal(t, expectedShortName, mc.ShortName())
 		assert.Equal(t, expectedArgNameWithExtensionsOnly, mc.ArgName())
+	})
+}
+
+func TestNewMultiCapabilityWithOtlpIngest(t *testing.T) {
+	t.Run(`creates new multicapability with OtlpIngest enabled`, func(t *testing.T) {
+		dk := buildDynakube(capabilities, false, true)
+		mc := NewMultiCapability(dk)
+		require.NotNil(t, mc)
+		assert.True(t, mc.Enabled())
+		assert.Equal(t, expectedShortName, mc.ShortName())
+		assert.Equal(t, expectedArgNameWithOtlpIngest, mc.ArgName())
+	})
+	t.Run(`creates new multicapability without capabilities set in dynakube and OtlpIngest enabled`, func(t *testing.T) {
+		var emptyCapabilites []activegate.CapabilityDisplayName
+		dk := buildDynakube(emptyCapabilites, false, true)
+		mc := NewMultiCapability(dk)
+		require.NotNil(t, mc)
+		assert.True(t, mc.Enabled())
+		assert.Equal(t, expectedShortName, mc.ShortName())
+		assert.Equal(t, expectedArgNameWithOtlpIngestOnly, mc.ArgName())
+	})
+}
+
+func TestNewMultiCapabilityWithExtensionsAndOtlpIngest(t *testing.T) {
+	t.Run(`creates new multicapability with Extensions and OtlpIngest enabled`, func(t *testing.T) {
+		dk := buildDynakube(capabilities, true, true)
+		mc := NewMultiCapability(dk)
+		require.NotNil(t, mc)
+		assert.True(t, mc.Enabled())
+		assert.Equal(t, expectedShortName, mc.ShortName())
+		assert.Equal(t, expectedArgNameWithExtensionsAndOtlpIngest, mc.ArgName())
 	})
 }
 
@@ -294,4 +340,77 @@ func TestBuildDNSEntryPoint(t *testing.T) {
 			assert.Equal(t, test.expectedDNS, dnsEntryPoint)
 		})
 	}
+}
+
+func TestActiveGateService(t *testing.T) {
+	t.Run(`creates dynakube with no AG capabilities`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{},
+		}
+		assert.False(t, dk.ActiveGate().NeedsService())
+	})
+	t.Run(`creates dynakube with Extensions enabled`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				Extensions: &dynakube.ExtensionsSpec{},
+			},
+		}
+		assert.True(t, dk.ActiveGate().NeedsService())
+	})
+	t.Run(`creates dynakube with Kspm enabled`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				Kspm: &kspm.Spec{},
+			},
+		}
+		assert.True(t, dk.ActiveGate().NeedsService())
+	})
+	t.Run(`creates dynakube with OtlpIngest enabled`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				EnableOtlpIngest: true,
+			},
+		}
+		assert.True(t, dk.ActiveGate().NeedsService())
+	})
+	t.Run(`creates dynakube with Routing enabled`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{activegate.RoutingCapability.DisplayName},
+				},
+			},
+		}
+		assert.True(t, dk.ActiveGate().NeedsService())
+	})
+	t.Run(`creates dynakube with DynatraceApi enabled`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{activegate.DynatraceApiCapability.DisplayName},
+				},
+			},
+		}
+		assert.True(t, dk.ActiveGate().NeedsService())
+	})
+	t.Run(`creates dynakube with MetricsIngest enabled`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{activegate.MetricsIngestCapability.DisplayName},
+				},
+			},
+		}
+		assert.True(t, dk.ActiveGate().NeedsService())
+	})
+	t.Run(`creates dynakube with KubeMon enabled`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{activegate.KubeMonCapability.DisplayName},
+				},
+			},
+		}
+		assert.False(t, dk.ActiveGate().NeedsService())
+	})
 }


### PR DESCRIPTION
[DAQ-1633](https://dt-rnd.atlassian.net/browse/DAQ-1633)

## Description

Enables the following capabilities on ActiveGate if OTLP ingest is required: 
- log_analytics_collector
- generic_ingest_enabled
- otlp_ingest

Dynakube.`EnableOtlpIngest` field is a temporary feature switch because it will be defined in follow-ups. It allows to add unit tests but can't be used directly in dynakube.yaml manifest.

:warning: OTLP feature branch is used as base branch.

## How can this be tested?

```
make go/test
```

[DAQ-1633]: https://dt-rnd.atlassian.net/browse/DAQ-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ