### PR TITLE
Add automountServiceAccountToken: true to fullstack OA serviceAccount

### DIFF
--- a/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/serviceaccount-oneagent.yaml
@@ -23,5 +23,5 @@ metadata:
   {{- end }}
   labels:
     {{- include "dynatrace-operator.oneagentLabels" . | nindent 4 }}
-automountServiceAccountToken: false
+automountServiceAccountToken: {{.Values.rbac.logMonitoring.create}}
 {{ end }}

--- a/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent_test.yaml
+++ b/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent_test.yaml
@@ -2,7 +2,7 @@ suite: test serviceaccount for oneagent
 templates:
   - Common/oneagent/serviceaccount-oneagent.yaml
 tests:
-  - it: should exist
+  - it: should exist on kubernetes
     set:
       platform: kubernetes
     asserts:
@@ -16,8 +16,7 @@ tests:
           value: NAMESPACE
       - isNull:
           path: imagePullSecrets
-
-  - it: should exist
+  - it: should exist on openshift
     set:
       platform: openshift
     asserts:
@@ -26,9 +25,9 @@ tests:
       - equal:
           path: metadata.name
           value: dynatrace-dynakube-oneagent
-
-  - it: should exist
+  - it: should add user annotations
     set:
+      rbac.oneAgent.create: true
       rbac.oneAgent.annotations:
         test: test
     asserts:
@@ -44,3 +43,23 @@ tests:
     asserts:
       - hasDocuments:
         count: 0
+  - it: should have automountServiceAccountToken set to TRUE, incase of log-monitoring is available
+    set:
+      rbac.oneAgent.create: true
+      rbac.logMonitoring.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+  - it: should have automountServiceAccountToken set to FALSE, incase of log-monitoring is NOT available
+    set:
+      rbac.oneAgent.create: true
+      rbac.logMonitoring.create: false
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: automountServiceAccountToken
+          value: false


### PR DESCRIPTION

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
[DAQ-3166](https://dt-rnd.atlassian.net/browse/DAQ-3166)

cherry pick of #4175

## How can this be tested?

same as #4175

[DAQ-3166]: https://dt-rnd.atlassian.net/browse/DAQ-3166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ