### PR TITLE
fix: supportarchive e2e test, wrong field selector

### DIFF
--- a/cmd/support_archive/builder.go
+++ b/cmd/support_archive/builder.go
@@ -39,7 +39,7 @@ const (
 	collectManagedLogsFlagName     = "managed-logs"
 	numEventsFlagName              = "num-events"
 	defaultSimFileSize             = 10
-	defaultNumEvents               = 300
+	DefaultNumEvents               = 300
 )
 
 const (
@@ -55,7 +55,7 @@ var (
 	loadsimFileSizeFlagValue    int
 	collectManagedLogsFlagValue bool
 	delayFlagValue              int
-	numEventsFlagValue          int
+	NumEventsFlagValue          int
 )
 
 type CommandBuilder struct {
@@ -94,7 +94,7 @@ func addFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&loadsimFilesFlagValue, loadsimFilesFlagName, 0, "Number of simulated log files (default 0)")
 	cmd.PersistentFlags().BoolVar(&collectManagedLogsFlagValue, collectManagedLogsFlagName, true, "Add logs from rolled out pods to the support archive.")
 	cmd.PersistentFlags().IntVar(&delayFlagValue, delayFlagName, 0, "Delay start of support-archive collection. Useful for standalone execution with 'kubectl run'")
-	cmd.PersistentFlags().IntVar(&numEventsFlagValue, numEventsFlagName, defaultNumEvents, fmt.Sprintf("Number of events to be fetched (default %d)", defaultNumEvents))
+	cmd.PersistentFlags().IntVar(&NumEventsFlagValue, numEventsFlagName, DefaultNumEvents, fmt.Sprintf("Number of events to be fetched (default %d)", DefaultNumEvents))
 }
 
 func (builder CommandBuilder) buildRun() func(*cobra.Command, []string) error {

--- a/cmd/support_archive/resource_query.go
+++ b/cmd/support_archive/resource_query.go
@@ -16,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var DefaultEventFieldSelector = fields.OneTermEqualSelector("type", corev1.EventTypeWarning)
+
 type resourceQueryGroup struct {
 	resources []schema.GroupVersionKind
 	filters   []client.ListOption
@@ -114,9 +116,9 @@ func getEventsQueryGroup(namespace string) resourceQueryGroup {
 		},
 		filters: []client.ListOption{
 			client.InNamespace(namespace),
-			client.Limit(numEventsFlagValue),
+			client.Limit(NumEventsFlagValue),
 			&client.ListOptions{
-				FieldSelector: fields.OneTermEqualSelector("type", corev1.EventTypeWarning),
+				FieldSelector: DefaultEventFieldSelector,
 			},
 		},
 	}

--- a/test/features/support_archive/files.go
+++ b/test/features/support_archive/files.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/statefulset"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 )
@@ -352,7 +353,11 @@ func (r requiredFiles) getRequiredConfigMapFiles() []string {
 }
 
 func (r requiredFiles) getRequiredEventFiles() []string {
-	events := event.List(r.t, r.ctx, r.resources, r.dk.Namespace)
+	optFunc := func(options *metav1.ListOptions) {
+		options.Limit = int64(support_archive.NumEventsFlagValue)
+		options.FieldSelector = fmt.Sprint(support_archive.DefaultEventFieldSelector)
+	}
+	events := event.List(r.t, r.ctx, r.resources, r.dk.Namespace, optFunc)
 	requiredFiles := make([]string, 0)
 
 	for _, requiredEvent := range events.Items {

--- a/test/helpers/kubeobjects/event/list.go
+++ b/test/helpers/kubeobjects/event/list.go
@@ -11,10 +11,10 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 )
 
-func List(t *testing.T, ctx context.Context, resource *resources.Resources, namespace string) corev1.EventList {
+func List(t *testing.T, ctx context.Context, resource *resources.Resources, namespace string, listOpt resources.ListOption) corev1.EventList {
 	var events corev1.EventList
 
-	require.NoError(t, resource.WithNamespace(namespace).List(ctx, &events))
+	require.NoError(t, resource.WithNamespace(namespace).List(ctx, &events, listOpt))
 
 	return events
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Addresses [DAQ-1936](https://dt-rnd.atlassian.net/browse/DAQ-1936)

fixing after this one https://github.com/Dynatrace/dynatrace-operator/pull/4533

## How can this be tested?

`make test/e2e/supportarchive`

or run some other tests before so emulate CI:

```
go test -v -tags "e2e" -timeout 20m -count=1  ./test/scenarios/standard -args --feature "app-monitoring-without-csi|public-registry-images|support-archive"
```


[DAQ-1936]: https://dt-rnd.atlassian.net/browse/DAQ-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ