### PR TITLE
Configure host volumes for host agent without CSI driver

### DIFF
--- a/doc/e2e/features.md
+++ b/doc/e2e/features.md
@@ -299,14 +299,14 @@ import "github.com/Dynatrace/dynatrace-operator/test/features/cloudnative/defaul
 
 ## Index
 
-- [func Feature(t *testing.T, istioEnabled bool) features.Feature](<#Feature>)
+- [func Feature(t *testing.T, istioEnabled bool, withCSI bool) features.Feature](<#Feature>)
 
 <a name="Feature"></a>
 
 ## func [Feature](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/cloudnative/default/default.go#L50>)
 
 ```go
-func Feature(t *testing.T, istioEnabled bool) features.Feature
+func Feature(t *testing.T, istioEnabled bool, withCSI bool) features.Feature
 ```
 
 ### With istio enabled
@@ -494,6 +494,26 @@ import "github.com/Dynatrace/dynatrace-operator/test/features/extensions"
 ```go
 func Feature(t *testing.T) features.Feature
 ```
+
+# hostmonitoring
+
+```go
+import "github.com/Dynatrace/dynatrace-operator/test/features/hostmonitoring"
+```
+
+## Index
+
+- [func WithoutCSI(t *testing.T) features.Feature](<#WithoutCSI>)
+
+<a name="WithoutCSI"></a>
+
+## func [WithoutCSI](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/hostmonitoring/without_csi.go#L17>)
+
+```go
+func WithoutCSI(t *testing.T) features.Feature
+```
+
+ApplicationMonitoring deployment without CSI driver
 
 # logmonitoring
 

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -153,3 +153,11 @@ test/e2e/extensions: manifests/crd/helm
 ## Runs LogMonitoring related e2e tests
 test/e2e/logmonitoring: manifests/crd/helm
 	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/no_csi -args --feature "logmonitoring-components-rollout" $(SKIPCLEANUP)
+
+## Runs Host Monitoring without CSI e2e test only
+test/e2e/hostmonitoring/withoutcsi: manifests/crd/helm
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/no_csi -args --feature "host-monitoring-without-csi" $(SKIPCLEANUP)
+
+## Runs CloudNative default e2e test only
+test/e2e/cloudnative/withoutcsi: manifests/crd/helm
+	go test -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/no_csi -args --feature "cloudnative" $(SKIPCLEANUP)

--- a/pkg/api/v1beta4/dynakube/oneagent/props.go
+++ b/pkg/api/v1beta4/dynakube/oneagent/props.go
@@ -104,7 +104,7 @@ func (oa *OneAgent) GetConnectionInfoConfigMapName() string {
 	return oa.name + OneAgentConnectionInfoConfigMapSuffix
 }
 
-func (oa *OneAgent) IsOneAgentModeSupportingReadOnlyFS() bool {
+func (oa *OneAgent) IsReadOnlyFSSupported() bool {
 	return oa.IsCloudNativeFullstackMode() || oa.IsHostMonitoringMode()
 }
 

--- a/pkg/api/v1beta4/dynakube/oneagent/props.go
+++ b/pkg/api/v1beta4/dynakube/oneagent/props.go
@@ -104,7 +104,7 @@ func (oa *OneAgent) GetConnectionInfoConfigMapName() string {
 	return oa.name + OneAgentConnectionInfoConfigMapSuffix
 }
 
-func (oa *OneAgent) IsReadOnlyOneAgentsMode() bool {
+func (oa *OneAgent) IsOneAgentModeSupportingReadOnlyFS() bool {
 	return oa.IsCloudNativeFullstackMode() || oa.IsHostMonitoringMode()
 }
 
@@ -331,16 +331,16 @@ func (oa *OneAgent) GetArgumentsMap() map[string][]string {
 // GetHostPath provides the host path for the storage volume if CSI driver is absent.
 func (oa *OneAgent) GetHostPath() string {
 	if oa.IsCloudNativeFullstackMode() {
-		if oa.Spec.CloudNativeFullStack.StorageHostPath != "" {
-			return oa.Spec.CloudNativeFullStack.StorageHostPath
+		if oa.CloudNativeFullStack.StorageHostPath != "" {
+			return oa.CloudNativeFullStack.StorageHostPath
 		}
 
 		return storageVolumeDefaultHostPath
 	}
 
 	if oa.IsHostMonitoringMode() {
-		if oa.Spec.HostMonitoring.StorageHostPath != "" {
-			return oa.Spec.HostMonitoring.StorageHostPath
+		if oa.HostMonitoring.StorageHostPath != "" {
+			return oa.HostMonitoring.StorageHostPath
 		}
 
 		return storageVolumeDefaultHostPath

--- a/pkg/api/v1beta4/dynakube/oneagent/props.go
+++ b/pkg/api/v1beta4/dynakube/oneagent/props.go
@@ -16,6 +16,7 @@ const (
 	OneAgentConnectionInfoConfigMapSuffix = "-oneagent-connection-info"
 	PodNameOsAgent                        = "oneagent"
 	DefaultOneAgentImageRegistrySubPath   = "/linux/oneagent"
+	storageVolumeDefaultHostPath          = "/var/opt/dynatrace"
 )
 
 func NewOneAgent(spec *Spec, status *Status, codeModulesStatus *CodeModulesStatus, //nolint:revive
@@ -104,7 +105,7 @@ func (oa *OneAgent) GetConnectionInfoConfigMapName() string {
 }
 
 func (oa *OneAgent) IsReadOnlyOneAgentsMode() bool {
-	return oa.IsCloudNativeFullstackMode() || (oa.IsHostMonitoringMode() && oa.IsCSIAvailable())
+	return oa.IsCloudNativeFullstackMode() || oa.IsHostMonitoringMode()
 }
 
 func (oa *OneAgent) IsAppInjectionNeeded() bool {
@@ -325,4 +326,25 @@ func (oa *OneAgent) GetArgumentsMap() map[string][]string {
 	}
 
 	return argMap
+}
+
+// GetHostPath provides the host path for the storage volume if CSI driver is absent.
+func (oa *OneAgent) GetHostPath() string {
+	if oa.IsCloudNativeFullstackMode() {
+		if oa.Spec.CloudNativeFullStack.StorageHostPath != "" {
+			return oa.Spec.CloudNativeFullStack.StorageHostPath
+		}
+
+		return storageVolumeDefaultHostPath
+	}
+
+	if oa.IsHostMonitoringMode() {
+		if oa.Spec.HostMonitoring.StorageHostPath != "" {
+			return oa.Spec.HostMonitoring.StorageHostPath
+		}
+
+		return storageVolumeDefaultHostPath
+	}
+
+	return ""
 }

--- a/pkg/api/v1beta4/dynakube/oneagent/props_test.go
+++ b/pkg/api/v1beta4/dynakube/oneagent/props_test.go
@@ -36,7 +36,7 @@ func TestNeedsReadonlyOneagent(t *testing.T) {
 				CloudNativeFullStack: &CloudNativeFullStackSpec{},
 			},
 		}
-		assert.True(t, oneagent.IsOneAgentModeSupportingReadOnlyFS())
+		assert.True(t, oneagent.IsReadOnlyFSSupported())
 	})
 
 	t.Run("host monitoring with readonly host agent", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestNeedsReadonlyOneagent(t *testing.T) {
 				HostMonitoring: &HostInjectSpec{},
 			},
 		}
-		assert.True(t, oneAgent.IsOneAgentModeSupportingReadOnlyFS())
+		assert.True(t, oneAgent.IsReadOnlyFSSupported())
 	})
 
 	t.Run("host monitoring without readonly host agent", func(t *testing.T) {
@@ -56,7 +56,7 @@ func TestNeedsReadonlyOneagent(t *testing.T) {
 				HostMonitoring: &HostInjectSpec{},
 			},
 		}
-		assert.True(t, oneAgent.IsOneAgentModeSupportingReadOnlyFS())
+		assert.True(t, oneAgent.IsReadOnlyFSSupported())
 	})
 }
 

--- a/pkg/api/v1beta4/dynakube/oneagent/props_test.go
+++ b/pkg/api/v1beta4/dynakube/oneagent/props_test.go
@@ -36,7 +36,7 @@ func TestNeedsReadonlyOneagent(t *testing.T) {
 				CloudNativeFullStack: &CloudNativeFullStackSpec{},
 			},
 		}
-		assert.True(t, oneagent.IsReadOnlyOneAgentsMode())
+		assert.True(t, oneagent.IsOneAgentModeSupportingReadOnlyFS())
 	})
 
 	t.Run("host monitoring with readonly host agent", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestNeedsReadonlyOneagent(t *testing.T) {
 				HostMonitoring: &HostInjectSpec{},
 			},
 		}
-		assert.True(t, oneAgent.IsReadOnlyOneAgentsMode())
+		assert.True(t, oneAgent.IsOneAgentModeSupportingReadOnlyFS())
 	})
 
 	t.Run("host monitoring without readonly host agent", func(t *testing.T) {
@@ -56,7 +56,7 @@ func TestNeedsReadonlyOneagent(t *testing.T) {
 				HostMonitoring: &HostInjectSpec{},
 			},
 		}
-		assert.True(t, oneAgent.IsReadOnlyOneAgentsMode())
+		assert.True(t, oneAgent.IsOneAgentModeSupportingReadOnlyFS())
 	})
 }
 

--- a/pkg/api/v1beta4/dynakube/oneagent/props_test.go
+++ b/pkg/api/v1beta4/dynakube/oneagent/props_test.go
@@ -56,7 +56,7 @@ func TestNeedsReadonlyOneagent(t *testing.T) {
 				HostMonitoring: &HostInjectSpec{},
 			},
 		}
-		assert.False(t, oneAgent.IsReadOnlyOneAgentsMode())
+		assert.True(t, oneAgent.IsReadOnlyOneAgentsMode())
 	})
 }
 

--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -131,7 +131,7 @@ func mapKeysToString(m map[string]bool, sep string) string {
 
 func publicImageSetWithoutReadOnlyMode(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
 	if dk.OneAgent().GetCustomImage() != "" {
-		if dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
+		if dk.OneAgent().IsReadOnlyFSSupported() {
 			return ""
 		}
 
@@ -197,7 +197,7 @@ func unsupportedOneAgentImage(_ context.Context, _ *Validator, dk *dynakube.Dyna
 
 func conflictingOneAgentVolumeStorageSettings(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	volumeStorageEnabled, volumeStorageSet := hasOneAgentVolumeStorageEnabled(dk)
-	if dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() && volumeStorageSet && !volumeStorageEnabled {
+	if dk.OneAgent().IsReadOnlyFSSupported() && volumeStorageSet && !volumeStorageEnabled {
 		return errorVolumeStorageReadOnlyModeConflict
 	}
 

--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -131,7 +131,7 @@ func mapKeysToString(m map[string]bool, sep string) string {
 
 func publicImageSetWithoutReadOnlyMode(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
 	if dk.OneAgent().GetCustomImage() != "" {
-		if dk.OneAgent().IsReadOnlyOneAgentsMode() {
+		if dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
 			return ""
 		}
 
@@ -197,7 +197,7 @@ func unsupportedOneAgentImage(_ context.Context, _ *Validator, dk *dynakube.Dyna
 
 func conflictingOneAgentVolumeStorageSettings(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	volumeStorageEnabled, volumeStorageSet := hasOneAgentVolumeStorageEnabled(dk)
-	if dk.OneAgent().IsReadOnlyOneAgentsMode() && volumeStorageSet && !volumeStorageEnabled {
+	if dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() && volumeStorageSet && !volumeStorageEnabled {
 		return errorVolumeStorageReadOnlyModeConflict
 	}
 

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -585,7 +585,7 @@ func TestIsOneAgentVersionValid(t *testing.T) {
 func TestPublicImageSetWithReadOnlyMode(t *testing.T) {
 	t.Run("reject dk with hostMon without csi and custom image", func(t *testing.T) {
 		setupDisabledCSIEnv(t)
-		assertAllowedWithWarnings(t, 1,
+		assertAllowedWithoutWarnings(t,
 			&dynakube.DynaKube{
 				ObjectMeta: defaultDynakubeObjectMeta,
 				Spec: dynakube.DynaKubeSpec{

--- a/pkg/controllers/csi/metadata/correctness.go
+++ b/pkg/controllers/csi/metadata/correctness.go
@@ -94,7 +94,7 @@ func (checker *CorrectnessChecker) migrateHostMounts(ctx context.Context) {
 	}
 
 	for _, dk := range dks {
-		if !dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
+		if !dk.OneAgent().IsReadOnlyFSSupported() {
 			continue
 		}
 
@@ -147,7 +147,7 @@ func GetRelevantDynaKubes(ctx context.Context, apiReader client.Reader) ([]dynak
 	var relevantDks []dynakube.DynaKube
 
 	for _, dk := range dkList.Items {
-		if dk.OneAgent().IsAppInjectionNeeded() || dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
+		if dk.OneAgent().IsAppInjectionNeeded() || dk.OneAgent().IsReadOnlyFSSupported() {
 			relevantDks = append(relevantDks, dk)
 		}
 	}

--- a/pkg/controllers/csi/metadata/correctness.go
+++ b/pkg/controllers/csi/metadata/correctness.go
@@ -94,7 +94,7 @@ func (checker *CorrectnessChecker) migrateHostMounts(ctx context.Context) {
 	}
 
 	for _, dk := range dks {
-		if !dk.OneAgent().IsReadOnlyOneAgentsMode() {
+		if !dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
 			continue
 		}
 
@@ -147,7 +147,7 @@ func GetRelevantDynaKubes(ctx context.Context, apiReader client.Reader) ([]dynak
 	var relevantDks []dynakube.DynaKube
 
 	for _, dk := range dkList.Items {
-		if dk.OneAgent().IsAppInjectionNeeded() || dk.OneAgent().IsReadOnlyOneAgentsMode() {
+		if dk.OneAgent().IsAppInjectionNeeded() || dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
 			relevantDks = append(relevantDks, dk)
 		}
 	}

--- a/pkg/controllers/csi/provisioner/cleanup/hostmounts.go
+++ b/pkg/controllers/csi/provisioner/cleanup/hostmounts.go
@@ -53,7 +53,7 @@ func (c *Cleaner) collectRelevantHostDirs(dks []dynakube.DynaKube) map[string]bo
 	hostDirs := map[string]bool{}
 
 	for _, dk := range dks {
-		if !dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
+		if !dk.OneAgent().IsReadOnlyFSSupported() {
 			continue
 		}
 

--- a/pkg/controllers/csi/provisioner/cleanup/hostmounts.go
+++ b/pkg/controllers/csi/provisioner/cleanup/hostmounts.go
@@ -53,7 +53,7 @@ func (c *Cleaner) collectRelevantHostDirs(dks []dynakube.DynaKube) map[string]bo
 	hostDirs := map[string]bool{}
 
 	for _, dk := range dks {
-		if !dk.OneAgent().IsReadOnlyOneAgentsMode() {
+		if !dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
 			continue
 		}
 

--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -151,7 +151,7 @@ func (provisioner *OneAgentProvisioner) Reconcile(ctx context.Context, request r
 }
 
 func isProvisionerNeeded(dk *dynakube.DynaKube) bool {
-	return dk.OneAgent().IsAppInjectionNeeded() || dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS()
+	return dk.OneAgent().IsAppInjectionNeeded() || dk.OneAgent().IsReadOnlyFSSupported()
 }
 
 func (provisioner *OneAgentProvisioner) setupFileSystem(dk dynakube.DynaKube) error {

--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -151,7 +151,7 @@ func (provisioner *OneAgentProvisioner) Reconcile(ctx context.Context, request r
 }
 
 func isProvisionerNeeded(dk *dynakube.DynaKube) bool {
-	return dk.OneAgent().IsAppInjectionNeeded() || dk.OneAgent().IsReadOnlyOneAgentsMode()
+	return dk.OneAgent().IsAppInjectionNeeded() || dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS()
 }
 
 func (provisioner *OneAgentProvisioner) setupFileSystem(dk dynakube.DynaKube) error {

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -321,7 +321,7 @@ func (b *builder) imagePullSecrets() []corev1.LocalObjectReference {
 
 func (b *builder) securityContext() *corev1.SecurityContext {
 	var securityContext corev1.SecurityContext
-	if b.dk != nil && b.dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
+	if b.dk != nil && b.dk.OneAgent().IsReadOnlyFSSupported() {
 		securityContext.RunAsNonRoot = ptr.To(true)
 		securityContext.RunAsUser = ptr.To(int64(1000))
 		securityContext.RunAsGroup = ptr.To(int64(1000))
@@ -417,7 +417,7 @@ func (b *builder) getReadinessProbe() *corev1.Probe {
 // if the version is not set, ie.: unknown, we  consider the OneAgent to support `ReadOnlyRootFilesystem`.
 func (b *builder) isRootFsReadonly() bool {
 	if b.dk != nil &&
-		b.dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() &&
+		b.dk.OneAgent().IsReadOnlyFSSupported() &&
 		b.dk.OneAgent().GetVersion() != "" &&
 		b.dk.OneAgent().GetVersion() != string(status.CustomImageVersionSource) {
 		agentSemver, err := dtversion.ToSemver(b.dk.OneAgent().GetVersion())

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -41,6 +41,8 @@ const (
 	csiStorageVolumeName  = "osagent-storage"
 	csiStorageVolumeMount = "/mnt/volume_storage_mount"
 
+	storageVolumeName = "volume-storage"
+
 	podName = "dynatrace-oneagent"
 
 	inframonHostIdSource = "k8s-node-name"

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -321,7 +321,7 @@ func (b *builder) imagePullSecrets() []corev1.LocalObjectReference {
 
 func (b *builder) securityContext() *corev1.SecurityContext {
 	var securityContext corev1.SecurityContext
-	if b.dk != nil && b.dk.OneAgent().IsReadOnlyOneAgentsMode() {
+	if b.dk != nil && b.dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
 		securityContext.RunAsNonRoot = ptr.To(true)
 		securityContext.RunAsUser = ptr.To(int64(1000))
 		securityContext.RunAsGroup = ptr.To(int64(1000))
@@ -417,7 +417,7 @@ func (b *builder) getReadinessProbe() *corev1.Probe {
 // if the version is not set, ie.: unknown, we  consider the OneAgent to support `ReadOnlyRootFilesystem`.
 func (b *builder) isRootFsReadonly() bool {
 	if b.dk != nil &&
-		b.dk.OneAgent().IsReadOnlyOneAgentsMode() &&
+		b.dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() &&
 		b.dk.OneAgent().GetVersion() != "" &&
 		b.dk.OneAgent().GetVersion() != string(status.CustomImageVersionSource) {
 		agentSemver, err := dtversion.ToSemver(b.dk.OneAgent().GetVersion())

--- a/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
@@ -122,7 +122,7 @@ func (b *builder) addProxyEnv(envVarMap *prioritymap.Map) {
 }
 
 func (b *builder) addReadOnlyEnv(envVarMap *prioritymap.Map) {
-	if b.dk != nil && b.dk.OneAgent().IsReadOnlyOneAgentsMode() {
+	if b.dk != nil && b.dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
 		addDefaultValue(envVarMap, oneagentReadOnlyMode, "true")
 	}
 }

--- a/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
@@ -122,7 +122,7 @@ func (b *builder) addProxyEnv(envVarMap *prioritymap.Map) {
 }
 
 func (b *builder) addReadOnlyEnv(envVarMap *prioritymap.Map) {
-	if b.dk != nil && b.dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
+	if b.dk != nil && b.dk.OneAgent().IsReadOnlyFSSupported() {
 		addDefaultValue(envVarMap, oneagentReadOnlyMode, "true")
 	}
 }

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -22,7 +22,7 @@ func prepareVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 		return volumeMounts
 	}
 
-	if dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
+	if dk.OneAgent().IsReadOnlyFSSupported() {
 		volumeMounts = append(volumeMounts, getReadOnlyRootMount())
 		if dk.OneAgent().IsCSIAvailable() {
 			volumeMounts = append(volumeMounts, getCSIStorageMount())
@@ -116,7 +116,7 @@ func prepareVolumes(dk *dynakube.DynaKube) []corev1.Volume {
 
 	volumes = append(volumes, getOneAgentSecretVolume(dk))
 
-	if dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
+	if dk.OneAgent().IsReadOnlyFSSupported() {
 		if dk.OneAgent().IsCSIAvailable() {
 			volumes = append(volumes, getCSIStorageVolume(dk))
 		} else {

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -22,7 +22,7 @@ func prepareVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 		return volumeMounts
 	}
 
-	if dk.OneAgent().IsCloudNativeFullstackMode() || dk.OneAgent().IsHostMonitoringMode() {
+	if dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
 		volumeMounts = append(volumeMounts, getReadOnlyRootMount())
 		if dk.OneAgent().IsCSIAvailable() {
 			volumeMounts = append(volumeMounts, getCSIStorageMount())
@@ -116,7 +116,7 @@ func prepareVolumes(dk *dynakube.DynaKube) []corev1.Volume {
 
 	volumes = append(volumes, getOneAgentSecretVolume(dk))
 
-	if dk.OneAgent().IsCloudNativeFullstackMode() || dk.OneAgent().IsHostMonitoringMode() {
+	if dk.OneAgent().IsOneAgentModeSupportingReadOnlyFS() {
 		if dk.OneAgent().IsCSIAvailable() {
 			volumes = append(volumes, getCSIStorageVolume(dk))
 		} else {

--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -298,4 +299,142 @@ func TestPrepareVolumeMounts(t *testing.T) {
 		assert.NotContains(t, volumes, buildHttpProxyVolume(dk))
 		assert.NotContains(t, mounts, getHttpProxyMount())
 	})
+}
+
+func TestVolumesAndVolumeMountsVsCSIDriver(t *testing.T) {
+	dkHostMonitoring := &dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: oneagent.Spec{
+				HostMonitoring: &oneagent.HostInjectSpec{},
+			},
+		},
+	}
+	dkCloudNativeFullStack := &dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: oneagent.Spec{
+				CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{},
+			},
+		},
+	}
+	dkClassicFullStack := &dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: oneagent.Spec{
+				ClassicFullStack: &oneagent.HostInjectSpec{},
+			},
+		},
+	}
+
+	type oneAgentVolumeTest struct {
+		testName                string
+		dk                      *dynakube.DynaKube
+		csi                     bool
+		csiVolume               bool
+		storageVolume           bool
+		rootReadOnlyVolumeMount bool
+	}
+
+	testCases := []oneAgentVolumeTest{
+		{
+			testName:                "hostMonitoring w/ CSI driver",
+			dk:                      dkHostMonitoring,
+			csi:                     true,
+			csiVolume:               true,
+			storageVolume:           false,
+			rootReadOnlyVolumeMount: true,
+		},
+		{
+			testName:                "hostMonitoring w/o CSI driver",
+			dk:                      dkHostMonitoring,
+			csi:                     false,
+			csiVolume:               false,
+			storageVolume:           true,
+			rootReadOnlyVolumeMount: true,
+		},
+
+		{
+			testName:                "cloudNativeFullStack w/ CSI driver",
+			dk:                      dkCloudNativeFullStack,
+			csi:                     true,
+			csiVolume:               true,
+			storageVolume:           false,
+			rootReadOnlyVolumeMount: true,
+		},
+		{
+			testName:                "cloudNativeFullStack w/o CSI driver",
+			dk:                      dkCloudNativeFullStack,
+			csi:                     false,
+			csiVolume:               false,
+			storageVolume:           true,
+			rootReadOnlyVolumeMount: true,
+		},
+
+		{
+			testName:                "classicFullStack w/o CSI driver",
+			dk:                      dkClassicFullStack,
+			csi:                     false,
+			csiVolume:               false,
+			storageVolume:           false,
+			rootReadOnlyVolumeMount: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("Volumes:"+tc.testName, func(t *testing.T) {
+			testVolumesVsCSIDriver(t, tc.dk, tc.csi, tc.csiVolume, tc.storageVolume)
+		})
+
+		t.Run("VolumeMounts:"+tc.testName, func(t *testing.T) {
+			testVolumeMountsVsCSIDriver(t, tc.dk, tc.csi, tc.csiVolume, tc.storageVolume, tc.rootReadOnlyVolumeMount)
+		})
+	}
+}
+
+func testVolumesVsCSIDriver(t *testing.T, dk *dynakube.DynaKube, csi bool, csiVolume bool, storageVolume bool) {
+	if csi {
+		installconfig.SetModulesOverride(t, installconfig.Modules{CSIDriver: true})
+	} else {
+		installconfig.SetModulesOverride(t, installconfig.Modules{CSIDriver: false})
+	}
+
+	volumes := prepareVolumes(dk)
+
+	if csiVolume {
+		assert.Contains(t, volumes, getCSIStorageVolume(dk))
+	} else {
+		assert.NotContains(t, volumes, getCSIStorageVolume(dk))
+	}
+
+	if storageVolume {
+		assert.Contains(t, volumes, getStorageVolume(dk))
+	} else {
+		assert.NotContains(t, volumes, getStorageVolume(dk))
+	}
+}
+
+func testVolumeMountsVsCSIDriver(t *testing.T, dk *dynakube.DynaKube, csi bool, csiVolume bool, storageVolume bool, rootReadOnlyVolumeMount bool) { //nolint:revive
+	if csi {
+		installconfig.SetModulesOverride(t, installconfig.Modules{CSIDriver: true})
+	} else {
+		installconfig.SetModulesOverride(t, installconfig.Modules{CSIDriver: false})
+	}
+
+	volumeMounts := prepareVolumeMounts(dk)
+
+	if csiVolume {
+		assert.Contains(t, volumeMounts, getCSIStorageMount())
+	} else {
+		assert.NotContains(t, volumeMounts, getCSIStorageMount())
+	}
+
+	if storageVolume {
+		assert.Contains(t, volumeMounts, getStorageVolumeMount(dk))
+	} else {
+		assert.NotContains(t, volumeMounts, getStorageVolumeMount(dk))
+	}
+
+	if rootReadOnlyVolumeMount {
+		assert.Contains(t, volumeMounts, getReadOnlyRootMount())
+	} else {
+		assert.Contains(t, volumeMounts, getRootMount())
+	}
 }

--- a/test/features/cloudnative/default/default.go
+++ b/test/features/cloudnative/default/default.go
@@ -47,7 +47,7 @@ import (
 //
 // Sample application Deployment is installed and restarted to check if OneAgent is
 // injected and VERSION environment variable is correct.
-func Feature(t *testing.T, istioEnabled bool) features.Feature {
+func Feature(t *testing.T, istioEnabled bool, withCSI bool) features.Feature {
 	builder := features.New("cloudnative")
 	t.Logf("istio enabled: %v", istioEnabled)
 	secretConfig := tenant.GetSingleTenantSecret(t)
@@ -80,7 +80,9 @@ func Feature(t *testing.T, istioEnabled bool) features.Feature {
 		istio.AssessIstio(builder, testDynakube, *sampleApp)
 	}
 
-	builder.Assess(fmt.Sprintf("check %s has no conn info", codemodules.RuxitAgentProcFile), codemodules.CheckRuxitAgentProcFileHasNoConnInfo(testDynakube))
+	if withCSI {
+		builder.Assess(fmt.Sprintf("check %s has no conn info", codemodules.RuxitAgentProcFile), codemodules.CheckRuxitAgentProcFileHasNoConnInfo(testDynakube))
+	}
 
 	// Register sample, dynakube and operator uninstall
 	builder.Teardown(sampleApp.Uninstall())

--- a/test/features/hostmonitoring/without_csi.go
+++ b/test/features/hostmonitoring/without_csi.go
@@ -1,0 +1,38 @@
+//go:build e2e
+
+package hostmonitoring
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/daemonset"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/tenant"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+// ApplicationMonitoring deployment without CSI driver
+func WithoutCSI(t *testing.T) features.Feature {
+	builder := features.New("host-monitoring-without-csi")
+	secretConfig := tenant.GetSingleTenantSecret(t)
+
+	options := []dynakube.Option{
+		dynakube.WithApiUrl(secretConfig.ApiUrl),
+		dynakube.WithHostMonitoringSpec(&oneagent.HostInjectSpec{}),
+	}
+	testDynakube := *dynakube.New(options...)
+
+	// Register dynakube install
+	dynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+
+	builder.Assess("one agent started", daemonset.WaitForDaemonset(testDynakube.OneAgent().GetDaemonsetName(), testDynakube.Namespace))
+
+	// Register sample, dynakube and operator uninstall
+	dynakube.Delete(builder, helpers.LevelTeardown, testDynakube)
+
+	builder.WithTeardown("deleted tenant secret", tenant.DeleteTenantSecret(testDynakube.Name, testDynakube.Namespace))
+
+	return builder.Feature()
+}

--- a/test/helpers/components/dynakube/options.go
+++ b/test/helpers/components/dynakube/options.go
@@ -152,6 +152,12 @@ func WithCloudNativeSpec(cloudNativeFullStackSpec *oneagent.CloudNativeFullStack
 	}
 }
 
+func WithHostMonitoringSpec(hostInjectSpec *oneagent.HostInjectSpec) Option {
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.OneAgent.HostMonitoring = hostInjectSpec
+	}
+}
+
 func WithApplicationMonitoringSpec(applicationMonitoringSpec *oneagent.ApplicationMonitoringSpec) Option {
 	return func(dk *dynakube.DynaKube) {
 		dk.Spec.OneAgent.ApplicationMonitoring = applicationMonitoringSpec

--- a/test/scenarios/istio/istio_test.go
+++ b/test/scenarios/istio/istio_test.go
@@ -51,7 +51,7 @@ func TestIstio(t *testing.T) {
 	feats := []features.Feature{
 		networkProblems.ResilienceFeature(t), // TODO: Fix so order do not matter, because its the first feature here for a reason => we don’t want to have any downloaded codemodules in the filesystem of the CSI-driver, and we can't clean the filesystem between features as the operator is not reinstalled and therefore the csi-driver is running, and you would have to mess with the database because removing it just bricks things.
 		activegate.Feature(t, proxy.ProxySpec),
-		cloudnativeDefault.Feature(t, true),
+		cloudnativeDefault.Feature(t, true, true),
 		codemodules.WithProxy(t, proxy.ProxySpec),
 		codemodules.WithProxyAndAGCert(t, proxy.ProxySpec),
 		codemodules.WithProxyAndAutomaticAGCert(t, proxy.ProxySpec),

--- a/test/scenarios/no_csi/no_csi_test.go
+++ b/test/scenarios/no_csi/no_csi_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/features/applicationmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/test/features/bootstrapper"
 	"github.com/Dynatrace/dynatrace-operator/test/features/classic"
+	cloudnativeDefault "github.com/Dynatrace/dynatrace-operator/test/features/cloudnative/default"
 	"github.com/Dynatrace/dynatrace-operator/test/features/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/test/features/extensions"
+	"github.com/Dynatrace/dynatrace-operator/test/features/hostmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/test/features/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
@@ -53,6 +55,8 @@ func TestNoCSI(t *testing.T) {
 		classic.Feature(t),
 		bootstrapper.NoCSI(t),
 		logmonitoring.Feature(t),
+		hostmonitoring.WithoutCSI(t),
+		cloudnativeDefault.Feature(t, false, false),
 	}
 
 	testEnv.Test(t, scenarios.FilterFeatures(*cfg, feats)...)

--- a/test/scenarios/standard/standard_test.go
+++ b/test/scenarios/standard/standard_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 
 func TestStandard(t *testing.T) {
 	feats := []features.Feature{
-		cloudnativeDefault.Feature(t, false),
+		cloudnativeDefault.Feature(t, false, true),
 		applicationmonitoring.ReadOnlyCSIVolume(t),
 		codemodules.InstallFromImage(t),
 		publicregistry.Feature(t),


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-5862)

## Description

CloudNativeFullStack and HostMonitoring run without CSI driver.

## How can this be tested?

1) unittests
2) deploy operator with and without CSI driver
```
make deploy
make deploy/no-csi
```
check Volumes / VolumeMounts for HostMonitoring / CloudNativeFullStack
```
spec:
  oneAgent:
    #hostMonitoring:
    #  storageHostPath: /var/opt/dynahm

    cloudNativeFullStack:
      storageHostPath: /var/opt/dynacn
```