### PR TITLE
Remove serviceName from Activegate Statefulset

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/serviceport.go
@@ -39,8 +39,6 @@ func (mod ServicePortModifier) Modify(sts *appsv1.StatefulSet) error {
 	baseContainer.Ports = append(baseContainer.Ports, mod.getPorts()...)
 	baseContainer.Env = mod.getEnvs()
 
-	sts.Spec.ServiceName = capability.BuildServiceName(mod.dk.Name)
-
 	return nil
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-8962](https://dt-rnd.atlassian.net/browse/DAQ-8962)

`serviceName` was added to Activegate Statefulset to provide a [more stable network ID](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id), but it's unclear whether that is currently the best approach and what exactly the implications of adding it will be. We'll remove it for now as it causes problems during upgrade (immutable field in Statefulset spec)!

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

1. Install Operator v1.5.1: `helm install dynatrace-operator oci://public.ecr.aws/dynatrace/dynatrace-operator --atomic --create-namespace -n dynatrace`
2. Apply Dynakube with Activegate present (any capability is fine)
3. Upgrade to local Operator: `make deploy`

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[DAQ-8962]: https://dt-rnd.atlassian.net/browse/DAQ-8962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ