### PR TITLE
Add built-in GKE Autopilot Allowlistsynchronizer

### DIFF
--- a/config/helm/chart/default/templates/Common/operator/allowlistsynchronizer.yaml
+++ b/config/helm/chart/default/templates/Common/operator/allowlistsynchronizer.yaml
@@ -1,0 +1,23 @@
+{{ if eq (include "dynatrace-operator.needAutopilotAllowlisting" .) "true" }}
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: auto.gke.io/v1
+kind: AllowlistSynchronizer
+metadata:
+  name: dynatrace-operator
+spec:
+  allowlistPaths:
+  - Dynatrace/csidriver/{{ .Chart.AppVersion }}/*
+  - Dynatrace/logmonitoring/{{ .Chart.AppVersion }}/*
+{{- end -}}

--- a/config/helm/chart/default/templates/_platform.tpl
+++ b/config/helm/chart/default/templates/_platform.tpl
@@ -26,6 +26,15 @@ Auto-detect the platform (if not set), according to the available APIVersions
 {{- end }}
 
 {{/*
+Auto-detect whether or not we need allowlisting for logagent and csi-driver
+*/}}
+{{- define "dynatrace-operator.needAutopilotAllowlisting" -}}
+    {{- if .Capabilities.APIVersions.Has "auto.gke.io/v1/AllowlistSynchronizer" }}
+        {{- printf "true" -}}
+    {{- end -}}
+{{- end }}
+
+{{/*
 Set install source how the Operator was installed
 */}}
 {{- define "dynatrace-operator.installSource" -}}

--- a/config/helm/chart/default/tests/Common/activegate/serviceaccount-activegate_test.yaml
+++ b/config/helm/chart/default/tests/Common/activegate/serviceaccount-activegate_test.yaml
@@ -18,4 +18,4 @@ tests:
       rbac.activeGate.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/edgeconnect/serviceaccount-edgeconnect_test.yaml
+++ b/config/helm/chart/default/tests/Common/edgeconnect/serviceaccount-edgeconnect_test.yaml
@@ -18,4 +18,4 @@ tests:
       rbac.edgeConnect.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/extensions/clusterrole-extensions-prometheus_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions/clusterrole-extensions-prometheus_test.yaml
@@ -96,4 +96,4 @@ tests:
       rbac.extensions.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/extensions/role-extensions-controller_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions/role-extensions-controller_test.yaml
@@ -48,4 +48,4 @@ tests:
       rbac.extensions.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/extensions/serviceaccount-extensions-controller_test.yaml
+++ b/config/helm/chart/default/tests/Common/extensions/serviceaccount-extensions-controller_test.yaml
@@ -33,4 +33,4 @@ tests:
       rbac.extensions.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/kspm/clusterrole-kubernetes-monitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/kspm/clusterrole-kubernetes-monitoring_test.yaml
@@ -41,4 +41,4 @@ tests:
       rbac.kspm.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/kspm/serviceaccount-node-config-collector_test.yaml
+++ b/config/helm/chart/default/tests/Common/kspm/serviceaccount-node-config-collector_test.yaml
@@ -43,4 +43,4 @@ tests:
       rbac.kspm.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/logmonitoring/clusterrole-logmonitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/logmonitoring/clusterrole-logmonitoring_test.yaml
@@ -58,4 +58,4 @@ tests:
       rbac.oneagent.create: true
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/logmonitoring/serviceaccount-logmonitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/logmonitoring/serviceaccount-logmonitoring_test.yaml
@@ -31,4 +31,4 @@ tests:
       rbac.logMonitoring.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/oneagent/clusterrole-oneagent_test.yaml
+++ b/config/helm/chart/default/tests/Common/oneagent/clusterrole-oneagent_test.yaml
@@ -47,4 +47,4 @@ tests:
       rbac.oneAgent.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent_test.yaml
+++ b/config/helm/chart/default/tests/Common/oneagent/serviceaccount-oneagent_test.yaml
@@ -42,7 +42,7 @@ tests:
       rbac.oneAgent.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0
   - it: should have automountServiceAccountToken set to TRUE, incase of log-monitoring is available
     set:
       rbac.oneAgent.create: true

--- a/config/helm/chart/default/tests/Common/opentelemetry-collector/clusterrole-telemetry-endpoints_test.yaml
+++ b/config/helm/chart/default/tests/Common/opentelemetry-collector/clusterrole-telemetry-endpoints_test.yaml
@@ -82,4 +82,4 @@ tests:
       rbac.telemetryIngest.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/opentelemetry-collector/serviceaccount-opentelemetry-collector_test.yaml
+++ b/config/helm/chart/default/tests/Common/opentelemetry-collector/serviceaccount-opentelemetry-collector_test.yaml
@@ -23,4 +23,4 @@ tests:
       rbac.telemetryIngest.create: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0

--- a/config/helm/chart/default/tests/Common/operator/allowlistsynchronizer_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/allowlistsynchronizer_test.yaml
@@ -1,0 +1,20 @@
+suite: test allowlistsynchronizer for GKE-Autopilot
+templates:
+  - Common/operator/allowlistsynchronizer.yaml
+tests:
+  - it: shouldn't exist by default
+    asserts:
+    - hasDocuments:
+        count: 0
+  - it: should exist on GKE-Autopilot
+    capabilities:
+      apiVersions:
+        - auto.gke.io/v1/AllowlistSynchronizer
+    asserts:
+      - isKind:
+          of: AllowlistSynchronizer
+      - isAPIVersion:
+          of: auto.gke.io/v1
+      - equal:
+          path: metadata.name
+          value: dynatrace-operator

--- a/config/helm/chart/default/tests/Common/webhook/poddisruptionbudget-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/poddisruptionbudget-webhook_test.yaml
@@ -19,4 +19,4 @@ tests:
       webhook.highAvailability: false
     asserts:
       - hasDocuments:
-        count: 0
+          count: 0


### PR DESCRIPTION
## Description

DAQ-1491 
Customers using GKE-Autopilot can apply exceptions to GKE-Autopilot allowing workloads with higher privileges like the standalone logagent and csi driver.  The PR adds an AllowlistSynchronizer (if supported) which automatically applies the Allowlist. 
Some assertions were also fixed along the way.

## How can this be tested?

If the helm chart is applied on a GKE Autopilot cluster >= 1.32 an AllowlistSynchronizer CR should be deployed additionally. This also allows the csi-driver and a standalone logagent to be rolled out, if enabled.