### PR TITLE
Improve CSI server logs

### DIFF
--- a/pkg/controllers/csi/driver/volumes/app/publisher.go
+++ b/pkg/controllers/csi/driver/volumes/app/publisher.go
@@ -60,14 +60,18 @@ func (pub *Publisher) PublishVolume(ctx context.Context, volumeCfg *csivolumes.V
 	}
 
 	if !pub.isCodeModuleAvailable(volumeCfg) {
+		msg := "version or digest is not yet set, csi-provisioner hasn't finished setup injection is delayed"
+
 		return nil, status.Error(
 			codes.Unavailable,
-			"version or digest is not yet set, csi-provisioner hasn't finished setup yet for DynaKube: "+volumeCfg.DynakubeName,
+			volumeCfg.GetErrorMessage(msg),
 		)
 	}
 
 	if err := pub.mountCodeModule(volumeCfg); err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to mount oneagent volume: %s", err))
+		msg := fmt.Sprintf("failed to mount oneagent volume: %s", err)
+
+		return nil, status.Error(codes.Internal, volumeCfg.GetErrorMessage(msg))
 	}
 
 	return &csi.NodePublishVolumeResponse{}, nil

--- a/pkg/controllers/csi/driver/volumes/host/publisher.go
+++ b/pkg/controllers/csi/driver/volumes/host/publisher.go
@@ -45,7 +45,9 @@ type Publisher struct {
 
 func (pub *Publisher) PublishVolume(ctx context.Context, volumeCfg *csivolumes.VolumeConfig) (*csi.NodePublishVolumeResponse, error) {
 	if err := pub.mountStorageVolume(volumeCfg); err != nil {
-		return nil, status.Error(codes.Internal, "failed to mount osagent volume: "+err.Error())
+		msg := "failed to mount osagent volume: " + err.Error()
+
+		return nil, status.Error(codes.Internal, volumeCfg.GetErrorMessage(msg))
 	}
 
 	return &csi.NodePublishVolumeResponse{}, nil

--- a/pkg/controllers/csi/driver/volumes/volume_config.go
+++ b/pkg/controllers/csi/driver/volumes/volume_config.go
@@ -1,6 +1,7 @@
 package csivolumes
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
@@ -97,6 +98,14 @@ func ParseNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) (*VolumeCo
 		DynakubeName: dynakubeName,
 		RetryTimeout: retryTimeout,
 	}, nil
+}
+
+func (cfg VolumeConfig) GetErrorPrefix() string {
+	return fmt.Sprintf("(%s) %s/%s:%s", cfg.DynakubeName, cfg.PodNamespace, cfg.PodName, cfg.VolumeID)
+}
+
+func (cfg VolumeConfig) GetErrorMessage(msg string) string {
+	return cfg.GetErrorPrefix() + " " + msg
 }
 
 // Transforms the NodeUnpublishVolumeRequest into a VolumeInfo

--- a/pkg/controllers/csi/driver/volumes/volume_config_test.go
+++ b/pkg/controllers/csi/driver/volumes/volume_config_test.go
@@ -1,6 +1,7 @@
 package csivolumes
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -169,5 +170,31 @@ func TestCSIDriverServer_ParsePublishVolumeRequest(t *testing.T) {
 		assert.Equal(t, testNs, volumeCfg.PodNamespace)
 		assert.Equal(t, "test", volumeCfg.Mode)
 		assert.Equal(t, testDynakubeName, volumeCfg.DynakubeName)
+	})
+}
+
+func TestGetErrorMessage(t *testing.T) {
+	t.Run("add prefix", func(t *testing.T) {
+		dkName := "myDk"
+		podName := "my-app-123"
+		nsName := "ns-dev"
+		volumeID := "csi-1235wsfds1agsdf3445"
+		msg := "failed to mount"
+
+		cfg := VolumeConfig{
+			VolumeInfo: VolumeInfo{
+				VolumeID: volumeID,
+			},
+			PodName:      podName,
+			PodNamespace: nsName,
+			DynakubeName: dkName,
+		}
+
+		// (myDk) ns-dev/my-app-123:csi-1235wsfds1agsdf3445 failed to mount"
+		expectedMsg := fmt.Sprintf("(%s) %s/%s:%s %s", cfg.DynakubeName, cfg.PodNamespace, cfg.PodName, cfg.VolumeID, msg)
+
+		actualMsg := cfg.GetErrorMessage(msg)
+
+		require.Equal(t, expectedMsg, actualMsg)
 	})
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

An error log of the csi-server, that is logged by the GRPC server is unclear, as it doesn't have the details such as:
- which pod, in which ns has the problem
- which volume-id
- which DK

The problem is that we are bound to use(not really) the `status.Error` to format our msg, so I tried to come up with a "prefix" for such errors based on the `VolumeConfig`.
- Now the error logs are a bit shouty, mainly due to the `volumeID`, but also if the name of the ns/pod/dk is long, the log line will also be.

## How can this be tested?

Deploy a sample app, while the provisioner is still downloading, should see the message.
In a unit-test there is an example how it would look like in a vacuum, here is a live example: 
```
{"level":"error","ts":"2025-03-04T13:20:43.333Z","logger":"csi-driver","msg":"GRPC call failed","method":"NodePublishVolume","full_method":"/csi.v1.Node/NodePublishVolume","error":"rpc error: code = Unavailable desc
 = (codemodules) php-zib50933-oa/php-glibc-oa-7c4c5485b9-246xr:csi-a8c06cc0e0e8c3f9a131573f59834805fe52d7cb254922d98065d78f372b5569 version or digest is not yet set, csi-provisioner hasn't finished setup injection i
s delayed","stacktrace":"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver.(*Server).Start.grpcLimiter.func2\n\tgithub.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/driver/server.go:322\ngith
ub.com/container-storage-interface/spec/lib/go/csi._Node_NodePublishVolume_Handler\n\tgithub.com/container-storage-interface/spec@v1.11.0/lib/go/csi/csi_grpc.pb.go:1352\ngoogle.golang.org/grpc.(*Server).processUnary
RPC\n\tgoogle.golang.org/grpc@v1.70.0/server.go:1400\ngoogle.golang.org/grpc.(*Server).handleStream\n\tgoogle.golang.org/grpc@v1.70.0/server.go:1810\ngoogle.golang.org/grpc.(*Server).serveStreams.func2.1\n\tgoogle.g
olang.org/grpc@v1.70.0/server.go:1030"}
```

I can't control the stack-trace 😬 , unless we want to move away from the `status.Error` for creating the erros in the `server`