### PR TITLE
Always require `--stdout` support archive argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9:9.5-1745854298@s
 RUN mkdir -p /tmp/rootfs-dependency
 COPY --from=base / /tmp/rootfs-dependency
 RUN dnf install --installroot /tmp/rootfs-dependency \
-      util-linux-core tar \
+      util-linux-core \
       --releasever 9 \
       --setopt install_weak_deps=false \
       --nodocs -y \

--- a/cmd/support_archive/cmd.go
+++ b/cmd/support_archive/cmd.go
@@ -63,6 +63,15 @@ func New() *cobra.Command {
 		Use:  use,
 		Long: "Pack logs and manifests useful for troubleshooting into single tarball",
 		RunE: run(),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed(archiveToStdoutFlagName) {
+				return nil
+			}
+			return fmt.Errorf("%s %s %s\n",
+				"The only option to retrieve the support archive is by using '--stdout'.",
+				"Please provide this parameter and make sure that you pipe the command output to a file.",
+				"Otherwise, your terminal will be flooded with binary data.")
+		},
 	}
 	addFlags(cmd)
 

--- a/cmd/support_archive/cmd_test.go
+++ b/cmd/support_archive/cmd_test.go
@@ -2,6 +2,8 @@ package support_archive
 
 import (
 	"context"
+	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
@@ -40,4 +42,15 @@ func TestGetAppName(t *testing.T) {
 
 	t.Setenv(env.PodName, alternativeOperatorName)
 	assert.Equal(t, alternativeOperatorName, getAppNameLabel(context.TODO(), fakeClientSet.CoreV1().Pods(alternativeNamespace)))
+}
+
+func TestStdout(t *testing.T) {
+	cmd := New()
+	// should fail when invoked without --stdout
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	cmd.SetArgs([]string{fmt.Sprintf("--%s", archiveToStdoutFlagName)})
+	err = cmd.Execute()
+	require.NoError(t, err)
 }

--- a/fips.Dockerfile
+++ b/fips.Dockerfile
@@ -34,7 +34,7 @@ FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9:9.5-1745854298@s
 RUN mkdir -p /tmp/rootfs-dependency
 COPY --from=base / /tmp/rootfs-dependency
 RUN dnf install --installroot /tmp/rootfs-dependency \
-      util-linux-core tar \
+      util-linux-core \
       --releasever 9 \
       --setopt install_weak_deps=false \
       --nodocs -y \


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
* Require users to use `--stdout` argument when invoking the `support-archive` command
* Remove `tar` from Dockerfiles
* Addresses [DAQ-23](https://dt-rnd.atlassian.net/browse/DAQ-23)
<!--

Please include the following:
* The motivation for the change
    * Link to the Github issue or Jira ticket, if exists.
* The summary of the change

-->

## How can this be tested?
* support archive e2e tests
* `cmd.go` unit tests
* run `k -n dynatrace exec  deployment/dynatrace-operator -- dynatrace-operator support-archive`
  * should fail unless `--stdout` is passed