### PR TITLE
Preserver sorting of keys inside pmc properties (#4744) cherry-pick

### DIFF
--- a/pkg/clients/dynatrace/processmoduleconfig.go
+++ b/pkg/clients/dynatrace/processmoduleconfig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sort"
 	"strconv"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/oneagent"
@@ -143,6 +144,12 @@ func (pmc ProcessModuleConfig) ToMap() ConfMap {
 	}
 
 	return sections
+}
+
+func (pmc *ProcessModuleConfig) SortPropertiesByKey() {
+	sort.Slice(pmc.Properties, func(i, j int) bool {
+		return pmc.Properties[i].Key < pmc.Properties[j].Key
+	})
 }
 
 func (pmc ProcessModuleConfig) IsEmpty() bool {

--- a/pkg/clients/dynatrace/processmoduleconfig_test.go
+++ b/pkg/clients/dynatrace/processmoduleconfig_test.go
@@ -2,6 +2,7 @@ package dynatrace
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -410,4 +411,75 @@ func TestProcessModuleConfig_AddNoProxy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessModuleConfig_SortPropertiesByKey(t *testing.T) {
+	processModuleConfig := &ProcessModuleConfig{
+		Revision: 0,
+		Properties: []ProcessModuleProperty{
+			{
+				Section: "general",
+				Key:     "baa",
+				Value:   "random",
+			},
+			{
+				Section: "general",
+				Key:     "aaa",
+				Value:   "random",
+			},
+			{
+				Section: "general",
+				Key:     "aba",
+				Value:   "random",
+			},
+			{
+				Section: "general",
+				Key:     "bbb",
+				Value:   "random",
+			},
+			{
+				Section: "general",
+				Key:     "aab",
+				Value:   "random",
+			},
+		},
+	}
+	processModuleConfig.SortPropertiesByKey()
+
+	expected := []ProcessModuleProperty{
+		{
+			Section: "general",
+			Key:     "aaa",
+			Value:   "random",
+		},
+		{
+			Section: "general",
+			Key:     "aab",
+			Value:   "random",
+		},
+		{
+			Section: "general",
+			Key:     "aba",
+			Value:   "random",
+		},
+		{
+			Section: "general",
+			Key:     "baa",
+			Value:   "random",
+		},
+		{
+			Section: "general",
+			Key:     "bbb",
+			Value:   "random",
+		},
+	}
+	assert.Equal(t, expected, processModuleConfig.Properties)
+
+	expectedByteds, err := json.Marshal(expected)
+	require.NoError(t, err)
+
+	actualBytes, err := json.Marshal(processModuleConfig.Properties)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedByteds, actualBytes)
 }

--- a/pkg/injection/namespace/bootstrapperconfig/pmc.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pmc.go
@@ -77,6 +77,8 @@ func (s *SecretGenerator) preparePMC(ctx context.Context, dk *dynakube.DynaKube)
 		pmc.AddNoProxy(dnsEntry)
 	}
 
+	pmc.SortPropertiesByKey()
+
 	marshaled, err := json.Marshal(pmc)
 	if err != nil {
 		conditions.SetSecretGenFailed(dk.Conditions(), ConditionType, err)


### PR DESCRIPTION

## Description

fix for [DAQ-7199](https://dt-rnd.atlassian.net/browse/DAQ-7199)

same as #4744

## How can this be tested?

same as #4744

[DAQ-7199]: https://dt-rnd.atlassian.net/browse/DAQ-7199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ