### PR TITLE
Setup the cert controller properly

### DIFF
--- a/cmd/operator/manager.go
+++ b/cmd/operator/manager.go
@@ -34,7 +34,6 @@ func getControllerAddFuncs(isOLM bool) []controllerSetupFunc {
 	}
 
 	return funcs
-
 }
 
 func createOperatorManager(cfg *rest.Config, namespace string, isOLM bool) (manager.Manager, error) {

--- a/cmd/operator/manager.go
+++ b/cmd/operator/manager.go
@@ -31,7 +31,7 @@ func createOperatorManager(cfg *rest.Config, namespace string, isOLM bool) (mana
 		return nil, errors.WithStack(err)
 	}
 
-	if isOLM {
+	if !isOLM {
 		err = certificates.Add(mgr, namespace)
 		if err != nil {
 			return nil, err

--- a/cmd/operator/manager.go
+++ b/cmd/operator/manager.go
@@ -20,6 +20,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
+type controllerSetupFunc func(manager.Manager, string) error
+
+func getControllerAddFuncs(isOLM bool) []controllerSetupFunc {
+	funcs := []controllerSetupFunc{
+		dynakube.Add,
+		nodes.Add,
+		edgeconnect.Add,
+	}
+
+	if !isOLM {
+		funcs = append(funcs, certificates.Add)
+	}
+
+	return funcs
+
+}
+
 func createOperatorManager(cfg *rest.Config, namespace string, isOLM bool) (manager.Manager, error) {
 	mgr, err := ctrl.NewManager(cfg, createOptions(namespace))
 	if err != nil {
@@ -31,26 +48,13 @@ func createOperatorManager(cfg *rest.Config, namespace string, isOLM bool) (mana
 		return nil, errors.WithStack(err)
 	}
 
-	if !isOLM {
-		err = certificates.Add(mgr, namespace)
+	addFuncs := getControllerAddFuncs(isOLM)
+
+	for _, add := range addFuncs {
+		err = add(mgr, namespace)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	err = dynakube.Add(mgr, namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	err = nodes.Add(mgr, namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	err = edgeconnect.Add(mgr, namespace)
-	if err != nil {
-		return nil, err
 	}
 
 	return mgr, nil

--- a/cmd/operator/manager_test.go
+++ b/cmd/operator/manager_test.go
@@ -1,0 +1,21 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetControllerAddFuncs(t *testing.T) {
+	t.Run("without OLM", func(t *testing.T) {
+		funcs := getControllerAddFuncs(false)
+
+		assert.Len(t, funcs, 4) // dk, ec, nodes, certs
+	})
+
+	t.Run("with OLM", func(t *testing.T) {
+		funcs := getControllerAddFuncs(true)
+
+		assert.Len(t, funcs, 3) // dk, ec, nodes
+	})
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

There is bug in the webhook certificate management.

We don't renew them in the default scenario.
- This is bad, because they get outdated after 7 days
We renew them in the OLM scenario.
- This is bad, because in case of OLM, the webhook expects different certs, which we break with our renewed ones.

## How can this be tested?

This only comes up in 2 cases:
- OLM deployments (here it will come up quickly)
- longer running deployments, when the generated certs gets outdated

### How to simulate each scenario
These are ways to configure the Operator deployment to let the error surface.

#### OLM
in the `values.yaml` add the olm-annotation to the Operator
```yaml
operator:
  annotations:
   olm.operatorNamespace: beep
```
__IMPORTANT__: in a correct OLM scenario, both the Webhook and Operator would have this annotation, and the Webhook would also behave differently, but setting it on the Webhook now will just fail it constantly. (as we are not actually deploying with OLM)

- this will cause the Operator to not create certs
  - so the `helm install` should fail (as we are not actually deploying via OLM that would handle the certs)
      - on 1.5 this is not that case -> baaad

#### Longer running envs

1. Deploy the Operator normally.
2. Look for the `dynatrace-webhook-certs`
3. Delete `dynatrace-webhook-certs`
4. Delete a pod of the webhook
5. See that the `dynatrace-webhook-certs` was recreated.
   - on 1.5, this doesn't happen -> baad

### According to the Logs

based on @andriisoldatenko's test:

run the following `k logs -n dynatrace deployments/dynatrace-operator | grep "Starting EventSource"`
- look for `webhook-cert-controller` and `webhook-boostrap-controller`
- Incase of OLM install, neither must be present
- Incase of default install, both must be present