### PR TITLE
Use `.spec.telemetryIngest.serviceName` as name for telemetry ingest service

### DIFF
--- a/pkg/api/v1beta4/dynakube/telemetryingest/props.go
+++ b/pkg/api/v1beta4/dynakube/telemetryingest/props.go
@@ -27,7 +27,7 @@ func (ts *TelemetryIngest) SetName(name string) {
 	ts.name = name
 }
 
-func (ts *TelemetryIngest) GetName() string {
+func (ts *TelemetryIngest) GetDefaultServiceName() string {
 	return ts.name + ServiceNameSuffix
 }
 

--- a/pkg/api/v1beta4/dynakube/telemetryingest/props.go
+++ b/pkg/api/v1beta4/dynakube/telemetryingest/props.go
@@ -3,7 +3,7 @@ package telemetryingest
 import "github.com/Dynatrace/dynatrace-operator/pkg/otelcgen"
 
 const (
-	nameSuffix = "-telemetry-ingest"
+	ServiceNameSuffix = "-telemetry-ingest"
 )
 
 func (spec *Spec) GetProtocols() otelcgen.Protocols {
@@ -28,7 +28,7 @@ func (ts *TelemetryIngest) SetName(name string) {
 }
 
 func (ts *TelemetryIngest) GetName() string {
-	return ts.name + nameSuffix
+	return ts.name + ServiceNameSuffix
 }
 
 func (ts *TelemetryIngest) IsEnabled() bool {

--- a/pkg/api/v1beta4/dynakube/telemetryingest/props.go
+++ b/pkg/api/v1beta4/dynakube/telemetryingest/props.go
@@ -31,6 +31,19 @@ func (ts *TelemetryIngest) GetDefaultServiceName() string {
 	return ts.name + ServiceNameSuffix
 }
 
+func (ts *TelemetryIngest) GetServiceName() string {
+	if ts.Spec == nil {
+		return ts.GetDefaultServiceName()
+	}
+
+	serviceName := ts.Spec.ServiceName
+	if serviceName == "" {
+		serviceName = ts.GetDefaultServiceName()
+	}
+
+	return serviceName
+}
+
 func (ts *TelemetryIngest) IsEnabled() bool {
 	return ts.Spec != nil
 }

--- a/pkg/api/validation/dynakube/telemetryservice.go
+++ b/pkg/api/validation/dynakube/telemetryservice.go
@@ -130,7 +130,7 @@ func conflictingTelemetryIngestServiceNames(ctx context.Context, dv *Validator, 
 
 	dkServiceName := dk.TelemetryIngest().ServiceName
 	if dkServiceName == "" {
-		dkServiceName = dk.TelemetryIngest().GetName()
+		dkServiceName = dk.TelemetryIngest().GetDefaultServiceName()
 	}
 
 	for _, otherDk := range dkList.Items {
@@ -144,7 +144,7 @@ func conflictingTelemetryIngestServiceNames(ctx context.Context, dv *Validator, 
 
 		otherDkServiceName := otherDk.TelemetryIngest().ServiceName
 		if otherDkServiceName == "" {
-			otherDkServiceName = otherDk.TelemetryIngest().GetName()
+			otherDkServiceName = otherDk.TelemetryIngest().GetDefaultServiceName()
 		}
 
 		if otherDkServiceName == dkServiceName {

--- a/pkg/api/validation/dynakube/telemetryservice.go
+++ b/pkg/api/validation/dynakube/telemetryservice.go
@@ -6,8 +6,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/telemetryingest"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/telemetryingest"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	agconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/otelcgen"
@@ -128,10 +128,7 @@ func conflictingTelemetryIngestServiceNames(ctx context.Context, dv *Validator, 
 		return ""
 	}
 
-	dkServiceName := dk.TelemetryIngest().ServiceName
-	if dkServiceName == "" {
-		dkServiceName = dk.TelemetryIngest().GetDefaultServiceName()
-	}
+	dkServiceName := dk.TelemetryIngest().GetServiceName()
 
 	for _, otherDk := range dkList.Items {
 		if otherDk.Name == dk.Name {
@@ -142,10 +139,7 @@ func conflictingTelemetryIngestServiceNames(ctx context.Context, dv *Validator, 
 			continue
 		}
 
-		otherDkServiceName := otherDk.TelemetryIngest().ServiceName
-		if otherDkServiceName == "" {
-			otherDkServiceName = otherDk.TelemetryIngest().GetDefaultServiceName()
-		}
+		otherDkServiceName := otherDk.TelemetryIngest().GetServiceName()
 
 		if otherDkServiceName == dkServiceName {
 			log.Info(errorTelemetryIngestServiceNameInUse, "other dynakube name", otherDk.Name, "other telemetry service name", otherDkServiceName, "namespace", otherDk.Namespace)

--- a/pkg/api/validation/dynakube/telemetryservice_test.go
+++ b/pkg/api/validation/dynakube/telemetryservice_test.go
@@ -3,8 +3,8 @@ package validation
 import (
 	"testing"
 
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/telemetryingest"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/telemetryingest"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	agconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/otelcgen"

--- a/pkg/api/validation/dynakube/telemetryservice_test.go
+++ b/pkg/api/validation/dynakube/telemetryservice_test.go
@@ -3,10 +3,24 @@ package validation
 import (
 	"testing"
 
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/telemetryingest"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube/telemetryingest"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	agconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/otelcgen"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const (
+	testOtherName        = "test-other-name"
+	testServiceName      = "test-service-name"
+	testOtherServiceName = "test-other-service-name"
+)
+
+var otherDynakubeObjectMeta = metav1.ObjectMeta{
+	Name:      testOtherName,
+	Namespace: testNamespace,
+}
 
 func TestTelemetryIngestProtocols(t *testing.T) {
 	t.Run(`no list of protocols`, func(t *testing.T) {
@@ -154,6 +168,146 @@ func TestTelemetryIngestProtocols(t *testing.T) {
 					APIURL: testApiUrl,
 					TelemetryIngest: &telemetryingest.Spec{
 						ServiceName: "0123",
+					},
+				},
+			})
+	})
+}
+
+func TestConflictingServiceNames(t *testing.T) {
+	t.Run(`no conflicts`, func(t *testing.T) {
+		assertAllowed(t,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL:          testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{},
+				},
+			},
+			&dynakube.DynaKube{
+				ObjectMeta: otherDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL:          testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{},
+				},
+			})
+	})
+
+	t.Run(`custom service name vs custom service name`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorTelemetryIngestServiceNameInUse},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{
+						ServiceName: testServiceName,
+					},
+				},
+			},
+			&dynakube.DynaKube{
+				ObjectMeta: otherDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{
+						ServiceName: testServiceName,
+					},
+				},
+			})
+	})
+
+	t.Run(`custom service name vs default service name`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorTelemetryIngestServiceNameInUse},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{
+						ServiceName: testOtherName + "-telemetry-ingest",
+					},
+				},
+			},
+			&dynakube.DynaKube{
+				ObjectMeta: otherDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL:          testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{},
+				},
+			})
+	})
+
+	t.Run(`default service name vs custom service name`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorTelemetryIngestServiceNameInUse},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL:          testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{},
+				},
+			},
+			&dynakube.DynaKube{
+				ObjectMeta: otherDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{
+						ServiceName: testName + "-telemetry-ingest",
+					},
+				},
+			})
+	})
+}
+
+func TestForbiddenSuffix(t *testing.T) {
+	t.Run(`activegate`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorTelemetryIngestForbiddenServiceName},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{
+						ServiceName: "test" + "-" + agconsts.MultiActiveGateName,
+					},
+				},
+			})
+	})
+	t.Run(`extensions`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorTelemetryIngestForbiddenServiceName},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{
+						ServiceName: "test" + consts.ExtensionsControllerSuffix,
+					},
+				},
+			})
+	})
+	t.Run(`telemetry ingest`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorTelemetryIngestForbiddenServiceName},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{
+						ServiceName: "test" + telemetryingest.ServiceNameSuffix,
+					},
+				},
+			})
+	})
+	t.Run(`webhook`, func(t *testing.T) {
+		assertDenied(t,
+			[]string{errorTelemetryIngestForbiddenServiceName},
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testApiUrl,
+					TelemetryIngest: &telemetryingest.Spec{
+						ServiceName: "test-webhook",
 					},
 				},
 			})

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -60,6 +60,8 @@ var (
 		unknownTelemetryIngestProtocols,
 		duplicatedTelemetryIngestProtocols,
 		invalidTelemetryIngestName,
+		forbiddenTelemetryIngestServiceNameSuffix,
+		conflictingTelemetryIngestServiceNames,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,

--- a/pkg/controllers/dynakube/otelc/service/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/service/reconciler.go
@@ -47,7 +47,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		return nil
 	}
 
-	r.removeServices(ctx, r.dk.TelemetryIngest().GetServiceName())
+	r.removeAllServicesExcept(ctx, r.dk.TelemetryIngest().GetServiceName())
 
 	return r.createOrUpdateService(ctx)
 }
@@ -58,10 +58,10 @@ func (r *Reconciler) removeServiceOnce(ctx context.Context) {
 	}
 	defer meta.RemoveStatusCondition(r.dk.Conditions(), serviceConditionType)
 
-	r.removeServices(ctx, "")
+	r.removeAllServicesExcept(ctx, "")
 }
 
-func (r *Reconciler) removeServices(ctx context.Context, actualServiceName string) {
+func (r *Reconciler) removeAllServicesExcept(ctx context.Context, actualServiceName string) {
 	telemetryServiceList := &corev1.ServiceList{}
 
 	listOps := []client.ListOption{

--- a/pkg/controllers/dynakube/otelc/service/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/service/reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/telemetryingest"
 	"github.com/Dynatrace/dynatrace-operator/pkg/otelcgen"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -61,33 +62,6 @@ func TestService(t *testing.T) {
 		assert.Equal(t, conditions.ServiceCreatedReason, dk.Status.Conditions[0].Reason)
 		assert.Equal(t, metav1.ConditionTrue, dk.Status.Conditions[0].Status)
 	})
-	t.Run("remove service if it is not needed", func(t *testing.T) {
-		dk := getTestDynakube(nil)
-		dk.Status.Conditions = []metav1.Condition{
-			{
-				Type: serviceConditionType,
-			},
-		}
-
-		mockK8sClient := fake.NewFakeClient()
-		err := mockK8sClient.Create(context.Background(), &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      dk.TelemetryIngest().GetName(),
-				Namespace: dk.Namespace,
-			},
-		})
-		require.NoError(t, err)
-
-		err = NewReconciler(mockK8sClient, mockK8sClient, dk).Reconcile(context.Background())
-		require.NoError(t, err)
-
-		service := &corev1.Service{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetName(), Namespace: dk.Namespace}, service)
-		require.Error(t, err)
-		assert.True(t, k8serrors.IsNotFound(err))
-
-		require.Empty(t, dk.Status.Conditions)
-	})
 	t.Run("create service for specified protocols", func(t *testing.T) {
 		mockK8sClient := fake.NewFakeClient()
 		dk := getTestDynakube(&telemetryingest.Spec{
@@ -112,20 +86,67 @@ func TestService(t *testing.T) {
 		assert.Equal(t, conditions.ServiceCreatedReason, dk.Status.Conditions[0].Reason)
 		assert.Equal(t, metav1.ConditionTrue, dk.Status.Conditions[0].Status)
 	})
-	t.Run("custom service", func(t *testing.T) {
+	t.Run("default service name, remove service if it is not needed", func(t *testing.T) {
+		dk := getTestDynakube(nil)
+		dk.Status.Conditions = []metav1.Condition{
+			{
+				Type: serviceConditionType,
+			},
+		}
+
 		mockK8sClient := fake.NewFakeClient()
-		dk := getTestDynakube(&telemetryingest.Spec{
-			ServiceName: testServiceName,
+		err := mockK8sClient.Create(context.Background(), &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dk.TelemetryIngest().GetName(),
+				Namespace: dk.Namespace,
+				Labels: map[string]string{
+					labels.AppCreatedByLabel:    dk.Name,
+					telemetryIngestServiceLabel: dk.Name,
+				},
+			},
 		})
-		err := NewReconciler(mockK8sClient, mockK8sClient, dk).Reconcile(context.Background())
+		require.NoError(t, err)
+
+		err = NewReconciler(mockK8sClient, mockK8sClient, dk).Reconcile(context.Background())
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: testServiceName, Namespace: dk.Namespace}, service)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetName(), Namespace: dk.Namespace}, service)
 		require.Error(t, err)
 		assert.True(t, k8serrors.IsNotFound(err))
 
-		assert.Empty(t, dk.Status.Conditions)
+		require.Empty(t, dk.Status.Conditions)
+	})
+	t.Run("custom service name, remove service if it is not needed", func(t *testing.T) {
+		dk := getTestDynakube(nil)
+		dk.Status.Conditions = []metav1.Condition{
+			{
+				Type: serviceConditionType,
+			},
+		}
+
+		mockK8sClient := fake.NewFakeClient()
+		err := mockK8sClient.Create(context.Background(), &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testServiceName,
+				Namespace: dk.Namespace,
+				Labels: map[string]string{
+					labels.AppCreatedByLabel:    dk.Name,
+					telemetryIngestServiceLabel: dk.Name,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		err = NewReconciler(mockK8sClient, mockK8sClient, dk).Reconcile(context.Background())
+		require.NoError(t, err)
+
+		service := &corev1.Service{}
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetName(), Namespace: dk.Namespace}, service)
+		require.Error(t, err)
+		assert.True(t, k8serrors.IsNotFound(err))
+
+		require.Empty(t, dk.Status.Conditions)
 	})
 	t.Run("update from default service to custom service", func(t *testing.T) {
 		mockK8sClient := fake.NewFakeClient()
@@ -154,6 +175,35 @@ func TestService(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, k8serrors.IsNotFound(err))
 
-		assert.Empty(t, dk.Status.Conditions)
+		assert.NotEmpty(t, dk.Status.Conditions)
+	})
+	t.Run("update from custom service to default service", func(t *testing.T) {
+		mockK8sClient := fake.NewFakeClient()
+		dk := getTestDynakube(&telemetryingest.Spec{
+			ServiceName: testServiceName,
+		})
+		err := NewReconciler(mockK8sClient, mockK8sClient, dk).Reconcile(context.Background())
+		require.NoError(t, err)
+
+		service := &corev1.Service{}
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: testServiceName, Namespace: dk.Namespace}, service)
+		require.NoError(t, err)
+
+		require.Len(t, dk.Status.Conditions, 1)
+		assert.Equal(t, serviceConditionType, dk.Status.Conditions[0].Type)
+		assert.Equal(t, conditions.ServiceCreatedReason, dk.Status.Conditions[0].Reason)
+		assert.Equal(t, metav1.ConditionTrue, dk.Status.Conditions[0].Status)
+
+		// update
+		dk.Spec.TelemetryIngest = &telemetryingest.Spec{}
+		err = NewReconciler(mockK8sClient, mockK8sClient, dk).Reconcile(context.Background())
+		require.NoError(t, err)
+
+		service = &corev1.Service{}
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: testServiceName, Namespace: dk.Namespace}, service)
+		require.Error(t, err)
+		assert.True(t, k8serrors.IsNotFound(err))
+
+		assert.NotEmpty(t, dk.Status.Conditions)
 	})
 }

--- a/pkg/controllers/dynakube/otelc/service/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/service/reconciler_test.go
@@ -45,7 +45,7 @@ func TestService(t *testing.T) {
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetName(), Namespace: dk.Namespace}, service)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetDefaultServiceName(), Namespace: dk.Namespace}, service)
 		require.NoError(t, err)
 
 		require.Len(t, service.Spec.Ports, 8)
@@ -74,7 +74,7 @@ func TestService(t *testing.T) {
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetName(), Namespace: dk.Namespace}, service)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetDefaultServiceName(), Namespace: dk.Namespace}, service)
 		require.NoError(t, err)
 
 		require.Len(t, service.Spec.Ports, 2)
@@ -97,11 +97,11 @@ func TestService(t *testing.T) {
 		mockK8sClient := fake.NewFakeClient()
 		err := mockK8sClient.Create(context.Background(), &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      dk.TelemetryIngest().GetName(),
+				Name:      dk.TelemetryIngest().GetDefaultServiceName(),
 				Namespace: dk.Namespace,
 				Labels: map[string]string{
-					labels.AppCreatedByLabel:    dk.Name,
-					telemetryIngestServiceLabel: dk.Name,
+					labels.AppComponentLabel: labels.OtelCComponentLabel,
+					labels.AppCreatedByLabel: dk.Name,
 				},
 			},
 		})
@@ -111,7 +111,7 @@ func TestService(t *testing.T) {
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetName(), Namespace: dk.Namespace}, service)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetDefaultServiceName(), Namespace: dk.Namespace}, service)
 		require.Error(t, err)
 		assert.True(t, k8serrors.IsNotFound(err))
 
@@ -131,8 +131,8 @@ func TestService(t *testing.T) {
 				Name:      testServiceName,
 				Namespace: dk.Namespace,
 				Labels: map[string]string{
-					labels.AppCreatedByLabel:    dk.Name,
-					telemetryIngestServiceLabel: dk.Name,
+					labels.AppComponentLabel: labels.OtelCComponentLabel,
+					labels.AppCreatedByLabel: dk.Name,
 				},
 			},
 		})
@@ -142,7 +142,7 @@ func TestService(t *testing.T) {
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetName(), Namespace: dk.Namespace}, service)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetDefaultServiceName(), Namespace: dk.Namespace}, service)
 		require.Error(t, err)
 		assert.True(t, k8serrors.IsNotFound(err))
 
@@ -155,7 +155,7 @@ func TestService(t *testing.T) {
 		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetName(), Namespace: dk.Namespace}, service)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetDefaultServiceName(), Namespace: dk.Namespace}, service)
 		require.NoError(t, err)
 
 		require.Len(t, dk.Status.Conditions, 1)
@@ -171,7 +171,7 @@ func TestService(t *testing.T) {
 		require.NoError(t, err)
 
 		service = &corev1.Service{}
-		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetName(), Namespace: dk.Namespace}, service)
+		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: dk.TelemetryIngest().GetDefaultServiceName(), Namespace: dk.Namespace}, service)
 		require.Error(t, err)
 		assert.True(t, k8serrors.IsNotFound(err))
 


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-6015)

## Description

Operator uses 
```
    app.kubernetes.io/component: dynatrace-opentelemetry-collector
    app.kubernetes.io/created-by: <dynakube  name>
```    
labels to find previous instance of the service if `telemetryIngest.serviceName` is changed and to delete the actual service if dynakube is undeployed.

## How can this be tested?
0) unittests
1) deploy dynakube
```
metadata:
  name: dynakube
spec:                                                                                                                                                                                                                                                                                                                   
  apiUrl: ...
  activeGate:                                                                                                                                                                                                                                                                                                           
    capabilities:                                                                                                                                                                                                                                                                                                       
    - dynatrace-api
  telemetryIngest: {}
```
2) `dynakube-telemetry-ingest` service created
3) change `serviceName`
```
  telemetryIngest:
    serviceName: ti
```
4) `dynakube-telemetry-ingest` service deleted
5) `ti` service created
6) try to deploy another dynakube

```
metadata:
  name: otherdynakube
spec:
  apiUrl: ...
  activeGate:
    capabilities:
    - dynatrace-api
  telemetryIngest:
    serviceName: ti
```
