### PR TITLE
Add `/var/log` mount to log agent

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
@@ -77,7 +77,7 @@ func getDTVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: dtLibVolumePath,
-					Type: ptr.To(corev1.HostPathDirectory),
+					Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 				},
 			},
 		},
@@ -104,6 +104,11 @@ func getIngestVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      containerLogsVolumeName,
 			MountPath: containerLogsVolumePath,
+			ReadOnly:  true,
+		},
+		{
+			Name:      journalLogsVolumeName,
+			MountPath: journalLogsVolumePath,
 			ReadOnly:  true,
 		},
 	}
@@ -139,23 +144,6 @@ func getIngestVolumes() []corev1.Volume {
 				},
 			},
 		},
-	}
-}
-
-// getIngestVolumeMounts provides the VolumeMounts for the log folders that will be ingested by the logmonitoring
-func getJournalLogsVolumeMounts() []corev1.VolumeMount {
-	return []corev1.VolumeMount{
-		{
-			Name:      journalLogsVolumeName,
-			MountPath: journalLogsVolumePath,
-			ReadOnly:  true,
-		},
-	}
-}
-
-// getIngestVolumeMounts provides the VolumeMounts for the log folders that will be ingested by the logmonitoring
-func getJournalLogsVolumes() []corev1.Volume {
-	return []corev1.Volume{
 		{
 			Name: journalLogsVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -173,7 +161,6 @@ func getVolumeMounts(tenantUUID string) []corev1.VolumeMount {
 	mounts = append(mounts, getConfigVolumeMount())
 	mounts = append(mounts, getDTVolumeMounts(tenantUUID)...)
 	mounts = append(mounts, getIngestVolumeMounts()...)
-	mounts = append(mounts, getJournalLogsVolumeMounts()...)
 
 	return mounts
 }
@@ -183,7 +170,6 @@ func getVolumes(dkName string) []corev1.Volume {
 	volumes = append(volumes, getConfigVolume(dkName))
 	volumes = append(volumes, getDTVolumes()...)
 	volumes = append(volumes, getIngestVolumes()...)
-	volumes = append(volumes, getJournalLogsVolumes()...)
 
 	return volumes
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	expectedMountLen     = 6
+	expectedMountLen     = 7
 	expectedInitMountLen = 2
 )
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

With this PR we add a new mount to `/var/log` to the `logAgent`. Also other mounts' type got changed to `Directory` as we do not want to create a directory if it does not exist on host filesystem.

[Ticket](https://dt-rnd.atlassian.net/browse/DAQ-4838)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Deploy logAgent and have a look at the `volumes` and the `volumeMounts`

Should look like this:

```
volumeMounts:
- mountPath: /var/log/journal
  name: var-log-journal
  readOnly: true
...
volumes:
- name: var-log-journal
  hostPath:
    path: /var/log
    type: Directory
```

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->