### PR TITLE
Makes livenessprobe and csi-node-driver-registrar commands provided by the operator opt-in

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -223,12 +223,12 @@ spec:
         - name: DRIVER_REG_SOCK_PATH
           value: {{ include "dynatrace-operator.CSISocketPath" . }}
         args:
-        {{- if .Values.csidriver.registrar.byOperatorCommand }}
+        {{- if .Values.csidriver.registrar.builtIn }}
         - csi-node-driver-registrar
         {{- end }}
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-        {{- if not .Values.csidriver.registrar.byOperatorCommand }}
+        {{- if not .Values.csidriver.registrar.builtIn }}
         command:
         - csi-node-driver-registrar
         {{- end }}
@@ -253,13 +253,13 @@ spec:
         image: {{ include "dynatrace-operator.image" . }}
         imagePullPolicy: Always
         args:
-        {{- if .Values.csidriver.livenessprobe.byOperatorCommand }}
+        {{- if .Values.csidriver.livenessprobe.builtIn }}
         - livenessprobe
         {{- end }}
         - --csi-address=/csi/csi.sock
         - --health-port=9808
         - --probe-timeout=9s
-        {{- if not .Values.csidriver.livenessprobe.byOperatorCommand }}
+        {{- if not .Values.csidriver.livenessprobe.builtIn }}
         command:
         - livenessprobe
         {{- end }}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -307,9 +307,10 @@ tests:
                     name: mountpoint-dir
                     readOnly: true
               - args:
-                  - "csi-node-driver-registrar"
                   - "--csi-address=/csi/csi.sock"
                   - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+                command:
+                  - csi-node-driver-registrar
                 env:
                   - name: DRIVER_REG_SOCK_PATH
                     value: "/var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/csi.sock"
@@ -340,10 +341,11 @@ tests:
                   - mountPath: "/var/lib/kubelet/plugins/csi.oneagent.dynatrace.com/"
                     name: lockfile-dir
               - args:
-                  - "livenessprobe"
                   - "--csi-address=/csi/csi.sock"
                   - "--health-port=9808"
                   - "--probe-timeout=9s"
+                command:
+                  - livenessprobe
                 image: image-name
                 imagePullPolicy: Always
                 name: liveness-probe
@@ -395,33 +397,27 @@ tests:
               - emptyDir: { }
                 name: tmp-dir
 
-  - it: should use native livenessprobe and csi-node-driver-registrar commands if they are preferred
+  - it: should use livenessprobe and csi-node-driver-registrar commands provided by the operator if they are preferred
     set:
       platform: kubernetes
       image: image-name
       csidriver.enabled: true
-      csidriver.livenessprobe.byOperatorCommand: false
-      csidriver.registrar.byOperatorCommand: false
+      csidriver.livenessprobe.byOperatorCommand: true
+      csidriver.registrar.byOperatorCommand: true
     asserts:
       - equal:
           path: spec.template.spec.containers[2].args
           value:
+          - "csi-node-driver-registrar"
           - "--csi-address=/csi/csi.sock"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
       - equal:
-          path: spec.template.spec.containers[2].command
-          value:
-            - csi-node-driver-registrar
-      - equal:
           path: spec.template.spec.containers[3].args
           value:
-          - "--csi-address=/csi/csi.sock"
-          - "--health-port=9808"
-          - "--probe-timeout=9s"
-      - equal:
-          path: spec.template.spec.containers[3].command
-          value:
-          - livenessprobe
+            - "livenessprobe"
+            - "--csi-address=/csi/csi.sock"
+            - "--health-port=9808"
+            - "--probe-timeout=9s"
 
   - it: should have default updateStrategy
     set:

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -402,8 +402,8 @@ tests:
       platform: kubernetes
       image: image-name
       csidriver.enabled: true
-      csidriver.livenessprobe.byOperatorCommand: true
-      csidriver.registrar.byOperatorCommand: true
+      csidriver.livenessprobe.builtIn: true
+      csidriver.registrar.builtIn: true
     asserts:
       - equal:
           path: spec.template.spec.containers[2].args
@@ -411,6 +411,8 @@ tests:
           - "csi-node-driver-registrar"
           - "--csi-address=/csi/csi.sock"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+      - isNull:
+          path: spec.template.spec.containers[2].command
       - equal:
           path: spec.template.spec.containers[3].args
           value:
@@ -418,6 +420,8 @@ tests:
             - "--csi-address=/csi/csi.sock"
             - "--health-port=9808"
             - "--probe-timeout=9s"
+      - isNull:
+          path: spec.template.spec.containers[3].command
 
   - it: should have default updateStrategy
     set:

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -181,7 +181,7 @@ csidriver:
       limits:
         cpu: 20m
         memory: 30Mi
-    byOperatorCommand: false
+    builtIn: false
   livenessprobe:
     securityContext:
       runAsUser: 0
@@ -198,7 +198,7 @@ csidriver:
       limits:
         cpu: 20m
         memory: 30Mi
-    byOperatorCommand: false
+    builtIn: false
 
 rbac:
   activeGate:

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -181,7 +181,7 @@ csidriver:
       limits:
         cpu: 20m
         memory: 30Mi
-    byOperatorCommand: true
+    byOperatorCommand: false
   livenessprobe:
     securityContext:
       runAsUser: 0
@@ -198,7 +198,7 @@ csidriver:
       limits:
         cpu: 20m
         memory: 30Mi
-    byOperatorCommand: true
+    byOperatorCommand: false
 
 rbac:
   activeGate:


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-8563)

## Description

New implementations can be enabled with values.yaml :
```
csidriver:
  livenessprobe:
    builtIn: true
  registrar:
    builtIn: true
```

## How can this be tested?

1) Genuine commands
- deploy operator
```
make deploy
```
- check csi.livenessprobe and csi.registrar containers (image, command, args)

2) Commands provided by the operator
- set values.yaml
```
csidriver:
  livenessprobe:
    builtIn: true
  registrar:
    builtIn: true
```
- deploy operator
```
make deploy
```
- check csi.livenessprobe and csi.registrar containers (image, command, args)

