### PR TITLE
Fix ignored automatic kubernetes monitoring feature flag

### DIFF
--- a/pkg/controllers/dynakube/activegate.go
+++ b/pkg/controllers/dynakube/activegate.go
@@ -24,7 +24,7 @@ func (controller *Controller) reconcileActiveGate(ctx context.Context, dk *dynak
 
 func (controller *Controller) setupAutomaticApiMonitoring(ctx context.Context, dtc dynatrace.Client, dk *dynakube.DynaKube) {
 	if dk.Status.KubeSystemUUID != "" &&
-		dk.FF().IsAutomaticInjection() &&
+		dk.FF().IsAutomaticK8sApiMonitoring() &&
 		dk.ActiveGate().IsKubernetesMonitoringEnabled() {
 		clusterLabel := dk.FF().GetAutomaticK8sApiMonitoringClusterName()
 		if clusterLabel == "" {

--- a/pkg/controllers/dynakube/apimonitoring/reconciler.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler.go
@@ -5,25 +5,27 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/monitoredentities"
 	"github.com/pkg/errors"
 )
 
 type Reconciler struct {
-	dtc                         dtclient.Client
-	dk                          *dynakube.DynaKube
-	monitoredEntitiesReconciler monitoredentities.ReconcilerBuilder
-	clusterLabel                string
+	dtc          dtclient.Client
+	dk           *dynakube.DynaKube
+	clusterLabel string
+
+	monitoredEntitiesReconciler controllers.Reconciler
 }
 
-type ReconcilerBuilder func(dtc dtclient.Client, dk *dynakube.DynaKube, clusterLabel string) *Reconciler
+type ReconcilerBuilder func(dtc dtclient.Client, dk *dynakube.DynaKube, clusterLabel string) controllers.Reconciler
 
-func NewReconciler(dtc dtclient.Client, dk *dynakube.DynaKube, clusterLabel string) *Reconciler {
+func NewReconciler(dtc dtclient.Client, dk *dynakube.DynaKube, clusterLabel string) controllers.Reconciler {
 	return &Reconciler{
 		dtc:                         dtc,
 		dk:                          dk,
 		clusterLabel:                clusterLabel,
-		monitoredEntitiesReconciler: monitoredentities.NewReconciler,
+		monitoredEntitiesReconciler: monitoredentities.NewReconciler(dtc, dk),
 	}
 }
 
@@ -47,7 +49,7 @@ func (r *Reconciler) createObjectIdIfNotExists(ctx context.Context) (string, err
 		return "", errors.New("no kube-system namespace UUID given")
 	}
 
-	err := r.monitoredEntitiesReconciler(r.dtc, r.dk).Reconcile(ctx)
+	err := r.monitoredEntitiesReconciler.Reconcile(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -83,7 +85,7 @@ func (r *Reconciler) createObjectIdIfNotExists(ctx context.Context) (string, err
 	if r.dk.Status.KubernetesClusterMEID == "" {
 		// the CreateOrUpdateKubernetesSetting call will create the ME(monitored-entity) if no scope was given (scope == entity-id), this happens on the "first run"
 		// so we have to run the entity reconciler AGAIN to set it in the status.
-		err := r.monitoredEntitiesReconciler(r.dtc, r.dk).Reconcile(ctx)
+		err := r.monitoredEntitiesReconciler.Reconcile(ctx)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -16,6 +16,7 @@ import (
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	ag "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/apimonitoring"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	oaconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension"
@@ -453,6 +454,12 @@ func createInjectionReconcilerBuilder(reconciler *injectionmock.Reconciler) inje
 
 func createKSPMReconcilerBuilder(reconciler controllers.Reconciler) kspm.ReconcilerBuilder {
 	return func(_ client.Client, _ client.Reader, _ *dynakube.DynaKube) controllers.Reconciler {
+		return reconciler
+	}
+}
+
+func createApiMonitoringReconcilerBuilder(reconciler controllers.Reconciler) apimonitoring.ReconcilerBuilder {
+	return func(_ dtclient.Client, _ *dynakube.DynaKube, _ string) controllers.Reconciler {
 		return reconciler
 	}
 }

--- a/pkg/controllers/dynakube/monitoredentities/reconciler.go
+++ b/pkg/controllers/dynakube/monitoredentities/reconciler.go
@@ -10,10 +10,13 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 )
 
-type ReconcilerBuilder func(
-	dtClient dynatrace.Client,
-	dk *dynakube.DynaKube,
-) controllers.Reconciler
+type Reconciler struct {
+	dk           *dynakube.DynaKube
+	dtClient     dynatrace.Client
+	timeProvider *timeprovider.Provider
+}
+
+type ReconcilerBuilder func(dtClient dynatrace.Client, dk *dynakube.DynaKube) controllers.Reconciler
 
 func NewReconciler( //nolint
 	dtClient dynatrace.Client,
@@ -24,12 +27,6 @@ func NewReconciler( //nolint
 		dtClient:     dtClient,
 		timeProvider: timeprovider.New(),
 	}
-}
-
-type Reconciler struct {
-	dk           *dynakube.DynaKube
-	dtClient     dynatrace.Client
-	timeProvider *timeprovider.Provider
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

[DAQ-8936](https://dt-rnd.atlassian.net/browse/DAQ-8936)

Update check to use correct feature flag.

Added a unit test to make sure the feature flag works as expected if disabled:
- Add mocks for api monitoring reconciler
- Update api monitoring (tests) to match common interface

## How can this be tested?

Feature flag `feature.dynatrace.com/automatic-kubernetes-api-monitoring` should be respected:
- `true`/not set should create setting
- `false` should not create setting

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->