### PR TITLE
Make Log agent host path static

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
@@ -27,7 +27,7 @@ var (
 	}
 )
 
-func getContainer(dk dynakube.DynaKube) corev1.Container {
+func getContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container {
 	securityContext := getBaseSecurityContext(dk)
 	securityContext.Capabilities.Add = neededCapabilities
 
@@ -35,7 +35,7 @@ func getContainer(dk dynakube.DynaKube) corev1.Container {
 		Name:            containerName,
 		Image:           dk.LogMonitoring().Template().ImageRef.StringWithDefaults(defaultImageRepo, defaultImageTag),
 		ImagePullPolicy: corev1.PullAlways,
-		VolumeMounts:    getVolumeMounts(),
+		VolumeMounts:    getVolumeMounts(tenantUUID),
 		Env:             getEnvs(),
 		SecurityContext: &securityContext,
 	}
@@ -43,7 +43,7 @@ func getContainer(dk dynakube.DynaKube) corev1.Container {
 	return container
 }
 
-func getInitContainer(dk dynakube.DynaKube) corev1.Container {
+func getInitContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container {
 	securityContext := getBaseSecurityContext(dk)
 	securityContext.Capabilities.Add = neededInitCapabilities
 
@@ -51,7 +51,7 @@ func getInitContainer(dk dynakube.DynaKube) corev1.Container {
 		Name:            initContainerName,
 		Image:           dk.LogMonitoring().Template().ImageRef.StringWithDefaults(defaultImageRepo, defaultImageTag),
 		ImagePullPolicy: corev1.PullAlways,
-		VolumeMounts:    getDTVolumeMounts(),
+		VolumeMounts:    getDTVolumeMounts(tenantUUID),
 		Command:         []string{bootstrapCommand},
 		Env:             getInitEnvs(dk),
 		Args:            getInitArgs(dk),

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container_test.go
@@ -11,9 +11,11 @@ import (
 )
 
 func TestGetContainer(t *testing.T) {
+	tenantUUID := "test-uuid"
+
 	t.Run("get main container", func(t *testing.T) {
 		dk := dynakube.DynaKube{}
-		mainContainer := getContainer(dk)
+		mainContainer := getContainer(dk, tenantUUID)
 
 		require.NotEmpty(t, mainContainer)
 
@@ -37,7 +39,7 @@ func TestGetContainer(t *testing.T) {
 				Tag:        expectedTag,
 			},
 		}
-		mainContainer := getContainer(dk)
+		mainContainer := getContainer(dk, tenantUUID)
 
 		require.NotEmpty(t, mainContainer)
 		assert.NotEmpty(t, mainContainer.Image)
@@ -46,9 +48,11 @@ func TestGetContainer(t *testing.T) {
 }
 
 func TestGetInitContainer(t *testing.T) {
+	tenantUUID := "test-uuid"
+
 	t.Run("get main container", func(t *testing.T) {
 		dk := dynakube.DynaKube{}
-		initContainer := getInitContainer(dk)
+		initContainer := getInitContainer(dk, tenantUUID)
 
 		require.NotEmpty(t, initContainer)
 
@@ -75,7 +79,7 @@ func TestGetInitContainer(t *testing.T) {
 				Tag:        expectedTag,
 			},
 		}
-		initContainer := getContainer(dk)
+		initContainer := getContainer(dk, tenantUUID)
 
 		require.NotEmpty(t, initContainer)
 		assert.NotEmpty(t, initContainer.Image)
@@ -84,6 +88,8 @@ func TestGetInitContainer(t *testing.T) {
 }
 
 func TestSecurityContext(t *testing.T) {
+	tenantUUID := "test-uuid"
+
 	t.Run("get base securityContext", func(t *testing.T) {
 		dk := dynakube.DynaKube{}
 		sc := getBaseSecurityContext(dk)
@@ -118,8 +124,8 @@ func TestSecurityContext(t *testing.T) {
 
 	t.Run("main and init container securityContext differ only in capabilities", func(t *testing.T) {
 		dk := dynakube.DynaKube{}
-		initContainer := getInitContainer(dk)
-		mainContainer := getContainer(dk)
+		initContainer := getInitContainer(dk, tenantUUID)
+		mainContainer := getContainer(dk, tenantUUID)
 
 		require.NotNil(t, initContainer)
 		require.NotNil(t, mainContainer)

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
@@ -89,8 +89,8 @@ func (r *Reconciler) generateDaemonSet() (*appsv1.DaemonSet, error) {
 
 	maxUnavailable := intstr.FromInt(r.dk.FeatureOneAgentMaxUnavailable())
 
-	ds, err := daemonset.Build(r.dk, r.dk.LogMonitoring().GetDaemonSetName(), getContainer(*r.dk),
-		daemonset.SetInitContainer(getInitContainer(*r.dk)),
+	ds, err := daemonset.Build(r.dk, r.dk.LogMonitoring().GetDaemonSetName(), getContainer(*r.dk, tenantUUID),
+		daemonset.SetInitContainer(getInitContainer(*r.dk, tenantUUID)),
 		daemonset.SetAllLabels(labels.BuildLabels(), labels.BuildMatchLabels(), labels.BuildLabels(), r.dk.LogMonitoring().Template().Labels),
 		daemonset.SetAllAnnotations(nil, r.dk.LogMonitoring().Template().Annotations),
 		daemonset.SetServiceAccount(serviceAccountName),
@@ -104,7 +104,7 @@ func (r *Reconciler) generateDaemonSet() (*appsv1.DaemonSet, error) {
 				MaxUnavailable: &maxUnavailable,
 			},
 		}),
-		daemonset.SetVolumes(getVolumes(r.dk.Name, tenantUUID)),
+		daemonset.SetVolumes(getVolumes(r.dk.Name)),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
@@ -13,11 +13,12 @@ const (
 	configVolumeMountPath = "/var/lib/dynatrace/oneagent/agent/config/deployment.conf"
 
 	// for the logmonitoring to read/write
-	dtLibVolumeName         = "dynatrace-lib"
-	dtLibVolumeMountPath    = "/var/lib/dynatrace"
-	dtLibVolumePathTemplate = "/tmp/dynatrace-logmonitoring-%s"
-	dtLogVolumeName         = "dynatrace-logs"
-	dtLogVolumeMountPath    = "/var/log/dynatrace"
+	dtLibVolumeName      = "dynatrace-lib"
+	dtLibVolumeMountPath = "/var/lib/dynatrace"
+	dtSubPathTemplate    = "logmonitoring-%s"
+	dtLibVolumePath      = "/tmp/dynatrace"
+	dtLogVolumeName      = "dynatrace-logs"
+	dtLogVolumeMountPath = "/var/log/dynatrace"
 
 	// for the logs that the logmonitoring will ingest
 	podLogsVolumeName       = "var-log-pods"
@@ -50,10 +51,11 @@ func getConfigVolume(dkName string) corev1.Volume {
 }
 
 // getDTVolumeMounts provides the VolumeMounts for the dynatrace specific folders
-func getDTVolumeMounts() []corev1.VolumeMount {
+func getDTVolumeMounts(tenantUUID string) []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
 			Name:      dtLibVolumeName,
+			SubPath:   fmt.Sprintf(dtSubPathTemplate, tenantUUID),
 			MountPath: dtLibVolumeMountPath,
 		},
 		{
@@ -64,13 +66,13 @@ func getDTVolumeMounts() []corev1.VolumeMount {
 }
 
 // getDTVolumes provides the Volumes for the dynatrace specific folders
-func getDTVolumes(tenantUUID string) []corev1.Volume {
+func getDTVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{
 			Name: dtLibVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: fmt.Sprintf(dtLibVolumePathTemplate, tenantUUID),
+					Path: dtLibVolumePath,
 				},
 			},
 		},
@@ -132,19 +134,19 @@ func getIngestVolumes() []corev1.Volume {
 	}
 }
 
-func getVolumeMounts() []corev1.VolumeMount {
-	mounts := []corev1.VolumeMount{}
+func getVolumeMounts(tenantUUID string) []corev1.VolumeMount {
+	var mounts []corev1.VolumeMount
 	mounts = append(mounts, getConfigVolumeMount())
-	mounts = append(mounts, getDTVolumeMounts()...)
+	mounts = append(mounts, getDTVolumeMounts(tenantUUID)...)
 	mounts = append(mounts, getIngestVolumeMounts()...)
 
 	return mounts
 }
 
-func getVolumes(dkName, tenantUUID string) []corev1.Volume {
-	volumes := []corev1.Volume{}
+func getVolumes(dkName string) []corev1.Volume {
+	var volumes []corev1.Volume
 	volumes = append(volumes, getConfigVolume(dkName))
-	volumes = append(volumes, getDTVolumes(tenantUUID)...)
+	volumes = append(volumes, getDTVolumes()...)
 	volumes = append(volumes, getIngestVolumes()...)
 
 	return volumes

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/configsecret"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -73,6 +74,7 @@ func getDTVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: dtLibVolumePath,
+					Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 				},
 			},
 		},

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes_test.go
@@ -10,12 +10,12 @@ import (
 const (
 	expectedMountLen     = 6
 	expectedInitMountLen = 2
-	expectedVolumeLen    = 6
 )
 
 func TestGetVolumeMounts(t *testing.T) {
+	tenantUUID := "test-uuid"
 	t.Run("get volume mounts", func(t *testing.T) {
-		mounts := getVolumeMounts()
+		mounts := getVolumeMounts(tenantUUID)
 
 		require.NotEmpty(t, mounts)
 		assert.Len(t, mounts, expectedMountLen)
@@ -29,10 +29,9 @@ func TestGetVolumeMounts(t *testing.T) {
 
 func TestGetVolumes(t *testing.T) {
 	dkName := "test-dk"
-	tenantUUID := "test-uuid"
 
 	t.Run("get volumes", func(t *testing.T) {
-		volumes := getVolumes(dkName, tenantUUID)
+		volumes := getVolumes(dkName)
 
 		require.NotEmpty(t, volumes)
 		assert.Len(t, volumes, expectedMountLen)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR resolves [DAQ-4044](https://dt-rnd.atlassian.net/browse/DAQ-4044) by making log agent host path static and use dynamic subpath.
```
volumeMounts:
- name: dynatrace-lib
  subPath: logmonitoring-<tenant>
  mountPath: /var/lib/dynatrace

volumes:
- name: dynatrace-lib
  hostPath:
    path: /tmp/dynatrace
    type: ""
```

## How can this be tested?

unit-tests

how to test on GKE:

1. Create GKE autopilot cluster 
2. Apply custom `WorkloadAllowlist` (ask @andriisoldatenko  for sample which includes custom dev image patch)
```
matchingCriteria:
  containers:
    - name: main
      image: ^(docker.io\/dynatrace\/dynatrace-logmodule|gcr.io\/dynatrace-marketplace-prod\/dynatrace-logmodule|public.ecr.aws\/dynatrace\/dyn>
      image: ^(us-central1-docker.pkg.dev\/cloud-platform-207208\/chmu\/logmodule|docker.io\/dynatrace\/dynatrace-logmodule|gcr.io\/dynatrace-m>
      env:
        - name: KUBELET_API_NODENAME
        - name: KUBELET_API_ADDRESS
@ Users/andrii.soldatenko/work/samples/gke/dynatrace-logmonitoring-v1.4.0-dev.yaml:39 @ matchingCriteria:
          name: docker-container-logs
  initContainers:
    - name: init-volume
      image: ^(docker.io\/dynatrace\/dynatrace-logmodule|gcr.io\/dynatrace-marketplace-prod\/dynatrace-logmodule|public.ecr.aws\/dynatrace\/dyn>
      image: ^(us-central1-docker.pkg.dev\/cloud-platform-207208\/chmu\/logmodule|docker.io\/dynatrace\/dynatrace-logmodule|gcr.io\/dynatrace-m>
      args:
        - -p k8s.cluster.name=$(K8S_CLUSTER_NAME)
        - -p k8s.cluster.uid=$(K8S_CLUSTER_UID)
```

3. Then apply it to your cluster
4. deploy operator using this branch, but better to test together with https://github.com/Dynatrace/dynatrace-operator/pull/4324
so first cherry-pick #4324 on top of #4323 and build image 

or use my image:
```
TAG=log-agent-host-path-must-not-be-dynamic-and ENABLE_CSI=false make deploy
```
5. Deploy DK with logMonitoring:
```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://tenant.dev.dynatracelabs.com/api
  activeGate:
    capabilities:
      - kubernetes-monitoring
  logMonitoring: {}
  templates:
    logMonitoring:
      labels:
        cloud.google.com/matching-allowlist: dynatrace-logmonitoring-v1.4.0
      imageRef:
        repository: us-central1-docker.pkg.dev/cloud-platform-207208/chmu/logmodule
        tag: latest
```

6. Make sure all pods are running no errors in operator logs

[DAQ-4044]: https://dt-rnd.atlassian.net/browse/DAQ-4044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ