### PR TITLE
Fix cleanup of unused agent versions. (#4783)

### DIFF
--- a/pkg/controllers/csi/metadata/correctness.go
+++ b/pkg/controllers/csi/metadata/correctness.go
@@ -176,13 +176,13 @@ func GetRelevantOverlayMounts(mounter mount.Interface, baseFolder string) ([]Ove
 			for _, opt := range mountPoint.Opts {
 				switch {
 				case strings.HasPrefix(opt, "lowerdir="):
-					split := strings.Split(opt, "=")
+					split := strings.SplitN(opt, "=", 2)
 					overlayMount.LowerDir = split[1]
 				case strings.HasPrefix(opt, "upperdir="):
-					split := strings.Split(opt, "=")
+					split := strings.SplitN(opt, "=", 2)
 					overlayMount.UpperDir = split[1]
 				case strings.HasPrefix(opt, "workdir="):
-					split := strings.Split(opt, "=")
+					split := strings.SplitN(opt, "=", 2)
 					overlayMount.WorkDir = split[1]
 				}
 			}

--- a/pkg/controllers/csi/metadata/correctness_test.go
+++ b/pkg/controllers/csi/metadata/correctness_test.go
@@ -12,9 +12,9 @@ func TestGetRelevantOverlayMounts(t *testing.T) {
 	t.Run("get only relevant mounts", func(t *testing.T) {
 		baseFolder := "/test/folder"
 		expectedPath := baseFolder + "/some/sub/folder"
-		expectedLowerDir := "/test/lower"
-		expectedUpperDir := "/test/upper"
-		expectedWorkDir := "/test/work"
+		expectedLowerDir := "/data/codemodules/cXVheS5pby9keW5hdHJhY2UvZHluYXRyYWNlLWJvb3RzdHJhcHBlcjpzbmFwc2hvdA=="
+		expectedUpperDir := "/data/appmounts/csi-a3dd8a9ab6e64e92efca99a0d180da60ab807f0e31a04e11edb451311130211c/var"
+		expectedWorkDir := "/data/appmounts/csi-a3dd8a9ab6e64e92efca99a0d180da60ab807f0e31a04e11edb451311130211c/work"
 
 		relevantMountPoint := mount.MountPoint{
 			Device: "overlay",


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
[DAQ-7546](https://dt-rnd.atlassian.net/browse/DAQ-7546)

cherry pick of https://github.com/Dynatrace/dynatrace-operator/pull/4783

## How can this be tested?

same as https://github.com/Dynatrace/dynatrace-operator/pull/4783

[DAQ-7546]: https://dt-rnd.atlassian.net/browse/DAQ-7546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ