### PR TITLE
Fixes 'make manifests' bug caused by overwritten generate_manifest definition

### DIFF
--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -1,4 +1,4 @@
-define generate_manifest
+define generate_k8s_manifest
 	helm template dynatrace-operator config/helm/chart/default \
 		--namespace dynatrace \
 		--set csidriver.enabled=$(1) \
@@ -11,15 +11,15 @@ endef
 
 ## Generates a Kubernetes manifest including CRD and CSI driver
 manifests/kubernetes/csi: manifests/crd/helm
-	$(call generate_manifest,true,$(KUBERNETES_CSIDRIVER_YAML))
+	$(call generate_k8s_manifest,true,$(KUBERNETES_CSIDRIVER_YAML))
 
 ## Generates a Kubernetes manifest including CRD without CSI driver
 manifests/kubernetes/core: manifests/crd/helm
-	$(call generate_manifest,false,$(KUBERNETES_CORE_YAML))
+	$(call generate_k8s_manifest,false,$(KUBERNETES_CORE_YAML))
 
 ## Generates a Kubernetes manifest including CRD and CSI driver with OLM set to true
 manifests/kubernetes/olm: manifests/crd/helm
-	OLM=true $(call generate_manifest,true,$(KUBERNETES_OLM_YAML))
+	OLM=true $(call generate_k8s_manifest,true,$(KUBERNETES_OLM_YAML))
 
 ## Generates a manifest for Kubernetes including a CRD, a CSI driver deployment
 manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi

--- a/hack/make/manifests/openshift.mk
+++ b/hack/make/manifests/openshift.mk
@@ -1,4 +1,4 @@
-define generate_manifest
+define generate_openshift_manifest
 	helm template dynatrace-operator config/helm/chart/default \
 		--namespace dynatrace \
 		--set csidriver.enabled=$(1) \
@@ -11,15 +11,15 @@ endef
 
 ## Generates an Openshift manifest including CRD and CSI driver
 manifests/openshift/csi: manifests/crd/helm
-	$(call generate_manifest,true,$(OPENSHIFT_CSIDRIVER_YAML))
+	$(call generate_openshift_manifest,true,$(OPENSHIFT_CSIDRIVER_YAML))
 
 ## Generates a Openshift manifest including CRD without CSI driver
 manifests/openshift/core: manifests/crd/helm
-	$(call generate_manifest,false,$(OPENSHIFT_CORE_YAML))
+	$(call generate_openshift_manifest,false,$(OPENSHIFT_CORE_YAML))
 
 ## Generates an Openshift manifest including CRD and CSI driver with OLM set to true
 manifests/openshift/olm: manifests/crd/helm
-	OLM=true $(call generate_manifest,true,$(OPENSHIFT_OLM_YAML))
+	OLM=true $(call generate_openshift_manifest,true,$(OPENSHIFT_OLM_YAML))
 
 ## Generates a manifest for OpenShift including a CRD and a CSI driver deployment
 manifests/openshift: manifests/openshift/core manifests/openshift/csi


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-2842)

## Description
The `platform` argument was set to `openshift` for both platforms:
```
[]$ make manifests/openshift
...
helm template dynatrace-operator config/helm/chart/default ... --set platform="openshift" ... > config/deploy/openshift/openshift.yaml
```
```
[]$ make manifests/kubernetes
...
helm template dynatrace-operator config/helm/chart/default ... --set platform="openshift" ... > config/deploy/kubernetes/kubernetes.yaml
```

## How can this be tested?

Run `make manifests/*` commands. Check value of the `platform` argument:
```
helm template dynatrace-operator config/helm/chart/default ... --set platform="openshift" ... > config/deploy/openshift/openshift.yaml
```

`make manifests/kubernetes` sets `platform` argument to `kubernetes`

`make manifests/openshift` sets `platform` argument to `openshift`