### PR TITLE
Use conditions properly in bootstrapper config reconciler

### DIFF
--- a/pkg/controllers/dynakube/injection/reconciler.go
+++ b/pkg/controllers/dynakube/injection/reconciler.go
@@ -206,7 +206,7 @@ func (r *reconciler) cleanupOneAgentInjection(ctx context.Context) {
 			return
 		}
 
-		err = bootstrapperconfig.Cleanup(ctx, r.client, r.apiReader, namespaces, *r.dk)
+		err = bootstrapperconfig.Cleanup(ctx, r.client, r.apiReader, namespaces, r.dk)
 		if err != nil {
 			log.Error(err, "failed to clean-up bootstrapper code module injection init-secrets")
 		}

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/conditions.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/conditions.go
@@ -1,5 +1,5 @@
 package processmoduleconfigsecret
 
 const (
-	PMCConditionType = "ProcessModuleConfig"
+	ConditionType = "ProcessModuleConfig"
 )

--- a/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/processmoduleconfigsecret/reconciler_test.go
@@ -49,7 +49,7 @@ func TestReconcile(t *testing.T) {
 
 		checkSecretForValue(t, mockK8sClient, "\"revision\":0")
 
-		condition := meta.FindStatusCondition(*dk.Conditions(), PMCConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), ConditionType)
 		oldTransitionTime := condition.LastTransitionTime
 		require.NotNil(t, condition)
 		require.NotEmpty(t, oldTransitionTime)
@@ -63,7 +63,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 		checkSecretForValue(t, mockK8sClient, "\"revision\":0")
 
-		condition = meta.FindStatusCondition(*dk.Conditions(), PMCConditionType)
+		condition = meta.FindStatusCondition(*dk.Conditions(), ConditionType)
 		require.NotNil(t, condition)
 		require.Equal(t, condition.LastTransitionTime, oldTransitionTime)
 
@@ -74,7 +74,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 		checkSecretForValue(t, mockK8sClient, "\"revision\":1")
 
-		condition = meta.FindStatusCondition(*dk.Conditions(), PMCConditionType)
+		condition = meta.FindStatusCondition(*dk.Conditions(), ConditionType)
 		require.NotNil(t, condition)
 		require.Greater(t, condition.LastTransitionTime.Time, oldTransitionTime.Time)
 		assert.Equal(t, conditions.SecretCreatedOrUpdatedReason, condition.Reason)
@@ -83,7 +83,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("Only runs when required, and cleans up condition and pmc secret", func(t *testing.T) {
 		dk := createDynakube(oneagent.Spec{
 			ClassicFullStack: &oneagent.HostInjectSpec{}})
-		conditions.SetSecretCreated(dk.Conditions(), PMCConditionType, "this is a test")
+		conditions.SetSecretCreated(dk.Conditions(), ConditionType, "this is a test")
 
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -134,7 +134,7 @@ func TestReconcile(t *testing.T) {
 
 		require.Error(t, err)
 		require.Len(t, *dk.Conditions(), 1)
-		condition := meta.FindStatusCondition(*dk.Conditions(), PMCConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), ConditionType)
 		assert.Equal(t, conditions.KubeApiErrorReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	})
@@ -155,7 +155,7 @@ func TestReconcile(t *testing.T) {
 
 		require.Error(t, err)
 		require.Len(t, *dk.Conditions(), 1)
-		condition := meta.FindStatusCondition(*dk.Conditions(), PMCConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), ConditionType)
 		assert.Equal(t, conditions.DynatraceApiErrorReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	})

--- a/pkg/injection/namespace/bootstrapperconfig/conditions.go
+++ b/pkg/injection/namespace/bootstrapperconfig/conditions.go
@@ -1,0 +1,5 @@
+package bootstrapperconfig
+
+const (
+	ConditionType = "BootstrapperConfig"
+)

--- a/pkg/injection/namespace/bootstrapperconfig/endpoints.go
+++ b/pkg/injection/namespace/bootstrapperconfig/endpoints.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	dtingestendpoint "github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/ingestendpoint"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,10 +24,14 @@ func (s *SecretGenerator) prepareEndpoints(ctx context.Context, dk *dynakube.Dyn
 
 	if dk.MetadataEnrichmentEnabled() {
 		if _, err := endpointPropertiesBuilder.WriteString(fmt.Sprintf("%s=%s\n", dtingestendpoint.MetricsUrlSecretField, fields[dtingestendpoint.MetricsUrlSecretField])); err != nil {
+			conditions.SetSecretGenFailed(dk.Conditions(), ConditionType, err)
+
 			return "", errors.WithStack(err)
 		}
 
 		if _, err := endpointPropertiesBuilder.WriteString(fmt.Sprintf("%s=%s\n", dtingestendpoint.MetricsTokenSecretField, fields[dtingestendpoint.MetricsTokenSecretField])); err != nil {
+			conditions.SetSecretGenFailed(dk.Conditions(), ConditionType, err)
+
 			return "", errors.WithStack(err)
 		}
 	}
@@ -39,6 +44,8 @@ func (s *SecretGenerator) prepareFieldsForEndpoints(ctx context.Context, dk *dyn
 
 	tokens, err := k8ssecret.Query(s.client, s.apiReader, log).Get(ctx, client.ObjectKey{Name: dk.Tokens(), Namespace: dk.Namespace})
 	if err != nil {
+		conditions.SetKubeApiError(dk.Conditions(), ConditionType, err)
+
 		return nil, errors.WithMessage(err, "failed to query tokens")
 	}
 

--- a/pkg/injection/namespace/bootstrapperconfig/pmc.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pmc.go
@@ -4,19 +4,33 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/oneagent/pmc"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/processmoduleconfigsecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (s *SecretGenerator) preparePMC(ctx context.Context, dk dynakube.DynaKube) ([]byte, error) {
+func (s *SecretGenerator) preparePMC(ctx context.Context, dk *dynakube.DynaKube) ([]byte, error) {
+	if !conditions.IsOutdated(s.timeProvider, dk, ConditionType) {
+		source, err := getSecretFromSource(ctx, *dk, k8ssecret.Query(s.client, s.apiReader, log), dk.Namespace)
+		if err != nil && !k8serrors.IsNotFound(err) {
+			conditions.SetKubeApiError(dk.Conditions(), ConditionType, err)
+
+			return nil, err
+		} else if err == nil && source.Data[pmc.InputFileName] != nil {
+			return source.Data[pmc.InputFileName], nil
+		}
+	}
+
+	conditions.SetSecretOutdated(dk.Conditions(), ConditionType, "secret is outdated, update in progress")
+
 	pmc, err := s.dtClient.GetProcessModuleConfig(ctx, 0)
 	if err != nil {
-		conditions.SetDynatraceApiError(dk.Conditions(), processmoduleconfigsecret.PMCConditionType, err)
+		conditions.SetDynatraceApiError(dk.Conditions(), ConditionType, err)
 
 		return nil, err
 	}
@@ -26,7 +40,7 @@ func (s *SecretGenerator) preparePMC(ctx context.Context, dk dynakube.DynaKube) 
 		Namespace: dk.Namespace,
 	}, connectioninfo.TenantTokenKey, log)
 	if err != nil {
-		conditions.SetKubeApiError(dk.Conditions(), processmoduleconfigsecret.PMCConditionType, err)
+		conditions.SetKubeApiError(dk.Conditions(), ConditionType, err)
 
 		return nil, err
 	}
@@ -40,14 +54,14 @@ func (s *SecretGenerator) preparePMC(ctx context.Context, dk dynakube.DynaKube) 
 	if dk.NeedsOneAgentProxy() {
 		proxy, err := dk.Proxy(ctx, s.apiReader)
 		if err != nil {
-			conditions.SetKubeApiError(dk.Conditions(), processmoduleconfigsecret.PMCConditionType, err)
+			conditions.SetKubeApiError(dk.Conditions(), ConditionType, err)
 
 			return nil, err
 		}
 
 		pmc.AddProxy(proxy)
 
-		multiCap := capability.NewMultiCapability(&dk)
+		multiCap := capability.NewMultiCapability(dk)
 		dnsEntry := capability.BuildDNSEntryPointWithoutEnvVars(dk.Name, dk.Namespace, multiCap)
 
 		if dk.FeatureNoProxy() != "" {
@@ -59,10 +73,12 @@ func (s *SecretGenerator) preparePMC(ctx context.Context, dk dynakube.DynaKube) 
 
 	marshaled, err := json.Marshal(pmc)
 	if err != nil {
+		conditions.SetSecretGenFailed(dk.Conditions(), ConditionType, err)
+
 		log.Info("could not marshal process module config")
 
 		return nil, err
 	}
 
-	return marshaled, err
+	return marshaled, nil
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

partial fix for [DAQ-7199](https://dt-rnd.atlassian.net/browse/DAQ-7199)

Use a unique Condition for the bootstarpper config secret.
- Only ping the Dynatrace API every now and then (or if the secret is missing)


## How can this be tested?
Deploy dk with `node-image-pull: true` and see that we do not ping the Dynatrace API every reconcile.
Also should fix the "continues reconcile"


[DAQ-7199]: https://dt-rnd.atlassian.net/browse/DAQ-7199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ