### PR TITLE
Ensure that automatic-kubernetes-api-monitoring is not disabled if KS…

### DIFF
--- a/pkg/api/validation/dynakube/kspm.go
+++ b/pkg/api/validation/dynakube/kspm.go
@@ -21,8 +21,7 @@ func tooManyAGReplicas(_ context.Context, _ *Validator, dk *dynakube.DynaKube) s
 }
 
 func missingKSPMDependency(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	if dk.KSPM().IsEnabled() &&
-		!dk.ActiveGate().IsKubernetesMonitoringEnabled() {
+	if dk.KSPM().IsEnabled() && (!dk.ActiveGate().IsKubernetesMonitoringEnabled() || !dk.FeatureAutomaticKubernetesApiMonitoring()) {
 		return errorKSPMMissingKubemon
 	}
 


### PR DESCRIPTION
## Description

KSPM relies on working Kubernetes monitoring. Ensure that `automatic-kubernetes-api-monitoring` is not disabled if KSPM is enabled.

## How can this be tested?

Deploy a DK with KSPM, AG capability `kubernetes-monitoring` and an annotation:
```
  annotations:
    automatic-kubernetes-api-monitoring: false
```

It should be rejected.

The same DK without the annotation should be accepted.

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-4344)