### PR TITLE
Add clusterrole for EC in case of OCP

### DIFF
--- a/config/helm/chart/default/templates/Common/edge-connect/clusterrole-edgeconnect.yaml
+++ b/config/helm/chart/default/templates/Common/edge-connect/clusterrole-edgeconnect.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: dynatrace-edgeconnect
-  namespace: {{ .Release.Namespace }}
   {{- if .Values.rbac.edgeConnect.annotations }}
   annotations:
     {{- toYaml .Values.rbac.edgeConnect.annotations | nindent 4 }}
@@ -12,14 +11,14 @@ metadata:
     {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
 rules:
 - apiGroups:
-  - security.openshift.io
+    - security.openshift.io
   resourceNames:
-  - nonroot
-  - nonroot-v2
+    - nonroot
+    - nonroot-v2
   resources:
-  - securitycontextconstraints
+    - securitycontextconstraints
   verbs:
-  - use
+    - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/helm/chart/default/templates/Common/edge-connect/clusterrole-edgeconnect.yaml
+++ b/config/helm/chart/default/templates/Common/edge-connect/clusterrole-edgeconnect.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.rbac.edgeConnect.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dynatrace-edgeconnect
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.rbac.edgeConnect.annotations }}
+  annotations:
+    {{- toYaml .Values.rbac.edgeConnect.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot
+  - nonroot-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dynatrace-edgeconnect
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.rbac.edgeConnect.annotations }}
+  annotations:
+    {{- toYaml .Values.rbac.edgeConnect.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dynatrace-edgeconnect
+subjects:
+- kind: ServiceAccount
+  name: dynatrace-edgeconnect
+  namespace: dynatrace
+{{ end }}

--- a/config/helm/chart/default/tests/Common/edgeconnect/clusterrole-edgeconnect_test.yaml
+++ b/config/helm/chart/default/tests/Common/edgeconnect/clusterrole-edgeconnect_test.yaml
@@ -1,0 +1,56 @@
+suite: test logmonitoring clusterrole
+templates:
+  - Common/edge-connect/clusterrole-edgeconnect.yaml
+tests:
+  - it: EdgeConnect ClusterRole should exist on OCP
+    set:
+      rbac.edgeConnect.create: true
+      platform: openshift
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: dynatrace-edgeconnect
+      - isNotEmpty:
+          path: metadata.labels
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - security.openshift.io
+            resourceNames:
+              - nonroot
+              - nonroot-v2
+            resources:
+              - securitycontextconstraints
+            verbs:
+              - use
+  - it: EdgeConnect ClusterRoleBinding should exist on OCP
+    documentIndex: 1
+    set:
+      rbac.edgeConnect.create: true
+      platform: openshift
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: dynatrace-edgeconnect
+      - isNotEmpty:
+          path: metadata.labels
+  - it: shouldn't exist if turned off
+    set:
+      rbac.edgeConnect.create: false
+      platform: openshift
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: shouldn't exist on k8s
+    set:
+      rbac.edgeConnect.create: true
+      platform: kubernetes
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/doc/e2e/features.md
+++ b/doc/e2e/features.md
@@ -465,7 +465,7 @@ func AutomationModeFeature(t *testing.T) features.Feature
 
 <a name="NormalModeFeature"></a>
 
-## func [NormalModeFeature](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/edgeconnect/edgeconnect.go#L36>)
+## func [NormalModeFeature](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/edgeconnect/edgeconnect.go#L32>)
 
 ```go
 func NormalModeFeature(t *testing.T) features.Feature
@@ -473,7 +473,7 @@ func NormalModeFeature(t *testing.T) features.Feature
 
 <a name="ProvisionerModeFeature"></a>
 
-## func [ProvisionerModeFeature](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/edgeconnect/edgeconnect.go#L73>)
+## func [ProvisionerModeFeature](<https://github.com/Dynatrace/dynatrace-operator/blob/main/test/features/edgeconnect/edgeconnect.go#L69>)
 
 ```go
 func ProvisionerModeFeature(t *testing.T) features.Feature

--- a/test/features/edgeconnect/edgeconnect.go
+++ b/test/features/edgeconnect/edgeconnect.go
@@ -106,7 +106,6 @@ func ProvisionerModeFeature(t *testing.T) features.Feature {
 	return builder.Feature()
 }
 
-
 var (
 	customServiceAccount = path.Join(project.TestDataDir(), "edgeconnect/custom-service-account.yaml")
 )

--- a/test/helpers/components/operator/installation.go
+++ b/test/helpers/components/operator/installation.go
@@ -90,7 +90,7 @@ func execMakeCommand(rootDir, makeTarget string, envVariables ...string) error {
 	err := command.Run()
 
 	if len(b.String()) != 0 {
-		fmt.Println("out:", b.String())    //nolint
+		fmt.Println("out:", b.String()) //nolint
 	}
 
 	if len(bErr.String()) != 0 {

--- a/test/helpers/components/operator/installation.go
+++ b/test/helpers/components/operator/installation.go
@@ -88,8 +88,14 @@ func execMakeCommand(rootDir, makeTarget string, envVariables ...string) error {
 	command.Stdout = b
 	command.Stderr = bErr
 	err := command.Run()
-	fmt.Println("out:", b.String())    //nolint
-	fmt.Println("err:", bErr.String()) //nolint
+
+	if len(b.String()) != 0 {
+		fmt.Println("out:", b.String())    //nolint
+	}
+
+	if len(bErr.String()) != 0 {
+		fmt.Println("err:", bErr.String()) //nolint
+	}
 
 	return err
 }

--- a/test/testdata/edgeconnect/custom-service-account.yaml
+++ b/test/testdata/edgeconnect/custom-service-account.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: custom-edgeconnect
+  namespace: dynatrace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom-edgeconnect
+rules:
+- apiGroups:
+    - security.openshift.io
+  resourceNames:
+    - nonroot
+    - nonroot-v2
+  resources:
+    - securitycontextconstraints
+  verbs:
+    - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: custom-edgeconnect
+  namespace: dynatrace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-edgeconnect
+subjects:
+- kind: ServiceAccount
+  name: custom-edgeconnect
+  namespace: dynatrace
+


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
[DAQ-8310](https://dt-rnd.atlassian.net/browse/DAQ-8310)

A ClusterRole (similar what we do for other components) for EdgeConnect is missing, that allows the default ServiceAccount of EdgeConnect to use the nonroot SCC, due to the SecurityContext using the user/group 1000 

## How can this be tested?

On CRC:
```
make test/e2e/edgeconnect
```
- ~2 out the 3 tests should pass~
   - ~the 1 that is not passing is because of the custom ServiceAccount, needs to be fixed later/separatly~
all test should pass

[DAQ-8310]: https://dt-rnd.atlassian.net/browse/DAQ-8310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ