### PR TITLE
Adding in the ability to pass in metrics and webhook ports via a valu…

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -87,6 +87,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: WEBHOOK_PORT
+              value: "{{ .Values.webhook.ports.server | default "8443" }}"
+            - name: HEALTH_PROBE_BIND_ADDRESS
+              value: ":{{ .Values.webhook.ports.healthProbe | default "10080" }}"
+            - name: METRICS_BIND_ADDRESS
+              value: ":{{ .Values.webhook.ports.metrics | default "8383" }}"
             {{ include "dynatrace-operator.modules-json-env" . | nindent 12 }}
           readinessProbe:
             httpGet:
@@ -104,11 +110,11 @@ spec:
             periodSeconds: 10
           ports:
             - name: server-port
-              containerPort: 8443
+              containerPort: {{ .Values.webhook.ports.server | default 8443 }}
             - name: livez
-              containerPort: 10080
+              containerPort: {{ .Values.webhook.ports.healthProbe | default 10080 }}
             - name: metrics
-              containerPort: 8080
+              containerPort: {{ .Values.webhook.ports.metrics | default 8383 }}
           resources:
             requests:
               {{- toYaml (.Values.webhook).requests | nindent 14 }}


### PR DESCRIPTION
…es file

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description



This pull request updates the Helm chart template for the webhook deployment to make port configurations more flexible by utilizing Helm values with defaults. The changes improve the configurability of the webhook's ports and associated environment variables.

This change is necessary to run 1.4.2 of Dynatrace on a host network where port 8443 is already in use.  Due to communication issues with 1.5.1, a patch of 1.4.2 will allow for things to function properly.

### Enhancements to webhook port configurability:

* Added environment variables `WEBHOOK_PORT`, `HEALTH_PROBE_BIND_ADDRESS`, and `METRICS_BIND_ADDRESS` to allow dynamic configuration of the server, health probe, and metrics ports, with defaults provided (`config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml`, [config/helm/chart/default/templates/Common/webhook/deployment-webhook.yamlR90-R95](diffhunk://#diff-e02b12eae74a3733e2df775821c2606e3d46f36dda1cbb6c216d0aaa86ba1f4eR90-R95)).
* Updated the container port definitions for `server-port`, `livez`, and `metrics` to use Helm values with defaults, enabling easier customization of these ports (`config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml`, [config/helm/chart/default/templates/Common/webhook/deployment-webhook.yamlL107-R117](diffhunk://#diff-e02b12eae74a3733e2df775821c2606e3d46f36dda1cbb6c216d0aaa86ba1f4eL107-R117)).

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

```
helm install dynatrace-operator ./dynatrace-operator-1.4.2.tgz \
   --namespace dynatrace  \
   --create-namespace  \
   --set webhook.hostNetwork=true  \
   --set webhook.ports.metrics=8798  \
   --set webhook.ports.server=8797
```

Validate the webhook is running on those ports.  use curl, nc, or perfered tools

This can be testsed on any cluster.  The test was done on an EKS cluter running calico.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->
