### PR TITLE
Bump operator prev version in upgrade e2e test to 1.3.2.

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -78,8 +78,9 @@ jobs:
       - name: Notify failure in Slack
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          payload: |
-            message: ":x: E2E ondemand tests failed on ${{ env.branch }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})",
-            run_id: "${{ github.run_id }}"
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
+          payload-templated: true
+          payload: |
+            "message": ":red_circle: E2E ondemand tests failed on ${{ env.branch }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            "run_id": "${{ github.run_id }}"

--- a/test/features/cloudnative/upgrade/upgrade.go
+++ b/test/features/cloudnative/upgrade/upgrade.go
@@ -5,7 +5,7 @@ package upgrade
 import (
 	"testing"
 
-	dynakubev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube" //nolint:staticcheck
+	dynakubev1beta2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube" //nolint:staticcheck
 	"github.com/Dynatrace/dynatrace-operator/test/features/cloudnative"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
@@ -31,7 +31,7 @@ func Feature(t *testing.T) features.Feature {
 	)
 	builder.Assess("create sample namespace", sampleApp.InstallNamespace())
 
-	previousVersionDynakube := &dynakubev1beta1.DynaKube{}
+	previousVersionDynakube := &dynakubev1beta2.DynaKube{}
 	previousVersionDynakube.ConvertFrom(&testDynakube)
 	dynakube.InstallPreviousVersion(builder, helpers.LevelAssess, &secretConfig, *previousVersionDynakube)
 

--- a/test/helpers/components/dynakube/dynakube.go
+++ b/test/helpers/components/dynakube/dynakube.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	prevDynakube "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube" //nolint:staticcheck
+	prevDynakube "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta2/dynakube" //nolint:staticcheck
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
@@ -63,7 +63,7 @@ func CreatePreviousVersion(builder *features.FeatureBuilder, level features.Leve
 
 func VerifyStartupPreviousVersion(builder *features.FeatureBuilder, level features.Level, prevDk prevDynakube.DynaKube) {
 	if prevDk.NeedsOneAgent() {
-		builder.WithStep("oneagent started", level, oneagent.WaitFromDaemonSetPrevDk(prevDk))
+		builder.WithStep("oneagent started", level, oneagent.WaitForDaemonset(prevDk.OneAgentDaemonsetName(), prevDk.Namespace))
 	}
 	builder.WithStep(
 		fmt.Sprintf("'%s' dynakube phase changes to 'Running'", prevDk.Name),
@@ -74,7 +74,7 @@ func VerifyStartupPreviousVersion(builder *features.FeatureBuilder, level featur
 func Delete(builder *features.FeatureBuilder, level features.Level, dk dynakube.DynaKube) {
 	builder.WithStep("dynakube deleted", level, remove(dk))
 	if dk.NeedsOneAgent() {
-		builder.WithStep("oneagent pods stopped", level, oneagent.WaitForDaemonSetPodsDeletion(dk))
+		builder.WithStep("oneagent pods stopped", level, oneagent.WaitForDaemonSetPodsDeletion(dk.OneAgentDaemonsetName(), dk.Namespace))
 	}
 	if dk.ClassicFullStackMode() {
 		oneagent.RunClassicUninstall(builder, level, dk)
@@ -83,7 +83,7 @@ func Delete(builder *features.FeatureBuilder, level features.Level, dk dynakube.
 
 func VerifyStartup(builder *features.FeatureBuilder, level features.Level, dk dynakube.DynaKube) {
 	if dk.NeedsOneAgent() {
-		builder.WithStep("oneagent started", level, oneagent.WaitForDaemonset(dk))
+		builder.WithStep("oneagent started", level, oneagent.WaitForDaemonset(dk.OneAgentDaemonsetName(), dk.Namespace))
 	}
 	builder.WithStep(
 		fmt.Sprintf("'%s' dynakube phase changes to 'Running'", dk.Name),

--- a/test/helpers/components/oneagent/daemonset.go
+++ b/test/helpers/components/oneagent/daemonset.go
@@ -5,7 +5,6 @@ package oneagent
 import (
 	"context"
 
-	dynakubev1beta1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta1/dynakube" //nolint
 	dynakubev1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
@@ -16,16 +15,12 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-func WaitForDaemonset(dk dynakubev1beta3.DynaKube) features.Func {
-	return helpers.ToFeatureFunc(daemonset.WaitFor(dk.OneAgentDaemonsetName(), dk.Namespace), true)
+func WaitForDaemonset(dsName, namespace string) features.Func {
+	return helpers.ToFeatureFunc(daemonset.WaitFor(dsName, namespace), true)
 }
 
-func WaitFromDaemonSetPrevDk(prevDk dynakubev1beta1.DynaKube) features.Func {
-	return helpers.ToFeatureFunc(daemonset.WaitFor(prevDk.OneAgentDaemonsetName(), prevDk.Namespace), true)
-}
-
-func WaitForDaemonSetPodsDeletion(dk dynakubev1beta3.DynaKube) features.Func {
-	return pod.WaitForPodsDeletionWithOwner(dk.OneAgentDaemonsetName(), dk.Namespace)
+func WaitForDaemonSetPodsDeletion(dsName, namespace string) features.Func {
+	return pod.WaitForPodsDeletionWithOwner(dsName, namespace)
 }
 
 func Get(ctx context.Context, resource *resources.Resources, dk dynakubev1beta3.DynaKube) (appsv1.DaemonSet, error) {

--- a/test/scenarios/release/release_test.go
+++ b/test/scenarios/release/release_test.go
@@ -20,7 +20,7 @@ var (
 	cfg     *envconf.Config
 )
 
-const releaseTag = "1.2.2"
+const releaseTag = "1.3.2"
 
 func TestMain(m *testing.M) {
 	cfg = environment.GetStandardKubeClusterEnvConfig()


### PR DESCRIPTION
## Description

Bump operator prev version in upgrade e2e test to 1.3.2.

Bonus: 
- I've fixed slack integration.
- removed redundant `WaitFromDaemonSetPrevDk` and replaced with `WaitFromDaemonset`

## How can this be tested?

Run `make test/e2e/release`