### PR TITLE
Fix hardcoded service name for telemetry ingest

### DIFF
--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
@@ -3,6 +3,7 @@ package endpoint
 import (
 	"context"
 	"fmt"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
@@ -89,7 +90,9 @@ func (r *Reconciler) getDtEndpoint() (string, error) {
 			return "", err
 		}
 
-		return fmt.Sprintf("https://%s-activegate.dynatrace.svc/e/%s/api/v2/otlp", r.dk.Name, tenantUUID), nil
+		serviceFqdn := capability.BuildServiceName(r.dk.Name) + "." + r.dk.Namespace + ".svc"
+
+		return fmt.Sprintf("https://%s/e/%s/api/v2/otlp", serviceFqdn, tenantUUID), nil
 	}
 
 	return r.dk.ApiUrl() + "/v2/otlp", nil

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
@@ -3,9 +3,9 @@ package endpoint
 import (
 	"context"
 	"fmt"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
@@ -95,7 +95,7 @@ func TestEndpoint(t *testing.T) {
 			name:             "in-cluster ActiveGate",
 			apiUrl:           fmt.Sprintf("https://%s.dev.dynatracelabs.com/api", testTenantUUID),
 			inClusterAg:      true,
-			expectedEndpoint: fmt.Sprintf("https://test-dk-activegate.dynatrace.svc/e/%s/api/v2/otlp", testTenantUUID),
+			expectedEndpoint: fmt.Sprintf("https://test-dk-activegate.test-namespace.svc/e/%s/api/v2/otlp", testTenantUUID),
 		},
 		{
 			name:             "public ActiveGate",
@@ -144,7 +144,8 @@ func TestEndpoint(t *testing.T) {
 func createDynaKube(telemetryIngestEnabled bool) dynakube.DynaKube {
 	dk := dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-dk",
+			Name:      "test-dk",
+			Namespace: "test-namespace",
 		},
 		Spec: dynakube.DynaKubeSpec{},
 		Status: dynakube.DynaKubeStatus{


### PR DESCRIPTION
## Description

The AG service name used by the OTel collector for telemetry ingest was hardcoded to the `dynatrace` namespace.
This PR now uses the namespace from the Dynakube to address the AG correctly.

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-9390)

## How can this be tested?

1. Deploy the operator in a namespace other then `dynatrace`
2. Deploy a Dynakube with `telemetryIngest` enabled.
3. Deploy some sample app that creates telemetry data
4. Observe in your tenant, that data is received correctly.