### PR TITLE
initialize recorder correctly

### DIFF
--- a/pkg/webhook/mutation/pod/register.go
+++ b/pkg/webhook/mutation/pod/register.go
@@ -65,6 +65,7 @@ func registerInjectEndpoint(ctx context.Context, mgr manager.Manager, webhookNam
 		webhookNamespace: webhookNamespace,
 		deployedViaOLM:   kubesystem.IsDeployedViaOlm(*webhookPod),
 		decoder:          admission.NewDecoder(mgr.GetScheme()),
+		recorder:         eventRecorder,
 	}})
 	log.Info("registered /inject endpoint")
 


### PR DESCRIPTION
## Description

Resolves bug https://dt-rnd.atlassian.net/browse/DAQ-10374

## How can this be tested?

Short test-case:
1. Install operator
2. Deploy dk + deploy php sample apps ( all is working)
3. undeploy dk + remove php samples
4. deploy php-samples with manual label for ns [dynakube.internal.dynatrace.com/instance]`(http://dynakube.internal.dynatrace.com/instance): no-existent`
webhook will panic (more details in bug report)

Or an advanced realistic test from the ticket also.

repeat with release-1.6 and patch, after patch you should see no panic but instead warning event:


![image](https://github.com/user-attachments/assets/b132a786-1e7b-4f64-8e69-b20c3d31e2c1)
