### PR TITLE
Mount telemetryService.TlsRefName secret to OtelC POD

### DIFF
--- a/pkg/api/consts.go
+++ b/pkg/api/consts.go
@@ -1,8 +1,9 @@
 package api
 
 const (
-	LatestTag            = "latest"
-	RawTag               = "raw"
-	InternalFlagPrefix   = "internal.operator.dynatrace.com/"
-	AnnotationSecretHash = InternalFlagPrefix + "secret-hash"
+	LatestTag                            = "latest"
+	RawTag                               = "raw"
+	InternalFlagPrefix                   = "internal.operator.dynatrace.com/"
+	AnnotationSecretHash                 = InternalFlagPrefix + "secret-hash"
+	AnnotationTelemetryServiceSecretHash = InternalFlagPrefix + "ts-secret-hash"
 )

--- a/pkg/api/consts.go
+++ b/pkg/api/consts.go
@@ -1,9 +1,8 @@
 package api
 
 const (
-	LatestTag                            = "latest"
-	RawTag                               = "raw"
-	InternalFlagPrefix                   = "internal.operator.dynatrace.com/"
-	AnnotationExtensionsSecretHash       = InternalFlagPrefix + "extensions-secret-hash"
-	AnnotationTelemetryServiceSecretHash = InternalFlagPrefix + "telemetry-service-secret-hash"
+	LatestTag                      = "latest"
+	RawTag                         = "raw"
+	InternalFlagPrefix             = "internal.operator.dynatrace.com/"
+	AnnotationExtensionsSecretHash = InternalFlagPrefix + "extensions-secret-hash"
 )

--- a/pkg/api/consts.go
+++ b/pkg/api/consts.go
@@ -4,6 +4,6 @@ const (
 	LatestTag                            = "latest"
 	RawTag                               = "raw"
 	InternalFlagPrefix                   = "internal.operator.dynatrace.com/"
-	AnnotationSecretHash                 = InternalFlagPrefix + "secret-hash"
-	AnnotationTelemetryServiceSecretHash = InternalFlagPrefix + "ts-secret-hash"
+	AnnotationExtensionsSecretHash       = InternalFlagPrefix + "extensions-secret-hash"
+	AnnotationTelemetryServiceSecretHash = InternalFlagPrefix + "telemetry-service-secret-hash"
 )

--- a/pkg/controllers/dynakube/extension/eec/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler_test.go
@@ -180,7 +180,7 @@ func TestSecretHashAnnotation(t *testing.T) {
 		statefulSet := getStatefulset(t, dk)
 
 		require.Len(t, statefulSet.Spec.Template.Annotations, 1)
-		assert.NotEmpty(t, statefulSet.Spec.Template.Annotations[api.AnnotationSecretHash])
+		assert.NotEmpty(t, statefulSet.Spec.Template.Annotations[api.AnnotationExtensionsSecretHash])
 	})
 	t.Run("annotation is set with tlsRefName", func(t *testing.T) {
 		dk := getTestDynakube()
@@ -188,7 +188,7 @@ func TestSecretHashAnnotation(t *testing.T) {
 		statefulSet := getStatefulset(t, dk)
 
 		require.Len(t, statefulSet.Spec.Template.Annotations, 1)
-		assert.NotEmpty(t, statefulSet.Spec.Template.Annotations[api.AnnotationSecretHash])
+		assert.NotEmpty(t, statefulSet.Spec.Template.Annotations[api.AnnotationExtensionsSecretHash])
 	})
 	t.Run("annotation is updated when TLS Secret gets updated", func(t *testing.T) {
 		statefulSet := &appsv1.StatefulSet{}
@@ -205,7 +205,7 @@ func TestSecretHashAnnotation(t *testing.T) {
 		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.ExtensionsExecutionControllerStatefulsetName(), Namespace: dk.Namespace}, statefulSet)
 		require.NoError(t, err)
 
-		originalSecretHash := statefulSet.Spec.Template.Annotations[api.AnnotationSecretHash]
+		originalSecretHash := statefulSet.Spec.Template.Annotations[api.AnnotationExtensionsSecretHash]
 
 		// then update the TLS Secret and call reconcile again
 		updatedTLSSecret := getTLSSecret(dk.ExtensionsTLSSecretName(), dk.Namespace, "updated-cert", "updated-key")
@@ -217,7 +217,7 @@ func TestSecretHashAnnotation(t *testing.T) {
 		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.ExtensionsExecutionControllerStatefulsetName(), Namespace: dk.Namespace}, statefulSet)
 		require.NoError(t, err)
 
-		resultingSecretHash := statefulSet.Spec.Template.Annotations[api.AnnotationSecretHash]
+		resultingSecretHash := statefulSet.Spec.Template.Annotations[api.AnnotationExtensionsSecretHash]
 
 		// original hash and resulting hash should be different, value got updated on reconcile
 		assert.NotEqual(t, originalSecretHash, resultingSecretHash)
@@ -548,7 +548,7 @@ func TestAnnotations(t *testing.T) {
 
 		assert.Len(t, statefulSet.ObjectMeta.Annotations, 2)
 		require.Len(t, statefulSet.Spec.Template.ObjectMeta.Annotations, 1)
-		assert.NotEmpty(t, statefulSet.Spec.Template.ObjectMeta.Annotations[api.AnnotationSecretHash])
+		assert.NotEmpty(t, statefulSet.Spec.Template.ObjectMeta.Annotations[api.AnnotationExtensionsSecretHash])
 	})
 
 	t.Run("custom annotations", func(t *testing.T) {
@@ -564,7 +564,7 @@ func TestAnnotations(t *testing.T) {
 		assert.Empty(t, statefulSet.ObjectMeta.Annotations["a"])
 		require.Len(t, statefulSet.Spec.Template.ObjectMeta.Annotations, 2)
 		assert.Equal(t, "b", statefulSet.Spec.Template.ObjectMeta.Annotations["a"])
-		assert.NotEmpty(t, statefulSet.Spec.Template.ObjectMeta.Annotations[api.AnnotationSecretHash])
+		assert.NotEmpty(t, statefulSet.Spec.Template.ObjectMeta.Annotations[api.AnnotationExtensionsSecretHash])
 	})
 }
 

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -152,7 +152,7 @@ func (r *reconciler) buildTemplateAnnotations(ctx context.Context) (map[string]s
 		return nil, err
 	}
 
-	templateAnnotations[api.AnnotationSecretHash] = tlsSecretHash
+	templateAnnotations[api.AnnotationExtensionsSecretHash] = tlsSecretHash
 
 	return templateAnnotations, nil
 }

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	serviceAccountName = "dynatrace-opentelemetry-collector"
+	serviceAccountName                   = "dynatrace-opentelemetry-collector"
+	annotationTelemetryServiceSecretHash = api.InternalFlagPrefix + "telemetry-service-secret-hash"
 )
 
 type Reconciler struct {
@@ -140,7 +141,7 @@ func (r *Reconciler) buildTemplateAnnotations(ctx context.Context) (map[string]s
 			return nil, err
 		}
 
-		templateAnnotations[api.AnnotationTelemetryServiceSecretHash] = tlsSecretHash
+		templateAnnotations[annotationTelemetryServiceSecretHash] = tlsSecretHash
 	}
 
 	return templateAnnotations, nil

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -132,7 +132,7 @@ func (r *Reconciler) buildTemplateAnnotations(ctx context.Context) (map[string]s
 		return nil, err
 	}
 
-	templateAnnotations[api.AnnotationSecretHash] = tlsSecretHash
+	templateAnnotations[api.AnnotationExtensionsSecretHash] = tlsSecretHash
 
 	if r.dk.TelemetryService().IsEnabled() && r.dk.TelemetryService().Spec.TlsRefName != "" {
 		tlsSecretHash, err = r.calculateSecretHash(ctx, r.dk.TelemetryService().Spec.TlsRefName)

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/telemetryservice"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/node"
@@ -27,9 +28,10 @@ import (
 )
 
 const (
-	testDynakubeName   = "dynakube"
-	testNamespaceName  = "dynatrace"
-	testOtelPullSecret = "otelc-pull-secret"
+	testDynakubeName           = "dynakube"
+	testNamespaceName          = "dynatrace"
+	testOtelPullSecret         = "otelc-pull-secret"
+	testTelemetryServiceSecret = "test-ts-secret"
 )
 
 func TestReconcile(t *testing.T) {
@@ -503,6 +505,45 @@ func TestVolumes(t *testing.T) {
 
 		assert.Contains(t, statefulSet.Spec.Template.Spec.Volumes, expectedVolume)
 	})
+
+	t.Run("volumes and volume mounts with telemetry service custom TLS certificate", func(t *testing.T) {
+		dk := getTestDynakube()
+		dk.Spec.TelemetryService = &telemetryservice.Spec{
+			TlsRefName: testTelemetryServiceSecret,
+		}
+
+		tlsSecret := getTLSSecret(dk.TelemetryService().Spec.TlsRefName, dk.Namespace, "crt", "key")
+		statefulSet := getStatefulset(t, dk, &tlsSecret)
+
+		expectedVolume := corev1.Volume{
+			Name: customTlsCertVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: dk.TelemetryService().Spec.TlsRefName,
+					Items: []corev1.KeyToPath{
+						{
+							Key:  consts.TLSCrtDataName,
+							Path: consts.TLSCrtDataName,
+						},
+						{
+							Key:  consts.TLSKeyDataName,
+							Path: consts.TLSKeyDataName,
+						},
+					},
+				},
+			},
+		}
+
+		assert.Contains(t, statefulSet.Spec.Template.Spec.Volumes, expectedVolume)
+
+		expectedVolumeMount := corev1.VolumeMount{
+			Name:      customTlsCertVolumeName,
+			MountPath: customTlsCertMountPath,
+			ReadOnly:  true,
+		}
+
+		assert.Contains(t, statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, expectedVolumeMount)
+	})
 }
 
 func getTestDynakube() *dynakube.DynaKube {
@@ -519,9 +560,14 @@ func getTestDynakube() *dynakube.DynaKube {
 	}
 }
 
-func getStatefulset(t *testing.T, dk *dynakube.DynaKube) *appsv1.StatefulSet {
+func getStatefulset(t *testing.T, dk *dynakube.DynaKube, objs ...client.Object) *appsv1.StatefulSet {
 	mockK8sClient := fake.NewClient(dk)
 	mockK8sClient = mockTLSSecret(t, mockK8sClient, dk)
+
+	for _, obj := range objs {
+		err := mockK8sClient.Create(context.Background(), obj)
+		require.NoError(t, err)
+	}
 
 	err := NewReconciler(mockK8sClient, mockK8sClient, dk).Reconcile(context.Background())
 	require.NoError(t, err)

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
@@ -100,7 +100,7 @@ func TestSecretHashAnnotation(t *testing.T) {
 		statefulSet := getStatefulset(t, dk)
 
 		require.Len(t, statefulSet.Spec.Template.Annotations, 1)
-		assert.NotEmpty(t, statefulSet.Spec.Template.Annotations[api.AnnotationSecretHash])
+		assert.NotEmpty(t, statefulSet.Spec.Template.Annotations[api.AnnotationExtensionsSecretHash])
 	})
 	t.Run("annotation is set with tlsRefName", func(t *testing.T) {
 		dk := getTestDynakube()
@@ -108,7 +108,7 @@ func TestSecretHashAnnotation(t *testing.T) {
 		statefulSet := getStatefulset(t, dk)
 
 		require.Len(t, statefulSet.Spec.Template.Annotations, 1)
-		assert.NotEmpty(t, statefulSet.Spec.Template.Annotations[api.AnnotationSecretHash])
+		assert.NotEmpty(t, statefulSet.Spec.Template.Annotations[api.AnnotationExtensionsSecretHash])
 	})
 	t.Run("annotation is updated when TLS Secret gets updated", func(t *testing.T) {
 		statefulSet := &appsv1.StatefulSet{}
@@ -125,7 +125,7 @@ func TestSecretHashAnnotation(t *testing.T) {
 		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.ExtensionsCollectorStatefulsetName(), Namespace: dk.Namespace}, statefulSet)
 		require.NoError(t, err)
 
-		originalSecretHash := statefulSet.Spec.Template.Annotations[api.AnnotationSecretHash]
+		originalSecretHash := statefulSet.Spec.Template.Annotations[api.AnnotationExtensionsSecretHash]
 
 		// then update the TLS Secret and call reconcile again
 		updatedTLSSecret := getTLSSecret(dk.ExtensionsTLSSecretName(), dk.Namespace, "updated-cert", "updated-key")
@@ -137,7 +137,7 @@ func TestSecretHashAnnotation(t *testing.T) {
 		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.ExtensionsCollectorStatefulsetName(), Namespace: dk.Namespace}, statefulSet)
 		require.NoError(t, err)
 
-		resultingSecretHash := statefulSet.Spec.Template.Annotations[api.AnnotationSecretHash]
+		resultingSecretHash := statefulSet.Spec.Template.Annotations[api.AnnotationExtensionsSecretHash]
 
 		// original hash and resulting hash should be different, value got updated on reconcile
 		assert.NotEqual(t, originalSecretHash, resultingSecretHash)
@@ -344,7 +344,7 @@ func TestAnnotations(t *testing.T) {
 
 		assert.Len(t, statefulSet.ObjectMeta.Annotations, 1)
 		require.Len(t, statefulSet.Spec.Template.ObjectMeta.Annotations, 1)
-		assert.NotEmpty(t, statefulSet.Spec.Template.ObjectMeta.Annotations[api.AnnotationSecretHash])
+		assert.NotEmpty(t, statefulSet.Spec.Template.ObjectMeta.Annotations[api.AnnotationExtensionsSecretHash])
 	})
 
 	t.Run("custom annotations", func(t *testing.T) {
@@ -360,7 +360,7 @@ func TestAnnotations(t *testing.T) {
 		assert.Empty(t, statefulSet.ObjectMeta.Annotations["a"])
 		require.Len(t, statefulSet.Spec.Template.ObjectMeta.Annotations, 2)
 		assert.Equal(t, "b", statefulSet.Spec.Template.ObjectMeta.Annotations["a"])
-		assert.NotEmpty(t, statefulSet.Spec.Template.ObjectMeta.Annotations[api.AnnotationSecretHash])
+		assert.NotEmpty(t, statefulSet.Spec.Template.ObjectMeta.Annotations[api.AnnotationExtensionsSecretHash])
 	})
 }
 


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-3223)

## Description

Mounts TLS secret to OtelC POD. 

`extensions-collector` POD is restarted if the secret is changed (added `ts-secret-hash` template annotation).

## How can this be tested?

1) unittests
2) dynakube

create secret
```
openssl req -nodes -x509 -newkey rsa:4096 -keyout key.pem -out crt.pem -days 5 -subj "/CN=test"
kctl create secret tls ts --cert=crt.pem --key=key.pem
```
deploy dynakube
```
  apiUrl: ...
  activeGate:
    capabilities:
    - kubernetes-monitoring
  extensions: {}
  customPullSecret: ...
  telemetryService:
    tlsRefName: ts
  templates:
    extensionExecutionController:
      imageRef:
        repository: ...
        tag: ...
```        
check `dynakube-extensions-collector-0` spec.volumes