### PR TITLE
Backport: Mount /var/log as read only to standalone logmonitoring #4522

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -14,11 +14,12 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 		fmt.Sprintf("-p dt.entity.kubernetes_cluster=$(%s)", entityEnv),
 		fmt.Sprintf("-c k8s_fullpodname $(%s)", podNameEnv),
 		fmt.Sprintf("-c k8s_poduid $(%s)", podUIDEnv),
-		fmt.Sprintf("-c k8s_containername %s", containerName), //nolint:perfsprint
 		fmt.Sprintf("-c k8s_basepodname $(%s)", basePodNameEnv),
 		fmt.Sprintf("-c k8s_namespace $(%s)", namespaceNameEnv),
 		fmt.Sprintf("-c k8s_node_name $(%s)", nodeNameEnv),
 		fmt.Sprintf("-c k8s_cluster_id $(%s)", clusterUIDEnv),
+		"-c k8s_containername " + containerName,
+		"-l " + dtLogVolumePath,
 	}
 
 	return append(baseArgs, dk.LogMonitoring().Template().Args...)

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	expectedBaseInitArgsLen = 11
+	expectedBaseInitArgsLen = 12
 )
 
 func TestGetInitArgs(t *testing.T) {

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
@@ -51,7 +51,7 @@ func getInitContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container 
 		Name:            initContainerName,
 		Image:           dk.LogMonitoring().Template().ImageRef.StringWithDefaults(defaultImageRepo, defaultImageTag),
 		ImagePullPolicy: corev1.PullAlways,
-		VolumeMounts:    getDTVolumeMounts(tenantUUID),
+		VolumeMounts:    []corev1.VolumeMount{getDTVolumeMounts(tenantUUID)},
 		Command:         []string{bootstrapCommand},
 		Env:             getInitEnvs(dk),
 		Args:            getInitArgs(dk),

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
@@ -17,17 +17,14 @@ const (
 	dtLibVolumeName      = "dynatrace-lib"
 	dtLibVolumeMountPath = "/var/lib/dynatrace"
 	dtSubPathTemplate    = "logmonitoring-%s"
-	dtLibVolumePath      = "/tmp/dynatrace"
+	dtLogVolumePath      = "/tmp/dynatrace"
 	dtLogVolumeName      = "dynatrace-logs"
-	dtLogVolumeMountPath = "/var/log/dynatrace"
 
 	// for the logs that the logmonitoring will ingest
-	podLogsVolumeName       = "var-log-pods"
-	podLogsVolumePath       = "/var/log/pods"
-	dockerLogsVolumeName    = "docker-container-logs"
-	dockerLogsVolumePath    = "/var/lib/docker/containers"
-	containerLogsVolumeName = "container-logs"
-	containerLogsVolumePath = "/var/log/containers"
+	dockerLogsVolumeName = "docker-container-logs"
+	dockerLogsVolumePath = "/var/lib/docker/containers"
+	logsVolumeHostPath   = "/var/log"
+	logsVolumeName       = "var-log"
 )
 
 // getConfigVolumeMount provides the VolumeMount for the deployment.conf
@@ -52,17 +49,22 @@ func getConfigVolume(dkName string) corev1.Volume {
 }
 
 // getDTVolumeMounts provides the VolumeMounts for the dynatrace specific folders
-func getDTVolumeMounts(tenantUUID string) []corev1.VolumeMount {
-	return []corev1.VolumeMount{
-		{
-			Name:      dtLibVolumeName,
-			SubPath:   fmt.Sprintf(dtSubPathTemplate, tenantUUID),
-			MountPath: dtLibVolumeMountPath,
-		},
-		{
-			Name:      dtLogVolumeName,
-			MountPath: dtLogVolumeMountPath,
-		},
+func getDTVolumeMounts(tenantUUID string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+
+		Name:      dtLibVolumeName,
+		SubPath:   fmt.Sprintf(dtSubPathTemplate, tenantUUID),
+		MountPath: dtLibVolumeMountPath,
+	}
+}
+
+// getDTVolumeMounts provides the VolumeMounts for the dynatrace specific folders
+func getDTLogVolumeMounts(tenantUUID string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+
+		Name:      dtLogVolumeName,
+		SubPath:   fmt.Sprintf(dtSubPathTemplate, tenantUUID),
+		MountPath: dtLogVolumePath,
 	}
 }
 
@@ -73,7 +75,7 @@ func getDTVolumes() []corev1.Volume {
 			Name: dtLibVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: dtLibVolumePath,
+					Path: dtLogVolumePath,
 					Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 				},
 			},
@@ -94,13 +96,8 @@ func getIngestVolumeMounts() []corev1.VolumeMount {
 			ReadOnly:  true,
 		},
 		{
-			Name:      podLogsVolumeName,
-			MountPath: podLogsVolumePath,
-			ReadOnly:  true,
-		},
-		{
-			Name:      containerLogsVolumeName,
-			MountPath: containerLogsVolumePath,
+			Name:      logsVolumeName,
+			MountPath: logsVolumeHostPath,
 			ReadOnly:  true,
 		},
 	}
@@ -114,24 +111,15 @@ func getIngestVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: dockerLogsVolumePath,
-					Type: ptr.To(corev1.HostPathDirectory),
+					Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 				},
 			},
 		},
 		{
-			Name: podLogsVolumeName,
+			Name: logsVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: podLogsVolumePath,
-					Type: ptr.To(corev1.HostPathDirectory),
-				},
-			},
-		},
-		{
-			Name: containerLogsVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: containerLogsVolumePath,
+					Path: logsVolumeHostPath,
 					Type: ptr.To(corev1.HostPathDirectory),
 				},
 			},
@@ -142,7 +130,8 @@ func getIngestVolumes() []corev1.Volume {
 func getVolumeMounts(tenantUUID string) []corev1.VolumeMount {
 	var mounts []corev1.VolumeMount
 	mounts = append(mounts, getConfigVolumeMount())
-	mounts = append(mounts, getDTVolumeMounts(tenantUUID)...)
+	mounts = append(mounts, getDTVolumeMounts(tenantUUID))
+	mounts = append(mounts, getDTLogVolumeMounts(tenantUUID))
 	mounts = append(mounts, getIngestVolumeMounts()...)
 
 	return mounts

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	expectedMountLen     = 6
-	expectedInitMountLen = 2
+	expectedMountLen     = 5
+	expectedInitMountLen = 1
 )
 
 func TestGetVolumeMounts(t *testing.T) {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-5544)

Backport for 1.4.2

Same as in #4522

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Same as in #4522

Please test properly!

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->