### PR TITLE
Remove non-existent fields in logmon samples

### DIFF
--- a/assets/samples/dynakube/v1beta3/logMonitoring.yaml
+++ b/assets/samples/dynakube/v1beta3/logMonitoring.yaml
@@ -176,7 +176,7 @@ spec:
       #
       # nodeSelector: {}
 
-      # Optional: Set the DNS policy for Log monitoring pods pods.
+      # Optional: Set the DNS policy for Log monitoring pods.
       #
       # dnsPolicy: "Default"
 

--- a/assets/samples/dynakube/v1beta4/logMonitoring.yaml
+++ b/assets/samples/dynakube/v1beta4/logMonitoring.yaml
@@ -176,7 +176,7 @@ spec:
       #
       # nodeSelector: {}
 
-      # Optional: Set the DNS policy for Log monitoring pods pods.
+      # Optional: Set the DNS policy for Log monitoring pods.
       #
       # dnsPolicy: "Default"
 

--- a/assets/samples/dynakube/v1beta5/logMonitoring.yaml
+++ b/assets/samples/dynakube/v1beta5/logMonitoring.yaml
@@ -176,7 +176,7 @@ spec:
       #
       # nodeSelector: {}
 
-      # Optional: Set the DNS policy for Log monitoring pods pods.
+      # Optional: Set the DNS policy for Log monitoring pods.
       #
       # dnsPolicy: "Default"
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-9755](https://dt-rnd.atlassian.net/browse/DAQ-9755)

Compared the `logmonitoring.TemplateSpec` fields to what is in the actual samples. 
- Removed the ones that were not present. (And added some that were missing)

## How can this be tested?

- The `logmonitoring.TemplateSpec`, for all versions(v1beta3, v1beta4, v1beta5), it is the same
```go
type TemplateSpec struct {
	// Add custom annotations to the LogMonitoring pods
	// +kubebuilder:validation:Optional
	Annotations map[string]string `json:"annotations,omitempty"`

	// Add custom labels to the LogMonitoring pods
	// +kubebuilder:validation:Optional
	Labels map[string]string `json:"labels,omitempty"`

	// Node selector to control the selection of nodes for the LogMonitoring pods
	// +kubebuilder:validation:Optional
	NodeSelector map[string]string `json:"nodeSelector,omitempty"`

	// Overrides the default image for the LogMonitoring pods
	// +kubebuilder:validation:Optional
	ImageRef image.Ref `json:"imageRef,omitempty"`

	// Sets DNS Policy for the LogMonitoring pods
	// +kubebuilder:validation:Optional
	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`

	// Assign a priority class to the LogMonitoring pods. By default, no class is set
	// +kubebuilder:validation:Optional
	PriorityClassName string `json:"priorityClassName,omitempty"`

	// The SecComp Profile that will be configured in order to run in secure computing mode for the LogMonitoring pods
	// +kubebuilder:validation:Optional
	SecCompProfile string `json:"secCompProfile,omitempty"`

	// Define resources' requests and limits for all the LogMonitoring pods
	// +kubebuilder:validation:Optional
	Resources corev1.ResourceRequirements `json:"resources,omitempty"`

	// Set tolerations for the LogMonitoring pods
	// +kubebuilder:validation:Optional
	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`

	// Set additional arguments to the LogMonitoring main container
	// +kubebuilder:validation:Optional
	Args []string `json:"args,omitempty"`
}
```
- Double check that the samples have all the fields

[DAQ-9755]: https://dt-rnd.atlassian.net/browse/DAQ-9755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ