### PR TITLE
Add new pipelins to on-demand E2E tests.

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -33,6 +33,8 @@ jobs:
             platform: k8s
           - version: 1-29
             platform: k8s
+          - version: 1-30
+            platform: k8s
           - version: 4-10
             platform: ocp
           - version: 4-11
@@ -44,6 +46,8 @@ jobs:
           - version: 4-14
             platform: ocp
           - version: 4-15
+            platform: ocp
+          - version: 4-16
             platform: ocp
     environment: E2E
     runs-on:


### PR DESCRIPTION
# Description

Add OpenShift 4.16 and K8S 1.30 pipelines to on-demand E2E tests

## How can this be tested?

Run on-demand pipelines.