### PR TITLE
Remove obsolete logAgent mounts under `var/log/` (release-1.4)

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
@@ -94,7 +94,6 @@ func getIngestVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      varLogsVolumeName,
 			MountPath: varLogsVolumePath,
-			ReadOnly:  true,
 		},
 	}
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
@@ -22,14 +22,10 @@ const (
 	dtLogVolumeMountPath = "/var/log/dynatrace"
 
 	// for the logs that the logmonitoring will ingest
-	podLogsVolumeName       = "var-log-pods"
-	podLogsVolumePath       = "/var/log/pods"
-	dockerLogsVolumeName    = "docker-container-logs"
-	dockerLogsVolumePath    = "/var/lib/docker/containers"
-	containerLogsVolumeName = "container-logs"
-	containerLogsVolumePath = "/var/log/containers"
-	journalLogsVolumeName   = "var-log"
-	journalLogsVolumePath   = "/var/log"
+	dockerLogsVolumeName = "docker-container-logs"
+	dockerLogsVolumePath = "/var/lib/docker/containers"
+	varLogsVolumeName    = "var-log"
+	varLogsVolumePath    = "/var/log"
 )
 
 // getConfigVolumeMount provides the VolumeMount for the deployment.conf
@@ -96,18 +92,8 @@ func getIngestVolumeMounts() []corev1.VolumeMount {
 			ReadOnly:  true,
 		},
 		{
-			Name:      podLogsVolumeName,
-			MountPath: podLogsVolumePath,
-			ReadOnly:  true,
-		},
-		{
-			Name:      containerLogsVolumeName,
-			MountPath: containerLogsVolumePath,
-			ReadOnly:  true,
-		},
-		{
-			Name:      journalLogsVolumeName,
-			MountPath: journalLogsVolumePath,
+			Name:      varLogsVolumeName,
+			MountPath: varLogsVolumePath,
 			ReadOnly:  true,
 		},
 	}
@@ -126,28 +112,10 @@ func getIngestVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: podLogsVolumeName,
+			Name: varLogsVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: podLogsVolumePath,
-					Type: ptr.To(corev1.HostPathDirectory),
-				},
-			},
-		},
-		{
-			Name: containerLogsVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: containerLogsVolumePath,
-					Type: ptr.To(corev1.HostPathDirectory),
-				},
-			},
-		},
-		{
-			Name: journalLogsVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: journalLogsVolumePath,
+					Path: varLogsVolumePath,
 					Type: ptr.To(corev1.HostPathDirectory),
 				},
 			},

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	expectedMountLen     = 7
+	expectedMountLen     = 5
 	expectedInitMountLen = 2
 )
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Fix #4431 as there are some volume mounts that are obsolete, as we have a mount at the parent directory `var/log/`  

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

same as in #4431

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->