### PR TITLE
Update dynatrace-bootstrapper to v1.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Dynatrace/dynatrace-operator
 go 1.23.4
 
 require (
-	github.com/Dynatrace/dynatrace-bootstrapper v1.0.1
+	github.com/Dynatrace/dynatrace-bootstrapper v1.0.2
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/docker/cli v28.0.2+incompatible
 	github.com/evanphx/json-patch v5.9.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Dynatrace/dynatrace-bootstrapper v1.0.1 h1:AokYM0BuvMdn/UBC66d4Ug2TgGbFuPi1pk6idKbngwo=
-github.com/Dynatrace/dynatrace-bootstrapper v1.0.1/go.mod h1:umzzdF2rIRhUBpYHVHLGVjfvMJVa/SK8RXbLvtyA6Ts=
+github.com/Dynatrace/dynatrace-bootstrapper v1.0.2 h1:IdjAJwJ7sT+q0TTyQxGcJlUif5Y7lVYJWJUQ/u/h0Tw=
+github.com/Dynatrace/dynatrace-bootstrapper v1.0.2/go.mod h1:iNHaw8wmanlJCBkKG7LzAJjWDZCo3xxZmwxM33Zm4GU=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/webhook/mutation/pod/v2/attributes.go
+++ b/pkg/webhook/mutation/pod/v2/attributes.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	containerattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/container"
-	podattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/pod"
+	containerattr "github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure/attributes/container"
+	podattr "github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure/attributes/pod"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/mounts"
@@ -19,16 +19,14 @@ func (wh *Injector) addPodAttributes(request *dtwebhook.MutationRequest) error {
 	attrs := podattr.Attributes{
 		PodInfo: podattr.PodInfo{
 			PodName:       createEnvVarRef(consts.K8sPodNameEnv),
-			PodUid:        createEnvVarRef(consts.K8sPodUIDEnv),
+			PodUID:        createEnvVarRef(consts.K8sPodUIDEnv),
+			NodeName:      createEnvVarRef(consts.K8sNodeNameEnv),
 			NamespaceName: request.Pod.Namespace,
 		},
 		ClusterInfo: podattr.ClusterInfo{
-			ClusterUId:      request.DynaKube.Status.KubeSystemUUID,
+			ClusterUID:      request.DynaKube.Status.KubeSystemUUID,
 			DTClusterEntity: request.DynaKube.Status.KubernetesClusterMEID,
-		},
-		UserDefined: map[string]string{
-			"k8s.cluster.name": request.DynaKube.Status.KubernetesClusterName, // TODO: make it part of podattr.Attributes
-			"k8s.node.name":    createEnvVarRef(consts.K8sNodeNameEnv),        // TODO: make it part of podattr.Attributes
+			ClusterName:     request.DynaKube.Status.KubernetesClusterName,
 		},
 	}
 

--- a/pkg/webhook/mutation/pod/v2/attributes_test.go
+++ b/pkg/webhook/mutation/pod/v2/attributes_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	containerattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/container"
-	podattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/pod"
+	containerattr "github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure/attributes/container"
+	podattr "github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure/attributes/pod"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
@@ -39,9 +39,11 @@ func TestAddPodAttributes(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, request.DynaKube.Status.KubernetesClusterMEID, attr.DTClusterEntity)
-		assert.Equal(t, request.DynaKube.Status.KubeSystemUUID, attr.ClusterUId)
+		assert.Equal(t, request.DynaKube.Status.KubernetesClusterName, attr.ClusterName)
+		assert.Equal(t, request.DynaKube.Status.KubeSystemUUID, attr.ClusterUID)
 		assert.Contains(t, attr.PodName, consts.K8sPodNameEnv)
-		assert.Contains(t, attr.PodUid, consts.K8sPodUIDEnv)
+		assert.Contains(t, attr.PodUID, consts.K8sPodUIDEnv)
+		assert.Contains(t, attr.NodeName, consts.K8sNodeNameEnv)
 		assert.Equal(t, request.Pod.Namespace, attr.NamespaceName)
 
 		require.Len(t, request.InstallContainer.Env, 3)
@@ -69,7 +71,7 @@ func TestAddPodAttributes(t *testing.T) {
 			}
 		}
 
-		assert.Len(t, attr.UserDefined, metaAnnotationCount+2) // TODO: this +2 should be removed once k8s.node.name and k8s.cluster.name are part of the actual Attributes
+		assert.Len(t, attr.UserDefined, metaAnnotationCount)
 		require.Len(t, request.Pod.Annotations, 3+metaAnnotationCount)
 		assert.Equal(t, strings.ToLower(request.Pod.OwnerReferences[0].Kind), request.Pod.Annotations[metacommon.AnnotationWorkloadKind])
 		assert.Equal(t, request.Pod.OwnerReferences[0].Name, request.Pod.Annotations[metacommon.AnnotationWorkloadName])

--- a/pkg/webhook/mutation/pod/v2/init.go
+++ b/pkg/webhook/mutation/pod/v2/init.go
@@ -1,7 +1,8 @@
 package v2
 
 import (
-	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure"
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd"
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
@@ -25,7 +26,7 @@ func createInitContainerBase(pod *corev1.Pod, dk dynakube.DynaKube) *corev1.Cont
 	}
 
 	if areErrorsSuppressed(pod, dk) {
-		args = append(args, arg.Arg{Name: "suppress-error"}) // TODO: import arg from bootstrapper package
+		args = append(args, arg.Arg{Name: cmd.SuppressErrorsFlag})
 	}
 
 	initContainer := &corev1.Container{

--- a/pkg/webhook/mutation/pod/v2/init_test.go
+++ b/pkg/webhook/mutation/pod/v2/init_test.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/mounts"
 	volumeutils "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/volumes"
@@ -124,7 +125,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		initContainer := createInitContainerBase(pod, *dk)
 
-		assert.NotContains(t, initContainer.Args, "--suppress-error")
+		assert.NotContains(t, initContainer.Args, "--"+cmd.SuppressErrorsFlag)
 	})
 
 	t.Run("should not set suppress-error arg - according to pod", func(t *testing.T) {
@@ -135,7 +136,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		initContainer := createInitContainerBase(pod, *dk)
 
-		assert.NotContains(t, initContainer.Args, "--suppress-error")
+		assert.NotContains(t, initContainer.Args, "--"+cmd.SuppressErrorsFlag)
 	})
 
 	t.Run("should set suppress-error arg - default", func(t *testing.T) {
@@ -146,7 +147,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		initContainer := createInitContainerBase(pod, *dk)
 
-		assert.Contains(t, initContainer.Args, "--suppress-error")
+		assert.Contains(t, initContainer.Args, "--"+cmd.SuppressErrorsFlag)
 	})
 
 	t.Run("should set suppress-error arg - unknown value", func(t *testing.T) {
@@ -157,7 +158,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		initContainer := createInitContainerBase(pod, *dk)
 
-		assert.Contains(t, initContainer.Args, "--suppress-error")
+		assert.Contains(t, initContainer.Args, "--"+cmd.SuppressErrorsFlag)
 
 		dk = getTestDynakube()
 		dk.Annotations = map[string]string{}
@@ -166,7 +167,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		initContainer = createInitContainerBase(pod, *dk)
 
-		assert.Contains(t, initContainer.Args, "--suppress-error")
+		assert.Contains(t, initContainer.Args, "--"+cmd.SuppressErrorsFlag)
 	})
 }
 

--- a/pkg/webhook/mutation/pod/v2/metadata/containers.go
+++ b/pkg/webhook/mutation/pod/v2/metadata/containers.go
@@ -4,7 +4,7 @@ import (
 	"maps"
 	"strings"
 
-	podattr "github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/attributes/pod"
+	podattr "github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure/attributes/pod"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	metacommon "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/common/metadata"

--- a/pkg/webhook/mutation/pod/v2/oneagent/containers_test.go
+++ b/pkg/webhook/mutation/pod/v2/oneagent/containers_test.go
@@ -3,7 +3,7 @@ package oneagent
 import (
 	"testing"
 
-	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure"
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"

--- a/pkg/webhook/mutation/pod/v2/oneagent/init.go
+++ b/pkg/webhook/mutation/pod/v2/oneagent/init.go
@@ -1,19 +1,15 @@
 package oneagent
 
 import (
-	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure"
-	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/move"
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd"
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure"
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/move"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
 	oacommon "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/common/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/v2/common/arg"
 	corev1 "k8s.io/api/core/v1"
-)
-
-const (
-	bootstrapperSourceArgument = "source" // TODO import consts from bootstrapper
-	bootstrapperTargetArgument = "target"
 )
 
 func mutateInitContainer(mutationRequest *dtwebhook.MutationRequest, installPath string) {
@@ -23,8 +19,8 @@ func mutateInitContainer(mutationRequest *dtwebhook.MutationRequest, installPath
 
 func addInitArgs(pod corev1.Pod, initContainer *corev1.Container, dk dynakube.DynaKube, installPath string) {
 	args := []arg.Arg{
-		{Name: bootstrapperSourceArgument, Value: consts.AgentCodeModuleSource}, // TODO import consts from bootstrapper
-		{Name: bootstrapperTargetArgument, Value: binInitMountPath},
+		{Name: cmd.SourceFolderFlag, Value: consts.AgentCodeModuleSource},
+		{Name: cmd.TargetFolderFlag, Value: binInitMountPath},
 		{Name: configure.InstallPathFlag, Value: installPath},
 	}
 

--- a/pkg/webhook/mutation/pod/v2/oneagent/volumes.go
+++ b/pkg/webhook/mutation/pod/v2/oneagent/volumes.go
@@ -3,6 +3,7 @@ package oneagent
 import (
 	"path/filepath"
 
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/oneagent/preload"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/v2/common/volumes"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -12,7 +13,7 @@ const (
 	binInitMountPath = "/mnt/bin"
 
 	ldPreloadPath    = "/etc/ld.so.preload"
-	ldPreloadSubPath = "oneagent/ld.so.preload" // TODO: Get from the bootsrapper lib.
+	ldPreloadSubPath = preload.ConfigPath
 )
 
 func addVolumeMounts(container *corev1.Container, installPath string) {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

It is mainly a cosmetic change.
Somethings were fixed in v1.0.2 of the dynatrace-bootstrapper, and I knew that it would break a few imports, so I didn't wait for renovate.

## How can this be tested?

No change in actual behavior, we just use less consts, because we import them