### PR TITLE
Add watch permission for provisioner

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/role-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/role-csi.yaml
@@ -52,6 +52,7 @@ rules:
       - list
       - create
       - delete
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/config/helm/chart/default/tests/Common/csi/role-csi_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/role-csi_test.yaml
@@ -67,6 +67,7 @@ tests:
                 - list
                 - create
                 - delete
+                - watch
             - apiGroups:
                 - ""
               resources:


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

The `provisioner` needs the `watch` permission for Job since I added `Owns(&batchv1.Job{})`
- everything is functioning without it, or seems so, but we get random error logs

## How can this be tested?

see no error logs in the `provisioner`