### PR TITLE
Reduce EdgeConnect client privileges in provisioner mode

### DIFF
--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -493,19 +493,22 @@ func (controller *Controller) getOauthCredentials(ctx context.Context, ec *edgec
 
 func newEdgeConnectClient() func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
 	return func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType) (edgeconnectClient.Client, error) {
+		oauthScopes := []string{
+			"app-engine:edge-connects:read",
+			"app-engine:edge-connects:write",
+			"app-engine:edge-connects:delete",
+			"oauth2:clients:manage",
+		}
+		if ec.IsK8SAutomationEnabled() {
+			oauthScopes = append(oauthScopes, "settings:objects:read", "settings:objects:write")
+		}
+
 		edgeConnectClient, err := edgeconnectClient.NewClient(
 			oauthCredentials.clientID,
 			oauthCredentials.clientSecret,
 			edgeconnectClient.WithBaseURL("https://"+ec.Spec.APIServer),
 			edgeconnectClient.WithTokenURL(ec.Spec.OAuth.Endpoint),
-			edgeconnectClient.WithOauthScopes([]string{
-				"app-engine:edge-connects:read",
-				"app-engine:edge-connects:write",
-				"app-engine:edge-connects:delete",
-				"oauth2:clients:manage",
-				"settings:objects:read",
-				"settings:objects:write",
-			}),
+			edgeconnectClient.WithOauthScopes(oauthScopes),
 			edgeconnectClient.WithContext(ctx),
 		)
 		if err != nil {


### PR DESCRIPTION
## 📝 Description
When creating EdgeConnect clients, we require the following OAuth scopes for the provisioner mode to work:
* `app-engine:edge-connects:read`
* `app-engine:edge-connects:write`
* `app-engine:edge-connects:delete`
* `oauth2:clients:manage`
* `settings:objects:read`
* `settings:objects:write`

However, we don't actually need `settings:objects:read` and `settings.objects.write` _unless_ Kubernetes automation mode is enabled. Address this issue by only using said scopes if required.

## 🧐 How can this be tested?
1. Create an OAuth client with the following scopes:

* `app-engine:edge-connects:read`
* `app-engine:edge-connects:write`
* `app-engine:edge-connects:delete`
* `oauth2:clients:manage`
2. Apply the following EdgeConnect configuration:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: ec-test
  namespace: dynatrace
stringData:
  oauth-client-id: ...
  oauth-client-secret: ...
---
apiVersion: dynatrace.com/v1alpha2
kind: EdgeConnect
metadata:
  name: ec-test
  namespace: dynatrace
spec:
  apiServer: dqz6149d.dev.apps.dynatracelabs.com
  oauth:
    provisioner: true
    clientSecret: ec-test
    endpoint: https://sso-dev.dynatracelabs.com/sso/oauth2/token
    resource: ...
  hostPatterns:
    - "*.external.org"
```

Performing the steps above _without_ the changes introduced with this PR _should_ make the EdgeConnect configuration crash immediately (without spawning any pods).