### PR TITLE
Adds FSGroup to EEC podSecurityContext

### DIFF
--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -72,10 +72,8 @@ const (
 
 	// misc
 	logVolumeName = "log"
-)
 
-var (
-	userGroupId = int64(1001)
+	userGroupId int64 = 1001
 )
 
 func (r *reconciler) createOrUpdateStatefulset(ctx context.Context) error {
@@ -221,8 +219,8 @@ func buildSecurityContext() *corev1.SecurityContext {
 			},
 		},
 		Privileged:               address.Of(false),
-		RunAsUser:                &userGroupId,
-		RunAsGroup:               &userGroupId,
+		RunAsUser:                address.Of(userGroupId),
+		RunAsGroup:               address.Of(userGroupId),
 		RunAsNonRoot:             address.Of(true),
 		ReadOnlyRootFilesystem:   address.Of(true),
 		AllowPrivilegeEscalation: address.Of(false),
@@ -240,7 +238,7 @@ func buildPodSecurityContext(dk *dynakube.DynaKube) *corev1.PodSecurityContext {
 	}
 
 	if !dk.Spec.Templates.ExtensionExecutionController.UseEphemeralVolume {
-		podSecurityContext.FSGroup = &userGroupId
+		podSecurityContext.FSGroup = address.Of(userGroupId)
 	}
 
 	return podSecurityContext


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-2685)

## Description

Adds FSGroup to podSecurityContext to allow the EEC app to write to `agent/runtime` volume if it is a PersistenVolume.

## How can this be tested?

1) Deploy dynakube
```
spec:
  activeGate:
    tlsSecretName: ...
  apiUrl: ...
  customPullSecret: ...
  extensions: {}
  templates:
    extensionExecutionController:
      imageRef:
        repository: ...
        tag: 1.305.0.20241029-011002
      useEphemeralVolume: false
```
2) Create a file in agent/runtime directory
```
[]$ kubectl -n dynatrace exec -it pod/dynakube-extensions-controller-0 -- /bin/bash
$ cd /var/lib/dynatrace/remotepluginmodule/agent/runtime
$ touch aaa
$ ls -l
```
3) Make sure there are no error messages in the log
```
2024-11-22 11:06:39.834 UTC [0000000e] warning [native] EventSender: Cannot change mode to reliable, because failed to create persistence
```