### PR TITLE
Add validation to deny init bootstrapper without code modules image set

### DIFF
--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -19,6 +19,8 @@ const (
 
 	errorImageFieldSetWithoutCSIFlag = `The DynaKube specification attempts to enable ApplicationMonitoring mode and retrieve the respective image, but the CSI driver and/or remote image download is not enabled.`
 
+	errorBootstrapperRemoteImageDownloadRequiresCodeModulesImage = `The DynaKube specification enables remote image download, but the code modules image is not set.`
+
 	errorNodeSelectorConflict = `The Dynakube specification conflicts with another Dynakube's OneAgent or Standalone-LogMonitoring. Only one Agent per node is supported.
 Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 
@@ -148,6 +150,14 @@ func imageFieldSetWithoutCSIFlag(_ context.Context, v *Validator, dk *dynakube.D
 		if len(dk.Spec.OneAgent.ApplicationMonitoring.CodeModulesImage) > 0 && !v.modules.CSIDriver && !dk.FeatureRemoteImageDownload() {
 			return errorImageFieldSetWithoutCSIFlag
 		}
+	}
+
+	return ""
+}
+
+func missingCodeModulesImage(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
+	if dk.FeatureBootstrapperInjection() && len(dk.Spec.OneAgent.ApplicationMonitoring.CodeModulesImage) == 0 {
+		return errorBootstrapperRemoteImageDownloadRequiresCodeModulesImage
 	}
 
 	return ""

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -46,6 +46,7 @@ var (
 		conflictingNamespaceSelector,
 		noResourcesAvailable,
 		imageFieldSetWithoutCSIFlag,
+		missingCodeModulesImage,
 		conflictingOneAgentVolumeStorageSettings,
 		nameViolatesDNS1035,
 		nameTooLong,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

The init bootstrapper without CSI driver requires a code modules image to be set. 
This PR adds the validation in the webhook.

## How can this be tested?

Apply and should fail:
```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/remote-image-download: "true"
spec:
  apiUrl: https://ppn33804.dev.dynatracelabs.com/api
  oneAgent:
    applicationMonitoring: {}
      #codeModulesImage: "quay.io/dynatrace/dynatrace-bootstrapper:gktest"
```

Should work: 
```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/remote-image-download: "true"
spec:
  apiUrl: https://ppn33804.dev.dynatracelabs.com/api

  oneAgent:
    applicationMonitoring:
      codeModulesImage: "quay.io/dynatrace/dynatrace-bootstrapper:gktest"
```

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->