### PR TITLE
Correct schemaVersion and improve error handling

### DIFF
--- a/pkg/clients/dynatrace/settings_logmonitoring.go
+++ b/pkg/clients/dynatrace/settings_logmonitoring.go
@@ -39,6 +39,7 @@ type posLogMonSettingsBody struct {
 
 const (
 	logMonitoringSettingsSchemaId = "builtin:logmonitoring.log-storage-settings"
+	schemaVersion                 = "1.0.16"
 )
 
 func (dtc *dynatraceClient) performCreateLogMonSetting(ctx context.Context, body []posLogMonSettingsBody) (string, error) { //nolint:dupl
@@ -114,7 +115,7 @@ func createBaseLogMonSettings(clusterName, schemaId string, schemaVersion string
 }
 
 func (dtc *dynatraceClient) CreateLogMonitoringSetting(ctx context.Context, scope, clusterName string, matchers []logmonitoring.IngestRuleMatchers) (string, error) {
-	settings := createBaseLogMonSettings(clusterName, logMonitoringSettingsSchemaId, "1.0.0", scope, matchers)
+	settings := createBaseLogMonSettings(clusterName, logMonitoringSettingsSchemaId, schemaVersion, scope, matchers)
 
 	objectId, err := dtc.performCreateLogMonSetting(ctx, []posLogMonSettingsBody{settings})
 	if err != nil {

--- a/pkg/controllers/dynakube/logmonitoring/logmonsettings/conditions.go
+++ b/pkg/controllers/dynakube/logmonitoring/logmonsettings/conditions.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	settingsExistReason = "LogMonSettingsExist"
+	settingsErrorReason = "LogMonSettingsError"
 
 	conditionType = "LogMonitoringSettings"
 )
@@ -17,6 +18,16 @@ func setLogMonitoringSettingExists(conditions *[]metav1.Condition, conditionType
 		Status:  metav1.ConditionTrue,
 		Reason:  settingsExistReason,
 		Message: "LogMonitoring settings already exist, will not create new ones.",
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
+}
+
+func setLogMonitoringSettingError(conditions *[]metav1.Condition, conditionType, message string) {
+	condition := metav1.Condition{
+		Type:    conditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  settingsErrorReason,
+		Message: "There was an error regarding LogMonitoring settings: " + message,
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }

--- a/pkg/controllers/dynakube/logmonitoring/logmonsettings/conditions.go
+++ b/pkg/controllers/dynakube/logmonitoring/logmonsettings/conditions.go
@@ -27,7 +27,7 @@ func setLogMonitoringSettingError(conditions *[]metav1.Condition, conditionType,
 		Type:    conditionType,
 		Status:  metav1.ConditionFalse,
 		Reason:  settingsErrorReason,
-		Message: "There was an error regarding LogMonitoring settings: " + message,
+		Message: "LogMonitoring settings could not be created: " + message,
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
 }

--- a/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
@@ -56,6 +56,8 @@ func (r *reconciler) checkLogMonitoringSettings(ctx context.Context) error {
 
 	logMonitoringSettings, err := r.dtc.GetSettingsForLogModule(ctx, r.dk.Status.KubernetesClusterMEID)
 	if err != nil {
+		setLogMonitoringSettingError(r.dk.Conditions(), conditionType, err.Error())
+
 		return errors.WithMessage(err, "error trying to check if setting exists")
 	}
 
@@ -75,6 +77,8 @@ func (r *reconciler) checkLogMonitoringSettings(ctx context.Context) error {
 	objectId, err := r.dtc.CreateLogMonitoringSetting(ctx, r.dk.Status.KubernetesClusterMEID, r.dk.Status.KubernetesClusterName, matchers)
 
 	if err != nil {
+		setLogMonitoringSettingError(r.dk.Conditions(), conditionType, err.Error())
+
 		return errors.WithMessage(err, "error when creating log monitoring setting")
 	}
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/DAQ-2991

This fixes:

- schemaVersion. Previously it was set to `1.0.0` but it should be set to `1.0.16`, as this is the most current version
- Error handling: If there is an error in the course of getting or creating logmon settings, We now mention it in the conditions of the `DynaKube`.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

I changed the version to a version that does not exist, or also used a wrong schemaID and built the image locally and had a look at the `DynaKube` status. I think this is the best way to test this properly.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->