### PR TITLE
Fix kspm cert volume related to AG TLS secret

### DIFF
--- a/pkg/controllers/dynakube/kspm/daemonset/certs.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/certs.go
@@ -16,7 +16,7 @@ func getCertVolume(dk dynakube.DynaKube) corev1.Volume {
 		Name: certVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: dk.ActiveGate().TlsSecretName,
+				SecretName: dk.ActiveGate().GetTLSSecretName(),
 			},
 		},
 	}

--- a/pkg/controllers/dynakube/kspm/daemonset/certs_test.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/certs_test.go
@@ -16,3 +16,12 @@ func getDynaKubeWithCerts(t *testing.T) dynakube.DynaKube {
 
 	return dk
 }
+
+func getDynaKubeWithAutomaticCerts(t *testing.T) dynakube.DynaKube {
+	t.Helper()
+
+	dk := dynakube.DynaKube{}
+	dk.ActiveGate().Capabilities = []activegate.CapabilityDisplayName{activegate.KubeMonCapability.DisplayName}
+
+	return dk
+}

--- a/pkg/controllers/dynakube/kspm/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/volumes_test.go
@@ -39,6 +39,19 @@ func TestGetMounts(t *testing.T) {
 			assert.NotEmpty(t, mount.MountPath)
 		}
 	})
+
+	t.Run("get cert mount with automatic AG cert", func(t *testing.T) {
+		dk := getDynaKubeWithAutomaticCerts(t)
+		mounts := getMounts(dk)
+
+		require.NotEmpty(t, mounts)
+		assert.Len(t, mounts, expectedMountLen+1)
+
+		for _, mount := range mounts {
+			assert.NotEmpty(t, mount.Name)
+			assert.NotEmpty(t, mount.MountPath)
+		}
+	})
 }
 
 func TestGetVolumes(t *testing.T) {
@@ -64,7 +77,28 @@ func TestGetVolumes(t *testing.T) {
 
 		for _, volume := range volumes {
 			assert.NotEmpty(t, volume.Name)
-			assert.NotEmpty(t, volume.VolumeSource)
+			require.NotEmpty(t, volume.VolumeSource)
+
+			if volume.Name == certVolumeName {
+				assert.NotEmpty(t, volume.VolumeSource.Secret.SecretName)
+			}
+		}
+	})
+
+	t.Run("add cert volume with automatic AG cert", func(t *testing.T) {
+		dk := getDynaKubeWithAutomaticCerts(t)
+		volumes := getVolumes(dk)
+
+		require.NotEmpty(t, volumes)
+		assert.Len(t, volumes, expectedMountLen+1)
+
+		for _, volume := range volumes {
+			assert.NotEmpty(t, volume.Name)
+			require.NotEmpty(t, volume.VolumeSource)
+
+			if volume.Name == certVolumeName {
+				assert.NotEmpty(t, volume.VolumeSource.Secret.SecretName)
+			}
 		}
 	})
 }


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-6918)

## Description

The secret name fixed. 

## How can this be tested?

unittests

deploy kspm
```
spec:                                                                                                                                                                                                                                                                                                                                                                                         
  apiUrl: ...
  activeGate:
    capabilities:
    - routing
    - kubernetes-monitoring
  kspm: {}
  templates:                                                                                                                                                                                                                                                                                                                                                                                  
    kspmNodeConfigurationCollector:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-k8s-node-config-collector
        tag: 1.0.0
```