### PR TITLE
Add bootstrap subcommand

### DIFF
--- a/cmd/bootstrapper/cmd.go
+++ b/cmd/bootstrapper/cmd.go
@@ -1,0 +1,127 @@
+package bootstrapper
+
+import (
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd"
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure"
+	"github.com/Dynatrace/dynatrace-operator/cmd/bootstrapper/download"
+	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
+	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/url"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	use = "bootstrap"
+
+	TargetFolderFlag   = cmd.TargetFolderFlag
+	TargetVersionFlag  = "version"
+	SuppressErrorsFlag = cmd.SuppressErrorsFlag
+	TechnologiesFlag   = "technologies"
+	FlavorFlag         = "flavor"
+)
+
+var (
+	targetFolder        string
+	targetVersion       string
+	areErrorsSuppressed bool
+	technologies        []string
+	flavor              string
+
+	log = logd.Get().WithName("bootstrap")
+)
+
+func New() *cobra.Command {
+	fs := afero.NewOsFs()
+
+	return newCmd(fs)
+}
+
+func newCmd(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                use,
+		RunE:               run(afero.Afero{Fs: fs}),
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		SilenceUsage:       true,
+	}
+
+	AddFlags(cmd)
+
+	return cmd
+}
+
+func AddFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&targetFolder, TargetFolderFlag, "", "Base path where to copy the codemodule to.")
+	_ = cmd.MarkPersistentFlagRequired(TargetFolderFlag)
+
+	cmd.PersistentFlags().StringVar(&targetVersion, TargetVersionFlag, "", "Version of the zip to be downloaded. If not set, CSI-driver mount is expected to be used.")
+
+	cmd.PersistentFlags().BoolVar(&areErrorsSuppressed, SuppressErrorsFlag, false, "(Optional) Always return exit code 0, even on error")
+
+	cmd.PersistentFlags().Lookup(SuppressErrorsFlag).NoOptDefVal = "true"
+
+	cmd.PersistentFlags().StringSliceVar(&technologies, TechnologiesFlag, []string{"all"}, "comma separated list of technologies that will be used to download the code modules image.")
+
+	cmd.PersistentFlags().StringVar(&flavor, FlavorFlag, arch.Flavor, "flavor of the code modules image.")
+
+	configure.AddFlags(cmd)
+}
+
+func run(fs afero.Afero) func(cmd *cobra.Command, _ []string) error {
+	return func(cmd *cobra.Command, _ []string) error {
+		unix.Umask(0000)
+
+		signalHandler := ctrl.SetupSignalHandler()
+
+		if targetVersion != "" {
+			inputDir, _ := cmd.Flags().GetString(configure.InputFolderFlag)
+
+			props := url.Properties{
+				Os:            dtclient.OsUnix,
+				Type:          dtclient.InstallerTypePaaS,
+				Flavor:        flavor,
+				Arch:          arch.Arch,
+				Technologies:  technologies,
+				TargetVersion: targetVersion,
+				Url:           "",
+				SkipMetadata:  false,
+				PathResolver:  metadata.PathResolver{RootDir: consts.AgentBinDirMount}, // ?
+			}
+
+			client := download.New()
+
+			err := client.Do(signalHandler, fs, inputDir, targetFolder, props)
+			if err != nil {
+				if areErrorsSuppressed {
+					log.Error(err, "error during download, the error was suppressed")
+
+					return nil
+				}
+
+				log.Error(err, "error during download")
+
+				return err
+			}
+		}
+
+		err := configure.Execute(log.Logger, fs, targetFolder)
+		if err != nil {
+			if areErrorsSuppressed {
+				log.Error(err, "error during configuration, the error was suppressed")
+
+				return nil
+			}
+
+			log.Error(err, "error during configuration")
+
+			return err
+		}
+
+		return nil
+	}
+}

--- a/cmd/bootstrapper/cmd.go
+++ b/cmd/bootstrapper/cmd.go
@@ -57,7 +57,6 @@ func newCmd(fs afero.Fs) *cobra.Command {
 
 func AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&targetFolder, TargetFolderFlag, "", "Base path where to copy the codemodule to.")
-	_ = cmd.MarkPersistentFlagRequired(TargetFolderFlag)
 
 	cmd.PersistentFlags().StringVar(&targetVersion, TargetVersionFlag, "", "Version of the zip to be downloaded. If not set, CSI-driver mount is expected to be used.")
 

--- a/cmd/bootstrapper/cmd.go
+++ b/cmd/bootstrapper/cmd.go
@@ -90,7 +90,7 @@ func run(fs afero.Afero) func(cmd *cobra.Command, _ []string) error {
 				TargetVersion: targetVersion,
 				Url:           "",
 				SkipMetadata:  false,
-				PathResolver:  metadata.PathResolver{RootDir: consts.AgentBinDirMount}, // ?
+				PathResolver:  metadata.PathResolver{RootDir: consts.AgentBinDirMount},
 			}
 
 			client := download.New()

--- a/cmd/bootstrapper/cmd_test.go
+++ b/cmd/bootstrapper/cmd_test.go
@@ -1,0 +1,170 @@
+package bootstrapper
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure"
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure/attributes/container"
+	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure/attributes/pod"
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/oneagent/preload"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBootstrapArgs(t *testing.T) {
+	t.Run("check if all required flags are set", func(t *testing.T) {
+		const (
+			targetValue                   = "test-target-directory"
+			versionValue                  = "test-version"
+			suppressErrorValue            = false
+			technologiesJava              = "java"
+			technologiesGo                = "go"
+			technologiesValue             = technologiesJava + "," + technologiesGo
+			flavorValue                   = "flavor"
+			inputDirectoryValue           = "test-input-directory"
+			configDirectoryValue          = "test-config-directory"
+			installPathValue              = "test-install-path"
+			attributeContainerNameValue   = "container-name=test-container-name"
+			attributeContainerLimitsValue = "container-limits=test-container-limits"
+			attributeNamespaceValue       = "namespace-name=test-namespace"
+			attributeWorkloadValue        = "statefulset-name=test-statefulset"
+		)
+
+		cmd := New()
+		cmd.RunE = nil
+
+		cmd.SetArgs([]string{
+			"bootstrap",
+			"--target=" + targetValue,
+			"--version=" + versionValue,
+			"--suppress-error=" + "false",
+			"--technologies=" + technologiesValue,
+			"--flavor=" + flavorValue,
+			"--input-directory=" + inputDirectoryValue,
+			"--config-directory=" + configDirectoryValue,
+			"--install-path=" + installPathValue,
+			"--attribute-container=" + attributeContainerNameValue,
+			"--attribute-container=" + attributeContainerLimitsValue,
+			"--attribute=" + attributeNamespaceValue,
+			"--attribute=" + attributeWorkloadValue,
+		})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		value, err := cmd.Flags().GetString(TargetFolderFlag)
+		require.NoError(t, err)
+		assert.Equal(t, targetValue, value)
+
+		value, err = cmd.Flags().GetString(TargetVersionFlag)
+		require.NoError(t, err)
+		assert.Equal(t, versionValue, value)
+
+		suppress, err := cmd.Flags().GetBool(SuppressErrorsFlag)
+		require.NoError(t, err)
+		assert.Equal(t, suppressErrorValue, suppress)
+
+		technologies, err = cmd.Flags().GetStringSlice(TechnologiesFlag)
+		require.NoError(t, err)
+		assert.Equal(t, technologiesJava, technologies[0])
+		assert.Equal(t, technologiesGo, technologies[1])
+
+		value, err = cmd.Flags().GetString(FlavorFlag)
+		require.NoError(t, err)
+		assert.Equal(t, flavorValue, value)
+
+		value, err = cmd.Flags().GetString(configure.InputFolderFlag)
+		require.NoError(t, err)
+		assert.Equal(t, inputDirectoryValue, value)
+
+		value, err = cmd.Flags().GetString(configure.ConfigFolderFlag)
+		require.NoError(t, err)
+		assert.Equal(t, configDirectoryValue, value)
+
+		value, err = cmd.Flags().GetString(configure.InstallPathFlag)
+		require.NoError(t, err)
+		assert.Equal(t, installPathValue, value)
+
+		attributeContainer, err := cmd.Flags().GetStringArray(container.Flag)
+		require.NoError(t, err)
+		assert.Equal(t, attributeContainerNameValue, attributeContainer[0])
+		assert.Equal(t, attributeContainerLimitsValue, attributeContainer[1])
+
+		attribute, err := cmd.Flags().GetStringArray(pod.Flag)
+		require.NoError(t, err)
+		assert.Equal(t, attributeNamespaceValue, attribute[0])
+		assert.Equal(t, attributeWorkloadValue, attribute[1])
+	})
+}
+
+func TestBootstrapConfigurationStep(t *testing.T) {
+	t.Run("check if configuration files are created", func(t *testing.T) {
+		const (
+			targetPath = "/mnt/bin"
+			configPath = "/mnt/config"
+			inputPath  = "/mnt/input"
+		)
+
+		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+		cmd := newCmd(fs)
+		cmd.SetArgs([]string{
+			"bootstrap",
+			"--config-directory=" + configPath,
+			"--input-directory=" + inputPath,
+			"--attribute-container={\"registry\":\"registry\"}",
+			"--source=/opt/dynatrace/oneagent",
+			"--target=" + targetPath,
+			"--install-path=/opt/dynatrace/oneagent-paas",
+			"--technologies=java",
+			"--attribute=k8s.cluster.name=dynakube",
+		})
+
+		createFile(t, fs, filepath.Join(inputPath, "ruxitagentproc.json"), `
+{
+  "properties": [
+    {
+      "section": "general",
+      "key": "hostGroup",
+      "value": "test-host-group"
+    }
+  ],
+  "revision": 123
+}
+`)
+
+		createFile(t, fs, filepath.Join(targetPath, "agent/conf/_ruxitagentproc.conf"), "[general]\n")
+
+		createFile(t, fs, filepath.Join(inputPath, "endpoint.properties"), `DT_METRICS_INGEST_URL=http://ingest-url
+	DT_METRICS_INGEST_API_TOKEN=apitoken`)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		exists, err := fs.Exists(filepath.Join(configPath, preload.ConfigPath))
+		require.NoError(t, err)
+		assert.True(t, exists)
+
+		exists, err = fs.Exists(filepath.Join(targetPath, "agent/conf/ruxitagentproc.conf"))
+		require.NoError(t, err)
+		assert.True(t, exists)
+
+		exists, err = fs.Exists(filepath.Join(configPath, "enrichment/endpoint/endpoint.properties"))
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+}
+
+func createFile(t *testing.T, fs afero.Fs, filePath string, content string) {
+	file, err := fs.Create(filePath)
+	require.NoError(t, err)
+
+	if content != "" {
+		_, err = file.Write([]byte(content))
+		require.NoError(t, err)
+	}
+
+	file.Close()
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"os"
 
+	"github.com/Dynatrace/dynatrace-operator/cmd/bootstrapper"
 	csiInit "github.com/Dynatrace/dynatrace-operator/cmd/csi/init"
 	"github.com/Dynatrace/dynatrace-operator/cmd/csi/livenessprobe"
 	csiProvisioner "github.com/Dynatrace/dynatrace-operator/cmd/csi/provisioner"
@@ -68,6 +69,7 @@ func main() {
 		csiServer.New(),
 		livenessprobe.New(),
 		registrar.New(),
+		bootstrapper.New(),
 	)
 
 	err := cmd.Execute()


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-7409)

## Description

Adds `bootstrap` command.

## How can this be tested?
Create a unittest which downloads an agent image.

Please use your own `<tenant url>` and `<token>`.

cmd/bootstrapper/cmd_live_test.go :
```
func TestBootstrapCmd(t *testing.T) {
	t.Run("live test", func(t *testing.T) {
		fs := afero.Afero{Fs: afero.NewMemMapFs()}

		cmd := newCmd(afero.Afero{Fs: fs})
		cmd.SetArgs([]string{
			"bootstrap",
			"--config-directory=/mnt/config",
			"--input-directory=/mnt/input",
			"--attribute-container={\"container_image.registry\":\"docker.io\"}",
			"--source=/opt/dynatrace/oneagent",
			"--target=/mnt/bin",
			"--install-path=/opt/dynatrace/oneagent-paas",
			"--technology=java",
			"--technologies=java",
			"--version=1.316.0.20250505-212724",
			"--attribute=k8s.cluster.name=dynakube",
		})

		config := download.Config{
			URL:           "https://<tenant url>/api",
			ApiToken:  <token>
		}

		dtClientConfigBytes, err := json.Marshal(config)
		require.NoError(t, err)

		err = fs.MkdirAll("/mnt/input", 0777)
		require.NoError(t, err)

		dtclientConfig, err := fs.Create("/mnt/input/" + "dtclient.config")
		require.NoError(t, err)

		_, err = dtclientConfig.Write(dtClientConfigBytes)
		require.NoError(t, err)

		err = cmd.Execute()
		require.NoError(t, err)
	})
}
```
output :
```
{"level":"info","ts":"2025-05-12T17:54:51.694+0200","logger":"oneagent-url","msg":"installing agent from url"}
{"level":"info","ts":"2025-05-12T17:54:51.694+0200","logger":"oneagent-url","msg":"installing agent","target dir":"/mnt/bin"}
{"level":"info","ts":"2025-05-12T17:54:51.695+0200","logger":"oneagent-url","msg":"downloading specific OneAgent package","version":"1.316.0.20250505-212724"}
{"level":"info","ts":"2025-05-12T17:56:42.633+0200","logger":"dtclient","msg":"downloaded agent file","os":"unix","type":"paas","flavor":"multidistro","arch":"x86","technologies":["java"],"md5":"e5fe39e44f1e41a62cf1804e1797dbfb"}
{"level":"info","ts":"2025-05-12T17:56:42.633+0200","logger":"oneagent-url","msg":"saved OneAgent package","dest":"/mnt/bin/download287553057","size":69027117}
{"level":"info","ts":"2025-05-12T17:56:42.633+0200","logger":"oneagent-url","msg":"unzipping OneAgent package"}
{"level":"info","ts":"2025-05-12T17:56:43.324+0200","logger":"oneagent-url","msg":"unzipped OneAgent package"}
...
```