### PR TITLE
Improve error logging on e2e test helm

### DIFF
--- a/test/helpers/components/operator/installation.go
+++ b/test/helpers/components/operator/installation.go
@@ -84,10 +84,12 @@ func execMakeCommand(rootDir, makeTarget string, envVariables ...string) error {
 	command := exec.Command("make", "-C", rootDir, makeTarget)
 	command.Env = os.Environ()
 	command.Env = append(command.Env, envVariables...)
-	b := new(bytes.Buffer)
+	b, bErr := new(bytes.Buffer), new(bytes.Buffer)
 	command.Stdout = b
+	command.Stderr = bErr
 	err := command.Run()
-	fmt.Println("out:", b.String()) //nolint
+	fmt.Println("out:", b.String())    //nolint
+	fmt.Println("err:", bErr.String()) //nolint
 
 	return err
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Small improvement to print std.error from make deploy during running e2e tests:

After this change:
```
err: Error: Unable to continue with install: ClusterRoleBinding "dynatrace-extensions-prometheus" in namespace "" exists and cannot be imported
into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm";
 annotation validation error: missing key "meta.helm.sh/release-name": must be set to "dynatrace-operator"; annotation validation error: missing
 key "meta.helm.sh/release-namespace": must be set to "dynatrace"
make[1]: *** [deploy] Error 1
```

Before:

```
exit 2
```


## How can this be tested?

Deploy operator using OLM or non HELM way, cleanup (manually not everything) and run e2e tests.