### PR TITLE
Only provide the custom-pull-secret to the download jobs

### DIFF
--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -166,7 +166,7 @@ func TestReconcile(t *testing.T) {
 		installer.AssertCalled(t, "InstallAgent", mock.Anything, mock.Anything)
 	})
 
-		t.Run("dynakube with job + custom-pull-secret => job installer used, with error", func(t *testing.T) {
+	t.Run("dynakube with job + custom-pull-secret => job installer used, with error", func(t *testing.T) {
 		dk := createDynaKubeWithJobFF(t)
 		dk.Spec.CustomPullSecret = "test-ps"
 		prov := createProvisioner(t, dk, createPMCSecret(t, dk))

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -97,10 +97,15 @@ func (provisioner *OneAgentProvisioner) getJobInstaller(ctx context.Context, dk 
 		imageUri = "public.ecr.aws/dynatrace/dynatrace-codemodules:" + dk.OneAgent().GetCodeModulesVersion()
 	}
 
+	pullSecrets := []string{}
+	if dk.Spec.CustomPullSecret != "" {
+		pullSecrets = append(pullSecrets, dk.Spec.CustomPullSecret)
+	}
+
 	props := &job.Properties{
 		ImageUri:     imageUri,
 		Owner:        &dk,
-		PullSecrets:  dk.PullSecretNames(),
+		PullSecrets:  pullSecrets,
 		ApiReader:    provisioner.apiReader,
 		Client:       provisioner.kubeClient,
 		PathResolver: provisioner.path,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-10243](https://dt-rnd.atlassian.net/browse/DAQ-10243)

The pull-secret created by the Operator (`dtpullsecret` package) is not needed in any way for the Jobs.
- This pull-secret is only meant for talking with the tenant registry
- The Jobs only get images from private/public registries

## How can this be tested?

No warning: `Warning   FailedToRetrieveImagePullSecret`, when using a dynakube (CSI-driver needs to be used) such as:
```yaml
apiVersion: dynatrace.com/v1beta3
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/node-image-pull: "true"
spec:
  apiUrl: <some-url>
  activeGate:
    capabilities:
      - routing
      - kubernetes-monitoring
  metadataEnrichment:
    enabled: true
  oneAgent:
    applicationMonitoring: 
      codeModulesImage: <some-image>
```



[DAQ-10243]: https://dt-rnd.atlassian.net/browse/DAQ-10243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ