### PR TITLE
Add NodeTaintsPolicy to TopologySpreadConstraints

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -62,6 +62,7 @@ spec:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"
           whenUnsatisfiable: DoNotSchedule
+          nodeTaintsPolicy: Honor
           labelSelector:
             matchLabels:
               {{- include "dynatrace-operator.webhookSelectorLabels" . | nindent 14 }}

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -64,6 +64,7 @@ tests:
               - maxSkew: 1
                 topologyKey: "kubernetes.io/hostname"
                 whenUnsatisfiable: DoNotSchedule
+                nodeTaintsPolicy: Honor
                 labelSelector:
                   matchLabels:
                     internal.dynatrace.com/app: webhook

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -188,6 +188,7 @@ func (statefulSetBuilder Builder) buildPodSecurityContext() *corev1.PodSecurityC
 
 func (statefulSetBuilder Builder) defaultTopologyConstraints() []corev1.TopologySpreadConstraint {
 	appLabels := statefulSetBuilder.buildAppLabels()
+	nodeInclusionPolicyHonor := corev1.NodeInclusionPolicyHonor
 
 	return []corev1.TopologySpreadConstraint{
 		{
@@ -200,6 +201,7 @@ func (statefulSetBuilder Builder) defaultTopologyConstraints() []corev1.Topology
 			MaxSkew:           1,
 			TopologyKey:       "kubernetes.io/hostname",
 			WhenUnsatisfiable: "DoNotSchedule",
+			NodeTaintsPolicy:  &nodeInclusionPolicyHonor,
 			LabelSelector:     &metav1.LabelSelector{MatchLabels: appLabels.BuildMatchLabels()},
 		},
 	}

--- a/pkg/util/kubeobjects/topology/constraint.go
+++ b/pkg/util/kubeobjects/topology/constraint.go
@@ -7,6 +7,8 @@ import (
 )
 
 func MaxOnePerNode(appLabels *labels.AppLabels) []corev1.TopologySpreadConstraint {
+	nodeInclusionPolicyHonor := corev1.NodeInclusionPolicyHonor
+
 	return []corev1.TopologySpreadConstraint{
 		{
 			MaxSkew:           1,
@@ -18,6 +20,7 @@ func MaxOnePerNode(appLabels *labels.AppLabels) []corev1.TopologySpreadConstrain
 			MaxSkew:           1,
 			TopologyKey:       "kubernetes.io/hostname",
 			WhenUnsatisfiable: "DoNotSchedule",
+			NodeTaintsPolicy:  &nodeInclusionPolicyHonor,
 			LabelSelector:     &metav1.LabelSelector{MatchLabels: appLabels.BuildMatchLabels()},
 		},
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR adds the `nodeTaintsPolicy: Honor` flag to all the `NodeTaintsPolicy`. The reason is that otherwise the ActiveGate scaling could be blocked by tainted nodes (if the number of worker nodes is less than the number of replicas required). 

With the flag set, tainted nodes are respected correctly. 

This affects the
- ActiveGate sts
- Webhook pods
- EEC & Otel Collector

[Jira](https://dt-rnd.atlassian.net/browse/DAQ-11421)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- Taint a node
- create more ActiveGate pods than worker nodes 
- some nodes should have multiple ActiveGates / nothing is blocked

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->