### PR TITLE
Log agent args must not contain dynamic strings

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -15,7 +15,7 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 		fmt.Sprintf("-c k8s_fullpodname $(%s)", podNameEnv),
 		fmt.Sprintf("-c k8s_poduid $(%s)", podUIDEnv),
 		fmt.Sprintf("-c k8s_containername %s", containerName), //nolint:perfsprint
-		fmt.Sprintf("-c k8s_basepodname %s", basePodNameEnv),  //nolint:perfsprint
+		fmt.Sprintf("-c k8s_basepodname $(%s)", basePodNameEnv),
 		fmt.Sprintf("-c k8s_namespace $(%s)", namespaceNameEnv),
 		fmt.Sprintf("-c k8s_node_name $(%s)", nodeNameEnv),
 		fmt.Sprintf("-c k8s_cluster_id $(%s)", clusterUIDEnv),

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -14,8 +14,8 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 		fmt.Sprintf("-p dt.entity.kubernetes_cluster=$(%s)", entityEnv),
 		fmt.Sprintf("-c k8s_fullpodname $(%s)", podNameEnv),
 		fmt.Sprintf("-c k8s_poduid $(%s)", podUIDEnv),
-		fmt.Sprintf("-c k8s_containername %s", containerName),                       //nolint:perfsprint
-		fmt.Sprintf("-c k8s_basepodname %s", dk.LogMonitoring().GetDaemonSetName()), //nolint:perfsprint
+		fmt.Sprintf("-c k8s_containername %s", containerName), //nolint:perfsprint
+		fmt.Sprintf("-c k8s_basepodname %s", basePodNameEnv),  //nolint:perfsprint
 		fmt.Sprintf("-c k8s_namespace $(%s)", namespaceNameEnv),
 		fmt.Sprintf("-c k8s_node_name $(%s)", nodeNameEnv),
 		fmt.Sprintf("-c k8s_cluster_id $(%s)", clusterUIDEnv),

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/env.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/env.go
@@ -14,6 +14,7 @@ const (
 	namespaceNameEnv = "K8S_NAMESPACE_NAME"
 	clusterUIDEnv    = "K8S_CLUSTER_UID"
 	clusterNameEnv   = "K8S_CLUSTER_NAME"
+	basePodNameEnv   = "K8S_BASEPODNAME"
 	entityEnv        = "DT_ENTITY_KUBERNETES_CLUSTER"
 
 	// main container envs
@@ -71,6 +72,10 @@ func getInitEnvs(dk dynakube.DynaKube) []corev1.EnvVar {
 		{
 			Name:  entityEnv,
 			Value: dk.Status.KubernetesClusterMEID,
+		},
+		{
+			Name:  basePodNameEnv,
+			Value: dk.LogMonitoring().GetDaemonSetName(),
 		},
 	}
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/env_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/env_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	expectedBaseInitEnvLen = 7
+	expectedBaseInitEnvLen = 8
 	expectedBaseEnvLen     = 4
 )
 


### PR DESCRIPTION
## Description

This PR makes use of the Log Agent argument value from env var to prevent dynamic strings.

resolves bug [DAQ-4261](https://dt-rnd.atlassian.net/browse/DAQ-4261)

## How can this be tested?

unit tests

detailed instruction of how to test using GKE can be found here https://github.com/Dynatrace/dynatrace-operator/pull/4323

[DAQ-4261]: https://dt-rnd.atlassian.net/browse/DAQ-4261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ