### PR TITLE
follow up: rename SA for extensions to dynatrace-opentelemetry-collector

### DIFF
--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	serviceAccountName = "dynatrace-extensions-collector"
+	serviceAccountName = "dynatrace-opentelemetry-collector"
 )
 
 type Reconciler struct {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR follow up for this rename I made recently https://github.com/Dynatrace/dynatrace-operator/pull/4312.

Related to original story with rename of SA [DAQ-3329](https://dt-rnd.atlassian.net/browse/DAQ-3329)

## How can this be tested?

via e2e tests or just deploy dynakube with extensions:

```
make test/e2e/extensions
```

[DAQ-3329]: https://dt-rnd.atlassian.net/browse/DAQ-3329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ