### PR TITLE
Add validator to only allow 1 AG replica in combination with KSPM

### DIFF
--- a/pkg/api/validation/dynakube/kspm.go
+++ b/pkg/api/validation/dynakube/kspm.go
@@ -7,9 +7,18 @@ import (
 )
 
 const (
+	errorTooManyAGReplicas  = `The Dynakube's specification specifies KSPM, but has more than one ActiveGate replica. Only one ActiveGate replica is allowed in combination with KSPM.`
 	errorKSPMMissingKubemon = `The Dynakube's specification specifies KSPM, but "kubernetes-monitoring" is not enabled on the Activegate.`
 	errorKSPMMissingImage   = `The Dynakube's specification specifies KSPM, but no image repository/tag is configured.`
 )
+
+func tooManyAGReplicas(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if dk.KSPM().IsEnabled() && dk.ActiveGate().GetReplicas() > 1 {
+		return errorTooManyAGReplicas
+	}
+
+	return ""
+}
 
 func missingKSPMDependency(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	if dk.KSPM().IsEnabled() &&

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -49,6 +49,7 @@ var (
 		imageFieldHasTenantImage,
 		extensionControllerImage,
 		extensionControllerPVCStorageDevice,
+		tooManyAGReplicas,
 		missingKSPMDependency,
 		missingKSPMImage,
 		missingLogMonitoringImage,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/DAQ-2890

KSPM only works with one ActiveGate replica. This is why here a new validation is added that validates exactly that.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Apply a dynakube with kspm enabled and play around with the `replica` section.

example:  
```
kspm: {}
  activeGate:
    replicas: 2
    tlsSecretName: dynakube-ag-tls
    capabilities:
      - kubernetes-monitoring
    customProperties:
      value: |
        [kubernetes_monitoring]
        kubernetes_configuration_dataset_pipeline_enabled = true
        kubernetes_configuration_dataset_pipeline_include_node_config = true
  templates:
     kspmNodeConfigurationCollector:
       imageRef:
         repository: us-central1-docker.pkg.dev/cloud-platform-207208/chmu/k8s-node-config-collector
         tag: latest
```

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->