### PR TITLE
Use consistent method receiver names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -252,7 +252,6 @@ linters:
     staticcheck:
       checks:
         - all
-        - "-ST1016" # this is stylecheck, but has been rolled into staticcheck
         - "-QF1008" # could remove embedded field from selector, example: dk.ObjectMeta.Labels == dk.Labels
   exclusions:
     generated: lax

--- a/pkg/api/v1alpha2/edgeconnect/properties.go
+++ b/pkg/api/v1alpha2/edgeconnect/properties.go
@@ -17,71 +17,71 @@ const (
 	defaultEdgeConnectRepository = "docker.io/dynatrace/edgeconnect"
 )
 
-func (edgeConnect *EdgeConnect) Image() string {
+func (ec *EdgeConnect) Image() string {
 	repository := defaultEdgeConnectRepository
 	tag := api.LatestTag
 
-	if edgeConnect.Spec.ImageRef.Repository != "" {
-		repository = edgeConnect.Spec.ImageRef.Repository
+	if ec.Spec.ImageRef.Repository != "" {
+		repository = ec.Spec.ImageRef.Repository
 	}
 
-	if edgeConnect.Spec.ImageRef.Tag != "" {
-		tag = edgeConnect.Spec.ImageRef.Tag
+	if ec.Spec.ImageRef.Tag != "" {
+		tag = ec.Spec.ImageRef.Tag
 	}
 
 	return fmt.Sprintf("%s:%s", repository, tag)
 }
 
-func (edgeConnect *EdgeConnect) IsCustomImage() bool {
-	return edgeConnect.Spec.ImageRef.Repository != ""
+func (ec *EdgeConnect) IsCustomImage() bool {
+	return ec.Spec.ImageRef.Repository != ""
 }
 
-func (edgeConnect *EdgeConnect) IsAutoUpdateEnabled() bool {
-	return edgeConnect.Spec.AutoUpdate == nil || *edgeConnect.Spec.AutoUpdate
+func (ec *EdgeConnect) IsAutoUpdateEnabled() bool {
+	return ec.Spec.AutoUpdate == nil || *ec.Spec.AutoUpdate
 }
 
-func (edgeConnect *EdgeConnect) GetServiceAccountName() string {
+func (ec *EdgeConnect) GetServiceAccountName() string {
 	defaultServiceAccount := "dynatrace-edgeconnect"
-	if edgeConnect.Spec.ServiceAccountName == nil {
+	if ec.Spec.ServiceAccountName == nil {
 		return defaultServiceAccount
 	}
 
-	return *edgeConnect.Spec.ServiceAccountName
+	return *ec.Spec.ServiceAccountName
 }
 
-func (edgeConnect *EdgeConnect) IsProvisionerModeEnabled() bool {
-	return edgeConnect.Spec.OAuth.Provisioner
+func (ec *EdgeConnect) IsProvisionerModeEnabled() bool {
+	return ec.Spec.OAuth.Provisioner
 }
 
-func (edgeConnect *EdgeConnect) IsK8SAutomationEnabled() bool {
-	return edgeConnect.Spec.KubernetesAutomation != nil && edgeConnect.Spec.KubernetesAutomation.Enabled
+func (ec *EdgeConnect) IsK8SAutomationEnabled() bool {
+	return ec.Spec.KubernetesAutomation != nil && ec.Spec.KubernetesAutomation.Enabled
 }
 
-func (edgeConnect *EdgeConnect) EmptyPullSecret() corev1.Secret {
+func (ec *EdgeConnect) EmptyPullSecret() corev1.Secret {
 	return corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      edgeConnect.Spec.CustomPullSecret,
-			Namespace: edgeConnect.Namespace,
+			Name:      ec.Spec.CustomPullSecret,
+			Namespace: ec.Namespace,
 		},
 	}
 }
 
 func (ec *EdgeConnect) Conditions() *[]metav1.Condition { return &ec.Status.Conditions }
 
-func (e *EdgeConnect) HostPatterns() []string {
-	if !e.IsK8SAutomationEnabled() {
-		return e.Spec.HostPatterns
+func (ec *EdgeConnect) HostPatterns() []string {
+	if !ec.IsK8SAutomationEnabled() {
+		return ec.Spec.HostPatterns
 	}
 
 	var hostPatterns []string
 
-	for _, hostPattern := range e.Spec.HostPatterns {
-		if !strings.EqualFold(hostPattern, e.K8sAutomationHostPattern()) {
+	for _, hostPattern := range ec.Spec.HostPatterns {
+		if !strings.EqualFold(hostPattern, ec.K8sAutomationHostPattern()) {
 			hostPatterns = append(hostPatterns, hostPattern)
 		}
 	}
 
-	hostPatterns = append(hostPatterns, e.K8sAutomationHostPattern())
+	hostPatterns = append(hostPatterns, ec.K8sAutomationHostPattern())
 
 	return hostPatterns
 }
@@ -91,13 +91,13 @@ type HostMapping struct {
 	To   string `json:"to"`
 }
 
-func (e *EdgeConnect) HostMappings() []HostMapping {
+func (ec *EdgeConnect) HostMappings() []HostMapping {
 	hostMappings := make([]HostMapping, 0)
-	hostMappings = append(hostMappings, HostMapping{From: e.K8sAutomationHostPattern(), To: KubernetesDefaultDNS})
+	hostMappings = append(hostMappings, HostMapping{From: ec.K8sAutomationHostPattern(), To: KubernetesDefaultDNS})
 
 	return hostMappings
 }
 
-func (e *EdgeConnect) K8sAutomationHostPattern() string {
-	return e.Name + "." + e.Namespace + "." + e.Status.KubeSystemUID + "." + kubernetesHostnameSuffix
+func (ec *EdgeConnect) K8sAutomationHostPattern() string {
+	return ec.Name + "." + ec.Namespace + "." + ec.Status.KubeSystemUID + "." + kubernetesHostnameSuffix
 }

--- a/pkg/api/v1beta4/dynakube/convert_from.go
+++ b/pkg/api/v1beta4/dynakube/convert_from.go
@@ -13,48 +13,48 @@ import (
 )
 
 // ConvertFrom converts from the Hub version (latest) to this version (v1beta4).
-func (dst *DynaKube) ConvertFrom(srcRaw conversion.Hub) error {
+func (dk *DynaKube) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*dynakubelatest.DynaKube)
 
-	dst.fromStatus(src)
+	dk.fromStatus(src)
 
-	dst.fromBase(src)
-	dst.fromMetadataEnrichment(src)
-	dst.fromLogMonitoringSpec(src)
-	dst.fromKspmSpec(src)
-	dst.fromExtensionsSpec(src)
-	dst.fromOneAgentSpec(src)
-	dst.fromActiveGateSpec(src)
-	dst.fromTemplatesSpec(src)
+	dk.fromBase(src)
+	dk.fromMetadataEnrichment(src)
+	dk.fromLogMonitoringSpec(src)
+	dk.fromKspmSpec(src)
+	dk.fromExtensionsSpec(src)
+	dk.fromOneAgentSpec(src)
+	dk.fromActiveGateSpec(src)
+	dk.fromTemplatesSpec(src)
 
 	return nil
 }
 
-func (dst *DynaKube) fromBase(src *dynakubelatest.DynaKube) {
+func (dk *DynaKube) fromBase(src *dynakubelatest.DynaKube) {
 	if src.Annotations == nil {
 		src.Annotations = map[string]string{}
 	}
 
-	dst.ObjectMeta = *src.ObjectMeta.DeepCopy() // DeepCopy mainly relevant for testing
+	dk.ObjectMeta = *src.ObjectMeta.DeepCopy() // DeepCopy mainly relevant for testing
 
-	dst.Spec.Proxy = src.Spec.Proxy
-	dst.Spec.DynatraceAPIRequestThreshold = src.Spec.DynatraceAPIRequestThreshold
-	dst.Spec.APIURL = src.Spec.APIURL
-	dst.Spec.Tokens = src.Spec.Tokens
-	dst.Spec.TrustedCAs = src.Spec.TrustedCAs
-	dst.Spec.NetworkZone = src.Spec.NetworkZone
-	dst.Spec.CustomPullSecret = src.Spec.CustomPullSecret
-	dst.Spec.SkipCertCheck = src.Spec.SkipCertCheck
-	dst.Spec.EnableIstio = src.Spec.EnableIstio
+	dk.Spec.Proxy = src.Spec.Proxy
+	dk.Spec.DynatraceAPIRequestThreshold = src.Spec.DynatraceAPIRequestThreshold
+	dk.Spec.APIURL = src.Spec.APIURL
+	dk.Spec.Tokens = src.Spec.Tokens
+	dk.Spec.TrustedCAs = src.Spec.TrustedCAs
+	dk.Spec.NetworkZone = src.Spec.NetworkZone
+	dk.Spec.CustomPullSecret = src.Spec.CustomPullSecret
+	dk.Spec.SkipCertCheck = src.Spec.SkipCertCheck
+	dk.Spec.EnableIstio = src.Spec.EnableIstio
 }
 
-func (dst *DynaKube) fromLogMonitoringSpec(src *dynakubelatest.DynaKube) {
+func (dk *DynaKube) fromLogMonitoringSpec(src *dynakubelatest.DynaKube) {
 	if src.Spec.LogMonitoring != nil {
-		dst.Spec.LogMonitoring = &logmonitoring.Spec{}
-		dst.Spec.LogMonitoring.IngestRuleMatchers = make([]logmonitoring.IngestRuleMatchers, 0)
+		dk.Spec.LogMonitoring = &logmonitoring.Spec{}
+		dk.Spec.LogMonitoring.IngestRuleMatchers = make([]logmonitoring.IngestRuleMatchers, 0)
 
 		for _, rule := range src.Spec.LogMonitoring.IngestRuleMatchers {
-			dst.Spec.LogMonitoring.IngestRuleMatchers = append(dst.Spec.LogMonitoring.IngestRuleMatchers, logmonitoring.IngestRuleMatchers{
+			dk.Spec.LogMonitoring.IngestRuleMatchers = append(dk.Spec.LogMonitoring.IngestRuleMatchers, logmonitoring.IngestRuleMatchers{
 				Attribute: rule.Attribute,
 				Values:    rule.Values,
 			})
@@ -62,42 +62,42 @@ func (dst *DynaKube) fromLogMonitoringSpec(src *dynakubelatest.DynaKube) {
 	}
 }
 
-func (dst *DynaKube) fromKspmSpec(src *dynakubelatest.DynaKube) {
+func (dk *DynaKube) fromKspmSpec(src *dynakubelatest.DynaKube) {
 	if src.Spec.Kspm != nil {
-		dst.Spec.Kspm = &kspm.Spec{}
+		dk.Spec.Kspm = &kspm.Spec{}
 	}
 }
 
-func (dst *DynaKube) fromExtensionsSpec(src *dynakubelatest.DynaKube) {
+func (dk *DynaKube) fromExtensionsSpec(src *dynakubelatest.DynaKube) {
 	if src.Spec.Extensions != nil {
-		dst.Spec.Extensions = &ExtensionsSpec{}
+		dk.Spec.Extensions = &ExtensionsSpec{}
 	}
 }
 
-func (dst *DynaKube) fromOneAgentSpec(src *dynakubelatest.DynaKube) { //nolint:dupl
+func (dk *DynaKube) fromOneAgentSpec(src *dynakubelatest.DynaKube) { //nolint:dupl
 	switch {
 	case src.OneAgent().IsClassicFullStackMode():
-		dst.Spec.OneAgent.ClassicFullStack = fromHostInjectSpec(*src.Spec.OneAgent.ClassicFullStack)
+		dk.Spec.OneAgent.ClassicFullStack = fromHostInjectSpec(*src.Spec.OneAgent.ClassicFullStack)
 	case src.OneAgent().IsCloudNativeFullstackMode():
-		dst.Spec.OneAgent.CloudNativeFullStack = &oneagent.CloudNativeFullStackSpec{}
-		dst.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec = *fromHostInjectSpec(src.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec)
-		dst.Spec.OneAgent.CloudNativeFullStack.AppInjectionSpec = *fromAppInjectSpec(src.Spec.OneAgent.CloudNativeFullStack.AppInjectionSpec)
+		dk.Spec.OneAgent.CloudNativeFullStack = &oneagent.CloudNativeFullStackSpec{}
+		dk.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec = *fromHostInjectSpec(src.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec)
+		dk.Spec.OneAgent.CloudNativeFullStack.AppInjectionSpec = *fromAppInjectSpec(src.Spec.OneAgent.CloudNativeFullStack.AppInjectionSpec)
 	case src.OneAgent().IsApplicationMonitoringMode():
-		dst.Spec.OneAgent.ApplicationMonitoring = &oneagent.ApplicationMonitoringSpec{}
-		dst.Spec.OneAgent.ApplicationMonitoring.Version = src.Spec.OneAgent.ApplicationMonitoring.Version
-		dst.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec = *fromAppInjectSpec(src.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec)
+		dk.Spec.OneAgent.ApplicationMonitoring = &oneagent.ApplicationMonitoringSpec{}
+		dk.Spec.OneAgent.ApplicationMonitoring.Version = src.Spec.OneAgent.ApplicationMonitoring.Version
+		dk.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec = *fromAppInjectSpec(src.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec)
 	case src.OneAgent().IsHostMonitoringMode():
-		dst.Spec.OneAgent.HostMonitoring = fromHostInjectSpec(*src.Spec.OneAgent.HostMonitoring)
+		dk.Spec.OneAgent.HostMonitoring = fromHostInjectSpec(*src.Spec.OneAgent.HostMonitoring)
 	}
 
-	dst.Spec.OneAgent.HostGroup = src.Spec.OneAgent.HostGroup
+	dk.Spec.OneAgent.HostGroup = src.Spec.OneAgent.HostGroup
 }
 
-func (dst *DynaKube) fromTemplatesSpec(src *dynakubelatest.DynaKube) {
-	dst.Spec.Templates.LogMonitoring = fromLogMonitoringTemplate(src.Spec.Templates.LogMonitoring)
-	dst.Spec.Templates.KspmNodeConfigurationCollector = fromKspmNodeConfigurationCollectorTemplate(src.Spec.Templates.KspmNodeConfigurationCollector)
-	dst.Spec.Templates.OpenTelemetryCollector = fromOpenTelemetryCollectorTemplate(src.Spec.Templates.OpenTelemetryCollector)
-	dst.Spec.Templates.ExtensionExecutionController = fromExtensionControllerTemplate(src.Spec.Templates.ExtensionExecutionController)
+func (dk *DynaKube) fromTemplatesSpec(src *dynakubelatest.DynaKube) {
+	dk.Spec.Templates.LogMonitoring = fromLogMonitoringTemplate(src.Spec.Templates.LogMonitoring)
+	dk.Spec.Templates.KspmNodeConfigurationCollector = fromKspmNodeConfigurationCollectorTemplate(src.Spec.Templates.KspmNodeConfigurationCollector)
+	dk.Spec.Templates.OpenTelemetryCollector = fromOpenTelemetryCollectorTemplate(src.Spec.Templates.OpenTelemetryCollector)
+	dk.Spec.Templates.ExtensionExecutionController = fromExtensionControllerTemplate(src.Spec.Templates.ExtensionExecutionController)
 }
 
 func fromLogMonitoringTemplate(src *logmonitoringlatest.TemplateSpec) *logmonitoring.TemplateSpec {
@@ -172,40 +172,40 @@ func fromExtensionControllerTemplate(src dynakubelatest.ExtensionExecutionContro
 	return dst
 }
 
-func (dst *DynaKube) fromActiveGateSpec(src *dynakubelatest.DynaKube) { //nolint:dupl
-	dst.Spec.ActiveGate.Annotations = src.Spec.ActiveGate.Annotations
-	dst.Spec.ActiveGate.TLSSecretName = src.Spec.ActiveGate.TLSSecretName
-	dst.Spec.ActiveGate.DNSPolicy = src.Spec.ActiveGate.DNSPolicy
-	dst.Spec.ActiveGate.PriorityClassName = src.Spec.ActiveGate.PriorityClassName
-	dst.Spec.ActiveGate.PersistentVolumeClaim = src.Spec.ActiveGate.VolumeClaimTemplate
+func (dk *DynaKube) fromActiveGateSpec(src *dynakubelatest.DynaKube) { //nolint:dupl
+	dk.Spec.ActiveGate.Annotations = src.Spec.ActiveGate.Annotations
+	dk.Spec.ActiveGate.TLSSecretName = src.Spec.ActiveGate.TLSSecretName
+	dk.Spec.ActiveGate.DNSPolicy = src.Spec.ActiveGate.DNSPolicy
+	dk.Spec.ActiveGate.PriorityClassName = src.Spec.ActiveGate.PriorityClassName
+	dk.Spec.ActiveGate.PersistentVolumeClaim = src.Spec.ActiveGate.VolumeClaimTemplate
 
-	dst.Spec.ActiveGate.CapabilityProperties.CustomProperties = src.Spec.ActiveGate.CapabilityProperties.CustomProperties
-	dst.Spec.ActiveGate.CapabilityProperties.NodeSelector = src.Spec.ActiveGate.CapabilityProperties.NodeSelector
-	dst.Spec.ActiveGate.CapabilityProperties.Labels = src.Spec.ActiveGate.CapabilityProperties.Labels
-	dst.Spec.ActiveGate.CapabilityProperties.Replicas = src.Spec.ActiveGate.CapabilityProperties.Replicas
-	dst.Spec.ActiveGate.CapabilityProperties.Image = src.Spec.ActiveGate.CapabilityProperties.Image
-	dst.Spec.ActiveGate.CapabilityProperties.Group = src.Spec.ActiveGate.CapabilityProperties.Group
-	dst.Spec.ActiveGate.CapabilityProperties.Resources = src.Spec.ActiveGate.CapabilityProperties.Resources
-	dst.Spec.ActiveGate.CapabilityProperties.Tolerations = src.Spec.ActiveGate.CapabilityProperties.Tolerations
-	dst.Spec.ActiveGate.CapabilityProperties.Env = src.Spec.ActiveGate.CapabilityProperties.Env
-	dst.Spec.ActiveGate.CapabilityProperties.TopologySpreadConstraints = src.Spec.ActiveGate.CapabilityProperties.TopologySpreadConstraints
+	dk.Spec.ActiveGate.CapabilityProperties.CustomProperties = src.Spec.ActiveGate.CapabilityProperties.CustomProperties
+	dk.Spec.ActiveGate.CapabilityProperties.NodeSelector = src.Spec.ActiveGate.CapabilityProperties.NodeSelector
+	dk.Spec.ActiveGate.CapabilityProperties.Labels = src.Spec.ActiveGate.CapabilityProperties.Labels
+	dk.Spec.ActiveGate.CapabilityProperties.Replicas = src.Spec.ActiveGate.CapabilityProperties.Replicas
+	dk.Spec.ActiveGate.CapabilityProperties.Image = src.Spec.ActiveGate.CapabilityProperties.Image
+	dk.Spec.ActiveGate.CapabilityProperties.Group = src.Spec.ActiveGate.CapabilityProperties.Group
+	dk.Spec.ActiveGate.CapabilityProperties.Resources = src.Spec.ActiveGate.CapabilityProperties.Resources
+	dk.Spec.ActiveGate.CapabilityProperties.Tolerations = src.Spec.ActiveGate.CapabilityProperties.Tolerations
+	dk.Spec.ActiveGate.CapabilityProperties.Env = src.Spec.ActiveGate.CapabilityProperties.Env
+	dk.Spec.ActiveGate.CapabilityProperties.TopologySpreadConstraints = src.Spec.ActiveGate.CapabilityProperties.TopologySpreadConstraints
 
-	dst.Spec.ActiveGate.Capabilities = make([]activegate.CapabilityDisplayName, 0)
+	dk.Spec.ActiveGate.Capabilities = make([]activegate.CapabilityDisplayName, 0)
 	for _, capability := range src.Spec.ActiveGate.Capabilities {
-		dst.Spec.ActiveGate.Capabilities = append(dst.Spec.ActiveGate.Capabilities, activegate.CapabilityDisplayName(capability))
+		dk.Spec.ActiveGate.Capabilities = append(dk.Spec.ActiveGate.Capabilities, activegate.CapabilityDisplayName(capability))
 	}
 }
 
-func (dst *DynaKube) fromStatus(src *dynakubelatest.DynaKube) {
-	dst.fromOneAgentStatus(*src)
-	dst.fromActiveGateStatus(*src)
-	dst.Status.CodeModules = oneagent.CodeModulesStatus{
+func (dk *DynaKube) fromStatus(src *dynakubelatest.DynaKube) {
+	dk.fromOneAgentStatus(*src)
+	dk.fromActiveGateStatus(*src)
+	dk.Status.CodeModules = oneagent.CodeModulesStatus{
 		VersionStatus: src.Status.CodeModules.VersionStatus,
 	}
 
-	dst.Status.MetadataEnrichment.Rules = make([]EnrichmentRule, 0)
+	dk.Status.MetadataEnrichment.Rules = make([]EnrichmentRule, 0)
 	for _, rule := range src.Status.MetadataEnrichment.Rules {
-		dst.Status.MetadataEnrichment.Rules = append(dst.Status.MetadataEnrichment.Rules,
+		dk.Status.MetadataEnrichment.Rules = append(dk.Status.MetadataEnrichment.Rules,
 			EnrichmentRule{
 				Type:   EnrichmentRuleType(rule.Type),
 				Source: rule.Source,
@@ -213,37 +213,37 @@ func (dst *DynaKube) fromStatus(src *dynakubelatest.DynaKube) {
 			})
 	}
 
-	dst.Status.Kspm.TokenSecretHash = src.Status.Kspm.TokenSecretHash
-	dst.Status.UpdatedTimestamp = src.Status.UpdatedTimestamp
-	dst.Status.DynatraceAPI = DynatraceAPIStatus{
+	dk.Status.Kspm.TokenSecretHash = src.Status.Kspm.TokenSecretHash
+	dk.Status.UpdatedTimestamp = src.Status.UpdatedTimestamp
+	dk.Status.DynatraceAPI = DynatraceAPIStatus{
 		LastTokenScopeRequest: src.Status.DynatraceAPI.LastTokenScopeRequest,
 	}
-	dst.Status.Phase = src.Status.Phase
-	dst.Status.KubeSystemUUID = src.Status.KubeSystemUUID
-	dst.Status.KubernetesClusterMEID = src.Status.KubernetesClusterMEID
-	dst.Status.KubernetesClusterName = src.Status.KubernetesClusterName
-	dst.Status.Conditions = src.Status.Conditions
+	dk.Status.Phase = src.Status.Phase
+	dk.Status.KubeSystemUUID = src.Status.KubeSystemUUID
+	dk.Status.KubernetesClusterMEID = src.Status.KubernetesClusterMEID
+	dk.Status.KubernetesClusterName = src.Status.KubernetesClusterName
+	dk.Status.Conditions = src.Status.Conditions
 }
 
-func (dst *DynaKube) fromOneAgentStatus(src dynakubelatest.DynaKube) { //nolint:dupl
-	dst.Status.OneAgent.VersionStatus = src.Status.OneAgent.VersionStatus
+func (dk *DynaKube) fromOneAgentStatus(src dynakubelatest.DynaKube) { //nolint:dupl
+	dk.Status.OneAgent.VersionStatus = src.Status.OneAgent.VersionStatus
 
-	dst.Status.OneAgent.Instances = map[string]oneagent.Instance{}
+	dk.Status.OneAgent.Instances = map[string]oneagent.Instance{}
 	for key, instance := range src.Status.OneAgent.Instances {
-		dst.Status.OneAgent.Instances[key] = oneagent.Instance{
+		dk.Status.OneAgent.Instances[key] = oneagent.Instance{
 			PodName:   instance.PodName,
 			IPAddress: instance.IPAddress,
 		}
 	}
 
-	dst.Status.OneAgent.LastInstanceStatusUpdate = src.Status.OneAgent.LastInstanceStatusUpdate
-	dst.Status.OneAgent.Healthcheck = src.Status.OneAgent.Healthcheck
-	dst.Status.OneAgent.ConnectionInfoStatus.ConnectionInfo = src.Status.OneAgent.ConnectionInfoStatus.ConnectionInfo
-	dst.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts = make([]oneagent.CommunicationHostStatus, 0)
+	dk.Status.OneAgent.LastInstanceStatusUpdate = src.Status.OneAgent.LastInstanceStatusUpdate
+	dk.Status.OneAgent.Healthcheck = src.Status.OneAgent.Healthcheck
+	dk.Status.OneAgent.ConnectionInfoStatus.ConnectionInfo = src.Status.OneAgent.ConnectionInfoStatus.ConnectionInfo
+	dk.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts = make([]oneagent.CommunicationHostStatus, 0)
 
 	for _, host := range src.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts {
-		dst.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts =
-			append(dst.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts, oneagent.CommunicationHostStatus{
+		dk.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts =
+			append(dk.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts, oneagent.CommunicationHostStatus{
 				Protocol: host.Protocol,
 				Host:     host.Host,
 				Port:     host.Port,
@@ -251,10 +251,10 @@ func (dst *DynaKube) fromOneAgentStatus(src dynakubelatest.DynaKube) { //nolint:
 	}
 }
 
-func (dst *DynaKube) fromActiveGateStatus(src dynakubelatest.DynaKube) {
-	dst.Status.ActiveGate.VersionStatus = src.Status.ActiveGate.VersionStatus
-	dst.Status.ActiveGate.ConnectionInfo = src.Status.ActiveGate.ConnectionInfo
-	dst.Status.ActiveGate.ServiceIPs = src.Status.ActiveGate.ServiceIPs
+func (dk *DynaKube) fromActiveGateStatus(src dynakubelatest.DynaKube) {
+	dk.Status.ActiveGate.VersionStatus = src.Status.ActiveGate.VersionStatus
+	dk.Status.ActiveGate.ConnectionInfo = src.Status.ActiveGate.ConnectionInfo
+	dk.Status.ActiveGate.ServiceIPs = src.Status.ActiveGate.ServiceIPs
 }
 
 func fromHostInjectSpec(src oneagentlatest.HostInjectSpec) *oneagent.HostInjectSpec {
@@ -287,7 +287,7 @@ func fromAppInjectSpec(src oneagentlatest.AppInjectionSpec) *oneagent.AppInjecti
 	return dst
 }
 
-func (dst *DynaKube) fromMetadataEnrichment(src *dynakubelatest.DynaKube) {
-	dst.Spec.MetadataEnrichment.Enabled = src.Spec.MetadataEnrichment.Enabled
-	dst.Spec.MetadataEnrichment.NamespaceSelector = src.Spec.MetadataEnrichment.NamespaceSelector
+func (dk *DynaKube) fromMetadataEnrichment(src *dynakubelatest.DynaKube) {
+	dk.Spec.MetadataEnrichment.Enabled = src.Spec.MetadataEnrichment.Enabled
+	dk.Spec.MetadataEnrichment.NamespaceSelector = src.Spec.MetadataEnrichment.NamespaceSelector
 }

--- a/pkg/api/v1beta4/dynakube/convert_to.go
+++ b/pkg/api/v1beta4/dynakube/convert_to.go
@@ -14,48 +14,48 @@ import (
 )
 
 // Convertto converts this version (src=v1beta4) to the Hub version.
-func (src *DynaKube) ConvertTo(dstRaw conversion.Hub) error {
+func (dk *DynaKube) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*dynakubelatest.DynaKube)
 
-	src.toStatus(dst)
+	dk.toStatus(dst)
 
-	src.toBase(dst)
-	src.toMetadataEnrichment(dst)
-	src.toLogMonitoringSpec(dst)
-	src.toKspmSpec(dst)
-	src.toExtensionsSpec(dst)
-	src.toOneAgentSpec(dst)
-	src.toActiveGateSpec(dst)
-	src.toTemplatesSpec(dst)
-	src.toTelemetryIngestSpec(dst)
+	dk.toBase(dst)
+	dk.toMetadataEnrichment(dst)
+	dk.toLogMonitoringSpec(dst)
+	dk.toKspmSpec(dst)
+	dk.toExtensionsSpec(dst)
+	dk.toOneAgentSpec(dst)
+	dk.toActiveGateSpec(dst)
+	dk.toTemplatesSpec(dst)
+	dk.toTelemetryIngestSpec(dst)
 
 	return nil
 }
 
-func (src *DynaKube) toBase(dst *dynakubelatest.DynaKube) {
-	if src.Annotations == nil {
+func (dk *DynaKube) toBase(dst *dynakubelatest.DynaKube) {
+	if dk.Annotations == nil {
 		dst.Annotations = map[string]string{}
 	}
 
-	dst.ObjectMeta = *src.ObjectMeta.DeepCopy() // DeepCopy mainly relevant for testing
+	dst.ObjectMeta = *dk.ObjectMeta.DeepCopy() // DeepCopy mainly relevant for testing
 
-	dst.Spec.Proxy = src.Spec.Proxy
-	dst.Spec.DynatraceAPIRequestThreshold = src.Spec.DynatraceAPIRequestThreshold
-	dst.Spec.APIURL = src.Spec.APIURL
-	dst.Spec.Tokens = src.Spec.Tokens
-	dst.Spec.TrustedCAs = src.Spec.TrustedCAs
-	dst.Spec.NetworkZone = src.Spec.NetworkZone
-	dst.Spec.CustomPullSecret = src.Spec.CustomPullSecret
-	dst.Spec.SkipCertCheck = src.Spec.SkipCertCheck
-	dst.Spec.EnableIstio = src.Spec.EnableIstio
+	dst.Spec.Proxy = dk.Spec.Proxy
+	dst.Spec.DynatraceAPIRequestThreshold = dk.Spec.DynatraceAPIRequestThreshold
+	dst.Spec.APIURL = dk.Spec.APIURL
+	dst.Spec.Tokens = dk.Spec.Tokens
+	dst.Spec.TrustedCAs = dk.Spec.TrustedCAs
+	dst.Spec.NetworkZone = dk.Spec.NetworkZone
+	dst.Spec.CustomPullSecret = dk.Spec.CustomPullSecret
+	dst.Spec.SkipCertCheck = dk.Spec.SkipCertCheck
+	dst.Spec.EnableIstio = dk.Spec.EnableIstio
 }
 
-func (src *DynaKube) toLogMonitoringSpec(dst *dynakubelatest.DynaKube) {
-	if src.Spec.LogMonitoring != nil {
+func (dk *DynaKube) toLogMonitoringSpec(dst *dynakubelatest.DynaKube) {
+	if dk.Spec.LogMonitoring != nil {
 		dst.Spec.LogMonitoring = &logmonitoringlatest.Spec{}
 		dst.Spec.LogMonitoring.IngestRuleMatchers = make([]logmonitoringlatest.IngestRuleMatchers, 0)
 
-		for _, rule := range src.Spec.LogMonitoring.IngestRuleMatchers {
+		for _, rule := range dk.Spec.LogMonitoring.IngestRuleMatchers {
 			dst.Spec.LogMonitoring.IngestRuleMatchers = append(dst.Spec.LogMonitoring.IngestRuleMatchers, logmonitoringlatest.IngestRuleMatchers{
 				Attribute: rule.Attribute,
 				Values:    rule.Values,
@@ -64,43 +64,43 @@ func (src *DynaKube) toLogMonitoringSpec(dst *dynakubelatest.DynaKube) {
 	}
 }
 
-func (src *DynaKube) toKspmSpec(dst *dynakubelatest.DynaKube) {
-	if src.Spec.Kspm != nil {
+func (dk *DynaKube) toKspmSpec(dst *dynakubelatest.DynaKube) {
+	if dk.Spec.Kspm != nil {
 		dst.Spec.Kspm = &kspmlatest.Spec{}
 		dst.Spec.Kspm.MappedHostPaths = []string{"/"}
 	}
 }
 
-func (src *DynaKube) toExtensionsSpec(dst *dynakubelatest.DynaKube) {
-	if src.Spec.Extensions != nil {
+func (dk *DynaKube) toExtensionsSpec(dst *dynakubelatest.DynaKube) {
+	if dk.Spec.Extensions != nil {
 		dst.Spec.Extensions = &dynakubelatest.ExtensionsSpec{}
 	}
 }
 
-func (src *DynaKube) toOneAgentSpec(dst *dynakubelatest.DynaKube) { //nolint:dupl
+func (dk *DynaKube) toOneAgentSpec(dst *dynakubelatest.DynaKube) { //nolint:dupl
 	switch {
-	case src.OneAgent().IsClassicFullStackMode():
-		dst.Spec.OneAgent.ClassicFullStack = toHostInjectSpec(*src.Spec.OneAgent.ClassicFullStack)
-	case src.OneAgent().IsCloudNativeFullstackMode():
+	case dk.OneAgent().IsClassicFullStackMode():
+		dst.Spec.OneAgent.ClassicFullStack = toHostInjectSpec(*dk.Spec.OneAgent.ClassicFullStack)
+	case dk.OneAgent().IsCloudNativeFullstackMode():
 		dst.Spec.OneAgent.CloudNativeFullStack = &oneagentlatest.CloudNativeFullStackSpec{}
-		dst.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec = *toHostInjectSpec(src.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec)
-		dst.Spec.OneAgent.CloudNativeFullStack.AppInjectionSpec = *toAppInjectSpec(src.Spec.OneAgent.CloudNativeFullStack.AppInjectionSpec)
-	case src.OneAgent().IsApplicationMonitoringMode():
+		dst.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec = *toHostInjectSpec(dk.Spec.OneAgent.CloudNativeFullStack.HostInjectSpec)
+		dst.Spec.OneAgent.CloudNativeFullStack.AppInjectionSpec = *toAppInjectSpec(dk.Spec.OneAgent.CloudNativeFullStack.AppInjectionSpec)
+	case dk.OneAgent().IsApplicationMonitoringMode():
 		dst.Spec.OneAgent.ApplicationMonitoring = &oneagentlatest.ApplicationMonitoringSpec{}
-		dst.Spec.OneAgent.ApplicationMonitoring.Version = src.Spec.OneAgent.ApplicationMonitoring.Version
-		dst.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec = *toAppInjectSpec(src.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec)
-	case src.OneAgent().IsHostMonitoringMode():
-		dst.Spec.OneAgent.HostMonitoring = toHostInjectSpec(*src.Spec.OneAgent.HostMonitoring)
+		dst.Spec.OneAgent.ApplicationMonitoring.Version = dk.Spec.OneAgent.ApplicationMonitoring.Version
+		dst.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec = *toAppInjectSpec(dk.Spec.OneAgent.ApplicationMonitoring.AppInjectionSpec)
+	case dk.OneAgent().IsHostMonitoringMode():
+		dst.Spec.OneAgent.HostMonitoring = toHostInjectSpec(*dk.Spec.OneAgent.HostMonitoring)
 	}
 
-	dst.Spec.OneAgent.HostGroup = src.Spec.OneAgent.HostGroup
+	dst.Spec.OneAgent.HostGroup = dk.Spec.OneAgent.HostGroup
 }
 
-func (src *DynaKube) toTemplatesSpec(dst *dynakubelatest.DynaKube) {
-	dst.Spec.Templates.LogMonitoring = toLogMonitoringTemplate(src.Spec.Templates.LogMonitoring)
-	dst.Spec.Templates.KspmNodeConfigurationCollector = toKspmNodeConfigurationCollectorTemplate(src.Spec.Templates.KspmNodeConfigurationCollector)
-	dst.Spec.Templates.OpenTelemetryCollector = toOpenTelemetryCollectorTemplate(src.Spec.Templates.OpenTelemetryCollector)
-	dst.Spec.Templates.ExtensionExecutionController = toExtensionControllerTemplate(src.Spec.Templates.ExtensionExecutionController)
+func (dk *DynaKube) toTemplatesSpec(dst *dynakubelatest.DynaKube) {
+	dst.Spec.Templates.LogMonitoring = toLogMonitoringTemplate(dk.Spec.Templates.LogMonitoring)
+	dst.Spec.Templates.KspmNodeConfigurationCollector = toKspmNodeConfigurationCollectorTemplate(dk.Spec.Templates.KspmNodeConfigurationCollector)
+	dst.Spec.Templates.OpenTelemetryCollector = toOpenTelemetryCollectorTemplate(dk.Spec.Templates.OpenTelemetryCollector)
+	dst.Spec.Templates.ExtensionExecutionController = toExtensionControllerTemplate(dk.Spec.Templates.ExtensionExecutionController)
 }
 
 func toLogMonitoringTemplate(src *logmonitoring.TemplateSpec) *logmonitoringlatest.TemplateSpec {
@@ -175,39 +175,39 @@ func toExtensionControllerTemplate(src ExtensionExecutionControllerSpec) dynakub
 	return dst
 }
 
-func (src *DynaKube) toActiveGateSpec(dst *dynakubelatest.DynaKube) { //nolint:dupl
-	dst.Spec.ActiveGate.Annotations = src.Spec.ActiveGate.Annotations
-	dst.Spec.ActiveGate.TLSSecretName = src.Spec.ActiveGate.TLSSecretName
-	dst.Spec.ActiveGate.DNSPolicy = src.Spec.ActiveGate.DNSPolicy
-	dst.Spec.ActiveGate.PriorityClassName = src.Spec.ActiveGate.PriorityClassName
-	dst.Spec.ActiveGate.VolumeClaimTemplate = src.Spec.ActiveGate.PersistentVolumeClaim
+func (dk *DynaKube) toActiveGateSpec(dst *dynakubelatest.DynaKube) { //nolint:dupl
+	dst.Spec.ActiveGate.Annotations = dk.Spec.ActiveGate.Annotations
+	dst.Spec.ActiveGate.TLSSecretName = dk.Spec.ActiveGate.TLSSecretName
+	dst.Spec.ActiveGate.DNSPolicy = dk.Spec.ActiveGate.DNSPolicy
+	dst.Spec.ActiveGate.PriorityClassName = dk.Spec.ActiveGate.PriorityClassName
+	dst.Spec.ActiveGate.VolumeClaimTemplate = dk.Spec.ActiveGate.PersistentVolumeClaim
 
-	dst.Spec.ActiveGate.CapabilityProperties.CustomProperties = src.Spec.ActiveGate.CapabilityProperties.CustomProperties
-	dst.Spec.ActiveGate.CapabilityProperties.NodeSelector = src.Spec.ActiveGate.CapabilityProperties.NodeSelector
-	dst.Spec.ActiveGate.CapabilityProperties.Labels = src.Spec.ActiveGate.CapabilityProperties.Labels
-	dst.Spec.ActiveGate.CapabilityProperties.Replicas = src.Spec.ActiveGate.CapabilityProperties.Replicas
-	dst.Spec.ActiveGate.CapabilityProperties.Image = src.Spec.ActiveGate.CapabilityProperties.Image
-	dst.Spec.ActiveGate.CapabilityProperties.Group = src.Spec.ActiveGate.CapabilityProperties.Group
-	dst.Spec.ActiveGate.CapabilityProperties.Resources = src.Spec.ActiveGate.CapabilityProperties.Resources
-	dst.Spec.ActiveGate.CapabilityProperties.Tolerations = src.Spec.ActiveGate.CapabilityProperties.Tolerations
-	dst.Spec.ActiveGate.CapabilityProperties.Env = src.Spec.ActiveGate.CapabilityProperties.Env
-	dst.Spec.ActiveGate.CapabilityProperties.TopologySpreadConstraints = src.Spec.ActiveGate.CapabilityProperties.TopologySpreadConstraints
+	dst.Spec.ActiveGate.CapabilityProperties.CustomProperties = dk.Spec.ActiveGate.CapabilityProperties.CustomProperties
+	dst.Spec.ActiveGate.CapabilityProperties.NodeSelector = dk.Spec.ActiveGate.CapabilityProperties.NodeSelector
+	dst.Spec.ActiveGate.CapabilityProperties.Labels = dk.Spec.ActiveGate.CapabilityProperties.Labels
+	dst.Spec.ActiveGate.CapabilityProperties.Replicas = dk.Spec.ActiveGate.CapabilityProperties.Replicas
+	dst.Spec.ActiveGate.CapabilityProperties.Image = dk.Spec.ActiveGate.CapabilityProperties.Image
+	dst.Spec.ActiveGate.CapabilityProperties.Group = dk.Spec.ActiveGate.CapabilityProperties.Group
+	dst.Spec.ActiveGate.CapabilityProperties.Resources = dk.Spec.ActiveGate.CapabilityProperties.Resources
+	dst.Spec.ActiveGate.CapabilityProperties.Tolerations = dk.Spec.ActiveGate.CapabilityProperties.Tolerations
+	dst.Spec.ActiveGate.CapabilityProperties.Env = dk.Spec.ActiveGate.CapabilityProperties.Env
+	dst.Spec.ActiveGate.CapabilityProperties.TopologySpreadConstraints = dk.Spec.ActiveGate.CapabilityProperties.TopologySpreadConstraints
 
 	dst.Spec.ActiveGate.Capabilities = make([]activegatelatest.CapabilityDisplayName, 0)
-	for _, capability := range src.Spec.ActiveGate.Capabilities {
+	for _, capability := range dk.Spec.ActiveGate.Capabilities {
 		dst.Spec.ActiveGate.Capabilities = append(dst.Spec.ActiveGate.Capabilities, activegatelatest.CapabilityDisplayName(capability))
 	}
 }
 
-func (src *DynaKube) toStatus(dst *dynakubelatest.DynaKube) {
-	src.toOneAgentStatus(dst)
-	src.toActiveGateStatus(dst)
+func (dk *DynaKube) toStatus(dst *dynakubelatest.DynaKube) {
+	dk.toOneAgentStatus(dst)
+	dk.toActiveGateStatus(dst)
 	dst.Status.CodeModules = oneagentlatest.CodeModulesStatus{
-		VersionStatus: src.Status.CodeModules.VersionStatus,
+		VersionStatus: dk.Status.CodeModules.VersionStatus,
 	}
 
 	dst.Status.MetadataEnrichment.Rules = make([]dynakubelatest.EnrichmentRule, 0)
-	for _, rule := range src.Status.MetadataEnrichment.Rules {
+	for _, rule := range dk.Status.MetadataEnrichment.Rules {
 		dst.Status.MetadataEnrichment.Rules = append(dst.Status.MetadataEnrichment.Rules,
 			dynakubelatest.EnrichmentRule{
 				Type:   dynakubelatest.EnrichmentRuleType(rule.Type),
@@ -216,36 +216,36 @@ func (src *DynaKube) toStatus(dst *dynakubelatest.DynaKube) {
 			})
 	}
 
-	dst.Status.Kspm.TokenSecretHash = src.Status.Kspm.TokenSecretHash
-	dst.Status.UpdatedTimestamp = src.Status.UpdatedTimestamp
+	dst.Status.Kspm.TokenSecretHash = dk.Status.Kspm.TokenSecretHash
+	dst.Status.UpdatedTimestamp = dk.Status.UpdatedTimestamp
 	dst.Status.DynatraceAPI = dynakubelatest.DynatraceAPIStatus{
-		LastTokenScopeRequest: src.Status.DynatraceAPI.LastTokenScopeRequest,
+		LastTokenScopeRequest: dk.Status.DynatraceAPI.LastTokenScopeRequest,
 	}
-	dst.Status.Phase = src.Status.Phase
-	dst.Status.KubeSystemUUID = src.Status.KubeSystemUUID
-	dst.Status.KubernetesClusterMEID = src.Status.KubernetesClusterMEID
-	dst.Status.KubernetesClusterName = src.Status.KubernetesClusterName
-	dst.Status.Conditions = src.Status.Conditions
+	dst.Status.Phase = dk.Status.Phase
+	dst.Status.KubeSystemUUID = dk.Status.KubeSystemUUID
+	dst.Status.KubernetesClusterMEID = dk.Status.KubernetesClusterMEID
+	dst.Status.KubernetesClusterName = dk.Status.KubernetesClusterName
+	dst.Status.Conditions = dk.Status.Conditions
 }
 
-func (src *DynaKube) toOneAgentStatus(dst *dynakubelatest.DynaKube) { //nolint:dupl
-	dst.Status.OneAgent.VersionStatus = src.Status.OneAgent.VersionStatus
+func (dk *DynaKube) toOneAgentStatus(dst *dynakubelatest.DynaKube) { //nolint:dupl
+	dst.Status.OneAgent.VersionStatus = dk.Status.OneAgent.VersionStatus
 
 	dst.Status.OneAgent.Instances = map[string]oneagentlatest.Instance{}
-	for key, instance := range src.Status.OneAgent.Instances {
+	for key, instance := range dk.Status.OneAgent.Instances {
 		dst.Status.OneAgent.Instances[key] = oneagentlatest.Instance{
 			PodName:   instance.PodName,
 			IPAddress: instance.IPAddress,
 		}
 	}
 
-	dst.Status.OneAgent.LastInstanceStatusUpdate = src.Status.OneAgent.LastInstanceStatusUpdate
-	dst.Status.OneAgent.Healthcheck = src.Status.OneAgent.Healthcheck
+	dst.Status.OneAgent.LastInstanceStatusUpdate = dk.Status.OneAgent.LastInstanceStatusUpdate
+	dst.Status.OneAgent.Healthcheck = dk.Status.OneAgent.Healthcheck
 
-	dst.Status.OneAgent.ConnectionInfoStatus.ConnectionInfo = src.Status.OneAgent.ConnectionInfoStatus.ConnectionInfo
+	dst.Status.OneAgent.ConnectionInfoStatus.ConnectionInfo = dk.Status.OneAgent.ConnectionInfoStatus.ConnectionInfo
 	dst.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts = make([]oneagentlatest.CommunicationHostStatus, 0)
 
-	for _, host := range src.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts {
+	for _, host := range dk.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts {
 		dst.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts =
 			append(dst.Status.OneAgent.ConnectionInfoStatus.CommunicationHosts, oneagentlatest.CommunicationHostStatus{
 				Protocol: host.Protocol,
@@ -255,10 +255,10 @@ func (src *DynaKube) toOneAgentStatus(dst *dynakubelatest.DynaKube) { //nolint:d
 	}
 }
 
-func (src *DynaKube) toActiveGateStatus(dst *dynakubelatest.DynaKube) {
-	dst.Status.ActiveGate.VersionStatus = src.Status.ActiveGate.VersionStatus
-	dst.Status.ActiveGate.ConnectionInfo = src.Status.ActiveGate.ConnectionInfo
-	dst.Status.ActiveGate.ServiceIPs = src.Status.ActiveGate.ServiceIPs
+func (dk *DynaKube) toActiveGateStatus(dst *dynakubelatest.DynaKube) {
+	dst.Status.ActiveGate.VersionStatus = dk.Status.ActiveGate.VersionStatus
+	dst.Status.ActiveGate.ConnectionInfo = dk.Status.ActiveGate.ConnectionInfo
+	dst.Status.ActiveGate.ServiceIPs = dk.Status.ActiveGate.ServiceIPs
 }
 
 func toHostInjectSpec(src oneagent.HostInjectSpec) *oneagentlatest.HostInjectSpec {
@@ -291,17 +291,17 @@ func toAppInjectSpec(src oneagent.AppInjectionSpec) *oneagentlatest.AppInjection
 	return dst
 }
 
-func (src *DynaKube) toMetadataEnrichment(dst *dynakubelatest.DynaKube) {
-	dst.Spec.MetadataEnrichment.Enabled = src.Spec.MetadataEnrichment.Enabled
-	dst.Spec.MetadataEnrichment.NamespaceSelector = src.Spec.MetadataEnrichment.NamespaceSelector
+func (dk *DynaKube) toMetadataEnrichment(dst *dynakubelatest.DynaKube) {
+	dst.Spec.MetadataEnrichment.Enabled = dk.Spec.MetadataEnrichment.Enabled
+	dst.Spec.MetadataEnrichment.NamespaceSelector = dk.Spec.MetadataEnrichment.NamespaceSelector
 }
 
-func (src *DynaKube) toTelemetryIngestSpec(dst *dynakubelatest.DynaKube) {
-	if src.Spec.TelemetryIngest != nil {
+func (dk *DynaKube) toTelemetryIngestSpec(dst *dynakubelatest.DynaKube) {
+	if dk.Spec.TelemetryIngest != nil {
 		dst.Spec.TelemetryIngest = &telemetryingestlatest.Spec{}
-		dst.Spec.TelemetryIngest.Protocols = src.Spec.TelemetryIngest.Protocols
-		dst.Spec.TelemetryIngest.ServiceName = src.Spec.TelemetryIngest.ServiceName
-		dst.Spec.TelemetryIngest.TLSRefName = src.Spec.TelemetryIngest.TLSRefName
+		dst.Spec.TelemetryIngest.Protocols = dk.Spec.TelemetryIngest.Protocols
+		dst.Spec.TelemetryIngest.ServiceName = dk.Spec.TelemetryIngest.ServiceName
+		dst.Spec.TelemetryIngest.TLSRefName = dk.Spec.TelemetryIngest.TLSRefName
 	} else {
 		dst.Spec.TelemetryIngest = nil
 	}

--- a/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/env_vars.go
@@ -135,7 +135,7 @@ func (b *builder) addLogMonitoringEnv(envVarMap *prioritymap.Map) {
 	}
 }
 
-func (b *hostMonitoring) appendInfraMonEnvVars(daemonset *appsv1.DaemonSet) {
+func (hm *hostMonitoring) appendInfraMonEnvVars(daemonset *appsv1.DaemonSet) {
 	envVars := prioritymap.New()
 	prioritymap.Append(envVars, daemonset.Spec.Template.Spec.Containers[0].Env)
 	addDefaultValue(envVars, oneagentDisableContainerInjection, "true")


### PR DESCRIPTION
## Description
Addresses Staticcheck `ST1016` errors:
* See https://staticcheck.dev/docs/checks/#ST1016
* Example: `ST1016: methods on the same type should have the same receiver name (seen 3x "e", 6x "ec", 7x "edgeConnect") (staticcheck)`

Relevant ticket: [DAQ-6691](https://dt-rnd.atlassian.net/browse/DAQ-6691)

## How can this be tested?
* Unit tests