### PR TITLE
Expose the output of the docker build

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -12,6 +12,10 @@ inputs:
     required: true
   annotation:
     description: The annotation added to the built image
+outputs:
+  digest:
+    description: "The digest of the built image"
+    value: ${{ steps.build-target.outputs.digest }}
 runs:
   using: "composite"
   steps:
@@ -37,6 +41,7 @@ runs:
       run: |
         touch dynatrace-operator-bin-sbom.cdx.json
     - name: Build target
+      id: build-target
       uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
       with:
         builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

The docker-build has an output of `digest`, but because we have the docker-build in a composite action, we have to expose it ourself aswell.

([see example](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action#creating-an-action-metadata-file))

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->