### PR TITLE
Consider logmonitoring in the node-selector check

### DIFF
--- a/pkg/api/validation/dynakube/logmonitoring_test.go
+++ b/pkg/api/validation/dynakube/logmonitoring_test.go
@@ -11,33 +11,44 @@ import (
 
 func TestIgnoredLogMonitoringTemplate(t *testing.T) {
 	t.Run("no warning if logMonitoring template section is empty", func(t *testing.T) {
-		dk := createStandaloneLogMonitoringDynakube(testName, "")
+		dk := createStandaloneLogMonitoringDynakube(testName, testApiUrl, "")
 		dk.Spec.OneAgent.CloudNativeFullStack = &dynakube.CloudNativeFullStackSpec{}
+		dk.Spec.Templates.LogMonitoring = nil
 		assertAllowedWithoutWarnings(t, dk)
 	})
 	t.Run("warning if logMonitoring template section is not empty", func(t *testing.T) {
-		dk := createStandaloneLogMonitoringDynakube(testName, "something")
+		dk := createStandaloneLogMonitoringDynakube(testName, testApiUrl, "something")
 		dk.Spec.OneAgent.CloudNativeFullStack = &dynakube.CloudNativeFullStackSpec{}
 		assertAllowedWithWarnings(t, 1, dk)
 	})
 }
 
-func createStandaloneLogMonitoringDynakube(name, nodeSelector string) *dynakube.DynaKube {
+func createStandaloneLogMonitoringDynakube(name, apiUrl, nodeSelector string) *dynakube.DynaKube {
 	dk := &dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testNamespace,
 		},
 		Spec: dynakube.DynaKubeSpec{
-			APIURL:        testApiUrl,
+			APIURL:        apiUrl,
 			LogMonitoring: &logmonitoring.Spec{},
+			Templates: dynakube.TemplatesSpec{
+				LogMonitoring: &logmonitoring.TemplateSpec{
+					ImageRef: image.Ref{
+						Repository: "repo/image",
+						Tag:        "version",
+					},
+				},
+			},
 		},
 	}
 
 	if nodeSelector != "" {
-		dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{
-			NodeSelector: map[string]string{"node": nodeSelector},
+		if dk.Spec.Templates.LogMonitoring == nil {
+			dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{}
 		}
+
+		dk.Spec.Templates.LogMonitoring.NodeSelector = map[string]string{"node": nodeSelector}
 	}
 
 	return dk

--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -60,7 +60,7 @@ func conflictingOneAgentConfiguration(_ context.Context, _ *Validator, dk *dynak
 }
 
 func conflictingOneAgentNodeSelector(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
-	if !dk.NeedsOneAgent() {
+	if !dk.NeedsOneAgent() && !dk.LogMonitoring().IsStandalone() {
 		return ""
 	}
 
@@ -79,7 +79,7 @@ func conflictingOneAgentNodeSelector(ctx context.Context, dv *Validator, dk *dyn
 			continue
 		}
 
-		if item.NeedsOneAgent() {
+		if hasLogMonitoringSelectorConflict(dk, &item) || hasOneAgentSelectorConflict(dk, &item) {
 			if hasConflictingMatchLabels(oneAgentNodeSelector, item.OneAgentNodeSelector()) {
 				log.Info("requested dynakube has conflicting OneAgent nodeSelector", "name", dk.Name, "namespace", dk.Namespace)
 
@@ -93,6 +93,18 @@ func conflictingOneAgentNodeSelector(ctx context.Context, dv *Validator, dk *dyn
 	}
 
 	return ""
+}
+
+func hasLogMonitoringSelectorConflict(dk1, dk2 *dynakube.DynaKube) bool {
+	return dk1.LogMonitoring().IsStandalone() && dk1.ApiUrl() == dk2.ApiUrl() &&
+		(dk2.NeedsOneAgent() || dk2.LogMonitoring().IsStandalone()) &&
+		hasConflictingMatchLabels(dk1.OneAgentNodeSelector(), dk2.OneAgentNodeSelector())
+}
+
+func hasOneAgentSelectorConflict(dk1, dk2 *dynakube.DynaKube) bool {
+	return dk1.NeedsOneAgent() &&
+		(dk2.NeedsOneAgent() || dk2.LogMonitoring().IsStandalone() && dk1.ApiUrl() == dk2.ApiUrl()) &&
+		hasConflictingMatchLabels(dk1.OneAgentNodeSelector(), dk2.OneAgentNodeSelector())
 }
 
 func mapKeysToString(m map[string]bool, sep string) string {


### PR DESCRIPTION
## Description

[DAQ-2191](https://dt-rnd.atlassian.net/browse/DAQ-2191)

Enhances the check previously removed in https://github.com/Dynatrace/dynatrace-operator/pull/4109
- With the caveat, that we use the`apiUrl` for checking if DynaKubes use the same tenant
  - this is not perfect, because of tenant aliases, but it is considered misconfiguration to use a tenant alias for 1 DynaKube and not for another one. 	

How the nodeSelector validation changed:
- 2 CloudNative (or any OneAgent) on same node with different tenant ==> ⛔  (this is not new)
- 2 LogMonitoring on same node with different tenant ==> 🆗 
- 1 LogMonitoring and 1 CloudNative(or any OneAgent) on same node with different tenant ==> 🆗 

## How can this be tested?

Try recreating the scenarios from the unit-tests

[DAQ-2191]: https://dt-rnd.atlassian.net/browse/DAQ-2191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ