### PR TITLE
Add validations for OneAgent arguments (release-1.4)

### DIFF
--- a/pkg/api/v1beta3/dynakube/oneagent_props.go
+++ b/pkg/api/v1beta3/dynakube/oneagent_props.go
@@ -228,6 +228,35 @@ func (dk *DynaKube) DefaultOneAgentImage(version string) string {
 	return apiUrlHost + DefaultOneAgentImageRegistrySubPath + ":" + tag
 }
 
+func (dk *DynaKube) OneAgentArgumentsMap() map[string][]string {
+	var args []string
+
+	switch {
+	case dk.CloudNativeFullstackMode() && dk.Spec.OneAgent.CloudNativeFullStack.Args != nil:
+		args = dk.Spec.OneAgent.CloudNativeFullStack.Args
+	case dk.ClassicFullStackMode() && dk.Spec.OneAgent.ClassicFullStack.Args != nil:
+		args = dk.Spec.OneAgent.ClassicFullStack.Args
+	case dk.HostMonitoringMode() && dk.Spec.OneAgent.HostMonitoring.Args != nil:
+		args = dk.Spec.OneAgent.HostMonitoring.Args
+
+	default:
+		return nil
+	}
+
+	argMap := make(map[string][]string)
+
+	for _, arg := range args {
+		key, value := splitArg(arg)
+		if _, exists := argMap[key]; !exists {
+			argMap[key] = []string{value}
+		} else {
+			argMap[key] = append(argMap[key], value)
+		}
+	}
+
+	return argMap
+}
+
 func (dk *DynaKube) HostGroup() string {
 	if dk.Spec.OneAgent.HostGroup != "" {
 		return dk.Spec.OneAgent.HostGroup

--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
@@ -32,6 +33,12 @@ Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 	versionRegex = `^\d+.\d+.\d+.\d{8}-\d{6}$`
 
 	versionInvalidMessage = "The OneAgent's version is only valid in the format 'major.minor.patch.timestamp', e.g. 1.0.0.20240101-000000"
+
+	errorDuplicateOneAgentArgument = "%s has been provided multiple times. Only --set-host-property and --set-host-tag arguments may be provided multiple times."
+
+	errorHostIdSourceArgumentInCloudNative = "Setting --set-host-id-source in CloudNativFullstack mode is not allowed."
+
+	errorSameHostTagMultipleTimes = "Providing the same tag(s) (%s) multiple times with --set-host-tag is not allowed."
 )
 
 func conflictingOneAgentConfiguration(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
@@ -200,4 +207,54 @@ func isOneAgentVersionValid(_ context.Context, _ *Validator, dk *dynakube.DynaKu
 	}
 
 	return ""
+}
+
+func duplicateOneAgentArguments(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	args := dk.OneAgentArgumentsMap()
+	if args == nil {
+		return ""
+	}
+
+	for key, values := range args {
+		if key != "--set-host-property" && key != "--set-host-tag" && len(values) > 1 {
+			return fmt.Sprintf(errorDuplicateOneAgentArgument, key)
+		} else if key == "--set-host-tag" {
+			if duplicatedTags := findDuplicates(values); len(duplicatedTags) > 0 {
+				return fmt.Sprintf(errorSameHostTagMultipleTimes, duplicatedTags)
+			}
+		}
+	}
+
+	return ""
+}
+
+func forbiddenHostIdSourceArgument(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	args := dk.OneAgentArgumentsMap()
+	if args == nil {
+		return ""
+	}
+
+	for key := range args {
+		if dk.CloudNativeFullstackMode() && key == "--set-host-id-source" {
+			return errorHostIdSourceArgumentInCloudNative
+		}
+	}
+
+	return ""
+}
+
+func findDuplicates[S ~[]E, E comparable](s S) []E {
+	seen := make(map[E]bool)
+
+	duplicates := make([]E, 0)
+
+	for _, val := range s {
+		if _, ok := seen[val]; !ok {
+			seen[val] = true
+		} else if !slices.Contains(duplicates, val) {
+			duplicates = append(duplicates, val)
+		}
+	}
+
+	return duplicates
 }

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -598,7 +598,7 @@ func TestOneAgentArguments(t *testing.T) {
 				"--set-host-tag=bar",
 				"--set-host-tag=foo",
 			},
-			expectedError: fmt.Sprintf(errorSameHostTagMultipleTimes, "[bar foo]"),
+			expectedError: fmt.Sprintf(errorSameHostTagMultipleTimes, "[foo bar]"),
 		},
 	}
 

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -534,3 +534,184 @@ func TestPublicImageSetWithReadOnlyMode(t *testing.T) {
 		})
 	})
 }
+
+func TestOneAgentArguments(t *testing.T) {
+	type oneAgentArgumentTest struct {
+		testName      string
+		arguments     []string
+		expectedError string
+	}
+
+	testcases := []oneAgentArgumentTest{
+		{
+			testName: "duplicate arguments are rejected",
+			arguments: []string{
+				"--set-server=foo",
+				"--set-server=bar",
+			},
+			expectedError: fmt.Sprintf(errorDuplicateOneAgentArgument, "--set-server"),
+		},
+		{
+			testName: "duplicate arguments with same value are rejected",
+			arguments: []string{
+				"--set-server=foo",
+				"--set-server=foo",
+			},
+			expectedError: fmt.Sprintf(errorDuplicateOneAgentArgument, "--set-server"),
+		},
+		{
+			testName: "no duplicate arguments",
+			arguments: []string{
+				"--set-server=foo",
+				"--set-host-source-id=bar",
+			},
+			expectedError: "",
+		},
+		{
+			testName: "duplicate host property",
+			arguments: []string{
+				"--set-server=foo",
+				"--set-host-property=foo",
+				"--set-host-property=bar",
+				"--set-host-property=dow",
+			},
+			expectedError: "",
+		},
+		{
+			testName: "duplicate host tag",
+			arguments: []string{
+				"--set-server=foo",
+				"--set-host-tag=foo",
+				"--set-host-tag=bar",
+				"--set-host-tag=dow",
+			},
+			expectedError: "",
+		},
+		{
+			testName: "duplicate host tag with same value",
+			arguments: []string{
+				"--set-host-tag=foo",
+				"--set-host-tag=bar",
+				"--set-host-tag=foo",
+				"--set-host-tag=bar",
+				"--set-host-tag=doh",
+				"--set-host-tag=bar",
+				"--set-host-tag=foo",
+			},
+			expectedError: fmt.Sprintf(errorSameHostTagMultipleTimes, "[bar foo]"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.testName, func(t *testing.T) {
+			dk := &dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+							HostInjectSpec: dynakube.HostInjectSpec{
+								Args: tc.arguments,
+							},
+						},
+					},
+				},
+			}
+			if tc.expectedError == "" {
+				assertAllowedWithoutWarnings(t, dk)
+			} else {
+				assertDenied(t, []string{tc.expectedError}, dk)
+			}
+		})
+	}
+}
+
+func TestNoHostIdSourceArgument(t *testing.T) {
+	type oneAgentArgumentTest struct {
+		testName      string
+		dk            dynakube.DynaKube
+		expectedError string
+	}
+
+	testcases := []oneAgentArgumentTest{
+		{
+			testName: "host id source argument in cloud native full stack",
+			dk: dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+							HostInjectSpec: dynakube.HostInjectSpec{
+								Args: []string{
+									"--set-server=foo",
+									"--set-host-id-source=foo",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: errorHostIdSourceArgumentInCloudNative,
+		},
+		{
+			testName: "no host id source argument in cloud native full stack",
+			dk: dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						CloudNativeFullStack: &dynakube.CloudNativeFullStackSpec{
+							HostInjectSpec: dynakube.HostInjectSpec{
+								Args: []string{
+									"--set-server=foo",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			testName: "host id source argument in host monitoring stack",
+			dk: dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					OneAgent: dynakube.OneAgentSpec{
+						HostMonitoring: &dynakube.HostInjectSpec{
+							Args: []string{
+								"--set-server=foo",
+								"--set-host-id-source=foo",
+							},
+						},
+					},
+				},
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.testName, func(t *testing.T) {
+			if tc.expectedError == "" {
+				assertAllowedWithoutWarnings(t, &tc.dk)
+			} else {
+				assertDenied(t, []string{tc.expectedError}, &tc.dk)
+			}
+		})
+	}
+}

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -30,6 +30,8 @@ var (
 		isKSPMDisabled,
 		isOneAgentModuleDisabled,
 		isOneAgentVersionValid,
+		duplicateOneAgentArguments,
+		forbiddenHostIdSourceArgument,
 		NoApiUrl,
 		IsInvalidApiUrl,
 		IsThirdGenAPIUrl,


### PR DESCRIPTION
## Description

Makes sure that there are
* no duplicate arguments for OneAgent are allowed (except for `--set-host-property` and `--set-host-tag`
* no duplicate host-tags are allowed
* `--set-host-id-source` is not allowed for cloud native fullstack

### Webhook response samples
```
  oneAgent:
    cloudNativeFullStack:
      args:
      - --set-host-property=prop1
      - --set-host-property=prop2
      - --set-host-tag=tag1
      - --set-server=foo
      - --set-server=bar

Error from server (Forbidden): error when creating "cloudNativeFullStack-v1beta3.yaml": admission webhook "v1beta3.dynakube.webhook.dynatrace.com" denied the request:
1 error(s) found in the DynaKube
 1. --set-server has been provided multiple times. Only --set-host-property and --set-host-tag arguments may be provided multiple times.
```

```
  oneAgent:
    cloudNativeFullStack:
      args:
      - --set-host-property=prop1
      - --set-host-property=prop2
      - --set-host-tag=tag1
      - --set-host-id-source=fqdn

Error from server (Forbidden): error when creating "cloudNativeFullStack-v1beta3.yaml": admission webhook "v1beta3.dynakube.webhook.dynatrace.com" denied the request:
1 error(s) found in the DynaKube
 1. Setting --set-host-id-source in CloudNativFullstack mode is not allowed.
```

```
  oneAgent:
    cloudNativeFullStack:
      args:
      - --set-host-property=prop1
      - --set-host-property=prop2
      - --set-host-tag=tag1
      - --set-host-tag=tag1

The DynaKube "dynakube" is invalid: spec.oneAgent.cloudNativeFullStack.args[3]: Duplicate value: "--set-host-tag=tag1"
```

## How can this be tested?

Deploy Dynakubes that violate above conditions, they should be rejected

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-4488)