### PR TITLE
Add logmonitoring rbac to OA ServiceAccount

### DIFF
--- a/config/helm/chart/default/templates/Common/logmonitoring/clusterrole-logmonitoring.yaml
+++ b/config/helm/chart/default/templates/Common/logmonitoring/clusterrole-logmonitoring.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.logMonitoring.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if .Values.rbac.logMonitoring.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,4 +48,21 @@ subjects:
 - kind: ServiceAccount
   name: dynatrace-logmonitoring
   namespace: {{ .Release.Namespace }}
+{{ if .Values.rbac.oneAgent.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dynatrace-logmonitoring-fullstack
+  labels:
+    {{- include "dynatrace-operator.logMonitoringLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dynatrace-logmonitoring
+subjects:
+- kind: ServiceAccount
+  name: dynatrace-dynakube-oneagent
+  namespace: {{ .Release.Namespace }}
+{{ end }}
 {{ end }}

--- a/config/helm/chart/default/tests/Common/logmonitoring/clusterrole-logmonitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/logmonitoring/clusterrole-logmonitoring_test.yaml
@@ -4,7 +4,8 @@ templates:
 tests:
   - it: logmonitoring ClusterRole should exist
     set:
-      platform: openshift
+      rbac.logMonitoring.create: true
+      rbac.oneagent.create: false
     documentIndex: 0
     asserts:
       - isKind:
@@ -28,7 +29,8 @@ tests:
   - it: logmonitoring ClusterRoleBinding should exist
     documentIndex: 1
     set:
-      platform: openshift
+      rbac.logMonitoring.create: true
+      rbac.oneagent.create: false
     asserts:
       - isKind:
           of: ClusterRoleBinding
@@ -37,16 +39,23 @@ tests:
           value: dynatrace-logmonitoring
       - isNotEmpty:
           path: metadata.labels
-  - it: shouldn't exist if not openshift
+  - it: extra binding should exist for fullstack
+    documentIndex: 2
     set:
       rbac.logMonitoring.create: true
-      platform: NOT-openshift
+      rbac.oneagent.create: true
     asserts:
-      - hasDocuments:
-        count: 0
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: dynatrace-logmonitoring-fullstack
+      - isNotEmpty:
+          path: metadata.labels
   - it: shouldn't exist if turned off
     set:
       rbac.logMonitoring.create: false
+      rbac.oneagent.create: true
     asserts:
       - hasDocuments:
         count: 0

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/env.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/env.go
@@ -17,8 +17,8 @@ const (
 	entityEnv        = "DT_ENTITY_KUBERNETES_CLUSTER"
 
 	// main container envs
-	apiNodeNameEnv  = "KUBELET_API_NODENAME"
-	apiIPAddressEnv = "KUBELET_API_ADDRESS"
+	ApiNodeNameEnv  = "KUBELET_API_NODENAME"
+	ApiIPAddressEnv = "KUBELET_API_ADDRESS"
 	dtStorageEnv    = "DT_STORAGE"
 	ruxitConfigEnv  = "APMNG_PA_CONFIG_PATH"
 
@@ -75,10 +75,10 @@ func getInitEnvs(dk dynakube.DynaKube) []corev1.EnvVar {
 	}
 }
 
-func getEnvs() []corev1.EnvVar {
+func GetAPIEnvs() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
-			Name: apiNodeNameEnv,
+			Name: ApiNodeNameEnv,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "spec.nodeName",
@@ -86,13 +86,19 @@ func getEnvs() []corev1.EnvVar {
 			},
 		},
 		{
-			Name: apiIPAddressEnv,
+			Name: ApiIPAddressEnv,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "status.hostIP",
 				},
 			},
 		},
+	}
+}
+
+func getEnvs() []corev1.EnvVar {
+	apiEnvs := GetAPIEnvs()
+	standaloneEnvs := []corev1.EnvVar{
 		{
 			Name:  dtStorageEnv,
 			Value: dtStoragePath,
@@ -102,4 +108,5 @@ func getEnvs() []corev1.EnvVar {
 			Value: ruxitConfigPath,
 		},
 	}
+	return append(apiEnvs, standaloneEnvs...)
 }

--- a/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
+	logmonitoring "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/address"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/prioritymap"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
@@ -42,6 +43,7 @@ func (b *builder) environmentVariables() ([]corev1.EnvVar, error) {
 	b.addOperatorVersionInfoEnv(envMap)
 	b.addConnectionInfoEnvs(envMap)
 	b.addReadOnlyEnv(envMap)
+	b.addLogMonitoringEnv(envMap)
 
 	isProxyAsEnvDeprecated, err := isProxyAsEnvVarDeprecated(b.dk.OneAgentVersion())
 	if err != nil {
@@ -122,6 +124,14 @@ func (b *builder) addProxyEnv(envVarMap *prioritymap.Map) {
 func (b *builder) addReadOnlyEnv(envVarMap *prioritymap.Map) {
 	if b.dk != nil && b.dk.UseReadOnlyOneAgents() {
 		addDefaultValue(envVarMap, oneagentReadOnlyMode, "true")
+	}
+}
+
+func (b *builder) addLogMonitoringEnv(envVarMap *prioritymap.Map) {
+	if b.dk != nil && b.dk.LogMonitoring().IsEnabled() {
+		for _, env := range logmonitoring.GetAPIEnvs() {
+			prioritymap.Append(envVarMap, env)
+		}
 	}
 }
 

--- a/pkg/controllers/dynakube/oneagent/daemonset/env_vars_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/env_vars_test.go
@@ -6,8 +6,10 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
+	logmonitoringds "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/daemonset"
 	k8senv "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/prioritymap"
 	"github.com/stretchr/testify/assert"
@@ -39,6 +41,7 @@ func TestEnvironmentVariables(t *testing.T) {
 				OneAgent: dynakube.OneAgentSpec{
 					CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{},
 				},
+				LogMonitoring: &logmonitoring.Spec{},
 			},
 		}
 		dsBuilder := builder{
@@ -53,6 +56,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		assertDeploymentMetadataEnv(t, envVars, dk.Name)
 
 		assertReadOnlyEnv(t, envVars)
+		assertLogMonitoringEnv(t, envVars)
 	})
 	t.Run("when injected envvars are provided then they will not be overridden", func(t *testing.T) {
 		potentiallyOverriddenEnvVars := []corev1.EnvVar{
@@ -288,6 +292,15 @@ func assertReadOnlyEnv(t *testing.T, envs []corev1.EnvVar) {
 	env := k8senv.FindEnvVar(envs, oneagentReadOnlyMode)
 	assert.Equal(t, oneagentReadOnlyMode, env.Name)
 	assert.Equal(t, "true", env.Value)
+}
+
+func assertLogMonitoringEnv(t *testing.T, envs []corev1.EnvVar) {
+	env := k8senv.FindEnvVar(envs, logmonitoringds.ApiIPAddressEnv)
+	require.NotNil(t, env)
+	assert.NotEmpty(t, env.ValueFrom)
+	env = k8senv.FindEnvVar(envs, logmonitoringds.ApiNodeNameEnv)
+	require.NotNil(t, env)
+	assert.NotEmpty(t, env.ValueFrom)
 }
 
 func TestIsProxyAsEnvVarDeprecated(t *testing.T) {


### PR DESCRIPTION
## Description
[DAQ-2891](https://dt-rnd.atlassian.net/browse/DAQ-2891)

Changes:
- The `dynatrace-logmonitoring` `ClusterRole` (and binding) is always created not only on Openshift
- LogMonitoring can work in the fullstack OneAgent `DaemonSet`
   - The `dynatrace-logmonitoring` `ClusterRole` is also bound to the OneAgent `ServiceAccount`(`dynatrace-dynakube-oneagent`)
   - The LogMonitoring related Envs are also added to the fullstack OneAgent `DaemonSet`

## How can this be tested?

Deploy LogMonitoring (standalone and with fullstack):
- The `dynatrace-logmonitoring` `ClusterRole` should always exist and be bound to ServiceAccounts
- The API envs (`KUBELET_API_NODENAME`, `KUBELET_API_ADRESS`) should always be present if LogMonitoring is enabled