### PR TITLE
Change readonly oneAgent + custom image validation to a warning

### DIFF
--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -24,7 +24,7 @@ Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 
 	errorVolumeStorageReadOnlyModeConflict = `The DynaKube specification specifies a read-only host file system while OneAgent has volume storage enabled.`
 
-	errorPublicImageWithWrongConfig = `The DynaKube specification specifies a custom (and therefor probably a public) image in combination with a mode that needs write permissions for volume mounts.`
+	warningPublicImageWithWrongConfig = `Custom OneAgent image is only supported when CSI Driver is used.`
 
 	warningOneAgentInstallerEnvVars = `The environment variables ONEAGENT_INSTALLER_SCRIPT_URL and ONEAGENT_INSTALLER_TOKEN are only relevant for an unsupported image type. Please ensure you are using a supported image.`
 
@@ -127,7 +127,7 @@ func mapKeysToString(m map[string]bool, sep string) string {
 
 func publicImageSetWithoutReadOnlyMode(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
 	if !dk.UseReadOnlyOneAgents() && dk.CustomOneAgentImage() != "" {
-		return errorPublicImageWithWrongConfig
+		return warningPublicImageWithWrongConfig
 	}
 
 	return ""

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -492,9 +492,9 @@ func TestIsOneAgentVersionValid(t *testing.T) {
 }
 
 func TestPublicImageSetWithReadOnlyMode(t *testing.T) {
-	t.Run("reject dk with hostMon without csi and custom image", func(t *testing.T) {
+	t.Run("allow with warning dk with hostMon without csi and custom image", func(t *testing.T) {
 		setupDisabledCSIEnv(t)
-		assertDenied(t, []string{errorPublicImageWithWrongConfig},
+		assertAllowedWithWarnings(t, 1,
 			&dynakube.DynaKube{
 				ObjectMeta: defaultDynakubeObjectMeta,
 				Spec: dynakube.DynaKubeSpec{

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -57,7 +57,6 @@ var (
 		missingLogMonitoringImage,
 		logMonitoringWithoutK8SMonitoring,
 		extensionsWithoutK8SMonitoring,
-		publicImageSetWithoutReadOnlyMode,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,
@@ -66,6 +65,7 @@ var (
 		deprecatedFeatureFlag,
 		ignoredLogMonitoringTemplate,
 		conflictingApiUrlForExtensions,
+		publicImageSetWithoutReadOnlyMode,
 	}
 	updateValidatorErrorFuncs = []updateValidatorFunc{
 		IsMutatedApiUrl,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

In #4346 we implemented a validation that rejected `dynakubes` that have configured a custom image and a mode that uses `readOnly` `oneAgents`. After some discussion we came to the conclusion that an error is too harsh and now we only give a warning.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Same as in #4346 with the difference that now the `dk` should not be rejected but allowed with a warning.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->