### PR TITLE
Custom version field should not be affected by autoUpdate

### DIFF
--- a/pkg/controllers/dynakube/version/updater.go
+++ b/pkg/controllers/dynakube/version/updater.go
@@ -47,7 +47,7 @@ func (r *reconciler) run(ctx context.Context, updater StatusUpdater) error {
 		return nil
 	}
 
-	if !updater.IsAutoUpdateEnabled() {
+	if !updater.IsAutoUpdateEnabled() && currentSource != status.CustomVersionVersionSource {
 		previousSource := updater.Target().Source
 
 		emptyVersionStatus := status.VersionStatus{}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-11120](https://dt-rnd.atlassian.net/browse/DAQ-11120)

Fixes the following scenario:
1. User creates a `DynaKube` with `autoUpdate: false` + sets the custom version to `version: 1.2.3`
  - Only affects host `OneAgent`
2. Operator deploys/uses version 1.2.3
3. (🕐  clock  time passes 🕐 )
4. User updates the custom version to `version: 1.3.0`
5. **we do NOT deploy/use version 1.3.0 (we should)**

## How can this be tested?

Follow instructions in description ☝️ (just use actual versions 😅 )