### PR TITLE
Reconcile enrichment rules when node-image-pull is used

### DIFF
--- a/pkg/controllers/dynakube/metadata/rules/reconciler.go
+++ b/pkg/controllers/dynakube/metadata/rules/reconciler.go
@@ -29,7 +29,7 @@ func NewReconciler(dtc dtclient.Client, dk *dynakube.DynaKube) controllers.Recon
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	if !r.dk.MetadataEnrichmentEnabled() {
+	if !r.dk.MetadataEnrichmentEnabled() && !r.dk.FF().IsNodeImagePull() {
 		if meta.FindStatusCondition(*r.dk.Conditions(), conditionType) == nil {
 			return nil
 		}

--- a/pkg/controllers/dynakube/metadata/rules/reconciler_test.go
+++ b/pkg/controllers/dynakube/metadata/rules/reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
@@ -91,6 +92,28 @@ func TestReconcile(t *testing.T) {
 
 	t.Run("set rules correctly", func(t *testing.T) {
 		dk := createDynaKube()
+		expectedResponse := createRulesResponse()
+
+		dtc := dtclientmock.NewClient(t)
+		dtc.On("GetRulesSettings", mock.AnythingOfType("context.backgroundCtx"), dk.Status.KubeSystemUUID, dk.Status.KubernetesClusterMEID).Return(expectedResponse, nil)
+		reconciler := NewReconciler(dtc, &dk)
+
+		err := reconciler.Reconcile(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, createRules(), dk.Status.MetadataEnrichment.Rules)
+		require.Len(t, dk.Status.Conditions, 1)
+		assert.Equal(t, conditions.StatusUpdatedReason, dk.Status.Conditions[0].Reason)
+	})
+
+		t.Run("set rules correctly, even if only node image pull is set", func(t *testing.T) {
+		dk := createDynaKube()
+		dk.Spec.MetadataEnrichment.Enabled = ptr.To(false)
+
+		dk.Annotations = map[string]string{
+			exp.OANodeImagePullKey: "true",
+		}
+
 		expectedResponse := createRulesResponse()
 
 		dtc := dtclientmock.NewClient(t)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-9393](https://dt-rnd.atlassian.net/browse/DAQ-9393)

If OA gets injected into a pod via `node-image-pull` (no CSI), then full metadata enrichment happen, no matter the `metadataEnrichment.enabled`.

Reasoning:
- The self-extracting CodeModule usecase (`node-image-pull` no-csi) uses the [bootstrappers](https://github.com/Dynatrace/dynatrace-bootstrapper) CLI, and the arguments for these were designed with this limitation. (you can't turn off metadataEnrichment)

## How can this be tested?

1. Deploy operator with no csi
2. Apply dynakube, example:
```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/node-image-pull: "true"
spec:
  apiUrl: https://<my-tenant>.dev.dynatracelabs.com/api
  tokens: dynakube
  metadataEnrichment:
    enabled: false
  oneAgent:
    cloudNativeFullStack:
      codeModulesImage: quay.io/dynatrace/dynatrace-bootstrapper:snapshot
```
3. Check in the dynakube's Status, that the Enrichment Rules are there