### PR TITLE
Use --fullstack arg in the v2 webhook

### DIFF
--- a/cmd/bootstrapper/cmd_test.go
+++ b/cmd/bootstrapper/cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure"
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure/attributes/container"
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure/attributes/pod"
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/oneagent/pmc"
 	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/oneagent/preload"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -100,27 +101,15 @@ func TestBootstrapArgs(t *testing.T) {
 }
 
 func TestBootstrapConfigurationStep(t *testing.T) {
-	t.Run("check if configuration files are created", func(t *testing.T) {
-		const (
-			targetPath = "/mnt/bin"
-			configPath = "/mnt/config"
-			inputPath  = "/mnt/input"
-		)
+	const (
+		targetPath = "/mnt/bin"
+		configPath = "/mnt/config"
+		inputPath  = "/mnt/input"
+	)
 
+	setupFS := func(t *testing.T) afero.Afero {
+		t.Helper()
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
-
-		cmd := newCmd(fs)
-		cmd.SetArgs([]string{
-			"bootstrap",
-			"--config-directory=" + configPath,
-			"--input-directory=" + inputPath,
-			"--attribute-container={\"registry\":\"registry\"}",
-			"--source=/opt/dynatrace/oneagent",
-			"--target=" + targetPath,
-			"--install-path=/opt/dynatrace/oneagent-paas",
-			"--technologies=java",
-			"--attribute=k8s.cluster.name=dynakube",
-		})
 
 		createFile(t, fs, filepath.Join(inputPath, "ruxitagentproc.json"), `
 {
@@ -135,10 +124,30 @@ func TestBootstrapConfigurationStep(t *testing.T) {
 }
 `)
 
-		createFile(t, fs, filepath.Join(targetPath, "agent/conf/_ruxitagentproc.conf"), "[general]\n")
+		createFile(t, fs, filepath.Join(targetPath, "agent/conf/ruxitagentproc.conf"), "[general]\n")
 
 		createFile(t, fs, filepath.Join(inputPath, "endpoint.properties"), `DT_METRICS_INGEST_URL=http://ingest-url
 	DT_METRICS_INGEST_API_TOKEN=apitoken`)
+
+		return fs
+	}
+
+	t.Run("only OA", func(t *testing.T) {
+		fs := setupFS(t)
+
+		cmd := newCmd(fs)
+		cmd.SetArgs([]string{
+			"bootstrap",
+			"--metadata-enrichment=false",
+			"--config-directory=" + configPath,
+			"--input-directory=" + inputPath,
+			"--attribute-container={\"k8s.container.name\":\"test-container\"}",
+			"--source=/opt/dynatrace/oneagent",
+			"--target=" + targetPath,
+			"--install-path=/opt/dynatrace/oneagent-paas",
+			"--technologies=java",
+			"--attribute=k8s.cluster.name=dynakube",
+		})
 
 		err := cmd.Execute()
 		require.NoError(t, err)
@@ -147,11 +156,79 @@ func TestBootstrapConfigurationStep(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = fs.Exists(filepath.Join(targetPath, "agent/conf/ruxitagentproc.conf"))
+		containerConfigPath := filepath.Join(configPath, "test-container")
+
+		exists, err = fs.Exists(pmc.GetDestinationRuxitAgentProcFilePath(containerConfigPath))
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = fs.Exists(filepath.Join(configPath, "enrichment/endpoint/endpoint.properties"))
+		exists, err = fs.Exists(filepath.Join(containerConfigPath, "enrichment/endpoint/endpoint.properties"))
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("only metadata", func(t *testing.T) {
+		fs := setupFS(t)
+
+		cmd := newCmd(fs)
+		cmd.SetArgs([]string{
+			"bootstrap",
+			"--metadata-enrichment",
+			"--config-directory=" + configPath,
+			"--input-directory=" + inputPath,
+			"--attribute-container={\"k8s.container.name\":\"test-container\"}",
+			"--attribute=k8s.cluster.name=dynakube",
+		})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		exists, err := fs.Exists(filepath.Join(configPath, preload.ConfigPath))
+		require.NoError(t, err)
+		assert.False(t, exists)
+
+		containerConfigPath := filepath.Join(configPath, "test-container")
+
+		exists, err = fs.Exists(pmc.GetDestinationRuxitAgentProcFilePath(containerConfigPath))
+		require.NoError(t, err)
+		assert.False(t, exists)
+
+		exists, err = fs.Exists(filepath.Join(containerConfigPath, "enrichment/endpoint/endpoint.properties"))
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("OA + metadata", func(t *testing.T) {
+		fs := setupFS(t)
+
+		cmd := newCmd(fs)
+		cmd.SetArgs([]string{
+			"bootstrap",
+			"--metadata-enrichment",
+			"--config-directory=" + configPath,
+			"--input-directory=" + inputPath,
+			"--attribute-container={\"k8s.container.name\":\"test-container\"}",
+			"--source=/opt/dynatrace/oneagent",
+			"--target=" + targetPath,
+			"--install-path=/opt/dynatrace/oneagent-paas",
+			"--technologies=java",
+			"--attribute=k8s.cluster.name=dynakube",
+		})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		exists, err := fs.Exists(filepath.Join(configPath, preload.ConfigPath))
+		require.NoError(t, err)
+		assert.True(t, exists)
+
+		containerConfigPath := filepath.Join(configPath, "test-container")
+
+		exists, err = fs.Exists(pmc.GetDestinationRuxitAgentProcFilePath(containerConfigPath))
+		require.NoError(t, err)
+		assert.True(t, exists)
+
+		exists, err = fs.Exists(filepath.Join(containerConfigPath, "enrichment/endpoint/endpoint.properties"))
 		require.NoError(t, err)
 		assert.True(t, exists)
 	})

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Dynatrace/dynatrace-operator
 go 1.24.2
 
 require (
-	github.com/Dynatrace/dynatrace-bootstrapper v1.0.4
+	github.com/Dynatrace/dynatrace-bootstrapper v1.1.0
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/docker/cli v28.1.1+incompatible
 	github.com/evanphx/json-patch v5.9.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Dynatrace/dynatrace-bootstrapper v1.0.4 h1:JBChk+YUXwZiunzygPZsyZx+YluRV69uOJw74Zpi3is=
 github.com/Dynatrace/dynatrace-bootstrapper v1.0.4/go.mod h1:LHHsJDxADbZ/41Sf+VVrRuhMhQeua4/y5f8N9My5Hk0=
+github.com/Dynatrace/dynatrace-bootstrapper v1.1.0 h1:DG27W+ZMzudq0X7JoRNBATQJFVQRBhK0fBqBDSDBdM8=
+github.com/Dynatrace/dynatrace-bootstrapper v1.1.0/go.mod h1:QKuOf8VjMDVZqNW5HJNtcFnRhaZupq3GcimQipBWkL8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/webhook/mutation/pod/v2/oneagent/containers.go
+++ b/pkg/webhook/mutation/pod/v2/oneagent/containers.go
@@ -15,7 +15,13 @@ const (
 
 func Mutate(request *dtwebhook.MutationRequest) bool {
 	installPath := maputils.GetField(request.Pod.Annotations, oacommon.AnnotationInstallPath, oacommon.DefaultInstallPath)
-	mutateInitContainer(request, installPath)
+
+	err := mutateInitContainer(request, installPath)
+	if err != nil {
+		log.Error(err, "failed to mutate the bootstrapping init-container")
+
+		return false
+	}
 
 	return mutateUserContainers(request.BaseRequest, installPath)
 }

--- a/pkg/webhook/mutation/pod/v2/oneagent/containers_test.go
+++ b/pkg/webhook/mutation/pod/v2/oneagent/containers_test.go
@@ -77,6 +77,23 @@ func TestMutate(t *testing.T) {
 		updated := Mutate(request)
 		require.False(t, updated)
 	})
+
+	t.Run("no tenantUUID + cloudnative => no update", func(t *testing.T) {
+		request := createTestMutationRequestWithoutInjectedContainers()
+		request.DynaKube.Spec.OneAgent.CloudNativeFullStack = &oneagent.CloudNativeFullStackSpec{}
+
+		updated := Mutate(request)
+		require.False(t, updated)
+	})
+
+	t.Run("tenantUUID + cloudnative => update", func(t *testing.T) {
+		request := createTestMutationRequestWithoutInjectedContainers()
+		request.DynaKube.Spec.OneAgent.CloudNativeFullStack = &oneagent.CloudNativeFullStackSpec{}
+		request.DynaKube.Status.OneAgent.ConnectionInfoStatus.TenantUUID = "example"
+
+		updated := Mutate(request)
+		require.True(t, updated)
+	})
 }
 
 func TestReinvoke(t *testing.T) {

--- a/pkg/webhook/mutation/pod/v2/oneagent/init_test.go
+++ b/pkg/webhook/mutation/pod/v2/oneagent/init_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
 	oacommon "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/common/oneagent"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -63,5 +65,32 @@ func TestAddInitArgs(t *testing.T) {
 
 		require.Contains(t, initContainer.Args, "--source=/opt/dynatrace/oneagent")
 		require.Contains(t, initContainer.Args, "--target=/mnt/bin")
+	})
+
+	t.Run("WithFullstack", func(t *testing.T) {
+		pod := corev1.Pod{}
+		initContainer := &corev1.Container{}
+		tenantUUID := "test-tenant-uuid"
+		dk := dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: oneagent.Spec{
+					CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{},
+				},
+			},
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: oneagent.Status{
+					ConnectionInfoStatus: oneagent.ConnectionInfoStatus{
+						ConnectionInfo: communication.ConnectionInfo{
+							TenantUUID: tenantUUID,
+						},
+					},
+				},
+			},
+		}
+
+		addInitArgs(pod, initContainer, dk, oacommon.DefaultInstallPath)
+
+		require.Contains(t, initContainer.Args, "--fullstack")
+		require.Contains(t, initContainer.Args, "--tenant="+tenantUUID)
 	})
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-9367](https://dt-rnd.atlassian.net/browse/DAQ-9367)

Bumps the bootstrapper version to 1.1.0, so we have access to the logic necessary.
- Updates the `cmd/bootstrapper/cmd.go` so it doesn't break, and can-do standalone metadata-enrichment


Adds the use of `--fullstack` + `--tenant=my-tenant` args in the v2 webhook incase cloudnative without CSI is used.

## How can this be tested?

The `cmd/bootstrapper/cmd.go` part => unittest for now
The `--fullstack` + `--tenant=my-tenant` args part => deploy a cloudnative without CSI, enable node-image-pull, inject into sample apps 