### PR TITLE
test: fixup e2e test after refactroing node-image-pull secret split

### DIFF
--- a/test/features/bootstrapper/without_csi.go
+++ b/test/features/bootstrapper/without_csi.go
@@ -133,8 +133,25 @@ func checkInjection(deployment *sample.App) features.Func {
 			expectedVolume := corev1.Volume{
 				Name: volumes.InputVolumeName,
 				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: consts.BootstrapperInitSecretName,
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{
+								Secret: &corev1.SecretProjection{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: consts.BootstrapperInitSecretName,
+									},
+									Optional: ptr.To(false),
+								},
+							},
+							{
+								Secret: &corev1.SecretProjection{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: consts.BootstrapperInitCertsSecretName,
+									},
+									Optional: ptr.To(true),
+								},
+							},
+						},
 					},
 				},
 			}
@@ -143,8 +160,7 @@ func checkInjection(deployment *sample.App) features.Func {
 			found := false
 			for _, v := range item.Spec.Volumes {
 				if v.Name == expectedVolume.Name {
-					require.NotNil(t, v.Secret)
-					require.Equal(t, expectedVolume.Secret.SecretName, v.Secret.SecretName)
+					require.Equal(t, expectedVolume.VolumeSource.Projected.Sources, v.VolumeSource.Projected.Sources)
 					found = true
 				}
 			}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Resolves some left overs from https://github.com/Dynatrace/dynatrace-operator/pull/4923

## How can this be tested?

`make test/e2e/applicationmonitoring/bootstrapper-no-csi`