### PR TITLE
Fix/restart on tenanttokenchange without fieldchange

### DIFF
--- a/pkg/controllers/dynakube/activegate/consts/consts.go
+++ b/pkg/controllers/dynakube/activegate/consts/consts.go
@@ -28,6 +28,7 @@ const (
 	EnvDtHttpPort        = "DT_HTTP_PORT"
 
 	AnnotationActiveGateConfigurationHash = api.InternalFlagPrefix + "activegate-configuration-hash"
+	AnnotationActiveGateTokenHash         = api.InternalFlagPrefix + "activegate-token-hash"
 	AnnotationActiveGateContainerAppArmor = "container.apparmor.security.beta.kubernetes.io/" + ActiveGateContainerName
 
 	GatewayConfigVolumeName  = "ag-lib-gateway-config"

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
@@ -11,7 +11,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/authtoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/statefulset"
 	"github.com/pkg/errors"
@@ -87,7 +89,12 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context) (*appsv1.State
 		return nil, err
 	}
 
-	statefulSetBuilder := NewStatefulSetBuilder(kubeUID, activeGateConfigurationHash, *r.dk, r.capability)
+	activeGateTokenHash, err := r.calculateActiveGateTokenHash(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	statefulSetBuilder := NewStatefulSetBuilder(kubeUID, activeGateConfigurationHash, activeGateTokenHash, *r.dk, r.capability)
 
 	desiredSts, err := statefulSetBuilder.CreateStatefulSet(r.modifiers)
 
@@ -115,6 +122,19 @@ func (r *Reconciler) calculateActiveGateConfigurationHash(ctx context.Context) (
 	}
 
 	return strconv.FormatUint(uint64(hash.Sum32()), 10), nil
+}
+
+func (r *Reconciler) calculateActiveGateTokenHash(ctx context.Context) (string, error) {
+	tenantToken, err := secret.GetDataFromSecretName(ctx, r.apiReader, types.NamespacedName{
+		Name:      r.dk.ActiveGate().GetTenantSecretName(),
+		Namespace: r.dk.Namespace,
+	}, connectioninfo.TenantTokenKey, log)
+
+	if err != nil {
+		log.Error(err, "secret for activegate token was not available at StatefulSet build time", "dynakube", r.dk.Name)
+	}
+
+	return hasher.GenerateHash(tenantToken)
 }
 
 func (r *Reconciler) getCustomPropertyValue(ctx context.Context) (string, error) {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -30,13 +30,15 @@ type Builder struct {
 	envMap     *prioritymap.Map
 	kubeUID    types.UID
 	configHash string
+	tokenHash  string
 	dynakube   dynakube.DynaKube
 }
 
-func NewStatefulSetBuilder(kubeUID types.UID, configHash string, dk dynakube.DynaKube, capability capability.Capability) Builder {
+func NewStatefulSetBuilder(kubeUID types.UID, configHash string, activeGateTokenHash string, dk dynakube.DynaKube, capability capability.Capability) Builder {
 	return Builder{
 		kubeUID:    kubeUID,
 		configHash: configHash,
+		tokenHash:  activeGateTokenHash,
 		dynakube:   dk,
 		capability: capability,
 		envMap:     prioritymap.New(prioritymap.WithPriority(defaultEnvPriority)),
@@ -88,6 +90,7 @@ func (statefulSetBuilder Builder) getBaseSpec() appsv1.StatefulSetSpec {
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					consts.AnnotationActiveGateConfigurationHash: statefulSetBuilder.configHash,
+					consts.AnnotationActiveGateTokenHash:         statefulSetBuilder.tokenHash,
 				},
 			},
 		},

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/annotations.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/annotations.go
@@ -1,0 +1,38 @@
+package daemonset
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
+	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const annotationTenantTokenHash = api.InternalFlagPrefix + "tenant-token-hash"
+
+func (r *Reconciler) calculateTenantTokenHash(ctx context.Context) (string, error) {
+	tenantToken, err := k8ssecret.GetDataFromSecretName(ctx, r.apiReader, types.NamespacedName{
+		Name:      r.dk.OneagentTenantSecret(),
+		Namespace: r.dk.Namespace,
+	}, connectioninfo.TenantTokenKey, log)
+
+	if err != nil {
+		log.Error(err, "secret for tenant token was not available at DaemonSet build time", "dynakube", r.dk.Name)
+		conditions.SetKubeApiError(r.dk.Conditions(), conditionType, err)
+	}
+
+	return hasher.GenerateHash(tenantToken)
+}
+
+func (r *Reconciler) buildAnnotations(ctx context.Context) (map[string]string, error) {
+	hash, err := r.calculateTenantTokenHash(ctx)
+
+	annotations := map[string]string{
+		annotationTenantTokenHash: hash,
+	}
+
+	return annotations, err
+}

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	testImageTag = "1.203.0.0-0"
+	testImageTag  = "1.203.0.0-0"
+	testTokenHash = "test-token-hash"
 )
 
 func TestUseImmutableImage(t *testing.T) {
@@ -42,7 +43,7 @@ func TestUseImmutableImage(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewClassicFullStack(&dk, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -83,7 +84,7 @@ func TestLabels(t *testing.T) {
 			labels.AppCreatedByLabel: dk.Name,
 			labels.AppManagedByLabel: version.AppName,
 		}
-		dsBuilder := NewClassicFullStack(&dk, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -116,7 +117,7 @@ func TestLabels(t *testing.T) {
 			labels.AppManagedByLabel: version.AppName,
 		}
 
-		dsBuilder := NewClassicFullStack(&dk, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -141,7 +142,7 @@ func TestCustomPullSecret(t *testing.T) {
 			CustomPullSecret: testName,
 		},
 	}
-	dsBuilder := NewClassicFullStack(&dk, testClusterID)
+	dsBuilder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 	ds, err := dsBuilder.BuildDaemonSet()
 	require.NoError(t, err)
 
@@ -162,7 +163,7 @@ func TestResources(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewClassicFullStack(&dk, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -199,7 +200,7 @@ func TestResources(t *testing.T) {
 			},
 		}
 
-		dsBuilder := NewClassicFullStack(&dk, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -261,7 +262,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewHostMonitoring(&dk, testClusterID)
+		dsBuilder := NewHostMonitoring(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -295,7 +296,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewHostMonitoring(&dk, testClusterID)
+		dsBuilder := NewHostMonitoring(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -324,7 +325,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewHostMonitoring(&dk, testClusterID)
+		dsBuilder := NewHostMonitoring(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -351,7 +352,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewHostMonitoring(&dk, testClusterID)
+		dsBuilder := NewHostMonitoring(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -382,7 +383,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewClassicFullStack(&dk, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -412,7 +413,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewClassicFullStack(&dk, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -447,7 +448,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 				},
 			},
 		}
-		dsBuilder := NewClassicFullStack(&dk, testClusterID)
+		dsBuilder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -770,9 +771,10 @@ func TestAnnotations(t *testing.T) {
 		expectedAnnotations := map[string]string{
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
+			annotationTenantTokenHash:         testTokenHash,
 		}
 
-		builder := NewCloudNativeFullStack(&dk, testClusterID)
+		builder := NewCloudNativeFullStack(&dk, testClusterID, testTokenHash)
 		daemonset, err := builder.BuildDaemonSet()
 
 		require.NoError(t, err)
@@ -790,9 +792,10 @@ func TestAnnotations(t *testing.T) {
 		expectedAnnotations := map[string]string{
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
+			annotationTenantTokenHash:         testTokenHash,
 		}
 
-		builder := NewHostMonitoring(&dk, testClusterID)
+		builder := NewHostMonitoring(&dk, testClusterID, testTokenHash)
 		daemonset, err := builder.BuildDaemonSet()
 
 		require.NoError(t, err)
@@ -810,9 +813,10 @@ func TestAnnotations(t *testing.T) {
 		expectedAnnotations := map[string]string{
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
+			annotationTenantTokenHash:         testTokenHash,
 		}
 
-		builder := NewClassicFullStack(&dk, testClusterID)
+		builder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 		daemonset, err := builder.BuildDaemonSet()
 
 		require.NoError(t, err)
@@ -837,9 +841,10 @@ func TestAnnotations(t *testing.T) {
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
+			annotationTenantTokenHash:         testTokenHash,
 		}
 
-		builder := NewCloudNativeFullStack(&dk, testClusterID)
+		builder := NewCloudNativeFullStack(&dk, testClusterID, testTokenHash)
 		daemonset, err := builder.BuildDaemonSet()
 
 		require.NoError(t, err)
@@ -862,9 +867,10 @@ func TestAnnotations(t *testing.T) {
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
+			annotationTenantTokenHash:         testTokenHash,
 		}
 
-		builder := NewHostMonitoring(&dk, testClusterID)
+		builder := NewHostMonitoring(&dk, testClusterID, testTokenHash)
 		daemonset, err := builder.BuildDaemonSet()
 
 		require.NoError(t, err)
@@ -887,9 +893,10 @@ func TestAnnotations(t *testing.T) {
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
+			annotationTenantTokenHash:         testTokenHash,
 		}
 
-		builder := NewClassicFullStack(&dk, testClusterID)
+		builder := NewClassicFullStack(&dk, testClusterID, testTokenHash)
 		daemonset, err := builder.BuildDaemonSet()
 
 		require.NoError(t, err)
@@ -915,7 +922,7 @@ func TestOneAgentHostGroup(t *testing.T) {
 			},
 		}
 
-		builder := NewCloudNativeFullStack(&dk, testClusterID)
+		builder := NewCloudNativeFullStack(&dk, testClusterID, testTokenHash)
 		daemonset, err := builder.BuildDaemonSet()
 
 		require.NoError(t, err)
@@ -957,7 +964,7 @@ func TestDefaultArguments(t *testing.T) {
 			"--set-server=https://hyper.super.com:9999",
 		}
 		dk.Spec.OneAgent.ClassicFullStack.Args = args
-		dsBuilder := NewClassicFullStack(dk, testClusterID)
+		dsBuilder := NewClassicFullStack(dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -982,7 +989,7 @@ func TestDefaultArguments(t *testing.T) {
 			"--set-server=https://hyper.super.com:9999",
 		}
 		dk.Spec.OneAgent.ClassicFullStack.Args = args
-		dsBuilder := NewClassicFullStack(dk, testClusterID)
+		dsBuilder := NewClassicFullStack(dk, testClusterID, testTokenHash)
 		ds, err := dsBuilder.BuildDaemonSet()
 		require.NoError(t, err)
 

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	testClusterID = "test-cluster-id"
+	testTokenHash = "test-token-hash"
 )
 
 func TestReconcile(t *testing.T) {
@@ -289,7 +290,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 		reconciler.versionReconciler = createVersionReconcilerMock(t)
 		reconciler.tokens = createTokens()
 		dk.Status.OneAgent.Version = oldComponentVersion
-		dsInfo := daemonset.NewClassicFullStack(dk, testClusterID)
+		dsInfo := daemonset.NewClassicFullStack(dk, testClusterID, testTokenHash)
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -322,7 +323,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 		reconciler.tokens = createTokens()
 		dk.Spec.OneAgent.ClassicFullStack.AutoUpdate = &autoUpdate
 		dk.Status.OneAgent.Version = oldComponentVersion
-		dsInfo := daemonset.NewClassicFullStack(dk, testClusterID)
+		dsInfo := daemonset.NewClassicFullStack(dk, testClusterID, testTokenHash)
 		ds, err := dsInfo.BuildDaemonSet()
 		require.NoError(t, err)
 
@@ -363,7 +364,7 @@ func TestMigrationForDaemonSetWithoutAnnotation(t *testing.T) {
 		},
 	}
 
-	ds2, err := r.buildDesiredDaemonSet(dk)
+	ds2, err := r.buildDesiredDaemonSet(dk, testTokenHash)
 	require.NoError(t, err)
 	assert.NotEmpty(t, ds2.Annotations[hasher.AnnotationHash])
 
@@ -521,10 +522,10 @@ func TestHasSpecChanged(t *testing.T) {
 				},
 			}
 			test.mod(&oldInstance, &newInstance)
-			ds1, err := r.buildDesiredDaemonSet(&oldInstance)
+			ds1, err := r.buildDesiredDaemonSet(&oldInstance, testTokenHash)
 			require.NoError(t, err)
 
-			ds2, err := r.buildDesiredDaemonSet(&newInstance)
+			ds2, err := r.buildDesiredDaemonSet(&newInstance, testTokenHash)
 			require.NoError(t, err)
 
 			assert.NotEmpty(t, ds1.Annotations[hasher.AnnotationHash])
@@ -539,7 +540,7 @@ func TestNewDaemonset_Affinity(t *testing.T) {
 	t.Run(`adds correct affinities`, func(t *testing.T) {
 		r := Reconciler{}
 		dk := newDynaKube()
-		ds, err := r.buildDesiredDaemonSet(dk)
+		ds, err := r.buildDesiredDaemonSet(dk, testTokenHash)
 
 		require.NoError(t, err)
 		assert.NotNil(t, ds)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

The tenant and ActiveGate tokens can be rotated using the [tenant's rotation API](https://docs.dynatrace.com/docs/shortlink/tenant-token).

This process updates the `oneagent-tenant-secret` and ActiveGate secret. To activate these changes, the OneAgents and ActiveGates need to be restarted.

To accomplish this, this PR adds a hash as an annotation to the DaemonSet and StatefulSet. If the hash changes, the pods will be restarted.

**To not introduce a new field on a bugfix version, it uses the old bugfix implementation. For the new implementation including a new field look at PR #4361

[Jira](https://dt-rnd.atlassian.net/browse/DAQ-4432)

## How can this be tested?

- Deploy dynakube with oneagents
- Navigate to the api docs in your tenant
- Start the token rotation
- the oneagents will be updated after some time.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->