### PR TITLE
Improve error verbosity in the Dynatrace client

### DIFF
--- a/pkg/clients/dynatrace/activegate_auth_token.go
+++ b/pkg/clients/dynatrace/activegate_auth_token.go
@@ -83,7 +83,7 @@ func (dtc *dynatraceClient) createAuthTokenRequest(ctx context.Context, dynakube
 func (dtc *dynatraceClient) handleAuthTokenResponse(response *http.Response) (*ActiveGateAuthTokenInfo, error) {
 	data, err := dtc.getServerResponseData(response)
 	if err != nil {
-		return nil, dtc.handleErrorResponseFromAPI(data, response.StatusCode)
+		return nil, dtc.handleErrorResponseFromAPI(data, response.StatusCode, response.Header)
 	}
 
 	authTokenInfo, err := dtc.readResponseForActiveGateAuthToken(data)

--- a/pkg/clients/dynatrace/activegate_connection_info.go
+++ b/pkg/clients/dynatrace/activegate_connection_info.go
@@ -38,7 +38,7 @@ func (dtc *dynatraceClient) GetActiveGateConnectionInfo(ctx context.Context) (Ac
 
 	data, err := dtc.getServerResponseData(response)
 	if err != nil {
-		return ActiveGateConnectionInfo{}, dtc.handleErrorResponseFromAPI(data, response.StatusCode)
+		return ActiveGateConnectionInfo{}, dtc.handleErrorResponseFromAPI(data, response.StatusCode, response.Header)
 	}
 
 	tenantInfo, err := dtc.readResponseForActiveGateTenantInfo(data)

--- a/pkg/clients/dynatrace/dynatrace_client.go
+++ b/pkg/clients/dynatrace/dynatrace_client.go
@@ -180,7 +180,7 @@ func (dtc *dynatraceClient) handleErrorResponseFromAPI(response []byte, statusCo
 			sb.WriteString(fmt.Sprintf(" (via proxy %s)", proxy))
 		}
 
-		responseLen := min(GetMaxResponseLen(), len(response))
+		responseLen := min(getMaxResponseLen(), len(response))
 		sb.WriteString(fmt.Sprintf("; can't unmarshal response (content-type: %s): %s", contentType, response[:responseLen]))
 
 		return errors.New(sb.String())
@@ -189,13 +189,13 @@ func (dtc *dynatraceClient) handleErrorResponseFromAPI(response []byte, statusCo
 	return se.ErrorMessage
 }
 
-func GetMaxResponseLen() int {
-	envVar, set := os.LookupEnv("DT_CLIENT_API_ERROR_LOG_LEN")
-	if set {
+func getMaxResponseLen() int {
+	if envVar, exists := os.LookupEnv("DT_CLIENT_API_ERROR_LOG_LEN"); exists {
 		maxResponseLen, err := strconv.Atoi(envVar)
-		if err == nil {
+		if err == nil && maxResponseLen > 0 {
 			return maxResponseLen
 		}
 	}
+
 	return defaultMaxResponseLen
 }

--- a/pkg/clients/dynatrace/dynatrace_client.go
+++ b/pkg/clients/dynatrace/dynatrace_client.go
@@ -41,6 +41,7 @@ const (
 	dynatraceApiToken tokenType = iota
 	dynatracePaaSToken
 	installerUrlToken // in this case we don't care about the token
+	MaxResponseLen    = 1000
 )
 
 // makeRequest does an HTTP request by formatting the URL from the given arguments and returns the response.
@@ -178,7 +179,7 @@ func (dtc *dynatraceClient) handleErrorResponseFromAPI(response []byte, statusCo
 			sb.WriteString(fmt.Sprintf(" (via proxy %s)", proxy))
 		}
 
-		responseLen := int(math.Min(1000, float64(len(response))))
+		responseLen := int(math.Min(MaxResponseLen, float64(len(response))))
 		sb.WriteString(fmt.Sprintf("; can't unmarshal response (content-type: %s): %s", contentType, response[:responseLen]))
 
 		return errors.New(sb.String())

--- a/pkg/clients/dynatrace/dynatrace_client.go
+++ b/pkg/clients/dynatrace/dynatrace_client.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -181,7 +180,7 @@ func (dtc *dynatraceClient) handleErrorResponseFromAPI(response []byte, statusCo
 			sb.WriteString(fmt.Sprintf(" (via proxy %s)", proxy))
 		}
 
-		responseLen := int(math.Min(float64(GetMaxResponseLen()), float64(len(response))))
+		responseLen := min(GetMaxResponseLen(), len(response))
 		sb.WriteString(fmt.Sprintf("; can't unmarshal response (content-type: %s): %s", contentType, response[:responseLen]))
 
 		return errors.New(sb.String())

--- a/pkg/clients/dynatrace/dynatrace_client_test.go
+++ b/pkg/clients/dynatrace/dynatrace_client_test.go
@@ -98,12 +98,10 @@ func TestGetResponseOrServerError(t *testing.T) {
 		err := dc.handleErrorResponseFromAPI(response, code, http.Header{})
 		require.Error(t, err)
 
-		maxLen := 1000
-
 		var shortenedResponse []byte
 
-		if len(response) >= maxLen {
-			shortenedResponse = response[:maxLen]
+		if len(response) >= MaxResponseLen {
+			shortenedResponse = response[:MaxResponseLen]
 		} else {
 			shortenedResponse = response
 		}

--- a/pkg/clients/dynatrace/dynatrace_client_test.go
+++ b/pkg/clients/dynatrace/dynatrace_client_test.go
@@ -98,13 +98,7 @@ func TestGetResponseOrServerError(t *testing.T) {
 		err := dc.handleErrorResponseFromAPI(response, code, http.Header{})
 		require.Error(t, err)
 
-		var shortenedResponse []byte
-
-		if len(response) >= MaxResponseLen {
-			shortenedResponse = response[:MaxResponseLen]
-		} else {
-			shortenedResponse = response
-		}
+		shortenedResponse := response[:MaxResponseLen]
 
 		assert.EqualError(t, err, fmt.Sprintf("Server returned status code %d; can't unmarshal response (content-type: unknown): %s", code, shortenedResponse))
 	})

--- a/pkg/clients/dynatrace/dynatrace_client_test.go
+++ b/pkg/clients/dynatrace/dynatrace_client_test.go
@@ -115,6 +115,7 @@ func TestGetResponseOrServerError(t *testing.T) {
 
 	t.Run("non-JSON response exceeding custom character limit", func(t *testing.T) {
 		response := []byte(strings.Repeat("really long response", 300))
+
 		t.Setenv("DT_CLIENT_API_ERROR_LOG_LEN", "6")
 
 		err := dc.handleErrorResponseFromAPI(response, http.StatusForbidden, http.Header{})

--- a/pkg/clients/dynatrace/dynatrace_client_test.go
+++ b/pkg/clients/dynatrace/dynatrace_client_test.go
@@ -108,7 +108,7 @@ func TestGetResponseOrServerError(t *testing.T) {
 		err := dc.handleErrorResponseFromAPI(response, http.StatusForbidden, http.Header{})
 		require.Error(t, err)
 
-		shortenedResponse := response[:GetMaxResponseLen()]
+		shortenedResponse := response[:getMaxResponseLen()]
 
 		assert.EqualError(t, err, fmt.Sprintf("Server returned status code 403; can't unmarshal response (content-type: unknown): %s", shortenedResponse))
 	})

--- a/pkg/clients/dynatrace/dynatrace_client_test.go
+++ b/pkg/clients/dynatrace/dynatrace_client_test.go
@@ -91,6 +91,19 @@ func TestGetResponseOrServerError(t *testing.T) {
 		assert.NotNil(t, body, "response body available")
 	})
 
+	t.Run("valid JSON response", func(t *testing.T) {
+		code := http.StatusUnauthorized
+		message := "Unauthorized request"
+		response := []byte(fmt.Sprintf(`{"error": {"code": %d, "message": "%s"}}`, code, message))
+
+		contentType := "application/json"
+		headers := http.Header{"Content-Type": []string{contentType}}
+		err := dc.handleErrorResponseFromAPI(response, code, headers)
+		require.Error(t, err)
+
+		assert.EqualError(t, err, fmt.Sprintf("dynatrace server error %d: %s", code, message))
+	})
+
 	t.Run("non-JSON response exceeding character limit", func(t *testing.T) {
 		response := []byte(strings.Repeat("really long response", 300))
 		code := http.StatusForbidden

--- a/pkg/clients/dynatrace/image.go
+++ b/pkg/clients/dynatrace/image.go
@@ -87,7 +87,7 @@ func (dtc *dynatraceClient) handleLatestImageResponse(response *http.Response) (
 
 	data, err := dtc.getServerResponseData(response)
 	if err != nil {
-		return nil, dtc.handleErrorResponseFromAPI(data, response.StatusCode)
+		return nil, dtc.handleErrorResponseFromAPI(data, response.StatusCode, response.Header)
 	}
 
 	latestImageInfo, err := dtc.readResponseForLatestImage(data)

--- a/pkg/clients/dynatrace/oneagent_connection_info.go
+++ b/pkg/clients/dynatrace/oneagent_connection_info.go
@@ -46,7 +46,7 @@ func (dtc *dynatraceClient) GetOneAgentConnectionInfo(ctx context.Context) (OneA
 
 	responseData, err := dtc.getServerResponseData(resp)
 	if err != nil {
-		return OneAgentConnectionInfo{}, dtc.handleErrorResponseFromAPI(responseData, resp.StatusCode)
+		return OneAgentConnectionInfo{}, dtc.handleErrorResponseFromAPI(responseData, resp.StatusCode, resp.Header)
 	}
 
 	connectionInfo, err := dtc.readResponseForOneAgentConnectionInfo(responseData)


### PR DESCRIPTION

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
If Dynatrace (or some proxy) returns non-JSON objects to the client (like `<!doctype html><html>hi</html>` for example), the following error message is currently returned:
```
response error, can't unmarshal json response 403: invalid character '<' looking for beginning of value
```

Now, this error message is more descriptive:
```
Server returned status code 403; can't unmarshal response (content-type: text/html): <!doctype html><html>hi</html>
```
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->
Addresses [DAQ-2762](https://dt-rnd.atlassian.net/browse/DAQ-2762)

## How can this be tested?
* Run unit tests in `pkg/clients/dynatrace/dynatrace_client_test.go`
<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[DAQ-2762]: https://dt-rnd.atlassian.net/browse/DAQ-2762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ