### PR TITLE
Reject dynakubes that use public image and not read only oneAgents

### DIFF
--- a/pkg/api/validation/dynakube/image_test.go
+++ b/pkg/api/validation/dynakube/image_test.go
@@ -49,7 +49,7 @@ func TestImageFieldHasTenantImage(t *testing.T) {
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testTenantUrl + "/api",
 				OneAgent: dynakube.OneAgentSpec{
-					ClassicFullStack: &dynakube.HostInjectSpec{
+					HostMonitoring: &dynakube.HostInjectSpec{
 						Image: testRegistryUrl + "/linux/oneagent:latest",
 					},
 				},
@@ -71,7 +71,7 @@ func TestImageFieldHasTenantImage(t *testing.T) {
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testTenantUrl + "/api",
 				OneAgent: dynakube.OneAgentSpec{
-					ClassicFullStack: &dynakube.HostInjectSpec{
+					HostMonitoring: &dynakube.HostInjectSpec{
 						Image: testRegistryUrl + "/linux/oneagent:latest",
 					},
 				},
@@ -87,7 +87,7 @@ func TestImageFieldHasTenantImage(t *testing.T) {
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testTenantUrl + "/api",
 				OneAgent: dynakube.OneAgentSpec{
-					ClassicFullStack: &dynakube.HostInjectSpec{
+					HostMonitoring: &dynakube.HostInjectSpec{
 						Image: "127.0.0.1:5000/test:tag",
 					},
 				},

--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -23,6 +23,8 @@ Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 
 	errorVolumeStorageReadOnlyModeConflict = `The DynaKube specification specifies a read-only host file system while OneAgent has volume storage enabled.`
 
+	errorPublicImageWithWrongConfig = `The DynaKube specification specifies a custom (and therefor probably a public) image in combination with a mode that needs write permissions for volume mounts.`
+
 	warningOneAgentInstallerEnvVars = `The environment variables ONEAGENT_INSTALLER_SCRIPT_URL and ONEAGENT_INSTALLER_TOKEN are only relevant for an unsupported image type. Please ensure you are using a supported image.`
 
 	warningHostGroupConflict = `The DynaKube specification sets the host group using the --set-host-group parameter. Instead, specify the new spec.oneagent.hostGroup field. If both settings are used, the new field takes precedence over the parameter.`
@@ -114,6 +116,14 @@ func mapKeysToString(m map[string]bool, sep string) string {
 	}
 
 	return strings.Join(keys, sep)
+}
+
+func publicImageSetWithoutReadOnlyMode(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
+	if !dk.UseReadOnlyOneAgents() && dk.CustomOneAgentImage() != "" {
+		return errorPublicImageWithWrongConfig
+	}
+
+	return ""
 }
 
 func imageFieldSetWithoutCSIFlag(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -490,3 +490,48 @@ func TestIsOneAgentVersionValid(t *testing.T) {
 		})
 	}
 }
+
+func TestPublicImageSetWithReadOnlyMode(t *testing.T) {
+	t.Run("reject dk with hostMon without csi and custom image", func(t *testing.T) {
+		setupDisabledCSIEnv(t)
+		assertDenied(t, []string{errorPublicImageWithWrongConfig},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{
+							Image: "test/image/test-image:some-tag",
+						},
+					},
+				},
+			})
+	})
+	t.Run("allow dk with hostMon without csi and no custom image", func(t *testing.T) {
+		setupDisabledCSIEnv(t)
+		assertAllowed(t,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{},
+					},
+				},
+			})
+	})
+	t.Run("allow dk with hostMon with csi and custom image", func(t *testing.T) {
+		assertAllowed(t, &dynakube.DynaKube{
+			ObjectMeta: defaultDynakubeObjectMeta,
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testApiUrl,
+				OneAgent: dynakube.OneAgentSpec{
+					HostMonitoring: &dynakube.HostInjectSpec{
+						Image: "test/image/test-image:some-tag",
+					},
+				},
+			},
+		})
+	})
+
+}

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -55,6 +55,7 @@ var (
 		missingLogMonitoringImage,
 		logMonitoringWithoutK8SMonitoring,
 		extensionsWithoutK8SMonitoring,
+		publicImageSetWithoutReadOnlyMode,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[Ticket](https://dt-rnd.atlassian.net/browse/DAQ-4337)

Previously when a dynakube was applied that had a mode that does not use read only oneagents (so everything that is not cloudNative or hostMon with csi) and a custom image (which we interpret as public images) then the oneAgent pods would run into a CrashLoopBackOff error.

In the pods you'd find this message:

```
❯ k logs daemonsets/cfg-oneagent
Found 3 pods, using pod/cfg-oneagent-2ghqj
[2025-01-22 13:41:58.584 UTC] [000a1650] [info   ] [bootstrapper] Started agent deployment as a container, PID 661072
[2025-01-22 13:41:58.586 UTC] [000a1650] [error  ] [bootstrapper] Volume storage should be mounted on /mnt/volume_storage_mount with write permissions
```

With this PR this configuration is now rejected in the first place.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Try those modes in combination with a custom image 

example:

`helm install dynatrace-operator -n dynatrace oci://public.ecr.aws/dynatrace/dynatrace-operator --version 1.4.0 -n dynatrace --set csidriver.enabled=false`

```
spec:
  oneAgent:
    hostMonitoring:
      image: public.ecr.aws/dynatrace/dynatrace-oneagent:1.305.98.20250114-172617
```

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->