### PR TITLE
Fix resilience e2e test

### DIFF
--- a/test/features/cloudnative/network_problems/network_problems.go
+++ b/test/features/cloudnative/network_problems/network_problems.go
@@ -56,7 +56,7 @@ func ResilienceFeature(t *testing.T) features.Feature {
 		dynakube.WithApiUrl(secretConfig.ApiUrl),
 		dynakube.WithCloudNativeSpec(cloudnative.DefaultCloudNativeSpec()),
 		dynakube.WithAnnotations(map[string]string{
-			"feature.dynatrace.com/max-csi-mount-attempts": "2",
+			"feature.dynatrace.com/max-csi-mount-timeout": "1m",
 		}),
 	)
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

A new FF was introduced to configure the timeout.
The old feature-flag is only converted in case an actual conversion happens (from v1beta2 to v1beta3)

## How can this be tested?

`make test/e2e/cloudnative/resilience/`