### PR TITLE
add back ability to trigger ondemand on latest release branch

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -1,6 +1,7 @@
 name: E2E tests ondemand
 
 on:
+  workflow_dispatch:
   schedule:
     # At 03:00 UTC on Monday, Wednesday, and Friday.
     - cron: 0 3 * * 1,3,5


### PR DESCRIPTION
## Description

Return back the ability to trigger the on-demand pipeline from GH ui.

## How can this be tested?

the button is back.