### PR TITLE
Rename Helm switch kubernetes monitoring full

### DIFF
--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring-full.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring-full.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.kubernetesMonitoringFull.create .Values.rbac.activeGate.create }}
+{{- if and .Values.preview .Values.preview.fullObjectCoverage .Values.preview.fullObjectCoverage.enabled .Values.rbac.activeGate.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring-full.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring-full.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.preview .Values.preview.fullObjectCoverage .Values.preview.fullObjectCoverage.enabled .Values.rbac.activeGate.create }}
+{{- if and ((.Values.preview).fullObjectCoverage).enabled .Values.rbac.activeGate.create }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring-full_test.yaml
+++ b/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring-full_test.yaml
@@ -6,7 +6,7 @@ tests:
     documentIndex: 0
     set:
       rbac.activeGate.create: true
-      rbac.kubernetesMonitoringFull.create.create: true
+      preview.fullObjectCoverage.enabled.create: true
 
     asserts:
       - isKind:
@@ -44,7 +44,7 @@ tests:
     set:
       platform: openshift
       rbac.activeGate.create: true
-      rbac.kubernetesMonitoringFull.create.create: true
+      preview.fullObjectCoverage.enabled.create: true
     asserts:
       - isKind:
           of: ClusterRole
@@ -67,7 +67,7 @@ tests:
               - use
   - it: shouldn't exist if activeGate is turned off
     set:
-      rbac.kubernetesMonitoringFull.create: true
+      preview.fullObjectCoverage.enabled: true
       rbac.activeGate.create: false
     asserts:
       - hasDocuments:

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -220,7 +220,4 @@ rbac:
   kspm:
     create: true
     annotations: {}
-  kubernetesMonitoringFull:
-    create: false
-    annotations: {}
   supportability: true


### PR DESCRIPTION
## Description

The Helm switch `rbac.kubernetesMonitoringFull` is renamed to `preview.fullObjectCoverage`

## How can this be tested?

* Helm unit tests
* Deploy operator with Helm and `--set preview.fullObjectCoverage.enabled=true` and check if ClusterRole(Binding) `kubernetes-monitoring-full` is created
* Deploy operator with Helm without the switch and the switch set to false and check that the ClusterRole is not created