### PR TITLE
Fix missing telemetryIngest converter from beta4 to latest

### DIFF
--- a/pkg/api/v1beta4/dynakube/convert_to.go
+++ b/pkg/api/v1beta4/dynakube/convert_to.go
@@ -6,6 +6,7 @@ import (
 	kspmlatest "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kspm"
 	logmonitoringlatest "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/logmonitoring"
 	oneagentlatest "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
+	telemetryingestlatest "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/telemetryingest"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/kspm"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/oneagent"
@@ -26,6 +27,7 @@ func (src *DynaKube) ConvertTo(dstRaw conversion.Hub) error {
 	src.toOneAgentSpec(dst)
 	src.toActiveGateSpec(dst)
 	src.toTemplatesSpec(dst)
+	src.toTelemetryIngestSpec(dst)
 
 	return nil
 }
@@ -292,4 +294,15 @@ func toAppInjectSpec(src oneagent.AppInjectionSpec) *oneagentlatest.AppInjection
 func (src *DynaKube) toMetadataEnrichment(dst *dynakubelatest.DynaKube) {
 	dst.Spec.MetadataEnrichment.Enabled = src.Spec.MetadataEnrichment.Enabled
 	dst.Spec.MetadataEnrichment.NamespaceSelector = src.Spec.MetadataEnrichment.NamespaceSelector
+}
+
+func (src *DynaKube) toTelemetryIngestSpec(dst *dynakubelatest.DynaKube) {
+	if src.Spec.TelemetryIngest != nil {
+		dst.Spec.TelemetryIngest = &telemetryingestlatest.Spec{}
+		dst.Spec.TelemetryIngest.Protocols = src.Spec.TelemetryIngest.Protocols
+		dst.Spec.TelemetryIngest.ServiceName = src.Spec.TelemetryIngest.ServiceName
+		dst.Spec.TelemetryIngest.TlsRefName = src.Spec.TelemetryIngest.TlsRefName
+	} else {
+		dst.Spec.TelemetryIngest = nil
+	}
 }

--- a/pkg/api/v1beta4/dynakube/convert_to_test.go
+++ b/pkg/api/v1beta4/dynakube/convert_to_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/kspm"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube/telemetryingest"
 	registryv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -225,6 +226,20 @@ func TestConvertTo(t *testing.T) {
 
 		assert.Equal(t, from.Spec.OneAgent.HostGroup, to.Spec.OneAgent.HostGroup)
 	})
+
+	t.Run("migrate telemetryIngest", func(t *testing.T) {
+		from := getOldDynakubeBase()
+		from.Status = getOldStatus()
+		to := dynakubelatest.DynaKube{}
+
+		err := from.ConvertTo(&to)
+		require.NoError(t, err)
+
+		require.NotNil(t, to.Spec.TelemetryIngest)
+		assert.Equal(t, from.Spec.TelemetryIngest.Protocols, to.Spec.TelemetryIngest.Protocols)
+		assert.Equal(t, from.Spec.TelemetryIngest.ServiceName, to.Spec.TelemetryIngest.ServiceName)
+		assert.Equal(t, from.Spec.TelemetryIngest.TlsRefName, to.Spec.TelemetryIngest.TlsRefName)
+	})
 }
 
 func getTestNamespaceSelector() metav1.LabelSelector {
@@ -271,6 +286,11 @@ func getOldDynakubeBase() DynaKube {
 			DynatraceApiRequestThreshold: ptr.To(uint16(42)),
 			MetadataEnrichment: MetadataEnrichment{
 				Enabled: ptr.To(false),
+			},
+			TelemetryIngest: &telemetryingest.Spec{
+				ServiceName: "telemetry-ingest-service-name",
+				TlsRefName:  "telemetry-ingest-tls-secret-name",
+				Protocols:   []string{"protocol1", "protocol2"},
 			},
 		},
 	}


### PR DESCRIPTION
## Description

Fix https://dt-rnd.atlassian.net/browse/DAQ-8775

`spec.telemetryIngest` converter from beta4 to latest was missing.

## How can this be tested?

- Unit tests :heavy_check_mark: 
- Deploy DK with `telemetryIngest` field on main and on this branch, check that on main the field is gone once deployed, and on this branch it is converted nicely.

```yaml
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynatrace-otel
  namespace: dynatrace
spec:
  apiUrl: https://pap94091.dev.dynatracelabs.com/api
  telemetryIngest:
    protocols:
    - "otlp"
    - "zipkin"
    - "jaeger"
    - "statsd"
    tlsRefName: ""
    serviceName: dynatrace-otel-telemetry-ingest
  tokens: dynakube
```