### PR TITLE
Fix helm upgrade if debug field is string

### DIFF
--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -42,19 +42,19 @@ Check if default image or imageref is used
 {{- end -}}
 
 {{- define "webhook.securityContext" -}}
-    {{- if ne .Values.debug true -}}
+    {{- if not .Values.debug -}}
         {{- toYaml .Values.webhook.securityContext -}}
     {{- end -}}
 {{- end -}}
 
 {{- define "csidriver.provisioner.resources" -}}
-    {{- if ne .Values.debug true -}}
+    {{- if not .Values.debug -}}
         {{- toYaml .Values.csidriver.provisioner.resources -}}
     {{- end -}}
 {{- end -}}
 
 {{- define "csidriver.server.resources" -}}
-    {{- if ne .Values.debug true -}}
+    {{- if not .Values.debug -}}
         {{- toYaml .Values.csidriver.server.resources -}}
     {{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Deployment of the operator failed when a string was assigned to the debug flag. The process should be more lenient and accept string values as well.

[Jira](https://dt-rnd.atlassian.net/browse/DAQ-5538)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

This should work now: 

```
helm upgrade dynatrace-operator config/helm/chart/default \
	--install \
	--namespace dynatrace \
	--create-namespace \
	--atomic \
	--set installCRD=true \
	--set csidriver.enabled=$(ENABLE_CSI) \
	--set manifests=true \
	--set image="$(IMAGE_URI)" \
	--set debug=""
```

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->