### PR TITLE
Add automountServiceAccountToken: true to fullstack OA serviceAccount

### DIFF
--- a/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent.yaml
@@ -23,5 +23,5 @@ metadata:
   {{- end }}
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
-automountServiceAccountToken: false
+automountServiceAccountToken: {{.Values.rbac.logMonitoring.create}}
 {{ end }}

--- a/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent_test.yaml
+++ b/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent_test.yaml
@@ -2,7 +2,7 @@ suite: test serviceaccount for oneagent
 templates:
   - Common/oneagent/serviceaccount-oneagent.yaml
 tests:
-  - it: should exist
+  - it: should exist on kubernetes
     set:
       platform: kubernetes
     asserts:
@@ -16,8 +16,7 @@ tests:
           value: NAMESPACE
       - isNull:
           path: imagePullSecrets
-
-  - it: should exist
+  - it: should exist on openshift
     set:
       platform: openshift
     asserts:
@@ -26,9 +25,9 @@ tests:
       - equal:
           path: metadata.name
           value: dynatrace-dynakube-oneagent
-
-  - it: should exist
+  - it: should add user annotations
     set:
+      rbac.oneAgent.create: true
       rbac.oneAgent.annotations:
         test: test
     asserts:
@@ -44,3 +43,23 @@ tests:
     asserts:
       - hasDocuments:
         count: 0
+  - it: should have automountServiceAccountToken set to TRUE, incase of log-monitoring is available
+    set:
+      rbac.oneAgent.create: true
+      rbac.logMonitoring.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+  - it: should have automountServiceAccountToken set to FALSE, incase of log-monitoring is NOT available
+    set:
+      rbac.oneAgent.create: true
+      rbac.logMonitoring.create: false
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: automountServiceAccountToken
+          value: false


### PR DESCRIPTION

## Description

Ticket: TBD

Incase the LogMonitoring feature is enabled within the fullstack OneAgent, then the fullstack OneAgent DaemonSet will need the kubernetes API-token (like the standalone LogMonitoring DaemonSet).
- So we enable the `automountServiceAccountToken` setting on the fullstack's ServiceAccount, if logMonitoring can be configured

## How can this be tested?
Play around with the `rbac.logMonitoring.create` value in helm

`rbac.logMonitoring.create: true` ==> `automountServiceAccountToken: true`
`rbac.logMonitoring.create: false` ==> `automountServiceAccountToken: false`