### PR TITLE
Add flag and permissions to enable pod provisioning

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/role-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/role-csi.yaml
@@ -32,6 +32,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
     verbs:
       - get
       - list
@@ -39,11 +40,12 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
+      - jobs
     verbs:
       - get
       - list
-      - watch
+      - create
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/config/helm/chart/default/tests/Common/csi/role-csi_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/role-csi_test.yaml
@@ -47,6 +47,7 @@ tests:
                 - ""
               resources:
                 - secrets
+                - configmaps
               verbs:
                 - get
                 - list
@@ -54,11 +55,12 @@ tests:
             - apiGroups:
                 - ""
               resources:
-                - configmaps
+                - jobs
               verbs:
                 - get
                 - list
-                - watch
+                - create
+                - delete
             - apiGroups:
                 - ""
               resources:

--- a/doc/api/feature-flags.md
+++ b/doc/api/feature-flags.md
@@ -17,7 +17,8 @@ import "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/tmp"
 
 ```go
 const (
-    AnnotationFeaturePrefix = "feature.dynatrace.com/"
+    AnnotationFeaturePrefix            = "feature.dynatrace.com/"
+    AnnotationFeatureCodeModulesPrefix = "codemodules.oneagent.dynatrace.com/"
 
     // General.
     AnnotationFeaturePublicRegistry = AnnotationFeaturePrefix + "public-registry"
@@ -53,9 +54,10 @@ const (
     AnnotationFeatureEnforcementMode       = AnnotationFeaturePrefix + "enforcement-mode"
 
     // CSI.
-    AnnotationFeatureMaxFailedCsiMountAttempts = AnnotationFeaturePrefix + "max-csi-mount-attempts"
-    AnnotationFeatureMaxCsiMountTimeout        = AnnotationFeaturePrefix + "max-csi-mount-timeout"
-    AnnotationFeatureReadOnlyCsiVolume         = AnnotationFeaturePrefix + "injection-readonly-volume"
+    AnnotationFeatureMaxFailedCsiMountAttempts      = AnnotationFeaturePrefix + "max-csi-mount-attempts"
+    AnnotationFeatureMaxCsiMountTimeout             = AnnotationFeaturePrefix + "max-csi-mount-timeout"
+    AnnotationFeatureReadOnlyCsiVolume              = AnnotationFeaturePrefix + "injection-readonly-volume"
+    AnnotationFeatureCodeModulesRemoteImageDownload = AnnotationFeatureCodeModulesPrefix + "remoteImageDownload"
 )
 ```
 
@@ -72,7 +74,7 @@ const (
 
 <a name="MountAttemptsToTimeout"></a>
 
-## func [MountAttemptsToTimeout](<https://github.com/Dynatrace/dynatrace-operator/blob/main/pkg/api/v1beta3/dynakube/tmp/feature_flags.go#L259>)
+## func [MountAttemptsToTimeout](<https://github.com/Dynatrace/dynatrace-operator/blob/main/pkg/api/v1beta3/dynakube/tmp/feature_flags.go#L261>)
 
 ```go
 func MountAttemptsToTimeout(maxAttempts int) string

--- a/pkg/api/v1beta3/dynakube/feature_flags.go
+++ b/pkg/api/v1beta3/dynakube/feature_flags.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	AnnotationFeaturePrefix = "feature.dynatrace.com/"
+	AnnotationFeaturePrefix            = "feature.dynatrace.com/"
+	AnnotationFeatureCodeModulesPrefix = "codemodules.oneagent.dynatrace.com/"
 
 	// General.
 	AnnotationFeaturePublicRegistry = AnnotationFeaturePrefix + "public-registry"
@@ -69,9 +70,10 @@ const (
 	AnnotationFeatureEnforcementMode       = AnnotationFeaturePrefix + "enforcement-mode"
 
 	// CSI.
-	AnnotationFeatureMaxFailedCsiMountAttempts = AnnotationFeaturePrefix + "max-csi-mount-attempts"
-	AnnotationFeatureMaxCsiMountTimeout        = AnnotationFeaturePrefix + "max-csi-mount-timeout"
-	AnnotationFeatureReadOnlyCsiVolume         = AnnotationFeaturePrefix + "injection-readonly-volume"
+	AnnotationFeatureMaxFailedCsiMountAttempts      = AnnotationFeaturePrefix + "max-csi-mount-attempts"
+	AnnotationFeatureMaxCsiMountTimeout             = AnnotationFeaturePrefix + "max-csi-mount-timeout"
+	AnnotationFeatureReadOnlyCsiVolume              = AnnotationFeaturePrefix + "injection-readonly-volume"
+	AnnotationFeatureCodeModulesRemoteImageDownload = AnnotationFeatureCodeModulesPrefix + "remoteImageDownload"
 
 	falsePhrase  = "false"
 	truePhrase   = "true"
@@ -266,6 +268,10 @@ func MountAttemptsToTimeout(maxAttempts int) string {
 
 func (dk *DynaKube) FeatureReadOnlyCsiVolume() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureReadOnlyCsiVolume) == truePhrase
+}
+
+func (dk *DynaKube) FeatureRemoteImageDownload() bool {
+	return dk.getFeatureFlagRaw(AnnotationFeatureCodeModulesRemoteImageDownload) == truePhrase
 }
 
 func (dk *DynaKube) FeatureInjectionFailurePolicy() string {

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes_test.go
@@ -14,6 +14,7 @@ const (
 
 func TestGetVolumeMounts(t *testing.T) {
 	tenantUUID := "test-uuid"
+
 	t.Run("get volume mounts", func(t *testing.T) {
 		mounts := getVolumeMounts(tenantUUID)
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR adds `codemodules.oneagent.dynatrace.com/remoteImageDownload: true` as feature flag. 
In addition permissions for creating jobs are added to the CSI driver. 

These changes are the first step to enabled remote docker image downloads.

[Jira](https://dt-rnd.atlassian.net/browse/DAQ-3990)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Just look at the permissions and the feature flags code

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->