### PR TITLE
misleading declaration of healthz port between server and liveness-probe

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -120,8 +120,6 @@ spec:
           timeoutSeconds: 4
         {{- end }}
         ports:
-        - containerPort: 9808
-          name: healthz
         - containerPort: 8080
           name: metrics
         resources:
@@ -246,6 +244,9 @@ spec:
         - --probe-timeout=4s
         command:
         - livenessprobe
+        ports:
+          - name: healthz
+            containerPort: 9808
         resources:
           {{- if .Values.csidriver.livenessprobe.resources }}
           {{- toYaml .Values.csidriver.livenessprobe.resources | nindent 10 }}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -193,8 +193,6 @@ tests:
                   timeoutSeconds: 4
                 name: server
                 ports:
-                  - containerPort: 9808
-                    name: healthz
                   - containerPort: 8080
                     name: metrics
                 resources:
@@ -339,6 +337,9 @@ tests:
                   - "--probe-timeout=4s"
                 command:
                   - livenessprobe
+                ports:
+                  - containerPort: 9808
+                    name: healthz
                 image: image-name
                 imagePullPolicy: Always
                 name: liveness-probe


### PR DESCRIPTION
## Description

This PR fixes bug [DAQ-4645](https://dt-rnd.atlassian.net/browse/DAQ-4645)

## How can this be tested?

1. helm unit tests
2. deploy dk with CSI driver enabled:
```
apiVersion: dynatrace.com/v1beta2
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://*****.dev.dynatracelabs.com/api
  oneAgent:
    applicationMonitoring:
      useCSIDriver: true
```

If you run, you will see that after this PR 

server **doesn't have** liveness probe port declaration
```
{
  "args": [
    "csi-server",
    "--endpoint=unix:/csi/csi.sock",
    "--node-id=$(KUBE_NODE_NAME)"
  ],
...
  "name": "server",
  "ports": [
    {
      "containerPort": 8080,
      "name": "metrics",
      "protocol": "TCP"
    }
  ],
...
}

```

and liveness-probe container has it:

```
k get pods dynatrace-oneagent-csi-driver-44888 -n dynatrace -o jsonpath='{.spec.
containers[3]}' | jq
{
  "args": [
    "--csi-address=/csi/csi.sock",
    "--health-port=9808",
    "--probe-timeout=4s"
  ],
  "command": [
    "livenessprobe"
  ],
  "image": "quay.io/dynatrace/dynatrace-operator:snapshot-misleading-declaration-healthz-port",
  "imagePullPolicy": "Always",
  "name": "liveness-probe",
  "ports": [
    {
      "containerPort": 9808,
      "name": "healthz",
      "protocol": "TCP"
    }
  ],
```

[DAQ-4645]: https://dt-rnd.atlassian.net/browse/DAQ-4645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ