### PR TITLE
Fix potential integer overflow in the CSI gRPC server

### DIFF
--- a/pkg/controllers/csi/driver/server.go
+++ b/pkg/controllers/csi/driver/server.go
@@ -44,7 +44,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-const MaxGrpcRequests = 20
+const DefaultMaxGrpcRequests = 20
 
 var counter atomic.Int32
 
@@ -105,7 +105,7 @@ func (srv *Server) Start(ctx context.Context) error {
 
 	maxGrpcRequests, err := strconv.ParseInt(os.Getenv("GRPC_MAX_REQUESTS_LIMIT"), 10, 32)
 	if err != nil {
-		maxGrpcRequests = MaxGrpcRequests
+		maxGrpcRequests = DefaultMaxGrpcRequests
 	}
 
 	server := grpc.NewServer(grpc.UnaryInterceptor(grpcLimiter(int32(maxGrpcRequests))))
@@ -334,7 +334,7 @@ func grpcLimiter(maxGrpcRequests int32) grpc.UnaryServerInterceptor {
 		defer counter.Add(-1)
 
 		if counter.Load() > maxGrpcRequests {
-			msg := fmt.Sprintf("rate limit exceeded, current value %d more than max %d", counter.Load(), MaxGrpcRequests)
+			msg := fmt.Sprintf("rate limit exceeded, current value %d more than max %d", counter.Load(), DefaultMaxGrpcRequests)
 
 			log.Info(msg, logValues...)
 

--- a/pkg/controllers/csi/driver/server.go
+++ b/pkg/controllers/csi/driver/server.go
@@ -103,12 +103,12 @@ func (srv *Server) Start(ctx context.Context) error {
 		return errors.WithMessage(err, "failed to start server")
 	}
 
-	maxGrpcRequests, err := strconv.Atoi(os.Getenv("GRPC_MAX_REQUESTS_LIMIT"))
+	maxGrpcRequests, err := strconv.ParseInt(os.Getenv("GRPC_MAX_REQUESTS_LIMIT"), 10, 32)
 	if err != nil {
 		maxGrpcRequests = MaxGrpcRequests
 	}
 
-	server := grpc.NewServer(grpc.UnaryInterceptor(grpcLimiter(int32(maxGrpcRequests)))) //nolint:gosec
+	server := grpc.NewServer(grpc.UnaryInterceptor(grpcLimiter(int32(maxGrpcRequests))))
 
 	go func() {
 		ticker := time.NewTicker(memoryMetricTick)


### PR DESCRIPTION
## Description
In #4062, we introduced a new environment variable, allowing users to control the value of `maxGrpcRequests`:
https://github.com/Dynatrace/dynatrace-operator/blob/ce77dbefd7834cb5c6f2e752f3584e62c12e725f/pkg/controllers/csi/driver/server.go#L106
This value is then cast to `int32` and used for configuring the gRPC server:
https://github.com/Dynatrace/dynatrace-operator/blob/ce77dbefd7834cb5c6f2e752f3584e62c12e725f/pkg/controllers/csi/driver/server.go#L111

The problem with this approach is that we don't ensure the value provided actually fits into `int32`. `strconv.Atoi` assumes the value to be of type `int`, not `int32` (see [golang docs](https://pkg.go.dev/strconv#ParseInt)).

ℹ️ This PR addresses [DTSEC-18257](https://dt-rnd.atlassian.net/browse/DTSEC-18257).

## How can this be tested?
Configure the environment variable like so:
```sh
export GRPC_MAX_REQUESTS_LIMIT=3000000000
```

Run this golang program:
```go
package main

import (
	"fmt"
	"math"
	"os"
	"strconv"
)

const MaxGrpcRequests = 20

func main() {
	maxGrpcRequests, err := strconv.Atoi(os.Getenv("GRPC_MAX_REQUESTS_LIMIT"))

	if err != nil {
		maxGrpcRequests = MaxGrpcRequests
	}

	if maxGrpcRequests > math.MaxInt32 {
		fmt.Println(int32(maxGrpcRequests))
	}
}
```

The following `maxGrpcRequests` value should be printed:

```sh
❯ go run main.go
-1294967296
```

### Solution
Use `strconv.ParseInt` instead:
```diff
diff --git a/main.go b/main.go
index 32b1106..a303c54 100644
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 const MaxGrpcRequests = 20
 
 func main() {
-	maxGrpcRequests, err := strconv.Atoi(os.Getenv("GRPC_MAX_REQUESTS_LIMIT"))
+	maxGrpcRequests, err := strconv.ParseInt(os.Getenv("GRPC_MAX_REQUESTS_LIMIT"), 10, 32)
 
 	if err != nil {
 		maxGrpcRequests = MaxGrpcRequests
```

[DTSEC-18257]: https://dt-rnd.atlassian.net/browse/DTSEC-18257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ