### PR TITLE
Remove tmp-crt volume from operator deployment

### DIFF
--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -78,9 +78,6 @@ spec:
               {{- toYaml (.Values.operator).requests | nindent 14 }}
             limits:
               {{- toYaml (.Values.operator).limits | nindent 14 }}
-          volumeMounts:
-            - name: tmp-cert-dir
-              mountPath: /tmp/dynatrace-operator
           livenessProbe:
             httpGet:
               path: /livez
@@ -92,9 +89,6 @@ spec:
           securityContext:
           {{- toYaml .Values.operator.securityContext | nindent 12 }}
       {{- include "dynatrace-operator.nodeAffinity" . | nindent 6 }}
-      volumes:
-        - emptyDir: { }
-          name: tmp-cert-dir
       serviceAccountName: dynatrace-operator
       securityContext:
         {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -110,9 +110,6 @@ tests:
                   limits:
                     cpu: 100m
                     memory: 128Mi
-                volumeMounts:
-                  - name: tmp-cert-dir
-                    mountPath: /tmp/dynatrace-operator
                 livenessProbe:
                   httpGet:
                     path: /livez
@@ -156,9 +153,6 @@ tests:
                           operator: In
                           values:
                             - linux
-            volumes:
-              - emptyDir: { }
-                name: tmp-cert-dir
             securityContext:
               seccompProfile:
                 type: RuntimeDefault
@@ -297,9 +291,6 @@ tests:
                   limits:
                     cpu: 100m
                     memory: 128Mi
-                volumeMounts:
-                  - name: tmp-cert-dir
-                    mountPath: /tmp/dynatrace-operator
                 livenessProbe:
                   httpGet:
                     path: /livez
@@ -343,9 +334,6 @@ tests:
                           operator: In
                           values:
                             - linux
-            volumes:
-              - emptyDir: { }
-                name: tmp-cert-dir
             securityContext:
               seccompProfile:
                 type: RuntimeDefault


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-8047)

It seems as though `tmp-cert-dir` is not needed anymore. The only very obvious use case was the storage of the support archive when not using the --stdout switch. As this is removed now, it is not needed anymore.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Helm unittests

Deploy the operator, check the operator pod if the volume is there. Apply some dynakubes, try out some scenarios, see if everything works as before.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->