### PR TITLE
Configure attributes for bootstrapper injection

### DIFF
--- a/pkg/webhook/mutation/pod/v1/metadata/config.go
+++ b/pkg/webhook/mutation/pod/v1/metadata/config.go
@@ -11,5 +11,5 @@ const (
 )
 
 var (
-	log = logd.Get().WithName("metadata-enrichment-pod-v1-mutation")
+	log = logd.Get().WithName("v1-pod-mutation-metadata-enrichment")
 )

--- a/pkg/webhook/mutation/pod/v1/oneagent/config.go
+++ b/pkg/webhook/mutation/pod/v1/oneagent/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	log = logd.Get().WithName("oneagent-pod-v1-mutation")
+	log = logd.Get().WithName("v1-pod-mutation-oneagent")
 )
 
 const (

--- a/pkg/webhook/mutation/pod/v1/oneagent/env.go
+++ b/pkg/webhook/mutation/pod/v1/oneagent/env.go
@@ -7,7 +7,7 @@ import (
 
 func addInstallerInitEnvs(initContainer *corev1.Container, installer installerInfo) {
 	initContainer.Env = append(initContainer.Env,
-		corev1.EnvVar{Name: consts.AgentInstallerFlavorEnv, Value: installer.flavor}, // TODO: is this needed
+		corev1.EnvVar{Name: consts.AgentInstallerFlavorEnv, Value: installer.flavor},
 		corev1.EnvVar{Name: consts.AgentInstallerTechEnv, Value: installer.technologies},
 		corev1.EnvVar{Name: consts.AgentInstallPathEnv, Value: installer.installPath},
 		corev1.EnvVar{Name: consts.AgentInstallerUrlEnv, Value: installer.installerURL},

--- a/pkg/webhook/mutation/pod/v2/attributes.go
+++ b/pkg/webhook/mutation/pod/v2/attributes.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (wh *Injector) addPodAttributes(request *dtwebhook.MutationRequest) error {
-	attr := podattr.Attributes{
+	attrs := podattr.Attributes{
 		PodInfo: podattr.PodInfo{
 			PodName:       createEnvVarRef(consts.K8sPodNameEnv),
 			PodUid:        createEnvVarRef(consts.K8sPodUIDEnv),
@@ -40,12 +40,12 @@ func (wh *Injector) addPodAttributes(request *dtwebhook.MutationRequest) error {
 
 	request.InstallContainer.Env = append(request.InstallContainer.Env, envs...)
 
-	err := metadata.Mutate(wh.metaClient, request, &attr)
+	err := metadata.Mutate(wh.metaClient, request, &attrs)
 	if err != nil {
 		return err
 	}
 
-	args, err := podattr.ToArgs(attr)
+	args, err := podattr.ToArgs(attrs)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/mutation/pod/v2/attributes.go
+++ b/pkg/webhook/mutation/pod/v2/attributes.go
@@ -26,11 +26,16 @@ func (wh *Injector) addPodAttributes(request *dtwebhook.MutationRequest) error {
 			ClusterUId:      request.DynaKube.Status.KubeSystemUUID,
 			DTClusterEntity: request.DynaKube.Status.KubernetesClusterMEID,
 		},
+		UserDefined: map[string]string{
+			"k8s.cluster.name": request.DynaKube.Status.KubernetesClusterName, // TODO: make it part of podattr.Attributes
+			"k8s.node.name":    createEnvVarRef(consts.K8sNodeNameEnv),        // TODO: make it part of podattr.Attributes
+		},
 	}
 
 	envs := []corev1.EnvVar{
 		{Name: consts.K8sPodNameEnv, ValueFrom: env.NewEnvVarSourceForField("metadata.name")},
 		{Name: consts.K8sPodUIDEnv, ValueFrom: env.NewEnvVarSourceForField("metadata.uid")},
+		{Name: consts.K8sNodeNameEnv, ValueFrom: env.NewEnvVarSourceForField("spec.nodeName")},
 	}
 
 	request.InstallContainer.Env = append(request.InstallContainer.Env, envs...)

--- a/pkg/webhook/mutation/pod/v2/attributes.go
+++ b/pkg/webhook/mutation/pod/v2/attributes.go
@@ -1,0 +1,94 @@
+package v2
+
+import (
+	"fmt"
+
+	containerattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/container"
+	podattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/pod"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/mounts"
+	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
+	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/v2/common/volumes"
+	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/v2/metadata"
+	"github.com/google/go-containerregistry/pkg/name"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (wh *Injector) addPodAttributes(request *dtwebhook.MutationRequest) {
+	attr := podattr.Attributes{
+		PodInfo: podattr.PodInfo{
+			PodName:       createEnvVarRef(consts.K8sPodNameEnv),
+			PodUid:        createEnvVarRef(consts.K8sPodUIDEnv),
+			NamespaceName: request.Pod.Namespace,
+		},
+		ClusterInfo: podattr.ClusterInfo{
+			ClusterUId:      request.DynaKube.Status.KubeSystemUUID,
+			DTClusterEntity: request.DynaKube.Status.KubernetesClusterMEID,
+		},
+	}
+
+	envs := []corev1.EnvVar{
+		{Name: consts.K8sPodNameEnv, ValueFrom: env.NewEnvVarSourceForField("metadata.name")},
+		{Name: consts.K8sPodUIDEnv, ValueFrom: env.NewEnvVarSourceForField("metadata.uid")},
+	}
+
+	request.InstallContainer.Env = append(request.InstallContainer.Env, envs...)
+
+	metadata.Mutate(wh.metaClient, request, &attr)
+
+	args, err := podattr.ToArgs(attr)
+	if err != nil {
+		return // TODO
+	}
+
+	request.InstallContainer.Args = append(request.InstallContainer.Args, args...)
+}
+
+func createEnvVarRef(envName string) string {
+	return fmt.Sprintf("$(%s)", envName)
+}
+
+func addContainerAttributes(request *dtwebhook.MutationRequest) {
+	attributes := []containerattr.Attributes{}
+	for _, c := range request.NewContainers(isInjected) {
+		attributes = append(attributes, containerattr.Attributes{
+			ImageInfo:     createImageInfo(c.Image),
+			ContainerName: c.Name,
+		})
+	}
+
+	if len(attributes) > 0 {
+		args, err := containerattr.ToArgs(attributes)
+		if err != nil {
+			return // TODO fix
+		}
+
+		request.InstallContainer.Args = append(request.InstallContainer.Args, args...)
+	}
+}
+
+func isInjected(container corev1.Container) bool {
+	return mounts.IsIn(container.VolumeMounts, volumes.ConfigVolumeName)
+}
+
+func createImageInfo(imageURI string) containerattr.ImageInfo { // TODO: move to bootstrapper repo
+	ref, _ := name.ParseReference(imageURI)
+
+	tag := ""
+	if taggedRef, ok := ref.(name.Tag); ok {
+		tag = taggedRef.TagStr()
+	}
+
+	digest := ""
+	if diggestRef, ok := ref.(name.Digest); ok {
+		digest = diggestRef.DigestStr()
+	}
+
+	return containerattr.ImageInfo{
+		Registry:    ref.Context().RegistryStr(),
+		Repository:  ref.Context().RepositoryStr(),
+		Tag:         tag,
+		ImageDigest: digest,
+	}
+}

--- a/pkg/webhook/mutation/pod/v2/attributes_test.go
+++ b/pkg/webhook/mutation/pod/v2/attributes_test.go
@@ -44,9 +44,10 @@ func TestAddPodAttributes(t *testing.T) {
 		assert.Contains(t, attr.PodUid, consts.K8sPodUIDEnv)
 		assert.Equal(t, request.Pod.Namespace, attr.NamespaceName)
 
-		require.Len(t, request.InstallContainer.Env, 2)
+		require.Len(t, request.InstallContainer.Env, 3)
 		assert.NotNil(t, env.FindEnvVar(request.InstallContainer.Env, consts.K8sPodNameEnv))
 		assert.NotNil(t, env.FindEnvVar(request.InstallContainer.Env, consts.K8sPodUIDEnv))
+		assert.NotNil(t, env.FindEnvVar(request.InstallContainer.Env, consts.K8sNodeNameEnv))
 
 		return attr
 	}
@@ -68,7 +69,7 @@ func TestAddPodAttributes(t *testing.T) {
 			}
 		}
 
-		assert.Len(t, attr.UserDefined, metaAnnotationCount)
+		assert.Len(t, attr.UserDefined, metaAnnotationCount+2) // TODO: this +2 should be removed once k8s.node.name and k8s.cluster.name are part of the actual Attributes
 		require.Len(t, request.Pod.Annotations, 3+metaAnnotationCount)
 		assert.Equal(t, strings.ToLower(request.Pod.OwnerReferences[0].Kind), request.Pod.Annotations[metacommon.AnnotationWorkloadKind])
 		assert.Equal(t, request.Pod.OwnerReferences[0].Name, request.Pod.Annotations[metacommon.AnnotationWorkloadName])
@@ -96,6 +97,7 @@ func TestAddPodAttributes(t *testing.T) {
 					Status: dynakube.DynaKubeStatus{
 						KubernetesClusterMEID: "meid",
 						KubeSystemUUID:        "systemuuid",
+						KubernetesClusterName: "meidname",
 					},
 				},
 			},
@@ -148,6 +150,11 @@ func TestAddPodAttributes(t *testing.T) {
 						MetadataEnrichment: dynakube.MetadataEnrichment{
 							Enabled: ptr.To(true),
 						},
+					},
+					Status: dynakube.DynaKubeStatus{
+						KubernetesClusterMEID: "meid",
+						KubeSystemUUID:        "systemuuid",
+						KubernetesClusterName: "meidname",
 					},
 				},
 			},
@@ -203,6 +210,7 @@ func TestAddPodAttributes(t *testing.T) {
 					Status: dynakube.DynaKubeStatus{
 						KubernetesClusterMEID: "meid",
 						KubeSystemUUID:        "systemuuid",
+						KubernetesClusterName: "meidname",
 					},
 				},
 			},

--- a/pkg/webhook/mutation/pod/v2/attributes_test.go
+++ b/pkg/webhook/mutation/pod/v2/attributes_test.go
@@ -1,0 +1,80 @@
+package v2
+
+import (
+	"testing"
+
+	containerattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/container"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddPodAttributes(t *testing.T) {
+
+}
+
+func TestAddContainerAttributes(t *testing.T) {
+
+}
+
+func TestCreateImageInfo(t *testing.T) {
+	t.Run("with tag", func(t *testing.T) {
+		imageURI := "registry.example.com/repository/image:tag"
+
+		imageInfo := createImageInfo(imageURI)
+
+		require.Equal(t, containerattr.ImageInfo{
+			Registry:    "registry.example.com",
+			Repository:  "repository/image",
+			Tag:         "tag",
+			ImageDigest: "",
+		}, imageInfo)
+	})
+	t.Run("with digest", func(t *testing.T) {
+		imageURI := "registry.example.com/repository/image@sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc"
+
+		imageInfo := createImageInfo(imageURI)
+
+		require.Equal(t, containerattr.ImageInfo{
+			Registry:    "registry.example.com",
+			Repository:  "repository/image",
+			Tag:         "",
+			ImageDigest: "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
+		}, imageInfo)
+	})
+	t.Run("with digest and tag", func(t *testing.T) {
+		imageURI := "registry.example.com/repository/image:tag@sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc"
+
+		imageInfo := createImageInfo(imageURI)
+
+		require.Equal(t, containerattr.ImageInfo{
+			Registry:    "registry.example.com",
+			Repository:  "repository/image",
+			Tag:         "tag",
+			ImageDigest: "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
+		}, imageInfo)
+	})
+	t.Run("with missing tag", func(t *testing.T) {
+		imageURI := "registry.example.com/repository/image"
+
+		imageInfo := createImageInfo(imageURI)
+
+		require.Equal(t, containerattr.ImageInfo{
+			Registry:    "registry.example.com",
+			Repository:  "repository/image",
+			Tag:         "",
+			ImageDigest: "",
+		}, imageInfo)
+	})
+
+	t.Run("actual example", func(t *testing.T) {
+		imageURI := "docker.io/php:fpm-stretch"
+
+		imageInfo := createImageInfo(imageURI)
+
+		require.Equal(t, containerattr.ImageInfo{
+			Registry:    "docker.io",
+			Repository:  "php",
+			Tag:         "fpm-stretch",
+			ImageDigest: "",
+		}, imageInfo)
+	})
+}

--- a/pkg/webhook/mutation/pod/v2/attributes_test.go
+++ b/pkg/webhook/mutation/pod/v2/attributes_test.go
@@ -1,10 +1,16 @@
 package v2
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	containerattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/container"
+	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
+	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/v2/common/volumes"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestAddPodAttributes(t *testing.T) {
@@ -12,7 +18,137 @@ func TestAddPodAttributes(t *testing.T) {
 }
 
 func TestAddContainerAttributes(t *testing.T) {
+	validateContainerArgs := func(t *testing.T, pod corev1.Pod, args []string) {
+		t.Helper()
 
+		require.NotEmpty(t, args)
+
+		for _, arg := range args {
+			splitArg := strings.Split(arg, "=")
+			require.Len(t, splitArg, 2)
+			var attr containerattr.Attributes
+			require.NoError(t, json.Unmarshal([]byte(splitArg[1]), &attr))
+			assert.Contains(t, pod.Spec.Containers, corev1.Container{
+				Name:  attr.ContainerName,
+				Image: attr.ToURI(),
+			})
+		}
+	}
+
+	t.Run("add attributes, do not change pod or app-container", func(t *testing.T) {
+		app1Container := corev1.Container{
+			Name:  "app-1-name",
+			Image: "registry1.example.com/repository/image:tag",
+		}
+		app2Container := corev1.Container{
+			Name:  "app-2-name",
+			Image: "registry2.example.com/repository/image:tag",
+		}
+		initContainer := corev1.Container{
+			Args: []string{},
+		}
+		pod := corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					app1Container,
+					app2Container,
+				},
+			},
+		}
+
+		expectedPod := pod.DeepCopy()
+
+		request := dtwebhook.MutationRequest{
+			BaseRequest: &dtwebhook.BaseRequest{
+				Pod: &pod,
+			},
+			InstallContainer: &initContainer,
+		}
+
+		addContainerAttributes(&request)
+
+		require.Equal(t, *expectedPod, *request.BaseRequest.Pod)
+
+		validateContainerArgs(t, pod, initContainer.Args)
+	})
+
+	t.Run("no new container ==> no new arg", func(t *testing.T) {
+		app1Container := corev1.Container{
+			Name:  "app-1-name",
+			Image: "registry1.example.com/repository/image:tag",
+		}
+		volumes.AddConfigVolumeMount(&app1Container)
+		app2Container := corev1.Container{
+			Name:  "app-2-name",
+			Image: "registry2.example.com/repository/image:tag",
+		}
+		volumes.AddConfigVolumeMount(&app2Container)
+
+		initContainer := corev1.Container{
+			Args: []string{},
+		}
+		pod := corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					app1Container,
+					app2Container,
+				},
+			},
+		}
+
+		expectedPod := pod.DeepCopy()
+
+		request := dtwebhook.MutationRequest{
+			BaseRequest: &dtwebhook.BaseRequest{
+				Pod: &pod,
+			},
+			InstallContainer: &initContainer,
+		}
+
+		addContainerAttributes(&request)
+
+		require.Equal(t, *expectedPod, *request.BaseRequest.Pod)
+		require.Empty(t, initContainer.Args)
+	})
+
+	t.Run("partially new => only add new", func(t *testing.T) {
+		app1Container := corev1.Container{
+			Name:  "app-1-name",
+			Image: "registry1.example.com/repository/image:tag",
+		}
+		volumes.AddConfigVolumeMount(&app1Container)
+		app2Container := corev1.Container{
+			Name:  "app-2-name",
+			Image: "registry2.example.com/repository/image:tag",
+		}
+
+		initContainer := corev1.Container{
+			Args: []string{},
+		}
+		pod := corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					app1Container,
+					app2Container,
+				},
+			},
+		}
+
+		expectedPod := pod.DeepCopy()
+
+		request := dtwebhook.MutationRequest{
+			BaseRequest: &dtwebhook.BaseRequest{
+				Pod: &pod,
+			},
+			InstallContainer: &initContainer,
+		}
+
+		addContainerAttributes(&request)
+
+		require.Equal(t, *expectedPod, *request.BaseRequest.Pod)
+		require.Len(t, initContainer.Args, 1)
+		validateContainerArgs(t, pod, initContainer.Args)
+	})
 }
 
 func TestCreateImageInfo(t *testing.T) {

--- a/pkg/webhook/mutation/pod/v2/attributes_test.go
+++ b/pkg/webhook/mutation/pod/v2/attributes_test.go
@@ -6,19 +6,217 @@ import (
 	"testing"
 
 	containerattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/container"
+	podattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/pod"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
+	metacommon "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/common/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/v2/common/volumes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestAddPodAttributes(t *testing.T) {
+	validateAttributes := func(t *testing.T, request dtwebhook.MutationRequest) podattr.Attributes {
+		t.Helper()
 
+		require.NotEmpty(t, request.InstallContainer.Args)
+
+		rawArgs := []string{}
+
+		for _, arg := range request.InstallContainer.Args {
+			splitArg := strings.SplitN(arg, "=", 2)
+			require.Len(t, splitArg, 2)
+			rawArgs = append(rawArgs, splitArg[1])
+		}
+
+		attr, err := podattr.ParseAttributes(rawArgs)
+		require.NoError(t, err)
+
+		assert.Equal(t, request.DynaKube.Status.KubernetesClusterMEID, attr.DTClusterEntity)
+		assert.Equal(t, request.DynaKube.Status.KubeSystemUUID, attr.ClusterUId)
+		assert.Contains(t, attr.PodName, consts.K8sPodNameEnv)
+		assert.Contains(t, attr.PodUid, consts.K8sPodUIDEnv)
+		assert.Equal(t, request.Pod.Namespace, attr.NamespaceName)
+
+		require.Len(t, request.InstallContainer.Env, 2)
+		assert.NotNil(t, env.FindEnvVar(request.InstallContainer.Env, consts.K8sPodNameEnv))
+		assert.NotNil(t, env.FindEnvVar(request.InstallContainer.Env, consts.K8sPodUIDEnv))
+
+		return attr
+	}
+
+	validateAdditionAttributes := func(t *testing.T, request dtwebhook.MutationRequest) {
+		t.Helper()
+
+		attr := validateAttributes(t, request)
+
+		require.NotEmpty(t, request.Pod.OwnerReferences)
+		assert.Equal(t, strings.ToLower(request.Pod.OwnerReferences[0].Kind), attr.WorkloadKind)
+		assert.Equal(t, request.Pod.OwnerReferences[0].Name, attr.WorkloadName)
+
+		metaAnnotationCount := 0
+
+		for key := range request.Namespace.Annotations {
+			if strings.Contains(key, metacommon.AnnotationPrefix) {
+				metaAnnotationCount++
+			}
+		}
+
+		assert.Len(t, attr.UserDefined, metaAnnotationCount)
+		require.Len(t, request.Pod.Annotations, 3+metaAnnotationCount)
+		assert.Equal(t, strings.ToLower(request.Pod.OwnerReferences[0].Kind), request.Pod.Annotations[metacommon.AnnotationWorkloadKind])
+		assert.Equal(t, request.Pod.OwnerReferences[0].Name, request.Pod.Annotations[metacommon.AnnotationWorkloadName])
+		assert.Equal(t, "true", request.Pod.Annotations[metacommon.AnnotationInjected])
+	}
+
+	t.Run("add attributes and related envs, do not change pod or app-container", func(t *testing.T) {
+		injector := createTestInjectorBase()
+
+		initContainer := corev1.Container{
+			Args: []string{},
+		}
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test",
+			},
+		}
+
+		expectedPod := pod.DeepCopy()
+
+		request := dtwebhook.MutationRequest{
+			BaseRequest: &dtwebhook.BaseRequest{
+				Pod: &pod,
+				DynaKube: dynakube.DynaKube{
+					Status: dynakube.DynaKubeStatus{
+						KubernetesClusterMEID: "meid",
+						KubeSystemUUID:        "systemuuid",
+					},
+				},
+			},
+			InstallContainer: &initContainer,
+		}
+
+		err := injector.addPodAttributes(&request)
+		require.NoError(t, err)
+
+		require.Equal(t, *expectedPod, *request.BaseRequest.Pod)
+		validateAttributes(t, request)
+	})
+
+	t.Run("metadata enrichment passes => additional args and annotations", func(t *testing.T) {
+		initContainer := corev1.Container{
+			Args: []string{},
+		}
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Name:       "owner",
+						APIVersion: "v1",
+						Kind:       "ReplicationController",
+						Controller: ptr.To(true),
+					},
+				},
+			},
+		}
+		owner := corev1.ReplicationController{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "ReplicationController",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "owner",
+			},
+		}
+		injector := createTestInjectorBase()
+		injector.metaClient = fake.NewClient(&owner, &pod)
+
+		expectedPod := pod.DeepCopy()
+
+		request := dtwebhook.MutationRequest{
+			BaseRequest: &dtwebhook.BaseRequest{
+				Pod: &pod,
+				DynaKube: dynakube.DynaKube{
+					Spec: dynakube.DynaKubeSpec{
+						MetadataEnrichment: dynakube.MetadataEnrichment{
+							Enabled: ptr.To(true),
+						},
+					},
+				},
+			},
+			InstallContainer: &initContainer,
+		}
+
+		err := injector.addPodAttributes(&request)
+		require.NoError(t, err)
+		require.NotEqual(t, *expectedPod, *request.BaseRequest.Pod)
+
+		validateAdditionAttributes(t, request)
+	})
+
+	t.Run("metadata enrichment fails => error", func(t *testing.T) {
+		injector := createTestInjectorBase()
+		injector.metaClient = fake.NewClient()
+
+		initContainer := corev1.Container{
+			Args: []string{},
+		}
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Name:       "owner",
+						APIVersion: "v1",
+						Kind:       "ReplicationController",
+						Controller: ptr.To(true),
+					},
+				},
+			},
+		}
+
+		expectedPod := pod.DeepCopy()
+
+		request := dtwebhook.MutationRequest{
+			BaseRequest: &dtwebhook.BaseRequest{
+				Pod: &pod,
+				Namespace: corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							metacommon.AnnotationPrefix + "/test": "test",
+						},
+					},
+				},
+				DynaKube: dynakube.DynaKube{
+					Spec: dynakube.DynaKubeSpec{
+						MetadataEnrichment: dynakube.MetadataEnrichment{
+							Enabled: ptr.To(true),
+						},
+					},
+					Status: dynakube.DynaKubeStatus{
+						KubernetesClusterMEID: "meid",
+						KubeSystemUUID:        "systemuuid",
+					},
+				},
+			},
+			InstallContainer: &initContainer,
+		}
+
+		err := injector.addPodAttributes(&request)
+		require.Error(t, err)
+		require.Equal(t, *expectedPod, *request.BaseRequest.Pod)
+	})
 }
 
 func TestAddContainerAttributes(t *testing.T) {
-	validateContainerArgs := func(t *testing.T, pod corev1.Pod, args []string) {
+	validateContainerAttributes := func(t *testing.T, pod corev1.Pod, args []string) {
 		t.Helper()
 
 		require.NotEmpty(t, args)
@@ -26,7 +224,9 @@ func TestAddContainerAttributes(t *testing.T) {
 		for _, arg := range args {
 			splitArg := strings.Split(arg, "=")
 			require.Len(t, splitArg, 2)
+
 			var attr containerattr.Attributes
+
 			require.NoError(t, json.Unmarshal([]byte(splitArg[1]), &attr))
 			assert.Contains(t, pod.Spec.Containers, corev1.Container{
 				Name:  attr.ContainerName,
@@ -35,7 +235,7 @@ func TestAddContainerAttributes(t *testing.T) {
 		}
 	}
 
-	t.Run("add attributes, do not change pod or app-container", func(t *testing.T) {
+	t.Run("add container-attributes, do not change pod or app-container", func(t *testing.T) {
 		app1Container := corev1.Container{
 			Name:  "app-1-name",
 			Image: "registry1.example.com/repository/image:tag",
@@ -69,7 +269,7 @@ func TestAddContainerAttributes(t *testing.T) {
 
 		require.Equal(t, *expectedPod, *request.BaseRequest.Pod)
 
-		validateContainerArgs(t, pod, initContainer.Args)
+		validateContainerAttributes(t, pod, initContainer.Args)
 	})
 
 	t.Run("no new container ==> no new arg", func(t *testing.T) {
@@ -78,6 +278,7 @@ func TestAddContainerAttributes(t *testing.T) {
 			Image: "registry1.example.com/repository/image:tag",
 		}
 		volumes.AddConfigVolumeMount(&app1Container)
+
 		app2Container := corev1.Container{
 			Name:  "app-2-name",
 			Image: "registry2.example.com/repository/image:tag",
@@ -117,6 +318,7 @@ func TestAddContainerAttributes(t *testing.T) {
 			Image: "registry1.example.com/repository/image:tag",
 		}
 		volumes.AddConfigVolumeMount(&app1Container)
+
 		app2Container := corev1.Container{
 			Name:  "app-2-name",
 			Image: "registry2.example.com/repository/image:tag",
@@ -147,7 +349,7 @@ func TestAddContainerAttributes(t *testing.T) {
 
 		require.Equal(t, *expectedPod, *request.BaseRequest.Pod)
 		require.Len(t, initContainer.Args, 1)
-		validateContainerArgs(t, pod, initContainer.Args)
+		validateContainerAttributes(t, pod, initContainer.Args)
 	})
 }
 

--- a/pkg/webhook/mutation/pod/v2/attributes_test.go
+++ b/pkg/webhook/mutation/pod/v2/attributes_test.go
@@ -362,7 +362,19 @@ func TestAddContainerAttributes(t *testing.T) {
 }
 
 func TestCreateImageInfo(t *testing.T) {
-	t.Run("with tag", func(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		imageURI := ""
+
+		imageInfo := createImageInfo(imageURI)
+
+		require.Equal(t, containerattr.ImageInfo{
+			Registry:    "",
+			Repository:  "",
+			Tag:         "",
+			ImageDigest: "",
+		}, imageInfo)
+	})
+	t.Run("URI with tag", func(t *testing.T) {
 		imageURI := "registry.example.com/repository/image:tag"
 
 		imageInfo := createImageInfo(imageURI)
@@ -374,7 +386,7 @@ func TestCreateImageInfo(t *testing.T) {
 			ImageDigest: "",
 		}, imageInfo)
 	})
-	t.Run("with digest", func(t *testing.T) {
+	t.Run("URI with digest", func(t *testing.T) {
 		imageURI := "registry.example.com/repository/image@sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc"
 
 		imageInfo := createImageInfo(imageURI)
@@ -386,7 +398,7 @@ func TestCreateImageInfo(t *testing.T) {
 			ImageDigest: "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
 		}, imageInfo)
 	})
-	t.Run("with digest and tag", func(t *testing.T) {
+	t.Run("URI with digest and tag", func(t *testing.T) {
 		imageURI := "registry.example.com/repository/image:tag@sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc"
 
 		imageInfo := createImageInfo(imageURI)
@@ -398,7 +410,7 @@ func TestCreateImageInfo(t *testing.T) {
 			ImageDigest: "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
 		}, imageInfo)
 	})
-	t.Run("with missing tag", func(t *testing.T) {
+	t.Run("URI with missing tag", func(t *testing.T) {
 		imageURI := "registry.example.com/repository/image"
 
 		imageInfo := createImageInfo(imageURI)
@@ -410,14 +422,25 @@ func TestCreateImageInfo(t *testing.T) {
 			ImageDigest: "",
 		}, imageInfo)
 	})
-
-	t.Run("actual example", func(t *testing.T) {
+	t.Run("URI with docker.io (special case in certain libraries)", func(t *testing.T) {
 		imageURI := "docker.io/php:fpm-stretch"
 
 		imageInfo := createImageInfo(imageURI)
 
 		require.Equal(t, containerattr.ImageInfo{
 			Registry:    "docker.io",
+			Repository:  "php",
+			Tag:         "fpm-stretch",
+			ImageDigest: "",
+		}, imageInfo)
+	})
+	t.Run("URI without registry", func(t *testing.T) {
+		imageURI := "php:fpm-stretch"
+
+		imageInfo := createImageInfo(imageURI)
+
+		require.Equal(t, containerattr.ImageInfo{
+			Registry:    "",
 			Repository:  "php",
 			Tag:         "fpm-stretch",
 			ImageDigest: "",

--- a/pkg/webhook/mutation/pod/v2/attributes_test.go
+++ b/pkg/webhook/mutation/pod/v2/attributes_test.go
@@ -362,88 +362,79 @@ func TestAddContainerAttributes(t *testing.T) {
 }
 
 func TestCreateImageInfo(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
-		imageURI := ""
+	type testCase struct {
+		title string
+		in    string
+		out   containerattr.ImageInfo
+	}
 
-		imageInfo := createImageInfo(imageURI)
+	testCases := []testCase{
+		{
+			title: "empty URI",
+			in:    "",
+			out:   containerattr.ImageInfo{},
+		},
+		{
+			title: "URI with tag",
+			in:    "registry.example.com/repository/image:tag",
+			out: containerattr.ImageInfo{
+				Registry:    "registry.example.com",
+				Repository:  "repository/image",
+				Tag:         "tag",
+				ImageDigest: "",
+			},
+		},
+		{
+			title: "URI with digest",
+			in:    "registry.example.com/repository/image@sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
+			out: containerattr.ImageInfo{
+				Registry:    "registry.example.com",
+				Repository:  "repository/image",
+				Tag:         "",
+				ImageDigest: "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
+			},
+		},
+		{
+			title: "URI with digest and tag",
+			in:    "registry.example.com/repository/image:tag@sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
+			out: containerattr.ImageInfo{
+				Registry:    "registry.example.com",
+				Repository:  "repository/image",
+				Tag:         "tag",
+				ImageDigest: "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
+			},
+		},
+		{
+			title: "URI with missing tag",
+			in:    "registry.example.com/repository/image",
+			out: containerattr.ImageInfo{
+				Registry:   "registry.example.com",
+				Repository: "repository/image",
+			},
+		},
+		{
+			title: "URI with docker.io (special case in certain libraries)",
+			in:    "docker.io/php:fpm-stretch",
+			out: containerattr.ImageInfo{
+				Registry:   "docker.io",
+				Repository: "php",
+				Tag:        "fpm-stretch",
+			},
+		},
+		{
+			title: "URI with missing registry",
+			in:    "php:fpm-stretch",
+			out: containerattr.ImageInfo{
+				Repository: "php",
+				Tag:        "fpm-stretch",
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.title, func(t *testing.T) {
+			imageInfo := createImageInfo(test.in)
 
-		require.Equal(t, containerattr.ImageInfo{
-			Registry:    "",
-			Repository:  "",
-			Tag:         "",
-			ImageDigest: "",
-		}, imageInfo)
-	})
-	t.Run("URI with tag", func(t *testing.T) {
-		imageURI := "registry.example.com/repository/image:tag"
-
-		imageInfo := createImageInfo(imageURI)
-
-		require.Equal(t, containerattr.ImageInfo{
-			Registry:    "registry.example.com",
-			Repository:  "repository/image",
-			Tag:         "tag",
-			ImageDigest: "",
-		}, imageInfo)
-	})
-	t.Run("URI with digest", func(t *testing.T) {
-		imageURI := "registry.example.com/repository/image@sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc"
-
-		imageInfo := createImageInfo(imageURI)
-
-		require.Equal(t, containerattr.ImageInfo{
-			Registry:    "registry.example.com",
-			Repository:  "repository/image",
-			Tag:         "",
-			ImageDigest: "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
-		}, imageInfo)
-	})
-	t.Run("URI with digest and tag", func(t *testing.T) {
-		imageURI := "registry.example.com/repository/image:tag@sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc"
-
-		imageInfo := createImageInfo(imageURI)
-
-		require.Equal(t, containerattr.ImageInfo{
-			Registry:    "registry.example.com",
-			Repository:  "repository/image",
-			Tag:         "tag",
-			ImageDigest: "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
-		}, imageInfo)
-	})
-	t.Run("URI with missing tag", func(t *testing.T) {
-		imageURI := "registry.example.com/repository/image"
-
-		imageInfo := createImageInfo(imageURI)
-
-		require.Equal(t, containerattr.ImageInfo{
-			Registry:    "registry.example.com",
-			Repository:  "repository/image",
-			Tag:         "",
-			ImageDigest: "",
-		}, imageInfo)
-	})
-	t.Run("URI with docker.io (special case in certain libraries)", func(t *testing.T) {
-		imageURI := "docker.io/php:fpm-stretch"
-
-		imageInfo := createImageInfo(imageURI)
-
-		require.Equal(t, containerattr.ImageInfo{
-			Registry:    "docker.io",
-			Repository:  "php",
-			Tag:         "fpm-stretch",
-			ImageDigest: "",
-		}, imageInfo)
-	})
-	t.Run("URI without registry", func(t *testing.T) {
-		imageURI := "php:fpm-stretch"
-
-		imageInfo := createImageInfo(imageURI)
-
-		require.Equal(t, containerattr.ImageInfo{
-			Registry:    "",
-			Repository:  "php",
-			Tag:         "fpm-stretch",
-			ImageDigest: "",
-		}, imageInfo)
-	})
+			require.Equal(t, test.out, imageInfo)
+		})
+	}
 }

--- a/pkg/webhook/mutation/pod/v2/common/arg/arg.go
+++ b/pkg/webhook/mutation/pod/v2/common/arg/arg.go
@@ -8,6 +8,10 @@ type Arg struct {
 }
 
 func (a Arg) String() string {
+	if a.Value == "" {
+		return "--" + a.Name
+	}
+
 	return fmt.Sprintf("--%s=%s", a.Name, a.Value)
 }
 

--- a/pkg/webhook/mutation/pod/v2/common/volumes/volumes.go
+++ b/pkg/webhook/mutation/pod/v2/common/volumes/volumes.go
@@ -13,7 +13,7 @@ const (
 	ConfigVolumeName    = "dynatrace-config"
 	InitConfigMountPath = "/mnt/config"
 	InitConfigSubPath   = "config"
-	ConfigMountPath     = "var/lib/dynatrace"
+	ConfigMountPath     = "/var/lib/dynatrace"
 
 	InputVolumeName    = "dynatrace-input"
 	InitInputMountPath = "/mnt/input"

--- a/pkg/webhook/mutation/pod/v2/init.go
+++ b/pkg/webhook/mutation/pod/v2/init.go
@@ -29,8 +29,6 @@ func createInitContainerBase(pod *corev1.Pod, dk dynakube.DynaKube) *corev1.Cont
 		initContainer.Args = append(initContainer.Args, "--suppress-errors") // TODO: import arg from bootstrapper package
 	}
 
-	// TODO: Add all `--attribute` args to init-container
-
 	return initContainer
 }
 

--- a/pkg/webhook/mutation/pod/v2/init.go
+++ b/pkg/webhook/mutation/pod/v2/init.go
@@ -25,7 +25,7 @@ func createInitContainerBase(pod *corev1.Pod, dk dynakube.DynaKube) *corev1.Cont
 	}
 
 	if areErrorsSuppressed(pod, dk) {
-		args = append(args, arg.Arg{Name: "suppress-errors"}) // TODO: import arg from bootstrapper package
+		args = append(args, arg.Arg{Name: "suppress-error"}) // TODO: import arg from bootstrapper package
 	}
 
 	initContainer := &corev1.Container{

--- a/pkg/webhook/mutation/pod/v2/init.go
+++ b/pkg/webhook/mutation/pod/v2/init.go
@@ -11,12 +11,18 @@ import (
 )
 
 func createInitContainerBase(pod *corev1.Pod, dk dynakube.DynaKube) *corev1.Container {
+	args := []string{ // TODO: import arg from bootstrapper package
+		"--config-directory=" + volumes.InitConfigMountPath,
+		"--input-directory=" + volumes.InitInputMountPath,
+	}
+
 	initContainer := &corev1.Container{
 		Name:            dtwebhook.InstallContainerName,
 		Image:           dk.OneAgent().GetCustomCodeModulesImage(),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: securityContextForInitContainer(pod, dk),
 		Resources:       initContainerResources(dk),
+		Args:            args,
 	}
 
 	if areErrorsSuppressed(pod, dk) {

--- a/pkg/webhook/mutation/pod/v2/init_test.go
+++ b/pkg/webhook/mutation/pod/v2/init_test.go
@@ -116,7 +116,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, initContainer.SecurityContext.SeccompProfile.Type)
 	})
 
-	t.Run("should not set suppress-errors arg - according to dk", func(t *testing.T) {
+	t.Run("should not set suppress-error arg - according to dk", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Annotations = map[string]string{dynakube.AnnotationInjectionFailurePolicy: "fail"}
 		pod := getTestPod()
@@ -124,10 +124,10 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		initContainer := createInitContainerBase(pod, *dk)
 
-		assert.NotContains(t, initContainer.Args, "--suppress-errors")
+		assert.NotContains(t, initContainer.Args, "--suppress-error")
 	})
 
-	t.Run("should not set suppress-errors arg - according to pod", func(t *testing.T) {
+	t.Run("should not set suppress-error arg - according to pod", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Annotations = map[string]string{dynakube.AnnotationInjectionFailurePolicy: "silent"}
 		pod := getTestPod()
@@ -135,10 +135,10 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		initContainer := createInitContainerBase(pod, *dk)
 
-		assert.NotContains(t, initContainer.Args, "--suppress-errors")
+		assert.NotContains(t, initContainer.Args, "--suppress-error")
 	})
 
-	t.Run("should set suppress-errors arg - default", func(t *testing.T) {
+	t.Run("should set suppress-error arg - default", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Annotations = map[string]string{}
 		pod := getTestPod()
@@ -146,10 +146,10 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		initContainer := createInitContainerBase(pod, *dk)
 
-		assert.Contains(t, initContainer.Args, "--suppress-errors")
+		assert.Contains(t, initContainer.Args, "--suppress-error")
 	})
 
-	t.Run("should set suppress-errors arg - unknown value", func(t *testing.T) {
+	t.Run("should set suppress-error arg - unknown value", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Annotations = map[string]string{dynakube.AnnotationInjectionFailurePolicy: "asd"}
 		pod := getTestPod()
@@ -157,7 +157,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		initContainer := createInitContainerBase(pod, *dk)
 
-		assert.Contains(t, initContainer.Args, "--suppress-errors")
+		assert.Contains(t, initContainer.Args, "--suppress-error")
 
 		dk = getTestDynakube()
 		dk.Annotations = map[string]string{}
@@ -166,7 +166,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		initContainer = createInitContainerBase(pod, *dk)
 
-		assert.Contains(t, initContainer.Args, "--suppress-errors")
+		assert.Contains(t, initContainer.Args, "--suppress-error")
 	})
 }
 

--- a/pkg/webhook/mutation/pod/v2/metadata/config.go
+++ b/pkg/webhook/mutation/pod/v2/metadata/config.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	log = logd.Get().WithName("metadata-enrichment-pod-v2-mutation")
+	log = logd.Get().WithName("v2-pod-mutation-metadata-enrichment")
 )

--- a/pkg/webhook/mutation/pod/v2/metadata/containers.go
+++ b/pkg/webhook/mutation/pod/v2/metadata/containers.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"maps"
 	"strings"
 
 	podattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/pod"
@@ -49,5 +50,5 @@ func addMetadataToInitArgs(request *dtwebhook.MutationRequest, attributes *podat
 		metadataAnnotations[split[1]] = value
 	}
 
-	attributes.UserDefined = metadataAnnotations
+	maps.Copy(attributes.UserDefined, metadataAnnotations)
 }

--- a/pkg/webhook/mutation/pod/v2/metadata/containers.go
+++ b/pkg/webhook/mutation/pod/v2/metadata/containers.go
@@ -18,20 +18,20 @@ func Mutate(metaClient client.Client, request *dtwebhook.MutationRequest, attrib
 
 	log.Info("adding metadata-enrichment to pod", "name", request.PodName())
 
-	worloadInfo, err := metacommon.RetrieveWorkload(metaClient, request)
+	workloadInfo, err := metacommon.RetrieveWorkload(metaClient, request)
 	if err != nil {
 		return err
 	}
 
 	attributes.WorkloadInfo = podattr.WorkloadInfo{
-		WorkloadKind: worloadInfo.Kind,
-		WorkloadName: worloadInfo.Name,
+		WorkloadKind: workloadInfo.Kind,
+		WorkloadName: workloadInfo.Name,
 	}
 
 	addMetadataToInitArgs(request, attributes)
 
 	metacommon.SetInjectedAnnotation(request.Pod)
-	metacommon.SetWorkloadAnnotations(request.Pod, worloadInfo)
+	metacommon.SetWorkloadAnnotations(request.Pod, workloadInfo)
 
 	return nil
 }

--- a/pkg/webhook/mutation/pod/v2/metadata/containers.go
+++ b/pkg/webhook/mutation/pod/v2/metadata/containers.go
@@ -10,16 +10,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Mutate(metaClient client.Client, request *dtwebhook.MutationRequest, attributes *podattr.Attributes) bool {
+func Mutate(metaClient client.Client, request *dtwebhook.MutationRequest, attributes *podattr.Attributes) error {
 	if !metacommon.IsEnabled(request.BaseRequest) {
-		return false
+		return nil
 	}
 
 	log.Info("adding metadata-enrichment to pod", "name", request.PodName())
 
 	worloadInfo, err := metacommon.RetrieveWorkload(metaClient, request)
 	if err != nil {
-		return false // TODO
+		return err
 	}
 
 	attributes.WorkloadInfo = podattr.WorkloadInfo{
@@ -32,7 +32,7 @@ func Mutate(metaClient client.Client, request *dtwebhook.MutationRequest, attrib
 	metacommon.SetInjectedAnnotation(request.Pod)
 	metacommon.SetWorkloadAnnotations(request.Pod, worloadInfo)
 
-	return true
+	return nil
 }
 
 func addMetadataToInitArgs(request *dtwebhook.MutationRequest, attributes *podattr.Attributes) {

--- a/pkg/webhook/mutation/pod/v2/metadata/containers.go
+++ b/pkg/webhook/mutation/pod/v2/metadata/containers.go
@@ -1,21 +1,53 @@
 package metadata
 
 import (
-	"context"
+	"strings"
 
+	podattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/pod"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	metacommon "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/common/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Mutate(context context.Context, metaClient client.Client, request *dtwebhook.MutationRequest) bool {
+func Mutate(metaClient client.Client, request *dtwebhook.MutationRequest, attributes *podattr.Attributes) bool {
 	if !metacommon.IsEnabled(request.BaseRequest) {
 		return false
 	}
 
 	log.Info("adding metadata-enrichment to pod", "name", request.PodName())
 
-	// TODO: probably will only modify the iniContainer and pod, not the containers
+	worloadInfo, err := metacommon.RetrieveWorkload(metaClient, request)
+	if err != nil {
+		return false // TODO
+	}
+
+	attributes.WorkloadInfo = podattr.WorkloadInfo{
+		WorkloadKind: worloadInfo.Kind,
+		WorkloadName: worloadInfo.Name,
+	}
+
+	addMetadataToInitArgs(request, attributes)
+
+	metacommon.SetInjectedAnnotation(request.Pod)
+	metacommon.SetWorkloadAnnotations(request.Pod, worloadInfo)
 
 	return true
+}
+
+func addMetadataToInitArgs(request *dtwebhook.MutationRequest, attributes *podattr.Attributes) {
+	metacommon.CopyMetadataFromNamespace(request.Pod, request.Namespace, request.DynaKube)
+
+	metadataAnnotations := map[string]string{}
+
+	for key, value := range request.Pod.Annotations {
+		if !strings.HasPrefix(key, dynakube.MetadataPrefix) {
+			continue
+		}
+
+		split := strings.Split(key, dynakube.MetadataPrefix)
+		metadataAnnotations[split[1]] = value
+	}
+
+	attributes.UserDefined = metadataAnnotations
 }

--- a/pkg/webhook/mutation/pod/v2/webhook_test.go
+++ b/pkg/webhook/mutation/pod/v2/webhook_test.go
@@ -38,7 +38,7 @@ func TestHandle(t *testing.T) {
 	}
 
 	t.Run("no init secret => no injection + only annotation", func(t *testing.T) {
-		injector := createTestInjector()
+		injector := createTestInjectorBase()
 		injector.apiReader = fake.NewClient()
 
 		request := createTestMutationRequest(getTestDynakube())
@@ -56,7 +56,7 @@ func TestHandle(t *testing.T) {
 	})
 
 	t.Run("no codeModulesImage => no injection + only annotation", func(t *testing.T) {
-		injector := createTestInjector()
+		injector := createTestInjectorBase()
 		injector.apiReader = fake.NewClient(&initSecret)
 
 		request := createTestMutationRequest(&dynakube.DynaKube{})
@@ -76,19 +76,19 @@ func TestHandle(t *testing.T) {
 
 func TestIsInjected(t *testing.T) {
 	t.Run("init-container present == injected", func(t *testing.T) {
-		injector := createTestInjector()
+		injector := createTestInjectorBase()
 
 		assert.True(t, injector.isInjected(createTestMutationRequestWithInjectedPod(getTestDynakube())))
 	})
 
 	t.Run("init-container NOT present != injected", func(t *testing.T) {
-		injector := createTestInjector()
+		injector := createTestInjectorBase()
 
 		assert.False(t, injector.isInjected(createTestMutationRequest(getTestDynakube())))
 	})
 }
 
-func createTestInjector() *Injector {
+func createTestInjectorBase() *Injector {
 	return &Injector{
 		recorder: events.NewRecorder(record.NewFakeRecorder(10)),
 	}

--- a/pkg/webhook/mutation/pod/v2/webhook_test.go
+++ b/pkg/webhook/mutation/pod/v2/webhook_test.go
@@ -92,8 +92,8 @@ func TestHandle(t *testing.T) {
 
 		installContainer := container.FindInitContainerInPodSpec(&request.Pod.Spec, dtwebhook.InstallContainerName)
 		require.NotNil(t, installContainer)
-		assert.Len(t, installContainer.Env, 2)
-		assert.Len(t, installContainer.Args, 10)
+		assert.Len(t, installContainer.Env, 3)
+		assert.Len(t, installContainer.Args, 14)
 	})
 }
 
@@ -122,6 +122,11 @@ func getTestDynakube() *dynakube.DynaKube {
 		ObjectMeta: getTestDynakubeMeta(),
 		Spec: dynakube.DynaKubeSpec{
 			OneAgent: getAppMonSpec(&testResourceRequirements),
+		},
+		Status: dynakube.DynaKubeStatus{
+			KubernetesClusterMEID: "meid",
+			KubeSystemUUID:        "systemuuid",
+			KubernetesClusterName: "meidname",
 		},
 	}
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
[DAQ-4190](https://dt-rnd.atlassian.net/browse/DAQ-4190)
[DAQ-4187](https://dt-rnd.atlassian.net/browse/DAQ-4187)

Adds the following to the init-container of during the bootstrapper injection (follow up for https://github.com/Dynatrace/dynatrace-operator/pull/4576)
- `--attribute-container`
- `--attributes`
- `--config-directory`
- `--input-directory`

Doing this, we have feature parity with the `v1` webhook.
- every feature (metadata-enrichement, etc) should work

Some notable differences: 
- we mainly configure the bootstrapper with `args` and not `envs`
  - so metadata annotation propagation is done with `--attributes` instead of an `env` 

## How can this be tested?

Setup is same to https://github.com/Dynatrace/dynatrace-operator/pull/4576

- `make deploy/no-csi`
- create your sample NAMESPACE (this is a limitation that will sooon be fixed)
- apply dynakube:
```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/remote-image-download: "true"
spec:
  apiUrl: https://....dev.dynatracelabs.com/api
  metadataEnrichment:
    enabled: true
  oneAgent:
    applicationMonitoring:
      codeModulesImage: quay.io/dynatrace/dynatrace-bootstrapper:snapshot
```
- you can also try "mixing features", like 1 namespace only should have OA injection, 1 only metadata-enrichment, 1 both:
   - Expected outcome:
       - OA only: bootstrapper image will be used, will have a few less args
       - metadata-enrichment only: will use the `v1` injection, as it makes 0 sense to "copy" the codemodule to a container that will not use it
       - both:  bootstrapper image will be used, with all the args

[DAQ-4190]: https://dt-rnd.atlassian.net/browse/DAQ-4190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DAQ-4187]: https://dt-rnd.atlassian.net/browse/DAQ-4187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ