### PR TITLE
Make full use of the `docker-metadata` action

### DIFF
--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -44,6 +44,11 @@ runs:
       shell: bash
       run: |
         touch dynatrace-operator-bin-sbom.cdx.json
+    - name: Set build date
+      shell: bash
+      id: set-build-date
+      run: |
+        echo "date=$(date --iso-8601)" >> $GITHUB_OUTPUT
     - name: Docker metadata
       uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
       id: meta
@@ -55,6 +60,18 @@ runs:
           ${{ inputs.annotation }}
         labels: |
           ${{ inputs.labels }}
+          quay.expires-after=${{ (github.ref_type != 'tag' && !startsWith(github.ref_name, 'release-') && github.ref_name != 'main') && '10d' || '' }}
+          vcs-ref=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          build-date=${{ steps.set-build-date.outputs.date }}
+        tags: |
+          # PRs
+          type=raw,value=snapshot-${{ github.head_ref }},enable=${{ github.event_name == 'pull_request' }}
+          # main branches
+          type=raw,value=snapshot,enable=${{ github.ref_name == 'main' }}
+          # tags
+          type=raw,value=${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
+          # everything else
+          type=raw,value=snapshot-${{ github.ref_name }},enable=${{ !(github.event_name == 'pull_request' || github.ref_name == 'main' || github.ref_type == 'tag') }},priority=0
     - name: Build target
       id: build-target
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -68,7 +85,7 @@ runs:
         provenance: false
         platforms: ${{ inputs.platforms }}
         push: true
-        tags: ${{ inputs.tags }}
+        tags: ${{ steps.meta.outputs.tags }}
         labels: |
           ${{ steps.meta.outputs.labels }}
         annotations: |

--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -7,7 +7,7 @@ inputs:
     required: true
   labels:
     description: The labels for the built image
-    required: true
+    required: false
   tags:
     description: The tags of the built image. Should be the whole image URIs, like docker.io/dynatrace/dynatrace-operator:snapshot,quay.io/dynatrace/dynatrace-operator:snapshot
     required: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,7 +246,7 @@ jobs:
       version: ${{ steps.prep.outputs.docker_image_tag }}
 
   build-push:
-    needs: [detect-changes, prepare]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.is_protected_branch || needs.detect-changes.outputs.go_changed || needs.detect-changes.outputs.docker_changed || needs.detect-changes.outputs.ci_changed
     name: Build images
     runs-on: ubuntu-latest
@@ -263,7 +263,6 @@ jobs:
         uses: ./.github/actions/build-push-image
         with:
           platforms: ${{github.ref_protected && env.PLATFORMS || env.PR_PLATFORMS }}
-          labels: ${{ needs.prepare.outputs.labels }}
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY }}:${{ needs.prepare.outputs.version }}
           annotation: "version=${{ needs.prepare.outputs.version }}"
 


### PR DESCRIPTION
## Description
Let's make full use of the [docker-metadata action](https://github.com/docker/metadata-action). Currently, we mostly use [our bash script](https://github.com/Dynatrace/dynatrace-operator/blob/1f01acb14b5d737cade37a0d6204592e87f77c1b/hack/build/ci/prepare-build-variables.sh#L3-L24) for creating image tags and labels in our CI.

Addresses [DAQ-7165](https://dt-rnd.atlassian.net/browse/DAQ-7165)

## How can this be tested?
1. Fork this repo, push everything to `main` and try the following:
  * Opening PRs
  * Creating tags
  * Pushing new commits to `main`
  * ...
2. Make sure the `docker-metadata` action behaves just like this bash script below 👇🏿 
https://github.com/Dynatrace/dynatrace-operator/blob/1f01acb14b5d737cade37a0d6204592e87f77c1b/hack/build/ci/prepare-build-variables.sh#L3-L24

[DAQ-7165]: https://dt-rnd.atlassian.net/browse/DAQ-7165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ