### PR TITLE
Fix extensions E2E test

### DIFF
--- a/test/features/extensions/extensions.go
+++ b/test/features/extensions/extensions.go
@@ -34,6 +34,7 @@ func Feature(t *testing.T) features.Feature {
 		componentDynakube.WithCustomPullSecret(consts.DevRegistryPullSecretName),
 		componentDynakube.WithExtensionsEnabledSpec(true),
 		componentDynakube.WithExtensionsEECImageRefSpec(consts.EecImageRepo, consts.EecImageTag),
+		componentDynakube.WithActiveGate(),
 	}
 
 	testDynakube := *componentDynakube.New(options...)

--- a/test/features/extensions/extensions.go
+++ b/test/features/extensions/extensions.go
@@ -30,11 +30,11 @@ func Feature(t *testing.T) features.Feature {
 
 	options := []componentDynakube.Option{
 		componentDynakube.WithApiUrl(secretConfig.ApiUrl),
-		componentDynakube.WithActiveGateTLSSecret(consts.AgSecretName),
 		componentDynakube.WithCustomPullSecret(consts.DevRegistryPullSecretName),
 		componentDynakube.WithExtensionsEnabledSpec(true),
 		componentDynakube.WithExtensionsEECImageRefSpec(consts.EecImageRepo, consts.EecImageTag),
 		componentDynakube.WithActiveGate(),
+		componentDynakube.WithActiveGateTLSSecret(consts.AgSecretName),
 	}
 
 	testDynakube := *componentDynakube.New(options...)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR fixes extension e2e tests in release branch

## How can this be tested?

`make test/e2e/extensions`

```

=== RUN   TestStandard
    default.go:52: istio enabled: false
=== RUN   TestStandard/extensions-components-rollout
=== RUN   TestStandard/extensions-components-rollout/create_AG_TLS_secret
=== RUN   TestStandard/extensions-components-rollout/created_tenant_secret
=== RUN   TestStandard/extensions-components-rollout/'dynakube'_dynakube_created
I0124 17:16:10.816788    4551 warning_handler.go:65] "ActiveGate specification missing memory limits. Can cause excess memory usage." logger="KubeAPIWarningLogger"
=== RUN   TestStandard/extensions-components-rollout/'dynakube'_dynakube_phase_changes_to_'Running'
=== RUN   TestStandard/extensions-components-rollout/active_gate_pod_is_running
=== RUN   TestStandard/extensions-components-rollout/extensions_execution_controller_started
=== RUN   TestStandard/extensions-components-rollout/extension_collector_started
--- PASS: TestStandard (138.16s)
    --- PASS: TestStandard/extensions-components-rollout (127.69s)
        --- PASS: TestStandard/extensions-components-rollout/create_AG_TLS_secret (0.50s)
        --- PASS: TestStandard/extensions-components-rollout/created_tenant_secret (0.36s)
        --- PASS: TestStandard/extensions-components-rollout/'dynakube'_dynakube_created (0.38s)
        --- PASS: TestStandard/extensions-components-rollout/'dynakube'_dynakube_phase_changes_to_'Running' (110.17s)
        --- PASS: TestStandard/extensions-components-rollout/active_gate_pod_is_running (0.19s)
        --- PASS: TestStandard/extensions-components-rollout/extensions_execution_controller_started (5.20s)
        --- PASS: TestStandard/extensions-components-rollout/extension_collector_started (5.20s)
PASS



out: helm uninstall dynatrace-operator \
                        --namespace dynatrace
release "dynatrace-operator" uninstalled

ok      github.com/Dynatrace/dynatrace-operator/test/scenarios/standard 231.439s

```