### PR TITLE
Remove obsolete validation warning in case of custom image is used

### DIFF
--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -26,8 +26,6 @@ Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 
 	errorVolumeStorageReadOnlyModeConflict = `The DynaKube specification specifies a read-only host file system while OneAgent has volume storage enabled.`
 
-	warningPublicImageWithWrongConfig = `You are using a custom OneAgent image without CSI driver. Only images from the tenant registry are supported."`
-
 	warningOneAgentInstallerEnvVars = `The environment variables ONEAGENT_INSTALLER_SCRIPT_URL and ONEAGENT_INSTALLER_TOKEN are only relevant for an unsupported image type. Please ensure you are using a supported image.`
 
 	warningHostGroupConflict = `The DynaKube specification sets the host group using the --set-host-group parameter. Instead, specify the new spec.oneagent.hostGroup field. If both settings are used, the new field takes precedence over the parameter.`
@@ -127,22 +125,6 @@ func mapKeysToString(m map[string]bool, sep string) string {
 	}
 
 	return strings.Join(keys, sep)
-}
-
-func publicImageSetWithoutReadOnlyMode(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
-	if dk.OneAgent().GetCustomImage() != "" {
-		if dk.OneAgent().IsReadOnlyFSSupported() {
-			return ""
-		}
-
-		if dk.OneAgent().IsClassicFullStackMode() {
-			return ""
-		}
-
-		return warningPublicImageWithWrongConfig
-	}
-
-	return ""
 }
 
 func imageFieldSetWithoutCSIFlag(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -70,7 +70,6 @@ var (
 		deprecatedFeatureFlag,
 		ignoredLogMonitoringTemplate,
 		conflictingApiUrlForExtensions,
-		publicImageSetWithoutReadOnlyMode,
 		logMonitoringWithoutK8SMonitoring,
 		kspmWithoutK8SMonitoring,
 		extensionsWithoutK8SMonitoring,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-7423)

In 1.4.0 we had the problem that if we had a DynaKube that ran a mode that supports OneAgents that are not readOnly (like for example hostMonitoring + custom image without CSI Driver) the OneAgents would error and stay in an error state because of:

```
    [2025-04-16 13:56:38.463 UTC] [00035ef2] [info   ] [bootstrapper] Started agent deployment as a container, PID 220914
    [2025-04-16 13:56:38.466 UTC] [00035ef2] [error  ] [bootstrapper] Volume storage should be mounted on /mnt/volume_storage_mount with write permissions
```

This is why this validation was added in the first place. By adding `hostPath` Volumes to the DynaKube this problem is fixed and does not need a validation anymore. Which is why I removed it in this PR.

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

Deploy the operator without CSI Driver and a DynaKube with hostMon and a custom image:

```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
spec:
  apiUrl: https://tenantuuid.dev.dynatracelabs.com/api
  oneAgent:
    hostMonitoring: 
      image: public.ecr.aws/dynatrace/dynatrace-oneagent:1.305.98.20250114-172617
```