### PR TITLE
Create-PR github action requires workflows permissions

### DIFF
--- a/.github/workflows/self-update-on-new-release-version.yaml
+++ b/.github/workflows/self-update-on-new-release-version.yaml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      workflows: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/self-update-on-new-release-version.yaml
+++ b/.github/workflows/self-update-on-new-release-version.yaml
@@ -45,7 +45,7 @@ jobs:
           branch: create-pull-request/update-renovate-json5
           branch-suffix: short-commit-hash
           add-paths: |
-            .github/renovate.json5
+            .github/*
           title: '[Automatic] Update because new branch created ${{ github.ref_name }}'
           labels: 'ci'
           commit-message: self update on new release ${{ github.ref_name }}

--- a/.github/workflows/self-update-on-new-release-version.yaml
+++ b/.github/workflows/self-update-on-new-release-version.yaml
@@ -46,7 +46,8 @@ jobs:
           branch: create-pull-request/update-renovate-json5
           branch-suffix: short-commit-hash
           add-paths: |
-            .github/*
+            .github/renovate.json5
+            .github/workflows/e2e-tests-ondemand.yaml
           title: '[Automatic] Update because new branch created ${{ github.ref_name }}'
           labels: 'ci'
           commit-message: self update on new release ${{ github.ref_name }}


### PR DESCRIPTION
## Description

follow-up for https://github.com/Dynatrace/dynatrace-operator/pull/4106

ticket https://dt-rnd.atlassian.net/browse/DAQ-2771

```
Pushing pull request branch to 'origin/create-pull-request/update-renovate-json5-fd216618'
  /usr/bin/git push --force-with-lease origin create-pull-request/update-renovate-json5-fd216618:refs/heads/create-pull-request/update-renovate-json5-fd216618
  To https://github.com/Dynatrace/dynatrace-operator
   ! [remote rejected]   create-pull-request/update-renovate-json5-fd216618 -> create-pull-request/update-renovate-json5-fd216618 (refusing to allow a GitHub App to create or update workflow `.github/workflows/e2e-tests-ondemand.yaml` without `workflows` permission)
  error: failed to push some refs to 'https://github.com/Dynatrace/dynatrace-operator'
  Error: The process '/usr/bin/git' failed with exit code 1
```

## How can this be tested?

trigger release