### PR TITLE
Remove hard-coded command from CodeModule download jobs

### DIFF
--- a/pkg/injection/codemodule/installer/job/bootstrapper.go
+++ b/pkg/injection/codemodule/installer/job/bootstrapper.go
@@ -14,9 +14,7 @@ import (
 const (
 	namePrefix = "codemodule-download-"
 
-	volumeName = "dynatrace-codemodules"
-
-	bootstrapCommand = "/opt/dynatrace/bin/bootstrap"
+	volumeName       = "dynatrace-codemodules"
 	codeModuleSource = "/opt/dynatrace/oneagent"
 )
 
@@ -40,7 +38,6 @@ func (inst *Installer) buildJob(name, targetDir string) (*batchv1.Job, error) {
 		Name:            "codemodule-download",
 		Image:           inst.props.ImageUri,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{bootstrapCommand},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      volumeName,

--- a/pkg/injection/codemodule/installer/job/bootstrapper_test.go
+++ b/pkg/injection/codemodule/installer/job/bootstrapper_test.go
@@ -124,7 +124,7 @@ func TestBuildJob(t *testing.T) {
 		container := job.Spec.Template.Spec.Containers[0]
 
 		assert.Equal(t, imageURI, container.Image)
-		assert.Contains(t, container.Command, bootstrapCommand)
+		assert.Empty(t, container.Command)
 		assert.NotEmpty(t, container.Args)
 		assert.NotEmpty(t, container.SecurityContext)
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

These images are expected to have an ENTRYPOINT defined, so we should use it, and decouple us from the internal structure of the image.

## How can this be tested?

[Same as original PR](https://github.com/Dynatrace/dynatrace-operator/pull/4392), BUT
- Use the image created for the [related PR](https://github.com/Dynatrace/dynatrace-bootstrapper/pull/6)
  - `codeModulesImage: quay.io/dynatrace/dynatrace-bootstrapper:snapshot-testing-add-entrypoint`