### PR TITLE
Update securityContext for node config collector container

### DIFF
--- a/pkg/controllers/dynakube/kspm/daemonset/container.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/container.go
@@ -12,7 +12,7 @@ const (
 	defaultImageTag  = "latest"
 
 	containerName       = "node-config-collector"
-	runAs         int64 = 0
+	runAs         int64 = 65532
 )
 
 func getContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container {
@@ -37,9 +37,9 @@ func getSecurityContext() corev1.SecurityContext {
 		AllowPrivilegeEscalation: ptr.To(false),
 		RunAsUser:                ptr.To(runAs),
 		RunAsGroup:               ptr.To(runAs),
-		RunAsNonRoot:             ptr.To(false),
+		RunAsNonRoot:             ptr.To(true),
 		ReadOnlyRootFilesystem:   ptr.To(true),
-		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		Capabilities:             &corev1.Capabilities{Add: []corev1.Capability{"DAC_OVERRIDE"}, Drop: []corev1.Capability{"ALL"}},
 	}
 
 	return securityContext


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-4042)

Node config collector should no longer run with a privileged user, therefor we need to update the securityContext of the container.

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

Deploy kspm and see if everything runs and works.

check the securityContext of the kspm pods, should look like this:

```
securityContext:
  allowPrivilegeEscalation: false
  capabilities:
    add:
      - DAC_OVERRIDE
    drop:
      - ALL
  privileged: false
  readOnlyRootFilesystem: true
  runAsGroup: 65532
  runAsNonRoot: true
  runAsUser: 65532
```