### PR TITLE
Uses ConfigMap instead of Secret for DT API endpoint.

### DIFF
--- a/doc/e2e/features.md
+++ b/doc/e2e/features.md
@@ -621,7 +621,7 @@ const (
 
 <a name="OtelCollectorConfigUpdate"></a>
 
-## func [OtelCollectorConfigUpdate](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/telemetryingest/telemetryingest.go#L151>)
+## func [OtelCollectorConfigUpdate](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/telemetryingest/telemetryingest.go#L154>)
 
 ```go
 func OtelCollectorConfigUpdate(t *testing.T) features.Feature
@@ -651,7 +651,7 @@ Rollout of OTel collector when no ActiveGate is configured in the Dynakube
 
 <a name="WithTelemetryIngestEndpointTLS"></a>
 
-## func [WithTelemetryIngestEndpointTLS](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/telemetryingest/telemetryingest.go#L119>)
+## func [WithTelemetryIngestEndpointTLS](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/telemetryingest/telemetryingest.go#L121>)
 
 ```go
 func WithTelemetryIngestEndpointTLS(t *testing.T) features.Feature

--- a/pkg/controllers/dynakube/otelc/consts/consts.go
+++ b/pkg/controllers/dynakube/otelc/consts/consts.go
@@ -1,7 +1,7 @@
 package consts
 
 const (
-	TelemetryApiCredentialsSecretName = "dynatrace-telemetry-api-credentials"
+	TelemetryApiEndpointConfigMapName = "dynatrace-telemetry-api-endpoint"
 
 	ConfigFieldName                   = "telemetry.yaml"
 	TelemetryCollectorConfigmapSuffix = "-telemetry-collector-config"

--- a/pkg/controllers/dynakube/otelc/consts/consts.go
+++ b/pkg/controllers/dynakube/otelc/consts/consts.go
@@ -1,7 +1,7 @@
 package consts
 
 const (
-	TelemetryApiEndpointConfigMapName = "dynatrace-telemetry-api-endpoint"
+	OtlpApiEndpointConfigMapName = "dynatrace-otlp-api-endpoint"
 
 	ConfigFieldName                   = "telemetry.yaml"
 	TelemetryCollectorConfigmapSuffix = "-telemetry-collector-config"

--- a/pkg/controllers/dynakube/otelc/endpoint/conditions.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/conditions.go
@@ -1,4 +1,4 @@
-package secret
+package endpoint
 
 const (
 	configMapConditionType = "TelemetryIngestApiEndpointConfigMap"

--- a/pkg/controllers/dynakube/otelc/endpoint/conditions.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/conditions.go
@@ -1,5 +1,5 @@
 package endpoint
 
 const (
-	configMapConditionType = "TelemetryIngestApiEndpointConfigMap"
+	configMapConditionType = "OtelpApiEndpointConfigMap"
 )

--- a/pkg/controllers/dynakube/otelc/endpoint/config.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/config.go
@@ -1,4 +1,4 @@
-package secret
+package endpoint
 
 import "github.com/Dynatrace/dynatrace-operator/pkg/logd"
 

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
@@ -1,4 +1,4 @@
-package secret
+package endpoint
 
 import (
 	"context"

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
@@ -46,11 +46,11 @@ func TestSecretCreation(t *testing.T) {
 
 		r := NewReconciler(clt, clt, &dk)
 
-		err = r.ensureTelemetryIngestApiEndpointConfigMap(ctx)
+		err = r.ensureOtlpApiEndpointConfigMap(ctx)
 		require.NoError(t, err)
 
 		var apiEndpointConfigMap corev1.ConfigMap
-		err = clt.Get(ctx, types.NamespacedName{Name: consts.TelemetryApiEndpointConfigMapName, Namespace: dk.Namespace}, &apiEndpointConfigMap)
+		err = clt.Get(ctx, types.NamespacedName{Name: consts.OtlpApiEndpointConfigMapName, Namespace: dk.Namespace}, &apiEndpointConfigMap)
 		require.NoError(t, err)
 		assert.NotEmpty(t, apiEndpointConfigMap)
 		require.NotNil(t, meta.FindStatusCondition(*dk.Conditions(), configMapConditionType))
@@ -59,12 +59,12 @@ func TestSecretCreation(t *testing.T) {
 
 	t.Run("removes secret if exists but we don't need it", func(t *testing.T) {
 		dk := createDynaKube(false)
-		conditions.SetConfigMapCreatedOrUpdated(dk.Conditions(), configMapConditionType, consts.TelemetryApiEndpointConfigMapName)
+		conditions.SetConfigMapCreatedOrUpdated(dk.Conditions(), configMapConditionType, consts.OtlpApiEndpointConfigMapName)
 
 		objs := []client.Object{
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      consts.TelemetryApiEndpointConfigMapName,
+					Name:      consts.OtlpApiEndpointConfigMapName,
 					Namespace: dk.Namespace,
 				},
 			},
@@ -77,7 +77,7 @@ func TestSecretCreation(t *testing.T) {
 		require.NoError(t, err)
 
 		var apiEndpointConfigmap corev1.ConfigMap
-		err = clt.Get(ctx, types.NamespacedName{Name: consts.TelemetryApiEndpointConfigMapName, Namespace: dk.Namespace}, &apiEndpointConfigmap)
+		err = clt.Get(ctx, types.NamespacedName{Name: consts.OtlpApiEndpointConfigMapName, Namespace: dk.Namespace}, &apiEndpointConfigmap)
 
 		require.Error(t, err)
 		assert.Empty(t, apiEndpointConfigmap)
@@ -125,7 +125,7 @@ func TestEndpoint(t *testing.T) {
 			objs := []client.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      consts.TelemetryApiEndpointConfigMapName,
+						Name:      consts.OtlpApiEndpointConfigMapName,
 						Namespace: dk.Namespace,
 					},
 				},

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
@@ -1,4 +1,4 @@
-package secret
+package endpoint
 
 import (
 	"context"

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
@@ -31,7 +31,7 @@ const (
 	testKubeSystemUUID = "12345"
 )
 
-func TestSecretCreation(t *testing.T) {
+func TestConfigMapCreation(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates config map if it does not exist", func(t *testing.T) {

--- a/pkg/controllers/dynakube/otelc/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/reconciler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/configuration"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/secret"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/endpoint"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/service"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/statefulset"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,7 +18,7 @@ type Reconciler struct {
 	dk                      *dynakube.DynaKube
 	statefulsetReconciler   controllers.Reconciler
 	serviceReconciler       *service.Reconciler
-	secretReconciler        *secret.Reconciler
+	endpointReconciler      *endpoint.Reconciler
 	configurationReconciler *configuration.Reconciler
 }
 
@@ -31,7 +31,7 @@ func NewReconciler(client client.Client, apiReader client.Reader, dk *dynakube.D
 		dk:                      dk,
 		statefulsetReconciler:   statefulset.NewReconciler(client, apiReader, dk),
 		serviceReconciler:       service.NewReconciler(client, apiReader, dk),
-		secretReconciler:        secret.NewReconciler(client, apiReader, dk),
+		endpointReconciler:      endpoint.NewReconciler(client, apiReader, dk),
 		configurationReconciler: configuration.NewReconciler(client, apiReader, dk),
 	}
 }
@@ -42,7 +42,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		return err
 	}
 
-	err = r.secretReconciler.Reconcile(ctx)
+	err = r.endpointReconciler.Reconcile(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/dynakube/otelc/secret/conditions.go
+++ b/pkg/controllers/dynakube/otelc/secret/conditions.go
@@ -1,5 +1,5 @@
 package secret
 
 const (
-	secretConditionType = "TelemetryIngestApiCredentialsSecret"
+	configMapConditionType = "TelemetryIngestApiEndpointConfigMap"
 )

--- a/pkg/controllers/dynakube/otelc/secret/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/secret/reconciler.go
@@ -8,8 +8,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
+	k8sconfigmap "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/configmap"
 	k8slabels "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
-	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -36,45 +36,45 @@ func NewReconciler(client client.Client, apiReader client.Reader, dk *dynakube.D
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
 	if r.dk.TelemetryIngest().IsEnabled() {
-		return r.ensureTelemetryIngestApiCredentialsSecret(ctx)
+		return r.ensureTelemetryIngestApiEndpointConfigMap(ctx)
 	}
 
-	return r.removeTelemetryIngestApiCredentialsSecret(ctx)
+	return r.removeTelemetryIngestApiEndpointConfigMap(ctx)
 }
 
-func (r *Reconciler) ensureTelemetryIngestApiCredentialsSecret(ctx context.Context) error {
-	query := k8ssecret.Query(r.client, r.apiReader, log)
-	_, err := query.Get(ctx, types.NamespacedName{Name: consts.TelemetryApiCredentialsSecretName, Namespace: r.dk.Namespace})
+func (r *Reconciler) ensureTelemetryIngestApiEndpointConfigMap(ctx context.Context) error {
+	query := k8sconfigmap.Query(r.client, r.apiReader, log)
+	_, err := query.Get(ctx, types.NamespacedName{Name: consts.TelemetryApiEndpointConfigMapName, Namespace: r.dk.Namespace})
 
 	if err != nil && k8serrors.IsNotFound(err) {
-		log.Info("creating new secret for telemetry api credentials")
+		log.Info("creating new config map for telemetry api endpoint")
 
-		secretConfig, err := r.generateTelemetryIngestApiCredentialsSecret(consts.TelemetryApiCredentialsSecretName)
+		configMap, err := r.generateTelemetryIngestApiEndpointConfigMap(consts.TelemetryApiEndpointConfigMapName)
 
 		if err != nil {
-			conditions.SetSecretGenFailed(r.dk.Conditions(), secretConditionType, err)
+			conditions.SetConfigMapGenFailed(r.dk.Conditions(), configMapConditionType, err)
 
 			return err
 		}
 
-		_, err = hasher.GenerateHash(secretConfig.Data)
+		_, err = hasher.GenerateHash(configMap.Data)
 		if err != nil {
-			conditions.SetSecretGenFailed(r.dk.Conditions(), secretConditionType, err)
+			conditions.SetConfigMapGenFailed(r.dk.Conditions(), configMapConditionType, err)
 
 			return err
 		}
 
-		err = query.Create(ctx, secretConfig)
+		err = query.Create(ctx, configMap)
 		if err != nil {
-			log.Info("could not create secret for telemetry api credentials", "name", secretConfig.Name)
-			conditions.SetKubeApiError(r.dk.Conditions(), secretConditionType, err)
+			log.Info("could not create secret for telemetry api credentials", "name", configMap.Name)
+			conditions.SetKubeApiError(r.dk.Conditions(), configMapConditionType, err)
 
 			return err
 		}
 
-		conditions.SetSecretCreated(r.dk.Conditions(), secretConditionType, consts.TelemetryApiCredentialsSecretName)
+		conditions.SetConfigMapCreatedOrUpdated(r.dk.Conditions(), configMapConditionType, consts.TelemetryApiEndpointConfigMapName)
 	} else if err != nil {
-		conditions.SetKubeApiError(r.dk.Conditions(), secretConditionType, err)
+		conditions.SetKubeApiError(r.dk.Conditions(), configMapConditionType, err)
 
 		return err
 	}
@@ -82,55 +82,55 @@ func (r *Reconciler) ensureTelemetryIngestApiCredentialsSecret(ctx context.Conte
 	return nil
 }
 
-func (r *Reconciler) getDtEndpoint() ([]byte, error) {
+func (r *Reconciler) getDtEndpoint() (string, error) {
 	if r.dk.ActiveGate().IsEnabled() {
 		tenantUUID, err := r.dk.TenantUUID()
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 
-		return []byte(fmt.Sprintf("https://%s-activegate.dynatrace.svc/e/%s/api/v2/otlp", r.dk.Name, tenantUUID)), nil
+		return fmt.Sprintf("https://%s-activegate.dynatrace.svc/e/%s/api/v2/otlp", r.dk.Name, tenantUUID), nil
 	}
 
-	return []byte(r.dk.ApiUrl() + "/v2/otlp"), nil
+	return r.dk.ApiUrl() + "/v2/otlp", nil
 }
 
-func (r *Reconciler) generateTelemetryIngestApiCredentialsSecret(name string) (secret *corev1.Secret, err error) {
-	secretData := make(map[string][]byte)
+func (r *Reconciler) generateTelemetryIngestApiEndpointConfigMap(name string) (secret *corev1.ConfigMap, err error) {
+	data := make(map[string]string)
 
 	dtEndpoint, err := r.getDtEndpoint()
 	if err != nil {
 		return nil, err
 	}
 
-	secretData["DT_ENDPOINT"] = dtEndpoint
+	data["DT_ENDPOINT"] = dtEndpoint
 
-	secretConfig, err := k8ssecret.Build(r.dk,
+	configMap, err := k8sconfigmap.Build(r.dk,
 		name,
-		secretData,
-		k8ssecret.SetLabels(k8slabels.NewCoreLabels(r.dk.Name, k8slabels.OtelCComponentLabel).BuildLabels()),
+		data,
+		k8sconfigmap.SetLabels(k8slabels.NewCoreLabels(r.dk.Name, k8slabels.OtelCComponentLabel).BuildLabels()),
 	)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return secretConfig, nil
+	return configMap, nil
 }
 
-func (r *Reconciler) removeTelemetryIngestApiCredentialsSecret(ctx context.Context) error {
-	if meta.FindStatusCondition(*r.dk.Conditions(), secretConditionType) == nil {
+func (r *Reconciler) removeTelemetryIngestApiEndpointConfigMap(ctx context.Context) error {
+	if meta.FindStatusCondition(*r.dk.Conditions(), configMapConditionType) == nil {
 		return nil // no condition == nothing is there to clean up
 	}
 
-	query := k8ssecret.Query(r.client, r.apiReader, log)
-	err := query.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: consts.TelemetryApiCredentialsSecretName, Namespace: r.dk.Namespace}})
+	query := k8sconfigmap.Query(r.client, r.apiReader, log)
+	err := query.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: consts.TelemetryApiEndpointConfigMapName, Namespace: r.dk.Namespace}})
 
 	if err != nil {
-		log.Error(err, "could not delete apiCredential secret", "name", consts.TelemetryApiCredentialsSecretName)
+		log.Error(err, "could not delete apiEndpoint config map", "name", consts.TelemetryApiEndpointConfigMapName)
 	}
 
-	meta.RemoveStatusCondition(r.dk.Conditions(), secretConditionType)
+	meta.RemoveStatusCondition(r.dk.Conditions(), configMapConditionType)
 
 	return nil
 }

--- a/pkg/controllers/dynakube/otelc/statefulset/env.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env.go
@@ -95,8 +95,8 @@ func getEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 	if dk.TelemetryIngest().IsEnabled() {
 		envs = append(envs,
 			corev1.EnvVar{Name: envDTendpoint, ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: otelcConsts.TelemetryApiCredentialsSecretName},
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: otelcConsts.TelemetryApiEndpointConfigMapName},
 					Key:                  envDTendpoint,
 				},
 			}},

--- a/pkg/controllers/dynakube/otelc/statefulset/env.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env.go
@@ -96,7 +96,7 @@ func getEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 		envs = append(envs,
 			corev1.EnvVar{Name: envDTendpoint, ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: otelcConsts.TelemetryApiEndpointConfigMapName},
+					LocalObjectReference: corev1.LocalObjectReference{Name: otelcConsts.OtlpApiEndpointConfigMapName},
 					Key:                  envDTendpoint,
 				},
 			}},

--- a/pkg/controllers/dynakube/otelc/statefulset/env_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env_test.go
@@ -90,8 +90,8 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Equal(t, corev1.EnvVar{Name: envDTentityK8sCluster, Value: dk.Status.KubernetesClusterMEID}, statefulSet.Spec.Template.Spec.Containers[0].Env[8])
 
 		assert.Equal(t, corev1.EnvVar{Name: envDTendpoint, ValueFrom: &corev1.EnvVarSource{
-			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: otelcConsts.TelemetryApiCredentialsSecretName},
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: otelcConsts.TelemetryApiEndpointConfigMapName},
 				Key:                  envDTendpoint,
 			},
 		}}, statefulSet.Spec.Template.Spec.Containers[0].Env[9])

--- a/pkg/controllers/dynakube/otelc/statefulset/env_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env_test.go
@@ -91,7 +91,7 @@ func TestEnvironmentVariables(t *testing.T) {
 
 		assert.Equal(t, corev1.EnvVar{Name: envDTendpoint, ValueFrom: &corev1.EnvVarSource{
 			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: otelcConsts.TelemetryApiEndpointConfigMapName},
+				LocalObjectReference: corev1.LocalObjectReference{Name: otelcConsts.OtlpApiEndpointConfigMapName},
 				Key:                  envDTendpoint,
 			},
 		}}, statefulSet.Spec.Template.Spec.Containers[0].Env[9])

--- a/test/features/telemetryingest/telemetryingest.go
+++ b/test/features/telemetryingest/telemetryingest.go
@@ -304,8 +304,9 @@ func checkOtelCollectorService(dk *dynakube.DynaKube) features.Func {
 
 func checkOtelCollectorEndpointConfigMap(dk *dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		_, err := getOtelCollectorEndpointConfigMap(dk, ctx, envConfig)
+		cm, err := getOtelCollectorEndpointConfigMap(dk, ctx, envConfig)
 		require.NoError(t, err)
+		assert.NotNil(t, cm)
 
 		return ctx
 	}

--- a/test/features/telemetryingest/telemetryingest.go
+++ b/test/features/telemetryingest/telemetryingest.go
@@ -381,7 +381,7 @@ func getOtelCollectorEndpointConfigMap(dk *dynakube.DynaKube, ctx context.Contex
 	resources := envConfig.Client().Resources()
 
 	var otelCollectorEndpointConfigMap corev1.ConfigMap
-	err := resources.WithNamespace(dk.Namespace).Get(ctx, otelcconsts.TelemetryApiEndpointConfigMapName, dk.Namespace, &otelCollectorEndpointConfigMap)
+	err := resources.WithNamespace(dk.Namespace).Get(ctx, otelcconsts.OtlpApiEndpointConfigMapName, dk.Namespace, &otelCollectorEndpointConfigMap)
 
 	if err != nil {
 		return nil, err

--- a/test/scenarios/no_csi/no_csi_test.go
+++ b/test/scenarios/no_csi/no_csi_test.go
@@ -3,6 +3,7 @@
 package no_csi
 
 import (
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/test/features/activegate"
@@ -16,7 +17,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/features/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/test/features/telemetryingest"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios"
 	"sigs.k8s.io/e2e-framework/pkg/env"

--- a/test/scenarios/no_csi/no_csi_test.go
+++ b/test/scenarios/no_csi/no_csi_test.go
@@ -3,7 +3,6 @@
 package no_csi
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/test/features/activegate"
@@ -17,6 +16,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/features/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/test/features/telemetryingest"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/scenarios"
 	"sigs.k8s.io/e2e-framework/pkg/env"


### PR DESCRIPTION
## Description

The value for `DT_ENDPOINT` doesn't need to be stored in a secret as it's public anyway. With storing it in a ConfigMap we get the benefit, that it's picked up by the support archive automatically.

Also E2E tests are updated to check that the ConfigMap is created.

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-6815)

## How can this be tested?

* deploy a DK with telemetryIngest:
```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace

spec:
  apiUrl: https://..../api

  telemetryIngest:
    protocols:
    - zipkin
```

* check OTel collector pod, value for env var `DT_ENDPOINT` shall be taken from ConfigMap `dynatrace-telemetry-api-endpoint`
```
    - name: DT_ENDPOINT
      valueFrom:
        configMapKeyRef:
          key: DT_ENDPOINT
          name: dynatrace-telemetry-api-endpoint
```
* pull support archive, make sure the ConfigMap `dynatrace-telemetry-api-endpoint` is contained
* `make test/e2e/telemetryingest`