### PR TITLE
Fix Endpoint URL generation to also work with managed API urls.

### DIFF
--- a/pkg/controllers/dynakube/otelc/secret/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/secret/reconciler.go
@@ -92,7 +92,7 @@ func (r *Reconciler) getDtEndpoint() ([]byte, error) {
 		return []byte(fmt.Sprintf("https://%s-activegate.dynatrace.svc/e/%s/api/v2/otlp", r.dk.Name, tenantUUID)), nil
 	}
 
-	return []byte(fmt.Sprintf("https://%s/api/v2/otlp", r.dk.ApiUrlHost())), nil
+	return []byte(r.dk.ApiUrl() + "/v2/otlp"), nil
 }
 
 func (r *Reconciler) generateTelemetryIngestApiCredentialsSecret(name string) (secret *corev1.Secret, err error) {

--- a/pkg/controllers/dynakube/otelc/secret/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/secret/reconciler_test.go
@@ -133,6 +133,28 @@ func TestEndpoint(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, apiUrl+"/v2/otlp", string(endpoint))
 	})
+
+	t.Run("managed ActiveGate", func(t *testing.T) {
+		dk := createDynaKube(true)
+		apiUrl := "https://dynatrace.foobar.com/e/abcdefgh-1234-5678-9abc-deadbeef/api"
+		dk.Spec.APIURL = apiUrl
+
+		objs := []client.Object{
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      consts.TelemetryApiCredentialsSecretName,
+					Namespace: dk.Namespace,
+				},
+			},
+		}
+
+		clt := schemeFake.NewClient(objs...)
+		r := NewReconciler(clt, clt, &dk)
+
+		endpoint, err := r.getDtEndpoint()
+		require.NoError(t, err)
+		assert.Equal(t, apiUrl+"/v2/otlp", string(endpoint))
+	})
 }
 
 func createDynaKube(telemetryIngestEnabled bool) dynakube.DynaKube {


### PR DESCRIPTION
## Description
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-6062)

API URLs used for managed environments are not handled correctly when creating endpoints for telemetry ingest.
This PR fixes this.

## How can this be tested?

* unit tests