### PR TITLE
Fix e2e test by splitting up extensive if condition

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
@@ -40,11 +40,9 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 	if !r.dk.LogMonitoring().IsEnabled() {
 		meta.RemoveStatusCondition(r.dk.Conditions(), conditionType)
 
-		if r.dk.Status.KubernetesClusterMEID == "" {
-			return errors.New("the status of the DynaKube is missing information about the kubernetes monitored-entity, skipping LogMonitoring deployment")
-		}
-
 		return nil
+	} else if r.dk.Status.KubernetesClusterMEID == "" {
+		return errors.New("the status of the DynaKube is missing information about the kubernetes monitored-entity, skipping LogMonitoring deployment")
 	}
 
 	err := r.checkLogMonitoringSettings(ctx)

--- a/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
@@ -37,7 +37,7 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		return nil
 	}
 
-	if !r.dk.LogMonitoring().IsEnabled() || r.dk.Status.KubernetesClusterMEID == "" {
+	if !r.dk.LogMonitoring().IsEnabled() {
 		meta.RemoveStatusCondition(r.dk.Conditions(), conditionType)
 
 		if r.dk.Status.KubernetesClusterMEID == "" {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-3366](https://dt-rnd.atlassian.net/browse/DAQ-3366)

e2e test failed because of the logical OR check in the if condition where we check if logmon is enabled. I removed it but kept the MEID check inside the if condition.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Run the e2e tests

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[DAQ-3366]: https://dt-rnd.atlassian.net/browse/DAQ-3366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ