### PR TITLE
Make automatic K8S monitoring mandatory for extensions.

### DIFF
--- a/pkg/api/validation/dynakube/extensions.go
+++ b/pkg/api/validation/dynakube/extensions.go
@@ -11,7 +11,7 @@ const (
 )
 
 func extensionsWithoutK8SMonitoring(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
-	if dk.IsExtensionsEnabled() && !dk.ActiveGate().IsKubernetesMonitoringEnabled() {
+	if dk.IsExtensionsEnabled() && (!dk.ActiveGate().IsKubernetesMonitoringEnabled() || !dk.FeatureAutomaticKubernetesApiMonitoring()) {
 		return errorExtensionsWithoutK8SMonitoring
 	}
 

--- a/pkg/api/validation/dynakube/extensions_test.go
+++ b/pkg/api/validation/dynakube/extensions_test.go
@@ -19,13 +19,31 @@ func TestExtensionsWithoutK8SMonitoring(t *testing.T) {
 				activegate.KubeMonCapability.DisplayName,
 			},
 		}
-
 		assertAllowed(t, dk)
 	})
 	t.Run("error if extensions are enabled without activegate with k8s-monitoring", func(t *testing.T) {
 		assertDenied(t,
 			[]string{errorExtensionsWithoutK8SMonitoring},
 			createStandaloneExtensionsDynakube(testDynakubeName, testApiUrl))
+	})
+	t.Run("error if extensions are enabled with activegate with k8s-monitoring but automatic Kuberenetes API monitoring is disabled", func(t *testing.T) {
+		dk := createStandaloneExtensionsDynakube(testDynakubeName, testApiUrl)
+		dk.ObjectMeta.Annotations = map[string]string{
+			dynakube.AnnotationFeatureAutomaticK8sApiMonitoring: "false",
+		}
+		dk.Spec.ActiveGate = activegate.Spec{
+			Capabilities: []activegate.CapabilityDisplayName{
+				activegate.KubeMonCapability.DisplayName,
+			},
+		}
+		assertDenied(t, []string{errorExtensionsWithoutK8SMonitoring}, dk)
+	})
+	t.Run("error if extensions are enabled but automatic Kuberenetes API monitoring is disabled and without activgate k8s-monitoring", func(t *testing.T) {
+		dk := createStandaloneExtensionsDynakube(testDynakubeName, testApiUrl)
+		dk.ObjectMeta.Annotations = map[string]string{
+			dynakube.AnnotationFeatureAutomaticK8sApiMonitoring: "false",
+		}
+		assertDenied(t, []string{errorExtensionsWithoutK8SMonitoring}, dk)
 	})
 }
 


### PR DESCRIPTION
## Description

Make sure that `feature.dynatrace.com/automatic-kubernetes-api-monitoring` is not set to false when extensions are enabled.

## How can this be tested?

1) Deploy the following Dynakube:

```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/activegate-authtoken: "true"
    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "false"

spec:
  ...
  activeGate:
    capabilities:
      - routing
      - dynatrace-api
      - metrics-ingest
  ...
  extensions: {}

  templates:
    extensionExecutionController:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-eec
        tag: 1.305.98.20250114-172617
```

This Dynakube shall be rejected.

2) Deploy the following Dynakube:

```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/activegate-authtoken: "true"

spec:
  ...
  activeGate:
    capabilities:
      - routing
      - dynatrace-api
      - metrics-ingest
      - kubernetes-monitoring
  ...
  extensions: {}

  templates:
    extensionExecutionController:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-eec
        tag: 1.305.98.20250114-172617
```

This Dynakube shall be accepted.

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-4227)
