### PR TITLE
Fix volume path and name to use correct one

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
@@ -22,15 +22,14 @@ const (
 	dtLogVolumeMountPath = "/var/log/dynatrace"
 
 	// for the logs that the logmonitoring will ingest
-	podLogsVolumeName         = "var-log-pods"
-	podLogsVolumePath         = "/var/log/pods"
-	dockerLogsVolumeName      = "docker-container-logs"
-	dockerLogsVolumePath      = "/var/lib/docker/containers"
-	containerLogsVolumeName   = "container-logs"
-	containerLogsVolumePath   = "/var/log/containers"
-	journalLogsVolumeName     = "var-log-journal"
-	journalLogsVolumePath     = "/var/log/journal"
-	journalLogsVolumeHostPath = "/var/log"
+	podLogsVolumeName       = "var-log-pods"
+	podLogsVolumePath       = "/var/log/pods"
+	dockerLogsVolumeName    = "docker-container-logs"
+	dockerLogsVolumePath    = "/var/lib/docker/containers"
+	containerLogsVolumeName = "container-logs"
+	containerLogsVolumePath = "/var/log/containers"
+	journalLogsVolumeName   = "var-log"
+	journalLogsVolumePath   = "/var/log"
 )
 
 // getConfigVolumeMount provides the VolumeMount for the deployment.conf
@@ -148,7 +147,7 @@ func getIngestVolumes() []corev1.Volume {
 			Name: journalLogsVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: journalLogsVolumeHostPath,
+					Path: journalLogsVolumePath,
 					Type: ptr.To(corev1.HostPathDirectory),
 				},
 			},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This corrects the volume name and path introduced in  #4413 to `var-log` and `/var/log` respectively.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Same as in  #4413

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->