### PR TITLE
The snapshot image shouldn't expire

### DIFF
--- a/hack/build/ci/prepare-build-variables.sh
+++ b/hack/build/ci/prepare-build-variables.sh
@@ -15,7 +15,7 @@ createDockerImageTag() {
 }
 
 createDockerImageLabels() {
-  if [[ "${GITHUB_REF_TYPE}" != "tag" ]] && [[ ! "${GITHUB_REF_NAME}" =~ ^release-* ]]; then
+  if [[ "${GITHUB_REF_TYPE}" != "tag" ]] && [[ ! "${GITHUB_REF_NAME}" =~ ^release-* ]] && [[ "${GITHUB_REF_NAME}" != "main" ]]; then
     echo "quay.expires-after=10d"
   fi
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[Issue found](https://github.com/Dynatrace/dynatrace-bootstrapper/pull/11)

The `snapshot` image should expire after 10 days.

## How can this be tested?

