### PR TITLE
Add `enable-ds-eviction` annotation in OneAgent DaemonSet

### DIFF
--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -151,14 +151,11 @@ func (b *builder) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 	)
 	maxUnavailable := intstr.FromInt(dk.FF().GetOneAgentMaxUnavailable())
 
-	daemonSetAnnotations := map[string]string{
-		annotationEnableDaemonSetEviction: "false",
-	}
-
 	templateAnnotations := map[string]string{
 		annotationUnprivileged:            annotationUnprivilegedValue,
 		webhook.AnnotationDynatraceInject: "false",
 		annotationTenantTokenHash:         dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash,
+		annotationEnableDaemonSetEviction: "false",
 	}
 
 	templateAnnotations = maputils.MergeMap(templateAnnotations, b.hostInjectSpec.Annotations)
@@ -168,7 +165,7 @@ func (b *builder) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 			Name:        dk.Name,
 			Namespace:   dk.Namespace,
 			Labels:      labels,
-			Annotations: daemonSetAnnotations,
+			Annotations: map[string]string{},
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -151,7 +151,7 @@ func (b *builder) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 	)
 	maxUnavailable := intstr.FromInt(dk.FF().GetOneAgentMaxUnavailable())
 
-	daemonsetAnnotations := map[string]string{
+	daemonSetAnnotations := map[string]string{
 		annotationEnableDaemonSetEviction: "false",
 	}
 
@@ -168,7 +168,7 @@ func (b *builder) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 			Name:        dk.Name,
 			Namespace:   dk.Namespace,
 			Labels:      labels,
-			Annotations: daemonsetAnnotations,
+			Annotations: daemonSetAnnotations,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -20,13 +20,10 @@ import (
 )
 
 const (
-	annotationUnprivileged     = "container.apparmor.security.beta.kubernetes.io/dynatrace-oneagent"
-	annotationTenantTokenHash  = api.InternalFlagPrefix + "tenant-token-hash"
-	annotationEnableDsEviction = "cluster-autoscaler.kubernetes.io/enable-ds-eviction"
-
-	annotationUnprivilegedValue = "unconfined"
-	annotationTrueValue         = "true"
-	annotationFalseValue        = "false"
+	annotationUnprivileged            = "container.apparmor.security.beta.kubernetes.io/dynatrace-oneagent"
+	annotationUnprivilegedValue       = "unconfined"
+	annotationTenantTokenHash         = api.InternalFlagPrefix + "tenant-token-hash"
+	annotationEnableDaemonSetEviction = "cluster-autoscaler.kubernetes.io/enable-ds-eviction"
 
 	serviceAccountName = "dynatrace-dynakube-oneagent"
 
@@ -155,16 +152,16 @@ func (b *builder) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 	maxUnavailable := intstr.FromInt(dk.FF().GetOneAgentMaxUnavailable())
 
 	daemonsetAnnotations := map[string]string{
-		annotationEnableDsEviction: annotationFalseValue,
+		annotationEnableDaemonSetEviction: "false",
 	}
 
-	annotations := map[string]string{
+	templateAnnotations := map[string]string{
 		annotationUnprivileged:            annotationUnprivilegedValue,
-		webhook.AnnotationDynatraceInject: annotationFalseValue,
+		webhook.AnnotationDynatraceInject: "false",
 		annotationTenantTokenHash:         dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash,
 	}
 
-	annotations = maputils.MergeMap(annotations, b.hostInjectSpec.Annotations)
+	templateAnnotations = maputils.MergeMap(templateAnnotations, b.hostInjectSpec.Annotations)
 
 	result := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -180,7 +177,7 @@ func (b *builder) BuildDaemonSet() (*appsv1.DaemonSet, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: annotations,
+					Annotations: templateAnnotations,
 				},
 				Spec: podSpec,
 			},

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -344,7 +344,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					exp.OAPrivilegedKey: "true",
+					exp.OAPrivilegedKey: annotationTrueValue,
 				},
 			},
 			Spec: dynakube.DynaKubeSpec{
@@ -375,7 +375,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					exp.OAPrivilegedKey: "true",
+					exp.OAPrivilegedKey: annotationTrueValue,
 				},
 			},
 			Spec: dynakube.DynaKubeSpec{
@@ -438,7 +438,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					exp.OAPrivilegedKey: "true",
+					exp.OAPrivilegedKey: annotationTrueValue,
 				},
 			},
 			Spec: dynakube.DynaKubeSpec{
@@ -482,7 +482,7 @@ func TestPodSpecServiceAccountName(t *testing.T) {
 			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						exp.OAPrivilegedKey: "true",
+						exp.OAPrivilegedKey: annotationTrueValue,
 					},
 				},
 			},
@@ -495,7 +495,7 @@ func TestPodSpecServiceAccountName(t *testing.T) {
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					exp.OAPrivilegedKey: "false",
+					exp.OAPrivilegedKey: annotationFalseValue,
 				},
 			},
 		}
@@ -584,7 +584,7 @@ func TestPodSpecProbes(t *testing.T) {
 			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						exp.OASkipLivenessProbeKey: "true",
+						exp.OASkipLivenessProbeKey: annotationTrueValue,
 					},
 				},
 				Status: dynakube.DynaKubeStatus{
@@ -771,8 +771,13 @@ func TestAnnotations(t *testing.T) {
 			},
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
-		expectedAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: "false",
+
+		expectedDaemonsetAnnotations := map[string]string{
+			annotationEnableDsEviction: annotationFalseValue,
+		}
+
+		expectedTemplateAnnotations := map[string]string{
+			webhook.AnnotationDynatraceInject: annotationFalseValue,
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			annotationTenantTokenHash:         testTokenHash,
 		}
@@ -782,7 +787,8 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedAnnotations, daemonset.Spec.Template.Annotations)
+		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("host monitoring has apparmor annotation by default", func(t *testing.T) {
 		dk := dynakube.DynaKube{
@@ -793,8 +799,13 @@ func TestAnnotations(t *testing.T) {
 			},
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
-		expectedAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: "false",
+
+		expectedDaemonsetAnnotations := map[string]string{
+			annotationEnableDsEviction: annotationFalseValue,
+		}
+
+		expectedTemplateAnnotations := map[string]string{
+			webhook.AnnotationDynatraceInject: annotationFalseValue,
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			annotationTenantTokenHash:         testTokenHash,
 		}
@@ -804,7 +815,8 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedAnnotations, daemonset.Spec.Template.Annotations)
+		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("classic fullstack has apparmor annotation by default", func(t *testing.T) {
 		dk := dynakube.DynaKube{
@@ -815,8 +827,13 @@ func TestAnnotations(t *testing.T) {
 			},
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
-		expectedAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: "false",
+
+		expectedDaemonsetAnnotations := map[string]string{
+			annotationEnableDsEviction: annotationFalseValue,
+		}
+
+		expectedTemplateAnnotations := map[string]string{
+			webhook.AnnotationDynatraceInject: annotationFalseValue,
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			annotationTenantTokenHash:         testTokenHash,
 		}
@@ -826,7 +843,8 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedAnnotations, daemonset.Spec.Template.Annotations)
+		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("annotations are added with cloud native", func(t *testing.T) {
 		dk := dynakube.DynaKube{
@@ -843,8 +861,13 @@ func TestAnnotations(t *testing.T) {
 			},
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
-		expectedAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: "false",
+
+		expectedDaemonsetAnnotations := map[string]string{
+			annotationEnableDsEviction: annotationFalseValue,
+		}
+
+		expectedTemplateAnnotations := map[string]string{
+			webhook.AnnotationDynatraceInject: annotationFalseValue,
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
 			annotationTenantTokenHash:         testTokenHash,
@@ -855,7 +878,8 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedAnnotations, daemonset.Spec.Template.Annotations)
+		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("annotations are added with host monitoring", func(t *testing.T) {
 		dk := dynakube.DynaKube{
@@ -870,8 +894,13 @@ func TestAnnotations(t *testing.T) {
 			},
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
-		expectedAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: "false",
+
+		expectedDaemonsetAnnotations := map[string]string{
+			annotationEnableDsEviction: annotationFalseValue,
+		}
+
+		expectedTemplateAnnotations := map[string]string{
+			webhook.AnnotationDynatraceInject: annotationFalseValue,
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
 			annotationTenantTokenHash:         testTokenHash,
@@ -882,7 +911,8 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedAnnotations, daemonset.Spec.Template.Annotations)
+		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("annotations are added with classic fullstack", func(t *testing.T) {
 		dk := dynakube.DynaKube{
@@ -897,8 +927,13 @@ func TestAnnotations(t *testing.T) {
 			},
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
-		expectedAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: "false",
+
+		expectedDaemonsetAnnotations := map[string]string{
+			annotationEnableDsEviction: annotationFalseValue,
+		}
+
+		expectedTemplateAnnotations := map[string]string{
+			webhook.AnnotationDynatraceInject: annotationFalseValue,
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
 			annotationTenantTokenHash:         testTokenHash,
@@ -909,7 +944,8 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedAnnotations, daemonset.Spec.Template.Annotations)
+		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 }
 

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -344,7 +344,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					exp.OAPrivilegedKey: annotationTrueValue,
+					exp.OAPrivilegedKey: "true",
 				},
 			},
 			Spec: dynakube.DynaKubeSpec{
@@ -375,7 +375,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					exp.OAPrivilegedKey: annotationTrueValue,
+					exp.OAPrivilegedKey: "true",
 				},
 			},
 			Spec: dynakube.DynaKubeSpec{
@@ -438,7 +438,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					exp.OAPrivilegedKey: annotationTrueValue,
+					exp.OAPrivilegedKey: "true",
 				},
 			},
 			Spec: dynakube.DynaKubeSpec{
@@ -482,7 +482,7 @@ func TestPodSpecServiceAccountName(t *testing.T) {
 			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						exp.OAPrivilegedKey: annotationTrueValue,
+						exp.OAPrivilegedKey: "true",
 					},
 				},
 			},
@@ -495,7 +495,7 @@ func TestPodSpecServiceAccountName(t *testing.T) {
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					exp.OAPrivilegedKey: annotationFalseValue,
+					exp.OAPrivilegedKey: "false",
 				},
 			},
 		}
@@ -584,7 +584,7 @@ func TestPodSpecProbes(t *testing.T) {
 			dk: &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						exp.OASkipLivenessProbeKey: annotationTrueValue,
+						exp.OASkipLivenessProbeKey: "true",
 					},
 				},
 				Status: dynakube.DynaKubeStatus{
@@ -773,11 +773,11 @@ func TestAnnotations(t *testing.T) {
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
 		expectedDaemonsetAnnotations := map[string]string{
-			annotationEnableDsEviction: annotationFalseValue,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		expectedTemplateAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: annotationFalseValue,
+			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			annotationTenantTokenHash:         testTokenHash,
 		}
@@ -801,11 +801,11 @@ func TestAnnotations(t *testing.T) {
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
 		expectedDaemonsetAnnotations := map[string]string{
-			annotationEnableDsEviction: annotationFalseValue,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		expectedTemplateAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: annotationFalseValue,
+			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			annotationTenantTokenHash:         testTokenHash,
 		}
@@ -829,11 +829,11 @@ func TestAnnotations(t *testing.T) {
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
 		expectedDaemonsetAnnotations := map[string]string{
-			annotationEnableDsEviction: annotationFalseValue,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		expectedTemplateAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: annotationFalseValue,
+			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			annotationTenantTokenHash:         testTokenHash,
 		}
@@ -863,11 +863,11 @@ func TestAnnotations(t *testing.T) {
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
 		expectedDaemonsetAnnotations := map[string]string{
-			annotationEnableDsEviction: annotationFalseValue,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		expectedTemplateAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: annotationFalseValue,
+			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
 			annotationTenantTokenHash:         testTokenHash,
@@ -896,11 +896,11 @@ func TestAnnotations(t *testing.T) {
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
 		expectedDaemonsetAnnotations := map[string]string{
-			annotationEnableDsEviction: annotationFalseValue,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		expectedTemplateAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: annotationFalseValue,
+			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
 			annotationTenantTokenHash:         testTokenHash,
@@ -929,11 +929,11 @@ func TestAnnotations(t *testing.T) {
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
 		expectedDaemonsetAnnotations := map[string]string{
-			annotationEnableDsEviction: annotationFalseValue,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		expectedTemplateAnnotations := map[string]string{
-			webhook.AnnotationDynatraceInject: annotationFalseValue,
+			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
 			annotationTenantTokenHash:         testTokenHash,

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -772,14 +772,11 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonSetAnnotations := map[string]string{
-			annotationEnableDaemonSetEviction: "false",
-		}
-
 		expectedTemplateAnnotations := map[string]string{
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			annotationTenantTokenHash:         testTokenHash,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		builder := NewCloudNativeFullStack(&dk, testClusterID)
@@ -787,7 +784,6 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("host monitoring has apparmor annotation by default", func(t *testing.T) {
@@ -800,14 +796,11 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonSetAnnotations := map[string]string{
-			annotationEnableDaemonSetEviction: "false",
-		}
-
 		expectedTemplateAnnotations := map[string]string{
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			annotationTenantTokenHash:         testTokenHash,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		builder := NewHostMonitoring(&dk, testClusterID)
@@ -815,7 +808,6 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("classic fullstack has apparmor annotation by default", func(t *testing.T) {
@@ -828,14 +820,11 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonSetAnnotations := map[string]string{
-			annotationEnableDaemonSetEviction: "false",
-		}
-
 		expectedTemplateAnnotations := map[string]string{
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			annotationTenantTokenHash:         testTokenHash,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		builder := NewClassicFullStack(&dk, testClusterID)
@@ -843,7 +832,6 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("annotations are added with cloud native", func(t *testing.T) {
@@ -862,15 +850,12 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonSetAnnotations := map[string]string{
-			annotationEnableDaemonSetEviction: "false",
-		}
-
 		expectedTemplateAnnotations := map[string]string{
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
 			annotationTenantTokenHash:         testTokenHash,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		builder := NewCloudNativeFullStack(&dk, testClusterID)
@@ -878,7 +863,6 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("annotations are added with host monitoring", func(t *testing.T) {
@@ -895,15 +879,12 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonSetAnnotations := map[string]string{
-			annotationEnableDaemonSetEviction: "false",
-		}
-
 		expectedTemplateAnnotations := map[string]string{
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
 			annotationTenantTokenHash:         testTokenHash,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		builder := NewHostMonitoring(&dk, testClusterID)
@@ -911,7 +892,6 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("annotations are added with classic fullstack", func(t *testing.T) {
@@ -928,15 +908,12 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonSetAnnotations := map[string]string{
-			annotationEnableDaemonSetEviction: "false",
-		}
-
 		expectedTemplateAnnotations := map[string]string{
 			webhook.AnnotationDynatraceInject: "false",
 			annotationUnprivileged:            annotationUnprivilegedValue,
 			testKey:                           testName,
 			annotationTenantTokenHash:         testTokenHash,
+			annotationEnableDaemonSetEviction: "false",
 		}
 
 		builder := NewClassicFullStack(&dk, testClusterID)
@@ -944,7 +921,6 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 }

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -772,7 +772,7 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonsetAnnotations := map[string]string{
+		expectedDaemonSetAnnotations := map[string]string{
 			annotationEnableDaemonSetEviction: "false",
 		}
 
@@ -787,7 +787,7 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("host monitoring has apparmor annotation by default", func(t *testing.T) {
@@ -800,7 +800,7 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonsetAnnotations := map[string]string{
+		expectedDaemonSetAnnotations := map[string]string{
 			annotationEnableDaemonSetEviction: "false",
 		}
 
@@ -815,7 +815,7 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("classic fullstack has apparmor annotation by default", func(t *testing.T) {
@@ -828,7 +828,7 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonsetAnnotations := map[string]string{
+		expectedDaemonSetAnnotations := map[string]string{
 			annotationEnableDaemonSetEviction: "false",
 		}
 
@@ -843,7 +843,7 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("annotations are added with cloud native", func(t *testing.T) {
@@ -862,7 +862,7 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonsetAnnotations := map[string]string{
+		expectedDaemonSetAnnotations := map[string]string{
 			annotationEnableDaemonSetEviction: "false",
 		}
 
@@ -878,7 +878,7 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("annotations are added with host monitoring", func(t *testing.T) {
@@ -895,7 +895,7 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonsetAnnotations := map[string]string{
+		expectedDaemonSetAnnotations := map[string]string{
 			annotationEnableDaemonSetEviction: "false",
 		}
 
@@ -911,7 +911,7 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 	t.Run("annotations are added with classic fullstack", func(t *testing.T) {
@@ -928,7 +928,7 @@ func TestAnnotations(t *testing.T) {
 		}
 		dk.Status.OneAgent.ConnectionInfoStatus.TenantTokenHash = testTokenHash
 
-		expectedDaemonsetAnnotations := map[string]string{
+		expectedDaemonSetAnnotations := map[string]string{
 			annotationEnableDaemonSetEviction: "false",
 		}
 
@@ -944,7 +944,7 @@ func TestAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotNil(t, daemonset)
-		assert.Equal(t, expectedDaemonsetAnnotations, daemonset.Annotations)
+		assert.Equal(t, expectedDaemonSetAnnotations, daemonset.Annotations)
 		assert.Equal(t, expectedTemplateAnnotations, daemonset.Spec.Template.Annotations)
 	})
 }


### PR DESCRIPTION
https://dt-rnd.atlassian.net/browse/DAQ-5871

## Description

Adds `cluster-autoscaler.kubernetes.io/enable-ds-eviction=false` to OneAgent DaemonSet Pods.

## How can this be tested?

- Deploy DynaKube and check that the OneAgent DaemonSet Pod template has the annotation, and also the Pods.
