### PR TITLE
Support OCI `codeModulesImage` as well

### DIFF
--- a/pkg/injection/codemodule/installer/image/unpack.go
+++ b/pkg/injection/codemodule/installer/image/unpack.go
@@ -104,7 +104,7 @@ func (installer *Installer) unpackOciImage(layers []containerv1.Layer, imageCach
 	for _, layer := range layers {
 		mediaType, _ := layer.MediaType()
 		switch mediaType {
-		case types.DockerLayer:
+		case types.DockerLayer, types.OCILayer:
 			digest, _ := layer.Digest()
 			sourcePath := filepath.Join(imageCacheDir, "blobs", digest.Algorithm, digest.Hex)
 			log.Info("unpackOciImage", "sourcePath", sourcePath)
@@ -112,8 +112,6 @@ func (installer *Installer) unpackOciImage(layers []containerv1.Layer, imageCach
 			if err := installer.extractor.ExtractGzip(sourcePath, targetDir); err != nil {
 				return err
 			}
-		case types.OCILayer:
-			return errors.New("OCILayer is not implemented")
 		case types.OCILayerZStd:
 			return errors.New("OCILayerZStd is not implemented")
 		default:


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-3546](https://dt-rnd.atlassian.net/browse/DAQ-3546)

If the `codeModulesImage` was built with OCI media type. (ie.: not docker), then we would get the following error:
```
"stacktrace":"OCILayer is not implemented"
```
- this is just in our code, nothing more specific then that.

as it turns out, when it comes to our needs, the docker media type function the same as the OCI media type

## How can this be tested?

Using Operator 1.4.1 (or earlier), try using the `quay.io/dynatrace/dynatrace-bootstrapper:snapshot-add-ruxit` as `codeModulesImage` (**without** the `codemodules.oneagent.dynatrace.com/remote-image-download: "true"` feature-flag)
- in the provisioner's logs you will see the `OCILayer is not implemented` error

Using the same `codeModulesImage`, but for this branch:
- you should see no errors
- and on the fs of the CSI-driver you should see:
```
bash-5.1# ls /data/codemodules/cXVheS5pby9keW5hdHJhY2UvZHluYXRyYWNlLWJvb3RzdHJhcHBlcjpzbmFwc2hvdC1hZGQtcnV4aXQ\=/
agent  datastorage  dynatrace-agent32.sh  dynatrace-agent64.sh  dynatrace-env.sh  graalnative  log  manifest.json
```

[DAQ-3546]: https://dt-rnd.atlassian.net/browse/DAQ-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ