### PR TITLE
Make the `/var/log` volumeMount not readOnly

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
@@ -94,7 +94,6 @@ func getIngestVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      varLogsVolumeName,
 			MountPath: varLogsVolumePath,
-			ReadOnly:  true,
 		},
 	}
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

~Fixes the conflict between the readOnly `/var/log` and the emptyDir `/var/log/dynatrace`, by making `/var/log/dynatrace` be mounted from the `/tmp/dyntrace` hostMount using a `subPath`.~

~So on the host FS `/tmp/dynatrace` will look like:~
~- `/tmp/dynatrace/logmonitoring-<tenant>`: we already had this, this translates to `/var/lib/dynatrace`~
~- `/tmp/dynatrace/logmonitoring-logs-<tenant>`: this is now the "new" `/var/log/dynatrace`~

The above mentioned solution doesn't work, it only worked during my initial tests, because folders/mounts were already created by previous fix attempts on the host, and my guess these were reused during my testing.
However when you try it on a "fresh" host FS it will fail the same way as if we were using an `emptyDir`

So now are going to mount the `/var/log` as NOT `readOnly`, and improve this in the future.

## How can this be tested?

When deploying standalone logmonitoring:

Expected `volumeMounts`:
```yaml
    volumeMounts:
    - mountPath: /var/lib/dynatrace/oneagent/agent/config/deployment.conf
      name: config
      subPath: deployment.conf
    - mountPath: /var/lib/dynatrace
      name: dynatrace-lib
      subPath: logmonitoring-<my-tenant>
    - mountPath: /var/log/dynatrace
      name: dynatrace-logs
    - mountPath: /var/lib/docker/containers
      name: docker-container-logs
      readOnly: true
    - mountPath: /var/log
      name: var-log
```

Expected `volumes`:
```yaml
 - name: config
    secret:
      defaultMode: 420
      secretName: <my-dk>-logmonitoring-config
  - hostPath:
      path: /tmp/dynatrace
      type: DirectoryOrCreate
    name: dynatrace-lib
  - emptyDir: {}
    name: dynatrace-logs
  - hostPath:
      path: /var/lib/docker/containers
      type: Directory
    name: docker-container-logs
  - hostPath:
      path: /var/log
      type: Directory
    name: var-log
```
