### PR TITLE
Creates AG TLS certificate (pem) if trustedCAs are used and tlsSecretName is empty

### DIFF
--- a/doc/api/feature-flags.md
+++ b/doc/api/feature-flags.md
@@ -35,7 +35,12 @@ const (
     AnnotationFeatureAutomaticK8sApiMonitoringClusterName = AnnotationFeaturePrefix + "automatic-kubernetes-api-monitoring-cluster-name"
     AnnotationFeatureK8sAppEnabled                        = AnnotationFeaturePrefix + "k8s-app-enabled"
 
+    AnnotationFeatureActiveGateAutomaticTLSCertificate = AnnotationFeaturePrefix + "automatic-tls-certificate"
+
     AnnotationFeatureNoProxy = AnnotationFeaturePrefix + "no-proxy"
+
+    AnnotationFeatureOneAgnetIgnoreAgTlsCertificate = AnnotationFeaturePrefix + "oneagent-ignore-ag-tls-certificate"
+    AnnotationFeatureOneAgnetIgnoreTrustedCAs       = AnnotationFeaturePrefix + "oneagent-ignore-trusted-cas"
 
     // Deprecated: AnnotationFeatureOneAgentIgnoreProxy use AnnotationFeatureNoProxy instead.
     AnnotationFeatureOneAgentIgnoreProxy = AnnotationFeaturePrefix + "oneagent-ignore-proxy"
@@ -74,7 +79,7 @@ const (
 
 <a name="MountAttemptsToTimeout"></a>
 
-## func [MountAttemptsToTimeout](<https://github.com/Dynatrace/dynatrace-operator/blob/main/pkg/api/v1beta3/dynakube/tmp/feature_flags.go#L261>)
+## func [MountAttemptsToTimeout](<https://github.com/Dynatrace/dynatrace-operator/blob/main/pkg/api/v1beta3/dynakube/tmp/feature_flags.go#L271>)
 
 ```go
 func MountAttemptsToTimeout(maxAttempts int) string

--- a/doc/api/feature-flags.md
+++ b/doc/api/feature-flags.md
@@ -39,9 +39,6 @@ const (
 
     AnnotationFeatureNoProxy = AnnotationFeaturePrefix + "no-proxy"
 
-    AnnotationFeatureOneAgnetIgnoreAgTlsCertificate = AnnotationFeaturePrefix + "oneagent-ignore-ag-tls-certificate"
-    AnnotationFeatureOneAgnetIgnoreTrustedCAs       = AnnotationFeaturePrefix + "oneagent-ignore-trusted-cas"
-
     // Deprecated: AnnotationFeatureOneAgentIgnoreProxy use AnnotationFeatureNoProxy instead.
     AnnotationFeatureOneAgentIgnoreProxy = AnnotationFeaturePrefix + "oneagent-ignore-proxy"
 
@@ -79,7 +76,7 @@ const (
 
 <a name="MountAttemptsToTimeout"></a>
 
-## func [MountAttemptsToTimeout](<https://github.com/Dynatrace/dynatrace-operator/blob/main/pkg/api/v1beta3/dynakube/tmp/feature_flags.go#L271>)
+## func [MountAttemptsToTimeout](<https://github.com/Dynatrace/dynatrace-operator/blob/main/pkg/api/v1beta3/dynakube/tmp/feature_flags.go#L268>)
 
 ```go
 func MountAttemptsToTimeout(maxAttempts int) string

--- a/doc/e2e/features.md
+++ b/doc/e2e/features.md
@@ -128,8 +128,8 @@ import "github.com/Dynatrace/dynatrace-operator/test/features/cloudnative"
 ## Index
 
 - [func AssessActiveGateContainer(builder *features.FeatureBuilder, dk *dynakube.DynaKube, trustedCAs []byte)](<#AssessActiveGateContainer>)
-- [func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrt []byte, trustedCAs []byte)](<#AssessOneAgentContainer>)
-- [func AssessSampleContainer(builder *features.FeatureBuilder, sampleApp *sample.App, agCrt []byte, trustedCAs []byte)](<#AssessSampleContainer>)
+- [func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrt func() []byte, trustedCAs []byte)](<#AssessOneAgentContainer>)
+- [func AssessSampleContainer(builder *features.FeatureBuilder, sampleApp *sample.App, agCrt func() []byte, trustedCAs []byte)](<#AssessSampleContainer>)
 - [func AssessSampleInitContainers(builder *features.FeatureBuilder, sampleApp *sample.App)](<#AssessSampleInitContainers>)
 - [func DefaultCloudNativeSpec() *oneagent.CloudNativeFullStackSpec](<#DefaultCloudNativeSpec>)
 
@@ -146,7 +146,7 @@ func AssessActiveGateContainer(builder *features.FeatureBuilder, dk *dynakube.Dy
 ## func [AssessOneAgentContainer](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/container.go#L66>)
 
 ```go
-func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrt []byte, trustedCAs []byte)
+func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrt func() []byte, trustedCAs []byte)
 ```
 
 <a name="AssessSampleContainer"></a>
@@ -154,7 +154,7 @@ func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrt []byte, tru
 ## func [AssessSampleContainer](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/container.go#L28>)
 
 ```go
-func AssessSampleContainer(builder *features.FeatureBuilder, sampleApp *sample.App, agCrt []byte, trustedCAs []byte)
+func AssessSampleContainer(builder *features.FeatureBuilder, sampleApp *sample.App, agCrt func() []byte, trustedCAs []byte)
 ```
 
 <a name="AssessSampleInitContainers"></a>
@@ -189,7 +189,7 @@ import "github.com/Dynatrace/dynatrace-operator/test/features/cloudnative/codemo
 
 <a name="InstallFromImage"></a>
 
-## func [InstallFromImage](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/codemodules/codemodules.go#L67>)
+## func [InstallFromImage](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/codemodules/codemodules.go#L68>)
 
 ```go
 func InstallFromImage(t *testing.T) features.Feature
@@ -199,7 +199,7 @@ Verification that the storage in the CSI driver directory does not increase when
 
 <a name="WithProxy"></a>
 
-## func [WithProxy](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/codemodules/codemodules.go#L136>)
+## func [WithProxy](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/codemodules/codemodules.go#L137>)
 
 ```go
 func WithProxy(t *testing.T, proxySpec *value.Source) features.Feature
@@ -215,7 +215,7 @@ Connectivity in the dynatrace namespace and sample application namespace is rest
 
 <a name="WithProxyAndAGCert"></a>
 
-## func [WithProxyAndAGCert](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/codemodules/codemodules.go#L251>)
+## func [WithProxyAndAGCert](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/codemodules/codemodules.go#L275>)
 
 ```go
 func WithProxyAndAGCert(t *testing.T, proxySpec *value.Source) features.Feature
@@ -223,7 +223,7 @@ func WithProxyAndAGCert(t *testing.T, proxySpec *value.Source) features.Feature
 
 <a name="WithProxyCA"></a>
 
-## func [WithProxyCA](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/codemodules/codemodules.go#L190>)
+## func [WithProxyCA](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/codemodules/codemodules.go#L191>)
 
 ```go
 func WithProxyCA(t *testing.T, proxySpec *value.Source) features.Feature
@@ -231,7 +231,7 @@ func WithProxyCA(t *testing.T, proxySpec *value.Source) features.Feature
 
 <a name="WithProxyCAAndAGCert"></a>
 
-## func [WithProxyCAAndAGCert](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/codemodules/codemodules.go#L316>)
+## func [WithProxyCAAndAGCert](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/codemodules/codemodules.go#L340>)
 
 ```go
 func WithProxyCAAndAGCert(t *testing.T, proxySpec *value.Source) features.Feature

--- a/doc/e2e/features.md
+++ b/doc/e2e/features.md
@@ -128,8 +128,8 @@ import "github.com/Dynatrace/dynatrace-operator/test/features/cloudnative"
 ## Index
 
 - [func AssessActiveGateContainer(builder *features.FeatureBuilder, dk *dynakube.DynaKube, trustedCAs []byte)](<#AssessActiveGateContainer>)
-- [func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrt func() []byte, trustedCAs []byte)](<#AssessOneAgentContainer>)
-- [func AssessSampleContainer(builder *features.FeatureBuilder, sampleApp *sample.App, agCrt func() []byte, trustedCAs []byte)](<#AssessSampleContainer>)
+- [func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrtFunc func() []byte, trustedCAs []byte)](<#AssessOneAgentContainer>)
+- [func AssessSampleContainer(builder *features.FeatureBuilder, sampleApp *sample.App, agCrtFunc func() []byte, trustedCAs []byte)](<#AssessSampleContainer>)
 - [func AssessSampleInitContainers(builder *features.FeatureBuilder, sampleApp *sample.App)](<#AssessSampleInitContainers>)
 - [func DefaultCloudNativeSpec() *oneagent.CloudNativeFullStackSpec](<#DefaultCloudNativeSpec>)
 
@@ -146,7 +146,7 @@ func AssessActiveGateContainer(builder *features.FeatureBuilder, dk *dynakube.Dy
 ## func [AssessOneAgentContainer](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/container.go#L66>)
 
 ```go
-func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrt func() []byte, trustedCAs []byte)
+func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrtFunc func() []byte, trustedCAs []byte)
 ```
 
 <a name="AssessSampleContainer"></a>
@@ -154,7 +154,7 @@ func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrt func() []by
 ## func [AssessSampleContainer](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/container.go#L28>)
 
 ```go
-func AssessSampleContainer(builder *features.FeatureBuilder, sampleApp *sample.App, agCrt func() []byte, trustedCAs []byte)
+func AssessSampleContainer(builder *features.FeatureBuilder, sampleApp *sample.App, agCrtFunc func() []byte, trustedCAs []byte)
 ```
 
 <a name="AssessSampleInitContainers"></a>

--- a/hack/doc/gen_e2e_features.sh
+++ b/hack/doc/gen_e2e_features.sh
@@ -23,7 +23,8 @@ done
 
 # remove gomarkdoc headers and add custom one
 output=$(echo "${output}" | sed s/"$gomarkdoc_header"//)
-output="${script_header}\n${output}"
+output="${script_header}
+${output}"
 
 # write output to file
 mkdir -p $output_dir

--- a/hack/doc/gen_feature_flags.sh
+++ b/hack/doc/gen_feature_flags.sh
@@ -17,7 +17,8 @@ output=$(echo "${output}" | sed '$d')
 
 # remove gomarkdoc headers and add custom one
 output=$(echo "${output}" | sed s/"$gomarkdoc_header"//)
-output="${script_header}\n${output}"
+output="${script_header}
+${output}"
 
 # write output to file
 mkdir -p $output_dir

--- a/pkg/api/v1beta3/dynakube/activegate/props.go
+++ b/pkg/api/v1beta3/dynakube/activegate/props.go
@@ -102,7 +102,7 @@ func (ag *Spec) IsMetricsIngestEnabled() bool {
 }
 
 func (ag *Spec) IsAutomaticTlsSecretEnabled() bool {
-	return ag.TlsSecretName == "" && ag.trustedCAs != "" && ag.automaticTLSCertificateEnabled
+	return ag.automaticTLSCertificateEnabled
 }
 
 func (ag *Spec) HasCaCert() bool {

--- a/pkg/api/v1beta3/dynakube/activegate/props.go
+++ b/pkg/api/v1beta3/dynakube/activegate/props.go
@@ -24,10 +24,6 @@ func (ag *Spec) SetName(name string) {
 	ag.name = name
 }
 
-func (ag *Spec) SetTrustedCAs(name string) {
-	ag.trustedCAs = name
-}
-
 func (ag *Spec) SetAutomaticTLSCertificate(enabled bool) {
 	ag.automaticTLSCertificateEnabled = enabled
 }

--- a/pkg/api/v1beta3/dynakube/activegate/props.go
+++ b/pkg/api/v1beta3/dynakube/activegate/props.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	TenantSecretSuffix            = "-activegate-tenant-secret"
+	TlsSecretSuffix               = "-activegate-tls-secret"
 	ConnectionInfoConfigMapSuffix = "-activegate-connection-info"
 	AuthTokenSecretSuffix         = "-activegate-authtoken-secret"
 	DefaultImageRegistrySubPath   = "/linux/activegate"
@@ -21,6 +22,10 @@ func (ag *Spec) SetApiUrl(apiUrl string) {
 
 func (ag *Spec) SetName(name string) {
 	ag.name = name
+}
+
+func (ag *Spec) SetTrustedCAs(name string) {
+	ag.trustedCAs = name
 }
 
 func (ag *Spec) SetExtensionsDependency(isEnabled bool) {
@@ -93,7 +98,7 @@ func (ag *Spec) IsMetricsIngestEnabled() bool {
 }
 
 func (ag *Spec) HasCaCert() bool {
-	return ag.IsEnabled() && ag.TlsSecretName != ""
+	return ag.IsEnabled() && (ag.TlsSecretName != "" || ag.TlsSecretName == "" && ag.trustedCAs != "")
 }
 
 // ActivegateTenantSecret returns the name of the secret containing tenant UUID, token and communication endpoints for ActiveGate.
@@ -104,6 +109,14 @@ func (ag *Spec) GetTenantSecretName() string {
 // ActiveGateAuthTokenSecret returns the name of the secret containing the ActiveGateAuthToken, which is mounted to the AGs.
 func (ag *Spec) GetAuthTokenSecretName() string {
 	return ag.name + AuthTokenSecretSuffix
+}
+
+func (ag *Spec) GetTlsSecretName() string {
+	if ag.TlsSecretName != "" {
+		return ag.TlsSecretName
+	}
+
+	return ag.name + TlsSecretSuffix
 }
 
 func (ag *Spec) GetConnectionInfoConfigMapName() string {

--- a/pkg/api/v1beta3/dynakube/activegate/props.go
+++ b/pkg/api/v1beta3/dynakube/activegate/props.go
@@ -119,8 +119,8 @@ func (ag *Spec) GetAuthTokenSecretName() string {
 	return ag.name + AuthTokenSecretSuffix
 }
 
-// GetTlsSecretName returns the name of the AG TLS secret.
-func (ag *Spec) GetTlsSecretName() string {
+// GetTLSSecretName returns the name of the AG TLS secret.
+func (ag *Spec) GetTLSSecretName() string {
 	if ag.TlsSecretName != "" {
 		return ag.TlsSecretName
 	}

--- a/pkg/api/v1beta3/dynakube/activegate/spec.go
+++ b/pkg/api/v1beta3/dynakube/activegate/spec.go
@@ -86,9 +86,8 @@ type Spec struct {
 	// +kubebuilder:validation:Optional
 	PersistentVolumeClaim *corev1.PersistentVolumeClaimSpec `json:"persistentVolumeClaim,omitempty"`
 
-	name       string
-	apiUrl     string
-	trustedCAs string
+	name   string
+	apiUrl string
 
 	// The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
 	// server.p12: certificate+key pair in pkcs12 format

--- a/pkg/api/v1beta3/dynakube/activegate/spec.go
+++ b/pkg/api/v1beta3/dynakube/activegate/spec.go
@@ -86,8 +86,9 @@ type Spec struct {
 	// +kubebuilder:validation:Optional
 	PersistentVolumeClaim *corev1.PersistentVolumeClaimSpec `json:"persistentVolumeClaim,omitempty"`
 
-	name   string
-	apiUrl string
+	name       string
+	apiUrl     string
+	trustedCAs string
 
 	// The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
 	// server.p12: certificate+key pair in pkcs12 format

--- a/pkg/api/v1beta3/dynakube/activegate/spec.go
+++ b/pkg/api/v1beta3/dynakube/activegate/spec.go
@@ -115,6 +115,8 @@ type Spec struct {
 
 	enabledDependencies dependencies
 
+	automaticTLSCertificateEnabled bool
+
 	// UseEphemeralVolume
 	UseEphemeralVolume bool `json:"useEphemeralVolume,omitempty"`
 }

--- a/pkg/api/v1beta3/dynakube/activegate_props.go
+++ b/pkg/api/v1beta3/dynakube/activegate_props.go
@@ -7,7 +7,6 @@ import (
 func (dk *DynaKube) ActiveGate() *activegate.ActiveGate {
 	dk.Spec.ActiveGate.SetApiUrl(dk.ApiUrl())
 	dk.Spec.ActiveGate.SetName(dk.Name)
-	dk.Spec.ActiveGate.SetTrustedCAs(dk.Spec.TrustedCAs)
 	dk.Spec.ActiveGate.SetAutomaticTLSCertificate(dk.FeatureActiveGateAutomaticTLSCertificate())
 	dk.Spec.ActiveGate.SetExtensionsDependency(dk.IsExtensionsEnabled())
 	dk.Spec.ActiveGate.SetOTLPingestDependency(dk.IsOTLPingestEnabled())

--- a/pkg/api/v1beta3/dynakube/activegate_props.go
+++ b/pkg/api/v1beta3/dynakube/activegate_props.go
@@ -7,6 +7,7 @@ import (
 func (dk *DynaKube) ActiveGate() *activegate.ActiveGate {
 	dk.Spec.ActiveGate.SetApiUrl(dk.ApiUrl())
 	dk.Spec.ActiveGate.SetName(dk.Name)
+	dk.Spec.ActiveGate.SetTrustedCAs(dk.Spec.TrustedCAs)
 	dk.Spec.ActiveGate.SetExtensionsDependency(dk.IsExtensionsEnabled())
 	dk.Spec.ActiveGate.SetOTLPingestDependency(dk.IsOTLPingestEnabled())
 

--- a/pkg/api/v1beta3/dynakube/activegate_props.go
+++ b/pkg/api/v1beta3/dynakube/activegate_props.go
@@ -8,6 +8,7 @@ func (dk *DynaKube) ActiveGate() *activegate.ActiveGate {
 	dk.Spec.ActiveGate.SetApiUrl(dk.ApiUrl())
 	dk.Spec.ActiveGate.SetName(dk.Name)
 	dk.Spec.ActiveGate.SetTrustedCAs(dk.Spec.TrustedCAs)
+	dk.Spec.ActiveGate.SetAutomaticTLSCertificate(dk.FeatureActiveGateAutomaticTLSCertificate())
 	dk.Spec.ActiveGate.SetExtensionsDependency(dk.IsExtensionsEnabled())
 	dk.Spec.ActiveGate.SetOTLPingestDependency(dk.IsOTLPingestEnabled())
 

--- a/pkg/api/v1beta3/dynakube/certs.go
+++ b/pkg/api/v1beta3/dynakube/certs.go
@@ -48,7 +48,7 @@ func (dk *DynaKube) TrustedCAs(ctx context.Context, kubeReader client.Reader) ([
 
 func (dk *DynaKube) ActiveGateTLSCert(ctx context.Context, kubeReader client.Reader) ([]byte, error) {
 	if dk.ActiveGate().HasCaCert() {
-		secretName := dk.Spec.ActiveGate.GetTlsSecretName()
+		secretName := dk.Spec.ActiveGate.GetTLSSecretName()
 
 		var tlsSecret corev1.Secret
 

--- a/pkg/api/v1beta3/dynakube/certs.go
+++ b/pkg/api/v1beta3/dynakube/certs.go
@@ -48,7 +48,7 @@ func (dk *DynaKube) TrustedCAs(ctx context.Context, kubeReader client.Reader) ([
 
 func (dk *DynaKube) ActiveGateTLSCert(ctx context.Context, kubeReader client.Reader) ([]byte, error) {
 	if dk.ActiveGate().HasCaCert() {
-		secretName := dk.Spec.ActiveGate.TlsSecretName
+		secretName := dk.Spec.ActiveGate.GetTlsSecretName()
 
 		var tlsSecret corev1.Secret
 

--- a/pkg/api/v1beta3/dynakube/feature_flags.go
+++ b/pkg/api/v1beta3/dynakube/feature_flags.go
@@ -55,9 +55,6 @@ const (
 
 	// oneAgent.
 
-	AnnotationFeatureOneAgnetIgnoreAgTlsCertificate = AnnotationFeaturePrefix + "oneagent-ignore-ag-tls-certificate"
-	AnnotationFeatureOneAgnetIgnoreTrustedCAs       = AnnotationFeaturePrefix + "oneagent-ignore-trusted-cas"
-
 	// Deprecated: AnnotationFeatureOneAgentIgnoreProxy use AnnotationFeatureNoProxy instead.
 	AnnotationFeatureOneAgentIgnoreProxy = AnnotationFeaturePrefix + "oneagent-ignore-proxy"
 
@@ -304,14 +301,4 @@ func (dk *DynaKube) FeatureInitContainerSeccomp() bool {
 // sets the tenantUUID to the container.conf file (always vs if oneAgent is present).
 func (dk *DynaKube) FeatureEnforcementMode() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureEnforcementMode) != falsePhrase
-}
-
-// FeatureOneAgentIgnoreActiveGateTlsCertificate is a feature flag to skip mounting AG TLS certificate to OneAgent POD.
-func (dk *DynaKube) FeatureOneAgentIgnoreActiveGateTlsCertificate() bool {
-	return dk.getFeatureFlagRaw(AnnotationFeatureOneAgnetIgnoreAgTlsCertificate) == truePhrase
-}
-
-// FeatureOneAgentIgnoreTrustedCAs is a feature flag to skip mounting TrustedCAs certificates to OneAgent POD.
-func (dk *DynaKube) FeatureOneAgentIgnoreTrustedCAs() bool {
-	return dk.getFeatureFlagRaw(AnnotationFeatureOneAgnetIgnoreTrustedCAs) == truePhrase
 }

--- a/pkg/api/v1beta3/dynakube/feature_flags.go
+++ b/pkg/api/v1beta3/dynakube/feature_flags.go
@@ -47,6 +47,8 @@ const (
 	AnnotationFeatureAutomaticK8sApiMonitoringClusterName = AnnotationFeaturePrefix + "automatic-kubernetes-api-monitoring-cluster-name"
 	AnnotationFeatureK8sAppEnabled                        = AnnotationFeaturePrefix + "k8s-app-enabled"
 
+	AnnotationFeatureActiveGateAutomaticTLSCertificate = AnnotationFeaturePrefix + "automatic-tls-certificate"
+
 	// dtClient.
 
 	AnnotationFeatureNoProxy = AnnotationFeaturePrefix + "no-proxy"
@@ -130,6 +132,11 @@ func (dk *DynaKube) FeatureDisableActiveGateUpdates() bool {
 // FeatureNoProxy is a feature flag to set the NO_PROXY value to be used by the dtClient.
 func (dk *DynaKube) FeatureNoProxy() string {
 	return dk.getFeatureFlagRaw(AnnotationFeatureNoProxy)
+}
+
+// FeatureActiveGateAutomaticTLSCertificate is a feature flag to enable automatic creation of AG TLS certificate if TrustedCAs are used.
+func (dk *DynaKube) FeatureActiveGateAutomaticTLSCertificate() bool {
+	return dk.getFeatureFlagRaw(AnnotationFeatureActiveGateAutomaticTLSCertificate) == truePhrase
 }
 
 // FeatureOneAgentMaxUnavailable is a feature flag to configure maxUnavailable on the OneAgent DaemonSets rolling upgrades.
@@ -299,10 +306,12 @@ func (dk *DynaKube) FeatureEnforcementMode() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureEnforcementMode) != falsePhrase
 }
 
+// FeatureOneAgentIgnoreActiveGateTlsCertificate is a feature flag to skip mounting AG TLS certificate to OneAgent POD.
 func (dk *DynaKube) FeatureOneAgentIgnoreActiveGateTlsCertificate() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureOneAgnetIgnoreAgTlsCertificate) == truePhrase
 }
 
+// FeatureOneAgentIgnoreTrustedCAs is a feature flag to skip mounting TrustedCAs certificates to OneAgent POD.
 func (dk *DynaKube) FeatureOneAgentIgnoreTrustedCAs() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureOneAgnetIgnoreTrustedCAs) == truePhrase
 }

--- a/pkg/api/v1beta3/dynakube/feature_flags.go
+++ b/pkg/api/v1beta3/dynakube/feature_flags.go
@@ -53,6 +53,9 @@ const (
 
 	// oneAgent.
 
+	AnnotationFeatureOneAgnetIgnoreAgTlsCertificate = AnnotationFeaturePrefix + "oneagent-ignore-ag-tls-certificate"
+	AnnotationFeatureOneAgnetIgnoreTrustedCAs       = AnnotationFeaturePrefix + "oneagent-ignore-trusted-cas"
+
 	// Deprecated: AnnotationFeatureOneAgentIgnoreProxy use AnnotationFeatureNoProxy instead.
 	AnnotationFeatureOneAgentIgnoreProxy = AnnotationFeaturePrefix + "oneagent-ignore-proxy"
 
@@ -294,4 +297,12 @@ func (dk *DynaKube) FeatureInitContainerSeccomp() bool {
 // sets the tenantUUID to the container.conf file (always vs if oneAgent is present).
 func (dk *DynaKube) FeatureEnforcementMode() bool {
 	return dk.getFeatureFlagRaw(AnnotationFeatureEnforcementMode) != falsePhrase
+}
+
+func (dk *DynaKube) FeatureOneAgentIgnoreActiveGateTlsCertificate() bool {
+	return dk.getFeatureFlagRaw(AnnotationFeatureOneAgnetIgnoreAgTlsCertificate) == truePhrase
+}
+
+func (dk *DynaKube) FeatureOneAgentIgnoreTrustedCAs() bool {
+	return dk.getFeatureFlagRaw(AnnotationFeatureOneAgnetIgnoreTrustedCAs) == truePhrase
 }

--- a/pkg/controllers/dynakube/activegate/internal/capability/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/capability/reconciler_test.go
@@ -93,8 +93,9 @@ func TestReconcile(t *testing.T) {
 		dk := buildDynakube(capabilitiesWithService)
 		mockStatefulSetReconciler := getMockReconciler(t, nil)
 		mockCustompropertiesReconciler := getMockReconciler(t, nil)
+		mockTlsSecretReconciler := getMockReconciler(t, nil)
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -107,8 +108,9 @@ func TestReconcile(t *testing.T) {
 		dk := buildDynakube(capabilitiesWithoutService)
 		mockStatefulSetReconciler := getMockReconciler(t, errors.New(""))
 		mockCustompropertiesReconciler := getMockReconciler(t, nil)
+		mockTlsSecretReconciler := getMockReconciler(t, nil)
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -121,8 +123,9 @@ func TestReconcile(t *testing.T) {
 		dk := buildDynakube(capabilitiesWithoutService)
 		mockStatefulSetReconciler := getMockReconciler(t)
 		mockCustompropertiesReconciler := getMockReconciler(t, errors.New(""))
+		mockTlsSecretReconciler := getMockReconciler(t, nil)
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -134,8 +137,9 @@ func TestReconcile(t *testing.T) {
 		dk := buildDynakube(capabilitiesWithoutService)
 		mockStatefulSetReconciler := getMockReconciler(t, errors.New(""))
 		mockCustompropertiesReconciler := getMockReconciler(t, errors.New(""))
+		mockTlsSecretReconciler := getMockReconciler(t, nil)
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -145,8 +149,9 @@ func TestReconcile(t *testing.T) {
 		dk := buildDynakube(capabilitiesWithService)
 		mockStatefulSetReconciler := getMockReconciler(t, nil)
 		mockCustompropertiesReconciler := getMockReconciler(t, nil)
+		mockTlsSecretReconciler := getMockReconciler(t, nil)
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -166,8 +171,9 @@ func TestReconcile(t *testing.T) {
 		dk := buildDynakube(capabilitiesWithoutService)
 		mockStatefulSetReconciler := getMockReconciler(t, nil)
 		mockCustompropertiesReconciler := getMockReconciler(t, nil)
+		mockTlsSecretReconciler := getMockReconciler(t, nil)
 
-		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.Reconcile(context.Background())
@@ -191,9 +197,10 @@ func TestCreateOrUpdateService(t *testing.T) {
 	dk := buildDynakube(capabilitiesWithService)
 	mockStatefulSetReconciler := getMockReconciler(t, nil)
 	mockCustompropertiesReconciler := getMockReconciler(t, nil)
+	mockTlsSecretReconciler := getMockReconciler(t, nil)
 
 	t.Run(`create service works`, func(t *testing.T) {
-		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		service := &corev1.Service{}
@@ -210,7 +217,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 		assert.NotNil(t, service)
 	})
 	t.Run(`ports get updated`, func(t *testing.T) {
-		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.createOrUpdateService(context.Background())
@@ -238,7 +245,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 		require.NotEqual(t, actualService.Spec.Ports, service.Spec.Ports)
 	})
 	t.Run(`labels get updated`, func(t *testing.T) {
-		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+		r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 		verifyReconciler(t, r)
 
 		err := r.createOrUpdateService(context.Background())
@@ -270,8 +277,9 @@ func TestPortsAreOutdated(t *testing.T) {
 	dk := buildDynakube(capabilitiesWithService)
 	mockStatefulSetReconciler := getMockReconciler(t, nil)
 	mockCustompropertiesReconciler := getMockReconciler(t, nil)
+	mockTlsSecretReconciler := getMockReconciler(t, nil)
 
-	r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+	r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 	verifyReconciler(t, r)
 
 	desiredService := CreateService(r.dk, r.capability.ShortName())
@@ -298,7 +306,9 @@ func TestLabelsAreOutdated(t *testing.T) {
 	dk := buildDynakube(capabilitiesWithService)
 	mockStatefulSetReconciler := getMockReconciler(t, nil)
 	mockCustompropertiesReconciler := getMockReconciler(t, nil)
-	r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler).(*Reconciler)
+	mockTlsSecretReconciler := getMockReconciler(t, nil)
+
+	r := NewReconciler(clt, capability.NewMultiCapability(dk), dk, mockStatefulSetReconciler, mockCustompropertiesReconciler, mockTlsSecretReconciler).(*Reconciler)
 	verifyReconciler(t, r)
 
 	desiredService := CreateService(r.dk, r.capability.ShortName())

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
@@ -48,7 +48,7 @@ func (mod CertificatesModifier) getVolumes() []corev1.Volume {
 			Name: jettyCerts,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: mod.dk.ActiveGate().GetTlsSecretName(),
+					SecretName: mod.dk.ActiveGate().GetTLSSecretName(),
 				},
 			},
 		},

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
@@ -48,7 +48,7 @@ func (mod CertificatesModifier) getVolumes() []corev1.Volume {
 			Name: jettyCerts,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: mod.dk.Spec.ActiveGate.TlsSecretName,
+					SecretName: mod.dk.ActiveGate().GetTlsSecretName(),
 				},
 			},
 		},

--- a/pkg/controllers/dynakube/activegate/internal/tls/conditions.go
+++ b/pkg/controllers/dynakube/activegate/internal/tls/conditions.go
@@ -1,0 +1,5 @@
+package tls
+
+const (
+	conditionType = "TlsSecret"
+)

--- a/pkg/controllers/dynakube/activegate/internal/tls/conditions.go
+++ b/pkg/controllers/dynakube/activegate/internal/tls/conditions.go
@@ -1,5 +1,5 @@
 package tls
 
 const (
-	conditionType = "TlsSecret"
+	conditionType = "TLSSecret"
 )

--- a/pkg/controllers/dynakube/activegate/internal/tls/config.go
+++ b/pkg/controllers/dynakube/activegate/internal/tls/config.go
@@ -1,0 +1,7 @@
+package tls
+
+import "github.com/Dynatrace/dynatrace-operator/pkg/logd"
+
+var (
+	log = logd.Get().WithName("dynakube-activegate-tls-secret")
+)

--- a/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
@@ -50,7 +50,7 @@ func NewReconciler(client client.Client, apiReader client.Reader, dk *dynakube.D
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	if r.dk.ActiveGate().IsEnabled() && r.dk.ActiveGate().TlsSecretName == "" && r.dk.Spec.TrustedCAs != "" {
+	if r.dk.ActiveGate().IsEnabled() && r.dk.ActiveGate().IsAutomaticTlsSecretEnabled() {
 		return r.reconcileSelfSignedTLSSecret(ctx)
 	}
 

--- a/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
@@ -1,0 +1,171 @@
+package tls
+
+import (
+	"context"
+	"crypto/x509"
+	"net"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/certificates"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	k8slabels "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
+	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	activeGateSelfSignedTLSCommonNameSuffix = "-activegate.dynatrace"
+
+	tlsCrtDataName = "server.crt"
+)
+
+var (
+	log = logd.Get().WithName("dynakube-activegate-tls-secret")
+)
+
+type Reconciler struct {
+	client       client.Client
+	apiReader    client.Reader
+	dk           *dynakube.DynaKube
+	timeProvider *timeprovider.Provider
+}
+
+type ReconcilerBuilder func(client client.Client, apiReader client.Reader, dk *dynakube.DynaKube) *Reconciler
+
+func NewReconciler(client client.Client, apiReader client.Reader, dk *dynakube.DynaKube) *Reconciler {
+	return &Reconciler{
+		client:       client,
+		dk:           dk,
+		apiReader:    apiReader,
+		timeProvider: timeprovider.New(),
+	}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context) error {
+	if r.dk.ActiveGate().IsEnabled() && r.dk.ActiveGate().TlsSecretName == "" && r.dk.Spec.TrustedCAs != "" {
+		return r.reconcileSelfSignedTLSSecret(ctx)
+	}
+
+	if meta.FindStatusCondition(*r.dk.Conditions(), conditionType) == nil {
+		return nil
+	}
+	defer meta.RemoveStatusCondition(r.dk.Conditions(), conditionType)
+
+	return r.deleteSelfSignedTLSSecret(ctx)
+}
+
+func (r *Reconciler) reconcileSelfSignedTLSSecret(ctx context.Context) error {
+	query := k8ssecret.Query(r.client, r.client, log)
+
+	_, err := query.Get(ctx, types.NamespacedName{
+		Name:      r.dk.ActiveGate().GetTlsSecretName(),
+		Namespace: r.dk.Namespace,
+	})
+
+	if err != nil && k8serrors.IsNotFound(err) {
+		return r.createSelfSignedTLSSecret(ctx)
+	}
+
+	if err != nil {
+		conditions.SetKubeApiError(r.dk.Conditions(), conditionType, err)
+
+		return err
+	}
+
+	return nil
+}
+
+func (r *Reconciler) deleteSelfSignedTLSSecret(ctx context.Context) error {
+	query := k8ssecret.Query(r.client, r.client, log)
+
+	return query.Delete(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.dk.ActiveGate().GetTlsSecretName(),
+			Namespace: r.dk.Namespace,
+		},
+	})
+}
+
+func (r *Reconciler) createSelfSignedTLSSecret(ctx context.Context) error {
+	cert, err := certificates.New(r.timeProvider)
+	if err != nil {
+		conditions.SetSecretGenFailed(r.dk.Conditions(), conditionType, err)
+
+		return err
+	}
+
+	cert.Cert.DNSNames = getCertificateAltNames(r.dk.Name)
+	cert.Cert.KeyUsage = x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment
+	cert.Cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	cert.Cert.Subject.CommonName = r.dk.Name + activeGateSelfSignedTLSCommonNameSuffix
+	cert.Cert.IPAddresses = getCertificateAltIPs(r.dk.Status.ActiveGate.ServiceIPs)
+
+	err = cert.SelfSign()
+	if err != nil {
+		conditions.SetSecretGenFailed(r.dk.Conditions(), conditionType, err)
+
+		return err
+	}
+
+	pemCert, pemPk, err := cert.ToPEM()
+	if err != nil {
+		conditions.SetSecretGenFailed(r.dk.Conditions(), conditionType, err)
+
+		return err
+	}
+
+	coreLabels := k8slabels.NewCoreLabels(r.dk.Name, k8slabels.ActiveGateComponentLabel)
+	secretData := map[string][]byte{
+		consts.TLSCrtDataName: pemCert,
+		consts.TLSKeyDataName: pemPk,
+		tlsCrtDataName:        pemCert,
+	}
+
+	secret, err := k8ssecret.Build(r.dk, r.dk.ActiveGate().GetTlsSecretName(), secretData, k8ssecret.SetLabels(coreLabels.BuildLabels()))
+	if err != nil {
+		conditions.SetSecretGenFailed(r.dk.Conditions(), conditionType, err)
+
+		return err
+	}
+
+	secret.Type = corev1.SecretTypeOpaque
+
+	query := k8ssecret.Query(r.client, r.client, log)
+
+	err = query.Create(ctx, secret)
+	if err != nil {
+		conditions.SetKubeApiError(r.dk.Conditions(), conditionType, err)
+
+		return err
+	}
+
+	conditions.SetSecretCreated(r.dk.Conditions(), conditionType, secret.Name)
+
+	return nil
+}
+
+func getCertificateAltNames(dkName string) []string {
+	return []string{
+		dkName + activeGateSelfSignedTLSCommonNameSuffix,
+		dkName + activeGateSelfSignedTLSCommonNameSuffix + ".svc",
+		dkName + activeGateSelfSignedTLSCommonNameSuffix + ".svc.cluster.local",
+	}
+}
+
+func getCertificateAltIPs(ips []string) []net.IP {
+	altIPs := []net.IP{}
+
+	for _, ip := range ips {
+		altIPs = append(altIPs, net.ParseIP(ip))
+	}
+
+	return altIPs
+}

--- a/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
@@ -46,7 +46,7 @@ func NewReconciler(client client.Client, apiReader client.Reader, dk *dynakube.D
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	if r.dk.ActiveGate().IsEnabled() && r.dk.ActiveGate().IsAutomaticTlsSecretEnabled() {
+	if r.dk.ActiveGate().IsEnabled() && r.dk.ActiveGate().IsAutomaticTlsSecretEnabled() && r.dk.ActiveGate().TlsSecretName == "" {
 		return r.reconcileSelfSignedTLSSecret(ctx)
 	}
 

--- a/pkg/controllers/dynakube/activegate/internal/tls/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/tls/reconciler_test.go
@@ -1,0 +1,137 @@
+package tls
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/activegate"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	testNamespace    = "test-namespace"
+	testDynakubeName = "test-dynakube"
+)
+
+func TestReconciler_Reconcile(t *testing.T) {
+	t.Run(`ActiveGate disabled`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureActiveGateAutomaticTLSCertificate: "true",
+				},
+				Namespace: testNamespace,
+				Name:      testDynakubeName,
+			},
+		}
+		fakeClient := fake.NewClient()
+		r := NewReconciler(fakeClient, fakeClient, dk)
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		agTLSSecret := corev1.Secret{}
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.ActiveGate().GetTLSSecretName(), Namespace: r.dk.Namespace}, &agTLSSecret)
+
+		require.Error(t, err)
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
+
+	t.Run(`custom ActiveGate TLS secret exists`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureActiveGateAutomaticTLSCertificate: "true",
+				},
+				Namespace: testNamespace,
+				Name:      testDynakubeName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.RoutingCapability.DisplayName,
+					},
+					TlsSecretName: "test",
+				},
+			},
+		}
+		fakeClient := fake.NewClient()
+		r := NewReconciler(fakeClient, fakeClient, dk)
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		agTLSSecret := corev1.Secret{}
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.ActiveGate().GetTLSSecretName(), Namespace: r.dk.Namespace}, &agTLSSecret)
+
+		require.Error(t, err)
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
+
+	t.Run(`automatic-tls-certificate feature disabled`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      testDynakubeName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.RoutingCapability.DisplayName,
+					},
+				},
+			},
+		}
+		fakeClient := fake.NewClient()
+		r := NewReconciler(fakeClient, fakeClient, dk)
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		agTLSSecret := corev1.Secret{}
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.ActiveGate().GetTLSSecretName(), Namespace: r.dk.Namespace}, &agTLSSecret)
+
+		require.Error(t, err)
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
+
+	t.Run(`secret created`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureActiveGateAutomaticTLSCertificate: "true",
+				},
+				Namespace: testNamespace,
+				Name:      testDynakubeName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.RoutingCapability.DisplayName,
+					},
+				},
+			},
+		}
+		fakeClient := fake.NewClient()
+		r := NewReconciler(fakeClient, fakeClient, dk)
+		err := r.Reconcile(context.Background())
+		require.NoError(t, err)
+
+		agTLSSecret := corev1.Secret{}
+		err = r.client.Get(context.Background(), client.ObjectKey{Name: r.dk.ActiveGate().GetTLSSecretName(), Namespace: r.dk.Namespace}, &agTLSSecret)
+
+		require.NoError(t, err)
+
+		condition := meta.FindStatusCondition(r.dk.Status.Conditions, conditionType)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
+		assert.Equal(t, fmt.Sprintf("%s created", agTLSSecret.Name), condition.Message)
+	})
+}

--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -10,6 +10,7 @@ import (
 	capabilityInternal "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/tls"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	agconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dtpullsecret"
@@ -180,8 +181,9 @@ func extractPublicData(dk *dynakube.DynaKube) map[string]string {
 func (r *Reconciler) createCapability(ctx context.Context, agCapability capability.Capability) error {
 	customPropertiesReconciler := r.newCustomPropertiesReconcilerFunc(r.dk.ActiveGate().GetServiceAccountOwner(), agCapability.Properties().CustomProperties) //nolint:typeCheck
 	statefulsetReconciler := r.newStatefulsetReconcilerFunc(r.client, r.apiReader, r.dk, agCapability)                                                        //nolint:typeCheck
+	tlsSecretReconciler := tls.NewReconciler(r.client, r.apiReader, r.dk)
 
-	capabilityReconciler := r.newCapabilityReconcilerFunc(r.client, agCapability, r.dk, statefulsetReconciler, customPropertiesReconciler)
+	capabilityReconciler := r.newCapabilityReconcilerFunc(r.client, agCapability, r.dk, statefulsetReconciler, customPropertiesReconciler, tlsSecretReconciler)
 
 	return capabilityReconciler.Reconcile(ctx)
 }

--- a/pkg/controllers/dynakube/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/reconciler_test.go
@@ -163,7 +163,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			newStatefulsetReconcilerFunc: func(_ client.Client, _ client.Reader, _ *dynakube.DynaKube, _ capability.Capability) controllers.Reconciler {
 				return fakeReconciler
 			},
-			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynakube.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
+			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynakube.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
 				return fakeReconciler
 			},
 			newCustomPropertiesReconcilerFunc: func(_ string, customPropertiesSource *value.Source) controllers.Reconciler {
@@ -184,7 +184,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			newStatefulsetReconcilerFunc: func(_ client.Client, _ client.Reader, _ *dynakube.DynaKube, _ capability.Capability) controllers.Reconciler {
 				return fakeReconciler
 			},
-			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynakube.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
+			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynakube.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
 				return fakeReconciler
 			},
 			newCustomPropertiesReconcilerFunc: func(_ string, customPropertiesSource *value.Source) controllers.Reconciler {
@@ -545,7 +545,7 @@ func TestReconcile_ActivegateConfigMap(t *testing.T) {
 			newStatefulsetReconcilerFunc: func(_ client.Client, _ client.Reader, _ *dynakube.DynaKube, _ capability.Capability) controllers.Reconciler {
 				return fakeReconciler
 			},
-			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynakube.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
+			newCapabilityReconcilerFunc: func(_ client.Client, _ capability.Capability, _ *dynakube.DynaKube, _ controllers.Reconciler, _ controllers.Reconciler, _ controllers.Reconciler) controllers.Reconciler {
 				return fakeReconciler
 			},
 			newCustomPropertiesReconcilerFunc: func(_ string, _ *value.Source) controllers.Reconciler {

--- a/pkg/controllers/dynakube/extension/eec/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler_test.go
@@ -1019,7 +1019,7 @@ func TestActiveGateVolumes(t *testing.T) {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &defaultMode,
-					SecretName:  dk.ActiveGate().GetTlsSecretName(),
+					SecretName:  dk.ActiveGate().GetTLSSecretName(),
 					Items: []corev1.KeyToPath{
 						{
 							Key:  activeGateTrustedCertSecretKeyPath,

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -254,7 +254,7 @@ func buildContainerEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 		{Name: envHttpsPrivKeyPathPem, Value: envEecHttpsPrivKeyPathPem},
 	}
 
-	if dk.Spec.ActiveGate.TlsSecretName != "" {
+	if dk.ActiveGate().HasCaCert() {
 		containerEnvs = append(containerEnvs, corev1.EnvVar{Name: envActiveGateTrustedCertName, Value: envActiveGateTrustedCert})
 	}
 
@@ -312,7 +312,7 @@ func buildContainerVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 		})
 	}
 
-	if dk.Spec.ActiveGate.TlsSecretName != "" {
+	if dk.ActiveGate().HasCaCert() {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      activeGateTrustedCertVolumeName,
 			MountPath: activeGateTrustedCertMountPath,
@@ -388,14 +388,14 @@ func setVolumes(dk *dynakube.DynaKube) func(o *appsv1.StatefulSet) {
 			})
 		}
 
-		if dk.Spec.ActiveGate.TlsSecretName != "" {
+		if dk.ActiveGate().HasCaCert() {
 			defaultMode := int32(420)
 			o.Spec.Template.Spec.Volumes = append(o.Spec.Template.Spec.Volumes, corev1.Volume{
 				Name: activeGateTrustedCertVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						DefaultMode: &defaultMode,
-						SecretName:  dk.Spec.ActiveGate.TlsSecretName,
+						SecretName:  dk.ActiveGate().GetTlsSecretName(),
 						Items: []corev1.KeyToPath{
 							{
 								Key:  activeGateTrustedCertSecretKeyPath,

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -395,7 +395,7 @@ func setVolumes(dk *dynakube.DynaKube) func(o *appsv1.StatefulSet) {
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						DefaultMode: &defaultMode,
-						SecretName:  dk.ActiveGate().GetTlsSecretName(),
+						SecretName:  dk.ActiveGate().GetTLSSecretName(),
 						Items: []corev1.KeyToPath{
 							{
 								Key:  activeGateTrustedCertSecretKeyPath,

--- a/pkg/controllers/dynakube/extension/tls/reconciler.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	extensionsSelfSignedTLSCommonNameSuffix = "-extensions-controller.dynatrace"
+	extensionsSelfSignedTLSCommonNameSuffix = "extensions-controller"
 )
 
 type reconciler struct {
@@ -94,10 +94,10 @@ func (r *reconciler) createSelfSignedTLSSecret(ctx context.Context) error {
 		return err
 	}
 
-	cert.Cert.DNSNames = getCertificateAltNames(r.dk.Name)
+	cert.Cert.DNSNames = certificates.AltNames(r.dk.Name, r.dk.Namespace, extensionsSelfSignedTLSCommonNameSuffix)
 	cert.Cert.KeyUsage = x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment
 	cert.Cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
-	cert.Cert.Subject.CommonName = r.dk.Name + extensionsSelfSignedTLSCommonNameSuffix
+	cert.Cert.Subject.CommonName = certificates.CommonName(r.dk.Name, r.dk.Namespace, extensionsSelfSignedTLSCommonNameSuffix)
 
 	err = cert.SelfSign()
 	if err != nil {
@@ -137,12 +137,4 @@ func (r *reconciler) createSelfSignedTLSSecret(ctx context.Context) error {
 	conditions.SetSecretCreated(r.dk.Conditions(), conditionType, secret.Name)
 
 	return nil
-}
-
-func getCertificateAltNames(dkName string) []string {
-	return []string{
-		dkName + "-extensions-controller.dynatrace",
-		dkName + "-extensions-controller.dynatrace.svc",
-		dkName + "-extensions-controller.dynatrace.svc.cluster.local",
-	}
 }

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -152,7 +152,7 @@ func getActiveGateCaCertVolume(dk *dynakube.DynaKube) corev1.Volume {
 		Name: activeGateCaCertVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: dk.Spec.ActiveGate.GetTlsSecretName(),
+				SecretName: dk.Spec.ActiveGate.GetTLSSecretName(),
 				Items: []corev1.KeyToPath{
 					{
 						Key:  "server.crt",

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -22,11 +22,11 @@ func prepareVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 		volumeMounts = append(volumeMounts, getRootMount())
 	}
 
-	if dk != nil && dk.Spec.TrustedCAs != "" && !dk.FeatureOneAgentIgnoreTrustedCAs() {
+	if dk != nil && dk.Spec.TrustedCAs != "" {
 		volumeMounts = append(volumeMounts, getClusterCaCertVolumeMount())
 	}
 
-	if dk != nil && dk.ActiveGate().HasCaCert() && !dk.FeatureOneAgentIgnoreActiveGateTlsCertificate() {
+	if dk != nil && dk.ActiveGate().HasCaCert() {
 		volumeMounts = append(volumeMounts, getActiveGateCaCertVolumeMount())
 	}
 
@@ -98,11 +98,11 @@ func prepareVolumes(dk *dynakube.DynaKube) []corev1.Volume {
 		volumes = append(volumes, getCSIStorageVolume(dk))
 	}
 
-	if dk.Spec.TrustedCAs != "" && !dk.FeatureOneAgentIgnoreTrustedCAs() {
+	if dk.Spec.TrustedCAs != "" {
 		volumes = append(volumes, getCertificateVolume(dk))
 	}
 
-	if dk.ActiveGate().HasCaCert() && !dk.FeatureOneAgentIgnoreActiveGateTlsCertificate() {
+	if dk.ActiveGate().HasCaCert() {
 		volumes = append(volumes, getActiveGateCaCertVolume(dk))
 	}
 

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -22,11 +22,11 @@ func prepareVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 		volumeMounts = append(volumeMounts, getRootMount())
 	}
 
-	if dk != nil && dk.Spec.TrustedCAs != "" {
+	if dk != nil && dk.Spec.TrustedCAs != "" && !dk.FeatureOneAgentIgnoreTrustedCAs() {
 		volumeMounts = append(volumeMounts, getClusterCaCertVolumeMount())
 	}
 
-	if dk != nil && dk.ActiveGate().HasCaCert() {
+	if dk != nil && dk.ActiveGate().HasCaCert() && !dk.FeatureOneAgentIgnoreActiveGateTlsCertificate() {
 		volumeMounts = append(volumeMounts, getActiveGateCaCertVolumeMount())
 	}
 
@@ -98,11 +98,11 @@ func prepareVolumes(dk *dynakube.DynaKube) []corev1.Volume {
 		volumes = append(volumes, getCSIStorageVolume(dk))
 	}
 
-	if dk.Spec.TrustedCAs != "" {
+	if dk.Spec.TrustedCAs != "" && !dk.FeatureOneAgentIgnoreTrustedCAs() {
 		volumes = append(volumes, getCertificateVolume(dk))
 	}
 
-	if dk.ActiveGate().HasCaCert() {
+	if dk.ActiveGate().HasCaCert() && !dk.FeatureOneAgentIgnoreActiveGateTlsCertificate() {
 		volumes = append(volumes, getActiveGateCaCertVolume(dk))
 	}
 
@@ -152,7 +152,7 @@ func getActiveGateCaCertVolume(dk *dynakube.DynaKube) corev1.Volume {
 		Name: activeGateCaCertVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: dk.Spec.ActiveGate.TlsSecretName,
+				SecretName: dk.Spec.ActiveGate.GetTlsSecretName(),
 				Items: []corev1.KeyToPath{
 					{
 						Key:  "server.crt",

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -56,6 +56,26 @@ func TestPrepareVolumes(t *testing.T) {
 		assert.Contains(t, volumes, getRootVolume())
 		assert.Contains(t, volumes, getCertificateVolume(dk))
 	})
+	t.Run(`doesn't have certificate volume if ff is used`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: corev1.ObjectMeta{
+				Name: "dynakube",
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureOneAgnetIgnoreTrustedCAs: "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				TrustedCAs: testName,
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{},
+				},
+			},
+		}
+		volumes := prepareVolumes(dk)
+
+		assert.Contains(t, volumes, getRootVolume())
+		assert.NotContains(t, volumes, getCertificateVolume(dk))
+	})
 	t.Run(`has http_proxy volume`, func(t *testing.T) {
 		dk := &dynakube.DynaKube{}
 		dk.Spec =
@@ -85,6 +105,77 @@ func TestPrepareVolumes(t *testing.T) {
 		}
 		volumes := prepareVolumes(dk)
 		assert.Contains(t, volumes, getActiveGateCaCertVolume(dk))
+	})
+	t.Run(`has automatically created tls volume`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: corev1.ObjectMeta{
+				Name: "dynakube",
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureActiveGateAutomaticTLSCertificate: "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.KubeMonCapability.DisplayName,
+					},
+				},
+				TrustedCAs: testName,
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{},
+				},
+			},
+		}
+		volumes := prepareVolumes(dk)
+		assert.Contains(t, volumes, getActiveGateCaCertVolume(dk))
+	})
+	t.Run(`doesn't have tls volume if ff is used`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: corev1.ObjectMeta{
+				Name: "dynakube",
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureOneAgnetIgnoreAgTlsCertificate: "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				TrustedCAs: testName,
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.KubeMonCapability.DisplayName,
+					},
+					TlsSecretName: "testing",
+				},
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{},
+				},
+			},
+		}
+		volumes := prepareVolumes(dk)
+		assert.NotContains(t, volumes, getActiveGateCaCertVolume(dk))
+	})
+	t.Run(`doesn't have automatically created tls volume if ff is used`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: corev1.ObjectMeta{
+				Name: "dynakube",
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureActiveGateAutomaticTLSCertificate: "true",
+					dynakube.AnnotationFeatureOneAgnetIgnoreAgTlsCertificate:    "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				TrustedCAs: testName,
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.KubeMonCapability.DisplayName,
+					},
+				},
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{},
+				},
+			},
+		}
+		volumes := prepareVolumes(dk)
+		assert.NotContains(t, volumes, getActiveGateCaCertVolume(dk))
 	})
 	t.Run(`csi volume not supported on classicFullStack`, func(t *testing.T) {
 		dk := &dynakube.DynaKube{
@@ -148,6 +239,7 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		volumeMounts := prepareVolumeMounts(dk)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
+		assert.NotContains(t, volumeMounts, getClusterCaCertVolumeMount())
 		assert.NotContains(t, volumeMounts, getActiveGateCaCertVolumeMount())
 	})
 	t.Run(`has cluster certificate volume mount`, func(t *testing.T) {
@@ -171,7 +263,6 @@ func TestPrepareVolumeMounts(t *testing.T) {
 				OneAgent: oneagent.Spec{
 					HostMonitoring: &oneagent.HostInjectSpec{},
 				},
-				TrustedCAs: testName,
 				ActiveGate: activegate.Spec{
 					Capabilities: []activegate.CapabilityDisplayName{
 						activegate.KubeMonCapability.DisplayName,
@@ -184,7 +275,108 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		volumeMounts := prepareVolumeMounts(dk)
 
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
+		assert.NotContains(t, volumeMounts, getClusterCaCertVolumeMount())
 		assert.Contains(t, volumeMounts, getActiveGateCaCertVolumeMount())
+	})
+	t.Run(`has automatically created ActiveGate CA volume mount`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: corev1.ObjectMeta{
+				Name: "dynakube",
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureActiveGateAutomaticTLSCertificate: "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{},
+				},
+				TrustedCAs: testName,
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.KubeMonCapability.DisplayName,
+					},
+				},
+			},
+		}
+
+		volumeMounts := prepareVolumeMounts(dk)
+
+		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
+		assert.Contains(t, volumeMounts, getClusterCaCertVolumeMount())
+		assert.Contains(t, volumeMounts, getActiveGateCaCertVolumeMount())
+	})
+	t.Run(`doesn't have cluster certificate volume mount if ff is used`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: corev1.ObjectMeta{
+				Name: "dynakube",
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureOneAgnetIgnoreTrustedCAs: "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{},
+				},
+				TrustedCAs: testName,
+			},
+		}
+		volumeMounts := prepareVolumeMounts(dk)
+
+		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
+		assert.NotContains(t, volumeMounts, getClusterCaCertVolumeMount())
+	})
+	t.Run(`doesn't have ActiveGate CA volume mount if ff is used`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: corev1.ObjectMeta{
+				Name: "dynakube",
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureOneAgnetIgnoreAgTlsCertificate: "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{},
+				},
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.KubeMonCapability.DisplayName,
+					},
+					TlsSecretName: "testing",
+				},
+			},
+		}
+
+		volumeMounts := prepareVolumeMounts(dk)
+
+		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
+		assert.NotContains(t, volumeMounts, getActiveGateCaCertVolumeMount())
+	})
+	t.Run(`doesn't have automatically created ActiveGate CA volume mount if ff is used`, func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: corev1.ObjectMeta{
+				Name: "dynakube",
+				Annotations: map[string]string{
+					dynakube.AnnotationFeatureActiveGateAutomaticTLSCertificate: "true",
+					dynakube.AnnotationFeatureOneAgnetIgnoreAgTlsCertificate:    "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{},
+				},
+				TrustedCAs: testName,
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.KubeMonCapability.DisplayName,
+					},
+				},
+			},
+		}
+
+		volumeMounts := prepareVolumeMounts(dk)
+
+		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
+		assert.NotContains(t, volumeMounts, getActiveGateCaCertVolumeMount())
 	})
 	t.Run(`readonly volume not supported on classicFullStack`, func(t *testing.T) {
 		dk := &dynakube.DynaKube{

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -56,26 +56,6 @@ func TestPrepareVolumes(t *testing.T) {
 		assert.Contains(t, volumes, getRootVolume())
 		assert.Contains(t, volumes, getCertificateVolume(dk))
 	})
-	t.Run(`doesn't have certificate volume if ff is used`, func(t *testing.T) {
-		dk := &dynakube.DynaKube{
-			ObjectMeta: corev1.ObjectMeta{
-				Name: "dynakube",
-				Annotations: map[string]string{
-					dynakube.AnnotationFeatureOneAgnetIgnoreTrustedCAs: "true",
-				},
-			},
-			Spec: dynakube.DynaKubeSpec{
-				TrustedCAs: testName,
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{},
-				},
-			},
-		}
-		volumes := prepareVolumes(dk)
-
-		assert.Contains(t, volumes, getRootVolume())
-		assert.NotContains(t, volumes, getCertificateVolume(dk))
-	})
 	t.Run(`has http_proxy volume`, func(t *testing.T) {
 		dk := &dynakube.DynaKube{}
 		dk.Spec =
@@ -128,54 +108,6 @@ func TestPrepareVolumes(t *testing.T) {
 		}
 		volumes := prepareVolumes(dk)
 		assert.Contains(t, volumes, getActiveGateCaCertVolume(dk))
-	})
-	t.Run(`doesn't have tls volume if ff is used`, func(t *testing.T) {
-		dk := &dynakube.DynaKube{
-			ObjectMeta: corev1.ObjectMeta{
-				Name: "dynakube",
-				Annotations: map[string]string{
-					dynakube.AnnotationFeatureOneAgnetIgnoreAgTlsCertificate: "true",
-				},
-			},
-			Spec: dynakube.DynaKubeSpec{
-				TrustedCAs: testName,
-				ActiveGate: activegate.Spec{
-					Capabilities: []activegate.CapabilityDisplayName{
-						activegate.KubeMonCapability.DisplayName,
-					},
-					TlsSecretName: "testing",
-				},
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{},
-				},
-			},
-		}
-		volumes := prepareVolumes(dk)
-		assert.NotContains(t, volumes, getActiveGateCaCertVolume(dk))
-	})
-	t.Run(`doesn't have automatically created tls volume if ff is used`, func(t *testing.T) {
-		dk := &dynakube.DynaKube{
-			ObjectMeta: corev1.ObjectMeta{
-				Name: "dynakube",
-				Annotations: map[string]string{
-					dynakube.AnnotationFeatureActiveGateAutomaticTLSCertificate: "true",
-					dynakube.AnnotationFeatureOneAgnetIgnoreAgTlsCertificate:    "true",
-				},
-			},
-			Spec: dynakube.DynaKubeSpec{
-				TrustedCAs: testName,
-				ActiveGate: activegate.Spec{
-					Capabilities: []activegate.CapabilityDisplayName{
-						activegate.KubeMonCapability.DisplayName,
-					},
-				},
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{},
-				},
-			},
-		}
-		volumes := prepareVolumes(dk)
-		assert.NotContains(t, volumes, getActiveGateCaCertVolume(dk))
 	})
 	t.Run(`csi volume not supported on classicFullStack`, func(t *testing.T) {
 		dk := &dynakube.DynaKube{
@@ -304,79 +236,6 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
 		assert.Contains(t, volumeMounts, getClusterCaCertVolumeMount())
 		assert.Contains(t, volumeMounts, getActiveGateCaCertVolumeMount())
-	})
-	t.Run(`doesn't have cluster certificate volume mount if ff is used`, func(t *testing.T) {
-		dk := &dynakube.DynaKube{
-			ObjectMeta: corev1.ObjectMeta{
-				Name: "dynakube",
-				Annotations: map[string]string{
-					dynakube.AnnotationFeatureOneAgnetIgnoreTrustedCAs: "true",
-				},
-			},
-			Spec: dynakube.DynaKubeSpec{
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{},
-				},
-				TrustedCAs: testName,
-			},
-		}
-		volumeMounts := prepareVolumeMounts(dk)
-
-		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.NotContains(t, volumeMounts, getClusterCaCertVolumeMount())
-	})
-	t.Run(`doesn't have ActiveGate CA volume mount if ff is used`, func(t *testing.T) {
-		dk := &dynakube.DynaKube{
-			ObjectMeta: corev1.ObjectMeta{
-				Name: "dynakube",
-				Annotations: map[string]string{
-					dynakube.AnnotationFeatureOneAgnetIgnoreAgTlsCertificate: "true",
-				},
-			},
-			Spec: dynakube.DynaKubeSpec{
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{},
-				},
-				ActiveGate: activegate.Spec{
-					Capabilities: []activegate.CapabilityDisplayName{
-						activegate.KubeMonCapability.DisplayName,
-					},
-					TlsSecretName: "testing",
-				},
-			},
-		}
-
-		volumeMounts := prepareVolumeMounts(dk)
-
-		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.NotContains(t, volumeMounts, getActiveGateCaCertVolumeMount())
-	})
-	t.Run(`doesn't have automatically created ActiveGate CA volume mount if ff is used`, func(t *testing.T) {
-		dk := &dynakube.DynaKube{
-			ObjectMeta: corev1.ObjectMeta{
-				Name: "dynakube",
-				Annotations: map[string]string{
-					dynakube.AnnotationFeatureActiveGateAutomaticTLSCertificate: "true",
-					dynakube.AnnotationFeatureOneAgnetIgnoreAgTlsCertificate:    "true",
-				},
-			},
-			Spec: dynakube.DynaKubeSpec{
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{},
-				},
-				TrustedCAs: testName,
-				ActiveGate: activegate.Spec{
-					Capabilities: []activegate.CapabilityDisplayName{
-						activegate.KubeMonCapability.DisplayName,
-					},
-				},
-			},
-		}
-
-		volumeMounts := prepareVolumeMounts(dk)
-
-		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
-		assert.NotContains(t, volumeMounts, getActiveGateCaCertVolumeMount())
 	})
 	t.Run(`readonly volume not supported on classicFullStack`, func(t *testing.T) {
 		dk := &dynakube.DynaKube{

--- a/pkg/util/certificates/certificates.go
+++ b/pkg/util/certificates/certificates.go
@@ -116,3 +116,15 @@ func ValidateCertificateExpiration(certData []byte, renewalThreshold time.Durati
 
 	return true, nil
 }
+
+func CommonName(dkName string, dkNamespace string, componentName string) string {
+	return dkName + "-" + componentName + "." + dkNamespace
+}
+
+func AltNames(dkName string, dkNamespace string, componentName string) []string {
+	return []string{
+		dkName + "-" + componentName + "." + dkNamespace,
+		dkName + "-" + componentName + "." + dkNamespace + ".svc",
+		dkName + "-" + componentName + "." + dkNamespace + ".svc.cluster.local",
+	}
+}

--- a/test/features/cloudnative/codemodules/codemodules.go
+++ b/test/features/cloudnative/codemodules/codemodules.go
@@ -240,7 +240,7 @@ func WithProxyCA(t *testing.T, proxySpec *value.Source) features.Feature {
 
 	agTlsSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cloudNativeDynakube.ActiveGate().GetTlsSecretName(),
+			Name:      cloudNativeDynakube.ActiveGate().GetTLSSecretName(),
 			Namespace: cloudNativeDynakube.Namespace,
 		},
 	}

--- a/test/features/cloudnative/codemodules/codemodules.go
+++ b/test/features/cloudnative/codemodules/codemodules.go
@@ -202,6 +202,9 @@ func WithProxyCA(t *testing.T, proxySpec *value.Source) features.Feature {
 		dynakubeComponents.WithActiveGate(),
 		dynakubeComponents.WithIstioIntegration(),
 		dynakubeComponents.WithProxy(proxySpec),
+		dynakubeComponents.WithAnnotations(map[string]string{
+			dynakube.AnnotationFeatureActiveGateAutomaticTLSCertificate: "true",
+		}),
 	)
 
 	sampleNamespace := *namespace.New("codemodules-sample-with-proxy-custom-ca", namespace.WithIstio())

--- a/test/features/cloudnative/container.go
+++ b/test/features/cloudnative/container.go
@@ -25,11 +25,11 @@ const (
 	activeGateRootCAPath       = "/var/lib/dynatrace/secrets/rootca/rootca.pem"
 )
 
-func AssessSampleContainer(builder *features.FeatureBuilder, sampleApp *sample.App, agCrt func() []byte, trustedCAs []byte) {
-	builder.Assess("certificates are propagated to sample apps containers", checkSampleContainer(sampleApp, agCrt, trustedCAs))
+func AssessSampleContainer(builder *features.FeatureBuilder, sampleApp *sample.App, agCrtFunc func() []byte, trustedCAs []byte) {
+	builder.Assess("certificates are propagated to sample apps containers", checkSampleContainer(sampleApp, agCrtFunc, trustedCAs))
 }
 
-func checkSampleContainer(sampleApp *sample.App, agCrt func() []byte, trustedCAs []byte) features.Func {
+func checkSampleContainer(sampleApp *sample.App, agCrtFunc func() []byte, trustedCAs []byte) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 
@@ -45,9 +45,9 @@ func checkSampleContainer(sampleApp *sample.App, agCrt func() []byte, trustedCAs
 			require.NotNil(t, podItem.Spec)
 			require.NotEmpty(t, podItem.Spec.Containers)
 
-			certs := string(agCrt()) + "\n" + string(trustedCAs)
+			certs := string(agCrtFunc()) + "\n" + string(trustedCAs)
 
-			if string(agCrt()) == "" && string(trustedCAs) == "" {
+			if string(agCrtFunc()) == "" && string(trustedCAs) == "" {
 				checkFileNotFound(ctx, t, resources, podItem, sampleApp.ContainerName(), oneAgentCustomPemPath)
 			} else {
 				checkFileContents(ctx, t, resources, podItem, sampleApp.ContainerName(), oneAgentCustomPemPath, certs)
@@ -63,11 +63,11 @@ func checkSampleContainer(sampleApp *sample.App, agCrt func() []byte, trustedCAs
 	}
 }
 
-func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrt func() []byte, trustedCAs []byte) {
-	builder.Assess("certificates are propagated to OneAgent containers", checkOneAgentContainer(agCrt, trustedCAs))
+func AssessOneAgentContainer(builder *features.FeatureBuilder, agCrtFunc func() []byte, trustedCAs []byte) {
+	builder.Assess("certificates are propagated to OneAgent containers", checkOneAgentContainer(agCrtFunc, trustedCAs))
 }
 
-func checkOneAgentContainer(agCrt func() []byte, trustedCAs []byte) features.Func {
+func checkOneAgentContainer(agCrtFunc func() []byte, trustedCAs []byte) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		// TODO: when OneAgent ticket is done, probably the same pem files as in case of sample container
 


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-1357)

## Description

### Operator

Operator creates ActiveGate TLS certificate (using PEM format) if TrustedCAs certificates are used. IP address of the AG service is also added to the AlternativeNames.

It solves the problem with OneAgents which use single `custom.pem` file to store TrustedCAs and AG certificates. A common scenario is that custom DynatraceServer certificate is  provided forcing the creation of AG certificate because OA verifies all TLS certificates if `custom.pem` file exists.

OSAgent (running in the OneAgent POD) needs IP address to connect to AG because is not able to resolve `<name>.<namespace>` hostname.

The `feature.dynatrace.com/automatic-tls-certificate` opt-in feature flag has to be used because AG>=1.307 only supports PEM format.

### Pipeline
regarding
- hack/doc/gen_e2e_features.sh
- hack/doc/gen_feature_flags.sh

`echo "..\n.."` is not interpreted as new line on all linux distributions so a multiline string is defined in one line using quotes and line continuation.


## How can this be tested?

### e2e test: `codemodules.WithProxyCA`
```
make test/e2e/istio
```

### Manual test

1) create a configmap with TrustedCAs certificate (any certificate, only existence is important)

2) install CloudNative dynakube with 
```
metadata:
  annotations:
    feature.dynatrace.com/automatic-tls-certificate: "true"
spec:
  apiUrl: ...
  activeGate:                                                                                                                                                                                                                                                                                                                                                                                 
    capabilities:                                                                                                                                                                                                                                                                                                                                                                             
    - routing  
  extensions: {}
  networkZone: <abc>
  oneAgent:
    cloudNativeFullStack: {}
  templates:
    extensionExecutionController:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-eec
        tag: 1.305.112.20250217-161735
  trustedCAs: <configmap> 
```

3) check if `dynakube-activegate-tls-secret` secret exists

4) check if AG cert is mounted to AG pod
```
 - name: server-certs
      secretName: dynakube-activegate-tls-secret 
```

5) Check if AG is using the PEM certificate (internally AG converts it to p12)
```
2025-02-24 15:37:19 UTC INFO	[entrypoint.sh] Setting custom SSL PEM certificate
2025-02-24 15:37:20 UTC INFO	[agctl] Creating keystore from PEM certificate
...
2025-02-24 15:37:24 UTC INFO    [<tec31546>] [<WebServer>, WebServerFactory] Starting Web Server...
2025-02-24 15:37:25 UTC INFO    [<tec31546>] [<WebServer>, WebServerFactory] Using SSL keystore file /var/lib/dynatrace/gateway/config/../ssl/server.p12
```

6) check if AG cert is mounted to Extensions pod
```
 - name: server-certs
      secretName: dynakube-activegate-tls-secret 
```

7) check if Extensions talk to AG
```
│      AG host:                       dynakube-activegate.dynatrace.svc.cluster.local 
...
│ 2025-02-24 15:26:51.766 UTC [00000010] info    [native] Logs ingest limits configuration arrived:
│      -MaxContentLength: 65536
│      -MaxAttributeLength: 250 
```

8) check osagent log in OA pod (choose the newest ruxitagent _host file)
```
bash-4.4$ cat /mnt/volume_storage_mount/host_root/var/log/dynatrace/oneagent/os/ruxitagent_host_310786.0.log | grep "\[comm  \]"
2025-02-24 16:00:59.927 UTC [0004be16] info    [comm  ] Connected to https://<AG serviceIP>:443/communication
```

9) install sample app

10) check agent log in the app pod (for my java app)
```
cat /opt/dynatrace/oneagent-paas/log/java/ruxitagent-....log | grep "\[comm  \]"
2025-02-24 16:15:20.566 UTC [00000007] info    [comm  ] Connected to https://dynakube-activegate.dynatrace:443/communication
```


