### PR TITLE
Revert "misleading declaration of healthz port between server and liveness-probe"

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -120,6 +120,8 @@ spec:
           timeoutSeconds: 4
         {{- end }}
         ports:
+        - containerPort: 9808
+          name: healthz
         - containerPort: 8080
           name: metrics
         resources:
@@ -244,9 +246,6 @@ spec:
         - --probe-timeout=4s
         command:
         - livenessprobe
-        ports:
-          - name: healthz
-            containerPort: 9808
         resources:
           {{- if .Values.csidriver.livenessprobe.resources }}
           {{- toYaml .Values.csidriver.livenessprobe.resources | nindent 10 }}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -193,6 +193,8 @@ tests:
                   timeoutSeconds: 4
                 name: server
                 ports:
+                  - containerPort: 9808
+                    name: healthz
                   - containerPort: 8080
                     name: metrics
                 resources:
@@ -337,9 +339,6 @@ tests:
                   - "--probe-timeout=4s"
                 command:
                   - livenessprobe
-                ports:
-                  - containerPort: 9808
-                    name: healthz
                 image: image-name
                 imagePullPolicy: Always
                 name: liveness-probe


### PR DESCRIPTION
Reverts Dynatrace/dynatrace-operator#4390

Because the original version was correct, otherwise 

k8s will assign random port:

`k describe pod dynatrace-oneagent-csi-driver-rjtxf`
>Liveness:  http-get http://:**15020**/app-health/server/livez delay=5s timeout=4s period=5s #success=1 #failure=5