### PR TITLE
Ensure that `kubernetes_monitoring` is activated in ActiveGate when extensions are used

### DIFF
--- a/pkg/api/validation/dynakube/eec_test.go
+++ b/pkg/api/validation/dynakube/eec_test.go
@@ -20,7 +20,12 @@ func TestExtensionExecutionControllerImage(t *testing.T) {
 			&dynakube.DynaKube{
 				ObjectMeta: defaultDynakubeObjectMeta,
 				Spec: dynakube.DynaKubeSpec{
-					APIURL:     testApiUrl,
+					APIURL: testApiUrl,
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
 					Extensions: &dynakube.ExtensionsSpec{},
 					Templates: dynakube.TemplatesSpec{
 						ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
@@ -42,6 +47,11 @@ func TestExtensionExecutionControllerImage(t *testing.T) {
 				Spec: dynakube.DynaKubeSpec{
 					APIURL:     testApiUrl,
 					Extensions: &dynakube.ExtensionsSpec{},
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
 					Templates: dynakube.TemplatesSpec{
 						ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
 							ImageRef: image.Ref{
@@ -61,6 +71,11 @@ func TestExtensionExecutionControllerImage(t *testing.T) {
 				Spec: dynakube.DynaKubeSpec{
 					APIURL:     testApiUrl,
 					Extensions: &dynakube.ExtensionsSpec{},
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
 					Templates: dynakube.TemplatesSpec{
 						ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
 							ImageRef: image.Ref{
@@ -80,6 +95,11 @@ func TestExtensionExecutionControllerImage(t *testing.T) {
 				Spec: dynakube.DynaKubeSpec{
 					APIURL:     testApiUrl,
 					Extensions: &dynakube.ExtensionsSpec{},
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
 				},
 			})
 	})
@@ -93,6 +113,11 @@ func TestExtensionExecutionControllerPVCSettings(t *testing.T) {
 				Spec: dynakube.DynaKubeSpec{
 					APIURL:     testApiUrl,
 					Extensions: &dynakube.ExtensionsSpec{},
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
 					Templates: dynakube.TemplatesSpec{
 						ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
 							ImageRef: image.Ref{
@@ -113,6 +138,11 @@ func TestExtensionExecutionControllerPVCSettings(t *testing.T) {
 				Spec: dynakube.DynaKubeSpec{
 					APIURL:     testApiUrl,
 					Extensions: &dynakube.ExtensionsSpec{},
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
 					Templates: dynakube.TemplatesSpec{
 						ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
 							ImageRef: image.Ref{
@@ -133,6 +163,11 @@ func TestExtensionExecutionControllerPVCSettings(t *testing.T) {
 				Spec: dynakube.DynaKubeSpec{
 					APIURL:     testApiUrl,
 					Extensions: &dynakube.ExtensionsSpec{},
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
 					Templates: dynakube.TemplatesSpec{
 						ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
 							ImageRef: image.Ref{
@@ -155,6 +190,9 @@ func TestWarnIfmultiplyDKwithExtensionsEnabled(t *testing.T) {
 	}
 	// we want to exclude AG resources warning.
 	agSpec := activegate.Spec{
+		Capabilities: []activegate.CapabilityDisplayName{
+			activegate.KubeMonCapability.DisplayName,
+		},
 		CapabilityProperties: activegate.CapabilityProperties{
 			Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{

--- a/pkg/api/validation/dynakube/extensions.go
+++ b/pkg/api/validation/dynakube/extensions.go
@@ -1,0 +1,19 @@
+package validation
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+)
+
+const (
+	errorExtensionsWithoutK8SMonitoring = "The Dynakube's specification enables extensions without an ActiveGate which has Kubernetes monitoring enabled. This is not feasible, as the cluster will not be visible in Dynatrace without the Kubernetes monitoring feature."
+)
+
+func extensionsWithoutK8SMonitoring(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	if dk.IsExtensionsEnabled() && !dk.ActiveGate().IsKubernetesMonitoringEnabled() {
+		return errorExtensionsWithoutK8SMonitoring
+	}
+
+	return ""
+}

--- a/pkg/api/validation/dynakube/extensions_test.go
+++ b/pkg/api/validation/dynakube/extensions_test.go
@@ -1,0 +1,53 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/activegate"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const testDynakubeName = "dynakube"
+
+func TestExtensionsWithoutK8SMonitoring(t *testing.T) {
+	t.Run("no error if extensions are enabled with activegate with k8s-monitoring", func(t *testing.T) {
+		dk := createStandaloneExtensionsDynakube(testDynakubeName, testApiUrl)
+		dk.Spec.ActiveGate = activegate.Spec{
+			Capabilities: []activegate.CapabilityDisplayName{
+				activegate.KubeMonCapability.DisplayName,
+			},
+		}
+
+		assertAllowed(t, dk)
+	})
+	t.Run("error if extensions are enabled without activegate with k8s-monitoring", func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorExtensionsWithoutK8SMonitoring},
+			createStandaloneExtensionsDynakube(testDynakubeName, testApiUrl))
+	})
+}
+
+func createStandaloneExtensionsDynakube(name, apiUrl string) *dynakube.DynaKube {
+	dk := &dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: dynakube.DynaKubeSpec{
+			APIURL:     apiUrl,
+			Extensions: &dynakube.ExtensionsSpec{},
+			Templates: dynakube.TemplatesSpec{
+				ExtensionExecutionController: dynakube.ExtensionExecutionControllerSpec{
+					ImageRef: image.Ref{
+						Repository: "repo/image",
+						Tag:        "version",
+					},
+				},
+			},
+		},
+	}
+
+	return dk
+}

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -53,6 +53,7 @@ var (
 		missingKSPMDependency,
 		missingKSPMImage,
 		missingLogMonitoringImage,
+		extensionsWithoutK8SMonitoring,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,


### PR DESCRIPTION
## Description

The ActiveGate capability `kubernetes_monitoring` is mandatory for using extensions. We don't want to do any auto-enabling magic behind the scenes, though. 
But we need to make sure, that the DynaKube is configured properly. So this PR adds a validation webhook that ensure that `kubernetes_monitoring` is enabled.

## How can this be tested?

* Deploy a DynaKube with extensions but without `kubernetes_monitoring`
```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
...
spec:
  extensions: {}

  templates:
    extensionExecutionController:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-eec
        tag: 1.305.98.20250114-172617
```
This DynaKube should be rejected.

* Deploy a Dynakube with extensions and `kubernetes_monitoring`

```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
...
spec:
  activeGate:
    capabilities:
      - routing
      - dynatrace-api
      - metrics-ingest
      - kubernetes-monitoring

  extensions: {}

  templates:
    extensionExecutionController:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-eec
        tag: 1.305.98.20250114-172617
```

This DynaKube should be accepted.

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-4227)
