### PR TITLE
Rename `.spec.activeGate.persistentVolumeClaim` to `.spec.activeGate.volumeClaimTemplate`

### DIFF
--- a/pkg/api/latest/dynakube/activegate/spec.go
+++ b/pkg/api/latest/dynakube/activegate/spec.go
@@ -75,7 +75,7 @@ type Spec struct {
 
 	// Defines storage device
 	// +kubebuilder:validation:Optional
-	PersistentVolumeClaim *corev1.PersistentVolumeClaimSpec `json:"persistentVolumeClaim,omitempty"`
+	VolumeClaimTemplate *corev1.PersistentVolumeClaimSpec `json:"volumeClaimTemplate,omitempty"`
 
 	// Configures the terminationGracePeriodSeconds parameter of the ActiveGate pod. Kubernetes defaults and rules apply.
 	// +kubebuild:validation:Optional

--- a/pkg/api/latest/dynakube/activegate/zz_generated.deepcopy.go
+++ b/pkg/api/latest/dynakube/activegate/zz_generated.deepcopy.go
@@ -94,8 +94,8 @@ func (in *Spec) DeepCopyInto(out *Spec) {
 			(*out)[key] = val
 		}
 	}
-	if in.PersistentVolumeClaim != nil {
-		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
+	if in.VolumeClaimTemplate != nil {
+		in, out := &in.VolumeClaimTemplate, &out.VolumeClaimTemplate
 		*out = new(v1.PersistentVolumeClaimSpec)
 		(*in).DeepCopyInto(*out)
 	}

--- a/pkg/api/v1beta4/dynakube/convert_from.go
+++ b/pkg/api/v1beta4/dynakube/convert_from.go
@@ -177,6 +177,7 @@ func (dst *DynaKube) fromActiveGateSpec(src *dynakubelatest.DynaKube) { //nolint
 	dst.Spec.ActiveGate.TlsSecretName = src.Spec.ActiveGate.TlsSecretName
 	dst.Spec.ActiveGate.DNSPolicy = src.Spec.ActiveGate.DNSPolicy
 	dst.Spec.ActiveGate.PriorityClassName = src.Spec.ActiveGate.PriorityClassName
+	dst.Spec.ActiveGate.PersistentVolumeClaim = src.Spec.ActiveGate.VolumeClaimTemplate
 
 	dst.Spec.ActiveGate.CapabilityProperties.CustomProperties = src.Spec.ActiveGate.CapabilityProperties.CustomProperties
 	dst.Spec.ActiveGate.CapabilityProperties.NodeSelector = src.Spec.ActiveGate.CapabilityProperties.NodeSelector

--- a/pkg/api/v1beta4/dynakube/convert_from_test.go
+++ b/pkg/api/v1beta4/dynakube/convert_from_test.go
@@ -308,6 +308,7 @@ func compareActiveGateSpec(t *testing.T, oldSpec activegate.Spec, newSpec active
 	assert.Equal(t, oldSpec.TlsSecretName, newSpec.TlsSecretName)
 	assert.Equal(t, oldSpec.DNSPolicy, newSpec.DNSPolicy)
 	assert.Equal(t, oldSpec.PriorityClassName, newSpec.PriorityClassName)
+	assert.Equal(t, oldSpec.PersistentVolumeClaim, newSpec.VolumeClaimTemplate)
 
 	if oldSpec.CapabilityProperties.CustomProperties != nil || newSpec.CapabilityProperties.CustomProperties != nil { // necessary so we don't explode with nil pointer when not set
 		require.NotNil(t, oldSpec.CapabilityProperties.CustomProperties)
@@ -564,8 +565,9 @@ func getNewActiveGateSpec() activegatelatest.Spec {
 		Annotations: map[string]string{
 			"activegate-annotation-key": "activegate-annotation-value",
 		},
-		TlsSecretName:     "activegate-tls-secret-name",
-		PriorityClassName: "activegate-priority-class-name",
+		VolumeClaimTemplate: getPersistentVolumeClaimSpec(),
+		TlsSecretName:       "activegate-tls-secret-name",
+		PriorityClassName:   "activegate-priority-class-name",
 		Capabilities: []activegatelatest.CapabilityDisplayName{
 			activegatelatest.DynatraceApiCapability.DisplayName,
 			activegatelatest.KubeMonCapability.DisplayName,

--- a/pkg/api/v1beta4/dynakube/convert_to.go
+++ b/pkg/api/v1beta4/dynakube/convert_to.go
@@ -180,6 +180,7 @@ func (src *DynaKube) toActiveGateSpec(dst *dynakubelatest.DynaKube) { //nolint:d
 	dst.Spec.ActiveGate.TlsSecretName = src.Spec.ActiveGate.TlsSecretName
 	dst.Spec.ActiveGate.DNSPolicy = src.Spec.ActiveGate.DNSPolicy
 	dst.Spec.ActiveGate.PriorityClassName = src.Spec.ActiveGate.PriorityClassName
+	dst.Spec.ActiveGate.VolumeClaimTemplate = src.Spec.ActiveGate.PersistentVolumeClaim
 
 	dst.Spec.ActiveGate.CapabilityProperties.CustomProperties = src.Spec.ActiveGate.CapabilityProperties.CustomProperties
 	dst.Spec.ActiveGate.CapabilityProperties.NodeSelector = src.Spec.ActiveGate.CapabilityProperties.NodeSelector

--- a/pkg/api/v1beta4/dynakube/convert_to_test.go
+++ b/pkg/api/v1beta4/dynakube/convert_to_test.go
@@ -370,8 +370,9 @@ func getOldActiveGateSpec() activegate.Spec {
 		Annotations: map[string]string{
 			"activegate-annotation-key": "activegate-annotation-value",
 		},
-		TlsSecretName:     "activegate-tls-secret-name",
-		PriorityClassName: "activegate-priority-class-name",
+		PersistentVolumeClaim: getPersistentVolumeClaimSpec(),
+		TlsSecretName:         "activegate-tls-secret-name",
+		PriorityClassName:     "activegate-priority-class-name",
 		Capabilities: []activegate.CapabilityDisplayName{
 			activegate.DynatraceApiCapability.DisplayName,
 			activegate.KubeMonCapability.DisplayName,

--- a/pkg/api/validation/dynakube/activegate.go
+++ b/pkg/api/validation/dynakube/activegate.go
@@ -70,12 +70,12 @@ func memoryLimitSet(resources corev1.ResourceRequirements) bool {
 }
 
 func activeGateMutuallyExclusivePVCSettings(dk *dynakube.DynaKube) bool {
-	return dk.Spec.ActiveGate.UseEphemeralVolume && dk.Spec.ActiveGate.PersistentVolumeClaim != nil
+	return dk.Spec.ActiveGate.UseEphemeralVolume && dk.Spec.ActiveGate.VolumeClaimTemplate != nil
 }
 
 func mutuallyExclusiveActiveGatePVsettings(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	if activeGateMutuallyExclusivePVCSettings(dk) {
-		log.Info("requested dynakube specifies mutually exclusive PersistentVolumeClaim settings for ActiveGate.", "name", dk.Name, "namespace", dk.Namespace)
+		log.Info("requested dynakube specifies mutually exclusive VolumeClaimTemplate settings for ActiveGate.", "name", dk.Name, "namespace", dk.Namespace)
 
 		return errorActiveGateInvalidPVCConfiguration
 	}

--- a/pkg/api/validation/dynakube/activegate_test.go
+++ b/pkg/api/validation/dynakube/activegate_test.go
@@ -96,8 +96,8 @@ func TestActiveGatePVCSettings(t *testing.T) {
 				Spec: dynakube.DynaKubeSpec{
 					APIURL: testApiUrl,
 					ActiveGate: activegate.Spec{
-						UseEphemeralVolume:    false,
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimSpec{},
+						UseEphemeralVolume:  false,
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{},
 					},
 				},
 			})
@@ -123,8 +123,8 @@ func TestActiveGatePVCSettings(t *testing.T) {
 					APIURL:     testApiUrl,
 					Extensions: &dynakube.ExtensionsSpec{},
 					ActiveGate: activegate.Spec{
-						UseEphemeralVolume:    true,
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimSpec{},
+						UseEphemeralVolume:  true,
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{},
 					},
 				},
 			})

--- a/pkg/api/validation/dynakube/eec.go
+++ b/pkg/api/validation/dynakube/eec.go
@@ -59,7 +59,7 @@ func extensionControllerPVCStorageDevice(_ context.Context, _ *Validator, dk *dy
 	}
 
 	if extensionControllerMutuallyExclusivePVCSettings(dk) {
-		log.Info("requested dynakube specifies mutually exclusive PersistentVolumeClaim settings for ExtensionExecutionController.", "name", dk.Name, "namespace", dk.Namespace)
+		log.Info("requested dynakube specifies mutually exclusive VolumeClaimTemplate settings for ExtensionExecutionController.", "name", dk.Name, "namespace", dk.Namespace)
 
 		return errorExtensionExecutionControllerInvalidPVCConfiguration
 	}

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -147,7 +147,7 @@ func (statefulSetBuilder Builder) buildTopologySpreadConstraints(capability capa
 func (statefulSetBuilder Builder) buildVolumes() []corev1.Volume {
 	volumes := []corev1.Volume{}
 
-	if statefulSetBuilder.dynakube.Spec.ActiveGate.PersistentVolumeClaim == nil {
+	if statefulSetBuilder.dynakube.Spec.ActiveGate.VolumeClaimTemplate == nil {
 		if !isDefaultPVCNeeded(statefulSetBuilder.dynakube) {
 			volumes = append(volumes, corev1.Volume{
 				Name: consts.GatewayTmpVolumeName,
@@ -282,14 +282,14 @@ func isDefaultPVCNeeded(dk dynakube.DynaKube) bool {
 }
 
 func (statefulSetBuilder Builder) addPersistentVolumeClaim(sts *appsv1.StatefulSet) {
-	if statefulSetBuilder.dynakube.Spec.ActiveGate.PersistentVolumeClaim != nil {
+	if statefulSetBuilder.dynakube.Spec.ActiveGate.VolumeClaimTemplate != nil {
 		// validation webhook ensures that statefulSetBuilder.dynakube.Spec.ActiveGate.UseEphemeralVolume is false at this point
 		sts.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: consts.GatewayTmpVolumeName,
 				},
-				Spec: *statefulSetBuilder.dynakube.Spec.ActiveGate.PersistentVolumeClaim,
+				Spec: *statefulSetBuilder.dynakube.Spec.ActiveGate.VolumeClaimTemplate,
 			},
 		}
 		sts.Spec.PersistentVolumeClaimRetentionPolicy = defaultPVCRetentionPolicy()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset_test.go
@@ -507,7 +507,7 @@ func TestTempVolume(t *testing.T) {
 		expectedPvcSpec  corev1.PersistentVolumeClaimSpec
 	}{
 		{
-			name:             "EmptyDir and no PVC when PersistentVolumeClaim = nil, TelemetryIngest enabled, UseEphemeralVolume = true",
+			name:             "EmptyDir and no PVC when VolumeClaimTemplate = nil, TelemetryIngest enabled, UseEphemeralVolume = true",
 			pvc:              nil,
 			telemetryIngest:  &telemetryingest.Spec{},
 			useEphemeral:     true,
@@ -515,7 +515,7 @@ func TestTempVolume(t *testing.T) {
 			pvcExpected:      false,
 		},
 		{
-			name:             "default PVC and no EmptyDir when PersistentVolumeClaim = nil, TelemetryIngest enabled, UseEphemeralVolume = false",
+			name:             "default PVC and no EmptyDir when VolumeClaimTemplate = nil, TelemetryIngest enabled, UseEphemeralVolume = false",
 			pvc:              nil,
 			telemetryIngest:  &telemetryingest.Spec{},
 			useEphemeral:     false,
@@ -524,7 +524,7 @@ func TestTempVolume(t *testing.T) {
 			expectedPvcSpec:  defaultPVCSpec(),
 		},
 		{
-			name:             "EmptyDir and no PVC when PersistentVolumeClaim = nil, TelemetryIngest not enabled, UseEphemeralVolume = true",
+			name:             "EmptyDir and no PVC when VolumeClaimTemplate = nil, TelemetryIngest not enabled, UseEphemeralVolume = true",
 			pvc:              nil,
 			telemetryIngest:  nil,
 			useEphemeral:     true,
@@ -532,7 +532,7 @@ func TestTempVolume(t *testing.T) {
 			pvcExpected:      false,
 		},
 		{
-			name:             "EmptyDir and no PVC when PersistentVolumeClaim = nil, TelemetryIngest not enabled, UseEphemeralVolume = false",
+			name:             "EmptyDir and no PVC when VolumeClaimTemplate = nil, TelemetryIngest not enabled, UseEphemeralVolume = false",
 			pvc:              nil,
 			telemetryIngest:  nil,
 			useEphemeral:     false,
@@ -540,7 +540,7 @@ func TestTempVolume(t *testing.T) {
 			pvcExpected:      false,
 		},
 		{
-			name:             "custom PVC and no EmptyDir when PersistentVolumeClaim != nil, TelemetryIngest enabled, UseEphemeralVolume = false",
+			name:             "custom PVC and no EmptyDir when VolumeClaimTemplate != nil, TelemetryIngest enabled, UseEphemeralVolume = false",
 			pvc:              &myPVCSpec,
 			telemetryIngest:  &telemetryingest.Spec{},
 			useEphemeral:     false,
@@ -549,7 +549,7 @@ func TestTempVolume(t *testing.T) {
 			expectedPvcSpec:  myPVCSpec,
 		},
 		{
-			name:             "custom PVC and no EmptyDir when PersistentVolumeClaim != nil, TelemetryIngest enabled, UseEphemeralVolume = true",
+			name:             "custom PVC and no EmptyDir when VolumeClaimTemplate != nil, TelemetryIngest enabled, UseEphemeralVolume = true",
 			pvc:              &myPVCSpec,
 			telemetryIngest:  &telemetryingest.Spec{},
 			useEphemeral:     true,
@@ -558,7 +558,7 @@ func TestTempVolume(t *testing.T) {
 			expectedPvcSpec:  myPVCSpec,
 		},
 		{
-			name:             "custom PVC and no EmptyDir when PersistentVolumeClaim != nil, TelemetryIngest not enabled, UseEphemeralVolume = false",
+			name:             "custom PVC and no EmptyDir when VolumeClaimTemplate != nil, TelemetryIngest not enabled, UseEphemeralVolume = false",
 			pvc:              &myPVCSpec,
 			telemetryIngest:  nil,
 			useEphemeral:     false,
@@ -567,7 +567,7 @@ func TestTempVolume(t *testing.T) {
 			expectedPvcSpec:  myPVCSpec,
 		},
 		{
-			name:             "custom PVC and no EmptyDir when PersistentVolumeClaim != nil, TelemetryIngest not enabled, UseEphemeralVolume = true",
+			name:             "custom PVC and no EmptyDir when VolumeClaimTemplate != nil, TelemetryIngest not enabled, UseEphemeralVolume = true",
 			pvc:              &myPVCSpec,
 			telemetryIngest:  nil,
 			useEphemeral:     true,
@@ -581,7 +581,7 @@ func TestTempVolume(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dk := getTestDynakube()
 
-			dk.Spec.ActiveGate.PersistentVolumeClaim = test.pvc
+			dk.Spec.ActiveGate.VolumeClaimTemplate = test.pvc
 			dk.Spec.TelemetryIngest = test.telemetryIngest
 			dk.Spec.ActiveGate.UseEphemeralVolume = test.useEphemeral
 


### PR DESCRIPTION
## Description

The field `.spec.activeGate.persistentVolumeClaim`  got renamed to `.spec.activeGate.volumeClaimTemplate` in `v1beta5`.
Missing conversion logic for the field has been added.

## How can this be tested?

* test usage of this field with a v1beta4 Dynakube with the old name
* test usage of this field with a v1beta5 Dynakube with the new name