### PR TITLE
Follow naming pattern of previous feature-flags for Job feature-flag

### DIFF
--- a/doc/api/feature-flags.md
+++ b/doc/api/feature-flags.md
@@ -57,7 +57,7 @@ const (
     AnnotationFeatureMaxFailedCsiMountAttempts = AnnotationFeaturePrefix + "max-csi-mount-attempts"
     AnnotationFeatureMaxCsiMountTimeout        = AnnotationFeaturePrefix + "max-csi-mount-timeout"
     AnnotationFeatureReadOnlyCsiVolume         = AnnotationFeaturePrefix + "injection-readonly-volume"
-    AnnotationFeatureDownloadViaJob            = AnnotationFeatureCodeModulesPrefix + "remoteImageDownload"
+    AnnotationFeatureDownloadViaJob            = AnnotationFeatureCodeModulesPrefix + "remote-image-download"
 )
 ```
 

--- a/pkg/api/v1beta3/dynakube/feature_flags.go
+++ b/pkg/api/v1beta3/dynakube/feature_flags.go
@@ -73,7 +73,7 @@ const (
 	AnnotationFeatureMaxFailedCsiMountAttempts = AnnotationFeaturePrefix + "max-csi-mount-attempts"
 	AnnotationFeatureMaxCsiMountTimeout        = AnnotationFeaturePrefix + "max-csi-mount-timeout"
 	AnnotationFeatureReadOnlyCsiVolume         = AnnotationFeaturePrefix + "injection-readonly-volume"
-	AnnotationFeatureDownloadViaJob            = AnnotationFeatureCodeModulesPrefix + "remoteImageDownload"
+	AnnotationFeatureDownloadViaJob            = AnnotationFeatureCodeModulesPrefix + "remote-image-download"
 
 	falsePhrase  = "false"
 	truePhrase   = "true"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

All other feature-flags we use are use `-` instead of camelCase.

## How can this be tested?

[Same as original PR](https://github.com/Dynatrace/dynatrace-operator/pull/4392), BUT
- Use the renamed FF: `codemodules.oneagent.dynatrace.com/remote-image-download: true`