### PR TITLE
Fix e2e cluster create/delete script

### DIFF
--- a/.github/scripts/create-cluster.sh
+++ b/.github/scripts/create-cluster.sh
@@ -2,9 +2,6 @@
 
 set -x
 
-DEFAULT_TIMEOUT="80m" # K8s takes <10min, Openshift >40min
-DESIRED_STATE="environment-deployed"
-
 kubectl version
 
 echo "Creating environment '$FLC_ENVIRONMENT' in namespace '$FLC_NAMESPACE'"
@@ -14,7 +11,7 @@ kubectl get flcenvironments --namespace "$FLC_NAMESPACE"
 echo "Patching environment '$FLC_ENVIRONMENT' to 'deployed'"
 kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch '{"spec": {"desiredState": "environment-deployed"}}' flcenvironment "$FLC_ENVIRONMENT"
 
-echo "Waiting up to '$DEFAULT_TIMEOUT' for successful deployment of environment '$FLC_ENVIRONMENT'"
+echo "Waiting up to 80m for successful deployment of environment '$FLC_ENVIRONMENT'"
 
 # wait until timeout or until the environment is in the desired state
 NEXT_WAIT_TIME=0

--- a/.github/scripts/destroy-cluster.sh
+++ b/.github/scripts/destroy-cluster.sh
@@ -2,14 +2,14 @@
 
 set -x
 
-DEFAULT_TIMEOUT="20m"
-
 echo "Destroying environment '$FLC_ENVIRONMENT' in namespace '$FLC_NAMESPACE'"
 
 kubectl get flcenvironments --namespace "$FLC_NAMESPACE"
 
 echo "Patching environment '$FLC_ENVIRONMENT' to 'not-deployed'"
 kubectl patch --namespace "$FLC_NAMESPACE" --type merge --patch '{"spec": {"desiredState": "environment-not-deployed"}}' flcenvironment "$FLC_ENVIRONMENT"
+
+echo "Waiting up to 20m for successful destruction of environment '$FLC_ENVIRONMENT'"
 
 # wait until timeout or until the environment is in the desired state
 NEXT_WAIT_TIME=0


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

`break` will just cause the script to reach the 
```bash
echo "Timeout reached while waiting for environment '$FLC_ENVIRONMENT' to be deployed."
exit 1
```
part, even if there was a success

## How can this be tested?

test it in a fork