### PR TITLE
Run e2e tests on PRs with certain labels or comments

### DIFF
--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -41,6 +41,9 @@ inputs:
   github-token:
     description: The GitHub token
     required: true
+  test-target:
+    description: E2E test target (i.e. make test/<target>)
+    required: false
 runs:
   using: composite
   steps:
@@ -88,6 +91,7 @@ runs:
         TENANT2_NAME: ${{ inputs.tenant2-name }}
         TENANT2_APITOKEN: ${{ inputs.tenant2-apitoken }}
         TENANT2_DATAINGESTTOKEN: ${{ inputs.tenant2-dataingesttoken }}
+        TEST_TARGET: ${{ inputs.test-target }}
     - name: Destroy cluster
       shell: bash
       run: ref/.github/scripts/destroy-cluster.sh

--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -52,7 +52,7 @@ EOF
 
 popd
 
-echo "Running tests for environment '$FLC_ENVIRONMENT'..."
-make BRANCH="$TARGET_BRANCH" test/e2e-publish
+echo "Running tests (${test_target}) for environment '$FLC_ENVIRONMENT'..."
+make BRANCH="$TARGET_BRANCH" "test/${TEST_TARGET:-e2e-publish}"
 
 echo "Success!"

--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -52,7 +52,7 @@ EOF
 
 popd
 
-echo "Running tests (${test_target}) for environment '$FLC_ENVIRONMENT'..."
+echo "Running tests (${TEST_TARGET}) for environment '$FLC_ENVIRONMENT'..."
 make BRANCH="$TARGET_BRANCH" "test/${TEST_TARGET:-e2e-publish}"
 
 echo "Success!"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -63,36 +63,10 @@ jobs:
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-target: ${{ steps.get-e2e-target.outputs.target }}
-  run-in-ocp:
-    name: Run in OpenShift latest (${{ github.event.inputs.target || 'main' }})
-    environment: E2E
-    runs-on:
-      - self-hosted
-      - operator-e2e
-    if: ${{ !contains(github.event.comment.html_url, '/pull/') || github.event.inputs.e2e-test-command == '' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Run e2e test
-        uses: ./.github/actions/run-e2e
-        with:
-          flc-namespace: dto-daily
-          flc-environment: dto-ocp-latest-flc
-          target-branch: ${{ github.event.inputs.target }}
-          tenant1-name: ${{ secrets.TENANT1_NAME }}
-          tenant1-apitoken: ${{ secrets.TENANT1_APITOKEN }}
-          tenant1-dataingesttoken: ${{ secrets.TENANT1_DATAINGESTTOKEN }}
-          tenant1-oauth-client-id: ${{ secrets.TENANT1_OAUTH_CLIENT_ID }}
-          tenant1-oauth-secret: ${{ secrets.TENANT1_OAUTH_SECRET }}
-          tenant1-oauth-urn: ${{ secrets.TENANT1_OAUTH_URN }}
-          tenant2-name: ${{ secrets.TENANT2_NAME }}
-          tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
-          tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
   notify-slack:
     name: Notify test results in Slack
     environment: E2E
-    needs: [ "run-in-k8s", "run-in-ocp" ]
+    needs: [ "run-in-k8s" ]
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
@@ -103,12 +77,12 @@ jobs:
           webhook-type: webhook-trigger
           payload-templated: true
           payload: |
-            "message": "tests ${{needs.run-in-k8s.result == 'success' && 'passed :green_heavy_check_mark:' || 'failed :red_circle:'}} on kubernetes :kubernetes:\ntests ${{needs.run-in-ocp.result == 'success' && 'passed :green_heavy_check_mark:' || 'failed :red_circle:'}} on openshift :openshift:\n using ${{ github.event.inputs.target || 'main' }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            "message": "tests ${{needs.run-in-k8s.result == 'success' && 'passed :green_heavy_check_mark:' || 'failed :red_circle:'}} on kubernetes :kubernetes:\nusing ${{ github.event.inputs.target || 'main' }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
             "run_id": "${{ github.run_id }}"
   notify-github:
     name: Publish test results on GitHub
     environment: E2E
-    needs: [ "run-in-k8s", "run-in-ocp" ]
+    needs: [ "run-in-k8s" ]
     runs-on: ubuntu-latest
     if: startsWith(github.event.inputs.e2e-test-command, '/run e2e') || contains(github.event.pull_request.labels.*.name, 'e2e test')
     steps:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -16,10 +16,6 @@ on:
         description: 'Target branch to run E2E tests over'
         required: true
         default: 'main'
-      e2e-test-command:
-        description: 'Command used for launching E2E tests (runs edgeconnect tests by default)'
-        required: true
-        default: '/run e2e edgeconnect'
 
 permissions:
   checks: write
@@ -38,9 +34,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get e2e test target
         env:
-          PR_COMMENT: ${{ github.event.inputs.e2e-test-command }}
+          PR_COMMENT: ${{ github.event.comment.body }}
         id: get-e2e-target
-        if: startsWith(github.event.inputs.e2e-test-command, '/run e2e')
+        if: startsWith(github.event.comment.body, '/run e2e')
         run: |
           target=$(echo $PR_COMMENT | cut -d " " -f 3)
           if [ -n "${target}" ]; then
@@ -84,7 +80,7 @@ jobs:
     environment: E2E
     needs: [ "run-in-k8s" ]
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.event.inputs.e2e-test-command, '/run e2e') || contains(github.event.pull_request.labels.*.name, 'e2e test') }}
+    if: ${{ startsWith(github.event.comment.body, '/run e2e') || contains(github.event.pull_request.labels.*.name, 'e2e test') }}
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
@@ -92,7 +88,7 @@ jobs:
             github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: 4773,
+                issue_number: context.issue.number,
                 body: '# E2E test results\n' +
                     'See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
             })

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -84,7 +84,7 @@ jobs:
     environment: E2E
     needs: [ "run-in-k8s" ]
     runs-on: ubuntu-latest
-    if: startsWith(github.event.inputs.e2e-test-command, '/run e2e') || contains(github.event.pull_request.labels.*.name, 'e2e test')
+    if: ${{ startsWith(github.event.inputs.e2e-test-command, '/run e2e') || contains(github.event.pull_request.labels.*.name, 'e2e test') }}
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -65,7 +65,7 @@ jobs:
     runs-on:
       - self-hosted
       - operator-e2e
-    if: !contains(github.event.comment.html_url, '/pull/')
+    if: ${{ !contains(github.event.comment.html_url, '/pull/') }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -16,6 +16,10 @@ on:
         description: 'Target branch to run E2E tests over'
         required: true
         default: 'main'
+      e2e-test-command:
+        description: 'Command used for launching E2E tests (runs edgeconnect tests by default)'
+        required: true
+        default: '/run e2e edgeconnect'
 
 permissions:
   checks: write
@@ -34,9 +38,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get e2e test target
         env:
-          PR_COMMENT: ${{ github.event.comment.body }}
+          PR_COMMENT: ${{ github.event.inputs.e2e-test-command }}
         id: get-e2e-target
-        if: startsWith(github.event.comment.body, '/run e2e')
+        if: startsWith(github.event.inputs.e2e-test-command, '/run e2e')
         run: |
           target=$(echo $PR_COMMENT | cut -d " " -f 3)
           if [ -n "${target}" ]; then
@@ -65,7 +69,7 @@ jobs:
     runs-on:
       - self-hosted
       - operator-e2e
-    if: ${{ !contains(github.event.comment.html_url, '/pull/') }}
+    if: ${{ !contains(github.event.comment.html_url, '/pull/') || github.event.inputs.e2e-test-command == '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -106,7 +110,7 @@ jobs:
     environment: E2E
     needs: [ "run-in-k8s", "run-in-ocp" ]
     runs-on: ubuntu-latest
-    if: startsWith(github.event.comment.body, '/run e2e') || contains(github.event.pull_request.labels.*.name, 'e2e test')
+    if: startsWith(github.event.inputs.e2e-test-command, '/run e2e') || contains(github.event.pull_request.labels.*.name, 'e2e test')
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
@@ -114,7 +118,7 @@ jobs:
             github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: 4773,
                 body: '# E2E test results\n' +
                     'See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
             })
@@ -126,7 +130,7 @@ jobs:
                     comment_id: context.payload.comment.id,
                     content: 'hooray'
                 })
-            } else {
+            } else if (context.payload.label) {
                 github.rest.issues.removeLabel({
                     owner: context.repo.owner,
                     repo: context.repo.repo,

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -4,6 +4,12 @@ on:
   schedule:
     # every work day at 00:00 UTC
     - cron: 0 0 * * 1-5
+  pull_request:
+    types:
+      - labeled
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
     inputs:
       target:
@@ -13,6 +19,8 @@ on:
 
 permissions:
   checks: write
+  pull-requests: write
+  issues: write
 
 jobs:
   run-in-k8s:
@@ -24,12 +32,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Get e2e test target
+        env:
+          PR_COMMENT: ${{ github.event.comment.body }}
+        id: get-e2e-target
+        if: startsWith(github.event.comment.body, '/run e2e')
+        run: |
+          target=$(echo $PR_COMMENT | cut -d " " -f 3)
+          if [ -n "${target}" ]; then
+            echo "target=e2e/${target}" >> $GITHUB_OUTPUT
+          fi
       - name: Run e2e test
         uses: ./.github/actions/run-e2e
         with:
           flc-namespace: dto-daily
           flc-environment: dto-k8s-latest-flc
-          target-branch: ${{ github.event.inputs.target }}
+          target-branch: ${{ github.head_ref || github.event.inputs.target }}
           tenant1-name: ${{ secrets.TENANT1_NAME }}
           tenant1-apitoken: ${{ secrets.TENANT1_APITOKEN }}
           tenant1-dataingesttoken: ${{ secrets.TENANT1_DATAINGESTTOKEN }}
@@ -40,12 +58,14 @@ jobs:
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          test-target: ${{ steps.get-e2e-target.outputs.target }}
   run-in-ocp:
     name: Run in OpenShift latest (${{ github.event.inputs.target || 'main' }})
     environment: E2E
     runs-on:
       - self-hosted
       - operator-e2e
+    if: !contains(github.event.comment.html_url, '/pull/')
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -81,3 +101,36 @@ jobs:
           payload: |
             "message": "tests ${{needs.run-in-k8s.result == 'success' && 'passed :green_heavy_check_mark:' || 'failed :red_circle:'}} on kubernetes :kubernetes:\ntests ${{needs.run-in-ocp.result == 'success' && 'passed :green_heavy_check_mark:' || 'failed :red_circle:'}} on openshift :openshift:\n using ${{ github.event.inputs.target || 'main' }} branch (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
             "run_id": "${{ github.run_id }}"
+  notify-github:
+    name: Publish test results on GitHub
+    environment: E2E
+    needs: [ "run-in-k8s", "run-in-ocp" ]
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, '/run e2e') || contains(github.event.pull_request.labels.*.name, 'e2e test')
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          script: |
+            github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: '# E2E test results\n' +
+                    'See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })
+
+            if (context.payload.comment) {
+                github.rest.reactions.createForIssueComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: context.payload.comment.id,
+                    content: 'hooray'
+                })
+            } else {
+                github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    name: 'e2e test'
+                })
+            }


### PR DESCRIPTION
## Description
This should allow us to trigger end-to-end tests on PRs because currently, they aren't run automatically.

Addresses [DAQ-1365](https://dt-rnd.atlassian.net/browse/DAQ-1365)

## How can this be tested?
* Label this PR: `e2e test`
  * This will always run the [default make target](https://github.com/Dynatrace/dynatrace-operator/blob/df7c2e68316e25c511e64209b50605e08b29b410/.github/scripts/run-e2e-tests.sh#L56), i.e. `test/e2e-publish`
* Comment `/run e2e`, or `/run e2e <test target>`
  * `/run e2e edgeconnect` _should_ run `make test/e2e/edgeconnect`

[DAQ-1365]: https://dt-rnd.atlassian.net/browse/DAQ-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ