### PR TITLE
bug: remove automatic-tls-certificate when disable AG

### DIFF
--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -196,6 +196,13 @@ func (r *Reconciler) deleteCapability(ctx context.Context) error {
 		return err
 	}
 
+	// we must run tls reconciler to ensure that the TLS secret is deleted
+	// TODO: consider to not mix two different patterns
+	tlsSecretReconciler := tls.NewReconciler(r.client, r.apiReader, r.dk)
+	if err := tlsSecretReconciler.Reconcile(ctx); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controllers/dynakube/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/reconciler_test.go
@@ -120,6 +120,10 @@ func TestReconciler_Reconcile(t *testing.T) {
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
 		require.NoError(t, err)
 
+		var secret corev1.Secret
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: r.dk.ActiveGate().GetTLSSecretName(), Namespace: testNamespace}, &secret)
+		require.NoError(t, err)
+
 		// remove AG from spec
 		dk.Spec.ActiveGate = activegate.Spec{}
 		r.connectionReconciler = createGenericReconcilerMock(t)
@@ -129,6 +133,9 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testServiceName, Namespace: testNamespace}, &service)
+		assert.True(t, k8serrors.IsNotFound(err))
+
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: r.dk.ActiveGate().GetTLSSecretName(), Namespace: testNamespace}, &secret)
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 	t.Run("Reconcile DynaKube without Proxy after a DynaKube with proxy must not interfere with the second DKs Proxy Secret", func(t *testing.T) { // TODO: This is not a unit test, it tests the functionality of another package, it should use a mock for that


### PR DESCRIPTION
## Description

The automatic-tls-certificate doesn't get deleted if AG is turned off in the DynaKube.

This PR resolves this problem https://dt-rnd.atlassian.net/browse/DAQ-9986

## How can this be tested?

1. Deploy DK with AG is enabled
```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://****.dev.dynatracelabs.com/api
  activeGate:
    capabilities:
      - routing
      - kubernetes-monitoring
  oneAgent:
    cloudNativeFullStack: {}
```
2.  Check secret is created:
```
k get secrets -n dynatrace | grep tls
dynakube-activegate-tls-secret                       Opaque                           3      77s
```

3. Change dynakube to disable AG:
```
spec:
  activeGate: {}
```

4. List all secrets, make sure tls secret deleted.
```
k get secrets -n dynatrace
NAME                                                 TYPE                             DATA   AGE
ag-ca                                                Opaque                           2      146m
app-codemodules                                      Opaque                           1      153m
client-secret-9ebc0a4a-4e61-4a02-9b1b-1846c1af2238   Opaque                           2      146m
cloudnative-codemodules                              Opaque                           1      155m
dynakube                                             Opaque                           2      2m37s
dynakube-oneagent-tenant-secret                      Opaque                           1      2m35s
dynakube-pmc-secret                                  Opaque                           1      2m35s
dynakube-pull-secret                                 kubernetes.io/dockerconfigjson   1      2m35s
dynatrace-webhook-certs                              Opaque                           5      3m24s
sh.helm.release.v1.dynatrace-operator.v1             helm.sh/release.v1               1      3m34s
```