### PR TITLE
Fix exporter endpoint and add unit tests.

### DIFF
--- a/pkg/controllers/dynakube/otelc/secret/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/secret/reconciler.go
@@ -83,16 +83,17 @@ func (r *Reconciler) ensureTelemetryIngestApiCredentialsSecret(ctx context.Conte
 }
 
 func (r *Reconciler) getDtEndpoint() ([]byte, error) {
-	tenantUUID, err := r.dk.TenantUUID()
-	if err != nil {
-		return nil, err
-	}
 
 	if r.dk.ActiveGate().IsApiEnabled() {
+		tenantUUID, err := r.dk.TenantUUID()
+		if err != nil {
+			return nil, err
+		}
+
 		return []byte(fmt.Sprintf("https://%s-activegate.dynatrace.svc/e/%s/api/v2/otlp", r.dk.Name, tenantUUID)), nil
 	}
 
-	return []byte(fmt.Sprintf("https://%s.%s/api/v2/otlp", tenantUUID, r.dk.ApiUrlHost())), nil
+	return []byte(fmt.Sprintf("https://%s/api/v2/otlp", r.dk.ApiUrlHost())), nil
 }
 
 func (r *Reconciler) generateTelemetryIngestApiCredentialsSecret(name string) (secret *corev1.Secret, err error) {

--- a/pkg/controllers/dynakube/otelc/secret/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/secret/reconciler.go
@@ -83,7 +83,6 @@ func (r *Reconciler) ensureTelemetryIngestApiCredentialsSecret(ctx context.Conte
 }
 
 func (r *Reconciler) getDtEndpoint() ([]byte, error) {
-
 	if r.dk.ActiveGate().IsApiEnabled() {
 		tenantUUID, err := r.dk.TenantUUID()
 		if err != nil {

--- a/pkg/controllers/dynakube/otelc/secret/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/secret/reconciler_test.go
@@ -107,6 +107,7 @@ func TestEndpoint(t *testing.T) {
 
 		endpoint, err := r.getDtEndpoint()
 		require.NoError(t, err)
+
 		expected := fmt.Sprintf("https://%s-activegate.dynatrace.svc/e/%s/api/v2/otlp", dk.Name, testTenantUUID)
 		assert.Equal(t, expected, string(endpoint))
 	})

--- a/pkg/controllers/dynakube/otelc/secret/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/secret/reconciler_test.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	schemeFake "github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
@@ -80,6 +81,56 @@ func TestSecretCreation(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Empty(t, apiTokenSecret)
+	})
+}
+
+func TestEndpoint(t *testing.T) {
+	t.Run("in-cluster ActiveGate", func(t *testing.T) {
+		dk := createDynaKube(true)
+		apiUrl := fmt.Sprintf("https://%s.dev.dynatracelabs.com/api", testTenantUUID)
+		dk.Spec.APIURL = apiUrl
+		dk.Spec.ActiveGate = activegate.Spec{
+			Capabilities: []activegate.CapabilityDisplayName{"dynatrace-api"},
+		}
+
+		objs := []client.Object{
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      consts.TelemetryApiCredentialsSecretName,
+					Namespace: dk.Namespace,
+				},
+			},
+		}
+
+		clt := schemeFake.NewClient(objs...)
+		r := NewReconciler(clt, clt, &dk)
+
+		endpoint, err := r.getDtEndpoint()
+		require.NoError(t, err)
+		expected := fmt.Sprintf("https://%s-activegate.dynatrace.svc/e/%s/api/v2/otlp", dk.Name, testTenantUUID)
+		assert.Equal(t, expected, string(endpoint))
+	})
+
+	t.Run("public ActiveGate", func(t *testing.T) {
+		dk := createDynaKube(true)
+		apiUrl := fmt.Sprintf("https://%s.dev.dynatracelabs.com/api", testTenantUUID)
+		dk.Spec.APIURL = apiUrl
+
+		objs := []client.Object{
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      consts.TelemetryApiCredentialsSecretName,
+					Namespace: dk.Namespace,
+				},
+			},
+		}
+
+		clt := schemeFake.NewClient(objs...)
+		r := NewReconciler(clt, clt, &dk)
+
+		endpoint, err := r.getDtEndpoint()
+		require.NoError(t, err)
+		assert.Equal(t, apiUrl+"/v2/otlp", string(endpoint))
 	})
 }
 


### PR DESCRIPTION
## Description

The endpoint for the OpenTelemeteryCollector in case of public AG was created wrong. It contained the tenantUUID twice.
Also if `telemetryIngest` was deployed standalone without AG or OA, it was still depending on the status field of AG or OA although it's not needed because the tenantUUID is already part of the apiURL set in the DynaKube

## How can this be tested?

Deploy Dynakube that has only `telemeterIngest` activated and nothing else.


