### PR TITLE
cherry-pick: Change logMonitoring error handling in case of no kubernetesClusterMEID (#4174)

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
@@ -37,8 +37,12 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		return nil
 	}
 
-	if !r.dk.LogMonitoring().IsEnabled() {
+	if !r.dk.LogMonitoring().IsEnabled() || r.dk.Status.KubernetesClusterMEID == "" {
 		meta.RemoveStatusCondition(r.dk.Conditions(), conditionType)
+
+		if r.dk.Status.KubernetesClusterMEID == "" {
+			return errors.New("the status of the DynaKube is missing information about the kubernetes monitored-entity, skipping LogMonitoring deployment")
+		}
 
 		return nil
 	}
@@ -79,7 +83,7 @@ func (r *reconciler) checkLogMonitoringSettings(ctx context.Context) error {
 	if err != nil {
 		setLogMonitoringSettingError(r.dk.Conditions(), conditionType, err.Error())
 
-		return errors.WithMessage(err, "error when creating log monitoring setting")
+		return err
 	}
 
 	log.Info("logmonitoring setting created", "settings", objectId)


### PR DESCRIPTION


<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

same as in https://github.com/Dynatrace/dynatrace-operator/pull/4174

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

same as in https://github.com/Dynatrace/dynatrace-operator/pull/4174

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->