### PR TITLE
Make standalone logmon privileged with FF

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/address"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -77,6 +78,11 @@ func getBaseSecurityContext(dk dynakube.DynaKube) corev1.SecurityContext {
 	seccomp := dk.LogMonitoring().Template().SecCompProfile
 	if seccomp != "" {
 		securityContext.SeccompProfile = &corev1.SeccompProfile{LocalhostProfile: &seccomp}
+	}
+
+	if dk.NeedsOneAgentPrivileged() {
+		securityContext.Privileged = ptr.To(true)
+		securityContext.AllowPrivilegeEscalation = ptr.To(true)
 	}
 
 	return securityContext

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container_test.go
@@ -135,4 +135,18 @@ func TestSecurityContext(t *testing.T) {
 		mainContainer.SecurityContext.Capabilities = nil
 		assert.Equal(t, *initContainer.SecurityContext, *mainContainer.SecurityContext)
 	})
+
+	t.Run("ocp scenario, OA needs to be privileged", func(t *testing.T) {
+		dk := dynakube.DynaKube{}
+		dk.Annotations = map[string]string{
+			dynakube.AnnotationFeatureRunOneAgentContainerPrivileged: "true",
+		}
+
+		sc := getBaseSecurityContext(dk)
+
+		require.NotNil(t, sc)
+		require.NotEmpty(t, sc)
+		assert.True(t, *sc.Privileged)
+		assert.True(t, *sc.AllowPrivilegeEscalation)
+	})
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
[DAQ-6362](https://dt-rnd.atlassian.net/browse/DAQ-6362)

On OCP, there strict restriction to touch `hostPath` volumes, so on OCP the standalone-logmon DaemonSet needs to be privileged.

## How can this be tested?

On OCP, (can be `crc`), deploy standalone logmonitoring

[DAQ-6362]: https://dt-rnd.atlassian.net/browse/DAQ-6362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ