### PR TITLE
Store manifest digests separately per platform in GitHub actions 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,7 +120,10 @@ jobs:
     permissions:
       id-token: write
     outputs:
-      digest: ${{ steps.create-manifests.outputs.digest }}
+      digest-rhcc: ${{ steps.store-digest.outputs.digest-rhcc }}
+      digest-gcr: ${{ steps.store-digest.outputs.digest-gcr }}
+      digest-dockerhub: ${{ steps.store-digest.outputs.digest-dockerhub }}
+      digest-amazon-ecr: ${{ steps.store-digest.outputs.digest-amazon-ecr }}
     strategy:
       matrix:
         registry: [gcr, dockerhub, rhcc, amazon-ecr]
@@ -172,6 +175,13 @@ jobs:
           registry: ${{ matrix.url }}
           repository: ${{ secrets[matrix.repository] }}
           platforms: "amd64, arm64, ppc64le, s390x"
+      - name: Store digest
+        id: store-digest
+        shell: bash
+        run: |
+          registry="${{ matrix.registry }}"
+          digest="${{ steps.create-manifests.outputs.digest }}"
+          echo "digest-${registry}=${digest}" >> "$GITHUB_OUTPUT"
       - name: Sign images for ${{matrix.registry}}
         uses: ./.github/actions/sign-image
         with:
@@ -282,10 +292,10 @@ jobs:
         run: |
           make manifests/crd/release CHART_VERSION="${VERSION_WITHOUT_PREFIX}"
 
-          make manifests/kubernetes/olm IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
-          make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
-          make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
-          make manifests/openshift IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest}}"
+          make manifests/kubernetes/olm IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest-ecr}}"
+          make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest-ecr}}"
+          make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest-rhcc}}"
+          make manifests/openshift IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${{needs.manifest.outputs.digest-rhcc}}"
           cp config/deploy/kubernetes/kubernetes.yaml config/deploy/kubernetes/gke-autopilot.yaml
       - name: Build helm packages
         uses: ./.github/actions/build-helm

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -32,165 +32,92 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: DynaKube is the Schema for the DynaKube API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DynaKubeSpec defines the desired state of DynaKube
             properties:
               activeGate:
-                description: General configuration about ActiveGate instances.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Adds additional annotations to the ActiveGate pods
                     type: object
                   capabilities:
-                    description: Activegate capabilities enabled (routing, kubernetes-monitoring,
-                      metrics-ingest, dynatrace-api)
                     items:
                       type: string
                     type: array
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called 'customProperties'
                     properties:
                       value:
-                        description: Custom properties value.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Custom properties secret.
                         nullable: true
                         type: string
                     type: object
                   dnsPolicy:
-                    description: Sets DNS Policy for the ActiveGate pods
                     type: string
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -202,58 +129,30 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: The ActiveGate container image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Node selector to control the selection of nodes
                     type: object
                   priorityClassName:
-                    description: |-
-                      If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-                      name. If not specified the setting will be removed from the StatefulSet.
                     type: string
                   replicas:
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: Define resources requests and limits for single ActiveGate
-                      pods
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -269,9 +168,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -280,94 +176,39 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tlsSecretName:
-                    description: |-
-                      The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
-                      server.p12: certificate+key pair in pkcs12 format
-                      password: passphrase to read server.p12
                     type: string
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints for the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -381,69 +222,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -453,148 +252,80 @@ spec:
                     type: array
                 type: object
               apiUrl:
-                description: |-
-                  Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
-                  For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.
                 type: string
               customPullSecret:
-                description: |-
-                  Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.
-                  To define a custom pull secret and learn about the expected behavior, see Configure customPullSecret
-                  (https://www.dynatrace.
                 type: string
               enableIstio:
-                description: |-
-                  When enabled, and if Istio is installed on the Kubernetes environment, Dynatrace Operator will create the corresponding
-                  VirtualService and ServiceEntry objects to allow access to the Dynatrace Cluster from the OneAgent or ActiveGate.
-                  Disabled by default.
                 type: boolean
               kubernetesMonitoring:
-                description: Configuration for Kubernetes Monitoring
                 properties:
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called 'customProperties'
                     properties:
                       value:
-                        description: Custom properties value.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Custom properties secret.
                         nullable: true
                         type: string
                     type: object
                   enabled:
-                    description: Enables Capability
                     type: boolean
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -606,53 +337,28 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: The ActiveGate container image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Node selector to control the selection of nodes
                     type: object
                   replicas:
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: Define resources requests and limits for single ActiveGate
-                      pods
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -668,9 +374,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -679,88 +382,37 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints for the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -774,69 +426,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -846,33 +456,15 @@ spec:
                     type: array
                 type: object
               namespaceSelector:
-                description: |-
-                  Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                  For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: |-
-                        A label selector requirement is a selector that contains values, a key, and an operator that
-                        relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: |-
-                            operator represents a key's relationship to a set of values.
-                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: |-
-                            values is an array of string values. If the operator is In or NotIn,
-                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                            the values array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -886,59 +478,26 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               networkZone:
-                description: Sets a network zone for the OneAgent and ActiveGate pods.
                 type: string
               oneAgent:
-                description: |-
-                  General configuration about OneAgent instances.
-                  You can't enable more than one module (classicFullStack, cloudNativeFullStack, hostMonitoring, or applicationMonitoring).
                 properties:
                   applicationMonitoring:
-                    description: |-
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has an optional CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       codeModulesImage:
-                        description: The OneAgent image that is used to inject into
-                          Pods.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -954,9 +513,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -965,158 +521,85 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       useCSIDriver:
-                        description: Set if you want to use the CSIDriver. Don't enable
-                          it if you do not have access to Kubernetes nodes or if you
-                          lack privileges.
                         type: boolean
                       version:
-                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   classicFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Injection is performed via the same OneAgent DaemonSet.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -1128,49 +611,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -1186,9 +643,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1197,203 +651,103 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   cloudNativeFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has a CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       codeModulesImage:
-                        description: The OneAgent image that is used to inject into
-                          Pods.
                         type: string
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -1405,37 +759,15 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -1451,9 +783,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1462,53 +791,24 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -1524,9 +824,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1535,201 +832,103 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   hostGroup:
-                    description: Sets a host group for OneAgent.
                     type: string
                   hostMonitoring:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Doesn't inject into application pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -1741,49 +940,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -1799,9 +972,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1810,203 +980,108 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used.
                         type: string
                     type: object
                 type: object
               proxy:
-                description: |-
-                  Set custom proxy settings either directly or from a secret with the field proxy.
-                  Note: Applies to Dynatrace Operator, ActiveGate, and OneAgents.
                 properties:
                   value:
-                    description: Proxy URL. It has preference over ValueFrom.
                     nullable: true
                     type: string
                   valueFrom:
-                    description: Secret containing proxy URL.
                     nullable: true
                     type: string
                 type: object
               routing:
-                description: Configuration for Routing
                 properties:
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called 'customProperties'
                     properties:
                       value:
-                        description: Custom properties value.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Custom properties secret.
                         nullable: true
                         type: string
                     type: object
                   enabled:
-                    description: Enables Capability
                     type: boolean
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -2018,53 +1093,28 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: The ActiveGate container image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Node selector to control the selection of nodes
                     type: object
                   replicas:
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: Define resources requests and limits for single ActiveGate
-                      pods
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -2080,9 +1130,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -2091,88 +1138,37 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints for the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2186,69 +1182,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -2258,139 +1212,85 @@ spec:
                     type: array
                 type: object
               skipCertCheck:
-                description: |-
-                  Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.
-                  Set to true if you want to skip certification validation checks.
                 type: boolean
               tokens:
-                description: Name of the secret holding the tokens used for connecting
-                  to Dynatrace.
                 type: string
               trustedCAs:
-                description: |-
-                  Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
-                  Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.
                 type: string
             required:
             - apiUrl
             type: object
           status:
-            description: DynaKubeStatus defines the observed state of DynaKube
             properties:
               activeGate:
-                description: Observed state of ActiveGate
                 properties:
                   connectionInfoStatus:
-                    description: Information about Active Gate's connections
                     properties:
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   serviceIPs:
-                    description: The ClusterIPs set by Kubernetes on the ActiveGate
-                      Service created by the Operator
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               codeModules:
-                description: Observed state of Code Modules
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -2403,104 +1303,72 @@ spec:
                   type: object
                 type: array
               dynatraceApi:
-                description: Observed state of Dynatrace API
                 properties:
                   lastTokenScopeRequest:
-                    description: Time of the last token request
                     format: date-time
                     type: string
                 type: object
               kubeSystemUUID:
-                description: KubeSystemUUID contains the UUID of the current Kubernetes
-                  cluster
                 type: string
               lastTokenProbeTimestamp:
-                description: LastTokenProbeTimestamp tracks when the last request
-                  for the API token validity was sent
                 format: date-time
                 type: string
               oneAgent:
-                description: Observed state of OneAgent
                 properties:
                   connectionInfoStatus:
-                    description: Information about OneAgent's connections
                     properties:
                       communicationHosts:
-                        description: List of communication hosts
                         items:
                           properties:
                             host:
-                              description: Host domain
                               type: string
                             port:
-                              description: Connection port
                               format: int32
                               type: integer
                             protocol:
-                              description: Connection protocol
                               type: string
                           type: object
                         type: array
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   healthcheck:
-                    description: Commands used for OneAgent's readiness probe
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   imageID:
-                    description: Image ID
                     type: string
                   instances:
                     additionalProperties:
                       properties:
                         ipAddress:
-                          description: IP address of the pod
                           type: string
                         podName:
-                          description: Name of the OneAgent pod
                           type: string
                       type: object
-                    description: List of deployed OneAgent instances
                     type: object
                   lastInstanceStatusUpdate:
-                    description: Time of the last instance status update
                     format: date-time
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: UpdatedTimestamp indicates when the instance was last
-                  updated
                 format: date-time
                 type: string
             type: object
@@ -2522,169 +1390,92 @@ spec:
     name: v1beta2
     schema:
       openAPIV3Schema:
-        description: DynaKube is the Schema for the DynaKube API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DynaKubeSpec defines the desired state of DynaKube
             properties:
               activeGate:
-                description: General configuration about ActiveGate instances.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Adds additional annotations to the ActiveGate pods
                     type: object
                   capabilities:
-                    description: "Defines the ActiveGate pod capabilities\nPossible
-                      values:\n\t- `routing` enables OneAgent routing.\n\t- `kubernetes-monitoring`
-                      enables Kubernetes API monitoring.\n\t- `metrics-ingest` opens
-                      the metrics ingest endpoint on the DynaKube ActiveGate and redirects
-                      all pods to it.\n\t- `dynatrace-api` enables calling the Dynatrace
-                      API via ActiveGate."
                     items:
                       type: string
                     type: array
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called `customProperties`
                     properties:
                       value:
-                        description: Custom properties value.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Custom properties secret.
                         nullable: true
                         type: string
                     type: object
                   dnsPolicy:
-                    description: Sets DNS Policy for the ActiveGate pods
                     type: string
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -2696,62 +1487,31 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: Use a custom ActiveGate image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Your defined labels for ActiveGate pods in order
-                      to structure workloads as desired.
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Specify the node selector that controls on which
-                      nodes ActiveGate will be deployed.
                     type: object
                   priorityClassName:
-                    description: |-
-                      Assign a priority class to the ActiveGate pods. By default, no class is set.
-                      For details, see Pod Priority and Preemption. (https://dt-url.net/n8437bl)
                     type: string
                   replicas:
                     default: 1
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: |-
-                      Resource settings for ActiveGate container.
-                      Consumption of the ActiveGate heavily depends on the workload to monitor. Adjust values accordingly.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -2767,9 +1527,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -2778,94 +1535,39 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tlsSecretName:
-                    description: |-
-                      The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
-                      `server.p12`: certificate+key pair in pkcs12 format
-                      `password`: passphrase to read server.p12
                     type: string
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints to the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2879,69 +1581,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -2951,61 +1611,29 @@ spec:
                     type: array
                 type: object
               apiUrl:
-                description: |-
-                  Dynatrace `apiUrl`, including the `/api` path at the end.
-                  - For SaaS, set `YOUR_ENVIRONMENT_ID` to your environment ID.
-                  - For Managed, change the `apiUrl` address.
-                  For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.
                 type: string
               customPullSecret:
-                description: |-
-                  Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.
-                  To define a custom pull secret and learn about the expected behavior, see Configure customPullSecret
-                  (https://www.dynatrace.
                 type: string
               dynatraceApiRequestThreshold:
                 default: 15
-                description: Minimum minutes between Dynatrace API requests.
                 type: integer
               enableIstio:
-                description: |-
-                  When enabled, and if Istio is installed in the Kubernetes environment, Dynatrace Operator will create the corresponding VirtualService and ServiceEntry objects to allow access to the Dynatrace Cluster from the OneAgent or ActiveGate.
-                  Disabled by default.
                 type: boolean
               metadataEnrichment:
-                description: Configuration for Metadata Enrichment.
                 properties:
                   enabled:
                     default: false
-                    description: Enables MetadataEnrichment, `false` by default.
                     type: boolean
                   namespaceSelector:
-                    description: The namespaces where you want Dynatrace Operator
-                      to inject enrichment.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -3019,10 +1647,6 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
@@ -3030,51 +1654,22 @@ spec:
                 - enabled
                 type: object
               networkZone:
-                description: Sets a network zone for the OneAgent and ActiveGate pods.
                 type: string
               oneAgent:
-                description: |-
-                  General configuration about OneAgent instances.
-                  You can't enable more than one module (classicFullStack, cloudNativeFullStack, hostMonitoring, or applicationMonitoring).
                 properties:
                   applicationMonitoring:
-                    description: |-
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has an optional CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       codeModulesImage:
-                        description: The OneAgent image that is used to inject into
-                          Pods.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3090,9 +1685,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -3101,41 +1693,18 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -3149,160 +1718,88 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       useCSIDriver:
                         default: false
-                        description: Set if you want to use the CSIDriver. Don't enable
-                          it if you do not have access to Kubernetes nodes or if you
-                          lack privileges.
                         type: boolean
                       version:
-                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   classicFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Injection is performed via the same OneAgent DaemonSet.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
                         default: true
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -3314,50 +1811,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          - `resource.requests` shows the values needed to run
-                          - `resource.limits` shows the maximum limits for the pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3373,9 +1843,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -3384,210 +1851,106 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used for OneAgents
-                          running in the dedicated pod. This setting doesn't affect
-                          the OneAgent version used for application monitoring.
                         type: string
                     type: object
                   cloudNativeFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has a CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
                         default: true
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       codeModulesImage:
-                        description: The OneAgent image that is used to inject into
-                          Pods.
                         type: string
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -3599,37 +1962,15 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3645,9 +1986,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -3656,47 +1994,22 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -3710,48 +2023,21 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          - `resource.requests` shows the values needed to run
-                          - `resource.limits` shows the maximum limits for the pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3767,9 +2053,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -3778,211 +2061,106 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used for OneAgents
-                          running in the dedicated pod. This setting doesn't affect
-                          the OneAgent version used for application monitoring.
                         type: string
                     type: object
                   hostGroup:
-                    description: |-
-                      Specify the name of the group to which you want to assign the host.
-                      This method is preferred over the now obsolete `--set-host-group` argument.
-                      If both settings are used, this field takes precedence over the `--set-host-group` argument.
                     type: string
                   hostMonitoring:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Doesn't inject into application pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
                         default: true
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -3994,50 +2172,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          - `resource.requests` shows the values needed to run
-                          - `resource.limits` shows the maximum limits for the pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -4053,9 +2204,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -4064,218 +2212,121 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used for OneAgents
-                          running in the dedicated pod. This setting doesn't affect
-                          the OneAgent version used for application monitoring.
                         type: string
                     type: object
                 type: object
               proxy:
-                description: |-
-                  Set custom proxy settings either directly or from a secret with the field `proxy`.
-                  Applies to Dynatrace Operator, ActiveGate, and OneAgents.
                 properties:
                   value:
-                    description: Proxy URL. It has preference over ValueFrom.
                     nullable: true
                     type: string
                   valueFrom:
-                    description: Secret containing proxy URL.
                     nullable: true
                     type: string
                 type: object
               skipCertCheck:
-                description: |-
-                  Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.
-                  Set to `true` if you want to skip certification validation checks.
                 type: boolean
               tokens:
-                description: Name of the secret holding the tokens used for connecting
-                  to Dynatrace.
                 type: string
               trustedCAs:
-                description: |-
-                  Adds custom RootCAs from a configmap.
-                  The key to the data must be `certs`.
-                  This applies to both the Dynatrace Operator and the OneAgent. Doesn't apply to ActiveGate.
                 type: string
             required:
             - apiUrl
             type: object
           status:
-            description: DynaKubeStatus defines the observed state of DynaKube
             properties:
               activeGate:
-                description: Observed state of ActiveGate
                 properties:
                   connectionInfoStatus:
-                    description: Information about Active Gate's connections
                     properties:
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   serviceIPs:
-                    description: The ClusterIPs set by Kubernetes on the ActiveGate
-                      Service created by the Operator
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               codeModules:
-                description: Observed state of Code Modules
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -4288,28 +2339,18 @@ spec:
                   type: object
                 type: array
               dynatraceApi:
-                description: Observed state of Dynatrace API
                 properties:
                   lastTokenScopeRequest:
-                    description: Time of the last token request
                     format: date-time
                     type: string
                 type: object
               kubeSystemUUID:
-                description: KubeSystemUUID contains the UUID of the current Kubernetes
-                  cluster
                 type: string
               kubernetesClusterMEID:
-                description: KubernetesClusterMEID contains the ID of the monitored
-                  entity that points to the Kubernetes cluster
                 type: string
               kubernetesClusterName:
-                description: KubernetesClusterName contains the display name (also
-                  know as label) of the monitored entity that points to the Kubernetes
-                  cluster
                 type: string
               metadataEnrichment:
-                description: Observed state of Metadata-Enrichment
                 properties:
                   rules:
                     items:
@@ -4326,87 +2367,61 @@ spec:
                     type: array
                 type: object
               oneAgent:
-                description: Observed state of OneAgent
                 properties:
                   connectionInfoStatus:
-                    description: Information about OneAgent's connections
                     properties:
                       communicationHosts:
-                        description: List of communication hosts
                         items:
                           properties:
                             host:
-                              description: Host domain
                               type: string
                             port:
-                              description: Connection port
                               format: int32
                               type: integer
                             protocol:
-                              description: Connection protocol
                               type: string
                           type: object
                         type: array
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   healthcheck:
-                    description: Commands used for OneAgent's readiness probe
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   imageID:
-                    description: Image ID
                     type: string
                   instances:
                     additionalProperties:
                       properties:
                         ipAddress:
-                          description: IP address of the pod
                           type: string
                         podName:
-                          description: Name of the OneAgent pod
                           type: string
                       type: object
-                    description: List of deployed OneAgent instances
                     type: object
                   lastInstanceStatusUpdate:
-                    description: Time of the last instance status update
                     format: date-time
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: UpdatedTimestamp indicates when the instance was last
-                  updated
                 format: date-time
                 type: string
             type: object
@@ -4428,165 +2443,92 @@ spec:
     name: v1beta3
     schema:
       openAPIV3Schema:
-        description: DynaKube is the Schema for the DynaKube API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DynaKubeSpec defines the desired state of DynaKube
             properties:
               activeGate:
-                description: General configuration about ActiveGate instances.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Adds additional annotations to the ActiveGate pods
                     type: object
                   capabilities:
-                    description: Activegate capabilities enabled (routing, kubernetes-monitoring,
-                      metrics-ingest, dynatrace-api)
                     items:
                       type: string
                     type: array
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called 'customProperties'
                     properties:
                       value:
-                        description: Raw value for given property.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Name of the secret to get the property from.
                         nullable: true
                         type: string
                     type: object
                   dnsPolicy:
-                    description: Sets DNS Policy for the ActiveGate pods
                     type: string
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -4598,58 +2540,30 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: The ActiveGate container image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Node selector to control the selection of nodes
                     type: object
                   priorityClassName:
-                    description: |-
-                      If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-                      name. If not specified the setting will be removed from the StatefulSet.
                     type: string
                   replicas:
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: Define resources requests and limits for single ActiveGate
-                      pods
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -4665,9 +2579,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4676,94 +2587,39 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tlsSecretName:
-                    description: |-
-                      The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
-                      server.p12: certificate+key pair in pkcs12 format
-                      password: passphrase to read server.p12
                     type: string
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints for the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4777,69 +2633,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -4849,36 +2663,19 @@ spec:
                     type: array
                 type: object
               apiUrl:
-                description: |-
-                  Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
-                  For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.
                 maxLength: 128
                 type: string
               customPullSecret:
-                description: |-
-                  Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.
-                  To define a custom pull secret and learn about the expected behavior, see Configure customPullSecret
-                  (https://www.dynatrace.
                 type: string
               dynatraceApiRequestThreshold:
-                description: Configuration for thresholding Dynatrace API requests.
                 type: integer
               enableIstio:
-                description: |-
-                  When enabled, and if Istio is installed on the Kubernetes environment, Dynatrace Operator will create the corresponding
-                  VirtualService and ServiceEntry objects to allow access to the Dynatrace Cluster from the OneAgent or ActiveGate.
-                  Disabled by default.
                 type: boolean
               extensions:
-                description: |-
-                  When an (empty) ExtensionsSpec is provided, the extensions related components (extensions controller and extensions collector)
-                  are deployed by the operator.
                 type: object
               kspm:
-                description: General configuration about the KSPM feature.
                 type: object
               logMonitoring:
-                description: General configuration about the LogMonitoring feature.
                 properties:
                   ingestRuleMatchers:
                     items:
@@ -4893,38 +2690,19 @@ spec:
                     type: array
                 type: object
               metadataEnrichment:
-                description: Configuration for Metadata Enrichment.
                 properties:
                   enabled:
-                    description: Enables MetadataEnrichment, `false` by default.
                     type: boolean
                   namespaceSelector:
-                    description: The namespaces where you want Dynatrace Operator
-                      to inject enrichment.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -4938,60 +2716,27 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
               networkZone:
-                description: Sets a network zone for the OneAgent and ActiveGate pods.
                 type: string
               oneAgent:
-                description: |-
-                  General configuration about OneAgent instances.
-                  You can't enable more than one module (classicFullStack, cloudNativeFullStack, hostMonitoring, or applicationMonitoring).
                 properties:
                   applicationMonitoring:
-                    description: |-
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has an optional CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       codeModulesImage:
-                        description: Use a custom OneAgent CodeModule image to download
-                          binaries.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -5007,9 +2752,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -5018,41 +2760,18 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -5066,154 +2785,84 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       version:
-                        description: Use a specific OneAgent CodeModule version. Defaults
-                          to the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   classicFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Injection is performed via the same OneAgent DaemonSet.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -5225,49 +2874,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -5283,9 +2906,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -5294,208 +2914,105 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   cloudNativeFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has a CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       codeModulesImage:
-                        description: Use a custom OneAgent CodeModule image to download
-                          binaries.
                         type: string
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -5507,37 +3024,15 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -5553,9 +3048,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -5564,47 +3056,22 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -5618,47 +3085,21 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -5674,9 +3115,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -5685,206 +3123,105 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   hostGroup:
-                    description: Sets a host group for OneAgent.
                     type: string
                   hostMonitoring:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Doesn't inject into application pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -5896,49 +3233,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -5954,9 +3265,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -5965,86 +3273,42 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                 type: object
               proxy:
-                description: |-
-                  Set custom proxy settings either directly or from a secret with the field proxy.
-                  Note: Applies to Dynatrace Operator, ActiveGate, and OneAgents.
                 properties:
                   value:
-                    description: Raw value for given property.
                     nullable: true
                     type: string
                   valueFrom:
-                    description: Name of the secret to get the property from.
                     nullable: true
                     type: string
                 type: object
               skipCertCheck:
-                description: |-
-                  Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.
-                  Set to true if you want to skip certification validation checks.
                 type: boolean
               templates:
                 properties:
@@ -6053,64 +3317,37 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations to the ExtensionExecutionController
-                          pods
                         type: object
                       customConfig:
-                        description: Defines name of ConfigMap containing custom configuration
-                          file
                         type: string
                       customExtensionCertificates:
-                        description: Defines name of Secret containing certificates
-                          for custom extensions signature validation
                         type: string
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the ExtensionExecutionController
-                          pods
                         type: object
                       persistentVolumeClaim:
-                        description: Defines storage device
                         properties:
                           accessModes:
-                            description: |-
-                              accessModes contains the desired access modes the volume should have.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
-                            description: |-
-                              dataSource field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                              * An existing PVC (PersistentVolumeClaim)
-                              If the provisioner or an external controller can support the specified data source,
-                              it will create a new volume based on the contents of the specified data source.
                             properties:
                               apiGroup:
-                                description: |-
-                                  APIGroup is the group for the resource being referenced.
-                                  If APIGroup is not specified, the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
-                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
-                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -6118,39 +3355,20 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
-                            description: |-
-                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                              volume is desired. This may be any object from a non-empty API group (non
-                              core object) or a PersistentVolumeClaim object.
                             properties:
                               apiGroup:
-                                description: |-
-                                  APIGroup is the group for the resource being referenced.
-                                  If APIGroup is not specified, the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
-                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
-                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace is the namespace of resource being referenced
-                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
-                            description: |-
-                              resources represents the minimum resources the volume should have.
-                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                              that are lower than previous value but must still be higher than capacity recorded in the
-                              status field of the claim.
-                              More info: https://kubernetes.
                             properties:
                               limits:
                                 additionalProperties:
@@ -6159,9 +3377,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -6170,40 +3385,18 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           selector:
-                            description: selector is a label query over volumes to
-                              consider for binding.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
                                 items:
-                                  description: |-
-                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                    relates the key and values.
                                   properties:
                                     key:
-                                      description: key is the label key that the selector
-                                        applies to.
                                       type: string
                                     operator:
-                                      description: |-
-                                        operator represents a key's relationship to a set of values.
-                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: |-
-                                        values is an array of string values. If the operator is In or NotIn,
-                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                        the values array must be empty. This array is replaced during a strategic
-                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -6217,62 +3410,26 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: |-
-                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
-                            description: |-
-                              storageClassName is the name of the StorageClass required by the claim.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                             type: string
                           volumeAttributesClassName:
-                            description: |-
-                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                              If specified, the CSI driver will create or update the volume with the attributes defined
-                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created.
                             type: string
                           volumeMode:
-                            description: |-
-                              volumeMode defines what type of volume is required by the claim.
-                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
-                            description: volumeName is the binding reference to the
-                              PersistentVolume backing this claim.
                             type: string
                         type: object
                       resources:
-                        description: Define resources' requests and limits for single
-                          ExtensionExecutionController pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -6288,9 +3445,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -6299,91 +3453,39 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tlsRefName:
                         type: string
                       tolerations:
-                        description: Set tolerations for the ExtensionExecutionController
-                          pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: Adds TopologySpreadConstraints for the ExtensionExecutionController
-                          pods
                         items:
-                          description: TopologySpreadConstraint specifies how to spread
-                            matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: |-
-                                LabelSelector is used to find matching pods.
-                                Pods that match this label selector are counted to determine the number of pods
-                                in their corresponding topology domain.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -6397,69 +3499,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select the pods over which
-                                spreading will be calculated. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are ANDed with labelSelector
-                                to select the group of existing pods over which spreading will be calculated
-                                for the incoming pod.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: |-
-                                MaxSkew describes the degree to which pods may be unevenly distributed.
-                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                between the number of matching pods in the target topology and the global minimum.
                               format: int32
                               type: integer
                             minDomains:
-                              description: |-
-                                MinDomains indicates a minimum number of eligible domains.
-                                When the number of eligible domains with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: |-
-                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                when calculating pod topology spread skew. Options are:
-                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                               type: string
                             nodeTaintsPolicy:
-                              description: |-
-                                NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                pod topology spread skew. Options are:
-                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                has a toleration, are included.
-                                - Ignore: node taints are ignored. All nodes are included.
                               type: string
                             topologyKey:
-                              description: |-
-                                TopologyKey is the key of node labels. Nodes that have a label with this key
-                                and identical values are considered to be in the same topology.
-                                We consider each <key, value> as a "bucket", and try to put balanced number
-                                of pods into each bucket.
-                                We define a domain as a particular instance of a topology.
                               type: string
                             whenUnsatisfiable:
-                              description: |-
-                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                  but giving higher precedence to topologies that would help reduce the
-                                  skew.
                               type: string
                           required:
                           - maxSkew
@@ -6468,7 +3528,6 @@ spec:
                           type: object
                         type: array
                       useEphemeralVolume:
-                        description: Selects EmptyDir volume to be storage device
                         type: boolean
                     type: object
                   kspmNodeConfigurationCollector:
@@ -6476,122 +3535,67 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations for the NodeConfigurationCollector
-                          pods
                         type: object
                       args:
-                        description: Set additional arguments to the NodeConfigurationCollector
-                          pods
                         items:
                           type: string
                         type: array
                       env:
-                        description: Set additional environment variables for the
-                          NodeConfigurationCollector pods
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -6603,65 +3607,32 @@ spec:
                           type: object
                         type: array
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the NodeConfigurationCollector
-                          pods
                         type: object
                       nodeAffinity:
-                        description: Define the nodeAffinity for the DaemonSet of
-                          the NodeConfigurationCollector
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
                             items:
-                              description: |-
-                                An empty preferred scheduling term matches all objects with implicit weight 0
-                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6673,29 +3644,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6709,8 +3664,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -6720,46 +3673,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
                                 items:
-                                  description: |-
-                                    A null or empty node selector term matches no objects. The requirements of
-                                    them are ANDed.
-                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6771,29 +3696,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6816,41 +3725,17 @@ spec:
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes NodeConfigurationCollector pods will be deployed.
                         type: object
                       priorityClassName:
-                        description: |-
-                          If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-                          name. If not specified the setting will be removed from the DaemonSet.
                         type: string
                       resources:
-                        description: Define resources' requests and limits for single
-                          NodeConfigurationCollector pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -6866,9 +3751,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -6877,163 +3759,81 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tolerations:
-                        description: Set tolerations for the NodeConfigurationCollector
-                          pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       updateStrategy:
-                        description: Define the NodeConfigurationCollector daemonSet
-                          updateStrategy
                         properties:
                           rollingUpdate:
-                            description: Rolling update config params. Present only
-                              if type = "RollingUpdate".
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of nodes with an existing available DaemonSet pod that
-                                  can have an updated DaemonSet pod during during an update.
-                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                                  This can not be 0 if MaxUnavailable is 0.
-                                  Absolute number is calculated from percentage by rounding up to a minimum of 1.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of DaemonSet pods that can be unavailable during the
-                                  update. Value can be an absolute number (ex: 5) or a percentage of total
-                                  number of DaemonSet pods at the start of the update (ex: 10%). Absolute
-                                  number is calculated from percentage by rounding up.
-                                  This cannot be 0 if MaxSurge is 0
-                                  Default value is 1.
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
-                            description: Type of daemon set update. Can be "RollingUpdate"
-                              or "OnDelete". Default is RollingUpdate.
                             type: string
                         type: object
                     type: object
                   logMonitoring:
-                    description: Low-level configuration options for the LogMonitoring
-                      feature.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom annotations to the LogMonitoring pods
                         type: object
                       args:
-                        description: Set additional arguments to the LogMonitoring
-                          main container
                         items:
                           type: string
                         type: array
                       dnsPolicy:
-                        description: Sets DNS Policy for the LogMonitoring pods
                         type: string
                       imageRef:
-                        description: Overrides the default image for the LogMonitoring
-                          pods
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Add custom labels to the LogMonitoring pods
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Node selector to control the selection of nodes
-                          for the LogMonitoring pods
                         type: object
                       priorityClassName:
-                        description: Assign a priority class to the LogMonitoring
-                          pods. By default, no class is set
                         type: string
                       resources:
-                        description: Define resources' requests and limits for all
-                          the LogMonitoring pods
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -7049,9 +3849,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -7060,54 +3857,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode for the LogMonitoring
-                          pods
                         type: string
                       tolerations:
-                        description: Set tolerations for the LogMonitoring pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -7117,57 +3883,30 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations to the OtelCollector
-                          pods
                         type: object
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the OtelCollector
-                          pods
                         type: object
                       replicas:
-                        description: Number of replicas for your OtelCollector
                         format: int32
                         type: integer
                       resources:
-                        description: Define resources' requests and limits for single
-                          OtelCollector pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -7183,9 +3922,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -7194,90 +3930,39 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tlsRefName:
                         type: string
                       tolerations:
-                        description: Set tolerations for the OtelCollector pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: Adds TopologySpreadConstraints for the OtelCollector
-                          pods
                         items:
-                          description: TopologySpreadConstraint specifies how to spread
-                            matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: |-
-                                LabelSelector is used to find matching pods.
-                                Pods that match this label selector are counted to determine the number of pods
-                                in their corresponding topology domain.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -7291,69 +3976,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select the pods over which
-                                spreading will be calculated. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are ANDed with labelSelector
-                                to select the group of existing pods over which spreading will be calculated
-                                for the incoming pod.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: |-
-                                MaxSkew describes the degree to which pods may be unevenly distributed.
-                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                between the number of matching pods in the target topology and the global minimum.
                               format: int32
                               type: integer
                             minDomains:
-                              description: |-
-                                MinDomains indicates a minimum number of eligible domains.
-                                When the number of eligible domains with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: |-
-                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                when calculating pod topology spread skew. Options are:
-                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                               type: string
                             nodeTaintsPolicy:
-                              description: |-
-                                NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                pod topology spread skew. Options are:
-                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                has a toleration, are included.
-                                - Ignore: node taints are ignored. All nodes are included.
                               type: string
                             topologyKey:
-                              description: |-
-                                TopologyKey is the key of node labels. Nodes that have a label with this key
-                                and identical values are considered to be in the same topology.
-                                We consider each <key, value> as a "bucket", and try to put balanced number
-                                of pods into each bucket.
-                                We define a domain as a particular instance of a topology.
                               type: string
                             whenUnsatisfiable:
-                              description: |-
-                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                  but giving higher precedence to topologies that would help reduce the
-                                  skew.
                               type: string
                           required:
                           - maxSkew
@@ -7364,134 +4007,83 @@ spec:
                     type: object
                 type: object
               tokens:
-                description: Name of the secret holding the tokens used for connecting
-                  to Dynatrace.
                 type: string
               trustedCAs:
-                description: |-
-                  Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
-                  Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.
                 type: string
             required:
             - apiUrl
             type: object
           status:
-            description: DynaKubeStatus defines the observed state of DynaKube
             properties:
               activeGate:
-                description: Observed state of ActiveGate
                 properties:
                   connectionInfoStatus:
-                    description: Information about Active Gate's connections
                     properties:
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   serviceIPs:
-                    description: The ClusterIPs set by Kubernetes on the ActiveGate
-                      Service created by the Operator
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               codeModules:
-                description: Observed state of Code Modules
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -7504,37 +4096,23 @@ spec:
                   type: object
                 type: array
               dynatraceApi:
-                description: Observed state of Dynatrace API
                 properties:
                   lastTokenScopeRequest:
-                    description: Time of the last token request
                     format: date-time
                     type: string
                 type: object
               kspm:
-                description: Observed state of Kspm
                 properties:
                   tokenSecretHash:
-                    description: |-
-                      TokenSecretHash contains the hash of the token that is passed to both the ActiveGate and Node-Configuration-Collector.
-                      Meant to keep the two in sync.
                     type: string
                 type: object
               kubeSystemUUID:
-                description: KubeSystemUUID contains the UUID of the current Kubernetes
-                  cluster
                 type: string
               kubernetesClusterMEID:
-                description: KubernetesClusterMEID contains the ID of the monitored
-                  entity that points to the Kubernetes cluster
                 type: string
               kubernetesClusterName:
-                description: KubernetesClusterName contains the display name (also
-                  know as label) of the monitored entity that points to the Kubernetes
-                  cluster
                 type: string
               metadataEnrichment:
-                description: Observed state of Metadata-Enrichment
                 properties:
                   rules:
                     items:
@@ -7551,87 +4129,61 @@ spec:
                     type: array
                 type: object
               oneAgent:
-                description: Observed state of OneAgent
                 properties:
                   connectionInfoStatus:
-                    description: Information about OneAgent's connections
                     properties:
                       communicationHosts:
-                        description: List of communication hosts
                         items:
                           properties:
                             host:
-                              description: Host domain
                               type: string
                             port:
-                              description: Connection port
                               format: int32
                               type: integer
                             protocol:
-                              description: Connection protocol
                               type: string
                           type: object
                         type: array
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   healthcheck:
-                    description: Commands used for OneAgent's readiness probe
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   imageID:
-                    description: Image ID
                     type: string
                   instances:
                     additionalProperties:
                       properties:
                         ipAddress:
-                          description: IP address of the pod
                           type: string
                         podName:
-                          description: Name of the OneAgent pod
                           type: string
                       type: object
-                    description: List of deployed OneAgent instances
                     type: object
                   lastInstanceStatusUpdate:
-                    description: Time of the last instance status update
                     format: date-time
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: UpdatedTimestamp indicates when the instance was last
-                  updated
                 format: date-time
                 type: string
             type: object
@@ -7653,165 +4205,92 @@ spec:
     name: v1beta4
     schema:
       openAPIV3Schema:
-        description: DynaKube is the Schema for the DynaKube API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DynaKubeSpec defines the desired state of DynaKube
             properties:
               activeGate:
-                description: General configuration about ActiveGate instances.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Adds additional annotations to the ActiveGate pods
                     type: object
                   capabilities:
-                    description: Activegate capabilities enabled (routing, kubernetes-monitoring,
-                      metrics-ingest, dynatrace-api)
                     items:
                       type: string
                     type: array
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called 'customProperties'
                     properties:
                       value:
-                        description: Raw value for given property.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Name of the secret to get the property from.
                         nullable: true
                         type: string
                     type: object
                   dnsPolicy:
-                    description: Sets DNS Policy for the ActiveGate pods
                     type: string
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -7823,52 +4302,31 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: The ActiveGate container image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Node selector to control the selection of nodes
                     type: object
                   persistentVolumeClaim:
-                    description: Defines storage device
                     properties:
                       accessModes:
-                        description: |-
-                          accessModes contains the desired access modes the volume should have.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       dataSource:
-                        description: |-
-                          dataSource field can be used to specify either:
-                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                          * An existing PVC (PersistentVolumeClaim)
-                          If the provisioner or an external controller can support the specified data source,
-                          it will create a new volume based on the contents of the specified data source.
                         properties:
                           apiGroup:
-                            description: |-
-                              APIGroup is the group for the resource being referenced.
-                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                              For any other third-party types, APIGroup is required.
                             type: string
                           kind:
-                            description: Kind is the type of resource being referenced
                             type: string
                           name:
-                            description: Name is the name of resource being referenced
                             type: string
                         required:
                         - kind
@@ -7876,39 +4334,20 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       dataSourceRef:
-                        description: |-
-                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                          volume is desired. This may be any object from a non-empty API group (non
-                          core object) or a PersistentVolumeClaim object.
                         properties:
                           apiGroup:
-                            description: |-
-                              APIGroup is the group for the resource being referenced.
-                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                              For any other third-party types, APIGroup is required.
                             type: string
                           kind:
-                            description: Kind is the type of resource being referenced
                             type: string
                           name:
-                            description: Name is the name of resource being referenced
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of resource being referenced
-                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
                             type: string
                         required:
                         - kind
                         - name
                         type: object
                       resources:
-                        description: |-
-                          resources represents the minimum resources the volume should have.
-                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                          that are lower than previous value but must still be higher than capacity recorded in the
-                          status field of the claim.
-                          More info: https://kubernetes.
                         properties:
                           limits:
                             additionalProperties:
@@ -7917,9 +4356,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -7928,40 +4364,18 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       selector:
-                        description: selector is a label query over volumes to consider
-                          for binding.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -7975,71 +4389,31 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       storageClassName:
-                        description: |-
-                          storageClassName is the name of the StorageClass required by the claim.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                         type: string
                       volumeAttributesClassName:
-                        description: |-
-                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                          If specified, the CSI driver will create or update the volume with the attributes defined
-                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created.
                         type: string
                       volumeMode:
-                        description: |-
-                          volumeMode defines what type of volume is required by the claim.
-                          Value of Filesystem is implied when not included in claim spec.
                         type: string
                       volumeName:
-                        description: volumeName is the binding reference to the PersistentVolume
-                          backing this claim.
                         type: string
                     type: object
                   priorityClassName:
-                    description: |-
-                      If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-                      name. If not specified the setting will be removed from the StatefulSet.
                     type: string
                   replicas:
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: Define resources requests and limits for single ActiveGate
-                      pods
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -8055,9 +4429,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -8066,99 +4437,42 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   terminationGracePeriodSeconds:
-                    description: Configures the terminationGracePeriodSeconds parameter
-                      of the ActiveGate pod. Kubernetes defaults and rules apply.
                     format: int64
                     type: integer
                   tlsSecretName:
-                    description: |-
-                      The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
-                      server.p12: certificate+key pair in pkcs12 format
-                      password: passphrase to read server.p12
                     type: string
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints for the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -8172,69 +4486,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -8243,40 +4515,22 @@ spec:
                       type: object
                     type: array
                   useEphemeralVolume:
-                    description: UseEphemeralVolume
                     type: boolean
                 type: object
               apiUrl:
-                description: |-
-                  Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
-                  For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.
                 maxLength: 128
                 type: string
               customPullSecret:
-                description: |-
-                  Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.
-                  To define a custom pull secret and learn about the expected behavior, see Configure customPullSecret
-                  (https://www.dynatrace.
                 type: string
               dynatraceApiRequestThreshold:
-                description: Configuration for thresholding Dynatrace API requests.
                 type: integer
               enableIstio:
-                description: |-
-                  When enabled, and if Istio is installed on the Kubernetes environment, Dynatrace Operator will create the corresponding
-                  VirtualService and ServiceEntry objects to allow access to the Dynatrace Cluster from the OneAgent or ActiveGate.
-                  Disabled by default.
                 type: boolean
               extensions:
-                description: |-
-                  When an (empty) ExtensionsSpec is provided, the extensions related components (extensions controller and extensions collector)
-                  are deployed by the operator.
                 type: object
               kspm:
-                description: General configuration about the KSPM feature.
                 type: object
               logMonitoring:
-                description: General configuration about the LogMonitoring feature.
                 properties:
                   ingestRuleMatchers:
                     items:
@@ -8291,38 +4545,19 @@ spec:
                     type: array
                 type: object
               metadataEnrichment:
-                description: Configuration for Metadata Enrichment.
                 properties:
                   enabled:
-                    description: Enables MetadataEnrichment, `false` by default.
                     type: boolean
                   namespaceSelector:
-                    description: The namespaces where you want Dynatrace Operator
-                      to inject enrichment.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -8336,60 +4571,27 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
               networkZone:
-                description: Sets a network zone for the OneAgent and ActiveGate pods.
                 type: string
               oneAgent:
-                description: |-
-                  General configuration about OneAgent instances.
-                  You can't enable more than one module (classicFullStack, cloudNativeFullStack, hostMonitoring, or applicationMonitoring).
                 properties:
                   applicationMonitoring:
-                    description: |-
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has an optional CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       codeModulesImage:
-                        description: Use a custom OneAgent CodeModule image to download
-                          binaries.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -8405,9 +4607,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -8416,41 +4615,18 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -8464,154 +4640,84 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       version:
-                        description: Use a specific OneAgent CodeModule version. Defaults
-                          to the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   classicFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Injection is performed via the same OneAgent DaemonSet.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -8623,49 +4729,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -8681,9 +4761,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -8692,213 +4769,107 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       storageHostPath:
-                        description: StorageHostPath is the writable directory on
-                          the host filesystem where OneAgent configurations will be
-                          stored.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   cloudNativeFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has a CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       codeModulesImage:
-                        description: Use a custom OneAgent CodeModule image to download
-                          binaries.
                         type: string
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -8910,37 +4881,15 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -8956,9 +4905,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -8967,47 +4913,22 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -9021,47 +4942,21 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -9077,9 +4972,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -9088,211 +4980,107 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       storageHostPath:
-                        description: StorageHostPath is the writable directory on
-                          the host filesystem where OneAgent configurations will be
-                          stored.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   hostGroup:
-                    description: Sets a host group for OneAgent.
                     type: string
                   hostMonitoring:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Doesn't inject into application pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -9304,49 +5092,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -9362,9 +5124,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -9373,95 +5132,46 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       storageHostPath:
-                        description: StorageHostPath is the writable directory on
-                          the host filesystem where OneAgent configurations will be
-                          stored.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                 type: object
               proxy:
-                description: |-
-                  Set custom proxy settings either directly or from a secret with the field proxy.
-                  Note: Applies to Dynatrace Operator, ActiveGate, and OneAgents.
                 properties:
                   value:
-                    description: Raw value for given property.
                     nullable: true
                     type: string
                   valueFrom:
-                    description: Name of the secret to get the property from.
                     nullable: true
                     type: string
                 type: object
               skipCertCheck:
-                description: |-
-                  Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.
-                  Set to true if you want to skip certification validation checks.
                 type: boolean
               telemetryIngest:
-                description: When a TelemetryIngestSpec is provided, the OTEL collector
-                  is deployed by the operator.
                 properties:
                   protocols:
                     items:
@@ -9479,64 +5189,37 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations to the ExtensionExecutionController
-                          pods
                         type: object
                       customConfig:
-                        description: Defines name of ConfigMap containing custom configuration
-                          file
                         type: string
                       customExtensionCertificates:
-                        description: Defines name of Secret containing certificates
-                          for custom extensions signature validation
                         type: string
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the ExtensionExecutionController
-                          pods
                         type: object
                       persistentVolumeClaim:
-                        description: Defines storage device
                         properties:
                           accessModes:
-                            description: |-
-                              accessModes contains the desired access modes the volume should have.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
-                            description: |-
-                              dataSource field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                              * An existing PVC (PersistentVolumeClaim)
-                              If the provisioner or an external controller can support the specified data source,
-                              it will create a new volume based on the contents of the specified data source.
                             properties:
                               apiGroup:
-                                description: |-
-                                  APIGroup is the group for the resource being referenced.
-                                  If APIGroup is not specified, the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
-                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
-                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -9544,39 +5227,20 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
-                            description: |-
-                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                              volume is desired. This may be any object from a non-empty API group (non
-                              core object) or a PersistentVolumeClaim object.
                             properties:
                               apiGroup:
-                                description: |-
-                                  APIGroup is the group for the resource being referenced.
-                                  If APIGroup is not specified, the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
-                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
-                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace is the namespace of resource being referenced
-                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
-                            description: |-
-                              resources represents the minimum resources the volume should have.
-                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                              that are lower than previous value but must still be higher than capacity recorded in the
-                              status field of the claim.
-                              More info: https://kubernetes.
                             properties:
                               limits:
                                 additionalProperties:
@@ -9585,9 +5249,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -9596,40 +5257,18 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           selector:
-                            description: selector is a label query over volumes to
-                              consider for binding.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
                                 items:
-                                  description: |-
-                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                    relates the key and values.
                                   properties:
                                     key:
-                                      description: key is the label key that the selector
-                                        applies to.
                                       type: string
                                     operator:
-                                      description: |-
-                                        operator represents a key's relationship to a set of values.
-                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: |-
-                                        values is an array of string values. If the operator is In or NotIn,
-                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                        the values array must be empty. This array is replaced during a strategic
-                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -9643,62 +5282,26 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: |-
-                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
-                            description: |-
-                              storageClassName is the name of the StorageClass required by the claim.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                             type: string
                           volumeAttributesClassName:
-                            description: |-
-                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                              If specified, the CSI driver will create or update the volume with the attributes defined
-                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created.
                             type: string
                           volumeMode:
-                            description: |-
-                              volumeMode defines what type of volume is required by the claim.
-                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
-                            description: volumeName is the binding reference to the
-                              PersistentVolume backing this claim.
                             type: string
                         type: object
                       resources:
-                        description: Define resources' requests and limits for single
-                          ExtensionExecutionController pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -9714,9 +5317,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -9725,91 +5325,39 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tlsRefName:
                         type: string
                       tolerations:
-                        description: Set tolerations for the ExtensionExecutionController
-                          pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: Adds TopologySpreadConstraints for the ExtensionExecutionController
-                          pods
                         items:
-                          description: TopologySpreadConstraint specifies how to spread
-                            matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: |-
-                                LabelSelector is used to find matching pods.
-                                Pods that match this label selector are counted to determine the number of pods
-                                in their corresponding topology domain.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -9823,69 +5371,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select the pods over which
-                                spreading will be calculated. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are ANDed with labelSelector
-                                to select the group of existing pods over which spreading will be calculated
-                                for the incoming pod.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: |-
-                                MaxSkew describes the degree to which pods may be unevenly distributed.
-                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                between the number of matching pods in the target topology and the global minimum.
                               format: int32
                               type: integer
                             minDomains:
-                              description: |-
-                                MinDomains indicates a minimum number of eligible domains.
-                                When the number of eligible domains with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: |-
-                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                when calculating pod topology spread skew. Options are:
-                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                               type: string
                             nodeTaintsPolicy:
-                              description: |-
-                                NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                pod topology spread skew. Options are:
-                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                has a toleration, are included.
-                                - Ignore: node taints are ignored. All nodes are included.
                               type: string
                             topologyKey:
-                              description: |-
-                                TopologyKey is the key of node labels. Nodes that have a label with this key
-                                and identical values are considered to be in the same topology.
-                                We consider each <key, value> as a "bucket", and try to put balanced number
-                                of pods into each bucket.
-                                We define a domain as a particular instance of a topology.
                               type: string
                             whenUnsatisfiable:
-                              description: |-
-                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                  but giving higher precedence to topologies that would help reduce the
-                                  skew.
                               type: string
                           required:
                           - maxSkew
@@ -9894,7 +5400,6 @@ spec:
                           type: object
                         type: array
                       useEphemeralVolume:
-                        description: Selects EmptyDir volume to be storage device
                         type: boolean
                     type: object
                   kspmNodeConfigurationCollector:
@@ -9902,122 +5407,67 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations for the NodeConfigurationCollector
-                          pods
                         type: object
                       args:
-                        description: Set additional arguments to the NodeConfigurationCollector
-                          pods
                         items:
                           type: string
                         type: array
                       env:
-                        description: Set additional environment variables for the
-                          NodeConfigurationCollector pods
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -10029,65 +5479,32 @@ spec:
                           type: object
                         type: array
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the NodeConfigurationCollector
-                          pods
                         type: object
                       nodeAffinity:
-                        description: Define the nodeAffinity for the DaemonSet of
-                          the NodeConfigurationCollector
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
                             items:
-                              description: |-
-                                An empty preferred scheduling term matches all objects with implicit weight 0
-                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -10099,29 +5516,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -10135,8 +5536,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -10146,46 +5545,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
                                 items:
-                                  description: |-
-                                    A null or empty node selector term matches no objects. The requirements of
-                                    them are ANDed.
-                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -10197,29 +5568,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -10242,41 +5597,17 @@ spec:
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes NodeConfigurationCollector pods will be deployed.
                         type: object
                       priorityClassName:
-                        description: |-
-                          If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-                          name. If not specified the setting will be removed from the DaemonSet.
                         type: string
                       resources:
-                        description: Define resources' requests and limits for single
-                          NodeConfigurationCollector pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -10292,9 +5623,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -10303,163 +5631,81 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tolerations:
-                        description: Set tolerations for the NodeConfigurationCollector
-                          pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       updateStrategy:
-                        description: Define the NodeConfigurationCollector daemonSet
-                          updateStrategy
                         properties:
                           rollingUpdate:
-                            description: Rolling update config params. Present only
-                              if type = "RollingUpdate".
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of nodes with an existing available DaemonSet pod that
-                                  can have an updated DaemonSet pod during during an update.
-                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                                  This can not be 0 if MaxUnavailable is 0.
-                                  Absolute number is calculated from percentage by rounding up to a minimum of 1.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of DaemonSet pods that can be unavailable during the
-                                  update. Value can be an absolute number (ex: 5) or a percentage of total
-                                  number of DaemonSet pods at the start of the update (ex: 10%). Absolute
-                                  number is calculated from percentage by rounding up.
-                                  This cannot be 0 if MaxSurge is 0
-                                  Default value is 1.
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
-                            description: Type of daemon set update. Can be "RollingUpdate"
-                              or "OnDelete". Default is RollingUpdate.
                             type: string
                         type: object
                     type: object
                   logMonitoring:
-                    description: Low-level configuration options for the LogMonitoring
-                      feature.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom annotations to the LogMonitoring pods
                         type: object
                       args:
-                        description: Set additional arguments to the LogMonitoring
-                          main container
                         items:
                           type: string
                         type: array
                       dnsPolicy:
-                        description: Sets DNS Policy for the LogMonitoring pods
                         type: string
                       imageRef:
-                        description: Overrides the default image for the LogMonitoring
-                          pods
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Add custom labels to the LogMonitoring pods
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Node selector to control the selection of nodes
-                          for the LogMonitoring pods
                         type: object
                       priorityClassName:
-                        description: Assign a priority class to the LogMonitoring
-                          pods. By default, no class is set
                         type: string
                       resources:
-                        description: Define resources' requests and limits for all
-                          the LogMonitoring pods
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -10475,9 +5721,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -10486,54 +5729,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode for the LogMonitoring
-                          pods
                         type: string
                       tolerations:
-                        description: Set tolerations for the LogMonitoring pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -10543,57 +5755,30 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations to the OtelCollector
-                          pods
                         type: object
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the OtelCollector
-                          pods
                         type: object
                       replicas:
-                        description: Number of replicas for your OtelCollector
                         format: int32
                         type: integer
                       resources:
-                        description: Define resources' requests and limits for single
-                          OtelCollector pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -10609,9 +5794,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -10620,90 +5802,39 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tlsRefName:
                         type: string
                       tolerations:
-                        description: Set tolerations for the OtelCollector pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: Adds TopologySpreadConstraints for the OtelCollector
-                          pods
                         items:
-                          description: TopologySpreadConstraint specifies how to spread
-                            matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: |-
-                                LabelSelector is used to find matching pods.
-                                Pods that match this label selector are counted to determine the number of pods
-                                in their corresponding topology domain.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -10717,69 +5848,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select the pods over which
-                                spreading will be calculated. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are ANDed with labelSelector
-                                to select the group of existing pods over which spreading will be calculated
-                                for the incoming pod.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: |-
-                                MaxSkew describes the degree to which pods may be unevenly distributed.
-                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                between the number of matching pods in the target topology and the global minimum.
                               format: int32
                               type: integer
                             minDomains:
-                              description: |-
-                                MinDomains indicates a minimum number of eligible domains.
-                                When the number of eligible domains with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: |-
-                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                when calculating pod topology spread skew. Options are:
-                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                               type: string
                             nodeTaintsPolicy:
-                              description: |-
-                                NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                pod topology spread skew. Options are:
-                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                has a toleration, are included.
-                                - Ignore: node taints are ignored. All nodes are included.
                               type: string
                             topologyKey:
-                              description: |-
-                                TopologyKey is the key of node labels. Nodes that have a label with this key
-                                and identical values are considered to be in the same topology.
-                                We consider each <key, value> as a "bucket", and try to put balanced number
-                                of pods into each bucket.
-                                We define a domain as a particular instance of a topology.
                               type: string
                             whenUnsatisfiable:
-                              description: |-
-                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                  but giving higher precedence to topologies that would help reduce the
-                                  skew.
                               type: string
                           required:
                           - maxSkew
@@ -10790,134 +5879,83 @@ spec:
                     type: object
                 type: object
               tokens:
-                description: Name of the secret holding the tokens used for connecting
-                  to Dynatrace.
                 type: string
               trustedCAs:
-                description: |-
-                  Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
-                  Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.
                 type: string
             required:
             - apiUrl
             type: object
           status:
-            description: DynaKubeStatus defines the observed state of DynaKube
             properties:
               activeGate:
-                description: Observed state of ActiveGate
                 properties:
                   connectionInfoStatus:
-                    description: Information about Active Gate's connections
                     properties:
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   serviceIPs:
-                    description: The ClusterIPs set by Kubernetes on the ActiveGate
-                      Service created by the Operator
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               codeModules:
-                description: Observed state of Code Modules
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -10930,37 +5968,23 @@ spec:
                   type: object
                 type: array
               dynatraceApi:
-                description: Observed state of Dynatrace API
                 properties:
                   lastTokenScopeRequest:
-                    description: Time of the last token request
                     format: date-time
                     type: string
                 type: object
               kspm:
-                description: Observed state of Kspm
                 properties:
                   tokenSecretHash:
-                    description: |-
-                      TokenSecretHash contains the hash of the token that is passed to both the ActiveGate and Node-Configuration-Collector.
-                      Meant to keep the two in sync.
                     type: string
                 type: object
               kubeSystemUUID:
-                description: KubeSystemUUID contains the UUID of the current Kubernetes
-                  cluster
                 type: string
               kubernetesClusterMEID:
-                description: KubernetesClusterMEID contains the ID of the monitored
-                  entity that points to the Kubernetes cluster
                 type: string
               kubernetesClusterName:
-                description: KubernetesClusterName contains the display name (also
-                  know as label) of the monitored entity that points to the Kubernetes
-                  cluster
                 type: string
               metadataEnrichment:
-                description: Observed state of Metadata-Enrichment
                 properties:
                   rules:
                     items:
@@ -10977,87 +6001,61 @@ spec:
                     type: array
                 type: object
               oneAgent:
-                description: Observed state of OneAgent
                 properties:
                   connectionInfoStatus:
-                    description: Information about OneAgent's connections
                     properties:
                       communicationHosts:
-                        description: List of communication hosts
                         items:
                           properties:
                             host:
-                              description: Host domain
                               type: string
                             port:
-                              description: Connection port
                               format: int32
                               type: integer
                             protocol:
-                              description: Connection protocol
                               type: string
                           type: object
                         type: array
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   healthcheck:
-                    description: Commands used for OneAgent's readiness probe
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   imageID:
-                    description: Image ID
                     type: string
                   instances:
                     additionalProperties:
                       properties:
                         ipAddress:
-                          description: IP address of the pod
                           type: string
                         podName:
-                          description: Name of the OneAgent pod
                           type: string
                       type: object
-                    description: List of deployed OneAgent instances
                     type: object
                   lastInstanceStatusUpdate:
-                    description: Time of the last instance status update
                     format: date-time
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: UpdatedTimestamp indicates when the instance was last
-                  updated
                 format: date-time
                 type: string
             type: object

--- a/config/crd/bases/dynatrace.com_edgeconnects.yaml
+++ b/config/crd/bases/dynatrace.com_edgeconnects.yaml
@@ -32,154 +32,84 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: EdgeConnect is the Schema for the EdgeConnect API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: EdgeConnectSpec defines the desired state of EdgeConnect.
             properties:
               annotations:
                 additionalProperties:
                   type: string
-                description: Adds additional annotations to the EdgeConnect pods
                 type: object
               apiServer:
-                description: Location of the Dynatrace API to connect to, including
-                  your specific environment UUID
                 type: string
               autoUpdate:
                 default: true
-                description: 'Enables automatic restarts of EdgeConnect pods in case
-                  a new version is available (the default value is: true)'
                 type: boolean
               caCertsRef:
-                description: Adds custom root certificate from a configmap. Put the
-                  certificate under certs within your configmap.
                 type: string
               customPullSecret:
-                description: Pull secret for your private registry
                 type: string
               env:
-                description: Adds additional environment variables to the EdgeConnect
-                  pods
                 items:
-                  description: EnvVar represents an environment variable present in
-                    a Container.
                   properties:
                     name:
-                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
-                      description: |-
-                        Variable references $(VAR_NAME) are expanded
-                        using the previously defined environment variables in the container and
-                        any service environment variables. If a variable cannot be resolved,
-                        the reference in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                       type: string
                     valueFrom:
-                      description: Source for the environment variable's value. Cannot
-                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
                           properties:
                             key:
-                              description: The key to select.
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
-                          description: |-
-                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                           properties:
                             apiVersion:
-                              description: Version of the schema the FieldPath is
-                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
-                              description: Path of the field to select in the specified
-                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
-                          description: |-
-                            Selects a resource of the container: only resources limits and requests
-                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                           properties:
                             containerName:
-                              description: 'Container name: required for volumes,
-                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Specifies the output format of the exposed
-                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
-                              description: 'Required: resource to select'
                               type: string
                           required:
                           - resource
                           type: object
                           x-kubernetes-map-type: atomic
                         secretKeyRef:
-                          description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -191,64 +121,42 @@ spec:
                   type: object
                 type: array
               hostPatterns:
-                description: Host patterns to be set in the tenant, only considered
-                  when provisioning is enabled.
                 items:
                   type: string
                 type: array
               hostRestrictions:
-                description: Restrict outgoing HTTP requests to your internal resources
-                  to specified hosts
                 example: internal.example.org,*.dev.example.org
                 type: string
               imageRef:
-                description: Overrides the default image
                 properties:
                   repository:
-                    description: Custom EdgeConnect image repository
                     example: docker.io/dynatrace/edgeconnect
                     type: string
                   tag:
-                    description: Indicates version of the EdgeConnect image to use
                     type: string
                 type: object
               kubernetesAutomation:
-                description: KubernetesAutomation enables Kubernetes Automation for
-                  Workflows
                 properties:
                   enabled:
-                    description: Enables Kubernetes Automation for Workflows
                     type: boolean
                 type: object
               labels:
                 additionalProperties:
                   type: string
-                description: Adds additional labels to the EdgeConnect pods
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: Node selector to control the selection of nodes for the
-                  EdgeConnect pods
                 type: object
               oauth:
-                description: EdgeConnect uses the OAuth client to authenticate itself
-                  with the Dynatrace platform.
                 properties:
                   clientSecret:
-                    description: Name of the secret that holds oauth clientId/secret
                     type: string
                   endpoint:
-                    description: Token endpoint URL of Dynatrace SSO
                     type: string
                   provisioner:
-                    description: Determines if the operator will create the EdgeConnect
-                      and light OAuth client on the cluster using the credentials
-                      provided. Requires more scopes than default behavior.
                     type: boolean
                   resource:
-                    description: URN identifying your account. You get the URN when
-                      creating the OAuth client
                     type: string
                 required:
                 - clientSecret
@@ -256,59 +164,29 @@ spec:
                 - resource
                 type: object
               proxy:
-                description: General configurations for proxy settings.
                 properties:
                   authRef:
-                    description: |-
-                      Secret name which contains the username and password used for authentication with the proxy, using the
-                      "Basic" HTTP authentication scheme.
                     type: string
                   host:
-                    description: Server address (hostname or IP address) of the proxy.
                     type: string
                   noProxy:
-                    description: |-
-                      NoProxy represents the NO_PROXY or no_proxy environment
-                      variable. It specifies a string that contains comma-separated values
-                      specifying hosts that should be excluded from proxying.
                     type: string
                   port:
-                    description: Port of the proxy.
                     format: int32
                     type: integer
                 type: object
               replicas:
                 default: 1
-                description: 'Amount of replicas for your EdgeConnect (the default
-                  value is: 1)'
                 format: int32
                 type: integer
               resources:
-                description: Defines resources requests and limits for single pods
                 properties:
                   claims:
-                    description: |-
-                      Claims lists the names of resources, defined in spec.resourceClaims,
-                      that are used by this container.
-
-                      This is an alpha field and requires enabling the
-                      DynamicResourceAllocation feature gate.
-
-                      This field is immutable. It can only be set for containers.
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: |-
-                            Name must match the name of one entry in pod.spec.resourceClaims of
-                            the Pod where this field is used. It makes that resource available
-                            inside a container.
                           type: string
                         request:
-                          description: |-
-                            Request is the name chosen for a request in the referenced claim.
-                            If empty, everything from the claim is made available, otherwise
-                            only the result of this request.
                           type: string
                       required:
                       - name
@@ -324,9 +202,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Limits describes the maximum amount of compute resources allowed.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                   requests:
                     additionalProperties:
@@ -335,93 +210,40 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Requests describes the minimum amount of compute resources required.
-                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
               serviceAccountName:
                 default: dynatrace-edgeconnect
-                description: ServiceAccountName that allows EdgeConnect to access
-                  the Kubernetes API
                 type: string
               tolerations:
-                description: Sets tolerations for the EdgeConnect pods
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               topologySpreadConstraints:
-                description: Sets topology spread constraints for the EdgeConnect
-                  pods
                 items:
-                  description: TopologySpreadConstraint specifies how to spread matching
-                    pods among the given topology.
                   properties:
                     labelSelector:
-                      description: |-
-                        LabelSelector is used to find matching pods.
-                        Pods that match this label selector are counted to determine the number of pods
-                        in their corresponding topology domain.
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
                           items:
-                            description: |-
-                              A label selector requirement is a selector that contains values, a key, and an operator that
-                              relates the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
                                 type: string
                               operator:
-                                description: |-
-                                  operator represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: |-
-                                  values is an array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. This array is replaced during a strategic
-                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -435,69 +257,27 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: |-
-                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
-                      description: |-
-                        MatchLabelKeys is a set of pod label keys to select the pods over which
-                        spreading will be calculated. The keys are used to lookup values from the
-                        incoming pod labels, those key-value labels are ANDed with labelSelector
-                        to select the group of existing pods over which spreading will be calculated
-                        for the incoming pod.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
-                      description: |-
-                        MaxSkew describes the degree to which pods may be unevenly distributed.
-                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                        between the number of matching pods in the target topology and the global minimum.
                       format: int32
                       type: integer
                     minDomains:
-                      description: |-
-                        MinDomains indicates a minimum number of eligible domains.
-                        When the number of eligible domains with matching topology keys is less than minDomains,
-                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
-                      description: |-
-                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                        when calculating pod topology spread skew. Options are:
-                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                       type: string
                     nodeTaintsPolicy:
-                      description: |-
-                        NodeTaintsPolicy indicates how we will treat node taints when calculating
-                        pod topology spread skew. Options are:
-                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                        has a toleration, are included.
-                        - Ignore: node taints are ignored. All nodes are included.
                       type: string
                     topologyKey:
-                      description: |-
-                        TopologyKey is the key of node labels. Nodes that have a label with this key
-                        and identical values are considered to be in the same topology.
-                        We consider each <key, value> as a "bucket", and try to put balanced number
-                        of pods into each bucket.
-                        We define a domain as a particular instance of a topology.
                       type: string
                     whenUnsatisfiable:
-                      description: |-
-                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                        the spread constraint.
-                        - DoNotSchedule (default) tells the scheduler not to schedule it.
-                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                          but giving higher precedence to topologies that would help reduce the
-                          skew.
                       type: string
                   required:
                   - maxSkew
@@ -510,55 +290,32 @@ spec:
             - oauth
             type: object
           status:
-            description: EdgeConnectStatus defines the observed state of EdgeConnect.
             properties:
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -571,36 +328,24 @@ spec:
                   type: object
                 type: array
               kubeSystemUID:
-                description: kube-system namespace uid
                 type: string
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: Indicates when the resource was last updated
                 format: date-time
                 type: string
               version:
-                description: Version used for the Edgeconnect image
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
             type: object
@@ -622,153 +367,83 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: EdgeConnect is the Schema for the EdgeConnect API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: EdgeConnectSpec defines the desired state of EdgeConnect.
             properties:
               annotations:
                 additionalProperties:
                   type: string
-                description: Adds additional annotations to the EdgeConnect pods
                 type: object
               apiServer:
-                description: Location of the Dynatrace API to connect to, including
-                  your specific environment UUID
                 type: string
               autoUpdate:
-                description: 'Enables automatic restarts of EdgeConnect pods in case
-                  a new version is available (the default value is: true)'
                 type: boolean
               caCertsRef:
-                description: Adds custom root certificate from a configmap. Put the
-                  certificate under certs within your configmap.
                 type: string
               customPullSecret:
-                description: Pull secret for your private registry
                 type: string
               env:
-                description: Adds additional environment variables to the EdgeConnect
-                  pods
                 items:
-                  description: EnvVar represents an environment variable present in
-                    a Container.
                   properties:
                     name:
-                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
-                      description: |-
-                        Variable references $(VAR_NAME) are expanded
-                        using the previously defined environment variables in the container and
-                        any service environment variables. If a variable cannot be resolved,
-                        the reference in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                       type: string
                     valueFrom:
-                      description: Source for the environment variable's value. Cannot
-                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
                           properties:
                             key:
-                              description: The key to select.
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
-                          description: |-
-                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                           properties:
                             apiVersion:
-                              description: Version of the schema the FieldPath is
-                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
-                              description: Path of the field to select in the specified
-                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
-                          description: |-
-                            Selects a resource of the container: only resources limits and requests
-                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                           properties:
                             containerName:
-                              description: 'Container name: required for volumes,
-                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Specifies the output format of the exposed
-                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
-                              description: 'Required: resource to select'
                               type: string
                           required:
                           - resource
                           type: object
                           x-kubernetes-map-type: atomic
                         secretKeyRef:
-                          description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -780,66 +455,44 @@ spec:
                   type: object
                 type: array
               hostPatterns:
-                description: Host patterns to be set in the tenant, only considered
-                  when provisioning is enabled.
                 items:
                   type: string
                 type: array
               hostRestrictions:
-                description: Restrict outgoing HTTP requests to your internal resources
-                  to specified hosts
                 example: internal.example.org,*.dev.example.org
                 items:
                   type: string
                 type: array
               imageRef:
-                description: Overrides the default image
                 properties:
                   repository:
-                    description: Custom image repository
                     example: docker.io/dynatrace/image-name
                     type: string
                   tag:
-                    description: Indicates a tag of the image to use
                     type: string
                 type: object
               kubernetesAutomation:
-                description: KubernetesAutomation enables Kubernetes Automation for
-                  Workflows
                 properties:
                   enabled:
-                    description: Enables Kubernetes Automation for Workflows
                     type: boolean
                 type: object
               labels:
                 additionalProperties:
                   type: string
-                description: Adds additional labels to the EdgeConnect pods
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: Node selector to control the selection of nodes for the
-                  EdgeConnect pods
                 type: object
               oauth:
-                description: EdgeConnect uses the OAuth client to authenticate itself
-                  with the Dynatrace platform.
                 properties:
                   clientSecret:
-                    description: Name of the secret that holds oauth clientId/secret
                     type: string
                   endpoint:
-                    description: Token endpoint URL of Dynatrace SSO
                     type: string
                   provisioner:
-                    description: Determines if the operator will create the EdgeConnect
-                      and light OAuth client on the cluster using the credentials
-                      provided. Requires more scopes than default behavior.
                     type: boolean
                   resource:
-                    description: URN identifying your account. You get the URN when
-                      creating the OAuth client
                     type: string
                 required:
                 - clientSecret
@@ -847,58 +500,28 @@ spec:
                 - resource
                 type: object
               proxy:
-                description: General configurations for proxy settings.
                 properties:
                   authRef:
-                    description: |-
-                      Secret name which contains the username and password used for authentication with the proxy, using the
-                      "Basic" HTTP authentication scheme.
                     type: string
                   host:
-                    description: Server address (hostname or IP address) of the proxy.
                     type: string
                   noProxy:
-                    description: |-
-                      NoProxy represents the NO_PROXY or no_proxy environment
-                      variable. It specifies a string that contains comma-separated values
-                      specifying hosts that should be excluded from proxying.
                     type: string
                   port:
-                    description: Port of the proxy.
                     format: int32
                     type: integer
                 type: object
               replicas:
-                description: 'Amount of replicas for your EdgeConnect (the default
-                  value is: 1)'
                 format: int32
                 type: integer
               resources:
-                description: Defines resources requests and limits for single pods
                 properties:
                   claims:
-                    description: |-
-                      Claims lists the names of resources, defined in spec.resourceClaims,
-                      that are used by this container.
-
-                      This is an alpha field and requires enabling the
-                      DynamicResourceAllocation feature gate.
-
-                      This field is immutable. It can only be set for containers.
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: |-
-                            Name must match the name of one entry in pod.spec.resourceClaims of
-                            the Pod where this field is used. It makes that resource available
-                            inside a container.
                           type: string
                         request:
-                          description: |-
-                            Request is the name chosen for a request in the referenced claim.
-                            If empty, everything from the claim is made available, otherwise
-                            only the result of this request.
                           type: string
                       required:
                       - name
@@ -914,9 +537,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Limits describes the maximum amount of compute resources allowed.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                   requests:
                     additionalProperties:
@@ -925,92 +545,39 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Requests describes the minimum amount of compute resources required.
-                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
               serviceAccountName:
-                description: ServiceAccountName that allows EdgeConnect to access
-                  the Kubernetes API
                 type: string
               tolerations:
-                description: Sets tolerations for the EdgeConnect pods
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               topologySpreadConstraints:
-                description: Sets topology spread constraints for the EdgeConnect
-                  pods
                 items:
-                  description: TopologySpreadConstraint specifies how to spread matching
-                    pods among the given topology.
                   properties:
                     labelSelector:
-                      description: |-
-                        LabelSelector is used to find matching pods.
-                        Pods that match this label selector are counted to determine the number of pods
-                        in their corresponding topology domain.
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
                           items:
-                            description: |-
-                              A label selector requirement is a selector that contains values, a key, and an operator that
-                              relates the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
                                 type: string
                               operator:
-                                description: |-
-                                  operator represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: |-
-                                  values is an array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. This array is replaced during a strategic
-                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -1024,69 +591,27 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: |-
-                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
-                      description: |-
-                        MatchLabelKeys is a set of pod label keys to select the pods over which
-                        spreading will be calculated. The keys are used to lookup values from the
-                        incoming pod labels, those key-value labels are ANDed with labelSelector
-                        to select the group of existing pods over which spreading will be calculated
-                        for the incoming pod.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
-                      description: |-
-                        MaxSkew describes the degree to which pods may be unevenly distributed.
-                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                        between the number of matching pods in the target topology and the global minimum.
                       format: int32
                       type: integer
                     minDomains:
-                      description: |-
-                        MinDomains indicates a minimum number of eligible domains.
-                        When the number of eligible domains with matching topology keys is less than minDomains,
-                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
-                      description: |-
-                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                        when calculating pod topology spread skew. Options are:
-                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                       type: string
                     nodeTaintsPolicy:
-                      description: |-
-                        NodeTaintsPolicy indicates how we will treat node taints when calculating
-                        pod topology spread skew. Options are:
-                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                        has a toleration, are included.
-                        - Ignore: node taints are ignored. All nodes are included.
                       type: string
                     topologyKey:
-                      description: |-
-                        TopologyKey is the key of node labels. Nodes that have a label with this key
-                        and identical values are considered to be in the same topology.
-                        We consider each <key, value> as a "bucket", and try to put balanced number
-                        of pods into each bucket.
-                        We define a domain as a particular instance of a topology.
                       type: string
                     whenUnsatisfiable:
-                      description: |-
-                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                        the spread constraint.
-                        - DoNotSchedule (default) tells the scheduler not to schedule it.
-                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                          but giving higher precedence to topologies that would help reduce the
-                          skew.
                       type: string
                   required:
                   - maxSkew
@@ -1099,55 +624,32 @@ spec:
             - oauth
             type: object
           status:
-            description: EdgeConnectStatus defines the observed state of EdgeConnect.
             properties:
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1160,36 +662,24 @@ spec:
                   type: object
                 type: array
               kubeSystemUID:
-                description: kube-system namespace uid
                 type: string
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: Indicates when the resource was last updated
                 format: date-time
                 type: string
               version:
-                description: Version used for the Edgeconnect image
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
             type: object

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -44,165 +44,92 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: DynaKube is the Schema for the DynaKube API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DynaKubeSpec defines the desired state of DynaKube
             properties:
               activeGate:
-                description: General configuration about ActiveGate instances.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Adds additional annotations to the ActiveGate pods
                     type: object
                   capabilities:
-                    description: Activegate capabilities enabled (routing, kubernetes-monitoring,
-                      metrics-ingest, dynatrace-api)
                     items:
                       type: string
                     type: array
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called 'customProperties'
                     properties:
                       value:
-                        description: Custom properties value.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Custom properties secret.
                         nullable: true
                         type: string
                     type: object
                   dnsPolicy:
-                    description: Sets DNS Policy for the ActiveGate pods
                     type: string
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -214,58 +141,30 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: The ActiveGate container image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Node selector to control the selection of nodes
                     type: object
                   priorityClassName:
-                    description: |-
-                      If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-                      name. If not specified the setting will be removed from the StatefulSet.
                     type: string
                   replicas:
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: Define resources requests and limits for single ActiveGate
-                      pods
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -281,9 +180,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -292,94 +188,39 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tlsSecretName:
-                    description: |-
-                      The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
-                      server.p12: certificate+key pair in pkcs12 format
-                      password: passphrase to read server.p12
                     type: string
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints for the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -393,69 +234,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -465,148 +264,80 @@ spec:
                     type: array
                 type: object
               apiUrl:
-                description: |-
-                  Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
-                  For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.
                 type: string
               customPullSecret:
-                description: |-
-                  Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.
-                  To define a custom pull secret and learn about the expected behavior, see Configure customPullSecret
-                  (https://www.dynatrace.
                 type: string
               enableIstio:
-                description: |-
-                  When enabled, and if Istio is installed on the Kubernetes environment, Dynatrace Operator will create the corresponding
-                  VirtualService and ServiceEntry objects to allow access to the Dynatrace Cluster from the OneAgent or ActiveGate.
-                  Disabled by default.
                 type: boolean
               kubernetesMonitoring:
-                description: Configuration for Kubernetes Monitoring
                 properties:
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called 'customProperties'
                     properties:
                       value:
-                        description: Custom properties value.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Custom properties secret.
                         nullable: true
                         type: string
                     type: object
                   enabled:
-                    description: Enables Capability
                     type: boolean
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -618,53 +349,28 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: The ActiveGate container image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Node selector to control the selection of nodes
                     type: object
                   replicas:
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: Define resources requests and limits for single ActiveGate
-                      pods
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -680,9 +386,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -691,88 +394,37 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints for the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -786,69 +438,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -858,33 +468,15 @@ spec:
                     type: array
                 type: object
               namespaceSelector:
-                description: |-
-                  Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                  For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: |-
-                        A label selector requirement is a selector that contains values, a key, and an operator that
-                        relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: |-
-                            operator represents a key's relationship to a set of values.
-                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: |-
-                            values is an array of string values. If the operator is In or NotIn,
-                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                            the values array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -898,59 +490,26 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               networkZone:
-                description: Sets a network zone for the OneAgent and ActiveGate pods.
                 type: string
               oneAgent:
-                description: |-
-                  General configuration about OneAgent instances.
-                  You can't enable more than one module (classicFullStack, cloudNativeFullStack, hostMonitoring, or applicationMonitoring).
                 properties:
                   applicationMonitoring:
-                    description: |-
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has an optional CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       codeModulesImage:
-                        description: The OneAgent image that is used to inject into
-                          Pods.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -966,9 +525,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -977,158 +533,85 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       useCSIDriver:
-                        description: Set if you want to use the CSIDriver. Don't enable
-                          it if you do not have access to Kubernetes nodes or if you
-                          lack privileges.
                         type: boolean
                       version:
-                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   classicFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Injection is performed via the same OneAgent DaemonSet.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -1140,49 +623,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -1198,9 +655,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1209,203 +663,103 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   cloudNativeFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has a CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       codeModulesImage:
-                        description: The OneAgent image that is used to inject into
-                          Pods.
                         type: string
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -1417,37 +771,15 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -1463,9 +795,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1474,53 +803,24 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -1536,9 +836,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1547,201 +844,103 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   hostGroup:
-                    description: Sets a host group for OneAgent.
                     type: string
                   hostMonitoring:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Doesn't inject into application pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -1753,49 +952,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -1811,9 +984,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1822,203 +992,108 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used.
                         type: string
                     type: object
                 type: object
               proxy:
-                description: |-
-                  Set custom proxy settings either directly or from a secret with the field proxy.
-                  Note: Applies to Dynatrace Operator, ActiveGate, and OneAgents.
                 properties:
                   value:
-                    description: Proxy URL. It has preference over ValueFrom.
                     nullable: true
                     type: string
                   valueFrom:
-                    description: Secret containing proxy URL.
                     nullable: true
                     type: string
                 type: object
               routing:
-                description: Configuration for Routing
                 properties:
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called 'customProperties'
                     properties:
                       value:
-                        description: Custom properties value.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Custom properties secret.
                         nullable: true
                         type: string
                     type: object
                   enabled:
-                    description: Enables Capability
                     type: boolean
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -2030,53 +1105,28 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: The ActiveGate container image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Node selector to control the selection of nodes
                     type: object
                   replicas:
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: Define resources requests and limits for single ActiveGate
-                      pods
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -2092,9 +1142,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -2103,88 +1150,37 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints for the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2198,69 +1194,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -2270,139 +1224,85 @@ spec:
                     type: array
                 type: object
               skipCertCheck:
-                description: |-
-                  Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.
-                  Set to true if you want to skip certification validation checks.
                 type: boolean
               tokens:
-                description: Name of the secret holding the tokens used for connecting
-                  to Dynatrace.
                 type: string
               trustedCAs:
-                description: |-
-                  Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
-                  Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.
                 type: string
             required:
             - apiUrl
             type: object
           status:
-            description: DynaKubeStatus defines the observed state of DynaKube
             properties:
               activeGate:
-                description: Observed state of ActiveGate
                 properties:
                   connectionInfoStatus:
-                    description: Information about Active Gate's connections
                     properties:
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   serviceIPs:
-                    description: The ClusterIPs set by Kubernetes on the ActiveGate
-                      Service created by the Operator
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               codeModules:
-                description: Observed state of Code Modules
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -2415,104 +1315,72 @@ spec:
                   type: object
                 type: array
               dynatraceApi:
-                description: Observed state of Dynatrace API
                 properties:
                   lastTokenScopeRequest:
-                    description: Time of the last token request
                     format: date-time
                     type: string
                 type: object
               kubeSystemUUID:
-                description: KubeSystemUUID contains the UUID of the current Kubernetes
-                  cluster
                 type: string
               lastTokenProbeTimestamp:
-                description: LastTokenProbeTimestamp tracks when the last request
-                  for the API token validity was sent
                 format: date-time
                 type: string
               oneAgent:
-                description: Observed state of OneAgent
                 properties:
                   connectionInfoStatus:
-                    description: Information about OneAgent's connections
                     properties:
                       communicationHosts:
-                        description: List of communication hosts
                         items:
                           properties:
                             host:
-                              description: Host domain
                               type: string
                             port:
-                              description: Connection port
                               format: int32
                               type: integer
                             protocol:
-                              description: Connection protocol
                               type: string
                           type: object
                         type: array
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   healthcheck:
-                    description: Commands used for OneAgent's readiness probe
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   imageID:
-                    description: Image ID
                     type: string
                   instances:
                     additionalProperties:
                       properties:
                         ipAddress:
-                          description: IP address of the pod
                           type: string
                         podName:
-                          description: Name of the OneAgent pod
                           type: string
                       type: object
-                    description: List of deployed OneAgent instances
                     type: object
                   lastInstanceStatusUpdate:
-                    description: Time of the last instance status update
                     format: date-time
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: UpdatedTimestamp indicates when the instance was last
-                  updated
                 format: date-time
                 type: string
             type: object
@@ -2534,169 +1402,92 @@ spec:
     name: v1beta2
     schema:
       openAPIV3Schema:
-        description: DynaKube is the Schema for the DynaKube API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DynaKubeSpec defines the desired state of DynaKube
             properties:
               activeGate:
-                description: General configuration about ActiveGate instances.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Adds additional annotations to the ActiveGate pods
                     type: object
                   capabilities:
-                    description: "Defines the ActiveGate pod capabilities\nPossible
-                      values:\n\t- `routing` enables OneAgent routing.\n\t- `kubernetes-monitoring`
-                      enables Kubernetes API monitoring.\n\t- `metrics-ingest` opens
-                      the metrics ingest endpoint on the DynaKube ActiveGate and redirects
-                      all pods to it.\n\t- `dynatrace-api` enables calling the Dynatrace
-                      API via ActiveGate."
                     items:
                       type: string
                     type: array
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called `customProperties`
                     properties:
                       value:
-                        description: Custom properties value.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Custom properties secret.
                         nullable: true
                         type: string
                     type: object
                   dnsPolicy:
-                    description: Sets DNS Policy for the ActiveGate pods
                     type: string
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -2708,62 +1499,31 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: Use a custom ActiveGate image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Your defined labels for ActiveGate pods in order
-                      to structure workloads as desired.
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Specify the node selector that controls on which
-                      nodes ActiveGate will be deployed.
                     type: object
                   priorityClassName:
-                    description: |-
-                      Assign a priority class to the ActiveGate pods. By default, no class is set.
-                      For details, see Pod Priority and Preemption. (https://dt-url.net/n8437bl)
                     type: string
                   replicas:
                     default: 1
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: |-
-                      Resource settings for ActiveGate container.
-                      Consumption of the ActiveGate heavily depends on the workload to monitor. Adjust values accordingly.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -2779,9 +1539,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -2790,94 +1547,39 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tlsSecretName:
-                    description: |-
-                      The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
-                      `server.p12`: certificate+key pair in pkcs12 format
-                      `password`: passphrase to read server.p12
                     type: string
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints to the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2891,69 +1593,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -2963,61 +1623,29 @@ spec:
                     type: array
                 type: object
               apiUrl:
-                description: |-
-                  Dynatrace `apiUrl`, including the `/api` path at the end.
-                  - For SaaS, set `YOUR_ENVIRONMENT_ID` to your environment ID.
-                  - For Managed, change the `apiUrl` address.
-                  For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.
                 type: string
               customPullSecret:
-                description: |-
-                  Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.
-                  To define a custom pull secret and learn about the expected behavior, see Configure customPullSecret
-                  (https://www.dynatrace.
                 type: string
               dynatraceApiRequestThreshold:
                 default: 15
-                description: Minimum minutes between Dynatrace API requests.
                 type: integer
               enableIstio:
-                description: |-
-                  When enabled, and if Istio is installed in the Kubernetes environment, Dynatrace Operator will create the corresponding VirtualService and ServiceEntry objects to allow access to the Dynatrace Cluster from the OneAgent or ActiveGate.
-                  Disabled by default.
                 type: boolean
               metadataEnrichment:
-                description: Configuration for Metadata Enrichment.
                 properties:
                   enabled:
                     default: false
-                    description: Enables MetadataEnrichment, `false` by default.
                     type: boolean
                   namespaceSelector:
-                    description: The namespaces where you want Dynatrace Operator
-                      to inject enrichment.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -3031,10 +1659,6 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
@@ -3042,51 +1666,22 @@ spec:
                 - enabled
                 type: object
               networkZone:
-                description: Sets a network zone for the OneAgent and ActiveGate pods.
                 type: string
               oneAgent:
-                description: |-
-                  General configuration about OneAgent instances.
-                  You can't enable more than one module (classicFullStack, cloudNativeFullStack, hostMonitoring, or applicationMonitoring).
                 properties:
                   applicationMonitoring:
-                    description: |-
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has an optional CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       codeModulesImage:
-                        description: The OneAgent image that is used to inject into
-                          Pods.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3102,9 +1697,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -3113,41 +1705,18 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -3161,160 +1730,88 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       useCSIDriver:
                         default: false
-                        description: Set if you want to use the CSIDriver. Don't enable
-                          it if you do not have access to Kubernetes nodes or if you
-                          lack privileges.
                         type: boolean
                       version:
-                        description: The OneAgent version to be used.
                         type: string
                     type: object
                   classicFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Injection is performed via the same OneAgent DaemonSet.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
                         default: true
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -3326,50 +1823,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          - `resource.requests` shows the values needed to run
-                          - `resource.limits` shows the maximum limits for the pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3385,9 +1855,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -3396,210 +1863,106 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used for OneAgents
-                          running in the dedicated pod. This setting doesn't affect
-                          the OneAgent version used for application monitoring.
                         type: string
                     type: object
                   cloudNativeFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has a CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
                         default: true
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       codeModulesImage:
-                        description: The OneAgent image that is used to inject into
-                          Pods.
                         type: string
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -3611,37 +1974,15 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3657,9 +1998,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -3668,47 +2006,22 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -3722,48 +2035,21 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          - `resource.requests` shows the values needed to run
-                          - `resource.limits` shows the maximum limits for the pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3779,9 +2065,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -3790,211 +2073,106 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used for OneAgents
-                          running in the dedicated pod. This setting doesn't affect
-                          the OneAgent version used for application monitoring.
                         type: string
                     type: object
                   hostGroup:
-                    description: |-
-                      Specify the name of the group to which you want to assign the host.
-                      This method is preferred over the now obsolete `--set-host-group` argument.
-                      If both settings are used, this field takes precedence over the `--set-host-group` argument.
                     type: string
                   hostMonitoring:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Doesn't inject into application pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
                         default: true
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -4006,50 +2184,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent Docker image. Defaults
-                          to the image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          - `resource.requests` shows the values needed to run
-                          - `resource.limits` shows the maximum limits for the pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -4065,9 +2216,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -4076,218 +2224,121 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: The OneAgent version to be used for OneAgents
-                          running in the dedicated pod. This setting doesn't affect
-                          the OneAgent version used for application monitoring.
                         type: string
                     type: object
                 type: object
               proxy:
-                description: |-
-                  Set custom proxy settings either directly or from a secret with the field `proxy`.
-                  Applies to Dynatrace Operator, ActiveGate, and OneAgents.
                 properties:
                   value:
-                    description: Proxy URL. It has preference over ValueFrom.
                     nullable: true
                     type: string
                   valueFrom:
-                    description: Secret containing proxy URL.
                     nullable: true
                     type: string
                 type: object
               skipCertCheck:
-                description: |-
-                  Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.
-                  Set to `true` if you want to skip certification validation checks.
                 type: boolean
               tokens:
-                description: Name of the secret holding the tokens used for connecting
-                  to Dynatrace.
                 type: string
               trustedCAs:
-                description: |-
-                  Adds custom RootCAs from a configmap.
-                  The key to the data must be `certs`.
-                  This applies to both the Dynatrace Operator and the OneAgent. Doesn't apply to ActiveGate.
                 type: string
             required:
             - apiUrl
             type: object
           status:
-            description: DynaKubeStatus defines the observed state of DynaKube
             properties:
               activeGate:
-                description: Observed state of ActiveGate
                 properties:
                   connectionInfoStatus:
-                    description: Information about Active Gate's connections
                     properties:
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   serviceIPs:
-                    description: The ClusterIPs set by Kubernetes on the ActiveGate
-                      Service created by the Operator
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               codeModules:
-                description: Observed state of Code Modules
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -4300,28 +2351,18 @@ spec:
                   type: object
                 type: array
               dynatraceApi:
-                description: Observed state of Dynatrace API
                 properties:
                   lastTokenScopeRequest:
-                    description: Time of the last token request
                     format: date-time
                     type: string
                 type: object
               kubeSystemUUID:
-                description: KubeSystemUUID contains the UUID of the current Kubernetes
-                  cluster
                 type: string
               kubernetesClusterMEID:
-                description: KubernetesClusterMEID contains the ID of the monitored
-                  entity that points to the Kubernetes cluster
                 type: string
               kubernetesClusterName:
-                description: KubernetesClusterName contains the display name (also
-                  know as label) of the monitored entity that points to the Kubernetes
-                  cluster
                 type: string
               metadataEnrichment:
-                description: Observed state of Metadata-Enrichment
                 properties:
                   rules:
                     items:
@@ -4338,87 +2379,61 @@ spec:
                     type: array
                 type: object
               oneAgent:
-                description: Observed state of OneAgent
                 properties:
                   connectionInfoStatus:
-                    description: Information about OneAgent's connections
                     properties:
                       communicationHosts:
-                        description: List of communication hosts
                         items:
                           properties:
                             host:
-                              description: Host domain
                               type: string
                             port:
-                              description: Connection port
                               format: int32
                               type: integer
                             protocol:
-                              description: Connection protocol
                               type: string
                           type: object
                         type: array
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   healthcheck:
-                    description: Commands used for OneAgent's readiness probe
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   imageID:
-                    description: Image ID
                     type: string
                   instances:
                     additionalProperties:
                       properties:
                         ipAddress:
-                          description: IP address of the pod
                           type: string
                         podName:
-                          description: Name of the OneAgent pod
                           type: string
                       type: object
-                    description: List of deployed OneAgent instances
                     type: object
                   lastInstanceStatusUpdate:
-                    description: Time of the last instance status update
                     format: date-time
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: UpdatedTimestamp indicates when the instance was last
-                  updated
                 format: date-time
                 type: string
             type: object
@@ -4440,165 +2455,92 @@ spec:
     name: v1beta3
     schema:
       openAPIV3Schema:
-        description: DynaKube is the Schema for the DynaKube API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DynaKubeSpec defines the desired state of DynaKube
             properties:
               activeGate:
-                description: General configuration about ActiveGate instances.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Adds additional annotations to the ActiveGate pods
                     type: object
                   capabilities:
-                    description: Activegate capabilities enabled (routing, kubernetes-monitoring,
-                      metrics-ingest, dynatrace-api)
                     items:
                       type: string
                     type: array
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called 'customProperties'
                     properties:
                       value:
-                        description: Raw value for given property.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Name of the secret to get the property from.
                         nullable: true
                         type: string
                     type: object
                   dnsPolicy:
-                    description: Sets DNS Policy for the ActiveGate pods
                     type: string
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -4610,58 +2552,30 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: The ActiveGate container image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Node selector to control the selection of nodes
                     type: object
                   priorityClassName:
-                    description: |-
-                      If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-                      name. If not specified the setting will be removed from the StatefulSet.
                     type: string
                   replicas:
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: Define resources requests and limits for single ActiveGate
-                      pods
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -4677,9 +2591,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4688,94 +2599,39 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tlsSecretName:
-                    description: |-
-                      The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
-                      server.p12: certificate+key pair in pkcs12 format
-                      password: passphrase to read server.p12
                     type: string
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints for the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4789,69 +2645,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -4861,36 +2675,19 @@ spec:
                     type: array
                 type: object
               apiUrl:
-                description: |-
-                  Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
-                  For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.
                 maxLength: 128
                 type: string
               customPullSecret:
-                description: |-
-                  Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.
-                  To define a custom pull secret and learn about the expected behavior, see Configure customPullSecret
-                  (https://www.dynatrace.
                 type: string
               dynatraceApiRequestThreshold:
-                description: Configuration for thresholding Dynatrace API requests.
                 type: integer
               enableIstio:
-                description: |-
-                  When enabled, and if Istio is installed on the Kubernetes environment, Dynatrace Operator will create the corresponding
-                  VirtualService and ServiceEntry objects to allow access to the Dynatrace Cluster from the OneAgent or ActiveGate.
-                  Disabled by default.
                 type: boolean
               extensions:
-                description: |-
-                  When an (empty) ExtensionsSpec is provided, the extensions related components (extensions controller and extensions collector)
-                  are deployed by the operator.
                 type: object
               kspm:
-                description: General configuration about the KSPM feature.
                 type: object
               logMonitoring:
-                description: General configuration about the LogMonitoring feature.
                 properties:
                   ingestRuleMatchers:
                     items:
@@ -4905,38 +2702,19 @@ spec:
                     type: array
                 type: object
               metadataEnrichment:
-                description: Configuration for Metadata Enrichment.
                 properties:
                   enabled:
-                    description: Enables MetadataEnrichment, `false` by default.
                     type: boolean
                   namespaceSelector:
-                    description: The namespaces where you want Dynatrace Operator
-                      to inject enrichment.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -4950,60 +2728,27 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
               networkZone:
-                description: Sets a network zone for the OneAgent and ActiveGate pods.
                 type: string
               oneAgent:
-                description: |-
-                  General configuration about OneAgent instances.
-                  You can't enable more than one module (classicFullStack, cloudNativeFullStack, hostMonitoring, or applicationMonitoring).
                 properties:
                   applicationMonitoring:
-                    description: |-
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has an optional CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       codeModulesImage:
-                        description: Use a custom OneAgent CodeModule image to download
-                          binaries.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -5019,9 +2764,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -5030,41 +2772,18 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -5078,154 +2797,84 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       version:
-                        description: Use a specific OneAgent CodeModule version. Defaults
-                          to the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   classicFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Injection is performed via the same OneAgent DaemonSet.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -5237,49 +2886,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -5295,9 +2918,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -5306,208 +2926,105 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   cloudNativeFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has a CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       codeModulesImage:
-                        description: Use a custom OneAgent CodeModule image to download
-                          binaries.
                         type: string
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -5519,37 +3036,15 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -5565,9 +3060,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -5576,47 +3068,22 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -5630,47 +3097,21 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -5686,9 +3127,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -5697,206 +3135,105 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   hostGroup:
-                    description: Sets a host group for OneAgent.
                     type: string
                   hostMonitoring:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Doesn't inject into application pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -5908,49 +3245,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -5966,9 +3277,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -5977,86 +3285,42 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                 type: object
               proxy:
-                description: |-
-                  Set custom proxy settings either directly or from a secret with the field proxy.
-                  Note: Applies to Dynatrace Operator, ActiveGate, and OneAgents.
                 properties:
                   value:
-                    description: Raw value for given property.
                     nullable: true
                     type: string
                   valueFrom:
-                    description: Name of the secret to get the property from.
                     nullable: true
                     type: string
                 type: object
               skipCertCheck:
-                description: |-
-                  Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.
-                  Set to true if you want to skip certification validation checks.
                 type: boolean
               templates:
                 properties:
@@ -6065,64 +3329,37 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations to the ExtensionExecutionController
-                          pods
                         type: object
                       customConfig:
-                        description: Defines name of ConfigMap containing custom configuration
-                          file
                         type: string
                       customExtensionCertificates:
-                        description: Defines name of Secret containing certificates
-                          for custom extensions signature validation
                         type: string
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the ExtensionExecutionController
-                          pods
                         type: object
                       persistentVolumeClaim:
-                        description: Defines storage device
                         properties:
                           accessModes:
-                            description: |-
-                              accessModes contains the desired access modes the volume should have.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
-                            description: |-
-                              dataSource field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                              * An existing PVC (PersistentVolumeClaim)
-                              If the provisioner or an external controller can support the specified data source,
-                              it will create a new volume based on the contents of the specified data source.
                             properties:
                               apiGroup:
-                                description: |-
-                                  APIGroup is the group for the resource being referenced.
-                                  If APIGroup is not specified, the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
-                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
-                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -6130,39 +3367,20 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
-                            description: |-
-                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                              volume is desired. This may be any object from a non-empty API group (non
-                              core object) or a PersistentVolumeClaim object.
                             properties:
                               apiGroup:
-                                description: |-
-                                  APIGroup is the group for the resource being referenced.
-                                  If APIGroup is not specified, the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
-                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
-                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace is the namespace of resource being referenced
-                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
-                            description: |-
-                              resources represents the minimum resources the volume should have.
-                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                              that are lower than previous value but must still be higher than capacity recorded in the
-                              status field of the claim.
-                              More info: https://kubernetes.
                             properties:
                               limits:
                                 additionalProperties:
@@ -6171,9 +3389,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -6182,40 +3397,18 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           selector:
-                            description: selector is a label query over volumes to
-                              consider for binding.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
                                 items:
-                                  description: |-
-                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                    relates the key and values.
                                   properties:
                                     key:
-                                      description: key is the label key that the selector
-                                        applies to.
                                       type: string
                                     operator:
-                                      description: |-
-                                        operator represents a key's relationship to a set of values.
-                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: |-
-                                        values is an array of string values. If the operator is In or NotIn,
-                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                        the values array must be empty. This array is replaced during a strategic
-                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -6229,62 +3422,26 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: |-
-                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
-                            description: |-
-                              storageClassName is the name of the StorageClass required by the claim.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                             type: string
                           volumeAttributesClassName:
-                            description: |-
-                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                              If specified, the CSI driver will create or update the volume with the attributes defined
-                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created.
                             type: string
                           volumeMode:
-                            description: |-
-                              volumeMode defines what type of volume is required by the claim.
-                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
-                            description: volumeName is the binding reference to the
-                              PersistentVolume backing this claim.
                             type: string
                         type: object
                       resources:
-                        description: Define resources' requests and limits for single
-                          ExtensionExecutionController pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -6300,9 +3457,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -6311,91 +3465,39 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tlsRefName:
                         type: string
                       tolerations:
-                        description: Set tolerations for the ExtensionExecutionController
-                          pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: Adds TopologySpreadConstraints for the ExtensionExecutionController
-                          pods
                         items:
-                          description: TopologySpreadConstraint specifies how to spread
-                            matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: |-
-                                LabelSelector is used to find matching pods.
-                                Pods that match this label selector are counted to determine the number of pods
-                                in their corresponding topology domain.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -6409,69 +3511,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select the pods over which
-                                spreading will be calculated. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are ANDed with labelSelector
-                                to select the group of existing pods over which spreading will be calculated
-                                for the incoming pod.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: |-
-                                MaxSkew describes the degree to which pods may be unevenly distributed.
-                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                between the number of matching pods in the target topology and the global minimum.
                               format: int32
                               type: integer
                             minDomains:
-                              description: |-
-                                MinDomains indicates a minimum number of eligible domains.
-                                When the number of eligible domains with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: |-
-                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                when calculating pod topology spread skew. Options are:
-                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                               type: string
                             nodeTaintsPolicy:
-                              description: |-
-                                NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                pod topology spread skew. Options are:
-                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                has a toleration, are included.
-                                - Ignore: node taints are ignored. All nodes are included.
                               type: string
                             topologyKey:
-                              description: |-
-                                TopologyKey is the key of node labels. Nodes that have a label with this key
-                                and identical values are considered to be in the same topology.
-                                We consider each <key, value> as a "bucket", and try to put balanced number
-                                of pods into each bucket.
-                                We define a domain as a particular instance of a topology.
                               type: string
                             whenUnsatisfiable:
-                              description: |-
-                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                  but giving higher precedence to topologies that would help reduce the
-                                  skew.
                               type: string
                           required:
                           - maxSkew
@@ -6480,7 +3540,6 @@ spec:
                           type: object
                         type: array
                       useEphemeralVolume:
-                        description: Selects EmptyDir volume to be storage device
                         type: boolean
                     type: object
                   kspmNodeConfigurationCollector:
@@ -6488,122 +3547,67 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations for the NodeConfigurationCollector
-                          pods
                         type: object
                       args:
-                        description: Set additional arguments to the NodeConfigurationCollector
-                          pods
                         items:
                           type: string
                         type: array
                       env:
-                        description: Set additional environment variables for the
-                          NodeConfigurationCollector pods
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -6615,65 +3619,32 @@ spec:
                           type: object
                         type: array
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the NodeConfigurationCollector
-                          pods
                         type: object
                       nodeAffinity:
-                        description: Define the nodeAffinity for the DaemonSet of
-                          the NodeConfigurationCollector
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
                             items:
-                              description: |-
-                                An empty preferred scheduling term matches all objects with implicit weight 0
-                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6685,29 +3656,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6721,8 +3676,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -6732,46 +3685,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
                                 items:
-                                  description: |-
-                                    A null or empty node selector term matches no objects. The requirements of
-                                    them are ANDed.
-                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6783,29 +3708,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6828,41 +3737,17 @@ spec:
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes NodeConfigurationCollector pods will be deployed.
                         type: object
                       priorityClassName:
-                        description: |-
-                          If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-                          name. If not specified the setting will be removed from the DaemonSet.
                         type: string
                       resources:
-                        description: Define resources' requests and limits for single
-                          NodeConfigurationCollector pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -6878,9 +3763,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -6889,163 +3771,81 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tolerations:
-                        description: Set tolerations for the NodeConfigurationCollector
-                          pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       updateStrategy:
-                        description: Define the NodeConfigurationCollector daemonSet
-                          updateStrategy
                         properties:
                           rollingUpdate:
-                            description: Rolling update config params. Present only
-                              if type = "RollingUpdate".
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of nodes with an existing available DaemonSet pod that
-                                  can have an updated DaemonSet pod during during an update.
-                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                                  This can not be 0 if MaxUnavailable is 0.
-                                  Absolute number is calculated from percentage by rounding up to a minimum of 1.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of DaemonSet pods that can be unavailable during the
-                                  update. Value can be an absolute number (ex: 5) or a percentage of total
-                                  number of DaemonSet pods at the start of the update (ex: 10%). Absolute
-                                  number is calculated from percentage by rounding up.
-                                  This cannot be 0 if MaxSurge is 0
-                                  Default value is 1.
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
-                            description: Type of daemon set update. Can be "RollingUpdate"
-                              or "OnDelete". Default is RollingUpdate.
                             type: string
                         type: object
                     type: object
                   logMonitoring:
-                    description: Low-level configuration options for the LogMonitoring
-                      feature.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom annotations to the LogMonitoring pods
                         type: object
                       args:
-                        description: Set additional arguments to the LogMonitoring
-                          main container
                         items:
                           type: string
                         type: array
                       dnsPolicy:
-                        description: Sets DNS Policy for the LogMonitoring pods
                         type: string
                       imageRef:
-                        description: Overrides the default image for the LogMonitoring
-                          pods
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Add custom labels to the LogMonitoring pods
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Node selector to control the selection of nodes
-                          for the LogMonitoring pods
                         type: object
                       priorityClassName:
-                        description: Assign a priority class to the LogMonitoring
-                          pods. By default, no class is set
                         type: string
                       resources:
-                        description: Define resources' requests and limits for all
-                          the LogMonitoring pods
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -7061,9 +3861,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -7072,54 +3869,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode for the LogMonitoring
-                          pods
                         type: string
                       tolerations:
-                        description: Set tolerations for the LogMonitoring pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -7129,57 +3895,30 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations to the OtelCollector
-                          pods
                         type: object
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the OtelCollector
-                          pods
                         type: object
                       replicas:
-                        description: Number of replicas for your OtelCollector
                         format: int32
                         type: integer
                       resources:
-                        description: Define resources' requests and limits for single
-                          OtelCollector pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -7195,9 +3934,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -7206,90 +3942,39 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tlsRefName:
                         type: string
                       tolerations:
-                        description: Set tolerations for the OtelCollector pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: Adds TopologySpreadConstraints for the OtelCollector
-                          pods
                         items:
-                          description: TopologySpreadConstraint specifies how to spread
-                            matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: |-
-                                LabelSelector is used to find matching pods.
-                                Pods that match this label selector are counted to determine the number of pods
-                                in their corresponding topology domain.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -7303,69 +3988,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select the pods over which
-                                spreading will be calculated. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are ANDed with labelSelector
-                                to select the group of existing pods over which spreading will be calculated
-                                for the incoming pod.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: |-
-                                MaxSkew describes the degree to which pods may be unevenly distributed.
-                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                between the number of matching pods in the target topology and the global minimum.
                               format: int32
                               type: integer
                             minDomains:
-                              description: |-
-                                MinDomains indicates a minimum number of eligible domains.
-                                When the number of eligible domains with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: |-
-                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                when calculating pod topology spread skew. Options are:
-                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                               type: string
                             nodeTaintsPolicy:
-                              description: |-
-                                NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                pod topology spread skew. Options are:
-                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                has a toleration, are included.
-                                - Ignore: node taints are ignored. All nodes are included.
                               type: string
                             topologyKey:
-                              description: |-
-                                TopologyKey is the key of node labels. Nodes that have a label with this key
-                                and identical values are considered to be in the same topology.
-                                We consider each <key, value> as a "bucket", and try to put balanced number
-                                of pods into each bucket.
-                                We define a domain as a particular instance of a topology.
                               type: string
                             whenUnsatisfiable:
-                              description: |-
-                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                  but giving higher precedence to topologies that would help reduce the
-                                  skew.
                               type: string
                           required:
                           - maxSkew
@@ -7376,134 +4019,83 @@ spec:
                     type: object
                 type: object
               tokens:
-                description: Name of the secret holding the tokens used for connecting
-                  to Dynatrace.
                 type: string
               trustedCAs:
-                description: |-
-                  Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
-                  Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.
                 type: string
             required:
             - apiUrl
             type: object
           status:
-            description: DynaKubeStatus defines the observed state of DynaKube
             properties:
               activeGate:
-                description: Observed state of ActiveGate
                 properties:
                   connectionInfoStatus:
-                    description: Information about Active Gate's connections
                     properties:
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   serviceIPs:
-                    description: The ClusterIPs set by Kubernetes on the ActiveGate
-                      Service created by the Operator
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               codeModules:
-                description: Observed state of Code Modules
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -7516,37 +4108,23 @@ spec:
                   type: object
                 type: array
               dynatraceApi:
-                description: Observed state of Dynatrace API
                 properties:
                   lastTokenScopeRequest:
-                    description: Time of the last token request
                     format: date-time
                     type: string
                 type: object
               kspm:
-                description: Observed state of Kspm
                 properties:
                   tokenSecretHash:
-                    description: |-
-                      TokenSecretHash contains the hash of the token that is passed to both the ActiveGate and Node-Configuration-Collector.
-                      Meant to keep the two in sync.
                     type: string
                 type: object
               kubeSystemUUID:
-                description: KubeSystemUUID contains the UUID of the current Kubernetes
-                  cluster
                 type: string
               kubernetesClusterMEID:
-                description: KubernetesClusterMEID contains the ID of the monitored
-                  entity that points to the Kubernetes cluster
                 type: string
               kubernetesClusterName:
-                description: KubernetesClusterName contains the display name (also
-                  know as label) of the monitored entity that points to the Kubernetes
-                  cluster
                 type: string
               metadataEnrichment:
-                description: Observed state of Metadata-Enrichment
                 properties:
                   rules:
                     items:
@@ -7563,87 +4141,61 @@ spec:
                     type: array
                 type: object
               oneAgent:
-                description: Observed state of OneAgent
                 properties:
                   connectionInfoStatus:
-                    description: Information about OneAgent's connections
                     properties:
                       communicationHosts:
-                        description: List of communication hosts
                         items:
                           properties:
                             host:
-                              description: Host domain
                               type: string
                             port:
-                              description: Connection port
                               format: int32
                               type: integer
                             protocol:
-                              description: Connection protocol
                               type: string
                           type: object
                         type: array
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   healthcheck:
-                    description: Commands used for OneAgent's readiness probe
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   imageID:
-                    description: Image ID
                     type: string
                   instances:
                     additionalProperties:
                       properties:
                         ipAddress:
-                          description: IP address of the pod
                           type: string
                         podName:
-                          description: Name of the OneAgent pod
                           type: string
                       type: object
-                    description: List of deployed OneAgent instances
                     type: object
                   lastInstanceStatusUpdate:
-                    description: Time of the last instance status update
                     format: date-time
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: UpdatedTimestamp indicates when the instance was last
-                  updated
                 format: date-time
                 type: string
             type: object
@@ -7665,165 +4217,92 @@ spec:
     name: v1beta4
     schema:
       openAPIV3Schema:
-        description: DynaKube is the Schema for the DynaKube API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DynaKubeSpec defines the desired state of DynaKube
             properties:
               activeGate:
-                description: General configuration about ActiveGate instances.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Adds additional annotations to the ActiveGate pods
                     type: object
                   capabilities:
-                    description: Activegate capabilities enabled (routing, kubernetes-monitoring,
-                      metrics-ingest, dynatrace-api)
                     items:
                       type: string
                     type: array
                   customProperties:
-                    description: |-
-                      Add a custom properties file by providing it as a value or reference it from a secret
-                      If referenced from a secret, make sure the key is called 'customProperties'
                     properties:
                       value:
-                        description: Raw value for given property.
                         nullable: true
                         type: string
                       valueFrom:
-                        description: Name of the secret to get the property from.
                         nullable: true
                         type: string
                     type: object
                   dnsPolicy:
-                    description: Sets DNS Policy for the ActiveGate pods
                     type: string
                   env:
-                    description: List of environment variables to set for the ActiveGate
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -7835,52 +4314,31 @@ spec:
                       type: object
                     type: array
                   group:
-                    description: Set activation group for ActiveGate
                     type: string
                   image:
-                    description: The ActiveGate container image. Defaults to the latest
-                      ActiveGate image provided by the registry on the tenant
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: Adds additional labels for the ActiveGate pods
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: Node selector to control the selection of nodes
                     type: object
                   persistentVolumeClaim:
-                    description: Defines storage device
                     properties:
                       accessModes:
-                        description: |-
-                          accessModes contains the desired access modes the volume should have.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       dataSource:
-                        description: |-
-                          dataSource field can be used to specify either:
-                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                          * An existing PVC (PersistentVolumeClaim)
-                          If the provisioner or an external controller can support the specified data source,
-                          it will create a new volume based on the contents of the specified data source.
                         properties:
                           apiGroup:
-                            description: |-
-                              APIGroup is the group for the resource being referenced.
-                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                              For any other third-party types, APIGroup is required.
                             type: string
                           kind:
-                            description: Kind is the type of resource being referenced
                             type: string
                           name:
-                            description: Name is the name of resource being referenced
                             type: string
                         required:
                         - kind
@@ -7888,39 +4346,20 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       dataSourceRef:
-                        description: |-
-                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                          volume is desired. This may be any object from a non-empty API group (non
-                          core object) or a PersistentVolumeClaim object.
                         properties:
                           apiGroup:
-                            description: |-
-                              APIGroup is the group for the resource being referenced.
-                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                              For any other third-party types, APIGroup is required.
                             type: string
                           kind:
-                            description: Kind is the type of resource being referenced
                             type: string
                           name:
-                            description: Name is the name of resource being referenced
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of resource being referenced
-                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
                             type: string
                         required:
                         - kind
                         - name
                         type: object
                       resources:
-                        description: |-
-                          resources represents the minimum resources the volume should have.
-                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                          that are lower than previous value but must still be higher than capacity recorded in the
-                          status field of the claim.
-                          More info: https://kubernetes.
                         properties:
                           limits:
                             additionalProperties:
@@ -7929,9 +4368,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -7940,40 +4376,18 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       selector:
-                        description: selector is a label query over volumes to consider
-                          for binding.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -7987,71 +4401,31 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       storageClassName:
-                        description: |-
-                          storageClassName is the name of the StorageClass required by the claim.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                         type: string
                       volumeAttributesClassName:
-                        description: |-
-                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                          If specified, the CSI driver will create or update the volume with the attributes defined
-                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created.
                         type: string
                       volumeMode:
-                        description: |-
-                          volumeMode defines what type of volume is required by the claim.
-                          Value of Filesystem is implied when not included in claim spec.
                         type: string
                       volumeName:
-                        description: volumeName is the binding reference to the PersistentVolume
-                          backing this claim.
                         type: string
                     type: object
                   priorityClassName:
-                    description: |-
-                      If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-                      name. If not specified the setting will be removed from the StatefulSet.
                     type: string
                   replicas:
-                    description: Amount of replicas for your ActiveGates
                     format: int32
                     type: integer
                   resources:
-                    description: Define resources requests and limits for single ActiveGate
-                      pods
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                             request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -8067,9 +4441,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -8078,99 +4449,42 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   terminationGracePeriodSeconds:
-                    description: Configures the terminationGracePeriodSeconds parameter
-                      of the ActiveGate pod. Kubernetes defaults and rules apply.
                     format: int64
                     type: integer
                   tlsSecretName:
-                    description: |-
-                      The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.
-                      server.p12: certificate+key pair in pkcs12 format
-                      password: passphrase to read server.p12
                     type: string
                   tolerations:
-                    description: Set tolerations for the ActiveGate pods
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: Adds TopologySpreadConstraints for the ActiveGate
-                      pods
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -8184,69 +4498,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
                           type: string
                       required:
                       - maxSkew
@@ -8255,40 +4527,22 @@ spec:
                       type: object
                     type: array
                   useEphemeralVolume:
-                    description: UseEphemeralVolume
                     type: boolean
                 type: object
               apiUrl:
-                description: |-
-                  Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.
-                  For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (https://www.dynatrace.
                 maxLength: 128
                 type: string
               customPullSecret:
-                description: |-
-                  Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.
-                  To define a custom pull secret and learn about the expected behavior, see Configure customPullSecret
-                  (https://www.dynatrace.
                 type: string
               dynatraceApiRequestThreshold:
-                description: Configuration for thresholding Dynatrace API requests.
                 type: integer
               enableIstio:
-                description: |-
-                  When enabled, and if Istio is installed on the Kubernetes environment, Dynatrace Operator will create the corresponding
-                  VirtualService and ServiceEntry objects to allow access to the Dynatrace Cluster from the OneAgent or ActiveGate.
-                  Disabled by default.
                 type: boolean
               extensions:
-                description: |-
-                  When an (empty) ExtensionsSpec is provided, the extensions related components (extensions controller and extensions collector)
-                  are deployed by the operator.
                 type: object
               kspm:
-                description: General configuration about the KSPM feature.
                 type: object
               logMonitoring:
-                description: General configuration about the LogMonitoring feature.
                 properties:
                   ingestRuleMatchers:
                     items:
@@ -8303,38 +4557,19 @@ spec:
                     type: array
                 type: object
               metadataEnrichment:
-                description: Configuration for Metadata Enrichment.
                 properties:
                   enabled:
-                    description: Enables MetadataEnrichment, `false` by default.
                     type: boolean
                   namespaceSelector:
-                    description: The namespaces where you want Dynatrace Operator
-                      to inject enrichment.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -8348,60 +4583,27 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
               networkZone:
-                description: Sets a network zone for the OneAgent and ActiveGate pods.
                 type: string
               oneAgent:
-                description: |-
-                  General configuration about OneAgent instances.
-                  You can't enable more than one module (classicFullStack, cloudNativeFullStack, hostMonitoring, or applicationMonitoring).
                 properties:
                   applicationMonitoring:
-                    description: |-
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has an optional CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       codeModulesImage:
-                        description: Use a custom OneAgent CodeModule image to download
-                          binaries.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -8417,9 +4619,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -8428,41 +4627,18 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -8476,154 +4652,84 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       version:
-                        description: Use a specific OneAgent CodeModule version. Defaults
-                          to the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   classicFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Injection is performed via the same OneAgent DaemonSet.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -8635,49 +4741,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -8693,9 +4773,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -8704,213 +4781,107 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       storageHostPath:
-                        description: StorageHostPath is the writable directory on
-                          the host filesystem where OneAgent configurations will be
-                          stored.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   cloudNativeFullStack:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      dynatrace-webhook injects into application pods based on labeled namespaces.
-                      Has a CSI driver per node via DaemonSet to provide binaries to pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       codeModulesImage:
-                        description: Use a custom OneAgent CodeModule image to download
-                          binaries.
                         type: string
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -8922,37 +4893,15 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       initResources:
-                        description: |-
-                          Define resources requests and limits for the initContainer. For details, see Managing resources for containers
-                          (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers).
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -8968,9 +4917,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -8979,47 +4925,22 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       namespaceSelector:
-                        description: |-
-                          Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
-                          For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -9033,47 +4954,21 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -9089,9 +4984,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -9100,211 +4992,107 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       storageHostPath:
-                        description: StorageHostPath is the writable directory on
-                          the host filesystem where OneAgent configurations will be
-                          stored.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                   hostGroup:
-                    description: Sets a host group for OneAgent.
                     type: string
                   hostMonitoring:
-                    description: |-
-                      Has a single OneAgent per node via DaemonSet.
-                      Doesn't inject into application pods.
                     nullable: true
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom OneAgent annotations.
                         type: object
                       args:
-                        description: |-
-                          Set additional arguments to the OneAgent installer.
-                          For available options, see Linux custom installation (https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux).
-                          For the list of limitations, see Limitations (https://www.dynatrace.
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
                       autoUpdate:
-                        description: |-
-                          Disables automatic restarts of OneAgent pods in case a new version is available (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto).
-                          Enabled by default.
                         type: boolean
                       dnsPolicy:
-                        description: Set the DNS Policy for OneAgent pods. For details,
-                          see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
                         type: string
                       env:
-                        description: Set additional environment variables for the
-                          OneAgent pods.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -9316,49 +5104,23 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Use a custom OneAgent image. Defaults to the
-                          latest image from the Dynatrace cluster.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: Your defined labels for OneAgent pods in order
-                          to structure workloads as desired.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes OneAgent will be deployed.
                         type: object
                       oneAgentResources:
-                        description: |-
-                          Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.
-                          Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -9374,9 +5136,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -9385,95 +5144,46 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       priorityClassName:
-                        description: |-
-                          Assign a priority class to the OneAgent pods. By default, no class is set.
-                          For details, see Pod Priority and Preemption (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
                         type: string
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode.
                         type: string
                       storageHostPath:
-                        description: StorageHostPath is the writable directory on
-                          the host filesystem where OneAgent configurations will be
-                          stored.
                         type: string
                       tolerations:
-                        description: Tolerations to include with the OneAgent DaemonSet.
-                          For details, see Taints and Tolerations (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       version:
-                        description: Use a specific OneAgent version. Defaults to
-                          the latest version from the Dynatrace cluster.
                         type: string
                     type: object
                 type: object
               proxy:
-                description: |-
-                  Set custom proxy settings either directly or from a secret with the field proxy.
-                  Note: Applies to Dynatrace Operator, ActiveGate, and OneAgents.
                 properties:
                   value:
-                    description: Raw value for given property.
                     nullable: true
                     type: string
                   valueFrom:
-                    description: Name of the secret to get the property from.
                     nullable: true
                     type: string
                 type: object
               skipCertCheck:
-                description: |-
-                  Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.
-                  Set to true if you want to skip certification validation checks.
                 type: boolean
               telemetryIngest:
-                description: When a TelemetryIngestSpec is provided, the OTEL collector
-                  is deployed by the operator.
                 properties:
                   protocols:
                     items:
@@ -9491,64 +5201,37 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations to the ExtensionExecutionController
-                          pods
                         type: object
                       customConfig:
-                        description: Defines name of ConfigMap containing custom configuration
-                          file
                         type: string
                       customExtensionCertificates:
-                        description: Defines name of Secret containing certificates
-                          for custom extensions signature validation
                         type: string
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the ExtensionExecutionController
-                          pods
                         type: object
                       persistentVolumeClaim:
-                        description: Defines storage device
                         properties:
                           accessModes:
-                            description: |-
-                              accessModes contains the desired access modes the volume should have.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
-                            description: |-
-                              dataSource field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                              * An existing PVC (PersistentVolumeClaim)
-                              If the provisioner or an external controller can support the specified data source,
-                              it will create a new volume based on the contents of the specified data source.
                             properties:
                               apiGroup:
-                                description: |-
-                                  APIGroup is the group for the resource being referenced.
-                                  If APIGroup is not specified, the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
-                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
-                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -9556,39 +5239,20 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
-                            description: |-
-                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                              volume is desired. This may be any object from a non-empty API group (non
-                              core object) or a PersistentVolumeClaim object.
                             properties:
                               apiGroup:
-                                description: |-
-                                  APIGroup is the group for the resource being referenced.
-                                  If APIGroup is not specified, the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
-                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
-                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace is the namespace of resource being referenced
-                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
-                            description: |-
-                              resources represents the minimum resources the volume should have.
-                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                              that are lower than previous value but must still be higher than capacity recorded in the
-                              status field of the claim.
-                              More info: https://kubernetes.
                             properties:
                               limits:
                                 additionalProperties:
@@ -9597,9 +5261,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -9608,40 +5269,18 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           selector:
-                            description: selector is a label query over volumes to
-                              consider for binding.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
                                 items:
-                                  description: |-
-                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                    relates the key and values.
                                   properties:
                                     key:
-                                      description: key is the label key that the selector
-                                        applies to.
                                       type: string
                                     operator:
-                                      description: |-
-                                        operator represents a key's relationship to a set of values.
-                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: |-
-                                        values is an array of string values. If the operator is In or NotIn,
-                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                        the values array must be empty. This array is replaced during a strategic
-                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -9655,62 +5294,26 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: |-
-                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
-                            description: |-
-                              storageClassName is the name of the StorageClass required by the claim.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                             type: string
                           volumeAttributesClassName:
-                            description: |-
-                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                              If specified, the CSI driver will create or update the volume with the attributes defined
-                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created.
                             type: string
                           volumeMode:
-                            description: |-
-                              volumeMode defines what type of volume is required by the claim.
-                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
-                            description: volumeName is the binding reference to the
-                              PersistentVolume backing this claim.
                             type: string
                         type: object
                       resources:
-                        description: Define resources' requests and limits for single
-                          ExtensionExecutionController pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -9726,9 +5329,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -9737,91 +5337,39 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tlsRefName:
                         type: string
                       tolerations:
-                        description: Set tolerations for the ExtensionExecutionController
-                          pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: Adds TopologySpreadConstraints for the ExtensionExecutionController
-                          pods
                         items:
-                          description: TopologySpreadConstraint specifies how to spread
-                            matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: |-
-                                LabelSelector is used to find matching pods.
-                                Pods that match this label selector are counted to determine the number of pods
-                                in their corresponding topology domain.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -9835,69 +5383,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select the pods over which
-                                spreading will be calculated. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are ANDed with labelSelector
-                                to select the group of existing pods over which spreading will be calculated
-                                for the incoming pod.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: |-
-                                MaxSkew describes the degree to which pods may be unevenly distributed.
-                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                between the number of matching pods in the target topology and the global minimum.
                               format: int32
                               type: integer
                             minDomains:
-                              description: |-
-                                MinDomains indicates a minimum number of eligible domains.
-                                When the number of eligible domains with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: |-
-                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                when calculating pod topology spread skew. Options are:
-                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                               type: string
                             nodeTaintsPolicy:
-                              description: |-
-                                NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                pod topology spread skew. Options are:
-                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                has a toleration, are included.
-                                - Ignore: node taints are ignored. All nodes are included.
                               type: string
                             topologyKey:
-                              description: |-
-                                TopologyKey is the key of node labels. Nodes that have a label with this key
-                                and identical values are considered to be in the same topology.
-                                We consider each <key, value> as a "bucket", and try to put balanced number
-                                of pods into each bucket.
-                                We define a domain as a particular instance of a topology.
                               type: string
                             whenUnsatisfiable:
-                              description: |-
-                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                  but giving higher precedence to topologies that would help reduce the
-                                  skew.
                               type: string
                           required:
                           - maxSkew
@@ -9906,7 +5412,6 @@ spec:
                           type: object
                         type: array
                       useEphemeralVolume:
-                        description: Selects EmptyDir volume to be storage device
                         type: boolean
                     type: object
                   kspmNodeConfigurationCollector:
@@ -9914,122 +5419,67 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations for the NodeConfigurationCollector
-                          pods
                         type: object
                       args:
-                        description: Set additional arguments to the NodeConfigurationCollector
-                          pods
                         items:
                           type: string
                         type: array
                       env:
-                        description: Set additional environment variables for the
-                          NodeConfigurationCollector pods
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -10041,65 +5491,32 @@ spec:
                           type: object
                         type: array
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the NodeConfigurationCollector
-                          pods
                         type: object
                       nodeAffinity:
-                        description: Define the nodeAffinity for the DaemonSet of
-                          the NodeConfigurationCollector
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
                             items:
-                              description: |-
-                                An empty preferred scheduling term matches all objects with implicit weight 0
-                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -10111,29 +5528,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -10147,8 +5548,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -10158,46 +5557,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
                                 items:
-                                  description: |-
-                                    A null or empty node selector term matches no objects. The requirements of
-                                    them are ANDed.
-                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -10209,29 +5580,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -10254,41 +5609,17 @@ spec:
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Specify the node selector that controls on which
-                          nodes NodeConfigurationCollector pods will be deployed.
                         type: object
                       priorityClassName:
-                        description: |-
-                          If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
-                          name. If not specified the setting will be removed from the DaemonSet.
                         type: string
                       resources:
-                        description: Define resources' requests and limits for single
-                          NodeConfigurationCollector pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -10304,9 +5635,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -10315,163 +5643,81 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tolerations:
-                        description: Set tolerations for the NodeConfigurationCollector
-                          pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       updateStrategy:
-                        description: Define the NodeConfigurationCollector daemonSet
-                          updateStrategy
                         properties:
                           rollingUpdate:
-                            description: Rolling update config params. Present only
-                              if type = "RollingUpdate".
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of nodes with an existing available DaemonSet pod that
-                                  can have an updated DaemonSet pod during during an update.
-                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                                  This can not be 0 if MaxUnavailable is 0.
-                                  Absolute number is calculated from percentage by rounding up to a minimum of 1.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of DaemonSet pods that can be unavailable during the
-                                  update. Value can be an absolute number (ex: 5) or a percentage of total
-                                  number of DaemonSet pods at the start of the update (ex: 10%). Absolute
-                                  number is calculated from percentage by rounding up.
-                                  This cannot be 0 if MaxSurge is 0
-                                  Default value is 1.
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
-                            description: Type of daemon set update. Can be "RollingUpdate"
-                              or "OnDelete". Default is RollingUpdate.
                             type: string
                         type: object
                     type: object
                   logMonitoring:
-                    description: Low-level configuration options for the LogMonitoring
-                      feature.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Add custom annotations to the LogMonitoring pods
                         type: object
                       args:
-                        description: Set additional arguments to the LogMonitoring
-                          main container
                         items:
                           type: string
                         type: array
                       dnsPolicy:
-                        description: Sets DNS Policy for the LogMonitoring pods
                         type: string
                       imageRef:
-                        description: Overrides the default image for the LogMonitoring
-                          pods
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Add custom labels to the LogMonitoring pods
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: Node selector to control the selection of nodes
-                          for the LogMonitoring pods
                         type: object
                       priorityClassName:
-                        description: Assign a priority class to the LogMonitoring
-                          pods. By default, no class is set
                         type: string
                       resources:
-                        description: Define resources' requests and limits for all
-                          the LogMonitoring pods
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -10487,9 +5733,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -10498,54 +5741,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       secCompProfile:
-                        description: The SecComp Profile that will be configured in
-                          order to run in secure computing mode for the LogMonitoring
-                          pods
                         type: string
                       tolerations:
-                        description: Set tolerations for the LogMonitoring pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -10555,57 +5767,30 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Adds additional annotations to the OtelCollector
-                          pods
                         type: object
                       imageRef:
-                        description: Overrides the default image
                         properties:
                           repository:
-                            description: Custom image repository
                             example: docker.io/dynatrace/image-name
                             type: string
                           tag:
-                            description: Indicates a tag of the image to use
                             type: string
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Adds additional labels for the OtelCollector
-                          pods
                         type: object
                       replicas:
-                        description: Number of replicas for your OtelCollector
                         format: int32
                         type: integer
                       resources:
-                        description: Define resources' requests and limits for single
-                          OtelCollector pod
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                                 request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -10621,9 +5806,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -10632,90 +5814,39 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tlsRefName:
                         type: string
                       tolerations:
-                        description: Set tolerations for the OtelCollector pods
                         items:
-                          description: |-
-                            The pod this Toleration is attached to tolerates any taint that matches
-                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: |-
-                                Effect indicates the taint effect to match. Empty means match all taint effects.
-                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: |-
-                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: |-
-                                Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: |-
-                                TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: |-
-                                Value is the taint value the toleration matches to.
-                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: Adds TopologySpreadConstraints for the OtelCollector
-                          pods
                         items:
-                          description: TopologySpreadConstraint specifies how to spread
-                            matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: |-
-                                LabelSelector is used to find matching pods.
-                                Pods that match this label selector are counted to determine the number of pods
-                                in their corresponding topology domain.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -10729,69 +5860,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select the pods over which
-                                spreading will be calculated. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are ANDed with labelSelector
-                                to select the group of existing pods over which spreading will be calculated
-                                for the incoming pod.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: |-
-                                MaxSkew describes the degree to which pods may be unevenly distributed.
-                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                between the number of matching pods in the target topology and the global minimum.
                               format: int32
                               type: integer
                             minDomains:
-                              description: |-
-                                MinDomains indicates a minimum number of eligible domains.
-                                When the number of eligible domains with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: |-
-                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                when calculating pod topology spread skew. Options are:
-                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                               type: string
                             nodeTaintsPolicy:
-                              description: |-
-                                NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                pod topology spread skew. Options are:
-                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                has a toleration, are included.
-                                - Ignore: node taints are ignored. All nodes are included.
                               type: string
                             topologyKey:
-                              description: |-
-                                TopologyKey is the key of node labels. Nodes that have a label with this key
-                                and identical values are considered to be in the same topology.
-                                We consider each <key, value> as a "bucket", and try to put balanced number
-                                of pods into each bucket.
-                                We define a domain as a particular instance of a topology.
                               type: string
                             whenUnsatisfiable:
-                              description: |-
-                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                  but giving higher precedence to topologies that would help reduce the
-                                  skew.
                               type: string
                           required:
                           - maxSkew
@@ -10802,134 +5891,83 @@ spec:
                     type: object
                 type: object
               tokens:
-                description: Name of the secret holding the tokens used for connecting
-                  to Dynatrace.
                 type: string
               trustedCAs:
-                description: |-
-                  Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.
-                  Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.
                 type: string
             required:
             - apiUrl
             type: object
           status:
-            description: DynaKubeStatus defines the observed state of DynaKube
             properties:
               activeGate:
-                description: Observed state of ActiveGate
                 properties:
                   connectionInfoStatus:
-                    description: Information about Active Gate's connections
                     properties:
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   serviceIPs:
-                    description: The ClusterIPs set by Kubernetes on the ActiveGate
-                      Service created by the Operator
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               codeModules:
-                description: Observed state of Code Modules
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -10942,37 +5980,23 @@ spec:
                   type: object
                 type: array
               dynatraceApi:
-                description: Observed state of Dynatrace API
                 properties:
                   lastTokenScopeRequest:
-                    description: Time of the last token request
                     format: date-time
                     type: string
                 type: object
               kspm:
-                description: Observed state of Kspm
                 properties:
                   tokenSecretHash:
-                    description: |-
-                      TokenSecretHash contains the hash of the token that is passed to both the ActiveGate and Node-Configuration-Collector.
-                      Meant to keep the two in sync.
                     type: string
                 type: object
               kubeSystemUUID:
-                description: KubeSystemUUID contains the UUID of the current Kubernetes
-                  cluster
                 type: string
               kubernetesClusterMEID:
-                description: KubernetesClusterMEID contains the ID of the monitored
-                  entity that points to the Kubernetes cluster
                 type: string
               kubernetesClusterName:
-                description: KubernetesClusterName contains the display name (also
-                  know as label) of the monitored entity that points to the Kubernetes
-                  cluster
                 type: string
               metadataEnrichment:
-                description: Observed state of Metadata-Enrichment
                 properties:
                   rules:
                     items:
@@ -10989,87 +6013,61 @@ spec:
                     type: array
                 type: object
               oneAgent:
-                description: Observed state of OneAgent
                 properties:
                   connectionInfoStatus:
-                    description: Information about OneAgent's connections
                     properties:
                       communicationHosts:
-                        description: List of communication hosts
                         items:
                           properties:
                             host:
-                              description: Host domain
                               type: string
                             port:
-                              description: Connection port
                               format: int32
                               type: integer
                             protocol:
-                              description: Connection protocol
                               type: string
                           type: object
                         type: array
                       endpoints:
-                        description: Available connection endpoints
                         type: string
                       lastRequest:
-                        description: Time of the last connection request
                         format: date-time
                         type: string
                       tenantTokenHash:
-                        description: Hash of the tenant token
                         type: string
                       tenantUUID:
-                        description: UUID of the tenant, received from the tenant
                         type: string
                     type: object
                   healthcheck:
-                    description: Commands used for OneAgent's readiness probe
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   imageID:
-                    description: Image ID
                     type: string
                   instances:
                     additionalProperties:
                       properties:
                         ipAddress:
-                          description: IP address of the pod
                           type: string
                         podName:
-                          description: Name of the OneAgent pod
                           type: string
                       type: object
-                    description: List of deployed OneAgent instances
                     type: object
                   lastInstanceStatusUpdate:
-                    description: Time of the last instance status update
                     format: date-time
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: UpdatedTimestamp indicates when the instance was last
-                  updated
                 format: date-time
                 type: string
             type: object
@@ -11124,154 +6122,84 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: EdgeConnect is the Schema for the EdgeConnect API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: EdgeConnectSpec defines the desired state of EdgeConnect.
             properties:
               annotations:
                 additionalProperties:
                   type: string
-                description: Adds additional annotations to the EdgeConnect pods
                 type: object
               apiServer:
-                description: Location of the Dynatrace API to connect to, including
-                  your specific environment UUID
                 type: string
               autoUpdate:
                 default: true
-                description: 'Enables automatic restarts of EdgeConnect pods in case
-                  a new version is available (the default value is: true)'
                 type: boolean
               caCertsRef:
-                description: Adds custom root certificate from a configmap. Put the
-                  certificate under certs within your configmap.
                 type: string
               customPullSecret:
-                description: Pull secret for your private registry
                 type: string
               env:
-                description: Adds additional environment variables to the EdgeConnect
-                  pods
                 items:
-                  description: EnvVar represents an environment variable present in
-                    a Container.
                   properties:
                     name:
-                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
-                      description: |-
-                        Variable references $(VAR_NAME) are expanded
-                        using the previously defined environment variables in the container and
-                        any service environment variables. If a variable cannot be resolved,
-                        the reference in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                       type: string
                     valueFrom:
-                      description: Source for the environment variable's value. Cannot
-                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
                           properties:
                             key:
-                              description: The key to select.
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
-                          description: |-
-                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                           properties:
                             apiVersion:
-                              description: Version of the schema the FieldPath is
-                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
-                              description: Path of the field to select in the specified
-                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
-                          description: |-
-                            Selects a resource of the container: only resources limits and requests
-                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                           properties:
                             containerName:
-                              description: 'Container name: required for volumes,
-                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Specifies the output format of the exposed
-                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
-                              description: 'Required: resource to select'
                               type: string
                           required:
                           - resource
                           type: object
                           x-kubernetes-map-type: atomic
                         secretKeyRef:
-                          description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -11283,64 +6211,42 @@ spec:
                   type: object
                 type: array
               hostPatterns:
-                description: Host patterns to be set in the tenant, only considered
-                  when provisioning is enabled.
                 items:
                   type: string
                 type: array
               hostRestrictions:
-                description: Restrict outgoing HTTP requests to your internal resources
-                  to specified hosts
                 example: internal.example.org,*.dev.example.org
                 type: string
               imageRef:
-                description: Overrides the default image
                 properties:
                   repository:
-                    description: Custom EdgeConnect image repository
                     example: docker.io/dynatrace/edgeconnect
                     type: string
                   tag:
-                    description: Indicates version of the EdgeConnect image to use
                     type: string
                 type: object
               kubernetesAutomation:
-                description: KubernetesAutomation enables Kubernetes Automation for
-                  Workflows
                 properties:
                   enabled:
-                    description: Enables Kubernetes Automation for Workflows
                     type: boolean
                 type: object
               labels:
                 additionalProperties:
                   type: string
-                description: Adds additional labels to the EdgeConnect pods
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: Node selector to control the selection of nodes for the
-                  EdgeConnect pods
                 type: object
               oauth:
-                description: EdgeConnect uses the OAuth client to authenticate itself
-                  with the Dynatrace platform.
                 properties:
                   clientSecret:
-                    description: Name of the secret that holds oauth clientId/secret
                     type: string
                   endpoint:
-                    description: Token endpoint URL of Dynatrace SSO
                     type: string
                   provisioner:
-                    description: Determines if the operator will create the EdgeConnect
-                      and light OAuth client on the cluster using the credentials
-                      provided. Requires more scopes than default behavior.
                     type: boolean
                   resource:
-                    description: URN identifying your account. You get the URN when
-                      creating the OAuth client
                     type: string
                 required:
                 - clientSecret
@@ -11348,59 +6254,29 @@ spec:
                 - resource
                 type: object
               proxy:
-                description: General configurations for proxy settings.
                 properties:
                   authRef:
-                    description: |-
-                      Secret name which contains the username and password used for authentication with the proxy, using the
-                      "Basic" HTTP authentication scheme.
                     type: string
                   host:
-                    description: Server address (hostname or IP address) of the proxy.
                     type: string
                   noProxy:
-                    description: |-
-                      NoProxy represents the NO_PROXY or no_proxy environment
-                      variable. It specifies a string that contains comma-separated values
-                      specifying hosts that should be excluded from proxying.
                     type: string
                   port:
-                    description: Port of the proxy.
                     format: int32
                     type: integer
                 type: object
               replicas:
                 default: 1
-                description: 'Amount of replicas for your EdgeConnect (the default
-                  value is: 1)'
                 format: int32
                 type: integer
               resources:
-                description: Defines resources requests and limits for single pods
                 properties:
                   claims:
-                    description: |-
-                      Claims lists the names of resources, defined in spec.resourceClaims,
-                      that are used by this container.
-
-                      This is an alpha field and requires enabling the
-                      DynamicResourceAllocation feature gate.
-
-                      This field is immutable. It can only be set for containers.
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: |-
-                            Name must match the name of one entry in pod.spec.resourceClaims of
-                            the Pod where this field is used. It makes that resource available
-                            inside a container.
                           type: string
                         request:
-                          description: |-
-                            Request is the name chosen for a request in the referenced claim.
-                            If empty, everything from the claim is made available, otherwise
-                            only the result of this request.
                           type: string
                       required:
                       - name
@@ -11416,9 +6292,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Limits describes the maximum amount of compute resources allowed.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                   requests:
                     additionalProperties:
@@ -11427,93 +6300,40 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Requests describes the minimum amount of compute resources required.
-                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
               serviceAccountName:
                 default: dynatrace-edgeconnect
-                description: ServiceAccountName that allows EdgeConnect to access
-                  the Kubernetes API
                 type: string
               tolerations:
-                description: Sets tolerations for the EdgeConnect pods
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               topologySpreadConstraints:
-                description: Sets topology spread constraints for the EdgeConnect
-                  pods
                 items:
-                  description: TopologySpreadConstraint specifies how to spread matching
-                    pods among the given topology.
                   properties:
                     labelSelector:
-                      description: |-
-                        LabelSelector is used to find matching pods.
-                        Pods that match this label selector are counted to determine the number of pods
-                        in their corresponding topology domain.
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
                           items:
-                            description: |-
-                              A label selector requirement is a selector that contains values, a key, and an operator that
-                              relates the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
                                 type: string
                               operator:
-                                description: |-
-                                  operator represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: |-
-                                  values is an array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. This array is replaced during a strategic
-                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -11527,69 +6347,27 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: |-
-                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
-                      description: |-
-                        MatchLabelKeys is a set of pod label keys to select the pods over which
-                        spreading will be calculated. The keys are used to lookup values from the
-                        incoming pod labels, those key-value labels are ANDed with labelSelector
-                        to select the group of existing pods over which spreading will be calculated
-                        for the incoming pod.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
-                      description: |-
-                        MaxSkew describes the degree to which pods may be unevenly distributed.
-                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                        between the number of matching pods in the target topology and the global minimum.
                       format: int32
                       type: integer
                     minDomains:
-                      description: |-
-                        MinDomains indicates a minimum number of eligible domains.
-                        When the number of eligible domains with matching topology keys is less than minDomains,
-                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
-                      description: |-
-                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                        when calculating pod topology spread skew. Options are:
-                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                       type: string
                     nodeTaintsPolicy:
-                      description: |-
-                        NodeTaintsPolicy indicates how we will treat node taints when calculating
-                        pod topology spread skew. Options are:
-                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                        has a toleration, are included.
-                        - Ignore: node taints are ignored. All nodes are included.
                       type: string
                     topologyKey:
-                      description: |-
-                        TopologyKey is the key of node labels. Nodes that have a label with this key
-                        and identical values are considered to be in the same topology.
-                        We consider each <key, value> as a "bucket", and try to put balanced number
-                        of pods into each bucket.
-                        We define a domain as a particular instance of a topology.
                       type: string
                     whenUnsatisfiable:
-                      description: |-
-                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                        the spread constraint.
-                        - DoNotSchedule (default) tells the scheduler not to schedule it.
-                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                          but giving higher precedence to topologies that would help reduce the
-                          skew.
                       type: string
                   required:
                   - maxSkew
@@ -11602,55 +6380,32 @@ spec:
             - oauth
             type: object
           status:
-            description: EdgeConnectStatus defines the observed state of EdgeConnect.
             properties:
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -11663,36 +6418,24 @@ spec:
                   type: object
                 type: array
               kubeSystemUID:
-                description: kube-system namespace uid
                 type: string
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: Indicates when the resource was last updated
                 format: date-time
                 type: string
               version:
-                description: Version used for the Edgeconnect image
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
             type: object
@@ -11714,153 +6457,83 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: EdgeConnect is the Schema for the EdgeConnect API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: EdgeConnectSpec defines the desired state of EdgeConnect.
             properties:
               annotations:
                 additionalProperties:
                   type: string
-                description: Adds additional annotations to the EdgeConnect pods
                 type: object
               apiServer:
-                description: Location of the Dynatrace API to connect to, including
-                  your specific environment UUID
                 type: string
               autoUpdate:
-                description: 'Enables automatic restarts of EdgeConnect pods in case
-                  a new version is available (the default value is: true)'
                 type: boolean
               caCertsRef:
-                description: Adds custom root certificate from a configmap. Put the
-                  certificate under certs within your configmap.
                 type: string
               customPullSecret:
-                description: Pull secret for your private registry
                 type: string
               env:
-                description: Adds additional environment variables to the EdgeConnect
-                  pods
                 items:
-                  description: EnvVar represents an environment variable present in
-                    a Container.
                   properties:
                     name:
-                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
-                      description: |-
-                        Variable references $(VAR_NAME) are expanded
-                        using the previously defined environment variables in the container and
-                        any service environment variables. If a variable cannot be resolved,
-                        the reference in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                       type: string
                     valueFrom:
-                      description: Source for the environment variable's value. Cannot
-                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
                           properties:
                             key:
-                              description: The key to select.
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
-                          description: |-
-                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                           properties:
                             apiVersion:
-                              description: Version of the schema the FieldPath is
-                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
-                              description: Path of the field to select in the specified
-                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
-                          description: |-
-                            Selects a resource of the container: only resources limits and requests
-                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                           properties:
                             containerName:
-                              description: 'Container name: required for volumes,
-                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Specifies the output format of the exposed
-                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
-                              description: 'Required: resource to select'
                               type: string
                           required:
                           - resource
                           type: object
                           x-kubernetes-map-type: atomic
                         secretKeyRef:
-                          description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -11872,66 +6545,44 @@ spec:
                   type: object
                 type: array
               hostPatterns:
-                description: Host patterns to be set in the tenant, only considered
-                  when provisioning is enabled.
                 items:
                   type: string
                 type: array
               hostRestrictions:
-                description: Restrict outgoing HTTP requests to your internal resources
-                  to specified hosts
                 example: internal.example.org,*.dev.example.org
                 items:
                   type: string
                 type: array
               imageRef:
-                description: Overrides the default image
                 properties:
                   repository:
-                    description: Custom image repository
                     example: docker.io/dynatrace/image-name
                     type: string
                   tag:
-                    description: Indicates a tag of the image to use
                     type: string
                 type: object
               kubernetesAutomation:
-                description: KubernetesAutomation enables Kubernetes Automation for
-                  Workflows
                 properties:
                   enabled:
-                    description: Enables Kubernetes Automation for Workflows
                     type: boolean
                 type: object
               labels:
                 additionalProperties:
                   type: string
-                description: Adds additional labels to the EdgeConnect pods
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: Node selector to control the selection of nodes for the
-                  EdgeConnect pods
                 type: object
               oauth:
-                description: EdgeConnect uses the OAuth client to authenticate itself
-                  with the Dynatrace platform.
                 properties:
                   clientSecret:
-                    description: Name of the secret that holds oauth clientId/secret
                     type: string
                   endpoint:
-                    description: Token endpoint URL of Dynatrace SSO
                     type: string
                   provisioner:
-                    description: Determines if the operator will create the EdgeConnect
-                      and light OAuth client on the cluster using the credentials
-                      provided. Requires more scopes than default behavior.
                     type: boolean
                   resource:
-                    description: URN identifying your account. You get the URN when
-                      creating the OAuth client
                     type: string
                 required:
                 - clientSecret
@@ -11939,58 +6590,28 @@ spec:
                 - resource
                 type: object
               proxy:
-                description: General configurations for proxy settings.
                 properties:
                   authRef:
-                    description: |-
-                      Secret name which contains the username and password used for authentication with the proxy, using the
-                      "Basic" HTTP authentication scheme.
                     type: string
                   host:
-                    description: Server address (hostname or IP address) of the proxy.
                     type: string
                   noProxy:
-                    description: |-
-                      NoProxy represents the NO_PROXY or no_proxy environment
-                      variable. It specifies a string that contains comma-separated values
-                      specifying hosts that should be excluded from proxying.
                     type: string
                   port:
-                    description: Port of the proxy.
                     format: int32
                     type: integer
                 type: object
               replicas:
-                description: 'Amount of replicas for your EdgeConnect (the default
-                  value is: 1)'
                 format: int32
                 type: integer
               resources:
-                description: Defines resources requests and limits for single pods
                 properties:
                   claims:
-                    description: |-
-                      Claims lists the names of resources, defined in spec.resourceClaims,
-                      that are used by this container.
-
-                      This is an alpha field and requires enabling the
-                      DynamicResourceAllocation feature gate.
-
-                      This field is immutable. It can only be set for containers.
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: |-
-                            Name must match the name of one entry in pod.spec.resourceClaims of
-                            the Pod where this field is used. It makes that resource available
-                            inside a container.
                           type: string
                         request:
-                          description: |-
-                            Request is the name chosen for a request in the referenced claim.
-                            If empty, everything from the claim is made available, otherwise
-                            only the result of this request.
                           type: string
                       required:
                       - name
@@ -12006,9 +6627,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Limits describes the maximum amount of compute resources allowed.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                   requests:
                     additionalProperties:
@@ -12017,92 +6635,39 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Requests describes the minimum amount of compute resources required.
-                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
               serviceAccountName:
-                description: ServiceAccountName that allows EdgeConnect to access
-                  the Kubernetes API
                 type: string
               tolerations:
-                description: Sets tolerations for the EdgeConnect pods
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               topologySpreadConstraints:
-                description: Sets topology spread constraints for the EdgeConnect
-                  pods
                 items:
-                  description: TopologySpreadConstraint specifies how to spread matching
-                    pods among the given topology.
                   properties:
                     labelSelector:
-                      description: |-
-                        LabelSelector is used to find matching pods.
-                        Pods that match this label selector are counted to determine the number of pods
-                        in their corresponding topology domain.
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
                           items:
-                            description: |-
-                              A label selector requirement is a selector that contains values, a key, and an operator that
-                              relates the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
                                 type: string
                               operator:
-                                description: |-
-                                  operator represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: |-
-                                  values is an array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. This array is replaced during a strategic
-                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -12116,69 +6681,27 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: |-
-                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
-                      description: |-
-                        MatchLabelKeys is a set of pod label keys to select the pods over which
-                        spreading will be calculated. The keys are used to lookup values from the
-                        incoming pod labels, those key-value labels are ANDed with labelSelector
-                        to select the group of existing pods over which spreading will be calculated
-                        for the incoming pod.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
-                      description: |-
-                        MaxSkew describes the degree to which pods may be unevenly distributed.
-                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                        between the number of matching pods in the target topology and the global minimum.
                       format: int32
                       type: integer
                     minDomains:
-                      description: |-
-                        MinDomains indicates a minimum number of eligible domains.
-                        When the number of eligible domains with matching topology keys is less than minDomains,
-                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
-                      description: |-
-                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                        when calculating pod topology spread skew. Options are:
-                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
                       type: string
                     nodeTaintsPolicy:
-                      description: |-
-                        NodeTaintsPolicy indicates how we will treat node taints when calculating
-                        pod topology spread skew. Options are:
-                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                        has a toleration, are included.
-                        - Ignore: node taints are ignored. All nodes are included.
                       type: string
                     topologyKey:
-                      description: |-
-                        TopologyKey is the key of node labels. Nodes that have a label with this key
-                        and identical values are considered to be in the same topology.
-                        We consider each <key, value> as a "bucket", and try to put balanced number
-                        of pods into each bucket.
-                        We define a domain as a particular instance of a topology.
                       type: string
                     whenUnsatisfiable:
-                      description: |-
-                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                        the spread constraint.
-                        - DoNotSchedule (default) tells the scheduler not to schedule it.
-                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                          but giving higher precedence to topologies that would help reduce the
-                          skew.
                       type: string
                   required:
                   - maxSkew
@@ -12191,55 +6714,32 @@ spec:
             - oauth
             type: object
           status:
-            description: EdgeConnectStatus defines the observed state of EdgeConnect.
             properties:
               conditions:
-                description: Conditions includes status about the current state of
-                  the instance
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -12252,36 +6752,24 @@ spec:
                   type: object
                 type: array
               kubeSystemUID:
-                description: kube-system namespace uid
                 type: string
               phase:
-                description: Defines the current state (Running, Updating, Error,
-                  ...)
                 type: string
               updatedTimestamp:
-                description: Indicates when the resource was last updated
                 format: date-time
                 type: string
               version:
-                description: Version used for the Edgeconnect image
                 properties:
                   imageID:
-                    description: Image ID
                     type: string
                   lastProbeTimestamp:
-                    description: Indicates when the last check for a new version was
-                      performed
                     format: date-time
                     type: string
                   source:
-                    description: Source of the image (tenant-registry, public-registry,
-                      ...)
                     type: string
                   type:
-                    description: Image type
                     type: string
                   version:
-                    description: Image version
                     type: string
                 type: object
             type: object

--- a/doc/api/dynakube-api-ref.md
+++ b/doc/api/dynakube-api-ref.md
@@ -4,45 +4,45 @@
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`apiUrl`|Dynatrace apiUrl, including the /api path at the end. For SaaS, set YOUR_ENVIRONMENT_ID to your environment ID. For Managed, change the apiUrl address.<br/>For instructions on how to determine the environment ID and how to configure the apiUrl address, see Environment ID (<https://www.dynatrace.|-|string|
-|`customPullSecret`|Defines a custom pull secret in case you use a private registry when pulling images from the Dynatrace environment.<br/>To define a custom pull secret and learn about the expected behavior, see Configure customPullSecret<br/>(<https://www.dynatrace.|-|string|
-|`dynatraceApiRequestThreshold`|Configuration for thresholding Dynatrace API requests.|-|integer|
-|`enableIstio`|When enabled, and if Istio is installed on the Kubernetes environment, Dynatrace Operator will create the corresponding<br/>VirtualService and ServiceEntry objects to allow access to the Dynatrace Cluster from the OneAgent or ActiveGate.<br/>Disabled by default.|-|boolean|
-|`extensions`|When an (empty) ExtensionsSpec is provided, the extensions related components (extensions controller and extensions collector)<br/>are deployed by the operator.|-|object|
-|`kspm`|General configuration about the KSPM feature.|-|object|
-|`networkZone`|Sets a network zone for the OneAgent and ActiveGate pods.|-|string|
-|`proxy`|Set custom proxy settings either directly or from a secret with the field proxy.<br/>Note: Applies to Dynatrace Operator, ActiveGate, and OneAgents.|-|object|
-|`skipCertCheck`|Disable certificate check for the connection between Dynatrace Operator and the Dynatrace Cluster.<br/>Set to true if you want to skip certification validation checks.|-|boolean|
-|`tokens`|Name of the secret holding the tokens used for connecting to Dynatrace.|-|string|
-|`trustedCAs`|Adds custom RootCAs from a configmap. Put the certificate under certs within your configmap.<br/>Note: Applies to Dynatrace Operator, OneAgent and ActiveGate.|-|string|
+|`apiUrl`||-|string|
+|`customPullSecret`||-|string|
+|`dynatraceApiRequestThreshold`||-|integer|
+|`enableIstio`||-|boolean|
+|`extensions`||-|object|
+|`kspm`||-|object|
+|`networkZone`||-|string|
+|`proxy`||-|object|
+|`skipCertCheck`||-|boolean|
+|`tokens`||-|string|
+|`trustedCAs`||-|string|
 
 ### .spec.oneAgent
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`hostGroup`|Sets a host group for OneAgent.|-|string|
+|`hostGroup`||-|string|
 
 ### .spec.activeGate
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`annotations`|Adds additional annotations to the ActiveGate pods|-|object|
-|`capabilities`|Activegate capabilities enabled (routing, kubernetes-monitoring, metrics-ingest, dynatrace-api)|-|array|
-|`customProperties`|Add a custom properties file by providing it as a value or reference it from a secret<br/>If referenced from a secret, make sure the key is called 'customProperties'|-|object|
-|`dnsPolicy`|Sets DNS Policy for the ActiveGate pods|-|string|
-|`env`|List of environment variables to set for the ActiveGate|-|array|
-|`group`|Set activation group for ActiveGate|-|string|
-|`image`|The ActiveGate container image. Defaults to the latest ActiveGate image provided by the registry on the tenant|-|string|
-|`labels`|Adds additional labels for the ActiveGate pods|-|object|
-|`nodeSelector`|Node selector to control the selection of nodes|-|object|
-|`priorityClassName`|If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that<br/>name. If not specified the setting will be removed from the StatefulSet.|-|string|
-|`replicas`|Amount of replicas for your ActiveGates|-|integer|
-|`resources`|Define resources requests and limits for single ActiveGate pods|-|object|
-|`terminationGracePeriodSeconds`|Configures the terminationGracePeriodSeconds parameter of the ActiveGate pod. Kubernetes defaults and rules apply.|-|integer|
-|`tlsSecretName`|The name of a secret containing ActiveGate TLS cert+key and password. If not set, self-signed certificate is used.<br/>server.p12: certificate+key pair in pkcs12 format<br/>password: passphrase to read server.p12|-|string|
-|`tolerations`|Set tolerations for the ActiveGate pods|-|array|
-|`topologySpreadConstraints`|Adds TopologySpreadConstraints for the ActiveGate pods|-|array|
-|`useEphemeralVolume`|UseEphemeralVolume|-|boolean|
+|`annotations`||-|object|
+|`capabilities`||-|array|
+|`customProperties`||-|object|
+|`dnsPolicy`||-|string|
+|`env`||-|array|
+|`group`||-|string|
+|`image`||-|string|
+|`labels`||-|object|
+|`nodeSelector`||-|object|
+|`priorityClassName`||-|string|
+|`replicas`||-|integer|
+|`resources`||-|object|
+|`terminationGracePeriodSeconds`||-|integer|
+|`tlsSecretName`||-|string|
+|`tolerations`||-|array|
+|`topologySpreadConstraints`||-|array|
+|`useEphemeralVolume`||-|boolean|
 
 ### .spec.logMonitoring
 
@@ -62,219 +62,219 @@
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`enabled`|Enables MetadataEnrichment, `false` by default.|-|boolean|
-|`namespaceSelector`|The namespaces where you want Dynatrace Operator to inject enrichment.|-|object|
+|`enabled`||-|boolean|
+|`namespaceSelector`||-|object|
 
 ### .spec.oneAgent.hostMonitoring
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`annotations`|Add custom OneAgent annotations.|-|object|
-|`args`|Set additional arguments to the OneAgent installer.<br/>For available options, see Linux custom installation (<https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux>).<br/>For the list of limitations, see Limitations (<https://www.dynatrace.|-|array|
-|`autoUpdate`|Disables automatic restarts of OneAgent pods in case a new version is available (<https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto>).<br/>Enabled by default.|-|boolean|
-|`dnsPolicy`|Set the DNS Policy for OneAgent pods. For details, see Pods DNS Policy (<https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy>).|-|string|
-|`env`|Set additional environment variables for the OneAgent pods.|-|array|
-|`image`|Use a custom OneAgent image. Defaults to the latest image from the Dynatrace cluster.|-|string|
-|`labels`|Your defined labels for OneAgent pods in order to structure workloads as desired.|-|object|
-|`nodeSelector`|Specify the node selector that controls on which nodes OneAgent will be deployed.|-|object|
-|`oneAgentResources`|Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.<br/>Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.|-|object|
-|`priorityClassName`|Assign a priority class to the OneAgent pods. By default, no class is set.<br/>For details, see Pod Priority and Preemption (<https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/>).|-|string|
-|`secCompProfile`|The SecComp Profile that will be configured in order to run in secure computing mode.|-|string|
-|`storageHostPath`|StorageHostPath is the writable directory on the host filesystem where OneAgent configurations will be stored.|-|string|
-|`tolerations`|Tolerations to include with the OneAgent DaemonSet. For details, see Taints and Tolerations (<https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>).|-|array|
-|`version`|Use a specific OneAgent version. Defaults to the latest version from the Dynatrace cluster.|-|string|
+|`annotations`||-|object|
+|`args`||-|array|
+|`autoUpdate`||-|boolean|
+|`dnsPolicy`||-|string|
+|`env`||-|array|
+|`image`||-|string|
+|`labels`||-|object|
+|`nodeSelector`||-|object|
+|`oneAgentResources`||-|object|
+|`priorityClassName`||-|string|
+|`secCompProfile`||-|string|
+|`storageHostPath`||-|string|
+|`tolerations`||-|array|
+|`version`||-|string|
 
 ### .spec.templates.logMonitoring
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`annotations`|Add custom annotations to the LogMonitoring pods|-|object|
-|`args`|Set additional arguments to the LogMonitoring main container|-|array|
-|`dnsPolicy`|Sets DNS Policy for the LogMonitoring pods|-|string|
-|`labels`|Add custom labels to the LogMonitoring pods|-|object|
-|`nodeSelector`|Node selector to control the selection of nodes for the LogMonitoring pods|-|object|
-|`priorityClassName`|Assign a priority class to the LogMonitoring pods. By default, no class is set|-|string|
-|`resources`|Define resources' requests and limits for all the LogMonitoring pods|-|object|
-|`secCompProfile`|The SecComp Profile that will be configured in order to run in secure computing mode for the LogMonitoring pods|-|string|
-|`tolerations`|Set tolerations for the LogMonitoring pods|-|array|
+|`annotations`||-|object|
+|`args`||-|array|
+|`dnsPolicy`||-|string|
+|`labels`||-|object|
+|`nodeSelector`||-|object|
+|`priorityClassName`||-|string|
+|`resources`||-|object|
+|`secCompProfile`||-|string|
+|`tolerations`||-|array|
 
 ### .spec.templates.otelCollector
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`annotations`|Adds additional annotations to the OtelCollector pods|-|object|
-|`labels`|Adds additional labels for the OtelCollector pods|-|object|
-|`replicas`|Number of replicas for your OtelCollector|-|integer|
-|`resources`|Define resources' requests and limits for single OtelCollector pod|-|object|
+|`annotations`||-|object|
+|`labels`||-|object|
+|`replicas`||-|integer|
+|`resources`||-|object|
 |`tlsRefName`||-|string|
-|`tolerations`|Set tolerations for the OtelCollector pods|-|array|
-|`topologySpreadConstraints`|Adds TopologySpreadConstraints for the OtelCollector pods|-|array|
+|`tolerations`||-|array|
+|`topologySpreadConstraints`||-|array|
 
 ### .spec.oneAgent.classicFullStack
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`annotations`|Add custom OneAgent annotations.|-|object|
-|`args`|Set additional arguments to the OneAgent installer.<br/>For available options, see Linux custom installation (<https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux>).<br/>For the list of limitations, see Limitations (<https://www.dynatrace.|-|array|
-|`autoUpdate`|Disables automatic restarts of OneAgent pods in case a new version is available (<https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto>).<br/>Enabled by default.|-|boolean|
-|`dnsPolicy`|Set the DNS Policy for OneAgent pods. For details, see Pods DNS Policy (<https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy>).|-|string|
-|`env`|Set additional environment variables for the OneAgent pods.|-|array|
-|`image`|Use a custom OneAgent image. Defaults to the latest image from the Dynatrace cluster.|-|string|
-|`labels`|Your defined labels for OneAgent pods in order to structure workloads as desired.|-|object|
-|`nodeSelector`|Specify the node selector that controls on which nodes OneAgent will be deployed.|-|object|
-|`oneAgentResources`|Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.<br/>Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.|-|object|
-|`priorityClassName`|Assign a priority class to the OneAgent pods. By default, no class is set.<br/>For details, see Pod Priority and Preemption (<https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/>).|-|string|
-|`secCompProfile`|The SecComp Profile that will be configured in order to run in secure computing mode.|-|string|
-|`storageHostPath`|StorageHostPath is the writable directory on the host filesystem where OneAgent configurations will be stored.|-|string|
-|`tolerations`|Tolerations to include with the OneAgent DaemonSet. For details, see Taints and Tolerations (<https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>).|-|array|
-|`version`|Use a specific OneAgent version. Defaults to the latest version from the Dynatrace cluster.|-|string|
+|`annotations`||-|object|
+|`args`||-|array|
+|`autoUpdate`||-|boolean|
+|`dnsPolicy`||-|string|
+|`env`||-|array|
+|`image`||-|string|
+|`labels`||-|object|
+|`nodeSelector`||-|object|
+|`oneAgentResources`||-|object|
+|`priorityClassName`||-|string|
+|`secCompProfile`||-|string|
+|`storageHostPath`||-|string|
+|`tolerations`||-|array|
+|`version`||-|string|
 
 ### .spec.oneAgent.cloudNativeFullStack
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`annotations`|Add custom OneAgent annotations.|-|object|
-|`args`|Set additional arguments to the OneAgent installer.<br/>For available options, see Linux custom installation (<https://www.dynatrace.com/support/help/setup-and-configuration/dynatrace-oneagent/installation-and-operation/linux/installation/customize-oneagent-installation-on-linux>).<br/>For the list of limitations, see Limitations (<https://www.dynatrace.|-|array|
-|`autoUpdate`|Disables automatic restarts of OneAgent pods in case a new version is available (<https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring#disable-auto>).<br/>Enabled by default.|-|boolean|
-|`codeModulesImage`|Use a custom OneAgent CodeModule image to download binaries.|-|string|
-|`dnsPolicy`|Set the DNS Policy for OneAgent pods. For details, see Pods DNS Policy (<https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy>).|-|string|
-|`env`|Set additional environment variables for the OneAgent pods.|-|array|
-|`image`|Use a custom OneAgent image. Defaults to the latest image from the Dynatrace cluster.|-|string|
-|`initResources`|Define resources requests and limits for the initContainer. For details, see Managing resources for containers<br/>(<https://kubernetes.io/docs/concepts/configuration/manage-resources-containers>).|-|object|
-|`labels`|Your defined labels for OneAgent pods in order to structure workloads as desired.|-|object|
-|`namespaceSelector`|Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.<br/>For more information, see Configure monitoring for namespaces and pods (<https://www.dynatrace.|-|object|
-|`nodeSelector`|Specify the node selector that controls on which nodes OneAgent will be deployed.|-|object|
-|`oneAgentResources`|Resource settings for OneAgent container. Consumption of the OneAgent heavily depends on the workload to monitor. You can use the default settings in the CR.<br/>Note: resource.requests shows the values needed to run; resource.limits shows the maximum limits for the pod.|-|object|
-|`priorityClassName`|Assign a priority class to the OneAgent pods. By default, no class is set.<br/>For details, see Pod Priority and Preemption (<https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/>).|-|string|
-|`secCompProfile`|The SecComp Profile that will be configured in order to run in secure computing mode.|-|string|
-|`storageHostPath`|StorageHostPath is the writable directory on the host filesystem where OneAgent configurations will be stored.|-|string|
-|`tolerations`|Tolerations to include with the OneAgent DaemonSet. For details, see Taints and Tolerations (<https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>).|-|array|
-|`version`|Use a specific OneAgent version. Defaults to the latest version from the Dynatrace cluster.|-|string|
+|`annotations`||-|object|
+|`args`||-|array|
+|`autoUpdate`||-|boolean|
+|`codeModulesImage`||-|string|
+|`dnsPolicy`||-|string|
+|`env`||-|array|
+|`image`||-|string|
+|`initResources`||-|object|
+|`labels`||-|object|
+|`namespaceSelector`||-|object|
+|`nodeSelector`||-|object|
+|`oneAgentResources`||-|object|
+|`priorityClassName`||-|string|
+|`secCompProfile`||-|string|
+|`storageHostPath`||-|string|
+|`tolerations`||-|array|
+|`version`||-|string|
 
 ### .spec.oneAgent.applicationMonitoring
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`codeModulesImage`|Use a custom OneAgent CodeModule image to download binaries.|-|string|
-|`initResources`|Define resources requests and limits for the initContainer. For details, see Managing resources for containers<br/>(<https://kubernetes.io/docs/concepts/configuration/manage-resources-containers>).|-|object|
-|`namespaceSelector`|Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.<br/>For more information, see Configure monitoring for namespaces and pods (<https://www.dynatrace.|-|object|
-|`version`|Use a specific OneAgent CodeModule version. Defaults to the latest version from the Dynatrace cluster.|-|string|
+|`codeModulesImage`||-|string|
+|`initResources`||-|object|
+|`namespaceSelector`||-|object|
+|`version`||-|string|
 
 ### .spec.activeGate.persistentVolumeClaim
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`accessModes`|accessModes contains the desired access modes the volume should have.<br/>More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1|-|array|
-|`dataSource`|dataSource field can be used to specify either:<br/>* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)<br/>* An existing PVC (PersistentVolumeClaim)<br/>If the provisioner or an external controller can support the specified data source,<br/>it will create a new volume based on the contents of the specified data source.|-|object|
-|`resources`|resources represents the minimum resources the volume should have.<br/>If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements<br/>that are lower than previous value but must still be higher than capacity recorded in the<br/>status field of the claim.<br/>More info: https://kubernetes.|-|object|
-|`selector`|selector is a label query over volumes to consider for binding.|-|object|
-|`storageClassName`|storageClassName is the name of the StorageClass required by the claim.<br/>More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1|-|string|
-|`volumeAttributesClassName`|volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.<br/>If specified, the CSI driver will create or update the volume with the attributes defined<br/>in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,<br/>it can be changed after the claim is created.|-|string|
-|`volumeMode`|volumeMode defines what type of volume is required by the claim.<br/>Value of Filesystem is implied when not included in claim spec.|-|string|
-|`volumeName`|volumeName is the binding reference to the PersistentVolume backing this claim.|-|string|
+|`accessModes`||-|array|
+|`dataSource`||-|object|
+|`resources`||-|object|
+|`selector`||-|object|
+|`storageClassName`||-|string|
+|`volumeAttributesClassName`||-|string|
+|`volumeMode`||-|string|
+|`volumeName`||-|string|
 
 ### .spec.templates.logMonitoring.imageRef
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`repository`|Custom image repository|-|string|
-|`tag`|Indicates a tag of the image to use|-|string|
+|`repository`||-|string|
+|`tag`||-|string|
 
 ### .spec.templates.otelCollector.imageRef
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`repository`|Custom image repository|-|string|
-|`tag`|Indicates a tag of the image to use|-|string|
+|`repository`||-|string|
+|`tag`||-|string|
 
 ### .spec.templates.extensionExecutionController
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`annotations`|Adds additional annotations to the ExtensionExecutionController pods|-|object|
-|`customConfig`|Defines name of ConfigMap containing custom configuration file|-|string|
-|`customExtensionCertificates`|Defines name of Secret containing certificates for custom extensions signature validation|-|string|
-|`labels`|Adds additional labels for the ExtensionExecutionController pods|-|object|
-|`resources`|Define resources' requests and limits for single ExtensionExecutionController pod|-|object|
+|`annotations`||-|object|
+|`customConfig`||-|string|
+|`customExtensionCertificates`||-|string|
+|`labels`||-|object|
+|`resources`||-|object|
 |`tlsRefName`||-|string|
-|`tolerations`|Set tolerations for the ExtensionExecutionController pods|-|array|
-|`topologySpreadConstraints`|Adds TopologySpreadConstraints for the ExtensionExecutionController pods|-|array|
-|`useEphemeralVolume`|Selects EmptyDir volume to be storage device|-|boolean|
+|`tolerations`||-|array|
+|`topologySpreadConstraints`||-|array|
+|`useEphemeralVolume`||-|boolean|
 
 ### .spec.templates.kspmNodeConfigurationCollector
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`annotations`|Adds additional annotations for the NodeConfigurationCollector pods|-|object|
-|`args`|Set additional arguments to the NodeConfigurationCollector pods|-|array|
-|`env`|Set additional environment variables for the NodeConfigurationCollector pods|-|array|
-|`labels`|Adds additional labels for the NodeConfigurationCollector pods|-|object|
-|`nodeSelector`|Specify the node selector that controls on which nodes NodeConfigurationCollector pods will be deployed.|-|object|
-|`priorityClassName`|If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that<br/>name. If not specified the setting will be removed from the DaemonSet.|-|string|
-|`resources`|Define resources' requests and limits for single NodeConfigurationCollector pod|-|object|
-|`tolerations`|Set tolerations for the NodeConfigurationCollector pods|-|array|
+|`annotations`||-|object|
+|`args`||-|array|
+|`env`||-|array|
+|`labels`||-|object|
+|`nodeSelector`||-|object|
+|`priorityClassName`||-|string|
+|`resources`||-|object|
+|`tolerations`||-|array|
 
 ### .spec.activeGate.persistentVolumeClaim.dataSourceRef
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`apiGroup`|APIGroup is the group for the resource being referenced.<br/>If APIGroup is not specified, the specified Kind must be in the core API group.<br/>For any other third-party types, APIGroup is required.|-|string|
-|`kind`|Kind is the type of resource being referenced|-|string|
-|`name`|Name is the name of resource being referenced|-|string|
-|`namespace`|Namespace is the namespace of resource being referenced<br/>Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.|-|string|
+|`apiGroup`||-|string|
+|`kind`||-|string|
+|`name`||-|string|
+|`namespace`||-|string|
 
 ### .spec.templates.extensionExecutionController.imageRef
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`repository`|Custom image repository|-|string|
-|`tag`|Indicates a tag of the image to use|-|string|
+|`repository`||-|string|
+|`tag`||-|string|
 
 ### .spec.templates.kspmNodeConfigurationCollector.imageRef
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`repository`|Custom image repository|-|string|
-|`tag`|Indicates a tag of the image to use|-|string|
+|`repository`||-|string|
+|`tag`||-|string|
 
 ### .spec.templates.kspmNodeConfigurationCollector.nodeAffinity
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`preferredDuringSchedulingIgnoredDuringExecution`|The scheduler will prefer to schedule pods to nodes that satisfy<br/>the affinity expressions specified by this field, but it may choose<br/>a node that violates one or more of the expressions. The node that is<br/>most preferred is the one with the greatest sum of weights, i.e.|-|array|
-|`requiredDuringSchedulingIgnoredDuringExecution`|If the affinity requirements specified by this field are not met at<br/>scheduling time, the pod will not be scheduled onto the node.<br/>If the affinity requirements specified by this field cease to be met<br/>at some point during pod execution (e.g. due to an update), the system<br/>may or may not try to eventually evict the pod from its node.|-|object|
+|`preferredDuringSchedulingIgnoredDuringExecution`||-|array|
+|`requiredDuringSchedulingIgnoredDuringExecution`||-|object|
 
 ### .spec.templates.kspmNodeConfigurationCollector.updateStrategy
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`type`|Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.|-|string|
+|`type`||-|string|
 
 ### .spec.templates.extensionExecutionController.persistentVolumeClaim
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`accessModes`|accessModes contains the desired access modes the volume should have.<br/>More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1|-|array|
-|`dataSource`|dataSource field can be used to specify either:<br/>* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)<br/>* An existing PVC (PersistentVolumeClaim)<br/>If the provisioner or an external controller can support the specified data source,<br/>it will create a new volume based on the contents of the specified data source.|-|object|
-|`resources`|resources represents the minimum resources the volume should have.<br/>If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements<br/>that are lower than previous value but must still be higher than capacity recorded in the<br/>status field of the claim.<br/>More info: https://kubernetes.|-|object|
-|`selector`|selector is a label query over volumes to consider for binding.|-|object|
-|`storageClassName`|storageClassName is the name of the StorageClass required by the claim.<br/>More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1|-|string|
-|`volumeAttributesClassName`|volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.<br/>If specified, the CSI driver will create or update the volume with the attributes defined<br/>in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,<br/>it can be changed after the claim is created.|-|string|
-|`volumeMode`|volumeMode defines what type of volume is required by the claim.<br/>Value of Filesystem is implied when not included in claim spec.|-|string|
-|`volumeName`|volumeName is the binding reference to the PersistentVolume backing this claim.|-|string|
+|`accessModes`||-|array|
+|`dataSource`||-|object|
+|`resources`||-|object|
+|`selector`||-|object|
+|`storageClassName`||-|string|
+|`volumeAttributesClassName`||-|string|
+|`volumeMode`||-|string|
+|`volumeName`||-|string|
 
 ### .spec.templates.kspmNodeConfigurationCollector.updateStrategy.rollingUpdate
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`maxSurge`|The maximum number of nodes with an existing available DaemonSet pod that<br/>can have an updated DaemonSet pod during during an update.<br/>Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).<br/>This can not be 0 if MaxUnavailable is 0.<br/>Absolute number is calculated from percentage by rounding up to a minimum of 1.|-|integer or string|
-|`maxUnavailable`|The maximum number of DaemonSet pods that can be unavailable during the<br/>update. Value can be an absolute number (ex: 5) or a percentage of total<br/>number of DaemonSet pods at the start of the update (ex: 10%). Absolute<br/>number is calculated from percentage by rounding up.<br/>This cannot be 0 if MaxSurge is 0<br/>Default value is 1.|-|integer or string|
+|`maxSurge`||-|integer or string|
+|`maxUnavailable`||-|integer or string|
 
 ### .spec.templates.extensionExecutionController.persistentVolumeClaim.dataSourceRef
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`apiGroup`|APIGroup is the group for the resource being referenced.<br/>If APIGroup is not specified, the specified Kind must be in the core API group.<br/>For any other third-party types, APIGroup is required.|-|string|
-|`kind`|Kind is the type of resource being referenced|-|string|
-|`name`|Name is the name of resource being referenced|-|string|
-|`namespace`|Namespace is the namespace of resource being referenced<br/>Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.|-|string|
+|`apiGroup`||-|string|
+|`kind`||-|string|
+|`name`||-|string|
+|`namespace`||-|string|

--- a/doc/api/edgeconnect-api-ref.md
+++ b/doc/api/edgeconnect-api-ref.md
@@ -4,49 +4,49 @@
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`annotations`|Adds additional annotations to the EdgeConnect pods|-|object|
-|`apiServer`|Location of the Dynatrace API to connect to, including your specific environment UUID|-|string|
-|`autoUpdate`|Enables automatic restarts of EdgeConnect pods in case a new version is available (the default value is: true)|-|boolean|
-|`caCertsRef`|Adds custom root certificate from a configmap. Put the certificate under certs within your configmap.|-|string|
-|`customPullSecret`|Pull secret for your private registry|-|string|
-|`env`|Adds additional environment variables to the EdgeConnect pods|-|array|
-|`hostPatterns`|Host patterns to be set in the tenant, only considered when provisioning is enabled.|-|array|
-|`hostRestrictions`|Restrict outgoing HTTP requests to your internal resources to specified hosts|-|array|
-|`labels`|Adds additional labels to the EdgeConnect pods|-|object|
-|`nodeSelector`|Node selector to control the selection of nodes for the EdgeConnect pods|-|object|
-|`replicas`|Amount of replicas for your EdgeConnect (the default value is: 1)|-|integer|
-|`resources`|Defines resources requests and limits for single pods|-|object|
-|`serviceAccountName`|ServiceAccountName that allows EdgeConnect to access the Kubernetes API|-|string|
-|`tolerations`|Sets tolerations for the EdgeConnect pods|-|array|
-|`topologySpreadConstraints`|Sets topology spread constraints for the EdgeConnect pods|-|array|
+|`annotations`||-|object|
+|`apiServer`||-|string|
+|`autoUpdate`||-|boolean|
+|`caCertsRef`||-|string|
+|`customPullSecret`||-|string|
+|`env`||-|array|
+|`hostPatterns`||-|array|
+|`hostRestrictions`||-|array|
+|`labels`||-|object|
+|`nodeSelector`||-|object|
+|`replicas`||-|integer|
+|`resources`||-|object|
+|`serviceAccountName`||-|string|
+|`tolerations`||-|array|
+|`topologySpreadConstraints`||-|array|
 
 ### .spec.oauth
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`clientSecret`|Name of the secret that holds oauth clientId/secret|-|string|
-|`endpoint`|Token endpoint URL of Dynatrace SSO|-|string|
-|`provisioner`|Determines if the operator will create the EdgeConnect and light OAuth client on the cluster using the credentials provided. Requires more scopes than default behavior.|-|boolean|
-|`resource`|URN identifying your account. You get the URN when creating the OAuth client|-|string|
+|`clientSecret`||-|string|
+|`endpoint`||-|string|
+|`provisioner`||-|boolean|
+|`resource`||-|string|
 
 ### .spec.proxy
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`authRef`|Secret name which contains the username and password used for authentication with the proxy, using the<br/>"Basic" HTTP authentication scheme.|-|string|
-|`host`|Server address (hostname or IP address) of the proxy.|-|string|
-|`noProxy`|NoProxy represents the NO_PROXY or no_proxy environment<br/>variable. It specifies a string that contains comma-separated values<br/>specifying hosts that should be excluded from proxying.|-|string|
-|`port`|Port of the proxy.|-|integer|
+|`authRef`||-|string|
+|`host`||-|string|
+|`noProxy`||-|string|
+|`port`||-|integer|
 
 ### .spec.imageRef
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`repository`|Custom image repository|-|string|
-|`tag`|Indicates a tag of the image to use|-|string|
+|`repository`||-|string|
+|`tag`||-|string|
 
 ### .spec.kubernetesAutomation
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
-|`enabled`|Enables Kubernetes Automation for Workflows|-|boolean|
+|`enabled`||-|boolean|


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Due to changes in how we build images, we have to store the manifests digests now separately for every platform as it differs. 

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Run the release action

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->