### PR TITLE
Create kubernetes-monitoring rbac's if only KSPM is enabled (#4125)

### DIFF
--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.activeGate.create }}
+{{- if or (eq .Values.rbac.activeGate.create true) (eq .Values.rbac.kspm.create true) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.activeGate.create }}
+{{- if or (eq .Values.rbac.activeGate.create true) (eq .Values.rbac.kspm.create true) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
@@ -149,9 +149,17 @@ tests:
             kind: ServiceAccount
             name: dynatrace-kubernetes-monitoring
             namespace: NAMESPACE
+  - it: should exist if only kspm is turned on
+    set:
+      rbac.activeGate.create: false
+      rbac.kspm.create: true
+    asserts:
+      - hasDocuments:
+          count: 2
   - it: shouldn't exist if turned off
     set:
       rbac.activeGate.create: false
+      rbac.kspm.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring_test.yaml
@@ -28,9 +28,17 @@ tests:
           path: metadata.annotations
           value:
             test: test
+  - it: should exist if only kspm is turned on
+    set:
+      rbac.activeGate.create: false
+      rbac.kspm.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
   - it: shouldn't exist if turned off
     set:
       rbac.activeGate.create: false
+      rbac.kspm.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/pkg/api/validation/dynakube/modules.go
+++ b/pkg/api/validation/dynakube/modules.go
@@ -25,7 +25,7 @@ func isOneAgentModuleDisabled(_ context.Context, v *Validator, dk *dynakube.Dyna
 }
 
 func isActiveGateModuleDisabled(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
-	if dk.ActiveGate().IsEnabled() && !v.modules.ActiveGate {
+	if dk.ActiveGate().IsEnabled() && !v.modules.ActiveGate && !v.modules.KSPM {
 		return errorActiveGateModuleDisabled
 	}
 

--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
@@ -18,7 +18,6 @@ import (
 )
 
 const (
-	nameSuffix         = "-node-config-collector"
 	serviceAccountName = "dynatrace-node-config-collector"
 )
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
https://dt-rnd.atlassian.net/browse/DAQ-2788

Same as in #4125

## How can this be tested?

Same as in #4125
