### PR TITLE
bump latest release tag for upgrade E2E test 1.5.1

### DIFF
--- a/test/scenarios/release/release_test.go
+++ b/test/scenarios/release/release_test.go
@@ -20,7 +20,7 @@ var (
 	cfg     *envconf.Config
 )
 
-const releaseTag = "1.4.1"
+const releaseTag = "1.5.1"
 
 func TestMain(m *testing.M) {
 	cfg = environment.GetStandardKubeClusterEnvConfig()


### PR DESCRIPTION
We released 1.5.1 https://github.com/Dynatrace/dynatrace-operator/releases/tag/v1.5.1 so we want to enable e2e test for it.