### PR TITLE
Consider platform when creating security context for job container

### DIFF
--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -81,6 +81,7 @@ startupProbe:
       "logMonitoring": {{ .Values.rbac.logMonitoring.create }},
       "edgeConnect": {{ .Values.rbac.edgeConnect.create }},
       "supportability": {{ .Values.rbac.supportability }},
-      "kspm": {{ .Values.rbac.kspm.create }}
+      "kspm": {{ .Values.rbac.kspm.create }},
+      "isOpenShift": {{ if eq .Values.platform "openshift" }}true{{ else }}false{{ end }}
     }
 {{- end -}}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -253,7 +253,8 @@ tests:
                         "logMonitoring": true,
                         "edgeConnect": true,
                         "supportability": true,
-                        "kspm": true
+                        "kspm": true,
+                        "isOpenShift": false
                       }
                 image: image-name
                 imagePullPolicy: Always

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -96,7 +96,8 @@ tests:
                         "logMonitoring": true,
                         "edgeConnect": true,
                         "supportability": true,
-                        "kspm": true
+                        "kspm": true,
+                        "isOpenShift": false
                       }
                 ports:
                   - containerPort: 10080
@@ -283,7 +284,8 @@ tests:
                         "logMonitoring": true,
                         "edgeConnect": true,
                         "supportability": true,
-                        "kspm": true
+                        "kspm": true,
+                        "isOpenShift": true
                       }
                 ports:
                   - containerPort: 10080

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -132,7 +132,8 @@ tests:
                         "logMonitoring": true,
                         "edgeConnect": true,
                         "supportability": true,
-                        "kspm": true
+                        "kspm": true,
+                        "isOpenShift": false
                       }
                 livenessProbe:
                   httpGet:
@@ -328,7 +329,8 @@ tests:
                         "logMonitoring": true,
                         "edgeConnect": true,
                         "supportability": true,
-                        "kspm": true
+                        "kspm": true,
+                        "isOpenShift": false
                       }
                 livenessProbe:
                   httpGet:
@@ -489,7 +491,8 @@ tests:
                         "logMonitoring": true,
                         "edgeConnect": true,
                         "supportability": true,
-                        "kspm": true
+                        "kspm": true,
+                        "isOpenShift": false
                       }
                 livenessProbe:
                   httpGet:

--- a/pkg/injection/codemodule/installer/job/installer.go
+++ b/pkg/injection/codemodule/installer/job/installer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/common"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/symlink"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
 	jobutil "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/job"
 	"github.com/pkg/errors"
@@ -30,16 +31,18 @@ type Properties struct {
 
 func NewInstaller(ctx context.Context, fs afero.Fs, props *Properties) installer.Installer {
 	return &Installer{
-		fs:       fs,
-		props:    props,
-		nodeName: env.GetNodeName(),
+		fs:          fs,
+		props:       props,
+		nodeName:    env.GetNodeName(),
+		isOpenShift: installconfig.GetModules().IsOpenShift,
 	}
 }
 
 type Installer struct {
-	fs       afero.Fs
-	props    *Properties
-	nodeName string
+	fs          afero.Fs
+	props       *Properties
+	nodeName    string
+	isOpenShift bool
 }
 
 func (inst *Installer) InstallAgent(ctx context.Context, targetDir string) (bool, error) {

--- a/pkg/util/installconfig/modules.go
+++ b/pkg/util/installconfig/modules.go
@@ -48,7 +48,7 @@ type Modules struct {
 	EdgeConnect    bool `json:"edgeConnect"`
 	Supportability bool `json:"supportability"`
 	KSPM           bool `json:"kspm"`
-	IsOpenShift    bool `json:"platform"`
+	IsOpenShift    bool `json:"isOpenShift"`
 }
 
 func GetModules() Modules {

--- a/pkg/util/installconfig/modules.go
+++ b/pkg/util/installconfig/modules.go
@@ -33,6 +33,7 @@ var (
 		EdgeConnect:    true,
 		Supportability: true,
 		KSPM:           true,
+		IsOpenShift:    false,
 	}
 
 	log = logd.Get().WithName("install-config")
@@ -47,6 +48,7 @@ type Modules struct {
 	EdgeConnect    bool `json:"edgeConnect"`
 	Supportability bool `json:"supportability"`
 	KSPM           bool `json:"kspm"`
+	IsOpenShift    bool `json:"platform"`
 }
 
 func GetModules() Modules {

--- a/pkg/util/installconfig/modules_test.go
+++ b/pkg/util/installconfig/modules_test.go
@@ -36,7 +36,8 @@ func TestGet(t *testing.T) {
 			"logMonitoring": false,
 			"edgeConnect": true,
 			"supportability": false,
-			"kspm": true
+			"kspm": true,
+			"isOpenShift": false
 		}`
 		expected := Modules{
 			CSIDriver:      false,
@@ -47,6 +48,7 @@ func TestGet(t *testing.T) {
 			EdgeConnect:    true,
 			Supportability: false,
 			KSPM:           true,
+			IsOpenShift:    false,
 		}
 
 		t.Setenv(ModulesJsonEnv, jsonValue)
@@ -67,7 +69,8 @@ func TestGet(t *testing.T) {
 			"logMonitoring": false,
 			"edgeConnect": true,
 			"supportability": false,
-			"kspm": true
+			"kspm": true,
+			"isOpenShift": false
 		}`
 		expected := Modules{
 			CSIDriver:      false,
@@ -78,6 +81,7 @@ func TestGet(t *testing.T) {
 			EdgeConnect:    true,
 			Supportability: false,
 			KSPM:           true,
+			IsOpenShift:    false,
 		}
 
 		t.Setenv(ModulesJsonEnv, jsonValue)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Fixes this [bug](https://dt-rnd.atlassian.net/browse/DAQ-7252)

Currently we always create a privileged container for the job in the context of bootstrapper. This should only be the case if the platform we deploy on is openshift. To fix this I pass the platform via the helm values file to the install config ConfigMap. 

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

- Helm unittests
- deploy operator both on k8s and ocp with bootstrapper + csi enabled and check the security context of the job container. 