### PR TITLE
Fix cleanup of unused agent versions.

### DIFF
--- a/pkg/controllers/csi/metadata/correctness.go
+++ b/pkg/controllers/csi/metadata/correctness.go
@@ -176,13 +176,13 @@ func GetRelevantOverlayMounts(mounter mount.Interface, baseFolder string) ([]Ove
 			for _, opt := range mountPoint.Opts {
 				switch {
 				case strings.HasPrefix(opt, "lowerdir="):
-					split := strings.Split(opt, "=")
+					split := strings.SplitN(opt, "=", 2)
 					overlayMount.LowerDir = split[1]
 				case strings.HasPrefix(opt, "upperdir="):
-					split := strings.Split(opt, "=")
+					split := strings.SplitN(opt, "=", 2)
 					overlayMount.UpperDir = split[1]
 				case strings.HasPrefix(opt, "workdir="):
-					split := strings.Split(opt, "=")
+					split := strings.SplitN(opt, "=", 2)
 					overlayMount.WorkDir = split[1]
 				}
 			}

--- a/pkg/controllers/csi/metadata/correctness_test.go
+++ b/pkg/controllers/csi/metadata/correctness_test.go
@@ -12,9 +12,9 @@ func TestGetRelevantOverlayMounts(t *testing.T) {
 	t.Run("get only relevant mounts", func(t *testing.T) {
 		baseFolder := "/test/folder"
 		expectedPath := baseFolder + "/some/sub/folder"
-		expectedLowerDir := "/test/lower"
-		expectedUpperDir := "/test/upper"
-		expectedWorkDir := "/test/work"
+		expectedLowerDir := "/data/codemodules/cXVheS5pby9keW5hdHJhY2UvZHluYXRyYWNlLWJvb3RzdHJhcHBlcjpzbmFwc2hvdA=="
+		expectedUpperDir := "/data/appmounts/csi-a3dd8a9ab6e64e92efca99a0d180da60ab807f0e31a04e11edb451311130211c/var"
+		expectedWorkDir := "/data/appmounts/csi-a3dd8a9ab6e64e92efca99a0d180da60ab807f0e31a04e11edb451311130211c/work"
 
 		relevantMountPoint := mount.MountPoint{
 			Device: "overlay",


### PR DESCRIPTION
## Description

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-7546)

Directory names contain a trailing "=", the split removed this and therefore the list of directories to be kept was wrong. Hence still used directories have been deleted.

Here's a sample of an overlay mount that is used to find directories to keep:

```
overlay on /var/lib/kubelet/pods/509b7e32-38ff-4b40-a67d-8ba8036196a0/volumes/kubernetes.io~csi/oneagent-bin/mount type overlay (rw,relatime,lowerdir=/data/codemodules/cXVheS5pby9keW5hdHJhY2UvZHluYXRyYWNlLWJvb3RzdHJhcHBlcjpzbmFwc2hvdA==,upperdir=/data/appmounts/csi-a3dd8a9ab6e64e92efca99a0d180da60ab807f0e31a04e11edb451311130211c/var,workdir=/data/appmounts/csi-a3dd8a9ab6e64e92efca99a0d180da60ab807f0e31a04e11edb451311130211c/work,uuid=on)
```

## How can this be tested?

Use the node image pull feature.
Deploy a sample app.
Deploy a sequence of Dynakubes with different code modules images with different agent versions.
After each DK scale up your sample app to use the latest agent.
Wait for CSI cleanup, it should not delete any agent versions.
Remove sample app.
Wait for CSI cleanup, it should now only keep the latest agent version.
