### PR TITLE
bump release tag for e2e tests to 1.5.1

### DIFF
--- a/test/scenarios/release/release_test.go
+++ b/test/scenarios/release/release_test.go
@@ -20,7 +20,7 @@ var (
 	cfg     *envconf.Config
 )
 
-const releaseTag = "1.4.2"
+const releaseTag = "1.5.1"
 
 func TestMain(m *testing.M) {
 	cfg = environment.GetStandardKubeClusterEnvConfig()


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

We released 1.5.1 https://github.com/Dynatrace/dynatrace-operator/releases/tag/v1.5.1 so we want to enable e2e test for it. 

## How can this be tested?

run release upgrade e2e tests:

```
make test/e2e/release
```
