### PR TITLE
Fix Settings API server error handler of EdgeConnect client.

### DIFF
--- a/pkg/clients/edgeconnect/client.go
+++ b/pkg/clients/edgeconnect/client.go
@@ -145,12 +145,12 @@ func (c *client) handleErrorResponseFromAPI(response []byte, statusCode int) err
 }
 
 func (c *client) handleErrorResponseFromSettingsApi(response []byte, statusCode int) error {
-	se := []SettingsApiResponse{}
+	se := SettingsApiResponse{}
 	if err := json.Unmarshal(response, &se); err != nil {
 		return errors.WithStack(errors.WithMessagef(err, "response error, can't unmarshal json response %d", statusCode))
 	}
 
-	return se[0].Error
+	return se.Error
 }
 
 func (c *client) getServerResponseData(response *http.Response) ([]byte, error) {

--- a/pkg/clients/edgeconnect/environment_settings_test.go
+++ b/pkg/clients/edgeconnect/environment_settings_test.go
@@ -164,8 +164,7 @@ func writeEnvironmentSettingsResponse(w http.ResponseWriter, status int) {
 }
 
 func writeSettingsApiResponse(w http.ResponseWriter, status int) {
-	errorResponse := []SettingsApiResponse{}
-	errorResponse = append(errorResponse, SettingsApiResponse{
+	errorResponse := SettingsApiResponse{
 		Error: SettingsApiError{
 			Message: "test-message",
 			ConstraintViolations: []ConstraintViolations{
@@ -178,8 +177,8 @@ func writeSettingsApiResponse(w http.ResponseWriter, status int) {
 			Code: status,
 		},
 		Code: status,
-	},
-	)
+	}
+
 	result, _ := json.Marshal(&errorResponse)
 
 	w.WriteHeader(status)


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-6704)

## Description

EdgeConnect client properly processes Settings API server error. 

## How can this be tested?

1) unittest

2) Break the operator to get 404 response from server
```
func (c *client) GetConnectionSettings() ([]EnvironmentSetting, error) {
        ...
	q.Add("schemaIds", KubernetesConnectionSchemaID+"error") <-- invalid schema or
	q.Add("scopes", KubernetesConnectionScope+"error")       <-- invalid scope
```
3) Deploy EdgeConnect Automation
```
spec:
  apiServer: <api>
  oauth:
    ...
  kubernetesAutomation:
    enabled: true
```
4) Check operator log.
```
error getting server response data: response error, can't unmarshal json response 404: json: cannot unmarshal object into Go value 
```
5) Apply the fix.

6) Check operator log.
```
{"level":"error","ts":"2025-03-26T13:29:36.970Z","logger":"main","msg":"Reconciler error","controller":"edgeconnect-controller","controllerGroup":"dynatrace.com","controllerKind":"EdgeConnect","EdgeConnect":{"name":"ao-ec-provisioner","namespace":"dynatrace"},"namespace":"dynatrace","name":"ao-ec-provisioner","reconcileID":"687489b7-381e-496a-8f99-776d2b01597a",

"error":"error getting server response data: edgeconnect Settings API error: code=404, message=Scope 'environmenterror' not found, ConstraintViolations=[]",

"stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.19.4/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.19.4/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.19.4/pkg/internal/controller/controller.go:224"}
```