### PR TITLE
update e2e tests ondemand according to available clusters

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -23,8 +23,6 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - version: 1-25
-            platform: k8s
           - version: 1-26
             platform: k8s
           - version: 1-27
@@ -34,6 +32,8 @@ jobs:
           - version: 1-29
             platform: k8s
           - version: 1-30
+            platform: k8s
+          - version: 1-31
             platform: k8s
           - version: 4-10
             platform: ocp
@@ -48,6 +48,8 @@ jobs:
           - version: 4-15
             platform: ocp
           - version: 4-16
+            platform: ocp
+          - version: 4-17
             platform: ocp
     environment: E2E
     runs-on:


### PR DESCRIPTION
## Description

```
➜  ~ kubectl get flcenvironments --namespace dto-ocp-ondemand
NAME           PLATFORM   PLATFORMVERSION   TENANT   ENVIRONMENTSTATE
dto-ocp-4-10   ocp4       4.10              none     environment-not-deployed
dto-ocp-4-11   ocp4       4.11              none     environment-not-deployed
dto-ocp-4-12   ocp4       4.12              none     environment-not-deployed
dto-ocp-4-13   ocp4       4.13              none     environment-not-deployed
dto-ocp-4-14   ocp4       4.14              none     environment-not-deployed
dto-ocp-4-15   ocp4       4.15              none     environment-not-deployed
dto-ocp-4-16   ocp4       4.16              none     environment-not-deployed
dto-ocp-4-17   ocp4       4.17              none     environment-not-deployed


➜  ~ kubectl get flcenvironments --namespace dto-k8s-ondemand
NAME           PLATFORM   PLATFORMVERSION   TENANT   ENVIRONMENTSTATE
dto-k8s-1-26   k8s        1.26              none     environment-not-deployed
dto-k8s-1-27   k8s        1.27              none     environment-not-deployed
dto-k8s-1-28   k8s        1.28              none     environment-not-deployed
dto-k8s-1-29   k8s        1.29              none     environment-not-deployed
dto-k8s-1-30   k8s        1.30              none     environment-not-deployed
dto-k8s-1-31   k8s        1.31              none     environment-not-deployed
```

## How can this be tested?

