### PR TITLE
Remove command descriptions in case the whole application is failing

### DIFF
--- a/cmd/csi/init/cmd.go
+++ b/cmd/csi/init/cmd.go
@@ -25,8 +25,9 @@ var nodeId, endpoint string
 
 func New() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  use,
-		RunE: run(),
+		Use:          use,
+		RunE:         run(),
+		SilenceUsage: true,
 	}
 
 	return cmd

--- a/cmd/csi/provisioner/cmd.go
+++ b/cmd/csi/provisioner/cmd.go
@@ -35,8 +35,9 @@ var probeAddress string
 
 func New() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  use,
-		RunE: run(),
+		Use:          use,
+		RunE:         run(),
+		SilenceUsage: true,
 	}
 
 	addFlags(cmd)

--- a/cmd/csi/server/cmd.go
+++ b/cmd/csi/server/cmd.go
@@ -31,8 +31,9 @@ var nodeId, endpoint string
 
 func New() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  use,
-		RunE: run(),
+		Use:          use,
+		RunE:         run(),
+		SilenceUsage: true,
 	}
 
 	addFlags(cmd)

--- a/cmd/operator/builder.go
+++ b/cmd/operator/builder.go
@@ -104,8 +104,9 @@ func (builder *CommandBuilder) getSignalHandler() context.Context {
 
 func (builder CommandBuilder) Build() *cobra.Command {
 	return &cobra.Command{
-		Use:  use,
-		RunE: builder.buildRun(),
+		Use:          use,
+		RunE:         builder.buildRun(),
+		SilenceUsage: true,
 	}
 }
 

--- a/cmd/standalone/standalone.go
+++ b/cmd/standalone/standalone.go
@@ -14,8 +14,9 @@ const (
 
 func NewStandaloneCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:  use,
-		RunE: startStandAloneInit,
+		Use:          use,
+		RunE:         startStandAloneInit,
+		SilenceUsage: true,
 	}
 }
 

--- a/cmd/webhook/builder.go
+++ b/cmd/webhook/builder.go
@@ -84,8 +84,9 @@ func (builder CommandBuilder) SetPodName(podName string) CommandBuilder {
 
 func (builder CommandBuilder) Build() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  use,
-		RunE: builder.buildRun(),
+		Use:          use,
+		RunE:         builder.buildRun(),
+		SilenceUsage: true,
 	}
 
 	addFlags(cmd)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Most of the operator subcommands are invoked by hardcoded pod commands. When these commands fail, a usage description is printed. This is unnecessary and causes confusion in the logs, so the print statements should be removed for subcommands that are not directly called by the user.

Example of confusing log: 
```
{"level":"info","ts":"2024-10-09T13:16:50.592Z","logger":"injection-startup","msg":"CONTAINER_INFO environment variable is missing"}
Usage:
  dynatrace-operator init [flags]

Flags:
  -h, --help   help for init
  ```

[Jira](https://dt-rnd.atlassian.net/browse/DAQ-2912)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Make the init container fail with an error, it should only log the error.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->