### PR TITLE
Makes ApiUrl immutable

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -4776,10 +4776,6 @@ spec:
                   For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.
                 maxLength: 128
                 type: string
-                x-kubernetes-validations:
-                - message: APIURL is immutable, please delete the CR and then apply
-                    new one
-                  rule: self == oldSelf
               customPullSecret:
                 description: |-
                   Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -4788,10 +4788,6 @@ spec:
                   For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.
                 maxLength: 128
                 type: string
-                x-kubernetes-validations:
-                - message: APIURL is immutable, please delete the CR and then apply
-                    new one
-                  rule: self == oldSelf
               customPullSecret:
                 description: |-
                   Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.

--- a/pkg/api/v1beta3/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta3/dynakube/dynakube_types.go
@@ -99,7 +99,6 @@ type DynaKubeSpec struct { //nolint:revive
 	// Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
 	// For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.com/support/help/get-started/monitoring-environment/environment-id).
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="APIURL is immutable, please delete the CR and then apply new one"
 	// +kubebuilder:validation:MaxLength=128
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="API URL",order=1,xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	APIURL string `json:"apiUrl"`

--- a/pkg/api/validation/dynakube/api_url.go
+++ b/pkg/api/validation/dynakube/api_url.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -82,19 +80,8 @@ func IsThirdGenAPIUrl(_ context.Context, _ *Validator, dk *dynakube.DynaKube) st
 	return ""
 }
 
-func IsMutatedApiUrl(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
-	oldDk := &dynakube.DynaKube{}
-	if err := dv.apiReader.Get(ctx, client.ObjectKey{Name: dk.Name, Namespace: dk.Namespace}, oldDk); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return ""
-		}
-
-		log.Info("error occurred while getting dynakube", "err", err.Error())
-
-		return ""
-	}
-
-	if oldDk.Spec.APIURL != dk.Spec.APIURL {
+func IsMutatedApiUrl(_ context.Context, _ *Validator, oldDk *dynakube.DynaKube, newDk *dynakube.DynaKube) string {
+	if oldDk.Spec.APIURL != newDk.Spec.APIURL {
 		return errorMutatedApiUrl
 	}
 

--- a/pkg/api/validation/dynakube/api_url.go
+++ b/pkg/api/validation/dynakube/api_url.go
@@ -23,7 +23,7 @@ const (
 	errorThirdGenApiUrl = `The DynaKube's specification has an 3rd gen API URL. Make sure to remove the 'apps' part
 	out of it. Example: ` + ExampleApiUrl
 
-	errorMutatedApiUrl = "The DynaKube's specification has mutated APIURL, APIURL is immutable, please delete the CR and then apply new one"
+	errorMutatedApiUrl = `The DynaKube's specification mutated the API URL although it is immutable. Please delete the CR and then apply a new one`
 )
 
 func NoApiUrl(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {

--- a/pkg/api/validation/dynakube/api_url_test.go
+++ b/pkg/api/validation/dynakube/api_url_test.go
@@ -77,4 +77,33 @@ func TestHasApiUrl(t *testing.T) {
 			},
 		})
 	})
+	t.Run(`unmutated API URL`, func(t *testing.T) {
+		assertAllowed(t,
+			&dynakube.DynaKube{
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: "https://tenant.live.dynatrace.com/api",
+				},
+			},
+			&dynakube.DynaKube{
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: "https://tenant.live.dynatrace.com/api",
+				},
+			},
+		)
+	})
+	t.Run(`mutated API URL`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorMutatedApiUrl},
+			&dynakube.DynaKube{
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: "https://tenant.live.dynatrace.com/api",
+				},
+			},
+			&dynakube.DynaKube{
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: "https://othertenant.live.dynatrace.com/api",
+				},
+			},
+		)
+	})
 }

--- a/pkg/api/validation/dynakube/api_url_test.go
+++ b/pkg/api/validation/dynakube/api_url_test.go
@@ -78,7 +78,7 @@ func TestHasApiUrl(t *testing.T) {
 		})
 	})
 	t.Run(`unmutated API URL`, func(t *testing.T) {
-		assertAllowed(t,
+		assertUpdateAllowedWithoutWarnings(t,
 			&dynakube.DynaKube{
 				Spec: dynakube.DynaKubeSpec{
 					APIURL: "https://tenant.live.dynatrace.com/api",
@@ -92,7 +92,7 @@ func TestHasApiUrl(t *testing.T) {
 		)
 	})
 	t.Run(`mutated API URL`, func(t *testing.T) {
-		assertDenied(t,
+		assertUpdateDenied(t,
 			[]string{errorMutatedApiUrl},
 			&dynakube.DynaKube{
 				Spec: dynakube.DynaKubeSpec{
@@ -101,7 +101,7 @@ func TestHasApiUrl(t *testing.T) {
 			},
 			&dynakube.DynaKube{
 				Spec: dynakube.DynaKubeSpec{
-					APIURL: "https://othertenant.live.dynatrace.com/api",
+					APIURL: "https://newtenant.live.dynatrace.com/api",
 				},
 			},
 		)

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -32,6 +32,7 @@ var (
 		NoApiUrl,
 		IsInvalidApiUrl,
 		IsThirdGenAPIUrl,
+		IsMutatedApiUrl,
 		missingCSIDaemonSet,
 		disabledCSIForReadonlyCSIVolume,
 		invalidActiveGateCapabilities,

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -32,7 +32,6 @@ var (
 		NoApiUrl,
 		IsInvalidApiUrl,
 		IsThirdGenAPIUrl,
-		IsMutatedApiUrl,
 		missingCSIDaemonSet,
 		disabledCSIForReadonlyCSIVolume,
 		invalidActiveGateCapabilities,
@@ -61,9 +60,13 @@ var (
 		deprecatedFeatureFlag,
 		ignoredLogMonitoringTemplate,
 	}
+	updateValidatorErrorFuncs = []updateValidatorFunc{
+		IsMutatedApiUrl,
+	}
 )
 
 type validatorFunc func(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string
+type updateValidatorFunc func(ctx context.Context, dv *Validator, oldDk *dynakube.DynaKube, newDk *dynakube.DynaKube) string
 
 func New(apiReader client.Reader, cfg *rest.Config) admission.CustomValidator {
 	return &Validator{
@@ -89,14 +92,21 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (war
 	return
 }
 
-func (v *Validator) ValidateUpdate(ctx context.Context, _, newObj runtime.Object) (warnings admission.Warnings, err error) {
-	dk, err := getDynakube(newObj)
+func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	oldDk, err := getDynakube(oldObj)
 	if err != nil {
 		return
 	}
 
-	errMessages := v.runValidators(ctx, validatorErrorFuncs, dk)
-	warnings = v.runValidators(ctx, validatorWarningFuncs, dk)
+	newDk, err := getDynakube(newObj)
+	if err != nil {
+		return
+	}
+
+	errMessages := v.runValidators(ctx, validatorErrorFuncs, newDk)
+	warnings = v.runValidators(ctx, validatorWarningFuncs, newDk)
+
+	errMessages = append(errMessages, v.runUpdateValidators(ctx, updateValidatorErrorFuncs, oldDk, newDk)...)
 
 	if len(errMessages) != 0 {
 		err = errors.New(validation.SumErrors(errMessages, "DynaKube"))
@@ -114,6 +124,18 @@ func (v *Validator) runValidators(ctx context.Context, validators []validatorFun
 
 	for _, validate := range validators {
 		if errMsg := validate(ctx, v, dk); errMsg != "" {
+			results = append(results, errMsg)
+		}
+	}
+
+	return results
+}
+
+func (v *Validator) runUpdateValidators(ctx context.Context, updateValidators []updateValidatorFunc, oldDk *dynakube.DynaKube, newDk *dynakube.DynaKube) []string {
+	results := []string{}
+
+	for _, validate := range updateValidators {
+		if errMsg := validate(ctx, v, oldDk, newDk); errMsg != "" {
 			results = append(results, errMsg)
 		}
 	}

--- a/pkg/api/validation/dynakube/validation_test.go
+++ b/pkg/api/validation/dynakube/validation_test.go
@@ -183,6 +183,15 @@ func assertDenied(t *testing.T, errMessages []string, dk *dynakube.DynaKube, oth
 	}
 }
 
+func assertUpdateDenied(t *testing.T, errMessages []string, oldDk *dynakube.DynaKube, newDk *dynakube.DynaKube, other ...client.Object) {
+	_, err := runUpdateValidators(oldDk, newDk, other...)
+	require.Error(t, err)
+
+	for _, errMsg := range errMessages {
+		assert.Contains(t, err.Error(), errMsg)
+	}
+}
+
 func assertAllowedWithoutWarnings(t *testing.T, dk *dynakube.DynaKube, other ...client.Object) {
 	warnings, _ := assertAllowed(t, dk, other...)
 	assert.Empty(t, warnings)
@@ -200,6 +209,18 @@ func assertAllowed(t *testing.T, dk *dynakube.DynaKube, other ...client.Object) 
 	return warnings, err
 }
 
+func assertUpdateAllowed(t *testing.T, oldDk *dynakube.DynaKube, newDk *dynakube.DynaKube, other ...client.Object) (admission.Warnings, error) {
+	warnings, err := runUpdateValidators(oldDk, newDk, other...)
+	assert.NoError(t, err)
+
+	return warnings, err
+}
+
+func assertUpdateAllowedWithoutWarnings(t *testing.T, oldDk *dynakube.DynaKube, newDk *dynakube.DynaKube, other ...client.Object) {
+	warnings, _ := assertUpdateAllowed(t, oldDk, newDk, other...)
+	assert.Empty(t, warnings)
+}
+
 func runValidators(dk *dynakube.DynaKube, other ...client.Object) (admission.Warnings, error) {
 	clt := fake.NewClient()
 	if other != nil {
@@ -213,4 +234,19 @@ func runValidators(dk *dynakube.DynaKube, other ...client.Object) (admission.War
 	}
 
 	return validator.ValidateCreate(context.Background(), dk)
+}
+
+func runUpdateValidators(oldDk *dynakube.DynaKube, newDk *dynakube.DynaKube, other ...client.Object) (admission.Warnings, error) {
+	clt := fake.NewClient()
+	if other != nil {
+		clt = fake.NewClient(other...)
+	}
+
+	validator := &Validator{
+		apiReader: clt,
+		cfg:       &rest.Config{},
+		modules:   installconfig.GetModules(),
+	}
+
+	return validator.ValidateUpdate(context.Background(), oldDk, newDk)
 }


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-2606)

## Description
Value of dynakube.spec.ApiUrl can't be changed.

```
[]$ kubectl -n dynatrace patch dynakube.dynatrace.com/dynakube  -p '{"spec":{"apiUrl":"https://<modified apiurl>"}}' --type=merge
Warning: ActiveGate specification missing memory limits. Can cause excess memory usage.
Error from server (Forbidden): admission webhook "v1beta3.dynakube.webhook.dynatrace.com" denied the request: 
1 error(s) found in the DynaKube
 1. The DynaKube's specification has mutated APIURL, APIURL is immutable, please delete the CR and then apply new one
```

## How can this be tested?

Apply a dynakube. Try to change apiUrl.
