### PR TITLE
Add LogMonitoring e2e test

### DIFF
--- a/doc/e2e/features.md
+++ b/doc/e2e/features.md
@@ -427,6 +427,8 @@ const (
     DevRegistryPullSecretName       = "devregistry"
     EecImageRepo                    = "478983378254.dkr.ecr.us-east-1.amazonaws.com/dynatrace/dynatrace-eec"
     EecImageTag                     = "1.303.0.20240930-183404"
+    LogMonitoringImageRepo          = "public.ecr.aws/dynatrace/dynatrace-logmodule"
+    LogMonitoringImageTag           = "1.309.59.20250319-140247"
 )
 ```
 
@@ -479,6 +481,24 @@ import "github.com/Dynatrace/dynatrace-operator/test/features/extensions"
 <a name="Feature"></a>
 
 ## func [Feature](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/extensions/extensions.go#L26>)
+
+```go
+func Feature(t *testing.T) features.Feature
+```
+
+# logmonitoring
+
+```go
+import "github.com/Dynatrace/dynatrace-operator/test/features/logmonitoring"
+```
+
+## Index
+
+- [func Feature(t *testing.T) features.Feature](<#Feature>)
+
+<a name="Feature"></a>
+
+## func [Feature](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/logmonitoring/logmonitoring.go#L34>)
 
 ```go
 func Feature(t *testing.T) features.Feature

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -145,3 +145,7 @@ test/e2e/gke-autopilot: manifests/crd/helm
 ## Runs extensions related e2e tests
 test/e2e/extensions: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/no_csi -args --feature "extensions-components-rollout" $(SKIPCLEANUP)
+
+## Runs LogMonitoring related e2e tests
+test/e2e/logmonitoring: manifests/crd/helm
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/no_csi -args --feature "logmonitoring-components-rollout" $(SKIPCLEANUP)

--- a/pkg/controllers/dynakube/logmonitoring/configsecret/conditions.go
+++ b/pkg/controllers/dynakube/logmonitoring/configsecret/conditions.go
@@ -1,5 +1,5 @@
 package configsecret
 
 const (
-	lmcConditionType = "LogMonitoringConfig"
+	LmcConditionType = "LogMonitoringConfig"
 )

--- a/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler.go
@@ -44,7 +44,7 @@ func NewReconciler(clt client.Client,
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
 	if !r.dk.LogMonitoring().IsStandalone() {
-		if meta.FindStatusCondition(*r.dk.Conditions(), lmcConditionType) == nil {
+		if meta.FindStatusCondition(*r.dk.Conditions(), LmcConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}
 
@@ -55,7 +55,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 			log.Error(err, "failed to clean-up LogMonitoring config-secret")
 		}
 
-		meta.RemoveStatusCondition(r.dk.Conditions(), lmcConditionType)
+		meta.RemoveStatusCondition(r.dk.Conditions(), LmcConditionType)
 
 		return nil // clean-up shouldn't cause a failure
 	}
@@ -73,14 +73,14 @@ func (r *Reconciler) reconcileSecret(ctx context.Context) error {
 
 	changed, err := query.CreateOrUpdate(ctx, newSecret)
 	if err != nil {
-		conditions.SetKubeApiError(r.dk.Conditions(), lmcConditionType, err)
+		conditions.SetKubeApiError(r.dk.Conditions(), LmcConditionType, err)
 
 		return err
 	} else if changed {
-		conditions.SetSecretOutdated(r.dk.Conditions(), lmcConditionType, newSecret.Name) // needed so the timestamp updates, will never actually show up in the status
+		conditions.SetSecretOutdated(r.dk.Conditions(), LmcConditionType, newSecret.Name) // needed so the timestamp updates, will never actually show up in the status
 	}
 
-	conditions.SetSecretCreated(r.dk.Conditions(), lmcConditionType, newSecret.Name)
+	conditions.SetSecretCreated(r.dk.Conditions(), LmcConditionType, newSecret.Name)
 
 	return nil
 }
@@ -99,7 +99,7 @@ func (r *Reconciler) prepareSecret(ctx context.Context) (*corev1.Secret, error) 
 		k8ssecret.SetLabels(coreLabels),
 	)
 	if err != nil {
-		conditions.SetSecretGenFailed(r.dk.Conditions(), lmcConditionType, err)
+		conditions.SetSecretGenFailed(r.dk.Conditions(), LmcConditionType, err)
 
 		return nil, err
 	}
@@ -113,14 +113,14 @@ func (r *Reconciler) getSecretData(ctx context.Context) (map[string][]byte, erro
 		Namespace: r.dk.Namespace,
 	}, connectioninfo.TenantTokenKey, log)
 	if err != nil {
-		conditions.SetKubeApiError(r.dk.Conditions(), lmcConditionType, err)
+		conditions.SetKubeApiError(r.dk.Conditions(), LmcConditionType, err)
 
 		return nil, err
 	}
 
 	tenantUUID, err := r.dk.TenantUUID()
 	if err != nil {
-		conditions.SetSecretGenFailed(r.dk.Conditions(), lmcConditionType, err)
+		conditions.SetSecretGenFailed(r.dk.Conditions(), LmcConditionType, err)
 
 		return nil, err
 	}

--- a/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler_test.go
@@ -37,7 +37,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("Only clean up if not standalone", func(t *testing.T) {
 		dk := createDynakube(true)
 		dk.Spec.OneAgent.CloudNativeFullStack = &oneagent.CloudNativeFullStackSpec{}
-		conditions.SetSecretCreated(dk.Conditions(), lmcConditionType, "testing")
+		conditions.SetSecretCreated(dk.Conditions(), LmcConditionType, "testing")
 
 		mockK8sClient := createK8sClientWithConfigSecret()
 
@@ -50,7 +50,7 @@ func TestReconcile(t *testing.T) {
 		err = mockK8sClient.Get(context.Background(), client.ObjectKey{Name: GetSecretName((dk.Name)), Namespace: dk.Namespace}, &secret)
 		require.True(t, k8serrors.IsNotFound(err))
 
-		condition := meta.FindStatusCondition(*dk.Conditions(), lmcConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), LmcConditionType)
 		require.Nil(t, condition)
 	})
 
@@ -66,7 +66,7 @@ func TestReconcile(t *testing.T) {
 
 		checkSecretForValue(t, mockK8sClient, dk)
 
-		condition := meta.FindStatusCondition(*dk.Conditions(), lmcConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), LmcConditionType)
 		require.NotNil(t, condition)
 		oldTransitionTime := condition.LastTransitionTime
 		require.NotEmpty(t, oldTransitionTime)
@@ -82,7 +82,7 @@ func TestReconcile(t *testing.T) {
 		dk := createDynakube(false)
 
 		mockK8sClient := createK8sClientWithOneAgentTenantSecret(dk, tokenValue)
-		conditions.SetSecretCreated(dk.Conditions(), lmcConditionType, "this is a test")
+		conditions.SetSecretCreated(dk.Conditions(), LmcConditionType, "this is a test")
 
 		reconciler := NewReconciler(mockK8sClient, mockK8sClient, dk)
 		err := reconciler.Reconcile(ctx)
@@ -110,7 +110,7 @@ func TestReconcile(t *testing.T) {
 
 		require.Error(t, err)
 		require.Len(t, *dk.Conditions(), 1)
-		condition := meta.FindStatusCondition(*dk.Conditions(), lmcConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), LmcConditionType)
 		assert.Equal(t, conditions.KubeApiErrorReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	})

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/conditions.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/conditions.go
@@ -1,5 +1,5 @@
 package daemonset
 
 const (
-	conditionType = "LogMonitoringDaemonSet"
+	ConditionType = "LogMonitoringDaemonSet"
 )

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
@@ -41,7 +41,7 @@ var KubernetesSettingsNotAvailableError = errors.New("the status of the DynaKube
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
 	if !r.dk.LogMonitoring().IsStandalone() {
-		if meta.FindStatusCondition(*r.dk.Conditions(), conditionType) == nil {
+		if meta.FindStatusCondition(*r.dk.Conditions(), ConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}
 
@@ -52,7 +52,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 			log.Error(err, "failed to clean-up LogMonitoring config-secret")
 		}
 
-		meta.RemoveStatusCondition(r.dk.Conditions(), conditionType)
+		meta.RemoveStatusCondition(r.dk.Conditions(), ConditionType)
 
 		return nil // clean-up shouldn't cause a failure
 	}
@@ -70,14 +70,14 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 
 	updated, err := daemonset.Query(r.client, r.apiReader, log).WithOwner(r.dk).CreateOrUpdate(ctx, ds)
 	if err != nil {
-		conditions.SetKubeApiError(r.dk.Conditions(), conditionType, err)
+		conditions.SetKubeApiError(r.dk.Conditions(), ConditionType, err)
 
 		return err
 	}
 
 	if updated {
-		conditions.SetDaemonSetOutdated(r.dk.Conditions(), conditionType, r.dk.LogMonitoring().GetDaemonSetName()) // needed to reset the timestamp
-		conditions.SetDaemonSetCreated(r.dk.Conditions(), conditionType, r.dk.LogMonitoring().GetDaemonSetName())
+		conditions.SetDaemonSetOutdated(r.dk.Conditions(), ConditionType, r.dk.LogMonitoring().GetDaemonSetName()) // needed to reset the timestamp
+		conditions.SetDaemonSetCreated(r.dk.Conditions(), ConditionType, r.dk.LogMonitoring().GetDaemonSetName())
 	}
 
 	return nil

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler_test.go
@@ -36,7 +36,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("Only clean up if not standalone", func(t *testing.T) {
 		dk := createDynakube(true)
 		dk.Spec.OneAgent.CloudNativeFullStack = &oneagent.CloudNativeFullStackSpec{}
-		conditions.SetDaemonSetCreated(dk.Conditions(), conditionType, "testing")
+		conditions.SetDaemonSetCreated(dk.Conditions(), ConditionType, "testing")
 
 		previousDaemonSet := appsv1.DaemonSet{}
 		previousDaemonSet.Name = dk.LogMonitoring().GetDaemonSetName()
@@ -55,7 +55,7 @@ func TestReconcile(t *testing.T) {
 		}, &daemonset)
 		require.True(t, k8serrors.IsNotFound(err))
 
-		condition := meta.FindStatusCondition(*dk.Conditions(), conditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), ConditionType)
 		require.Nil(t, condition)
 	})
 
@@ -69,7 +69,7 @@ func TestReconcile(t *testing.T) {
 		err := reconciler.Reconcile(ctx)
 		require.NoError(t, err)
 
-		condition := meta.FindStatusCondition(*dk.Conditions(), conditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), ConditionType)
 		require.NotNil(t, condition)
 		oldTransitionTime := condition.LastTransitionTime
 		require.NotEmpty(t, oldTransitionTime)
@@ -95,7 +95,7 @@ func TestReconcile(t *testing.T) {
 		previousDaemonSet.Namespace = dk.Namespace
 		mockK8sClient := fake.NewClient(&previousDaemonSet)
 
-		conditions.SetDaemonSetCreated(dk.Conditions(), conditionType, "this is a test")
+		conditions.SetDaemonSetCreated(dk.Conditions(), ConditionType, "this is a test")
 
 		reconciler := NewReconciler(mockK8sClient, mockK8sClient, dk)
 		err := reconciler.Reconcile(ctx)
@@ -123,7 +123,7 @@ func TestReconcile(t *testing.T) {
 
 		require.Error(t, err)
 		require.Len(t, *dk.Conditions(), 1)
-		condition := meta.FindStatusCondition(*dk.Conditions(), conditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), ConditionType)
 		assert.Equal(t, conditions.KubeApiErrorReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	})

--- a/pkg/controllers/dynakube/logmonitoring/logmonsettings/conditions.go
+++ b/pkg/controllers/dynakube/logmonitoring/logmonsettings/conditions.go
@@ -9,7 +9,7 @@ const (
 	settingsExistReason = "LogMonSettingsExist"
 	settingsErrorReason = "LogMonSettingsError"
 
-	conditionType = "LogMonitoringSettings"
+	ConditionType = "LogMonitoringSettings"
 )
 
 func setLogMonitoringSettingExists(conditions *[]metav1.Condition, conditionType string) {

--- a/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
@@ -34,12 +34,12 @@ func NewReconciler(dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Recon
 }
 
 func (r *reconciler) Reconcile(ctx context.Context) error {
-	if !conditions.IsOutdated(r.timeProvider, r.dk, conditionType) {
+	if !conditions.IsOutdated(r.timeProvider, r.dk, ConditionType) {
 		return nil
 	}
 
 	if !r.dk.LogMonitoring().IsEnabled() {
-		meta.RemoveStatusCondition(r.dk.Conditions(), conditionType)
+		meta.RemoveStatusCondition(r.dk.Conditions(), ConditionType)
 
 		return nil
 	} else if r.dk.Status.KubernetesClusterMEID == "" {
@@ -61,7 +61,7 @@ func (r *reconciler) checkLogMonitoringSettings(ctx context.Context) error {
 
 	logMonitoringSettings, err := r.dtc.GetSettingsForLogModule(ctx, r.dk.Status.KubernetesClusterMEID)
 	if err != nil {
-		setLogMonitoringSettingError(r.dk.Conditions(), conditionType, err.Error())
+		setLogMonitoringSettingError(r.dk.Conditions(), ConditionType, err.Error())
 
 		return errors.WithMessage(err, "error trying to check if setting exists")
 	}
@@ -69,7 +69,7 @@ func (r *reconciler) checkLogMonitoringSettings(ctx context.Context) error {
 	if logMonitoringSettings.TotalCount > 0 {
 		log.Info("there are already settings", "settings", logMonitoringSettings)
 
-		setLogMonitoringSettingExists(r.dk.Conditions(), conditionType)
+		setLogMonitoringSettingExists(r.dk.Conditions(), ConditionType)
 
 		return nil
 	}
@@ -82,7 +82,7 @@ func (r *reconciler) checkLogMonitoringSettings(ctx context.Context) error {
 	objectId, err := r.dtc.CreateLogMonitoringSetting(ctx, r.dk.Status.KubernetesClusterMEID, r.dk.Status.KubernetesClusterName, matchers)
 
 	if err != nil {
-		setLogMonitoringSettingError(r.dk.Conditions(), conditionType, err.Error())
+		setLogMonitoringSettingError(r.dk.Conditions(), ConditionType, err.Error())
 
 		return err
 	}

--- a/test/features/consts/consts.go
+++ b/test/features/consts/consts.go
@@ -8,4 +8,6 @@ const (
 	DevRegistryPullSecretName       = "devregistry"
 	EecImageRepo                    = "478983378254.dkr.ecr.us-east-1.amazonaws.com/dynatrace/dynatrace-eec"
 	EecImageTag                     = "1.303.0.20240930-183404"
+	LogMonitoringImageRepo          = "public.ecr.aws/dynatrace/dynatrace-logmodule"
+	LogMonitoringImageTag           = "1.309.59.20250319-140247"
 )

--- a/test/features/logmonitoring/logmonitoring.go
+++ b/test/features/logmonitoring/logmonitoring.go
@@ -1,0 +1,125 @@
+//go:build e2e
+
+package logmonitoring
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/configsecret"
+	lmdaemonset "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/daemonset"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/logmonsettings"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	"github.com/Dynatrace/dynatrace-operator/test/features/consts"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/activegate"
+	componentDynakube "github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/secret"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/platform"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
+	"github.com/Dynatrace/dynatrace-operator/test/project"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func Feature(t *testing.T) features.Feature {
+	builder := features.New("logmonitoring-components-rollout")
+
+	secretConfig := tenant.GetSingleTenantSecret(t)
+
+	options := []componentDynakube.Option{
+		componentDynakube.WithApiUrl(secretConfig.ApiUrl),
+		componentDynakube.WithCustomPullSecret(consts.DevRegistryPullSecretName),
+		componentDynakube.WithLogMonitoring(),
+		componentDynakube.WithLogMonitoringImageRefSpec(consts.LogMonitoringImageRepo, consts.LogMonitoringImageTag),
+		componentDynakube.WithActiveGate(),
+		componentDynakube.WithActiveGateTLSSecret(consts.AgSecretName),
+	}
+
+	isOpenshift, err := platform.NewResolver().IsOpenshift()
+	require.NoError(t, err)
+	if isOpenshift {
+		options = append(options, componentDynakube.WithAnnotations(map[string]string{
+			dynakube.AnnotationFeatureRunOneAgentContainerPrivileged: "true",
+		}))
+	}
+
+	testDynakube := *componentDynakube.New(options...)
+
+	agCrt, err := os.ReadFile(path.Join(project.TestDataDir(), consts.AgCertificate))
+	require.NoError(t, err)
+
+	agP12, err := os.ReadFile(path.Join(project.TestDataDir(), consts.AgCertificateAndPrivateKey))
+	require.NoError(t, err)
+
+	agSecret := secret.New(consts.AgSecretName, testDynakube.Namespace,
+		map[string][]byte{
+			dynakube.TLSCertKey:                    agCrt,
+			consts.AgCertificateAndPrivateKeyField: agP12,
+		})
+	builder.Assess("create AG TLS secret", secret.Create(agSecret))
+
+	componentDynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+
+	builder.Assess("active gate pod is running", checkActiveGateContainer(&testDynakube))
+
+	builder.Assess("log agent started", daemonset.WaitForDaemonset(testDynakube.LogMonitoring().GetDaemonSetName(), testDynakube.Namespace))
+
+	builder.Assess("log monitoring conditions", checkConditions(testDynakube.Name, testDynakube.Namespace))
+
+	componentDynakube.Delete(builder, helpers.LevelTeardown, testDynakube)
+
+	builder.WithTeardown("deleted tenant secret", tenant.DeleteTenantSecret(testDynakube.Name, testDynakube.Namespace))
+
+	builder.WithTeardown("deleted ag secret", secret.Delete(agSecret))
+
+	return builder.Feature()
+}
+
+func checkActiveGateContainer(dk *dynakube.DynaKube) features.Func {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
+
+		var activeGatePod corev1.Pod
+		require.NoError(t, resources.WithNamespace(dk.Namespace).Get(ctx, activegate.GetActiveGatePodName(dk, "activegate"), dk.Namespace, &activeGatePod))
+
+		require.NotNil(t, activeGatePod.Spec)
+		require.NotEmpty(t, activeGatePod.Spec.Containers)
+
+		return ctx
+	}
+}
+
+func checkConditions(name string, namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		dk := &dynakube.DynaKube{}
+		err := envConfig.Client().Resources().Get(ctx, name, namespace, dk)
+		require.NoError(t, err)
+
+		condition := meta.FindStatusCondition(*dk.Conditions(), configsecret.LmcConditionType)
+		require.NotNil(t, condition)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
+
+		condition = meta.FindStatusCondition(*dk.Conditions(), lmdaemonset.ConditionType)
+		require.NotNil(t, condition)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, conditions.DaemonSetSetCreatedReason, condition.Reason)
+
+		condition = meta.FindStatusCondition(*dk.Conditions(), logmonsettings.ConditionType)
+		if condition != nil {
+			assert.NotEqual(t, metav1.ConditionFalse, condition.Status)
+		}
+
+		return ctx
+	}
+}

--- a/test/helpers/components/dynakube/options.go
+++ b/test/helpers/components/dynakube/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/activegate"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -180,5 +181,22 @@ func WithExtensionsEECImageRefSpec(repo, tag string) Option {
 func WithCustomPullSecret(secretName string) Option {
 	return func(dk *dynakube.DynaKube) {
 		dk.Spec.CustomPullSecret = secretName
+	}
+}
+
+func WithLogMonitoring() Option {
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.LogMonitoring = &logmonitoring.Spec{}
+	}
+}
+
+func WithLogMonitoringImageRefSpec(repo, tag string) Option {
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{
+			ImageRef: image.Ref{
+				Repository: repo,
+				Tag:        tag,
+			},
+		}
 	}
 }

--- a/test/helpers/kubeobjects/daemonset/wait.go
+++ b/test/helpers/kubeobjects/daemonset/wait.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
@@ -13,6 +14,7 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
 func WaitFor(name string, namespace string) env.Func {
@@ -32,4 +34,8 @@ func WaitFor(name string, namespace string) env.Func {
 
 		return ctx, err
 	}
+}
+
+func WaitForDaemonset(name string, namespace string) features.Func {
+	return helpers.ToFeatureFunc(WaitFor(name, namespace), true)
 }

--- a/test/scenarios/no_csi/no_csi_test.go
+++ b/test/scenarios/no_csi/no_csi_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/features/classic"
 	"github.com/Dynatrace/dynatrace-operator/test/features/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/test/features/extensions"
+	"github.com/Dynatrace/dynatrace-operator/test/features/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
@@ -51,6 +52,7 @@ func TestNoCSI(t *testing.T) {
 		edgeconnect.AutomationModeFeature(t),
 		classic.Feature(t),
 		bootstrapper.NoCSI(t),
+		logmonitoring.Feature(t),
 	}
 
 	testEnv.Test(t, scenarios.FilterFeatures(*cfg, feats)...)


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-5586)

## Description

Adds LogMonitoring e2e test.

It is part of `standard` group of tests and there is new make target to run it
```
make test/e2e/logmonitoring
```

The test checks `dynakube.status.conditions` related to LogMonitoring
- LogMonitoringConfig - if secret has been created
- LogMonitoringDaemonSet - if daemonset has been created
- LogMonitoringSettings - if GetSettings and/or CreateSettings have been successful

Uses LogAgent images from ECR public registry.

## How can this be tested?

k8s and ( OpenShift or crc )  cluster

```
make test/e2e/logmonitoring
```