### PR TITLE
Use dk.templates.logMonitoring.resources to set value of main and init container resources

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
@@ -37,6 +37,7 @@ func getContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container {
 		ImagePullPolicy: corev1.PullAlways,
 		VolumeMounts:    getVolumeMounts(tenantUUID),
 		Env:             getEnvs(),
+		Resources:       dk.LogMonitoring().Template().Resources,
 		SecurityContext: &securityContext,
 	}
 

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
@@ -56,6 +56,7 @@ func getInitContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container 
 		Command:         []string{bootstrapCommand},
 		Env:             getInitEnvs(dk),
 		Args:            getInitArgs(dk),
+		Resources:       dk.LogMonitoring().Template().Resources,
 		SecurityContext: &securityContext,
 	}
 


### PR DESCRIPTION
For the main container: [JIRA](https://dt-rnd.atlassian.net/browse/DAQ-10368)
For the init container: [JIRA](https://dt-rnd.atlassian.net/browse/DAQ-10370)

## Description

dk.templates.logMonitoring.resources field is used to set value of LogMonitoring main AND init container resources.

## How can this be tested?

unittests