### PR TITLE
Fix: Use correcrt dockerfile in case of fips

### DIFF
--- a/.github/workflows/fips-ci.yaml
+++ b/.github/workflows/fips-ci.yaml
@@ -46,12 +46,12 @@ jobs:
             **/*.go
             go.mod
           base_sha: ${{ github.event_name == 'pull_request' && 'HEAD^' || github.event.before }}
-      - name: Detect Dockerfile changes
+      - name: Detect fips.Dockerfile changes
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         id: dockerfile
         with:
           files: |
-            Dockerfile
+            fips.Dockerfile
           base_sha: ${{ github.event_name == 'pull_request' && 'HEAD^' || github.event.before }}
       - name: List Changed Files
         run: |


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/DAQ-6753

In #4849 we added checks to speed up the CI, I wrongly used `Dockerfile` and not `fips.Dockerfile` in the fips-ci. This is fixed now.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

same as in #4849

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->