### PR TITLE
Add setup-go to `build` step in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Prepare SBOM
+      - name: Setup Golang
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: "${{ github.workspace }}/go.mod"
+      - name: Prepare SBOM # Needs setup-go, uses a binary installed via `go install`
         id: sbom
         run: |
           make release/gen-sbom


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

To use a binary installed via `go install` in an action, you need the `actions/setup-go` step to be done before, otherwise you will get a `... command not found`.

` make release/gen-sbom` will do a `go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod` so we need that step.

## How can this be tested?

Test on fork