### PR TITLE
Always lowercase workload kind in enrichment file

### DIFF
--- a/pkg/webhook/mutation/pod/metadata/mutator.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator.go
@@ -2,8 +2,6 @@ package metadata
 
 import (
 	"context"
-	"strings"
-
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/ingestendpoint"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
@@ -127,9 +125,7 @@ func setWorkloadAnnotations(pod *corev1.Pod, workload *workloadInfo) {
 		pod.Annotations = make(map[string]string)
 	}
 
-	// workload kind annotation in lower case according to dt semantic-dictionary
-	// https://bitbucket.lab.dynatrace.org/projects/DEUS/repos/semantic-dictionary/browse/source/fields/k8s.yaml
-	pod.Annotations[dtwebhook.AnnotationWorkloadKind] = strings.ToLower(workload.kind)
+	pod.Annotations[dtwebhook.AnnotationWorkloadKind] = workload.kind
 	pod.Annotations[dtwebhook.AnnotationWorkloadName] = workload.name
 }
 

--- a/pkg/webhook/mutation/pod/metadata/mutator.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/ingestendpoint"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"

--- a/pkg/webhook/mutation/pod/metadata/mutator_test.go
+++ b/pkg/webhook/mutation/pod/metadata/mutator_test.go
@@ -223,7 +223,12 @@ func TestWorkloadAnnotations(t *testing.T) {
 	})
 	t.Run("should lower case kind annotation", func(t *testing.T) {
 		request := createTestMutationRequest(nil, nil, false)
-		setWorkloadAnnotations(request.Pod, &workloadInfo{name: testWorkloadInfoName, kind: "SuperWorkload"})
+		objectMeta := &metav1.PartialObjectMetadata{
+			ObjectMeta: metav1.ObjectMeta{Name: testWorkloadInfoName},
+			TypeMeta:   metav1.TypeMeta{Kind: "SuperWorkload"},
+		}
+
+		setWorkloadAnnotations(request.Pod, newWorkloadInfo(objectMeta))
 		assert.Contains(t, request.Pod.Annotations, dtwebhook.AnnotationWorkloadKind)
 		assert.Equal(t, "superworkload", request.Pod.Annotations[dtwebhook.AnnotationWorkloadKind])
 	})

--- a/pkg/webhook/mutation/pod/metadata/workload.go
+++ b/pkg/webhook/mutation/pod/metadata/workload.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"strings"
 
 	kubeobjects "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/pod"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
@@ -19,7 +20,10 @@ type workloadInfo struct {
 func newWorkloadInfo(partialObjectMetadata *metav1.PartialObjectMetadata) *workloadInfo {
 	return &workloadInfo{
 		name: partialObjectMetadata.ObjectMeta.Name,
-		kind: partialObjectMetadata.Kind,
+
+		// workload kind in lower case according to dt semantic-dictionary
+		// https://docs.dynatrace.com/docs/discover-dynatrace/references/semantic-dictionary/fields#kubernetes
+		kind: strings.ToLower(partialObjectMetadata.Kind),
 	}
 }
 

--- a/pkg/webhook/mutation/pod/metadata/workload_test.go
+++ b/pkg/webhook/mutation/pod/metadata/workload_test.go
@@ -74,7 +74,7 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 		workloadInfo, err := findRootOwnerOfPod(ctx, client, &pod, namespaceName)
 		require.NoError(t, err)
 		assert.Equal(t, resourceName, workloadInfo.name)
-		assert.Equal(t, "DaemonSet", workloadInfo.kind)
+		assert.Equal(t, "daemonset", workloadInfo.kind)
 	})
 
 	t.Run("should return Pod if owner references are empty", func(t *testing.T) {
@@ -91,7 +91,7 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 		workloadInfo, err := findRootOwnerOfPod(ctx, client, &pod, namespaceName)
 		require.NoError(t, err)
 		assert.Equal(t, resourceName, workloadInfo.name)
-		assert.Equal(t, "Pod", workloadInfo.kind)
+		assert.Equal(t, "pod", workloadInfo.kind)
 	})
 
 	t.Run("should be pod if owner is not well known", func(t *testing.T) {
@@ -121,7 +121,7 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 		workloadInfo, err := findRootOwnerOfPod(ctx, client, &pod, namespaceName)
 		require.NoError(t, err)
 		assert.Equal(t, resourceName, workloadInfo.name)
-		assert.Equal(t, "Pod", workloadInfo.kind)
+		assert.Equal(t, "pod", workloadInfo.kind)
 	})
 
 	t.Run("should be pod if no controller is the owner", func(t *testing.T) {
@@ -146,7 +146,7 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 		workloadInfo, err := findRootOwnerOfPod(ctx, client, &pod, namespaceName)
 		require.NoError(t, err)
 		assert.Equal(t, namespaceName, workloadInfo.name)
-		assert.Equal(t, "Pod", workloadInfo.kind)
+		assert.Equal(t, "pod", workloadInfo.kind)
 	})
 	t.Run("should find the root owner of the pod if the root owner is unknown", func(t *testing.T) {
 		pod := corev1.Pod{
@@ -204,7 +204,7 @@ func TestFindRootOwnerOfPod(t *testing.T) {
 		workloadInfo, err := findRootOwnerOfPod(ctx, client, &pod, namespaceName)
 		require.NoError(t, err)
 		assert.Equal(t, resourceName, workloadInfo.name)
-		assert.Equal(t, "Deployment", workloadInfo.kind)
+		assert.Equal(t, "deployment", workloadInfo.kind)
 	})
 	t.Run("should not make an api-call if workload is not well known", func(t *testing.T) {
 		pod := corev1.Pod{


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

Jira: [DAQ-3254](https://dt-rnd.atlassian.net/browse/DAQ-3254)

[Dynatrace semantic dictionary](https://docs.dynatrace.com/docs/discover-dynatrace/references/semantic-dictionary/fields#kubernetes) has requirements on how values should be set. `k8s.workload.kind` must always be lowercase, which we only did for the annotation and not the enrichment file.

## How can this be tested?

- Inject a pod with metadata enrichment
- Check `DT_WORKLOAD_KIND` environment variable and value of `k8s.workload.kind` in `/var/lib/dynatrace/enrichment/dt_metadata.json/properties` (value should be ALL lowercase)

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[DAQ-3254]: https://dt-rnd.atlassian.net/browse/DAQ-3254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ