### PR TITLE
Ensure that automatic-kubernetes-api-monitoring is not disabled if KSPM is enabled

### DIFF
--- a/pkg/api/validation/dynakube/kspm.go
+++ b/pkg/api/validation/dynakube/kspm.go
@@ -21,8 +21,7 @@ func tooManyAGReplicas(_ context.Context, _ *Validator, dk *dynakube.DynaKube) s
 }
 
 func missingKSPMDependency(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	if dk.KSPM().IsEnabled() &&
-		!dk.ActiveGate().IsKubernetesMonitoringEnabled() {
+	if dk.KSPM().IsEnabled() && (!dk.ActiveGate().IsKubernetesMonitoringEnabled() || !dk.FeatureAutomaticKubernetesApiMonitoring()) {
 		return errorKSPMMissingKubemon
 	}
 


### PR DESCRIPTION
## Description

Cherry-pick: #4332

## How can this be tested?
See #4332 

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-4344)