### PR TITLE
Removes a log message that corrupts support_archive zip package

### DIFF
--- a/cmd/csi/init/cmd.go
+++ b/cmd/csi/init/cmd.go
@@ -37,7 +37,7 @@ func New() *cobra.Command {
 func run() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(dtcsi.UnixUmask)
-		installconfig.GetModules()
+		installconfig.ReadModules()
 		version.LogVersion()
 		logd.LogBaseLoggerSettings()
 

--- a/cmd/csi/init/cmd.go
+++ b/cmd/csi/init/cmd.go
@@ -8,6 +8,7 @@ import (
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/pkg/errors"
@@ -36,6 +37,7 @@ func New() *cobra.Command {
 func run() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(dtcsi.UnixUmask)
+		installconfig.GetModules()
 		version.LogVersion()
 		logd.LogBaseLoggerSettings()
 

--- a/cmd/csi/provisioner/cmd.go
+++ b/cmd/csi/provisioner/cmd.go
@@ -53,7 +53,7 @@ func addFlags(cmd *cobra.Command) {
 func run() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(dtcsi.UnixUmask)
-		installconfig.GetModules()
+		installconfig.ReadModules()
 		version.LogVersion()
 		logd.LogBaseLoggerSettings()
 

--- a/cmd/csi/provisioner/cmd.go
+++ b/cmd/csi/provisioner/cmd.go
@@ -8,6 +8,7 @@ import (
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	csiprovisioner "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/provisioner"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/pkg/errors"
@@ -52,6 +53,7 @@ func addFlags(cmd *cobra.Command) {
 func run() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(dtcsi.UnixUmask)
+		installconfig.GetModules()
 		version.LogVersion()
 		logd.LogBaseLoggerSettings()
 

--- a/cmd/csi/server/cmd.go
+++ b/cmd/csi/server/cmd.go
@@ -8,6 +8,7 @@ import (
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	csidriver "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/pkg/errors"
@@ -49,6 +50,7 @@ func addFlags(cmd *cobra.Command) {
 func run() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(dtcsi.UnixUmask)
+		installconfig.GetModules()
 		version.LogVersion()
 		logd.LogBaseLoggerSettings()
 

--- a/cmd/csi/server/cmd.go
+++ b/cmd/csi/server/cmd.go
@@ -50,7 +50,7 @@ func addFlags(cmd *cobra.Command) {
 func run() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		unix.Umask(dtcsi.UnixUmask)
-		installconfig.GetModules()
+		installconfig.ReadModules()
 		version.LogVersion()
 		logd.LogBaseLoggerSettings()
 

--- a/cmd/operator/builder.go
+++ b/cmd/operator/builder.go
@@ -7,6 +7,7 @@ import (
 	cmdManager "github.com/Dynatrace/dynatrace-operator/cmd/manager"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/certificates"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
@@ -125,6 +126,7 @@ func (builder CommandBuilder) setClientFromConfig(kubeCfg *rest.Config) (Command
 
 func (builder CommandBuilder) buildRun() func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		installconfig.GetModules()
 		version.LogVersion()
 		logd.LogBaseLoggerSettings()
 

--- a/cmd/operator/builder.go
+++ b/cmd/operator/builder.go
@@ -126,7 +126,7 @@ func (builder CommandBuilder) setClientFromConfig(kubeCfg *rest.Config) (Command
 
 func (builder CommandBuilder) buildRun() func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		installconfig.GetModules()
+		installconfig.ReadModules()
 		version.LogVersion()
 		logd.LogBaseLoggerSettings()
 

--- a/cmd/support_archive/builder.go
+++ b/cmd/support_archive/builder.go
@@ -98,7 +98,7 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 
 		logBuffer := bytes.Buffer{}
 		log := newSupportArchiveLogger(getLogOutput(archiveToStdoutFlagValue, &logBuffer))
-		installconfig.GetModulesToLogger(log)
+		installconfig.ReadModulesToLogger(log)
 		version.LogVersionToLogger(log)
 
 		archiveTargetFile, err := createZipArchiveTargetFile(archiveToStdoutFlagValue, defaultSupportArchiveTargetDir)

--- a/cmd/support_archive/builder.go
+++ b/cmd/support_archive/builder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/cmd/remote_command"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
@@ -97,6 +98,7 @@ func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 
 		logBuffer := bytes.Buffer{}
 		log := newSupportArchiveLogger(getLogOutput(archiveToStdoutFlagValue, &logBuffer))
+		installconfig.GetModulesToLogger(log)
 		version.LogVersionToLogger(log)
 
 		archiveTargetFile, err := createZipArchiveTargetFile(archiveToStdoutFlagValue, defaultSupportArchiveTargetDir)

--- a/cmd/webhook/builder.go
+++ b/cmd/webhook/builder.go
@@ -122,7 +122,7 @@ func startCertificateWatcher(webhookManager manager.Manager, namespace string, p
 
 func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		installconfig.GetModules()
+		installconfig.ReadModules()
 		version.LogVersion()
 		logd.LogBaseLoggerSettings()
 

--- a/cmd/webhook/builder.go
+++ b/cmd/webhook/builder.go
@@ -14,6 +14,7 @@ import (
 	dynakubevalidation "github.com/Dynatrace/dynatrace-operator/pkg/api/validation/dynakube"
 	edgeconnectvalidation "github.com/Dynatrace/dynatrace-operator/pkg/api/validation/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/pod"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
@@ -121,6 +122,7 @@ func startCertificateWatcher(webhookManager manager.Manager, namespace string, p
 
 func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		installconfig.GetModules()
 		version.LogVersion()
 		logd.LogBaseLoggerSettings()
 

--- a/pkg/api/v1beta1/dynakube/convert_from.go
+++ b/pkg/api/v1beta1/dynakube/convert_from.go
@@ -10,12 +10,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
-var isEnabledModules installconfig.Modules
-
 // ConvertFrom converts v1beta3 to v1beta1.
 func (dst *DynaKube) ConvertFrom(srcRaw conversion.Hub) error {
-	isEnabledModules = installconfig.GetModules()
-
 	src := srcRaw.(*dynakube.DynaKube)
 	dst.fromBase(src)
 	dst.fromOneAgentSpec(src)
@@ -63,7 +59,7 @@ func (dst *DynaKube) fromOneAgentSpec(src *dynakube.DynaKube) {
 		dst.Spec.OneAgent.ApplicationMonitoring = &ApplicationMonitoringSpec{}
 		dst.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec = *fromAppInjectSpec(src.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec)
 		dst.Spec.OneAgent.ApplicationMonitoring.Version = src.Spec.OneAgent.ApplicationMonitoring.Version
-		dst.Spec.OneAgent.ApplicationMonitoring.UseCSIDriver = &isEnabledModules.CSIDriver
+		dst.Spec.OneAgent.ApplicationMonitoring.UseCSIDriver = ptr.To(installconfig.GetModules().CSIDriver)
 	}
 }
 

--- a/pkg/api/v1beta1/dynakube/convert_from.go
+++ b/pkg/api/v1beta1/dynakube/convert_from.go
@@ -10,10 +10,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
-var isEnabledModules = installconfig.GetModules()
+var isEnabledModules installconfig.Modules
 
 // ConvertFrom converts v1beta3 to v1beta1.
 func (dst *DynaKube) ConvertFrom(srcRaw conversion.Hub) error {
+	isEnabledModules = installconfig.GetModules()
+
 	src := srcRaw.(*dynakube.DynaKube)
 	dst.fromBase(src)
 	dst.fromOneAgentSpec(src)

--- a/pkg/api/v1beta1/dynakube/convert_from_test.go
+++ b/pkg/api/v1beta1/dynakube/convert_from_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	registryv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -176,7 +177,7 @@ func compareCloudNativeSpec(t *testing.T, oldSpec CloudNativeFullStackSpec, newS
 
 func compareApplicationMonitoringSpec(t *testing.T, oldSpec ApplicationMonitoringSpec, newSpec oneagent.ApplicationMonitoringSpec) {
 	compareAppInjectionSpec(t, oldSpec.AppInjectionSpec, newSpec.AppInjectionSpec)
-	assert.Equal(t, *oldSpec.UseCSIDriver, isEnabledModules.CSIDriver)
+	assert.Equal(t, *oldSpec.UseCSIDriver, installconfig.GetModules().CSIDriver)
 	assert.Equal(t, oldSpec.Version, newSpec.Version)
 }
 

--- a/pkg/api/v1beta2/dynakube/convert_from.go
+++ b/pkg/api/v1beta2/dynakube/convert_from.go
@@ -7,10 +7,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
-var isEnabledModules = installconfig.GetModules()
+var isEnabledModules installconfig.Modules
 
 // ConvertFrom converts from the Hub version (v1beta3) to this version (v1beta3).
 func (dst *DynaKube) ConvertFrom(srcRaw conversion.Hub) error {
+	isEnabledModules = installconfig.GetModules()
+
 	src := srcRaw.(*dynakube.DynaKube)
 
 	dst.fromBase(src)

--- a/pkg/api/v1beta2/dynakube/convert_from.go
+++ b/pkg/api/v1beta2/dynakube/convert_from.go
@@ -7,12 +7,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
-var isEnabledModules installconfig.Modules
-
 // ConvertFrom converts from the Hub version (v1beta3) to this version (v1beta3).
 func (dst *DynaKube) ConvertFrom(srcRaw conversion.Hub) error {
-	isEnabledModules = installconfig.GetModules()
-
 	src := srcRaw.(*dynakube.DynaKube)
 
 	dst.fromBase(src)
@@ -58,7 +54,7 @@ func (dst *DynaKube) fromOneAgentSpec(src *dynakube.DynaKube) {
 		dst.Spec.OneAgent.ApplicationMonitoring = &ApplicationMonitoringSpec{}
 		dst.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec = *fromAppInjectSpec(src.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec)
 		dst.Spec.OneAgent.ApplicationMonitoring.Version = src.Spec.OneAgent.ApplicationMonitoring.Version
-		dst.Spec.OneAgent.ApplicationMonitoring.UseCSIDriver = isEnabledModules.CSIDriver
+		dst.Spec.OneAgent.ApplicationMonitoring.UseCSIDriver = installconfig.GetModules().CSIDriver
 	}
 }
 

--- a/pkg/api/v1beta2/dynakube/convert_from_test.go
+++ b/pkg/api/v1beta2/dynakube/convert_from_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	registryv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -167,7 +168,7 @@ func compareCloudNativeSpec(t *testing.T, oldSpec CloudNativeFullStackSpec, newS
 
 func compareApplicationMonitoringSpec(t *testing.T, oldSpec ApplicationMonitoringSpec, newSpec oneagent.ApplicationMonitoringSpec) {
 	compareAppInjectionSpec(t, oldSpec.AppInjectionSpec, newSpec.AppInjectionSpec)
-	assert.Equal(t, oldSpec.UseCSIDriver, isEnabledModules.CSIDriver)
+	assert.Equal(t, oldSpec.UseCSIDriver, installconfig.GetModules().CSIDriver)
 	assert.Equal(t, oldSpec.Version, newSpec.Version)
 }
 

--- a/pkg/util/installconfig/modules.go
+++ b/pkg/util/installconfig/modules.go
@@ -50,14 +50,20 @@ type Modules struct {
 }
 
 func GetModules() Modules {
-	return GetModulesToLogger(log)
-}
-
-func GetModulesToLogger(log logd.Logger) Modules {
 	if override != nil {
 		return *override
 	}
 
+	ReadModules()
+
+	return modules
+}
+
+func ReadModules() {
+	ReadModulesToLogger(log)
+}
+
+func ReadModulesToLogger(log logd.Logger) {
 	once.Do(func() {
 		modulesJson := os.Getenv(ModulesJsonEnv)
 		if modulesJson == "" {
@@ -75,8 +81,6 @@ func GetModulesToLogger(log logd.Logger) Modules {
 
 		log.Info("envvar content read and set", "envvar", ModulesJsonEnv, "value", modulesJson)
 	})
-
-	return modules
 }
 
 // SetModulesOverride is a testing function, so you can easily unittest function using the GetModules() func

--- a/pkg/util/installconfig/modules.go
+++ b/pkg/util/installconfig/modules.go
@@ -50,6 +50,10 @@ type Modules struct {
 }
 
 func GetModules() Modules {
+	return GetModulesToLogger(log)
+}
+
+func GetModulesToLogger(log logd.Logger) Modules {
 	if override != nil {
 		return *override
 	}


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-4465)

## Description

At startup, the operator immediately issues a log line :
```
{"level":"info","ts":"2025-01-27T14:02:26.877Z","logger":"install-config","msg":"envvar content read and set","envvar":"modules.json","value":"..."} 
PK^C^D^T...
```
which precedes the first ZIP header so the package can't be unpacked by some implementations of zip command. 

Changes: 
- removed global initialization of the Modules from v1beta1(2)/convert_from packages to fix support_archive command
- GetModules function  is called by all operator subcommands to put the message at the beginning of a log file

## How can this be tested?
```
kubectl exec -n dynatrace deployment/dynatrace-operator -- dynatrace-operator support-archive --stdout > operator-support-archive.zip
```

`operator-support-archive.zip` should be decompressed with no errors.

supportarchive_console.log contains the message :
```
[support-archive]       envvar content read and set     {"envvar": "modules.json", "value": "{\n  \"csiDriver\": true,\n  \"activeGate\": true,\n  \"oneAgent\": true,\n  \"extensions\": true,\n  \"logMonitoring\": true,\n  \"edgeConnect\": true,\n  \"supportability\": true,\n  \"kspm\": true\n}\n"}
[support-archive]       dynatrace-operator      {"version": "snapshot-bugfix-corrupted-sup-arch", "gitCommit": "f00e14a06a6c72f33d7906ca07e441546802f412", "buildDate": "2025-01-27T15:29:01+00:00", "goVersion": "go1.23.5", "platform": "linux/amd64"} 
...
```
