### PR TITLE
Fix OneAgent command line arguments

### DIFF
--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
@@ -18,7 +18,9 @@ func (b *builder) arguments() ([]string, error) {
 	argMap := prioritymap.New(
 		prioritymap.WithSeparator(prioritymap.DefaultSeparator),
 		prioritymap.WithPriority(defaultArgumentPriority),
-		prioritymap.WithAllowDuplicates(),
+		prioritymap.WithAvoidDuplicates(),
+		prioritymap.WithAllowDuplicatesFor("--set-host-property"),
+		prioritymap.WithAllowDuplicatesFor("--set-host-tag"),
 	)
 
 	isProxyAsEnvDeprecated, err := isProxyAsEnvVarDeprecated(b.dk.OneAgentVersion())

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -87,16 +87,30 @@ func TestArguments(t *testing.T) {
 		}
 		assert.Equal(t, expectedDefaultArguments, arguments)
 	})
-	t.Run("when injected arguments are provided then they come last", func(t *testing.T) {
-		args := []string{
+	t.Run("when injected arguments are provided then they come last, only allowed duplicates and no duplicate key/value pairs", func(t *testing.T) {
+		custArgs := []string{
 			"--set-app-log-content-access=true",
-			"--set-host-id-source=lustiglustig",
+			"--set-host-id-source=fqdn",
 			"--set-host-group=APP_LUSTIG_PETER",
 			"--set-server=https://hyper.super.com:9999",
+			"--set-host-property=prop1",
+			"--set-host-property=prop1",
+			"--set-host-property=prop1",
+			"--set-host-property=prop2",
+			"--set-host-property=prop2",
+			"--set-host-property=prop3",
+			"--set-host-property=prop3",
+			"--set-host-property=prop3",
+			"--set-host-tag=tag1",
+			"--set-host-tag=tag2",
+			"--set-host-tag=tag2",
+			"--set-host-tag=tag2",
+			"--set-host-tag=tag3",
 		}
 		builder := builder{
-			dk:             &dynakube.DynaKube{},
-			hostInjectSpec: &dynakube.HostInjectSpec{Args: args},
+			dk:             &dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{OneAgent: dynakube.OneAgentSpec{ClassicFullStack: &dynakube.HostInjectSpec{}}}},
+			hostInjectSpec: &dynakube.HostInjectSpec{Args: custArgs},
+			deploymentType: deploymentmetadata.CloudNativeDeploymentType,
 		}
 
 		arguments, _ := builder.arguments()
@@ -104,11 +118,16 @@ func TestArguments(t *testing.T) {
 		expectedDefaultArguments := []string{
 			"--set-app-log-content-access=true",
 			"--set-host-group=APP_LUSTIG_PETER",
-			"--set-host-id-source=lustiglustig",
+			"--set-host-id-source=fqdn",
 			"--set-host-property=OperatorVersion=$(DT_OPERATOR_VERSION)",
+			"--set-host-property=prop1",
+			"--set-host-property=prop2",
+			"--set-host-property=prop3",
+			"--set-host-tag=tag1",
+			"--set-host-tag=tag2",
+			"--set-host-tag=tag3",
 			"--set-no-proxy=",
 			"--set-proxy=",
-			"--set-server={$(DT_SERVER)}",
 			"--set-server=https://hyper.super.com:9999",
 			"--set-tenant=$(DT_TENANT)",
 		}
@@ -216,7 +235,6 @@ func TestArguments(t *testing.T) {
 			"--set-host-property=item2=value2",
 			"--set-no-proxy=",
 			"--set-proxy=",
-			"--set-server={$(DT_SERVER)}",
 			"--set-server=https://hyper.super.com:9999",
 			"--set-tenant=$(DT_TENANT)",
 		}

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -920,7 +920,7 @@ func TestOneAgentHostGroup(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, daemonset)
-		assert.Equal(t, "--set-host-group=newgroup", daemonset.Spec.Template.Spec.Containers[0].Args[1])
+		assert.Equal(t, "--set-host-group=newgroup", daemonset.Spec.Template.Spec.Containers[0].Args[0])
 	})
 }
 
@@ -964,12 +964,10 @@ func TestDefaultArguments(t *testing.T) {
 		expectedDefaultArguments := []string{
 			"--set-app-log-content-access=true",
 			"--set-host-group=APP_LUSTIG_PETER",
-			"--set-host-id-source=auto",
 			"--set-host-id-source=fqdn",
 			"--set-host-property=OperatorVersion=$(DT_OPERATOR_VERSION)",
 			"--set-no-proxy=",
 			"--set-proxy=",
-			"--set-server={$(DT_SERVER)}",
 			"--set-server=https://hyper.super.com:9999",
 			"--set-tenant=$(DT_TENANT)",
 		}
@@ -995,7 +993,6 @@ func TestDefaultArguments(t *testing.T) {
 			"--set-host-property=OperatorVersion=$(DT_OPERATOR_VERSION)",
 			"--set-no-proxy=",
 			"--set-proxy=",
-			"--set-server={$(DT_SERVER)}",
 			"--set-server=https://hyper.super.com:9999",
 			"--set-tenant=$(DT_TENANT)",
 		}

--- a/pkg/util/prioritymap/map.go
+++ b/pkg/util/prioritymap/map.go
@@ -3,7 +3,7 @@ package prioritymap
 import (
 	"strings"
 
-	"golang.org/x/exp/slices"
+	"slices"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/util/prioritymap/map.go
+++ b/pkg/util/prioritymap/map.go
@@ -1,9 +1,9 @@
 package prioritymap
 
 import (
+	"slices"
 	"strings"
 
-	"slices"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/util/prioritymap/map.go
+++ b/pkg/util/prioritymap/map.go
@@ -3,6 +3,7 @@ package prioritymap
 import (
 	"strings"
 
+	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -18,6 +19,7 @@ type Map struct {
 
 type entry struct {
 	value           any
+	key             string
 	delimiter       string
 	priority        int
 	allowDuplicates bool
@@ -37,10 +39,31 @@ func WithSeparator(separator string) Option {
 	}
 }
 
-// WithAllowDuplicatesForKey allows to add multiple values for the same key (covers all keys)
 func WithAllowDuplicates() Option {
 	return func(a *entry) {
 		a.allowDuplicates = true
+	}
+}
+
+func WithAvoidDuplicates() Option {
+	return func(a *entry) {
+		a.allowDuplicates = false
+	}
+}
+
+func WithAvoidDuplicatesFor(key string) Option {
+	return func(a *entry) {
+		if a.key == key {
+			a.allowDuplicates = false
+		}
+	}
+}
+
+func WithAllowDuplicatesFor(key string) Option {
+	return func(a *entry) {
+		if a.key == key {
+			a.allowDuplicates = true
+		}
 	}
 }
 
@@ -59,6 +82,7 @@ func (m Map) Append(key string, value any, opts ...Option) {
 	}
 
 	newArg := entry{
+		key:             key,
 		value:           value,
 		priority:        DefaultPriority,
 		allowDuplicates: false,
@@ -79,7 +103,11 @@ func (m Map) Append(key string, value any, opts ...Option) {
 			m.entries[key] = make([]entry, 0)
 		}
 
-		m.entries[key] = append(m.entries[key], newArg)
+		if !slices.ContainsFunc(m.entries[key], func(e entry) bool {
+			return e.value == value
+		}) {
+			m.entries[key] = append(m.entries[key], newArg)
+		}
 	}
 }
 

--- a/pkg/util/prioritymap/map_test.go
+++ b/pkg/util/prioritymap/map_test.go
@@ -158,3 +158,132 @@ func TestArgumentSlice(t *testing.T) {
 
 	assert.Equal(t, expectedArgs, argMap.AsKeyValueStrings())
 }
+
+func TestDuplicateArguments(t *testing.T) {
+	defaultArgs := []string{
+		"--set-proxy=127.0.0.1",
+		"--set-host-id-source=auto",
+		"--set-server=localhost",
+		"--set-host-property=prop1",
+		"--set-host-property=prop2",
+		"--set-host-property=prop3",
+		"--set-host-property=prop3",
+		"--set-host-property=prop3",
+	}
+
+	custArgs := []string{
+		"--set-host-id-source=fqdn",
+		"--set-server=foobar.com",
+		"--set-host-property=cust-prop1",
+		"--set-host-property=cust-prop2",
+		"--set-host-property=cust-prop3",
+		"--set-host-property=cust-prop3",
+		"--set-host-property=cust-prop3",
+	}
+
+	var tests = []struct {
+		title          string
+		expectedArgs   []string
+		defaultArgPrio int
+		custArgPrio    int
+		mapOptions     []Option
+	}{
+		{
+			title: "Enter avoided duplicates with higher prio",
+			expectedArgs: []string{
+				"--set-host-id-source=fqdn",
+				"--set-host-property=prop1",
+				"--set-host-property=prop2",
+				"--set-host-property=prop3",
+				"--set-host-property=cust-prop1",
+				"--set-host-property=cust-prop2",
+				"--set-host-property=cust-prop3",
+				"--set-proxy=127.0.0.1",
+				"--set-server=foobar.com",
+			},
+			defaultArgPrio: DefaultPriority,
+			custArgPrio:    HighPriority,
+			mapOptions: []Option{
+				WithSeparator("="),
+				WithAllowDuplicates(),
+				WithAvoidDuplicatesFor("--set-host-id-source"),
+				WithAvoidDuplicatesFor("--set-server"),
+			},
+		},
+		{
+			title: "Enter avoided duplicates with lower prio",
+			expectedArgs: []string{
+				"--set-host-id-source=auto",
+				"--set-host-property=cust-prop1",
+				"--set-host-property=cust-prop2",
+				"--set-host-property=cust-prop3",
+				"--set-host-property=prop1",
+				"--set-host-property=prop2",
+				"--set-host-property=prop3",
+				"--set-proxy=127.0.0.1",
+				"--set-server=localhost",
+			},
+			defaultArgPrio: HighPriority,
+			custArgPrio:    DefaultPriority,
+			mapOptions: []Option{
+				WithSeparator("="),
+				WithAllowDuplicates(),
+				WithAvoidDuplicatesFor("--set-host-id-source"),
+				WithAvoidDuplicatesFor("--set-server"),
+			},
+		},
+		{
+			title: "Enter avoided duplicates with higher prio",
+			expectedArgs: []string{
+				"--set-host-id-source=fqdn",
+				"--set-host-property=prop1",
+				"--set-host-property=prop2",
+				"--set-host-property=prop3",
+				"--set-host-property=cust-prop1",
+				"--set-host-property=cust-prop2",
+				"--set-host-property=cust-prop3",
+				"--set-proxy=127.0.0.1",
+				"--set-server=foobar.com",
+			},
+			defaultArgPrio: DefaultPriority,
+			custArgPrio:    HighPriority,
+			mapOptions: []Option{
+				WithSeparator("="),
+				WithAvoidDuplicates(),
+				WithAllowDuplicatesFor("--set-host-property"),
+			},
+		},
+		{
+			title: "Enter avoided duplicates with lower prio",
+			expectedArgs: []string{
+				"--set-host-id-source=auto",
+				"--set-host-property=cust-prop1",
+				"--set-host-property=cust-prop2",
+				"--set-host-property=cust-prop3",
+				"--set-host-property=prop1",
+				"--set-host-property=prop2",
+				"--set-host-property=prop3",
+				"--set-proxy=127.0.0.1",
+				"--set-server=localhost",
+			},
+			defaultArgPrio: HighPriority,
+			custArgPrio:    DefaultPriority,
+			mapOptions: []Option{
+				WithSeparator("="),
+				WithAvoidDuplicates(),
+				WithAllowDuplicatesFor("--set-host-property"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			argMap := New(tt.mapOptions...)
+
+			Append(argMap, defaultArgs, WithPriority(tt.defaultArgPrio))
+			Append(argMap, custArgs, WithPriority(tt.custArgPrio))
+
+			assert.Equal(t, tt.expectedArgs, argMap.AsKeyValueStrings())
+		})
+	}
+}

--- a/pkg/util/prioritymap/map_test.go
+++ b/pkg/util/prioritymap/map_test.go
@@ -171,21 +171,21 @@ func TestDuplicateArguments(t *testing.T) {
 		"--set-host-property=prop3",
 	}
 
-	custArgs := []string{
+	customArgs := []string{
 		"--set-host-id-source=fqdn",
 		"--set-server=foobar.com",
-		"--set-host-property=cust-prop1",
-		"--set-host-property=cust-prop2",
-		"--set-host-property=cust-prop3",
-		"--set-host-property=cust-prop3",
-		"--set-host-property=cust-prop3",
+		"--set-host-property=custom-prop1",
+		"--set-host-property=custom-prop2",
+		"--set-host-property=custom-prop3",
+		"--set-host-property=custom-prop3",
+		"--set-host-property=custom-prop3",
 	}
 
 	var tests = []struct {
 		title          string
 		expectedArgs   []string
 		defaultArgPrio int
-		custArgPrio    int
+		customArgsPrio int
 		mapOptions     []Option
 	}{
 		{
@@ -195,14 +195,14 @@ func TestDuplicateArguments(t *testing.T) {
 				"--set-host-property=prop1",
 				"--set-host-property=prop2",
 				"--set-host-property=prop3",
-				"--set-host-property=cust-prop1",
-				"--set-host-property=cust-prop2",
-				"--set-host-property=cust-prop3",
+				"--set-host-property=custom-prop1",
+				"--set-host-property=custom-prop2",
+				"--set-host-property=custom-prop3",
 				"--set-proxy=127.0.0.1",
 				"--set-server=foobar.com",
 			},
 			defaultArgPrio: DefaultPriority,
-			custArgPrio:    HighPriority,
+			customArgsPrio: HighPriority,
 			mapOptions: []Option{
 				WithSeparator("="),
 				WithAllowDuplicates(),
@@ -214,9 +214,9 @@ func TestDuplicateArguments(t *testing.T) {
 			title: "Enter avoided duplicates with lower prio",
 			expectedArgs: []string{
 				"--set-host-id-source=auto",
-				"--set-host-property=cust-prop1",
-				"--set-host-property=cust-prop2",
-				"--set-host-property=cust-prop3",
+				"--set-host-property=custom-prop1",
+				"--set-host-property=custom-prop2",
+				"--set-host-property=custom-prop3",
 				"--set-host-property=prop1",
 				"--set-host-property=prop2",
 				"--set-host-property=prop3",
@@ -224,7 +224,7 @@ func TestDuplicateArguments(t *testing.T) {
 				"--set-server=localhost",
 			},
 			defaultArgPrio: HighPriority,
-			custArgPrio:    DefaultPriority,
+			customArgsPrio: DefaultPriority,
 			mapOptions: []Option{
 				WithSeparator("="),
 				WithAllowDuplicates(),
@@ -239,14 +239,14 @@ func TestDuplicateArguments(t *testing.T) {
 				"--set-host-property=prop1",
 				"--set-host-property=prop2",
 				"--set-host-property=prop3",
-				"--set-host-property=cust-prop1",
-				"--set-host-property=cust-prop2",
-				"--set-host-property=cust-prop3",
+				"--set-host-property=custom-prop1",
+				"--set-host-property=custom-prop2",
+				"--set-host-property=custom-prop3",
 				"--set-proxy=127.0.0.1",
 				"--set-server=foobar.com",
 			},
 			defaultArgPrio: DefaultPriority,
-			custArgPrio:    HighPriority,
+			customArgsPrio: HighPriority,
 			mapOptions: []Option{
 				WithSeparator("="),
 				WithAvoidDuplicates(),
@@ -257,9 +257,9 @@ func TestDuplicateArguments(t *testing.T) {
 			title: "Enter avoided duplicates with lower prio",
 			expectedArgs: []string{
 				"--set-host-id-source=auto",
-				"--set-host-property=cust-prop1",
-				"--set-host-property=cust-prop2",
-				"--set-host-property=cust-prop3",
+				"--set-host-property=custom-prop1",
+				"--set-host-property=custom-prop2",
+				"--set-host-property=custom-prop3",
 				"--set-host-property=prop1",
 				"--set-host-property=prop2",
 				"--set-host-property=prop3",
@@ -267,7 +267,7 @@ func TestDuplicateArguments(t *testing.T) {
 				"--set-server=localhost",
 			},
 			defaultArgPrio: HighPriority,
-			custArgPrio:    DefaultPriority,
+			customArgsPrio: DefaultPriority,
 			mapOptions: []Option{
 				WithSeparator("="),
 				WithAvoidDuplicates(),
@@ -281,7 +281,7 @@ func TestDuplicateArguments(t *testing.T) {
 			argMap := New(tt.mapOptions...)
 
 			Append(argMap, defaultArgs, WithPriority(tt.defaultArgPrio))
-			Append(argMap, custArgs, WithPriority(tt.custArgPrio))
+			Append(argMap, customArgs, WithPriority(tt.customArgsPrio))
 
 			assert.Equal(t, tt.expectedArgs, argMap.AsKeyValueStrings())
 		})


### PR DESCRIPTION
## Description

Multiple occasions of command line arguments for OneAgent shall be avoided. Exceptions are only `--set-host-property` and `--set-host-tag`. Host tags shall not be provided multiple times with the same value.

## How can this be tested?

Deploy a Dynakube with custom OneAgent arguments and make sure that the custom arguments take precedence in the OneAgent daemon set and that no duplications show up (besidd the exceptions)