### PR TITLE
Transfer EC.Labels and EC.Annotations to the POD spec

### DIFF
--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -674,7 +674,11 @@ func (controller *Controller) createOrUpdateEdgeConnectDeploymentAndSettings(ctx
 
 	desiredDeployment := deployment.New(ec)
 
-	desiredDeployment.Spec.Template.Annotations = map[string]string{consts.EdgeConnectAnnotationSecretHash: secretHash}
+	if desiredDeployment.Spec.Template.Annotations == nil {
+		desiredDeployment.Spec.Template.Annotations = map[string]string{}
+	}
+
+	desiredDeployment.Spec.Template.Annotations[consts.EdgeConnectAnnotationSecretHash] = secretHash
 	_log = _log.WithValues("deploymentName", desiredDeployment.Name)
 
 	if err := controllerutil.SetControllerReference(ec, desiredDeployment, scheme.Scheme); err != nil {

--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -377,7 +377,11 @@ func (controller *Controller) reconcileEdgeConnectRegular(ctx context.Context, e
 		return err
 	}
 
-	desiredDeployment.Spec.Template.Annotations = map[string]string{consts.EdgeConnectAnnotationSecretHash: secretHash}
+	if desiredDeployment.Spec.Template.Annotations == nil {
+		desiredDeployment.Spec.Template.Annotations = map[string]string{}
+	}
+
+	desiredDeployment.Spec.Template.Annotations[consts.EdgeConnectAnnotationSecretHash] = secretHash
 
 	_, err = k8sdeployment.Query(controller.client, controller.apiReader, log).WithOwner(ec).CreateOrUpdate(ctx, desiredDeployment)
 	if err != nil {

--- a/pkg/controllers/edgeconnect/deployment/deployment.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment.go
@@ -38,7 +38,7 @@ func create(ec *edgeconnect.EdgeConnect) *appsv1.Deployment {
 			Name:        ec.Name,
 			Namespace:   ec.Namespace,
 			Labels:      labels,
-			Annotations: buildAnnotations(ec),
+			Annotations: buildAnnotations(),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: ec.Spec.Replicas,
@@ -92,14 +92,11 @@ func buildAppLabels(ec *edgeconnect.EdgeConnect) *labels.AppLabels {
 		ec.Status.Version.Version)
 }
 
-func buildAnnotations(ec *edgeconnect.EdgeConnect) map[string]string {
-	annotations := map[string]string{
+func buildAnnotations() map[string]string {
+	return map[string]string{
 		consts.AnnotationEdgeConnectContainerAppArmor: "runtime/default",
 		webhook.AnnotationDynatraceInject:             "false",
 	}
-	annotations = maputils.MergeMap(ec.Annotations, annotations)
-
-	return annotations
 }
 
 func edgeConnectContainer(ec *edgeconnect.EdgeConnect) corev1.Container {

--- a/pkg/controllers/edgeconnect/deployment/deployment.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment.go
@@ -24,20 +24,20 @@ func New(ec *edgeconnect.EdgeConnect) *appsv1.Deployment {
 
 func create(ec *edgeconnect.EdgeConnect) *appsv1.Deployment {
 	appLabels := buildAppLabels(ec)
-	buildLabels := appLabels.BuildLabels()
+	labels := appLabels.BuildLabels()
 
 	customPodLabels := maputils.MergeMap(
 		ec.Spec.Labels,
-		buildLabels, // higher priority
+		labels, // higher priority
 	)
 
-	log.Debug("EdgeConnect deployment app labels", "labels", buildLabels)
+	log.Debug("EdgeConnect deployment app labels", "labels", labels)
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        ec.Name,
 			Namespace:   ec.Namespace,
-			Labels:      buildLabels,
+			Labels:      labels,
 			Annotations: buildAnnotations(ec),
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/controllers/edgeconnect/deployment/deployment_test.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment_test.go
@@ -66,6 +66,88 @@ func Test_buildAppLabels(t *testing.T) {
 	})
 }
 
+func TestLabels(t *testing.T) {
+	testLabelKey := "test-label-key"
+	testLabelValue := "test-label-value"
+
+	t.Run("Check empty custom labels", func(t *testing.T) {
+		ec := &edgeconnect.EdgeConnect{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: edgeconnect.EdgeConnectSpec{},
+		}
+
+		deployment := New(ec)
+
+		assert.Len(t, deployment.Spec.Template.Labels, 5)
+	})
+
+	t.Run("Check custom label set correctly", func(t *testing.T) {
+		ec := &edgeconnect.EdgeConnect{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: edgeconnect.EdgeConnectSpec{
+				Labels: map[string]string{
+					testLabelKey: testLabelValue,
+				},
+			},
+		}
+
+		deployment := New(ec)
+
+		assert.Len(t, deployment.Spec.Template.Labels, 6)
+		assert.Contains(t, deployment.Spec.Template.ObjectMeta.Labels, testLabelKey)
+		assert.Equal(t, testLabelValue, deployment.Spec.Template.ObjectMeta.Labels[testLabelKey])
+
+		assert.NotContains(t, deployment.ObjectMeta.Labels, testLabelKey)
+	})
+}
+
+func TestAnnotations(t *testing.T) {
+	testAnnotationKey := "test-annotation-key"
+	testAnnotationValue := "test-annotation-value"
+
+	t.Run("Check empty annotations", func(t *testing.T) {
+		ec := &edgeconnect.EdgeConnect{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: edgeconnect.EdgeConnectSpec{},
+		}
+
+		deployment := New(ec)
+
+		assert.Nil(t, deployment.Spec.Template.ObjectMeta.Annotations)
+	})
+
+	t.Run("Check custom annotations set correctly", func(t *testing.T) {
+		ec := &edgeconnect.EdgeConnect{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: edgeconnect.EdgeConnectSpec{
+				Annotations: map[string]string{
+					testAnnotationKey: testAnnotationValue,
+				},
+			},
+		}
+
+		deployment := New(ec)
+
+		assert.Len(t, deployment.Spec.Template.Annotations, 1)
+		assert.Contains(t, deployment.Spec.Template.ObjectMeta.Annotations, testAnnotationKey)
+		assert.Equal(t, testAnnotationValue, deployment.Spec.Template.ObjectMeta.Annotations[testAnnotationKey])
+
+		assert.NotContains(t, deployment.ObjectMeta.Annotations, testAnnotationKey)
+	})
+}
+
 func Test_prepareResourceRequirements(t *testing.T) {
 	ec := &edgeconnect.EdgeConnect{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/edgeconnect/deployment/deployment_test.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment_test.go
@@ -69,6 +69,9 @@ func Test_buildAppLabels(t *testing.T) {
 }
 
 func TestLabels(t *testing.T) {
+	testObjectMetaLabelKey := "test-om-label-key"
+	testObjectMetaValue := "test-om-label-value"
+
 	testLabelKey := "test-label-key"
 	testLabelValue := "test-label-value"
 
@@ -77,6 +80,9 @@ func TestLabels(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
+				Labels: map[string]string{
+					testObjectMetaLabelKey: testObjectMetaValue,
+				},
 			},
 			Spec: edgeconnect.EdgeConnectSpec{},
 		}
@@ -89,6 +95,13 @@ func TestLabels(t *testing.T) {
 		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppManagedByLabel)
 		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppVersionLabel)
 		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppComponentLabel)
+
+		require.Len(t, deployment.ObjectMeta.Labels, 5)
+		assert.Contains(t, deployment.ObjectMeta.Labels, labels.AppNameLabel)
+		assert.Contains(t, deployment.ObjectMeta.Labels, labels.AppCreatedByLabel)
+		assert.Contains(t, deployment.ObjectMeta.Labels, labels.AppManagedByLabel)
+		assert.Contains(t, deployment.ObjectMeta.Labels, labels.AppVersionLabel)
+		assert.Contains(t, deployment.ObjectMeta.Labels, labels.AppComponentLabel)
 	})
 
 	t.Run("Check custom label set correctly", func(t *testing.T) {
@@ -96,6 +109,9 @@ func TestLabels(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
+				Labels: map[string]string{
+					testObjectMetaLabelKey: testObjectMetaValue,
+				},
 			},
 			Spec: edgeconnect.EdgeConnectSpec{
 				Labels: map[string]string{
@@ -116,11 +132,19 @@ func TestLabels(t *testing.T) {
 		assert.Contains(t, deployment.Spec.Template.ObjectMeta.Labels, testLabelKey)
 		assert.Equal(t, testLabelValue, deployment.Spec.Template.ObjectMeta.Labels[testLabelKey])
 
-		assert.NotContains(t, deployment.ObjectMeta.Labels, testLabelKey)
+		require.Len(t, deployment.ObjectMeta.Labels, 5)
+		assert.Contains(t, deployment.ObjectMeta.Labels, labels.AppNameLabel)
+		assert.Contains(t, deployment.ObjectMeta.Labels, labels.AppCreatedByLabel)
+		assert.Contains(t, deployment.ObjectMeta.Labels, labels.AppManagedByLabel)
+		assert.Contains(t, deployment.ObjectMeta.Labels, labels.AppVersionLabel)
+		assert.Contains(t, deployment.ObjectMeta.Labels, labels.AppComponentLabel)
 	})
 }
 
 func TestAnnotations(t *testing.T) {
+	testObjectMetaAnnotationKey := "test-om-annotation-key"
+	testObjectMetaAnnotationValue := "test-om-annotation-value"
+
 	testAnnotationKey := "test-annotation-key"
 	testAnnotationValue := "test-annotation-value"
 
@@ -129,6 +153,9 @@ func TestAnnotations(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
+				Annotations: map[string]string{
+					testObjectMetaAnnotationKey: testObjectMetaAnnotationValue,
+				},
 			},
 			Spec: edgeconnect.EdgeConnectSpec{},
 		}
@@ -136,6 +163,8 @@ func TestAnnotations(t *testing.T) {
 		deployment := New(ec)
 
 		assert.Nil(t, deployment.Spec.Template.ObjectMeta.Annotations)
+
+		assert.NotContains(t, deployment.ObjectMeta.Annotations, testObjectMetaAnnotationKey)
 	})
 
 	t.Run("Check custom annotations set correctly", func(t *testing.T) {
@@ -143,6 +172,9 @@ func TestAnnotations(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testName,
 				Namespace: testNamespace,
+				Annotations: map[string]string{
+					testObjectMetaAnnotationKey: testObjectMetaAnnotationValue,
+				},
 			},
 			Spec: edgeconnect.EdgeConnectSpec{
 				Annotations: map[string]string{
@@ -158,6 +190,7 @@ func TestAnnotations(t *testing.T) {
 		assert.Equal(t, testAnnotationValue, deployment.Spec.Template.ObjectMeta.Annotations[testAnnotationKey])
 
 		assert.NotContains(t, deployment.ObjectMeta.Annotations, testAnnotationKey)
+		assert.NotContains(t, deployment.ObjectMeta.Annotations, testObjectMetaAnnotationKey)
 	})
 }
 

--- a/pkg/controllers/edgeconnect/deployment/deployment_test.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/resources"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -81,7 +83,12 @@ func TestLabels(t *testing.T) {
 
 		deployment := New(ec)
 
-		assert.Len(t, deployment.Spec.Template.Labels, 5)
+		require.Len(t, deployment.Spec.Template.Labels, 5)
+		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppNameLabel)
+		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppCreatedByLabel)
+		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppManagedByLabel)
+		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppVersionLabel)
+		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppComponentLabel)
 	})
 
 	t.Run("Check custom label set correctly", func(t *testing.T) {
@@ -100,6 +107,12 @@ func TestLabels(t *testing.T) {
 		deployment := New(ec)
 
 		assert.Len(t, deployment.Spec.Template.Labels, 6)
+		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppNameLabel)
+		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppCreatedByLabel)
+		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppManagedByLabel)
+		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppVersionLabel)
+		assert.Contains(t, deployment.Spec.Template.Labels, labels.AppComponentLabel)
+
 		assert.Contains(t, deployment.Spec.Template.ObjectMeta.Labels, testLabelKey)
 		assert.Equal(t, testLabelValue, deployment.Spec.Template.ObjectMeta.Labels[testLabelKey])
 


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-3032)

## Description

`edgeconnect.Spec.Labels` and `edgeconnect.Spec.Annotations` are applied to `ObjectMeta` of the EC POD being created.

`deployment.ObjectMeta.Labels`, `deployment.Spec.Selector` values are calculated in the same way as in case of EEC/OTELC [statefulset](https://github.com/Dynatrace/dynatrace-operator/blob/main/pkg/controllers/dynakube/extension/eec/statefulset.go#L90).

## How can this be tested?
1) unittests
```
make go/test
```
2) deploy EdgeConnect with custom labels, annotations