### PR TITLE
Respect custom nodeSelector when building logMon/KSPM DaemonSet

### DIFF
--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
@@ -91,6 +91,7 @@ func (r *Reconciler) generateDaemonSet() (*appsv1.DaemonSet, error) {
 		daemonset.SetServiceAccount(serviceAccountName),
 		daemonset.SetAffinity(node.AMDOnlyAffinity()),
 		daemonset.SetPriorityClass(r.dk.KSPM().PriorityClassName),
+		daemonset.SetNodeSelector(r.dk.KSPM().NodeSelector),
 		daemonset.SetTolerations(r.dk.KSPM().Tolerations),
 		daemonset.SetPullSecret(r.dk.ImagePullSecretReferences()...),
 		daemonset.SetUpdateStrategy(r.getUpdateStrategy()),

--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler_test.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler_test.go
@@ -220,6 +220,21 @@ func TestGenerateDaemonSet(t *testing.T) {
 
 		assert.Equal(t, daemonset.Spec.Template.Spec.Tolerations, customTolerations)
 	})
+	t.Run("respect custom nodeSelector", func(t *testing.T) {
+		customNodeSelector := map[string]string{
+			"some.nodeSelector.key": "true",
+		}
+
+		dk := createDynakube(true)
+		dk.KSPM().NodeSelector = customNodeSelector
+		reconciler := NewReconciler(nil,
+			nil, dk)
+		daemonset, err := reconciler.generateDaemonSet()
+		require.NoError(t, err)
+		require.NotNil(t, daemonset)
+
+		assert.Equal(t, daemonset.Spec.Template.Spec.NodeSelector, customNodeSelector)
+	})
 }
 
 func createDynakube(isEnabled bool) *dynakube.DynaKube {

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
@@ -101,6 +101,7 @@ func (r *Reconciler) generateDaemonSet() (*appsv1.DaemonSet, error) {
 		daemonset.SetDNSPolicy(r.dk.LogMonitoring().Template().DNSPolicy),
 		daemonset.SetAffinity(node.Affinity()),
 		daemonset.SetPriorityClass(r.dk.LogMonitoring().Template().PriorityClassName),
+		daemonset.SetNodeSelector(r.dk.LogMonitoring().Template().NodeSelector),
 		daemonset.SetTolerations(r.dk.LogMonitoring().Template().Tolerations),
 		daemonset.SetPullSecret(r.dk.ImagePullSecretReferences()...),
 		daemonset.SetUpdateStrategy(appsv1.DaemonSetUpdateStrategy{

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler_test.go
@@ -279,6 +279,22 @@ func TestGenerateDaemonSet(t *testing.T) {
 
 		assert.Equal(t, daemonset.Spec.Template.Spec.Tolerations, customTolerations)
 	})
+	t.Run("respect custom nodeselector", func(t *testing.T) {
+		customNodeSelector := map[string]string{
+			"some.nodeSelector.key": "true",
+		}
+
+		dk := createDynakube(true)
+		dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{
+			NodeSelector: customNodeSelector,
+		}
+		reconciler := NewReconciler(nil, fake.NewClient(), dk)
+		daemonset, err := reconciler.generateDaemonSet()
+		require.NoError(t, err)
+		require.NotNil(t, daemonset)
+
+		assert.Equal(t, daemonset.Spec.Template.Spec.NodeSelector, customNodeSelector)
+	})
 }
 
 func createDynakube(isEnabled bool) *dynakube.DynaKube {

--- a/pkg/util/kubeobjects/daemonset/builder.go
+++ b/pkg/util/kubeobjects/daemonset/builder.go
@@ -46,6 +46,12 @@ func SetTolerations(tolerations []corev1.Toleration) builder.Option[*appsv1.Daem
 	}
 }
 
+func SetNodeSelector(nodeSelector map[string]string) builder.Option[*appsv1.DaemonSet] {
+	return func(s *appsv1.DaemonSet) {
+		s.Spec.Template.Spec.NodeSelector = nodeSelector
+	}
+}
+
 func SetDNSPolicy(policy corev1.DNSPolicy) builder.Option[*appsv1.DaemonSet] {
 	return func(s *appsv1.DaemonSet) {
 		s.Spec.Template.Spec.DNSPolicy = policy


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

[Jira](https://dt-rnd.atlassian.net/browse/DAQ-5776)

Currently when defining a `nodeSelector` for `logMonitoring` and `KSPM` we do not pass it from the `DynaKube` to the `DaemonSet`.

Now this should be fixed.

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

Deploy a `DynaKube` that defines `logMonitoring`/`KSPM` with a `nodeSelector`. Check the `DaemonSet`, have a look if it has a `nodeSelector` and if it was considered when creating `Pods`.