### PR TITLE
Use docker metadata action

### DIFF
--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -51,6 +51,10 @@ runs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: ${{ contains(inputs.platforms, ',') && 'manifest,index' || 'manifest' }}
       with:
         images: ${{ inputs.image }}
+        annotations: |
+          ${{ inputs.annotation }}
+        labels: |
+          ${{ inputs.labels }}
     - name: Build target
       id: build-target
       uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
@@ -66,9 +70,7 @@ runs:
         push: true
         tags: ${{ inputs.tags }}
         labels: |
-          ${{ inputs.labels }}
           ${{ steps.meta.outputs.labels }}
         annotations: |
-          ${{ inputs.annotation }}
           ${{ steps.meta.outputs.annotations }}
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
 
Uses the `docker-metadata` action to set the labels/annotations on both the index and manifest of the built images.


## How can this be tested?
Look for the `"version": "snapshot-ci-annotations"` annotation in the built images.

Image index scenario:
```bash
skopeo inspect --raw docker://quay.io/dynatrace/dynatrace-operator:snapshot-ci-annotations
```

Image manfiest scenario:
```bash
# using the fips image
skopeo inspect --raw docker://quay.io/dynatrace/dynatrace-operator:snapshot-ci-annotations-fips-arm64
# using a digest from the index
skopeo inspect --raw docker://quay.io/dynatrace/dynatrace-operator@sha256....
```
