### PR TITLE
Moves the `/tmp/dynatrace` logmon host-path to `/var/opt/dynatrace`

### DIFF
--- a/pkg/api/latest/dynakube/oneagent/props.go
+++ b/pkg/api/latest/dynakube/oneagent/props.go
@@ -16,7 +16,7 @@ const (
 	OneAgentConnectionInfoConfigMapSuffix = "-oneagent-connection-info"
 	PodNameOsAgent                        = "oneagent"
 	DefaultOneAgentImageRegistrySubPath   = "/linux/oneagent"
-	storageVolumeDefaultHostPath          = "/var/opt/dynatrace"
+	StorageVolumeDefaultHostPath          = "/var/opt/dynatrace"
 )
 
 func NewOneAgent(spec *Spec, status *Status, codeModulesStatus *CodeModulesStatus, //nolint:revive
@@ -335,7 +335,7 @@ func (oa *OneAgent) GetHostPath() string {
 			return oa.CloudNativeFullStack.StorageHostPath
 		}
 
-		return storageVolumeDefaultHostPath
+		return StorageVolumeDefaultHostPath
 	}
 
 	if oa.IsHostMonitoringMode() {
@@ -343,7 +343,7 @@ func (oa *OneAgent) GetHostPath() string {
 			return oa.HostMonitoring.StorageHostPath
 		}
 
-		return storageVolumeDefaultHostPath
+		return StorageVolumeDefaultHostPath
 	}
 
 	return ""

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -19,7 +19,7 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 		fmt.Sprintf("-c k8s_node_name $(%s)", nodeNameEnv),
 		fmt.Sprintf("-c k8s_cluster_id $(%s)", clusterUIDEnv),
 		"-c k8s_containername " + containerName,
-		"-l " + dtLogVolumePath,
+		"-l " + dtLogVolumeMountPath,
 	}
 
 	return append(baseArgs, dk.LogMonitoring().Template().Args...)

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/volumes.go
@@ -3,6 +3,7 @@ package daemonset
 import (
 	"fmt"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/configsecret"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -13,12 +14,15 @@ const (
 	configVolumeName      = "config"
 	configVolumeMountPath = "/var/lib/dynatrace/oneagent/agent/config/deployment.conf"
 
-	// for the logmonitoring to read/write
-	dtLibVolumeName      = "dynatrace-lib"
-	dtLibVolumeMountPath = "/var/lib/dynatrace"
-	dtSubPathTemplate    = "logmonitoring-%s"
-	dtLogVolumePath      = "/tmp/dynatrace"
+	// for the logmonitoring configurations to read/write
+	dtLibVolumeName                 = "dynatrace-lib"
+	dtLibVolumeMountPath            = "/var/lib/dynatrace"
+	dtLibVolumeMountSubPathTemplate = "logmonitoring-%s"
+	dtLibVolumeHostPath             = oneagent.StorageVolumeDefaultHostPath
+
+	// for the logmonitoring logs to read/write
 	dtLogVolumeName      = "dynatrace-logs"
+	dtLogVolumeMountPath = "/tmp/dynatrace"
 
 	// for the logs that the logmonitoring will ingest
 	dockerLogsVolumeName = "docker-container-logs"
@@ -53,7 +57,7 @@ func getDTVolumeMounts(tenantUUID string) corev1.VolumeMount {
 	return corev1.VolumeMount{
 
 		Name:      dtLibVolumeName,
-		SubPath:   fmt.Sprintf(dtSubPathTemplate, tenantUUID),
+		SubPath:   fmt.Sprintf(dtLibVolumeMountSubPathTemplate, tenantUUID),
 		MountPath: dtLibVolumeMountPath,
 	}
 }
@@ -63,8 +67,8 @@ func getDTLogVolumeMounts(tenantUUID string) corev1.VolumeMount {
 	return corev1.VolumeMount{
 
 		Name:      dtLogVolumeName,
-		SubPath:   fmt.Sprintf(dtSubPathTemplate, tenantUUID),
-		MountPath: dtLogVolumePath,
+		SubPath:   fmt.Sprintf(dtLibVolumeMountSubPathTemplate, tenantUUID),
+		MountPath: dtLogVolumeMountPath,
 	}
 }
 
@@ -75,7 +79,7 @@ func getDTVolumes() []corev1.Volume {
 			Name: dtLibVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: dtLogVolumePath,
+					Path: dtLibVolumeHostPath,
 					Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 				},
 			},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

In certain host FS, the `/tmp` folder is cleaned often, if files were not touched.
This causes issues with the standalone LogMonitoring.

So, we move it to the new default host-storage path that is used in `CloudNativeFullstack/HostMonitoring` without CSI.

## How can this be tested?

Check the host-path used by the logmonitoring `DaemonSet`