### PR TITLE
Preserver sorting of keys inside pmc properties

### DIFF
--- a/pkg/clients/dynatrace/processmoduleconfig.go
+++ b/pkg/clients/dynatrace/processmoduleconfig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sort"
 	"strconv"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/oneagent"
@@ -143,6 +144,12 @@ func (pmc ProcessModuleConfig) ToMap() ConfMap {
 	}
 
 	return sections
+}
+
+func (pmc *ProcessModuleConfig) SortPropertiesByKey() {
+	sort.Slice(pmc.Properties, func(i, j int) bool {
+		return pmc.Properties[i].Key < pmc.Properties[j].Key
+	})
 }
 
 func (pmc ProcessModuleConfig) IsEmpty() bool {

--- a/pkg/clients/dynatrace/processmoduleconfig_test.go
+++ b/pkg/clients/dynatrace/processmoduleconfig_test.go
@@ -2,6 +2,7 @@ package dynatrace
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -410,4 +411,75 @@ func TestProcessModuleConfig_AddNoProxy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessModuleConfig_SortPropertiesByKey(t *testing.T) {
+	processModuleConfig := &ProcessModuleConfig{
+		Revision: 0,
+		Properties: []ProcessModuleProperty{
+			{
+				Section: "general",
+				Key:     "baa",
+				Value:   "random",
+			},
+			{
+				Section: "general",
+				Key:     "aaa",
+				Value:   "random",
+			},
+			{
+				Section: "general",
+				Key:     "aba",
+				Value:   "random",
+			},
+			{
+				Section: "general",
+				Key:     "bbb",
+				Value:   "random",
+			},
+			{
+				Section: "general",
+				Key:     "aab",
+				Value:   "random",
+			},
+		},
+	}
+	processModuleConfig.SortPropertiesByKey()
+
+	expected := []ProcessModuleProperty{
+		{
+			Section: "general",
+			Key:     "aaa",
+			Value:   "random",
+		},
+		{
+			Section: "general",
+			Key:     "aab",
+			Value:   "random",
+		},
+		{
+			Section: "general",
+			Key:     "aba",
+			Value:   "random",
+		},
+		{
+			Section: "general",
+			Key:     "baa",
+			Value:   "random",
+		},
+		{
+			Section: "general",
+			Key:     "bbb",
+			Value:   "random",
+		},
+	}
+	assert.Equal(t, expected, processModuleConfig.Properties)
+
+	expectedByteds, err := json.Marshal(expected)
+	require.NoError(t, err)
+
+	actualBytes, err := json.Marshal(processModuleConfig.Properties)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedByteds, actualBytes)
 }

--- a/pkg/injection/namespace/bootstrapperconfig/pmc.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pmc.go
@@ -57,6 +57,8 @@ func (s *SecretGenerator) preparePMC(ctx context.Context, dk dynakube.DynaKube) 
 		pmc.AddNoProxy(dnsEntry)
 	}
 
+	pmc.SortPropertiesByKey()
+
 	marshaled, err := json.Marshal(pmc)
 	if err != nil {
 		log.Info("could not marshal process module config")


### PR DESCRIPTION
## Description

This PR resolves https://dt-rnd.atlassian.net/browse/DAQ-7199

## How can this be tested?

unit tests, or deploy DK with 

```
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: lupl-bhd-1-5-0-autopilot
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/node-image-pull: "true"
    feature.dynatrace.com/k8s-app-enabled: "true"
# Link to api reference for further information: https://docs.dynatrace.com/docs/ingest-from/setup-on-k8s/reference/dynakube-parameters
spec:
  apiUrl: https://****.dev.dynatracelabs.com/api
  networkZone: lupl-bhd-1-5-0-autopilot
  metadataEnrichment:
    enabled: true
  oneAgent:
    applicationMonitoring:
      codeModulesImage: quay.io/dynatrace/dynatrace-bootstrapper:snapshot
  activeGate:
    capabilities:
      - routing
      - kubernetes-monitoring
    resources:
      requests:
        cpu: 500m
        memory: 1.5Gi
      limits:
        cpu: 1000m
        memory: 1.5Gi
  templates:
    extensionExecutionController:
      imageRef:
        repository: hvq8020d.dev.dynatracelabs.com/linux/dynatrace-eec
        tag: latest
    logMonitoring:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-logmodule
        tag: 1.309.66.20250401-150134
      labels:
        cloud.google.com/matching-allowlist: dynatrace-logmonitoring-v1.5.0
  extensions: {}
  logMonitoring: {}
```

make sure after few mins or quicker you see: `reconciling DynaKube finished`

```
{"level":"info","ts":"2025-04-10T11:36:21.221+0200","logger":"dynakube","msg":"reconciling DynaKube finished","namespace":"dynatrace","name":"lupl-bhd-1-5-0-autopilot","result":{"Requeue":false,"RequeueAfter":1800000000000}}
```

and it's not loop forever.