### PR TITLE
Add log monitoring config to `applicationMonitoring` DynaKube samples

### DIFF
--- a/assets/samples/dynakube/v1beta3/applicationMonitoring.yaml
+++ b/assets/samples/dynakube/v1beta3/applicationMonitoring.yaml
@@ -58,6 +58,23 @@ spec:
     #     operator: In
     #     values: [my-frontend, my-backend, my-database]
 
+    # Configuration for Log monitoring.
+    #
+    # logMonitoring: {}
+
+    # Optional: Specifies the rules and conditions for matching ingest attributes.
+    #
+    # ingestRuleMatchers:
+    #   - attribute: "k8s.namespace.name"
+    #     values:
+    #       - "kube-system"
+    #       - "dynatrace"
+    #       - "default"
+    #   - attribute: "k8s.pod.annotation",
+    #     values:
+    #       - "logs.dynatrace.com/ingest=true"
+    #       - "category=security"
+
   # Configuration for OneAgent
   #
   oneAgent:
@@ -175,3 +192,9 @@ spec:
     # Optional: Add TopologySpreadConstraints to the ActiveGate pods
     #
     # topologySpreadConstraints: []
+
+  # templates:
+  #   logMonitoring:
+  #     imageRef:
+  #       repository: public.ecr.aws/dynatrace/dynatrace-logmodule
+  #       tag: <tag>

--- a/assets/samples/dynakube/v1beta4/applicationMonitoring.yaml
+++ b/assets/samples/dynakube/v1beta4/applicationMonitoring.yaml
@@ -58,6 +58,23 @@ spec:
     #     operator: In
     #     values: [my-frontend, my-backend, my-database]
 
+    # Configuration for Log monitoring.
+    #
+    # logMonitoring: {}
+
+    # Optional: Specifies the rules and conditions for matching ingest attributes.
+    #
+    # ingestRuleMatchers:
+    #   - attribute: "k8s.namespace.name"
+    #     values:
+    #       - "kube-system"
+    #       - "dynatrace"
+    #       - "default"
+    #   - attribute: "k8s.pod.annotation",
+    #     values:
+    #       - "logs.dynatrace.com/ingest=true"
+    #       - "category=security"
+
   # Configuration for OneAgent
   #
   oneAgent:
@@ -175,3 +192,9 @@ spec:
     # Optional: Add TopologySpreadConstraints to the ActiveGate pods
     #
     # topologySpreadConstraints: []
+
+  # templates:
+  #   logMonitoring:
+  #     imageRef:
+  #       repository: public.ecr.aws/dynatrace/dynatrace-logmodule
+  #       tag: <tag>

--- a/assets/samples/dynakube/v1beta5/applicationMonitoring.yaml
+++ b/assets/samples/dynakube/v1beta5/applicationMonitoring.yaml
@@ -58,6 +58,23 @@ spec:
     #     operator: In
     #     values: [my-frontend, my-backend, my-database]
 
+  # Configuration for Log monitoring.
+  #
+  #  logMonitoring: {}
+
+  # Optional: Specifies the rules and conditions for matching ingest attributes.
+  #
+  # ingestRuleMatchers:
+  #   - attribute: "k8s.namespace.name"
+  #     values:
+  #       - "kube-system"
+  #       - "dynatrace"
+  #       - "default"
+  #   - attribute: "k8s.pod.annotation",
+  #     values:
+  #       - "logs.dynatrace.com/ingest=true"
+  #       - "category=security"
+
   # Configuration for OneAgent
   #
   oneAgent:
@@ -175,3 +192,9 @@ spec:
     # Optional: Add TopologySpreadConstraints to the ActiveGate pods
     #
     # topologySpreadConstraints: []
+
+  # templates:
+  #   logMonitoring:
+  #     imageRef:
+  #       repository: public.ecr.aws/dynatrace/dynatrace-logmodule
+  #       tag: <tag>


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
Cherry-picked from https://github.com/Dynatrace/dynatrace-operator/pull/5061:

> `logMonitoring` is missing from our application monitoring DynaKube samples. This PR adds the missing config.
> 
> Addresses [DAQ-10221](https://dt-rnd.atlassian.net/browse/DAQ-10221)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?
Apply the DynaKube configs.
<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[DAQ-10221]: https://dt-rnd.atlassian.net/browse/DAQ-10221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ