### PR TITLE
[CRD] Warning if multiple Dyankubes with extensions are enabled for same ApiURL

### DIFF
--- a/pkg/api/validation/dynakube/eec.go
+++ b/pkg/api/validation/dynakube/eec.go
@@ -3,11 +3,13 @@ package validation
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"golang.org/x/net/context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	errorExtensionExecutionControllerImageNotSpecified       = `DynaKube's specification enables the Prometheus feature, make sure you correctly specify the ExtensionExecutionController image.`
 	errorExtensionExecutionControllerInvalidPVCConfiguration = `DynaKube specifies a PVC for the extension controller while ephemeral volume is also enabled. These settings are mutually exclusive, please choose only one.`
+	warningIfmultiplyDKwithExtensionsEnabled                 = `You are already using a Dynakube that enables extensions. Having multiple Dynakubes with '.spec.extensions' enabled can have severe side-effects on “sum” and “count” metrics and cause double-billing.`
 )
 
 func extensionControllerImage(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
@@ -19,6 +21,31 @@ func extensionControllerImage(_ context.Context, _ *Validator, dk *dynakube.Dyna
 		log.Info("requested dynakube doesn't specify the ExtensionExecutionController image.", "name", dk.Name, "namespace", dk.Namespace)
 
 		return errorExtensionExecutionControllerImageNotSpecified
+	}
+
+	return ""
+}
+
+func warnIfmultiplyDKwithExtensionsEnabled(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	if !dk.IsExtensionsEnabled() {
+		return ""
+	}
+
+	validDynakubes := &dynakube.DynaKubeList{}
+	if err := dv.apiReader.List(ctx, validDynakubes, &client.ListOptions{Namespace: dk.Namespace}); err != nil {
+		log.Info("error occurred while listing dynakubes", "err", err.Error())
+
+		return ""
+	}
+
+	for _, item := range validDynakubes.Items {
+		if item.Name == dk.Name {
+			continue
+		}
+
+		if item.IsExtensionsEnabled() && (dk.ApiUrl() == item.ApiUrl()) {
+			return warningIfmultiplyDKwithExtensionsEnabled
+		}
 	}
 
 	return ""

--- a/pkg/api/validation/dynakube/eec.go
+++ b/pkg/api/validation/dynakube/eec.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"golang.org/x/net/context"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/api/validation/dynakube/eec.go
+++ b/pkg/api/validation/dynakube/eec.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"golang.org/x/net/context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -9,7 +10,7 @@ import (
 const (
 	errorExtensionExecutionControllerImageNotSpecified       = `DynaKube's specification enables the Prometheus feature, make sure you correctly specify the ExtensionExecutionController image.`
 	errorExtensionExecutionControllerInvalidPVCConfiguration = `DynaKube specifies a PVC for the extension controller while ephemeral volume is also enabled. These settings are mutually exclusive, please choose only one.`
-	warningConflictingApiUrlForExtensions                    = `You are already using a Dynakube that enables extensions. Having multiple Dynakubes with '.spec.extensions' enabled can have severe side-effects on “sum” and “count” metrics and cause double-billing.`
+	warningConflictingApiUrlForExtensions                    = `You are already using a Dynakube ('%s') that enables extensions. Having multiple Dynakubes with same '.spec.apiUrl' and '.spec.extensions' enabled can have severe side-effects on “sum” and “count” metrics and cause double-billing.`
 )
 
 func extensionControllerImage(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
@@ -44,7 +45,7 @@ func conflictingApiUrlForExtensions(ctx context.Context, dv *Validator, dk *dyna
 		}
 
 		if item.IsExtensionsEnabled() && (dk.ApiUrl() == item.ApiUrl()) {
-			return warningConflictingApiUrlForExtensions
+			return fmt.Sprintf(warningConflictingApiUrlForExtensions, item.Name)
 		}
 	}
 

--- a/pkg/api/validation/dynakube/eec.go
+++ b/pkg/api/validation/dynakube/eec.go
@@ -9,7 +9,7 @@ import (
 const (
 	errorExtensionExecutionControllerImageNotSpecified       = `DynaKube's specification enables the Prometheus feature, make sure you correctly specify the ExtensionExecutionController image.`
 	errorExtensionExecutionControllerInvalidPVCConfiguration = `DynaKube specifies a PVC for the extension controller while ephemeral volume is also enabled. These settings are mutually exclusive, please choose only one.`
-	warningIfmultiplyDKwithExtensionsEnabled                 = `You are already using a Dynakube that enables extensions. Having multiple Dynakubes with '.spec.extensions' enabled can have severe side-effects on “sum” and “count” metrics and cause double-billing.`
+	warningConflictingApiUrlForExtensions                    = `You are already using a Dynakube that enables extensions. Having multiple Dynakubes with '.spec.extensions' enabled can have severe side-effects on “sum” and “count” metrics and cause double-billing.`
 )
 
 func extensionControllerImage(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
@@ -26,7 +26,7 @@ func extensionControllerImage(_ context.Context, _ *Validator, dk *dynakube.Dyna
 	return ""
 }
 
-func warnIfmultiplyDKwithExtensionsEnabled(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+func conflictingApiUrlForExtensions(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
 	if !dk.IsExtensionsEnabled() {
 		return ""
 	}
@@ -44,7 +44,7 @@ func warnIfmultiplyDKwithExtensionsEnabled(ctx context.Context, dv *Validator, d
 		}
 
 		if item.IsExtensionsEnabled() && (dk.ApiUrl() == item.ApiUrl()) {
-			return warningIfmultiplyDKwithExtensionsEnabled
+			return warningConflictingApiUrlForExtensions
 		}
 	}
 

--- a/pkg/api/validation/dynakube/eec_test.go
+++ b/pkg/api/validation/dynakube/eec_test.go
@@ -216,6 +216,7 @@ func TestWarnIfmultiplyDKwithExtensionsEnabled(t *testing.T) {
 		warnings, err := assertAllowed(t, dk1, dk2)
 		require.NoError(t, err)
 		require.Len(t, warnings, 1)
+
 		expected := fmt.Sprintf(warningConflictingApiUrlForExtensions, dk2.Name)
 		assert.Equal(t, expected, warnings[0])
 	})

--- a/pkg/api/validation/dynakube/eec_test.go
+++ b/pkg/api/validation/dynakube/eec_test.go
@@ -215,7 +215,7 @@ func TestWarnIfmultiplyDKwithExtensionsEnabled(t *testing.T) {
 		warnings, err := assertAllowed(t, dk1, dk2)
 		require.NoError(t, err)
 		require.Len(t, warnings, 1)
-		assert.Equal(t, warningIfmultiplyDKwithExtensionsEnabled, warnings[0])
+		assert.Equal(t, warningConflictingApiUrlForExtensions, warnings[0])
 	})
 
 	t.Run("no warning same ApiUrls and for second dk: extensions feature is disabled", func(t *testing.T) {

--- a/pkg/api/validation/dynakube/eec_test.go
+++ b/pkg/api/validation/dynakube/eec_test.go
@@ -5,7 +5,12 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/activegate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestExtensionExecutionControllerImage(t *testing.T) {
@@ -139,5 +144,97 @@ func TestExtensionExecutionControllerPVCSettings(t *testing.T) {
 					},
 				},
 			})
+	})
+}
+
+func TestWarnIfmultiplyDKwithExtensionsEnabled(t *testing.T) {
+	imgRef := image.Ref{
+		Repository: "a",
+		Tag:        "b",
+	}
+	// we want to exclude AG resources warning.
+	agSpec := activegate.Spec{
+		CapabilityProperties: activegate.CapabilityProperties{
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+		},
+	}
+	dk1 := &dynakube.DynaKube{
+		ObjectMeta: defaultDynakubeObjectMeta,
+		Spec: dynakube.DynaKubeSpec{
+			APIURL:     testApiUrl,
+			Extensions: &dynakube.ExtensionsSpec{},
+			Templates: dynakube.TemplatesSpec{
+				ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
+					ImageRef: imgRef,
+				},
+			},
+			ActiveGate: agSpec,
+		},
+	}
+
+	t.Run("no warning different ApiUrls", func(t *testing.T) {
+		dk2 := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName + "second",
+				Namespace: testNamespace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL:     "https://f.q.d.n/123",
+				Extensions: &dynakube.ExtensionsSpec{},
+				Templates: dynakube.TemplatesSpec{
+					ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
+						ImageRef: imgRef,
+					},
+				},
+				ActiveGate: agSpec,
+			},
+		}
+		assertAllowedWithoutWarnings(t, dk1, dk2)
+	})
+	t.Run("warning same ApiUrls", func(t *testing.T) {
+		dk2 := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName + "second",
+				Namespace: testNamespace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL:     testApiUrl,
+				Extensions: &dynakube.ExtensionsSpec{},
+				Templates: dynakube.TemplatesSpec{
+					ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
+						ImageRef: imgRef,
+					},
+				},
+				ActiveGate: agSpec,
+			},
+		}
+		warnings, err := assertAllowed(t, dk1, dk2)
+		require.NoError(t, err)
+		require.Len(t, warnings, 1)
+		assert.Equal(t, warningIfmultiplyDKwithExtensionsEnabled, warnings[0])
+	})
+
+	t.Run("no warning same ApiUrls and for second dk: extensions feature is disabled", func(t *testing.T) {
+		dk2 := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName + "second",
+				Namespace: testNamespace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL:     testApiUrl,
+				Extensions: nil,
+				Templates: dynakube.TemplatesSpec{
+					ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
+						ImageRef: imgRef,
+					},
+				},
+				ActiveGate: agSpec,
+			},
+		}
+		assertAllowedWithoutWarnings(t, dk1, dk2)
 	})
 }

--- a/pkg/api/validation/dynakube/eec_test.go
+++ b/pkg/api/validation/dynakube/eec_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
@@ -215,7 +216,8 @@ func TestWarnIfmultiplyDKwithExtensionsEnabled(t *testing.T) {
 		warnings, err := assertAllowed(t, dk1, dk2)
 		require.NoError(t, err)
 		require.Len(t, warnings, 1)
-		assert.Equal(t, warningConflictingApiUrlForExtensions, warnings[0])
+		expected := fmt.Sprintf(warningConflictingApiUrlForExtensions, dk2.Name)
+		assert.Equal(t, expected, warnings[0])
 	})
 
 	t.Run("no warning same ApiUrls and for second dk: extensions feature is disabled", func(t *testing.T) {

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -59,7 +59,7 @@ var (
 		conflictingHostGroupSettings,
 		deprecatedFeatureFlag,
 		ignoredLogMonitoringTemplate,
-		warnIfmultiplyDKwithExtensionsEnabled,
+		conflictingApiUrlForExtensions,
 	}
 	updateValidatorErrorFuncs = []updateValidatorFunc{
 		IsMutatedApiUrl,

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -59,6 +59,7 @@ var (
 		conflictingHostGroupSettings,
 		deprecatedFeatureFlag,
 		ignoredLogMonitoringTemplate,
+		warnIfmultiplyDKwithExtensionsEnabled,
 	}
 	updateValidatorErrorFuncs = []updateValidatorFunc{
 		IsMutatedApiUrl,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Ticket [DAQ-1617](https://dt-rnd.atlassian.net/browse/DAQ-1617)

Currently having multiple Dynakubes with extensions enabled for the same tenant in the same K8S cluster will have unwanted side-effects. OTOH we don’t want to completely prevent this scenario.

This PR introduce warning validation check for this scenario.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

unit tests/ or create 2 dks extensions enabled with same APIURLs and see no-blocking warning:
```
You are already using a Dynakube that enables extensions. Having multiple Dynakubes with '.spec.extensions' enabled can have severe side-effects on “sum” and “count” metrics and cause double-billing.
```

[DAQ-1617]: https://dt-rnd.atlassian.net/browse/DAQ-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ