### PR TITLE
Revert "Improve how we wait for status when we create/destroy clusters"

### DIFF
--- a/.github/scripts/create-cluster.sh
+++ b/.github/scripts/create-cluster.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-DEFAULT_TIMEOUT="60m" # K8s takes <10min, Openshift >40min
+DEFAULT_TIMEOUT="80m" # K8s takes <10min, Openshift >40min
 DESIRED_STATE="environment-deployed"
 
 kubectl version
@@ -12,7 +12,7 @@ echo "Creating environment '$FLC_ENVIRONMENT' in namespace '$FLC_NAMESPACE'"
 kubectl get flcenvironments --namespace "$FLC_NAMESPACE"
 
 echo "Patching environment '$FLC_ENVIRONMENT' to 'deployed'"
-kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch '{"spec": {"desiredState": "environment-deployed"}}' flcenvironment "$FLC_ENVIRONMENT"
+kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch "{\"spec\": {\"desiredState\": \"$DESIRED_STATE\"}}" flcenvironment "$FLC_ENVIRONMENT"
 
 echo "Waiting up to '$DEFAULT_TIMEOUT' for successful deployment of environment '$FLC_ENVIRONMENT'"
 kubectl wait --namespace "$FLC_NAMESPACE" --timeout="$DEFAULT_TIMEOUT" --for=condition=InTransition=false flcenvironment "$FLC_ENVIRONMENT"

--- a/.github/scripts/create-cluster.sh
+++ b/.github/scripts/create-cluster.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-DEFAULT_TIMEOUT="80m" # K8s takes <10min, Openshift >40min
+DEFAULT_TIMEOUT="60m" # K8s takes <10min, Openshift >40min
 DESIRED_STATE="environment-deployed"
 
 kubectl version
@@ -15,4 +15,20 @@ echo "Patching environment '$FLC_ENVIRONMENT' to 'deployed'"
 kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch '{"spec": {"desiredState": "environment-deployed"}}' flcenvironment "$FLC_ENVIRONMENT"
 
 echo "Waiting up to '$DEFAULT_TIMEOUT' for successful deployment of environment '$FLC_ENVIRONMENT'"
-kubectl wait --namespace "$FLC_NAMESPACE" --timeout="$DEFAULT_TIMEOUT" --for jsonpath='{.status.currentState}'="$DESIRED_STATE" flcenvironment "$FLC_ENVIRONMENT"
+kubectl wait --namespace "$FLC_NAMESPACE" --timeout="$DEFAULT_TIMEOUT" --for=condition=InTransition=false flcenvironment "$FLC_ENVIRONMENT"
+
+if [[ "$FLC_ENVIRONMENT" == *"ocp"* ]]; then
+  echo "PLATFORM is set to 'ocp'. Waiting for 5 minutes..."
+  sleep 300  # Wait for 5 minutes (300 seconds)
+  echo "done"
+fi
+
+echo "Checking currentState='$DESIRED_STATE' for '$FLC_ENVIRONMENT'..."
+flc_state=$(kubectl get flcenvironment "$FLC_ENVIRONMENT" --namespace "$FLC_NAMESPACE" -ojsonpath="{.status.currentState}")
+if [[ "$flc_state" != "$DESIRED_STATE" ]]; then
+  echo "Pipeline deployment did not reach expected state '$DESIRED_STATE', currentState: ${flc_state}..."
+  exit 1
+  else
+    echo "successful..."
+fi
+echo "done"

--- a/.github/scripts/destroy-cluster.sh
+++ b/.github/scripts/destroy-cluster.sh
@@ -3,10 +3,30 @@
 set -x
 
 DEFAULT_TIMEOUT="20m"
+DESIRED_STATE="environment-not-deployed"
 
 echo "Destroying environment '$FLC_ENVIRONMENT' in namespace '$FLC_NAMESPACE'"
 
 kubectl get flcenvironments --namespace "$FLC_NAMESPACE"
 
 echo "Patching environment '$FLC_ENVIRONMENT' to 'not-deployed'"
-kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch '{"spec": {"desiredState": "environment-not-deployed"}}' flcenvironment "$FLC_ENVIRONMENT"
+kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch "{\"spec\": {\"desiredState\": \"$DESIRED_STATE\"}}" flcenvironment "$FLC_ENVIRONMENT"
+
+echo "Waiting up to '$DEFAULT_TIMEOUT' for successful destruction of environment '$FLC_ENVIRONMENT'"
+kubectl wait --namespace "$FLC_NAMESPACE" --timeout="$DEFAULT_TIMEOUT" --for=condition=InTransition=false flcenvironment "$FLC_ENVIRONMENT"
+
+if [[ "$FLC_ENVIRONMENT" == *"ocp"* ]]; then
+  echo "PLATFORM is set to 'ocp'. Waiting for 5 minutes..."
+  sleep 300  # Wait for 5 minutes (300 seconds)
+  echo "done"
+fi
+
+echo "Checking currentState='$DESIRED_STATE' for '$FLC_ENVIRONMENT'..."
+flc_state=$(kubectl get flcenvironment "$FLC_ENVIRONMENT" --namespace "$FLC_NAMESPACE" -ojsonpath="{.status.currentState}")
+if [[ "$flc_state" != "$DESIRED_STATE" ]]; then
+  echo "Pipeline destruction did not reach expected state '$DESIRED_STATE', currentState: ${flc_state}..."
+  exit 1
+  else
+    echo "successful..."
+fi
+echo "done"

--- a/.github/scripts/destroy-cluster.sh
+++ b/.github/scripts/destroy-cluster.sh
@@ -10,5 +10,3 @@ kubectl get flcenvironments --namespace "$FLC_NAMESPACE"
 
 echo "Patching environment '$FLC_ENVIRONMENT' to 'not-deployed'"
 kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch '{"spec": {"desiredState": "environment-not-deployed"}}' flcenvironment "$FLC_ENVIRONMENT"
-
-kubectl wait --namespace "$FLC_NAMESPACE" --timeout="$DEFAULT_TIMEOUT" --for jsonpath='{.status.currentState}'=environment-not-deployed flcenvironment "$FLC_ENVIRONMENT"


### PR DESCRIPTION
## Description
[DAQ-8528](https://dt-rnd.atlassian.net/browse/DAQ-8528)

Just a revert of https://github.com/Dynatrace/dynatrace-operator/pull/3805 with some extra fixes.
- We don't just wait till we reach `environment-deployed`, we wait until transition, then check if we are in the correct state


## How can this be tested?

Run e2e pipeline on this branch