### PR TITLE
Fix e2e log check

### DIFF
--- a/test/features/cloudnative/init_containers.go
+++ b/test/features/cloudnative/init_containers.go
@@ -63,7 +63,7 @@ func checkInitContainers(sampleApp *sample.App) features.Func {
 			}).Stream(ctx)
 
 			require.NoError(t, err)
-			logs.AssertContains(t, logStream, "finished oneagent configuration")
+			logs.AssertContains(t, logStream, "init completed")
 
 			ifNotEmptyCommand := shell.Shell(shell.CheckIfNotEmpty("/opt/dynatrace/oneagent-paas/log/php/"))
 			executionResult, err := pod.Exec(ctx, resources, podItem, sampleApp.ContainerName(), ifNotEmptyCommand...)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

I accidentally committed a tiny e2e change to https://github.com/Dynatrace/dynatrace-operator/pull/5116 instead of https://github.com/Dynatrace/dynatrace-operator/pull/5103

## How can this be tested?

E2e test should work