### PR TITLE
Make Job installer work on OCP

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/role-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/role-csi.yaml
@@ -38,6 +38,12 @@ rules:
       - list
       - watch
   - apiGroups:
+      - dynatrace.com
+    resources:
+      - dynakubes/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - batch
     resources:
       - jobs

--- a/config/helm/chart/default/tests/Common/csi/role-csi_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/role-csi_test.yaml
@@ -53,7 +53,13 @@ tests:
                 - list
                 - watch
             - apiGroups:
-                - "batch"
+                - dynatrace.com
+              resources:
+                - dynakubes/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - batch
               resources:
                 - jobs
               verbs:

--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/url"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+	batchv1 "k8s.io/api/batch/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/mount-utils"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -86,6 +87,7 @@ func NewOneAgentProvisioner(mgr manager.Manager, opts dtcsi.CSIOptions) *OneAgen
 func (provisioner *OneAgentProvisioner) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&dynakube.DynaKube{}).
+		Owns(&batchv1.Job{}).
 		Named("provisioner-controller").
 		Complete(provisioner)
 }

--- a/pkg/injection/codemodule/installer/job/bootstrapper.go
+++ b/pkg/injection/codemodule/installer/job/bootstrapper.go
@@ -17,6 +17,8 @@ const (
 	volumeName       = "dynatrace-codemodules"
 	codeModuleSource = "/opt/dynatrace/oneagent"
 
+	provisionerServiceAccount = "dynatrace-oneagent-csi-driver" // TODO: Get it from env
+
 	activeDeadlineSeconds   int64 = 600 // 10 min, after which the Job will be put into a Failed state
 	ttlSecondsAfterFinished int32 = 10  // 10 sec after the Job is put into a Succeeded or Failed state the Job and related Pods will be terminated
 )
@@ -85,6 +87,7 @@ func (inst *Installer) buildJob(name, targetDir string) (*batchv1.Job, error) {
 		jobutil.SetAutomountServiceAccountToken(false),
 		jobutil.SetActiveDeadlineSeconds(activeDeadlineSeconds),
 		jobutil.SetTTLSecondsAfterFinished(ttlSecondsAfterFinished),
+		jobutil.SetServiceAccount(provisionerServiceAccount),
 	)
 }
 

--- a/pkg/injection/codemodule/installer/job/bootstrapper.go
+++ b/pkg/injection/codemodule/installer/job/bootstrapper.go
@@ -50,8 +50,11 @@ func (inst *Installer) buildJob(name, targetDir string) (*batchv1.Job, error) {
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{ // TODO: Use the SecurityContext from the `provisioner` container
-			RunAsUser:              ptr.To(int64(0)),
-			ReadOnlyRootFilesystem: ptr.To(true),
+			RunAsUser:                ptr.To(int64(0)),
+			RunAsNonRoot:             ptr.To(false),
+			Privileged:               ptr.To(true),
+			AllowPrivilegeEscalation: ptr.To(true),
+			ReadOnlyRootFilesystem:   ptr.To(true),
 			SELinuxOptions: &corev1.SELinuxOptions{
 				Level: "s0",
 			},

--- a/pkg/injection/codemodule/installer/job/bootstrapper_test.go
+++ b/pkg/injection/codemodule/installer/job/bootstrapper_test.go
@@ -113,6 +113,9 @@ func TestBuildJob(t *testing.T) {
 		require.NotNil(t, job.Spec.Template.Spec.Volumes[0].HostPath)
 		assert.Equal(t, dataDir, job.Spec.Template.Spec.Volumes[0].HostPath.Path)
 
+		require.Equal(t, provisionerServiceAccount, job.Spec.Template.Spec.ServiceAccountName)
+		require.Equal(t, provisionerServiceAccount, job.Spec.Template.Spec.DeprecatedServiceAccount)
+
 		require.Len(t, job.Spec.Template.Spec.ImagePullSecrets, len(pullSecrets))
 
 		for i, ps := range pullSecrets {

--- a/pkg/util/kubeobjects/job/builder.go
+++ b/pkg/util/kubeobjects/job/builder.go
@@ -78,6 +78,13 @@ func SetPodAnnotations(annotations map[string]string) builder.Option[*batchv1.Jo
 	}
 }
 
+func SetServiceAccount(serviceAccountName string) builder.Option[*batchv1.Job] {
+	return func(s *batchv1.Job) {
+		s.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+		s.Spec.Template.Spec.DeprecatedServiceAccount = serviceAccountName
+	}
+}
+
 func SetTTLSecondsAfterFinished(ttl int32) builder.Option[*batchv1.Job] {
 	return func(s *batchv1.Job) {
 		s.Spec.TTLSecondsAfterFinished = ptr.To(ttl)


### PR DESCRIPTION
In OCP to add an owner-reference you need to be able to update the finalizer of the owner
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-6457](https://dt-rnd.atlassian.net/browse/DAQ-6457)

OCP is more strict when it comes to doing things, so I had to:
- [Add role to update dynakube finalizer](https://github.com/Dynatrace/dynatrace-operator/commit/f379ab96788f7e6a445c3cd9c8330fba1407df73)
- [Use the provisioner serviceAccount for download job](https://github.com/Dynatrace/dynatrace-operator/commit/9f56a86809117a67fb5b89d8b9bc545488b676f9)
- [Sync job securityContext with provisioner container](https://github.com/Dynatrace/dynatrace-operator/pull/4631/commits/639b667ed374e4ea4fc92269dc18dd84ff54c895)

~(it is a draft so I can build an arm image in peace, so I can test it in `crc`)~
- on `crc` there is some weird error
- works on actual cluster

## How can this be tested?

Run the `make test/e2e/applicationmonitoring/bootstrapper-csi` on an OCP cluster

[DAQ-6457]: https://dt-rnd.atlassian.net/browse/DAQ-6457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ