### PR TITLE
Cherry-pick to release-1.6: improve node-image-pull with-no-csi e2e for ocp (#5002)

### DIFF
--- a/test/features/applicationmonitoring/without_csi.go
+++ b/test/features/applicationmonitoring/without_csi.go
@@ -51,7 +51,7 @@ func WithoutCSI(t *testing.T) features.Feature {
 	randomUserSample := sample.NewApp(t, &appOnlyDynakube,
 		sample.WithName("random-user"),
 		sample.AsDeployment(),
-		sample.WithSecurityContext(corev1.PodSecurityContext{
+		sample.WithPodSecurityContext(corev1.PodSecurityContext{
 			RunAsUser:  ptr.To[int64](1234),
 			RunAsGroup: ptr.To[int64](1234),
 		}),

--- a/test/helpers/kubeobjects/deployment/wait.go
+++ b/test/helpers/kubeobjects/deployment/wait.go
@@ -18,7 +18,7 @@ import (
 
 const DeploymentAvailableTimeout = 5 * time.Minute
 
-const DeploymentReplicaFailureTimeout = 2 * time.Minute
+const DeploymentReplicaFailureTimeout = 5 * time.Minute
 
 func WaitFor(name string, namespace string) env.Func {
 	return func(ctx context.Context, envConfig *envconf.Config) (context.Context, error) {

--- a/test/helpers/sample/app.go
+++ b/test/helpers/sample/app.go
@@ -127,9 +127,15 @@ func WithEnvs(envs []corev1.EnvVar) Option {
 	}
 }
 
-func WithSecurityContext(securityContext corev1.PodSecurityContext) Option {
+func WithPodSecurityContext(securityContext corev1.PodSecurityContext) Option {
 	return func(app *App) {
 		app.base.Spec.SecurityContext = &securityContext
+	}
+}
+
+func WithContainerSecurityContext(securityContext corev1.SecurityContext) Option {
+	return func(app *App) {
+		app.base.Spec.Containers[0].SecurityContext = &securityContext
 	}
 }
 


### PR DESCRIPTION
## Description


## How can this be tested?
