### PR TITLE
Sets proxy env variables for otel collector

### DIFF
--- a/pkg/controllers/dynakube/otelc/configuration/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/configuration/reconciler.go
@@ -110,6 +110,7 @@ func (r *Reconciler) getData() (map[string]string, error) {
 		options = append(options, otelcgen.WithCA(otelcconsts.ActiveGateTLSCertVolumePath))
 	} else if r.dk.IsCACertificateNeeded() {
 		options = append(options, otelcgen.WithCA(otelcconsts.TrustedCAVolumePath))
+		options = append(options, otelcgen.WithSystemCAs(true))
 	}
 
 	if r.dk.TelemetryIngest().IsEnabled() && r.dk.TelemetryIngest().Spec.TlsRefName != "" {

--- a/pkg/controllers/dynakube/otelc/statefulset/env.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env.go
@@ -39,7 +39,8 @@ const (
 	// See https://www.openssl.org/docs/man1.0.2/man1/c_rehash.html.
 	envCertDir          = "SSL_CERT_DIR"
 	envEECcontrollerTLS = "EXTENSIONS_CONTROLLER_TLS"
-	envProxy            = "HTTPS_PROXY"
+	envHttpProxy        = "HTTP_PROXY"
+	envHttpsProxy       = "HTTPS_PROXY"
 	envNoProxy          = "NO_PROXY"
 
 	// Volume names and paths
@@ -73,7 +74,16 @@ func getEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 	if dk.HasProxy() {
 		if dk.Spec.Proxy.ValueFrom != "" {
 			envs = append(envs, corev1.EnvVar{
-				Name: envProxy,
+				Name: envHttpsProxy,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: dk.Spec.Proxy.ValueFrom},
+						Key:                  dynakube.ProxyKey,
+					},
+				},
+			})
+			envs = append(envs, corev1.EnvVar{
+				Name: envHttpProxy,
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: dk.Spec.Proxy.ValueFrom},
@@ -82,7 +92,8 @@ func getEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 				},
 			})
 		} else {
-			envs = append(envs, corev1.EnvVar{Name: envProxy, Value: dk.Spec.Proxy.Value})
+			envs = append(envs, corev1.EnvVar{Name: envHttpsProxy, Value: dk.Spec.Proxy.Value})
+			envs = append(envs, corev1.EnvVar{Name: envHttpProxy, Value: dk.Spec.Proxy.Value})
 		}
 
 		envs = append(envs, corev1.EnvVar{Name: envNoProxy, Value: getNoProxyValue(dk)})

--- a/pkg/controllers/dynakube/otelc/statefulset/env.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env.go
@@ -1,10 +1,10 @@
 package statefulset
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"strconv"
 	"strings"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"

--- a/pkg/controllers/dynakube/otelc/statefulset/env.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env.go
@@ -73,9 +73,9 @@ func getEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 	}
 
 	if dk.HasProxy() {
-		envs = append(envs, getProxyEnvValue(envHttpsProxy, dk.Spec.Proxy))
-		envs = append(envs, getProxyEnvValue(envHttpProxy, dk.Spec.Proxy))
-		envs = append(envs, corev1.EnvVar{Name: envNoProxy, Value: getNoProxyValue(dk)})
+		envs = append(envs, getDynakubeProxyEnvValue(envHttpsProxy, dk.Spec.Proxy))
+		envs = append(envs, getDynakubeProxyEnvValue(envHttpProxy, dk.Spec.Proxy))
+		envs = append(envs, corev1.EnvVar{Name: envNoProxy, Value: getDynakubeNoProxyEnvValue(dk)})
 	}
 
 	if dk.IsExtensionsEnabled() {
@@ -121,7 +121,7 @@ func getEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 	return envs
 }
 
-func getProxyEnvValue(envVar string, src *value.Source) corev1.EnvVar {
+func getDynakubeProxyEnvValue(envVar string, src *value.Source) corev1.EnvVar {
 	if src.ValueFrom != "" {
 		return corev1.EnvVar{
 			Name: envVar,
@@ -137,7 +137,7 @@ func getProxyEnvValue(envVar string, src *value.Source) corev1.EnvVar {
 	return corev1.EnvVar{Name: envVar, Value: src.Value}
 }
 
-func getNoProxyValue(dk *dynakube.DynaKube) string {
+func getDynakubeNoProxyEnvValue(dk *dynakube.DynaKube) string {
 	noProxyValues := []string{}
 
 	if dk.IsExtensionsEnabled() {

--- a/pkg/controllers/dynakube/otelc/statefulset/env_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/telemetryingest"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
@@ -105,4 +108,185 @@ func TestEnvironmentVariables(t *testing.T) {
 			},
 		}}, statefulSet.Spec.Template.Spec.Containers[0].Env[11])
 	})
+}
+
+func TestProxyEnvs(t *testing.T) {
+	const testProxySecretName = "test-proxy-secret"
+
+	const testProxyValue = "test.proxy.com:8888"
+
+	testActiveGate := activegate.Spec{
+		CapabilityProperties: activegate.CapabilityProperties{},
+		Capabilities:         []activegate.CapabilityDisplayName{"otlp-ingest"},
+		UseEphemeralVolume:   false,
+	}
+
+	tests := []struct {
+		name            string
+		extensions      *dynakube.ExtensionsSpec
+		telemetryIngest *telemetryingest.Spec
+		activeGate      *activegate.Spec
+		proxy           *value.Source
+
+		expectedNoProxy string
+	}{
+		{
+			name:            "extensions without proxy",
+			extensions:      &dynakube.ExtensionsSpec{},
+			telemetryIngest: nil,
+			proxy:           nil,
+			expectedNoProxy: "",
+		},
+		{
+			name:            "extensions with proxy secret",
+			extensions:      &dynakube.ExtensionsSpec{},
+			telemetryIngest: nil,
+			proxy: &value.Source{
+				ValueFrom: testProxySecretName,
+			},
+			expectedNoProxy: "dynakube-extensions-controller.dynatrace,dynakube-activegate.dynatrace",
+		},
+		{
+			name:            "extensions with proxy value",
+			extensions:      &dynakube.ExtensionsSpec{},
+			telemetryIngest: nil,
+			proxy: &value.Source{
+				Value: testProxyValue,
+			},
+			expectedNoProxy: "dynakube-extensions-controller.dynatrace,dynakube-activegate.dynatrace",
+		},
+		{
+			name:            "telemetryIngest, public AG, without proxy",
+			extensions:      nil,
+			telemetryIngest: &telemetryingest.Spec{},
+			activeGate:      nil,
+			proxy:           nil,
+			expectedNoProxy: "",
+		},
+		{
+			name:            "telemetryIngest, public AG, with proxy secret",
+			extensions:      nil,
+			telemetryIngest: &telemetryingest.Spec{},
+			activeGate:      nil,
+			proxy: &value.Source{
+				ValueFrom: testProxySecretName,
+			},
+			expectedNoProxy: "",
+		},
+		{
+			name:            "telemetryIngest, public AG, with proxy value",
+			extensions:      nil,
+			telemetryIngest: &telemetryingest.Spec{},
+			activeGate:      nil,
+			proxy: &value.Source{
+				Value: testProxyValue,
+			},
+			expectedNoProxy: "",
+		},
+		{
+			name:            "telemetryIngest, local AG, without proxy",
+			extensions:      nil,
+			telemetryIngest: &telemetryingest.Spec{},
+			activeGate:      &testActiveGate,
+			proxy:           nil,
+			expectedNoProxy: "",
+		},
+		{
+			name:            "telemetryIngest, local AG, with proxy secret",
+			extensions:      nil,
+			telemetryIngest: &telemetryingest.Spec{},
+			activeGate:      &testActiveGate,
+			proxy: &value.Source{
+				ValueFrom: testProxySecretName,
+			},
+			expectedNoProxy: "dynakube-activegate.dynatrace",
+		},
+		{
+			name:            "telemetryIngest, local AG, with proxy value",
+			extensions:      nil,
+			telemetryIngest: &telemetryingest.Spec{},
+			activeGate:      &testActiveGate,
+			proxy: &value.Source{
+				Value: testProxyValue,
+			},
+			expectedNoProxy: "dynakube-activegate.dynatrace",
+		},
+		{
+			name:            "telemetryIngest, extensions, private AG, without proxy",
+			extensions:      &dynakube.ExtensionsSpec{},
+			telemetryIngest: &telemetryingest.Spec{},
+			activeGate:      nil,
+			proxy:           nil,
+			expectedNoProxy: "",
+		},
+		{
+			name:            "telemetryIngest, extensions, private AG, with proxy secret",
+			extensions:      &dynakube.ExtensionsSpec{},
+			telemetryIngest: &telemetryingest.Spec{},
+			activeGate:      nil,
+			proxy: &value.Source{
+				ValueFrom: testProxySecretName,
+			},
+			expectedNoProxy: "dynakube-extensions-controller.dynatrace,dynakube-activegate.dynatrace",
+		},
+		{
+			name:            "telemetryIngest, extensions, private AG, with proxy value",
+			extensions:      &dynakube.ExtensionsSpec{},
+			telemetryIngest: &telemetryingest.Spec{},
+			activeGate:      nil,
+			proxy: &value.Source{
+				Value: testProxyValue,
+			},
+			expectedNoProxy: "dynakube-extensions-controller.dynatrace,dynakube-activegate.dynatrace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dk := getTestDynakube()
+			dk.Spec.Extensions = tt.extensions
+			dk.Spec.TelemetryIngest = tt.telemetryIngest
+			dk.Spec.Proxy = tt.proxy
+
+			if tt.activeGate != nil {
+				dk.Spec.ActiveGate = *tt.activeGate
+			}
+
+			dataIngestToken := getTokens(dk.Name, dk.Namespace)
+			configMap := getConfigConfigMap(dk.Name, dk.Namespace)
+			statefulSet := getStatefulset(t, dk, &dataIngestToken, &configMap)
+
+			switch {
+			case tt.proxy == nil:
+				{
+					assert.NotContains(t, statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envProxy})
+				}
+			case tt.proxy.ValueFrom != "":
+				{
+					assert.Contains(t, statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+						Name: envProxy,
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: tt.proxy.ValueFrom},
+								Key:                  dynakube.ProxyKey,
+							},
+						},
+					})
+				}
+			default:
+				{
+					assert.Contains(t, statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+						Name:  envProxy,
+						Value: tt.proxy.Value,
+					})
+				}
+			}
+
+			if tt.proxy != nil {
+				assert.Contains(t, statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envNoProxy, Value: tt.expectedNoProxy})
+			} else {
+				assert.NotContains(t, statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envNoProxy})
+			}
+		})
+	}
 }

--- a/pkg/controllers/dynakube/otelc/statefulset/env_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env_test.go
@@ -212,7 +212,7 @@ func TestProxyEnvs(t *testing.T) {
 			expectedNoProxy: "dynakube-activegate.dynatrace",
 		},
 		{
-			name:            "telemetryIngest, extensions, private AG, without proxy",
+			name:            "telemetryIngest, extensions, local AG, without proxy",
 			extensions:      &dynakube.ExtensionsSpec{},
 			telemetryIngest: &telemetryingest.Spec{},
 			activeGate:      nil,
@@ -220,7 +220,7 @@ func TestProxyEnvs(t *testing.T) {
 			expectedNoProxy: "",
 		},
 		{
-			name:            "telemetryIngest, extensions, private AG, with proxy secret",
+			name:            "telemetryIngest, extensions, local AG, with proxy secret",
 			extensions:      &dynakube.ExtensionsSpec{},
 			telemetryIngest: &telemetryingest.Spec{},
 			activeGate:      nil,
@@ -230,7 +230,7 @@ func TestProxyEnvs(t *testing.T) {
 			expectedNoProxy: "dynakube-extensions-controller.dynatrace,dynakube-activegate.dynatrace",
 		},
 		{
-			name:            "telemetryIngest, extensions, private AG, with proxy value",
+			name:            "telemetryIngest, extensions, local AG, with proxy value",
 			extensions:      &dynakube.ExtensionsSpec{},
 			telemetryIngest: &telemetryingest.Spec{},
 			activeGate:      nil,

--- a/pkg/otelcgen/exporters.go
+++ b/pkg/otelcgen/exporters.go
@@ -15,7 +15,8 @@ func (c *Config) buildExporters() map[component.ID]component.Config {
 
 	if c.caFile != "" {
 		serverConfig.TLSSetting = &TLSSetting{
-			CAFile: c.caFile,
+			CAFile:                   c.caFile,
+			IncludeSystemCACertsPool: &c.includeSystemCACertsPool,
 		}
 	}
 

--- a/pkg/otelcgen/exporters.go
+++ b/pkg/otelcgen/exporters.go
@@ -15,8 +15,10 @@ func (c *Config) buildExporters() map[component.ID]component.Config {
 
 	if c.caFile != "" {
 		serverConfig.TLSSetting = &TLSSetting{
-			CAFile:                   c.caFile,
-			IncludeSystemCACertsPool: &c.includeSystemCACertsPool,
+			CAFile: c.caFile,
+		}
+		if c.includeSystemCACertsPool {
+			serverConfig.TLSSetting.IncludeSystemCACertsPool = &c.includeSystemCACertsPool
 		}
 	}
 
@@ -26,7 +28,6 @@ func (c *Config) buildExporters() map[component.ID]component.Config {
 	}
 
 	return map[component.ID]component.Config{
-		debug:    nil,
 		otlphttp: serverConfig,
 	}
 }

--- a/pkg/otelcgen/otelcgen.go
+++ b/pkg/otelcgen/otelcgen.go
@@ -28,10 +28,10 @@ type TimerHistogramMapping struct {
 // "go.opentelemetry.io/collector/config/configtls.TLSSetting"
 // with reduced number of attributes to reduce the number of dependencies.
 type TLSSetting struct {
+	IncludeSystemCACertsPool *bool  `mapstructure:"include_system_ca_certs_pool,omitempty"`
 	CAFile                   string `mapstructure:"ca_file,omitempty"`
 	KeyFile                  string `mapstructure:"key_file,omitempty"`
 	CertFile                 string `mapstructure:"cert_file,omitempty"`
-	IncludeSystemCACertsPool *bool  `mapstructure:"include_system_ca_certs_pool,omitempty"`
 }
 
 // ServerConfig is based on "go.opentelemetry.io/collector/config/confighttp.ServerConfig" and
@@ -86,16 +86,17 @@ type Config struct {
 	// Extensions is a map of ComponentID to extensions.
 	Extensions map[component.ID]component.Config `mapstructure:"extensions"`
 
-	tlsKey                   string
-	tlsCert                  string
-	caFile                   string
-	includeSystemCACertsPool bool
-	podIP                    string
-	endpoint                 string
-	apiToken                 string
-	protocols                Protocols
+	tlsKey   string
+	tlsCert  string
+	caFile   string
+	podIP    string
+	endpoint string
+	apiToken string
 
-	Service ServiceConfig `mapstructure:"service"`
+	Service   ServiceConfig `mapstructure:"service"`
+	protocols Protocols
+
+	includeSystemCACertsPool bool
 }
 
 type Option func(c *Config) error
@@ -121,8 +122,8 @@ func (c *Config) Marshal() ([]byte, error) {
 	if err := conf.Marshal(c); err != nil {
 		return nil, err
 	}
-
-	return yaml.Marshal(conf.ToStringMap())
+	sm := conf.ToStringMap()
+	return yaml.Marshal(sm)
 }
 
 func (c *Config) buildTLSSetting() *TLSSetting {

--- a/pkg/otelcgen/otelcgen.go
+++ b/pkg/otelcgen/otelcgen.go
@@ -122,7 +122,9 @@ func (c *Config) Marshal() ([]byte, error) {
 	if err := conf.Marshal(c); err != nil {
 		return nil, err
 	}
+
 	sm := conf.ToStringMap()
+
 	return yaml.Marshal(sm)
 }
 

--- a/pkg/otelcgen/otelcgen.go
+++ b/pkg/otelcgen/otelcgen.go
@@ -28,9 +28,10 @@ type TimerHistogramMapping struct {
 // "go.opentelemetry.io/collector/config/configtls.TLSSetting"
 // with reduced number of attributes to reduce the number of dependencies.
 type TLSSetting struct {
-	CAFile   string `mapstructure:"ca_file,omitempty"`
-	KeyFile  string `mapstructure:"key_file,omitempty"`
-	CertFile string `mapstructure:"cert_file,omitempty"`
+	CAFile                   string `mapstructure:"ca_file,omitempty"`
+	KeyFile                  string `mapstructure:"key_file,omitempty"`
+	CertFile                 string `mapstructure:"cert_file,omitempty"`
+	IncludeSystemCACertsPool *bool  `mapstructure:"include_system_ca_certs_pool,omitempty"`
 }
 
 // ServerConfig is based on "go.opentelemetry.io/collector/config/confighttp.ServerConfig" and
@@ -85,13 +86,14 @@ type Config struct {
 	// Extensions is a map of ComponentID to extensions.
 	Extensions map[component.ID]component.Config `mapstructure:"extensions"`
 
-	tlsKey    string
-	tlsCert   string
-	caFile    string
-	podIP     string
-	endpoint  string
-	apiToken  string
-	protocols Protocols
+	tlsKey                   string
+	tlsCert                  string
+	caFile                   string
+	includeSystemCACertsPool bool
+	podIP                    string
+	endpoint                 string
+	apiToken                 string
+	protocols                Protocols
 
 	Service ServiceConfig `mapstructure:"service"`
 }
@@ -233,6 +235,14 @@ func WithTLS(tlsCert, tlsKey string) Option {
 func WithCA(caFile string) Option {
 	return func(c *Config) error {
 		c.caFile = caFile
+
+		return nil
+	}
+}
+
+func WithSystemCAs(useSystemCAs bool) Option {
+	return func(c *Config) error {
+		c.includeSystemCACertsPool = useSystemCAs
 
 		return nil
 	}

--- a/pkg/otelcgen/otelcgen_test.go
+++ b/pkg/otelcgen/otelcgen_test.go
@@ -14,6 +14,7 @@ func TestNewConfigFull(t *testing.T) {
 		"test",
 		Protocols{OtlpProtocol, JaegerProtocol, StatsdProtocol, ZipkinProtocol},
 		WithCA("/run/opensignals/cacerts/certs"),
+		WithSystemCAs(true),
 		WithApiToken("test-token"),
 		WithTLS("/run/opensignals/tls/tls.crt", "/run/opensignals/tls/tls.key"),
 		WithReceivers(),

--- a/pkg/otelcgen/services.go
+++ b/pkg/otelcgen/services.go
@@ -88,7 +88,7 @@ func (c *Config) buildPipelinesReceivers(allowed []component.ID) []component.ID 
 
 func buildExporters() []component.ID {
 	return []component.ID{
-		otlphttp, debug,
+		otlphttp,
 	}
 }
 

--- a/pkg/otelcgen/services.go
+++ b/pkg/otelcgen/services.go
@@ -14,7 +14,6 @@ var (
 	traces  = pipeline.MustNewID("traces")
 	metrics = pipeline.MustNewID("metrics")
 	logs    = pipeline.MustNewID("logs")
-	debug   = component.MustNewID("debug")
 
 	allowedPipelinesLogsReceiversIDs = []component.ID{OtlpID}
 

--- a/pkg/otelcgen/testdata/exporters_only.yaml
+++ b/pkg/otelcgen/testdata/exporters_only.yaml
@@ -1,10 +1,10 @@
 connectors: {}
 exporters:
-  debug:
   otlphttp:
     endpoint: "test"
     tls:
       ca_file: "/run/opensignals/cacerts/certs"
+
     headers:
       Authorization: "Api-Token test-token"
 extensions: {}

--- a/pkg/otelcgen/testdata/full_config.yaml
+++ b/pkg/otelcgen/testdata/full_config.yaml
@@ -197,7 +197,6 @@ service:
     logs:
       exporters:
         - otlphttp
-        - debug
       receivers:
         - otlp
       processors:
@@ -208,7 +207,6 @@ service:
     metrics:
       exporters:
         - otlphttp
-        - debug
       receivers:
         - otlp
         - statsd
@@ -221,7 +219,6 @@ service:
     traces:
       exporters:
         - otlphttp
-        - debug
       receivers:
         - otlp
         - jaeger

--- a/pkg/otelcgen/testdata/full_config.yaml
+++ b/pkg/otelcgen/testdata/full_config.yaml
@@ -1,10 +1,10 @@
 connectors: {}
 exporters:
-  debug:
   otlphttp:
     endpoint: "exporters-test-endpoint"
     tls:
       ca_file: "/run/opensignals/cacerts/certs"
+      include_system_ca_certs_pool: true
     headers:
       Authorization: "Api-Token test-token"
 extensions:

--- a/pkg/otelcgen/testdata/services_only.yaml
+++ b/pkg/otelcgen/testdata/services_only.yaml
@@ -10,7 +10,6 @@ service:
     logs:
       exporters:
         - otlphttp
-        - debug
       receivers:
         - otlp
       processors:
@@ -21,7 +20,6 @@ service:
     metrics:
       exporters:
         - otlphttp
-        - debug
       receivers:
         - otlp
         - statsd
@@ -34,7 +32,6 @@ service:
     traces:
       exporters:
         - otlphttp
-        - debug
       receivers:
         - otlp
         - jaeger

--- a/pkg/otelcgen/testdata/services_statsd_only.yaml
+++ b/pkg/otelcgen/testdata/services_statsd_only.yaml
@@ -10,7 +10,6 @@ service:
     metrics:
       exporters:
         - otlphttp
-        - debug
       receivers:
         - statsd
       processors:

--- a/pkg/otelcgen/testdata/services_zipkin_only.yaml
+++ b/pkg/otelcgen/testdata/services_zipkin_only.yaml
@@ -10,7 +10,6 @@ service:
     traces:
       exporters:
         - otlphttp
-        - debug
       receivers:
         - zipkin
       processors:


### PR DESCRIPTION
## Description

The env vars to control proxy usage (`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`) are now set.

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-6174)

## How can this be tested?

### Proxy settings with in-cluster AG
Deploy this Dynakube
```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/activegate-authtoken: "true"

spec:
  apiUrl: https://....../api

  proxy:
    value: http://squid.proxy.svc.cluster.local:3128

  activeGate:
    capabilities:
      - routing
      - kubernetes-monitoring

    replicas: 1
    resources:
      requests:
        cpu: 1000m
        memory: 1.5Gi
      limits:
        cpu: 1000m
        memory: 1.5Gi

  extensions: {}

  telemetryIngest:
    protocols:
    - otlp

  templates:
    extensionExecutionController:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-eec
        tag: 1.307.61.20250226-155505
```

Check the env vars on the otel collector pod:
* `HTTP/HTTPS_PROXY`: `http://squid.proxy.svc.cluster.local:3128`
* `NO_PROXY`: 'dynakube-extensions-controller.dynatrace,dynakube-activegate.dynatrace'

## Proxy settings without local ActiveGate

```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/activegate-authtoken: "true"

spec:
  apiUrl: https://.../api

  proxy:
    value: "http://squid.proxy.svc.cluster.local:3128"

  telemetryIngest:
    protocols:
    - otlp
    - jaeger
    - zipkin
    - statsd
```

Check the env vars on the otel collector pod:
* `HTTP/HTTPS_PROXY`: `http://squid.proxy.svc.cluster.local:3128`
* `NO_PROXY`: '<empty>'
