### PR TITLE
Remove `entities.read` scope usage and replace it with `settings.read`

### DIFF
--- a/pkg/api/latest/dynakube/oneagent/props.go
+++ b/pkg/api/latest/dynakube/oneagent/props.go
@@ -128,9 +128,9 @@ func (oa *OneAgent) GetNamespaceSelector() *metav1.LabelSelector {
 		return &oa.CloudNativeFullStack.NamespaceSelector
 	case oa.IsApplicationMonitoringMode():
 		return &oa.ApplicationMonitoring.NamespaceSelector
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 func (oa *OneAgent) GetSecCompProfile() string {
@@ -154,9 +154,9 @@ func (oa *OneAgent) GetNodeSelector(fallbackNodeSelector map[string]string) map[
 		return oa.HostMonitoring.NodeSelector
 	case oa.IsCloudNativeFullstackMode():
 		return oa.CloudNativeFullStack.NodeSelector
+	default:
+		return fallbackNodeSelector
 	}
-
-	return fallbackNodeSelector
 }
 
 // GetImage provides the image reference set in Status for the OneAgent.
@@ -181,9 +181,9 @@ func (oa *OneAgent) GetCustomVersion() string {
 		return oa.ApplicationMonitoring.Version
 	case oa.IsHostMonitoringMode():
 		return oa.HostMonitoring.Version
+	default:
+		return ""
 	}
-
-	return ""
 }
 
 // GetCustomImage provides the image reference for the OneAgent provided in the Spec.

--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -68,17 +68,17 @@ type Client interface {
 	// CreateOrUpdateKubernetesAppSetting returns the object id of the created k8s app settings if successful, or an api error otherwise
 	CreateOrUpdateKubernetesAppSetting(ctx context.Context, scope string) (string, error)
 
-	// GetKubernetesClusterEntity returns the KUBERNETES_CLUSTER entity for the give kubernetes cluster,
+	// GetK8sClusterME returns the Kubernetes Cluster Monitored Entity for the give kubernetes cluster.
 	// Uses the `settings.read` scope to list the `builtin:cloud.kubernetes` settings.
 	// - Only 1 such setting exists per tenant per kubernetes cluster
-	// - The `scope` for the setting is the ID of the KUBERNETES_CLUSTER entity
-	// - The `label` of the setting is the Name of the KUBERNETES_CLUSTER entity
-	// In case 0 settings are found, so no KUBERNETES_CLUSTER entity exist, we return an empty object, without an error.
-	GetKubernetesClusterEntity(ctx context.Context, kubeSystemUUID string) (KubernetesClusterEntity, error)
+	// - The `scope` for the setting is the ID (example: KUBERNETES_CLUSTER-A1234567BCD8EFGH) of the Kubernetes Cluster Monitored Entity
+	// - The `label` of the setting is the Name (example: my-dynakube) of the Kubernetes Cluster Monitored Entity
+	// In case 0 settings are found, so no Kubernetes Cluster Monitored Entity exist, we return an empty object, without an error.
+	GetK8sClusterME(ctx context.Context, kubeSystemUUID string) (K8sClusterME, error)
 
 	// GetSettingsForMonitoredEntity returns the settings response with the number of settings objects,
 	// or an api error otherwise
-	GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity KubernetesClusterEntity, schemaID string) (GetSettingsResponse, error)
+	GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity K8sClusterME, schemaID string) (GetSettingsResponse, error)
 
 	// GetSettingsForLogModule returns the settings response with the number of settings objects,
 	// or an api error otherwise

--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -68,6 +68,12 @@ type Client interface {
 	// CreateOrUpdateKubernetesAppSetting returns the object id of the created k8s app settings if successful, or an api error otherwise
 	CreateOrUpdateKubernetesAppSetting(ctx context.Context, scope string) (string, error)
 
+	// GetKubernetesClusterEntity returns the KUBERNETES_CLUSTER entity for the give kubernetes cluster,
+	// Uses the `settings.read` scope to list the `builtin:cloud.kubernetes` settings.
+	// - Only 1 such setting exists per tenant per kubernetes cluster
+	// - The `scope` for the setting is the ID of the KUBERNETES_CLUSTER entity
+	// - The `label` of the setting is the Name of the KUBERNETES_CLUSTER entity
+	// In case 0 settings are found, so no KUBERNETES_CLUSTER entity exist, we return an empty object, without an error.
 	GetKubernetesClusterEntity(ctx context.Context, kubeSystemUUID string) (KubernetesClusterEntity, error)
 
 	// GetSettingsForMonitoredEntity returns the settings response with the number of settings objects,

--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -68,13 +68,11 @@ type Client interface {
 	// CreateOrUpdateKubernetesAppSetting returns the object id of the created k8s app settings if successful, or an api error otherwise
 	CreateOrUpdateKubernetesAppSetting(ctx context.Context, scope string) (string, error)
 
-	// GetMonitoredEntitiesForKubeSystemUUID returns a (possibly empty) list of k8s monitored entities for the given uuid,
-	// or an api error otherwise
-	GetMonitoredEntitiesForKubeSystemUUID(ctx context.Context, kubeSystemUUID string) ([]MonitoredEntity, error)
+	GetKubernetesClusterEntity(ctx context.Context, kubeSystemUUID string) (KubernetesClusterEntity, error)
 
 	// GetSettingsForMonitoredEntity returns the settings response with the number of settings objects,
 	// or an api error otherwise
-	GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity *MonitoredEntity, schemaID string) (GetSettingsResponse, error)
+	GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity KubernetesClusterEntity, schemaID string) (GetSettingsResponse, error)
 
 	// GetSettingsForLogModule returns the settings response with the number of settings objects,
 	// or an api error otherwise
@@ -113,7 +111,6 @@ const (
 const (
 	TokenScopeInstallerDownload     = "InstallerDownload"
 	TokenScopeMetricsIngest         = "metrics.ingest"
-	TokenScopeEntitiesRead          = "entities.read"
 	TokenScopeSettingsRead          = "settings.read"
 	TokenScopeSettingsWrite         = "settings.write"
 	TokenScopeActiveGateTokenCreate = "activeGateTokenManagement.create"
@@ -122,14 +119,12 @@ const (
 const (
 	ConditionTypeAPITokenSettingsRead  = "ApiTokenSettingsRead"
 	ConditionTypeAPITokenSettingsWrite = "ApiTokenSettingsWrite"
-	ConditionTypeAPITokenEntitiesRead  = "ApiTokenEntitiesRead"
 )
 
 var (
 	OptionalScopes = map[string]string{
 		TokenScopeSettingsRead:  ConditionTypeAPITokenSettingsRead,
 		TokenScopeSettingsWrite: ConditionTypeAPITokenSettingsWrite,
-		TokenScopeEntitiesRead:  ConditionTypeAPITokenEntitiesRead,
 	}
 )
 

--- a/pkg/clients/dynatrace/endpoints.go
+++ b/pkg/clients/dynatrace/endpoints.go
@@ -53,10 +53,6 @@ func (dtc *dynatraceClient) getActiveGateConnectionInfoURL() string {
 	return dtc.url + "/v1/deployment/installer/gateway/connectioninfo"
 }
 
-func (dtc *dynatraceClient) getEntitiesURL() string {
-	return dtc.url + "/v2/entities"
-}
-
 func (dtc *dynatraceClient) getSettingsURL(validate bool) string {
 	validationQuery := ""
 	if !validate {

--- a/pkg/clients/dynatrace/settings.go
+++ b/pkg/clients/dynatrace/settings.go
@@ -26,7 +26,8 @@ type kubernetesSettingValue struct {
 	Label string `json:"label"`
 }
 
-type KubernetesClusterEntity struct {
+// K8sClusterME is representing the relevant info for a Kubernetes Cluster Monitored Entity
+type K8sClusterME struct {
 	ID   string
 	Name string
 }
@@ -57,14 +58,14 @@ const (
 	kubernetesSettingsSchemaID = "builtin:cloud.kubernetes"
 )
 
-func (dtc *dynatraceClient) GetKubernetesClusterEntity(ctx context.Context, kubeSystemUUID string) (KubernetesClusterEntity, error) {
+func (dtc *dynatraceClient) GetK8sClusterME(ctx context.Context, kubeSystemUUID string) (K8sClusterME, error) {
 	if kubeSystemUUID == "" {
-		return KubernetesClusterEntity{}, errors.New("no kube-system namespace UUID given")
+		return K8sClusterME{}, errors.New("no kube-system namespace UUID given")
 	}
 
 	req, err := createBaseRequest(ctx, dtc.getSettingsURL(true), http.MethodGet, dtc.apiToken, nil)
 	if err != nil {
-		return KubernetesClusterEntity{}, err
+		return K8sClusterME{}, err
 	}
 
 	q := req.URL.Query()
@@ -80,29 +81,29 @@ func (dtc *dynatraceClient) GetKubernetesClusterEntity(ctx context.Context, kube
 	if err != nil {
 		log.Info("request for kubernetes setting exists failed")
 
-		return KubernetesClusterEntity{}, err
+		return K8sClusterME{}, err
 	}
 
 	var resDataJSON getSettingsForKubeSystemUUIDResponse
 
 	err = dtc.unmarshalToJSON(res, &resDataJSON)
 	if err != nil {
-		return KubernetesClusterEntity{}, errors.WithMessage(err, "error parsing response body")
+		return K8sClusterME{}, errors.WithMessage(err, "error parsing response body")
 	}
 
 	if len(resDataJSON.Settings) == 0 {
 		log.Info("no kubernetes settings object according to API", "resp", resDataJSON)
 
-		return KubernetesClusterEntity{}, nil
+		return K8sClusterME{}, nil
 	}
 
-	return KubernetesClusterEntity{
+	return K8sClusterME{
 		ID:   resDataJSON.Settings[0].EntityID,
 		Name: resDataJSON.Settings[0].Value.Label,
 	}, nil
 }
 
-func (dtc *dynatraceClient) GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity KubernetesClusterEntity, schemaID string) (GetSettingsResponse, error) {
+func (dtc *dynatraceClient) GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity K8sClusterME, schemaID string) (GetSettingsResponse, error) {
 	if monitoredEntity.ID == "" {
 		return GetSettingsResponse{TotalCount: 0}, nil
 	}

--- a/pkg/clients/dynatrace/settings.go
+++ b/pkg/clients/dynatrace/settings.go
@@ -57,6 +57,12 @@ const (
 	kubernetesSettingsSchemaID = "builtin:cloud.kubernetes"
 )
 
+// GetKubernetesClusterEntity returns the KUBERNETES_CLUSTER entity for the give kubernetes cluster,
+// Uses the `settings.read` scope to list the `builtin:cloud.kubernetes` settings.
+// - Only 1 such setting exists per tenant per kubernetes cluster
+// - The `scope` for the setting is the ID of the KUBERNETES_CLUSTER entity
+// - The `label` of the setting is the Name of the KUBERNETES_CLUSTER entity
+// In case 0 settings are found, so no KUBERNETES_CLUSTER entity exist, we return an empty object, without an error.
 func (dtc *dynatraceClient) GetKubernetesClusterEntity(ctx context.Context, kubeSystemUUID string) (KubernetesClusterEntity, error) {
 	if kubeSystemUUID == "" {
 		return KubernetesClusterEntity{}, errors.New("no kube-system namespace UUID given")

--- a/pkg/clients/dynatrace/settings.go
+++ b/pkg/clients/dynatrace/settings.go
@@ -57,12 +57,6 @@ const (
 	kubernetesSettingsSchemaID = "builtin:cloud.kubernetes"
 )
 
-// GetKubernetesClusterEntity returns the KUBERNETES_CLUSTER entity for the give kubernetes cluster,
-// Uses the `settings.read` scope to list the `builtin:cloud.kubernetes` settings.
-// - Only 1 such setting exists per tenant per kubernetes cluster
-// - The `scope` for the setting is the ID of the KUBERNETES_CLUSTER entity
-// - The `label` of the setting is the Name of the KUBERNETES_CLUSTER entity
-// In case 0 settings are found, so no KUBERNETES_CLUSTER entity exist, we return an empty object, without an error.
 func (dtc *dynatraceClient) GetKubernetesClusterEntity(ctx context.Context, kubeSystemUUID string) (KubernetesClusterEntity, error) {
 	if kubeSystemUUID == "" {
 		return KubernetesClusterEntity{}, errors.New("no kube-system namespace UUID given")

--- a/pkg/clients/dynatrace/settings_enrichment_test.go
+++ b/pkg/clients/dynatrace/settings_enrichment_test.go
@@ -17,10 +17,6 @@ func TestGetRulesSetting(t *testing.T) {
 
 	t.Run("get rules", func(t *testing.T) {
 		mockParams := v2APIMockParams{
-			entitiesAPI: entitiesMockParams{
-				status:   http.StatusOK,
-				expected: createMonitoredEntitiesForTesting(),
-			},
 			settingsAPI: settingsMockParams{
 				status:     http.StatusOK,
 				totalCount: 1,
@@ -61,10 +57,6 @@ func TestGetRulesSetting(t *testing.T) {
 
 	t.Run("no monitored-entities, use environment scope -> return not-empty, no error", func(t *testing.T) {
 		mockParams := v2APIMockParams{
-			entitiesAPI: entitiesMockParams{
-				status:   http.StatusOK,
-				expected: []MonitoredEntity{},
-			},
 			settingsAPI: settingsMockParams{
 				status:     http.StatusOK,
 				totalCount: 1,

--- a/pkg/clients/dynatrace/settings_test.go
+++ b/pkg/clients/dynatrace/settings_test.go
@@ -18,8 +18,8 @@ const (
 	testScope    = "test-scope"
 )
 
-func TestDynatraceClient_GetKubernetesClusterEntity(t *testing.T) {
-	mockK8sSettingsAPI := func(status int, expectedEntity KubernetesClusterEntity) http.HandlerFunc {
+func TestDynatraceClient_GetK8sClusterME(t *testing.T) {
+	mockK8sSettingsAPI := func(status int, expectedEntity K8sClusterME) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 
@@ -85,7 +85,7 @@ func TestDynatraceClient_GetKubernetesClusterEntity(t *testing.T) {
 		require.NotNil(t, dtc)
 
 		// act
-		actual, err := dtc.GetKubernetesClusterEntity(ctx, testUID)
+		actual, err := dtc.GetK8sClusterME(ctx, testUID)
 
 		// assert
 		require.NotNil(t, actual)
@@ -95,7 +95,7 @@ func TestDynatraceClient_GetKubernetesClusterEntity(t *testing.T) {
 
 	t.Run("no k8s entity for this uuid exist", func(t *testing.T) {
 		// arrange
-		expected := KubernetesClusterEntity{}
+		expected := K8sClusterME{}
 
 		dynatraceServer := httptest.NewServer(mockK8sSettingsAPI(http.StatusOK, expected))
 		defer dynatraceServer.Close()
@@ -106,7 +106,7 @@ func TestDynatraceClient_GetKubernetesClusterEntity(t *testing.T) {
 		require.NotNil(t, dtc)
 
 		// act
-		actual, err := dtc.GetKubernetesClusterEntity(ctx, testUID)
+		actual, err := dtc.GetK8sClusterME(ctx, testUID)
 
 		// assert
 		require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestDynatraceClient_GetKubernetesClusterEntity(t *testing.T) {
 		require.NotNil(t, dtc)
 
 		// act
-		actual, err := dtc.GetKubernetesClusterEntity(ctx, "")
+		actual, err := dtc.GetK8sClusterME(ctx, "")
 
 		// assert
 		require.Error(t, err)
@@ -133,7 +133,7 @@ func TestDynatraceClient_GetKubernetesClusterEntity(t *testing.T) {
 
 	t.Run("no monitored entities found because of an api error", func(t *testing.T) {
 		// arrange
-		dynatraceServer := httptest.NewServer(mockK8sSettingsAPI(http.StatusInternalServerError, KubernetesClusterEntity{}))
+		dynatraceServer := httptest.NewServer(mockK8sSettingsAPI(http.StatusInternalServerError, K8sClusterME{}))
 		defer dynatraceServer.Close()
 
 		skipCert := SkipCertificateValidation(true)
@@ -142,7 +142,7 @@ func TestDynatraceClient_GetKubernetesClusterEntity(t *testing.T) {
 		require.NotNil(t, dtc)
 
 		// act
-		actual, err := dtc.GetKubernetesClusterEntity(ctx, testUID)
+		actual, err := dtc.GetK8sClusterME(ctx, testUID)
 
 		// assert
 		require.Error(t, err)
@@ -211,7 +211,7 @@ func TestDynatraceClient_GetSettingsForMonitoredEntity(t *testing.T) {
 		require.NotNil(t, dtc)
 
 		// act
-		actual, err := dtc.GetSettingsForMonitoredEntity(ctx, KubernetesClusterEntity{}, KubernetesSettingsSchemaID)
+		actual, err := dtc.GetSettingsForMonitoredEntity(ctx, K8sClusterME{}, KubernetesSettingsSchemaID)
 
 		// assert
 		require.NoError(t, err)
@@ -242,8 +242,8 @@ func TestDynatraceClient_GetSettingsForMonitoredEntity(t *testing.T) {
 	})
 }
 
-func createKubernetesClusterEntityForTesting() KubernetesClusterEntity {
-	return KubernetesClusterEntity{
+func createKubernetesClusterEntityForTesting() K8sClusterME {
+	return K8sClusterME{
 		ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: "operator test entity 1",
 	}
 }

--- a/pkg/clients/dynatrace/settings_test.go
+++ b/pkg/clients/dynatrace/settings_test.go
@@ -156,7 +156,7 @@ func TestDynatraceClient_GetSettingsForMonitoredEntity(t *testing.T) {
 	t.Run(`settings for the given monitored entities exist`, func(t *testing.T) {
 		// arrange
 		expected := createKubernetesClusterEntityForTesting()
-		totalCount := 2
+		totalCount := 1
 
 		dynatraceServer := httptest.NewServer(mockDynatraceServerV2Handler(createKubernetesSettingsMockParams(totalCount, "", http.StatusOK)))
 		defer dynatraceServer.Close()
@@ -173,7 +173,6 @@ func TestDynatraceClient_GetSettingsForMonitoredEntity(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, actual)
 		assert.Positive(t, actual.TotalCount)
-		assert.Len(t, expected, actual.TotalCount)
 	})
 
 	t.Run(`no settings for the given monitored entities exist`, func(t *testing.T) {

--- a/pkg/clients/dynatrace/settings_test.go
+++ b/pkg/clients/dynatrace/settings_test.go
@@ -26,6 +26,7 @@ func TestDynatraceClient_GetKubernetesClusterEntity(t *testing.T) {
 			if r.FormValue("Api-Token") == "" && r.Header.Get("Authorization") == "" {
 				writeError(w, http.StatusUnauthorized)
 			}
+
 			if r.Method != http.MethodGet {
 				writeError(w, http.StatusMethodNotAllowed)
 			}

--- a/pkg/controllers/dynakube/activegate_test.go
+++ b/pkg/controllers/dynakube/activegate_test.go
@@ -175,11 +175,18 @@ func TestReconcileActiveGate(t *testing.T) {
 			},
 			Status: dynakube.DynaKubeStatus{
 				KubeSystemUUID: testUID,
+				Conditions: []metav1.Condition{
+					{
+						Type:   dtclient.ConditionTypeAPITokenSettingsRead,
+						Status: metav1.ConditionTrue,
+					},
+				},
 			},
 		}
+
 		fakeClient := fake.NewClientWithIndex(dk)
 
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{})
+		mockClient := createDTMockClient(t, dtclient.TokenScopes{}, dtclient.TokenScopes{dtclient.ConditionTypeAPITokenSettingsRead})
 		mockClient.On("CreateOrUpdateKubernetesSetting",
 			mock.AnythingOfType("context.backgroundCtx"),
 			mock.AnythingOfType("string"),

--- a/pkg/controllers/dynakube/apimonitoring/reconciler.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler.go
@@ -6,26 +6,26 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/monitoredentities"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/k8sentity"
 	"github.com/pkg/errors"
 )
 
 type Reconciler struct {
 	dtc dtclient.Client
 
-	monitoredEntitiesReconciler controllers.Reconciler
-	dk                          *dynakube.DynaKube
-	clusterLabel                string
+	k8sEntityReconciler controllers.Reconciler
+	dk                  *dynakube.DynaKube
+	clusterLabel        string
 }
 
 type ReconcilerBuilder func(dtc dtclient.Client, dk *dynakube.DynaKube, clusterLabel string) controllers.Reconciler
 
 func NewReconciler(dtc dtclient.Client, dk *dynakube.DynaKube, clusterLabel string) controllers.Reconciler {
 	return &Reconciler{
-		dtc:                         dtc,
-		dk:                          dk,
-		clusterLabel:                clusterLabel,
-		monitoredEntitiesReconciler: monitoredentities.NewReconciler(dtc, dk),
+		dtc:                 dtc,
+		dk:                  dk,
+		clusterLabel:        clusterLabel,
+		k8sEntityReconciler: k8sentity.NewReconciler(dtc, dk),
 	}
 }
 
@@ -49,15 +49,15 @@ func (r *Reconciler) createObjectIDIfNotExists(ctx context.Context) (string, err
 		return "", errors.New("no kube-system namespace UUID given")
 	}
 
-	err := r.monitoredEntitiesReconciler.Reconcile(ctx)
+	err := r.k8sEntityReconciler.Reconcile(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	var k8sEntity dtclient.KubernetesClusterEntity
+	var k8sEntity dtclient.K8sClusterME
 
 	if r.dk.Status.KubernetesClusterMEID != "" {
-		k8sEntity = dtclient.KubernetesClusterEntity{
+		k8sEntity = dtclient.K8sClusterME{
 			ID: r.dk.Status.KubernetesClusterMEID,
 		}
 	}
@@ -85,7 +85,7 @@ func (r *Reconciler) createObjectIDIfNotExists(ctx context.Context) (string, err
 	if r.dk.Status.KubernetesClusterMEID == "" {
 		// the CreateOrUpdateKubernetesSetting call will create the ME(monitored-entity) if no scope was given (scope == entity-id), this happens on the "first run"
 		// so we have to run the entity reconciler AGAIN to set it in the status.
-		err := r.monitoredEntitiesReconciler.Reconcile(ctx)
+		err := r.k8sEntityReconciler.Reconcile(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -94,7 +94,7 @@ func (r *Reconciler) createObjectIDIfNotExists(ctx context.Context) (string, err
 	return objectID, nil
 }
 
-func (r *Reconciler) handleKubernetesAppEnabled(ctx context.Context, k8sEntity dtclient.KubernetesClusterEntity) (string, error) {
+func (r *Reconciler) handleKubernetesAppEnabled(ctx context.Context, k8sEntity dtclient.K8sClusterME) (string, error) {
 	if r.dk.FF().IsK8sAppEnabled() {
 		appSettings, err := r.dtc.GetSettingsForMonitoredEntity(ctx, k8sEntity, dtclient.AppTransitionSchemaID)
 		if err != nil {

--- a/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
@@ -105,7 +105,7 @@ func createReconcilerWithError(t *testing.T, dk *dynakube.DynaKube, monitoredEnt
 		Return(dtclient.K8sClusterME{}, monitoredEntitiesError)
 	mockClient.On("GetSettingsForMonitoredEntity",
 		mock.AnythingOfType("context.backgroundCtx"),
-		mock.AnythingOfType("dynatrace.KubernetesClusterEntity"),
+		mock.AnythingOfType("dynatrace.K8sClusterME"),
 		mock.AnythingOfType("string")).
 		Return(dtclient.GetSettingsResponse{}, getSettingsResponseError)
 	mockClient.On("CreateOrUpdateKubernetesSetting", mock.AnythingOfType("context.backgroundCtx"), testName, testUID, "KUBERNETES_CLUSTER-119C75CCDA94799F").

--- a/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
+++ b/pkg/controllers/dynakube/apimonitoring/reconciler_test.go
@@ -28,14 +28,14 @@ func TestNewDefaultReconiler(t *testing.T) {
 }
 
 func createDefaultReconciler(t *testing.T) Reconciler {
-	return createReconciler(t, newDynaKube(), dtclient.KubernetesClusterEntity{}, dtclient.GetSettingsResponse{TotalCount: 0}, "", "")
+	return createReconciler(t, newDynaKube(), dtclient.K8sClusterME{}, dtclient.GetSettingsResponse{TotalCount: 0}, "", "")
 }
 
-func createReconciler(t *testing.T, dk *dynakube.DynaKube, monitoredEntity dtclient.KubernetesClusterEntity, getSettingsResponse dtclient.GetSettingsResponse, objectID string, meID interface{}) Reconciler { //nolint:revive // argument-limit doesn't apply to constructors
+func createReconciler(t *testing.T, dk *dynakube.DynaKube, monitoredEntity dtclient.K8sClusterME, getSettingsResponse dtclient.GetSettingsResponse, objectID string, meID interface{}) Reconciler { //nolint:revive // argument-limit doesn't apply to constructors
 	mockClient := dtclientmock.NewClient(t)
-	mockClient.On("GetKubernetesClusterEntity", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
+	mockClient.On("GetK8sClusterME", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
 		Return(monitoredEntity, nil)
-	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), dtclient.KubernetesClusterEntity{ID: "test-MEID"},
+	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), dtclient.K8sClusterME{ID: "test-MEID"},
 		mock.AnythingOfType("string")).
 		Return(getSettingsResponse, nil)
 	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), monitoredEntity,
@@ -55,20 +55,20 @@ func createReconciler(t *testing.T, dk *dynakube.DynaKube, monitoredEntity dtcli
 
 	passMonitoredEntities := createPassingReconciler(t)
 	r := Reconciler{
-		dtc:                         mockClient,
-		dk:                          dk,
-		monitoredEntitiesReconciler: passMonitoredEntities,
-		clusterLabel:                testName,
+		dtc:                 mockClient,
+		dk:                  dk,
+		k8sEntityReconciler: passMonitoredEntities,
+		clusterLabel:        testName,
 	}
 
 	return r
 }
 
-func createReadOnlyReconciler(t *testing.T, dk *dynakube.DynaKube, monitoredEntity dtclient.KubernetesClusterEntity, getSettingsResponse dtclient.GetSettingsResponse) Reconciler {
+func createReadOnlyReconciler(t *testing.T, dk *dynakube.DynaKube, monitoredEntity dtclient.K8sClusterME, getSettingsResponse dtclient.GetSettingsResponse) Reconciler {
 	mockClient := dtclientmock.NewClient(t)
-	mockClient.On("GetKubernetesClusterEntity", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
+	mockClient.On("GetK8sClusterME", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
 		Return(monitoredEntity, nil)
-	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), dtclient.KubernetesClusterEntity{ID: "test-MEID"},
+	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), dtclient.K8sClusterME{ID: "test-MEID"},
 		mock.AnythingOfType("string")).
 		Return(getSettingsResponse, nil)
 	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), monitoredEntity,
@@ -90,10 +90,10 @@ func createReadOnlyReconciler(t *testing.T, dk *dynakube.DynaKube, monitoredEnti
 
 	passMonitoredEntities := createPassingReconciler(t)
 	r := Reconciler{
-		dtc:                         mockClient,
-		dk:                          dk,
-		monitoredEntitiesReconciler: passMonitoredEntities,
-		clusterLabel:                testName,
+		dtc:                 mockClient,
+		dk:                  dk,
+		k8sEntityReconciler: passMonitoredEntities,
+		clusterLabel:        testName,
 	}
 
 	return r
@@ -101,8 +101,8 @@ func createReadOnlyReconciler(t *testing.T, dk *dynakube.DynaKube, monitoredEnti
 
 func createReconcilerWithError(t *testing.T, dk *dynakube.DynaKube, monitoredEntitiesError error, getSettingsResponseError error, createSettingsResponseError error, createAppSettingsResponseError error) Reconciler { //nolint:revive
 	mockClient := dtclientmock.NewClient(t)
-	mockClient.On("GetKubernetesClusterEntity", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
-		Return(dtclient.KubernetesClusterEntity{}, monitoredEntitiesError)
+	mockClient.On("GetK8sClusterME", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
+		Return(dtclient.K8sClusterME{}, monitoredEntitiesError)
 	mockClient.On("GetSettingsForMonitoredEntity",
 		mock.AnythingOfType("context.backgroundCtx"),
 		mock.AnythingOfType("dynatrace.KubernetesClusterEntity"),
@@ -121,17 +121,17 @@ func createReconcilerWithError(t *testing.T, dk *dynakube.DynaKube, monitoredEnt
 
 	passMonitoredEntities := createPassingReconciler(t)
 	r := Reconciler{
-		dtc:                         mockClient,
-		dk:                          dk,
-		monitoredEntitiesReconciler: passMonitoredEntities,
-		clusterLabel:                testName,
+		dtc:                 mockClient,
+		dk:                  dk,
+		k8sEntityReconciler: passMonitoredEntities,
+		clusterLabel:        testName,
 	}
 
 	return r
 }
 
-func createMonitoredEntities() dtclient.KubernetesClusterEntity {
-	return dtclient.KubernetesClusterEntity{
+func createMonitoredEntities() dtclient.K8sClusterME {
+	return dtclient.K8sClusterME{
 		ID: "KUBERNETES_CLUSTER-119C75CCDA94799F", Name: "operator test entity 1",
 	}
 }
@@ -153,7 +153,7 @@ func TestReconcile(t *testing.T) {
 
 	t.Run("create setting when no monitored entities are existing", func(t *testing.T) {
 		// arrange
-		r := createReconciler(t, dk, dtclient.KubernetesClusterEntity{}, dtclient.GetSettingsResponse{}, testObjectID, "")
+		r := createReconciler(t, dk, dtclient.K8sClusterME{}, dtclient.GetSettingsResponse{}, testObjectID, "")
 
 		// act
 		actual, err := r.createObjectIDIfNotExists(ctx)
@@ -196,7 +196,7 @@ func TestReconcileErrors(t *testing.T) {
 
 	t.Run("don't create setting when no kube-system uuid is given", func(t *testing.T) {
 		// arrange
-		r := createReconciler(t, dk, dtclient.KubernetesClusterEntity{ID: "test-MEID"}, dtclient.GetSettingsResponse{}, testObjectID, "")
+		r := createReconciler(t, dk, dtclient.K8sClusterME{ID: "test-MEID"}, dtclient.GetSettingsResponse{}, testObjectID, "")
 		dk.Status.KubeSystemUUID = ""
 
 		// act
@@ -262,10 +262,10 @@ func TestHandleKubernetesAppEnabled(t *testing.T) {
 
 	t.Run("don't create app setting due to empty MonitoredEntitys", func(t *testing.T) {
 		// arrange
-		r := createReconciler(t, dk, dtclient.KubernetesClusterEntity{}, dtclient.GetSettingsResponse{}, "", "")
+		r := createReconciler(t, dk, dtclient.K8sClusterME{}, dtclient.GetSettingsResponse{}, "", "")
 
 		// act
-		_, err := r.handleKubernetesAppEnabled(ctx, dtclient.KubernetesClusterEntity{})
+		_, err := r.handleKubernetesAppEnabled(ctx, dtclient.K8sClusterME{})
 
 		// assert
 		require.NoError(t, err)
@@ -288,7 +288,7 @@ func TestHandleKubernetesAppEnabled(t *testing.T) {
 		r := createReconcilerWithError(t, dk, nil, errors.New("could not get monitored entities"), nil, nil)
 
 		// act
-		_, err := r.handleKubernetesAppEnabled(ctx, dtclient.KubernetesClusterEntity{})
+		_, err := r.handleKubernetesAppEnabled(ctx, dtclient.K8sClusterME{})
 
 		// assert
 		require.Error(t, err)
@@ -298,7 +298,7 @@ func TestHandleKubernetesAppEnabled(t *testing.T) {
 		// arrange
 		r := createReconcilerWithError(t, dk, nil, nil, nil, errors.New("could not get monitored entities"))
 		meID := "KUBERNETES_CLUSTER-0E30FE4BF2007587"
-		entity := dtclient.KubernetesClusterEntity{ID: meID, Name: "operator test entity newest"}
+		entity := dtclient.K8sClusterME{ID: meID, Name: "operator test entity newest"}
 
 		// act
 		_, err := r.handleKubernetesAppEnabled(ctx, entity)
@@ -310,7 +310,7 @@ func TestHandleKubernetesAppEnabled(t *testing.T) {
 	t.Run("create app setting as settings already exist", func(t *testing.T) {
 		// arrange
 		meID := "KUBERNETES_CLUSTER-0E30FE4BF2007587"
-		entities := dtclient.KubernetesClusterEntity{
+		entities := dtclient.K8sClusterME{
 			ID: meID, Name: "operator test entity newest",
 		}
 		r := createReconciler(t, dk, entities, dtclient.GetSettingsResponse{}, "", meID)

--- a/pkg/controllers/dynakube/controller_system_test.go
+++ b/pkg/controllers/dynakube/controller_system_test.go
@@ -374,11 +374,11 @@ func createDTMockClient(t *testing.T, paasTokenScopes, apiTokenScopes dtclient.T
 			}, nil).Maybe()
 	mockClient.On("GetLatestAgentVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything, mock.Anything).
 		Return(testVersion, nil).Maybe()
-	mockClient.On("GetKubernetesClusterEntity", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
-		Return(dtclient.KubernetesClusterEntity{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: "operator test entity 1"}, nil).Maybe()
-	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), dtclient.KubernetesClusterEntity{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: "operator test entity 1"}, mock.AnythingOfType("string")).
+	mockClient.On("GetK8sClusterME", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
+		Return(dtclient.K8sClusterME{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: "operator test entity 1"}, nil).Maybe()
+	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), dtclient.K8sClusterME{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: "operator test entity 1"}, mock.AnythingOfType("string")).
 		Return(dtclient.GetSettingsResponse{}, nil).Maybe()
-	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), dtclient.KubernetesClusterEntity{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: ""}, mock.AnythingOfType("string")).
+	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), dtclient.K8sClusterME{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: ""}, mock.AnythingOfType("string")).
 		Return(dtclient.GetSettingsResponse{}, nil).Maybe()
 	mockClient.On("CreateOrUpdateKubernetesSetting", mock.AnythingOfType("context.backgroundCtx"), testName, testUID, mock.AnythingOfType("string")).
 		Return(testObjectID, nil).Maybe()

--- a/pkg/controllers/dynakube/controller_system_test.go
+++ b/pkg/controllers/dynakube/controller_system_test.go
@@ -78,7 +78,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		assert.NotNil(t, result)
 	})
 	t.Run(`Create reconciles proxy secret`, func(t *testing.T) {
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeActiveGateTokenCreate})
+		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeActiveGateTokenCreate, dtclient.TokenScopeSettingsRead})
 		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenID: "test", Token: "dt.some.valuegoeshere"}, nil)
 		mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
 
@@ -117,7 +117,7 @@ func TestReconcileActiveGate_Reconcile(t *testing.T) {
 		assert.NotNil(t, proxySecret)
 	})
 	t.Run("reconciles phase change correctly", func(t *testing.T) {
-		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeEntitiesRead, dtclient.TokenScopeSettingsRead, dtclient.TokenScopeSettingsWrite, dtclient.TokenScopeActiveGateTokenCreate})
+		mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{dtclient.TokenScopeSettingsRead, dtclient.TokenScopeSettingsWrite, dtclient.TokenScopeActiveGateTokenCreate})
 
 		mockClient.On("GetActiveGateAuthToken", mock.AnythingOfType("context.backgroundCtx"), testName).Return(&dtclient.ActiveGateAuthTokenInfo{TokenID: "test", Token: "dt.some.valuegoeshere"}, nil)
 		mockClient.On("GetLatestActiveGateVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return(testVersion, nil)
@@ -200,7 +200,7 @@ func TestReconcileOnlyOneTokenProvided_Reconcile(t *testing.T) {
 }
 func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 	mockClient := createDTMockClient(t, dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, dtclient.TokenScopes{
-
+		dtclient.TokenScopeSettingsRead,
 		dtclient.TokenScopeMetricsIngest,
 		dtclient.TokenScopeActiveGateTokenCreate,
 	})
@@ -223,6 +223,14 @@ func TestReconcile_ActiveGateMultiCapability(t *testing.T) {
 				},
 			},
 			LogMonitoring: &logmonitoring.Spec{},
+		},
+		Status: dynakube.DynaKubeStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   dtclient.ConditionTypeAPITokenSettingsRead,
+					Status: metav1.ConditionTrue,
+				},
+			},
 		},
 	}
 
@@ -366,11 +374,11 @@ func createDTMockClient(t *testing.T, paasTokenScopes, apiTokenScopes dtclient.T
 			}, nil).Maybe()
 	mockClient.On("GetLatestAgentVersion", mock.AnythingOfType("context.backgroundCtx"), mock.Anything, mock.Anything).
 		Return(testVersion, nil).Maybe()
-	mockClient.On("GetMonitoredEntitiesForKubeSystemUUID", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
-		Return([]dtclient.MonitoredEntity{{EntityID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", DisplayName: "operator test entity 1", LastSeenTms: 1639483869085}}, nil).Maybe()
-	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), &dtclient.MonitoredEntity{EntityID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", DisplayName: "operator test entity 1", LastSeenTms: 1639483869085}, mock.AnythingOfType("string")).
+	mockClient.On("GetKubernetesClusterEntity", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("string")).
+		Return(dtclient.KubernetesClusterEntity{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: "operator test entity 1"}, nil).Maybe()
+	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), dtclient.KubernetesClusterEntity{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: "operator test entity 1"}, mock.AnythingOfType("string")).
 		Return(dtclient.GetSettingsResponse{}, nil).Maybe()
-	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), &dtclient.MonitoredEntity{EntityID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", DisplayName: "", LastSeenTms: 0}, mock.AnythingOfType("string")).
+	mockClient.On("GetSettingsForMonitoredEntity", mock.AnythingOfType("context.backgroundCtx"), dtclient.KubernetesClusterEntity{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: ""}, mock.AnythingOfType("string")).
 		Return(dtclient.GetSettingsResponse{}, nil).Maybe()
 	mockClient.On("CreateOrUpdateKubernetesSetting", mock.AnythingOfType("context.backgroundCtx"), testName, testUID, mock.AnythingOfType("string")).
 		Return(testObjectID, nil).Maybe()

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -286,7 +286,6 @@ func TestSetupTokensAndClient(t *testing.T) {
 
 		mockedDtc := dtclientmock.NewClient(t)
 		mockedDtc.On("GetTokenScopes", mock.Anything, "this is a token").Return(dtclient.TokenScopes{
-			dtclient.TokenScopeEntitiesRead,
 			dtclient.TokenScopeSettingsRead,
 			dtclient.TokenScopeSettingsWrite,
 			dtclient.TokenScopeInstallerDownload,
@@ -574,7 +573,6 @@ func TestTokenConditions(t *testing.T) {
 		})
 		mockClient := dtclientmock.NewClient(t)
 		mockClient.On("GetTokenScopes", mock.Anything, testAPIToken).Return(dtclient.TokenScopes{
-			dtclient.TokenScopeEntitiesRead,
 			dtclient.TokenScopeSettingsRead,
 			dtclient.TokenScopeSettingsWrite,
 			dtclient.TokenScopeInstallerDownload,
@@ -724,6 +722,12 @@ func getTestDynkubeStatus() *dynakube.DynaKubeStatus {
 			},
 		},
 		KubeSystemUUID: testUID,
+		Conditions: []metav1.Condition{
+			{
+				Type:   dtclient.ConditionTypeAPITokenSettingsRead,
+				Status: metav1.ConditionTrue,
+			},
+		},
 	}
 }
 
@@ -764,10 +768,9 @@ func TestTokenConditionsOptionalScopes(t *testing.T) {
 		}
 
 		_, err := controller.setupTokensAndClient(ctx, dk)
-
 		require.Error(t, err)
+
 		assertCondition(t, dk, dynakube.TokenConditionType, metav1.ConditionFalse, dynakube.ReasonTokenError, "secrets \""+testName+"\" not found")
-		assert.Nil(t, meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenEntitiesRead))
 		assert.Nil(t, meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsRead))
 		assert.Nil(t, meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsWrite))
 	})
@@ -775,7 +778,6 @@ func TestTokenConditionsOptionalScopes(t *testing.T) {
 		dk := createDynakubeWithK8SMonitoring()
 
 		controller := createFakeControllerAndClients(t, dtclient.TokenScopes{
-			dtclient.TokenScopeEntitiesRead,
 			dtclient.TokenScopeSettingsRead,
 			dtclient.TokenScopeSettingsWrite,
 			dtclient.TokenScopeInstallerDownload,
@@ -785,10 +787,7 @@ func TestTokenConditionsOptionalScopes(t *testing.T) {
 		_, err := controller.setupTokensAndClient(ctx, dk)
 		require.NoError(t, err)
 
-		cond := meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenEntitiesRead)
-		require.NotNil(t, cond)
-		assert.Equal(t, metav1.ConditionTrue, cond.Status)
-		cond = meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsRead)
+		cond := meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsRead)
 		require.NotNil(t, cond)
 		assert.Equal(t, metav1.ConditionTrue, cond.Status)
 		cond = meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsWrite)
@@ -808,10 +807,7 @@ func TestTokenConditionsOptionalScopes(t *testing.T) {
 		_, err := controller.setupTokensAndClient(ctx, dk)
 		require.NoError(t, err)
 
-		cond := meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenEntitiesRead)
-		require.NotNil(t, cond)
-		assert.Equal(t, metav1.ConditionFalse, cond.Status)
-		cond = meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsRead)
+		cond := meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsRead)
 		require.NotNil(t, cond)
 		assert.Equal(t, metav1.ConditionTrue, cond.Status)
 		cond = meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsWrite)
@@ -829,10 +825,7 @@ func TestTokenConditionsOptionalScopes(t *testing.T) {
 		_, err := controller.setupTokensAndClient(ctx, dk)
 		require.NoError(t, err)
 
-		cond := meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenEntitiesRead)
-		require.NotNil(t, cond)
-		assert.Equal(t, metav1.ConditionFalse, cond.Status)
-		cond = meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsRead)
+		cond := meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsRead)
 		require.NotNil(t, cond)
 		assert.Equal(t, metav1.ConditionFalse, cond.Status)
 		cond = meta.FindStatusCondition(dk.Status.Conditions, dtclient.ConditionTypeAPITokenSettingsWrite)

--- a/pkg/controllers/dynakube/injection/reconciler_test.go
+++ b/pkg/controllers/dynakube/injection/reconciler_test.go
@@ -125,7 +125,7 @@ func TestReconciler(t *testing.T) {
 
 		rec := NewReconciler(clt, clt, dtClient, istioClient, dk)
 		fakeReconciler := createReconcilerMock(t)
-		rec.(*Reconciler).monitoredEntitiesReconciler = fakeReconciler
+		rec.(*Reconciler).k8sEntityReconciler = fakeReconciler
 
 		err := rec.Reconcile(context.Background())
 		require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestReconciler(t *testing.T) {
 
 		rec := NewReconciler(clt, clt, dtClient, istioClient, dk)
 		fakeReconciler := createUncalledReconcilerMock(t)
-		rec.(*Reconciler).monitoredEntitiesReconciler = fakeReconciler
+		rec.(*Reconciler).k8sEntityReconciler = fakeReconciler
 
 		err := rec.Reconcile(context.Background())
 		require.NoError(t, err)
@@ -245,7 +245,7 @@ func TestReconciler(t *testing.T) {
 		rec := NewReconciler(boomClient, boomClient, nil, istioClient, dk).(*Reconciler)
 		rec.connectionInfoReconciler = fakeReconciler
 		rec.versionReconciler = fakeVersionReconciler
-		rec.monitoredEntitiesReconciler = fakeReconciler
+		rec.k8sEntityReconciler = fakeReconciler
 
 		err := rec.Reconcile(context.Background())
 		require.Error(t, err)
@@ -264,7 +264,7 @@ func TestRemoveAppInjection(t *testing.T) {
 	rec.versionReconciler = createVersionReconcilerMock(t)
 	rec.connectionInfoReconciler = createUncalledReconcilerMock(t)
 	rec.enrichmentRulesReconciler = createUncalledReconcilerMock(t)
-	rec.monitoredEntitiesReconciler = createUncalledReconcilerMock(t)
+	rec.k8sEntityReconciler = createUncalledReconcilerMock(t)
 	setCodeModulesInjectionCreatedCondition(rec.dk.Conditions())
 	setMetadataEnrichmentCreatedCondition(rec.dk.Conditions())
 
@@ -296,7 +296,7 @@ func TestSetupOneAgentInjection(t *testing.T) {
 		})
 		rec.versionReconciler = createVersionReconcilerMock(t)
 		rec.connectionInfoReconciler = createReconcilerMock(t)
-		rec.monitoredEntitiesReconciler = createUncalledReconcilerMock(t)
+		rec.k8sEntityReconciler = createUncalledReconcilerMock(t)
 
 		err := rec.setupOneAgentInjection(context.Background())
 		require.NoError(t, err)
@@ -309,7 +309,7 @@ func TestSetupOneAgentInjection(t *testing.T) {
 		})
 		rec.versionReconciler = createVersionReconcilerMock(t)
 		rec.connectionInfoReconciler = createReconcilerMock(t)
-		rec.monitoredEntitiesReconciler = createUncalledReconcilerMock(t)
+		rec.k8sEntityReconciler = createUncalledReconcilerMock(t)
 
 		err := rec.setupOneAgentInjection(context.Background())
 		require.NoError(t, err)
@@ -322,7 +322,7 @@ func TestSetupOneAgentInjection(t *testing.T) {
 		})
 		rec.versionReconciler = createVersionReconcilerMock(t)
 		rec.connectionInfoReconciler = createReconcilerMock(t)
-		rec.monitoredEntitiesReconciler = createUncalledReconcilerMock(t)
+		rec.k8sEntityReconciler = createUncalledReconcilerMock(t)
 
 		err := rec.setupOneAgentInjection(context.Background())
 		require.NoError(t, err)
@@ -335,7 +335,7 @@ func TestSetupOneAgentInjection(t *testing.T) {
 		})
 		rec.versionReconciler = createVersionReconcilerMock(t)
 		rec.connectionInfoReconciler = createReconcilerMock(t)
-		rec.monitoredEntitiesReconciler = createUncalledReconcilerMock(t)
+		rec.k8sEntityReconciler = createUncalledReconcilerMock(t)
 
 		err := rec.setupOneAgentInjection(context.Background())
 		require.NoError(t, err)
@@ -349,7 +349,7 @@ func TestSetupEnrichmentInjection(t *testing.T) {
 			CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{},
 		})
 		rec.enrichmentRulesReconciler = createUncalledReconcilerMock(t)
-		rec.monitoredEntitiesReconciler = createUncalledReconcilerMock(t)
+		rec.k8sEntityReconciler = createUncalledReconcilerMock(t)
 		rec.dk.Spec.MetadataEnrichment.Enabled = ptr.To(false)
 
 		err := rec.setupEnrichmentInjection(context.Background())
@@ -362,7 +362,7 @@ func TestSetupEnrichmentInjection(t *testing.T) {
 			CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{},
 		})
 		rec.enrichmentRulesReconciler = createReconcilerMock(t)
-		rec.monitoredEntitiesReconciler = createReconcilerMock(t)
+		rec.k8sEntityReconciler = createReconcilerMock(t)
 		rec.dk.Spec.MetadataEnrichment.Enabled = ptr.To(true)
 
 		err := rec.setupEnrichmentInjection(context.Background())

--- a/pkg/controllers/dynakube/k8sentity/conditions.go
+++ b/pkg/controllers/dynakube/k8sentity/conditions.go
@@ -1,0 +1,5 @@
+package k8sentity
+
+const (
+	meIDConditionType = "MonitoredEntity"
+)

--- a/pkg/controllers/dynakube/k8sentity/config.go
+++ b/pkg/controllers/dynakube/k8sentity/config.go
@@ -1,4 +1,4 @@
-package monitoredentities
+package k8sentity
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"

--- a/pkg/controllers/dynakube/k8sentity/reconciler.go
+++ b/pkg/controllers/dynakube/k8sentity/reconciler.go
@@ -1,4 +1,13 @@
-package monitoredentities
+// Package k8sentity provides functionality for reconciling Kubernetes Cluster Monitored Entities for a given DynaKube.
+// The only purpose of this package is to look for (and not create) an already existing Kubernetes Cluster Monitored Entity in the Dynatrace Environment and store relevant info in the DynaKube's Status.
+//
+// A Kubernetes Cluster Monitored Entity (example: KUBERNETES_CLUSTER-A1234567BCD8EFGH) is calculated in the Dynatrace Environment.
+// - This happens when certain Setting (`builtin:cloud.kubernetes`) is created
+//   - Looking at this Setting via the API we can determine the Kubernetes Cluster Monitored Entity
+//
+// This ME(Monitored Entity) is an important configuration, yet optional, for most Dynatrace Components.
+// - If the Operator provides the ID and Name of the ME when possible, then it reduces the computational cost on ingest.
+package k8sentity
 
 import (
 	"context"
@@ -30,25 +39,25 @@ func NewReconciler( //nolint
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	log.Info("start reconciling monitored entities")
+	log.Info("start reconciling Kubernetes Cluster MEID")
 
-	if !conditions.IsOutdated(r.timeProvider, r.dk, MEIDConditionType) {
+	if !conditions.IsOutdated(r.timeProvider, r.dk, meIDConditionType) {
 		log.Info("Kubernetes Cluster MEID not outdated, skipping reconciliation")
 
 		return nil
 	}
 
-	conditions.SetStatusOutdated(r.dk.Conditions(), MEIDConditionType, "Kubernetes Cluster MEID is outdated in the status")
+	conditions.SetStatusOutdated(r.dk.Conditions(), meIDConditionType, "Kubernetes Cluster MEID is outdated in the status")
 
 	if !conditions.IsOptionalScopeAvailable(r.dk, dynatrace.ConditionTypeAPITokenSettingsRead) {
 		msg := dynatrace.TokenScopeSettingsRead + " optional scope not available"
 		log.Info(msg)
-		conditions.SetScopeMissing(r.dk.Conditions(), MEIDConditionType, msg)
+		conditions.SetScopeMissing(r.dk.Conditions(), meIDConditionType, msg)
 
 		return nil
 	}
 
-	k8sEntity, err := r.dtClient.GetKubernetesClusterEntity(ctx, r.dk.Status.KubeSystemUUID)
+	k8sEntity, err := r.dtClient.GetK8sClusterME(ctx, r.dk.Status.KubeSystemUUID)
 	if err != nil {
 		log.Info("failed to retrieve MEs")
 
@@ -63,7 +72,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 
 	r.dk.Status.KubernetesClusterMEID = k8sEntity.ID
 	r.dk.Status.KubernetesClusterName = k8sEntity.Name
-	conditions.SetStatusUpdated(r.dk.Conditions(), MEIDConditionType, "Kubernetes Cluster MEID is up to date")
+	conditions.SetStatusUpdated(r.dk.Conditions(), meIDConditionType, "Kubernetes Cluster MEID is up to date")
 
 	log.Info("kubernetesClusterMEID set in dynakube status, done reconciling", "kubernetesClusterMEID", r.dk.Status.KubernetesClusterMEID)
 

--- a/pkg/controllers/dynakube/k8sentity/reconciler_test.go
+++ b/pkg/controllers/dynakube/k8sentity/reconciler_test.go
@@ -1,4 +1,4 @@
-package monitoredentities
+package k8sentity
 
 import (
 	"context"
@@ -31,7 +31,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, dk.Status.KubernetesClusterMEID)
 
-		condition := meta.FindStatusCondition(*dk.Conditions(), MEIDConditionType)
+		condition := meta.FindStatusCondition(*dk.Conditions(), meIDConditionType)
 		require.NotNil(t, condition)
 		assert.Equal(t, conditions.ScopeMissingReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
@@ -39,8 +39,8 @@ func TestReconcile(t *testing.T) {
 	})
 	t.Run("no error if has valid kube system uuid", func(t *testing.T) {
 		clt := dtclientmock.NewClient(t)
-		clt.On("GetKubernetesClusterEntity",
-			mock.AnythingOfType("context.backgroundCtx"), "kube-system-uuid").Return(dtclient.KubernetesClusterEntity{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: "operator test entity 1"}, nil)
+		clt.On("GetK8sClusterME",
+			mock.AnythingOfType("context.backgroundCtx"), "kube-system-uuid").Return(dtclient.K8sClusterME{ID: "KUBERNETES_CLUSTER-0E30FE4BF2007587", Name: "operator test entity 1"}, nil)
 
 		dk := createDynaKube()
 
@@ -53,8 +53,8 @@ func TestReconcile(t *testing.T) {
 	})
 	t.Run("no error if no MEs are found", func(t *testing.T) {
 		clt := dtclientmock.NewClient(t)
-		clt.On("GetKubernetesClusterEntity",
-			mock.AnythingOfType("context.backgroundCtx"), "kube-system-uuid").Return(dtclient.KubernetesClusterEntity{}, nil)
+		clt.On("GetK8sClusterME",
+			mock.AnythingOfType("context.backgroundCtx"), "kube-system-uuid").Return(dtclient.K8sClusterME{}, nil)
 
 		dk := createDynaKube()
 

--- a/pkg/controllers/dynakube/logmonitoring/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/reconciler.go
@@ -7,10 +7,10 @@ import (
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	oaconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/k8sentity"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/configsecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/logmonsettings"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/monitoredentities"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,7 +23,7 @@ type Reconciler struct {
 	configSecretReconciler           controllers.Reconciler
 	daemonsetReconciler              controllers.Reconciler
 	oneAgentConnectionInfoReconciler controllers.Reconciler
-	monitoredEntitiesReconciler      controllers.Reconciler
+	k8sEntityReconciler              controllers.Reconciler
 	logmonsettingsReconciler         controllers.Reconciler
 }
 
@@ -42,13 +42,13 @@ func NewReconciler(clt client.Client,
 		configSecretReconciler:           configsecret.NewReconciler(clt, apiReader, dk),
 		daemonsetReconciler:              daemonset.NewReconciler(clt, apiReader, dk),
 		oneAgentConnectionInfoReconciler: oaconnectioninfo.NewReconciler(clt, apiReader, dtc, dk),
-		monitoredEntitiesReconciler:      monitoredentities.NewReconciler(dtc, dk),
+		k8sEntityReconciler:              k8sentity.NewReconciler(dtc, dk),
 		logmonsettingsReconciler:         logmonsettings.NewReconciler(dtc, dk),
 	}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	err := r.monitoredEntitiesReconciler.Reconcile(ctx)
+	err := r.k8sEntityReconciler.Reconcile(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/dynakube/logmonitoring/reconciler_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/reconciler_test.go
@@ -23,7 +23,7 @@ func TestReconcile(t *testing.T) {
 		passMonitoredEntity := createPassingMonitoredEntityReconciler(t, dk)
 		r := Reconciler{
 			dk:                               dk,
-			monitoredEntitiesReconciler:      passMonitoredEntity,
+			k8sEntityReconciler:              passMonitoredEntity,
 			oneAgentConnectionInfoReconciler: failOAConnectionInfo,
 		}
 
@@ -41,7 +41,7 @@ func TestReconcile(t *testing.T) {
 		passMonitoredEntity := createPassingMonitoredEntityReconciler(t, dk)
 		r := Reconciler{
 			dk:                               dk,
-			monitoredEntitiesReconciler:      passMonitoredEntity,
+			k8sEntityReconciler:              passMonitoredEntity,
 			oneAgentConnectionInfoReconciler: passOAConnectionInfo,
 			configSecretReconciler:           failConfigSecret,
 		}
@@ -73,7 +73,7 @@ func TestReconcile(t *testing.T) {
 		passMonitoredEntity := createPassingMonitoredEntityReconciler(t, dk)
 		r := Reconciler{
 			dk:                               dk,
-			monitoredEntitiesReconciler:      passMonitoredEntity,
+			k8sEntityReconciler:              passMonitoredEntity,
 			oneAgentConnectionInfoReconciler: passOAConnectionInfo,
 			configSecretReconciler:           passConfigSecret,
 			daemonsetReconciler:              passDaemonSet,

--- a/pkg/controllers/dynakube/monitoredentities/conditions.go
+++ b/pkg/controllers/dynakube/monitoredentities/conditions.go
@@ -1,9 +1,5 @@
 package monitoredentities
 
 const (
-	MEIDOutdatedReason = "MEIDOutdated"
-
-	MEIDEmptyReason = "MEIDEmpty"
-
 	MEIDConditionType = "MonitoredEntity"
 )

--- a/pkg/controllers/dynakube/monitoredentities/conditions.go
+++ b/pkg/controllers/dynakube/monitoredentities/conditions.go
@@ -1,5 +1,0 @@
-package monitoredentities
-
-const (
-	MEIDConditionType = "MonitoredEntity"
-)

--- a/pkg/controllers/dynakube/monitoredentities/reconciler.go
+++ b/pkg/controllers/dynakube/monitoredentities/reconciler.go
@@ -41,7 +41,9 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	conditions.SetStatusOutdated(r.dk.Conditions(), MEIDConditionType, "Kubernetes Cluster MEID is outdated in the status")
 
 	if !conditions.IsOptionalScopeAvailable(r.dk, dynatrace.ConditionTypeAPITokenSettingsRead) {
-		log.Info(dynatrace.TokenScopeSettingsRead + " optional scope not available")
+		msg := dynatrace.TokenScopeSettingsRead + " optional scope not available"
+		log.Info(msg)
+		conditions.SetScopeMissing(r.dk.Conditions(), MEIDConditionType, msg)
 
 		return nil
 	}

--- a/pkg/controllers/dynakube/monitoredentities/reconciler_test.go
+++ b/pkg/controllers/dynakube/monitoredentities/reconciler_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestReconcile(t *testing.T) {
 	ctx := context.Background()
+
 	t.Run("no error + no run if no scope in status", func(t *testing.T) {
 		clt := dtclientmock.NewClient(t)
 		dk := createDynaKube()

--- a/pkg/controllers/dynakube/monitoredentities/reconciler_test.go
+++ b/pkg/controllers/dynakube/monitoredentities/reconciler_test.go
@@ -6,9 +6,12 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -27,6 +30,12 @@ func TestReconcile(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Empty(t, dk.Status.KubernetesClusterMEID)
+
+		condition := meta.FindStatusCondition(*dk.Conditions(), MEIDConditionType)
+		require.NotNil(t, condition)
+		assert.Equal(t, conditions.ScopeMissingReason, condition.Reason)
+		assert.Equal(t, metav1.ConditionFalse, condition.Status)
+		assert.Contains(t, condition.Message, dtclient.TokenScopeSettingsRead)
 	})
 	t.Run("no error if has valid kube system uuid", func(t *testing.T) {
 		clt := dtclientmock.NewClient(t)

--- a/pkg/controllers/dynakube/token/feature.go
+++ b/pkg/controllers/dynakube/token/feature.go
@@ -42,7 +42,6 @@ func getFeaturesForAPIToken(paasTokenExists bool) []Feature {
 		{
 			Name: "Kubernetes API Monitoring",
 			OptionalScopes: []string{
-				dtclient.TokenScopeEntitiesRead,
 				dtclient.TokenScopeSettingsRead,
 				dtclient.TokenScopeSettingsWrite},
 			IsEnabled: func(dk dynakube.DynaKube) bool {

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -202,9 +202,8 @@ func TestOptionalTokens(t *testing.T) {
 		}, nil).Maybe()
 
 		missingScopes := map[string][]string{
-			apiTokenNoMissingScopes: {},
-			apiTokenMissingEntitiesRead: {
-			},
+			apiTokenNoMissingScopes:     {},
+			apiTokenMissingEntitiesRead: {},
 			apiTokenMissingEntitiesReadSettingsRead: {
 				dtclient.TokenScopeSettingsRead,
 			},

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -18,7 +18,6 @@ import (
 
 func getAllScopesForAPIToken() dtclient.TokenScopes {
 	return []string{
-		dtclient.TokenScopeEntitiesRead,
 		dtclient.TokenScopeSettingsRead,
 		dtclient.TokenScopeSettingsWrite,
 		dtclient.TokenScopeActiveGateTokenCreate,
@@ -185,7 +184,6 @@ func TestOptionalTokens(t *testing.T) {
 
 		fakeClient := dtclientmock.NewClient(t)
 		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenNoMissingScopes).Return(dtclient.TokenScopes{
-			dtclient.TokenScopeEntitiesRead,
 			dtclient.TokenScopeSettingsRead,
 			dtclient.TokenScopeSettingsWrite,
 			dtclient.TokenScopeInstallerDownload,
@@ -206,10 +204,8 @@ func TestOptionalTokens(t *testing.T) {
 		missingScopes := map[string][]string{
 			apiTokenNoMissingScopes: {},
 			apiTokenMissingEntitiesRead: {
-				dtclient.TokenScopeEntitiesRead,
 			},
 			apiTokenMissingEntitiesReadSettingsRead: {
-				dtclient.TokenScopeEntitiesRead,
 				dtclient.TokenScopeSettingsRead,
 			},
 		}

--- a/pkg/util/conditions/time.go
+++ b/pkg/util/conditions/time.go
@@ -15,5 +15,5 @@ func IsOutdated(timeProvider *timeprovider.Provider, dk *dynakube.DynaKube, cond
 		return true
 	}
 
-	return condition.Status == metav1.ConditionFalse || timeProvider.IsOutdated(&condition.LastTransitionTime, dk.APIRequestThreshold())
+	return (condition.Status == metav1.ConditionFalse && condition.Reason != ScopeMissingReason) || timeProvider.IsOutdated(&condition.LastTransitionTime, dk.APIRequestThreshold())
 }

--- a/pkg/util/conditions/token.go
+++ b/pkg/util/conditions/token.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	DataIngestTokenMissing string = "DataIngestTokenMissing"
+	DataIngestTokenMissing = "DataIngestTokenMissing"
+	ScopeMissingReason     = "ScopeMissing"
 )
 
 func SetDataIngestTokenMissing(conditions *[]metav1.Condition, conditionType string, msg string) {
@@ -14,6 +15,16 @@ func SetDataIngestTokenMissing(conditions *[]metav1.Condition, conditionType str
 		Type:    conditionType,
 		Status:  metav1.ConditionFalse,
 		Reason:  DataIngestTokenMissing,
+		Message: msg,
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
+}
+
+func SetScopeMissing(conditions *[]metav1.Condition, conditionType, msg string) {
+	condition := metav1.Condition{
+		Type:    conditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  ScopeMissingReason,
 		Message: msg,
 	}
 	_ = meta.SetStatusCondition(conditions, condition)

--- a/test/mocks/pkg/clients/dynatrace/client.go
+++ b/test/mocks/pkg/clients/dynatrace/client.go
@@ -741,8 +741,8 @@ func (_c *Client_GetK8sClusterME_Call) Run(run func(ctx context.Context, kubeSys
 	return _c
 }
 
-func (_c *Client_GetK8sClusterME_Call) Return(kubernetesClusterEntity dynatrace.K8sClusterME, err error) *Client_GetK8sClusterME_Call {
-	_c.Call.Return(kubernetesClusterEntity, err)
+func (_c *Client_GetK8sClusterME_Call) Return(k8sClusterME dynatrace.K8sClusterME, err error) *Client_GetK8sClusterME_Call {
+	_c.Call.Return(k8sClusterME, err)
 	return _c
 }
 
@@ -1467,7 +1467,7 @@ type Client_GetSettingsForMonitoredEntity_Call struct {
 
 // GetSettingsForMonitoredEntity is a helper method to define mock.On call
 //   - ctx context.Context
-//   - monitoredEntity dynatrace.KubernetesClusterEntity
+//   - monitoredEntity dynatrace.K8sClusterME
 //   - schemaID string
 func (_e *Client_Expecter) GetSettingsForMonitoredEntity(ctx interface{}, monitoredEntity interface{}, schemaID interface{}) *Client_GetSettingsForMonitoredEntity_Call {
 	return &Client_GetSettingsForMonitoredEntity_Call{Call: _e.mock.On("GetSettingsForMonitoredEntity", ctx, monitoredEntity, schemaID)}

--- a/test/mocks/pkg/clients/dynatrace/client.go
+++ b/test/mocks/pkg/clients/dynatrace/client.go
@@ -685,23 +685,23 @@ func (_c *Client_GetCommunicationHostForClient_Call) RunAndReturn(run func() (dy
 	return _c
 }
 
-// GetKubernetesClusterEntity provides a mock function for the type Client
-func (_mock *Client) GetKubernetesClusterEntity(ctx context.Context, kubeSystemUUID string) (dynatrace.KubernetesClusterEntity, error) {
+// GetK8sClusterME provides a mock function for the type Client
+func (_mock *Client) GetK8sClusterME(ctx context.Context, kubeSystemUUID string) (dynatrace.K8sClusterME, error) {
 	ret := _mock.Called(ctx, kubeSystemUUID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetKubernetesClusterEntity")
+		panic("no return value specified for GetK8sClusterME")
 	}
 
-	var r0 dynatrace.KubernetesClusterEntity
+	var r0 dynatrace.K8sClusterME
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (dynatrace.KubernetesClusterEntity, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (dynatrace.K8sClusterME, error)); ok {
 		return returnFunc(ctx, kubeSystemUUID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) dynatrace.KubernetesClusterEntity); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) dynatrace.K8sClusterME); ok {
 		r0 = returnFunc(ctx, kubeSystemUUID)
 	} else {
-		r0 = ret.Get(0).(dynatrace.KubernetesClusterEntity)
+		r0 = ret.Get(0).(dynatrace.K8sClusterME)
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = returnFunc(ctx, kubeSystemUUID)
@@ -711,19 +711,19 @@ func (_mock *Client) GetKubernetesClusterEntity(ctx context.Context, kubeSystemU
 	return r0, r1
 }
 
-// Client_GetKubernetesClusterEntity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetKubernetesClusterEntity'
-type Client_GetKubernetesClusterEntity_Call struct {
+// Client_GetK8sClusterME_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetK8sClusterME'
+type Client_GetK8sClusterME_Call struct {
 	*mock.Call
 }
 
-// GetKubernetesClusterEntity is a helper method to define mock.On call
+// GetK8sClusterME is a helper method to define mock.On call
 //   - ctx context.Context
 //   - kubeSystemUUID string
-func (_e *Client_Expecter) GetKubernetesClusterEntity(ctx interface{}, kubeSystemUUID interface{}) *Client_GetKubernetesClusterEntity_Call {
-	return &Client_GetKubernetesClusterEntity_Call{Call: _e.mock.On("GetKubernetesClusterEntity", ctx, kubeSystemUUID)}
+func (_e *Client_Expecter) GetK8sClusterME(ctx interface{}, kubeSystemUUID interface{}) *Client_GetK8sClusterME_Call {
+	return &Client_GetK8sClusterME_Call{Call: _e.mock.On("GetK8sClusterME", ctx, kubeSystemUUID)}
 }
 
-func (_c *Client_GetKubernetesClusterEntity_Call) Run(run func(ctx context.Context, kubeSystemUUID string)) *Client_GetKubernetesClusterEntity_Call {
+func (_c *Client_GetK8sClusterME_Call) Run(run func(ctx context.Context, kubeSystemUUID string)) *Client_GetK8sClusterME_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -741,12 +741,12 @@ func (_c *Client_GetKubernetesClusterEntity_Call) Run(run func(ctx context.Conte
 	return _c
 }
 
-func (_c *Client_GetKubernetesClusterEntity_Call) Return(kubernetesClusterEntity dynatrace.KubernetesClusterEntity, err error) *Client_GetKubernetesClusterEntity_Call {
+func (_c *Client_GetK8sClusterME_Call) Return(kubernetesClusterEntity dynatrace.K8sClusterME, err error) *Client_GetK8sClusterME_Call {
 	_c.Call.Return(kubernetesClusterEntity, err)
 	return _c
 }
 
-func (_c *Client_GetKubernetesClusterEntity_Call) RunAndReturn(run func(ctx context.Context, kubeSystemUUID string) (dynatrace.KubernetesClusterEntity, error)) *Client_GetKubernetesClusterEntity_Call {
+func (_c *Client_GetK8sClusterME_Call) RunAndReturn(run func(ctx context.Context, kubeSystemUUID string) (dynatrace.K8sClusterME, error)) *Client_GetK8sClusterME_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1435,7 +1435,7 @@ func (_c *Client_GetSettingsForLogModule_Call) RunAndReturn(run func(ctx context
 }
 
 // GetSettingsForMonitoredEntity provides a mock function for the type Client
-func (_mock *Client) GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity dynatrace.KubernetesClusterEntity, schemaID string) (dynatrace.GetSettingsResponse, error) {
+func (_mock *Client) GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity dynatrace.K8sClusterME, schemaID string) (dynatrace.GetSettingsResponse, error) {
 	ret := _mock.Called(ctx, monitoredEntity, schemaID)
 
 	if len(ret) == 0 {
@@ -1444,15 +1444,15 @@ func (_mock *Client) GetSettingsForMonitoredEntity(ctx context.Context, monitore
 
 	var r0 dynatrace.GetSettingsResponse
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, dynatrace.KubernetesClusterEntity, string) (dynatrace.GetSettingsResponse, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, dynatrace.K8sClusterME, string) (dynatrace.GetSettingsResponse, error)); ok {
 		return returnFunc(ctx, monitoredEntity, schemaID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, dynatrace.KubernetesClusterEntity, string) dynatrace.GetSettingsResponse); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, dynatrace.K8sClusterME, string) dynatrace.GetSettingsResponse); ok {
 		r0 = returnFunc(ctx, monitoredEntity, schemaID)
 	} else {
 		r0 = ret.Get(0).(dynatrace.GetSettingsResponse)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, dynatrace.KubernetesClusterEntity, string) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, dynatrace.K8sClusterME, string) error); ok {
 		r1 = returnFunc(ctx, monitoredEntity, schemaID)
 	} else {
 		r1 = ret.Error(1)
@@ -1473,15 +1473,15 @@ func (_e *Client_Expecter) GetSettingsForMonitoredEntity(ctx interface{}, monito
 	return &Client_GetSettingsForMonitoredEntity_Call{Call: _e.mock.On("GetSettingsForMonitoredEntity", ctx, monitoredEntity, schemaID)}
 }
 
-func (_c *Client_GetSettingsForMonitoredEntity_Call) Run(run func(ctx context.Context, monitoredEntity dynatrace.KubernetesClusterEntity, schemaID string)) *Client_GetSettingsForMonitoredEntity_Call {
+func (_c *Client_GetSettingsForMonitoredEntity_Call) Run(run func(ctx context.Context, monitoredEntity dynatrace.K8sClusterME, schemaID string)) *Client_GetSettingsForMonitoredEntity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 dynatrace.KubernetesClusterEntity
+		var arg1 dynatrace.K8sClusterME
 		if args[1] != nil {
-			arg1 = args[1].(dynatrace.KubernetesClusterEntity)
+			arg1 = args[1].(dynatrace.K8sClusterME)
 		}
 		var arg2 string
 		if args[2] != nil {
@@ -1501,7 +1501,7 @@ func (_c *Client_GetSettingsForMonitoredEntity_Call) Return(getSettingsResponse 
 	return _c
 }
 
-func (_c *Client_GetSettingsForMonitoredEntity_Call) RunAndReturn(run func(ctx context.Context, monitoredEntity dynatrace.KubernetesClusterEntity, schemaID string) (dynatrace.GetSettingsResponse, error)) *Client_GetSettingsForMonitoredEntity_Call {
+func (_c *Client_GetSettingsForMonitoredEntity_Call) RunAndReturn(run func(ctx context.Context, monitoredEntity dynatrace.K8sClusterME, schemaID string) (dynatrace.GetSettingsResponse, error)) *Client_GetSettingsForMonitoredEntity_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/test/mocks/pkg/clients/dynatrace/client.go
+++ b/test/mocks/pkg/clients/dynatrace/client.go
@@ -685,6 +685,72 @@ func (_c *Client_GetCommunicationHostForClient_Call) RunAndReturn(run func() (dy
 	return _c
 }
 
+// GetKubernetesClusterEntity provides a mock function for the type Client
+func (_mock *Client) GetKubernetesClusterEntity(ctx context.Context, kubeSystemUUID string) (dynatrace.KubernetesClusterEntity, error) {
+	ret := _mock.Called(ctx, kubeSystemUUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetKubernetesClusterEntity")
+	}
+
+	var r0 dynatrace.KubernetesClusterEntity
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (dynatrace.KubernetesClusterEntity, error)); ok {
+		return returnFunc(ctx, kubeSystemUUID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) dynatrace.KubernetesClusterEntity); ok {
+		r0 = returnFunc(ctx, kubeSystemUUID)
+	} else {
+		r0 = ret.Get(0).(dynatrace.KubernetesClusterEntity)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, kubeSystemUUID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Client_GetKubernetesClusterEntity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetKubernetesClusterEntity'
+type Client_GetKubernetesClusterEntity_Call struct {
+	*mock.Call
+}
+
+// GetKubernetesClusterEntity is a helper method to define mock.On call
+//   - ctx context.Context
+//   - kubeSystemUUID string
+func (_e *Client_Expecter) GetKubernetesClusterEntity(ctx interface{}, kubeSystemUUID interface{}) *Client_GetKubernetesClusterEntity_Call {
+	return &Client_GetKubernetesClusterEntity_Call{Call: _e.mock.On("GetKubernetesClusterEntity", ctx, kubeSystemUUID)}
+}
+
+func (_c *Client_GetKubernetesClusterEntity_Call) Run(run func(ctx context.Context, kubeSystemUUID string)) *Client_GetKubernetesClusterEntity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_GetKubernetesClusterEntity_Call) Return(kubernetesClusterEntity dynatrace.KubernetesClusterEntity, err error) *Client_GetKubernetesClusterEntity_Call {
+	_c.Call.Return(kubernetesClusterEntity, err)
+	return _c
+}
+
+func (_c *Client_GetKubernetesClusterEntity_Call) RunAndReturn(run func(ctx context.Context, kubeSystemUUID string) (dynatrace.KubernetesClusterEntity, error)) *Client_GetKubernetesClusterEntity_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLatestActiveGateImage provides a mock function for the type Client
 func (_mock *Client) GetLatestActiveGateImage(ctx context.Context) (*dynatrace.LatestImageInfo, error) {
 	ret := _mock.Called(ctx)
@@ -1298,72 +1364,6 @@ func (_c *Client_GetRulesSettings_Call) Return(getRulesSettingsResponse dynatrac
 }
 
 func (_c *Client_GetRulesSettings_Call) RunAndReturn(run func(ctx context.Context, kubeSystemUUID string, entityID string) (dynatrace.GetRulesSettingsResponse, error)) *Client_GetRulesSettings_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetKubernetesClusterEntity provides a mock function for the type Client
-func (_mock *Client) GetKubernetesClusterEntity(ctx context.Context, kubeSystemUUID string) (dynatrace.KubernetesClusterEntity, error) {
-	ret := _mock.Called(ctx, kubeSystemUUID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetKubernetesClusterEntity")
-	}
-
-	var r0 dynatrace.KubernetesClusterEntity
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (dynatrace.KubernetesClusterEntity, error)); ok {
-		return returnFunc(ctx, kubeSystemUUID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) dynatrace.KubernetesClusterEntity); ok {
-		r0 = returnFunc(ctx, kubeSystemUUID)
-	} else {
-		r0 = ret.Get(0).(dynatrace.KubernetesClusterEntity)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, kubeSystemUUID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// Client_GetKubernetesClusterEntity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetKubernetesClusterEntity'
-type Client_GetKubernetesClusterEntity_Call struct {
-	*mock.Call
-}
-
-// GetKubernetesClusterEntity is a helper method to define mock.On call
-//   - ctx context.Context
-//   - kubeSystemUUID string
-func (_e *Client_Expecter) GetKubernetesClusterEntity(ctx interface{}, kubeSystemUUID interface{}) *Client_GetKubernetesClusterEntity_Call {
-	return &Client_GetKubernetesClusterEntity_Call{Call: _e.mock.On("GetKubernetesClusterEntity", ctx, kubeSystemUUID)}
-}
-
-func (_c *Client_GetKubernetesClusterEntity_Call) Run(run func(ctx context.Context, kubeSystemUUID string)) *Client_GetKubernetesClusterEntity_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *Client_GetKubernetesClusterEntity_Call) Return(kubernetesClusterEntity dynatrace.KubernetesClusterEntity, err error) *Client_GetKubernetesClusterEntity_Call {
-	_c.Call.Return(kubernetesClusterEntity, err)
-	return _c
-}
-
-func (_c *Client_GetKubernetesClusterEntity_Call) RunAndReturn(run func(ctx context.Context, kubeSystemUUID string) (dynatrace.KubernetesClusterEntity, error)) *Client_GetKubernetesClusterEntity_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/test/mocks/pkg/clients/dynatrace/client.go
+++ b/test/mocks/pkg/clients/dynatrace/client.go
@@ -1102,74 +1102,6 @@ func (_c *Client_GetLatestOneAgentImage_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
-// GetMonitoredEntitiesForKubeSystemUUID provides a mock function for the type Client
-func (_mock *Client) GetMonitoredEntitiesForKubeSystemUUID(ctx context.Context, kubeSystemUUID string) ([]dynatrace.MonitoredEntity, error) {
-	ret := _mock.Called(ctx, kubeSystemUUID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetMonitoredEntitiesForKubeSystemUUID")
-	}
-
-	var r0 []dynatrace.MonitoredEntity
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]dynatrace.MonitoredEntity, error)); ok {
-		return returnFunc(ctx, kubeSystemUUID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []dynatrace.MonitoredEntity); ok {
-		r0 = returnFunc(ctx, kubeSystemUUID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]dynatrace.MonitoredEntity)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, kubeSystemUUID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// Client_GetMonitoredEntitiesForKubeSystemUUID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMonitoredEntitiesForKubeSystemUUID'
-type Client_GetMonitoredEntitiesForKubeSystemUUID_Call struct {
-	*mock.Call
-}
-
-// GetMonitoredEntitiesForKubeSystemUUID is a helper method to define mock.On call
-//   - ctx context.Context
-//   - kubeSystemUUID string
-func (_e *Client_Expecter) GetMonitoredEntitiesForKubeSystemUUID(ctx interface{}, kubeSystemUUID interface{}) *Client_GetMonitoredEntitiesForKubeSystemUUID_Call {
-	return &Client_GetMonitoredEntitiesForKubeSystemUUID_Call{Call: _e.mock.On("GetMonitoredEntitiesForKubeSystemUUID", ctx, kubeSystemUUID)}
-}
-
-func (_c *Client_GetMonitoredEntitiesForKubeSystemUUID_Call) Run(run func(ctx context.Context, kubeSystemUUID string)) *Client_GetMonitoredEntitiesForKubeSystemUUID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *Client_GetMonitoredEntitiesForKubeSystemUUID_Call) Return(monitoredEntitys []dynatrace.MonitoredEntity, err error) *Client_GetMonitoredEntitiesForKubeSystemUUID_Call {
-	_c.Call.Return(monitoredEntitys, err)
-	return _c
-}
-
-func (_c *Client_GetMonitoredEntitiesForKubeSystemUUID_Call) RunAndReturn(run func(ctx context.Context, kubeSystemUUID string) ([]dynatrace.MonitoredEntity, error)) *Client_GetMonitoredEntitiesForKubeSystemUUID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetOneAgentConnectionInfo provides a mock function for the type Client
 func (_mock *Client) GetOneAgentConnectionInfo(ctx context.Context) (dynatrace.OneAgentConnectionInfo, error) {
 	ret := _mock.Called(ctx)
@@ -1370,6 +1302,72 @@ func (_c *Client_GetRulesSettings_Call) RunAndReturn(run func(ctx context.Contex
 	return _c
 }
 
+// GetKubernetesClusterEntity provides a mock function for the type Client
+func (_mock *Client) GetKubernetesClusterEntity(ctx context.Context, kubeSystemUUID string) (dynatrace.KubernetesClusterEntity, error) {
+	ret := _mock.Called(ctx, kubeSystemUUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetKubernetesClusterEntity")
+	}
+
+	var r0 dynatrace.KubernetesClusterEntity
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (dynatrace.KubernetesClusterEntity, error)); ok {
+		return returnFunc(ctx, kubeSystemUUID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) dynatrace.KubernetesClusterEntity); ok {
+		r0 = returnFunc(ctx, kubeSystemUUID)
+	} else {
+		r0 = ret.Get(0).(dynatrace.KubernetesClusterEntity)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, kubeSystemUUID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Client_GetKubernetesClusterEntity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetKubernetesClusterEntity'
+type Client_GetKubernetesClusterEntity_Call struct {
+	*mock.Call
+}
+
+// GetKubernetesClusterEntity is a helper method to define mock.On call
+//   - ctx context.Context
+//   - kubeSystemUUID string
+func (_e *Client_Expecter) GetKubernetesClusterEntity(ctx interface{}, kubeSystemUUID interface{}) *Client_GetKubernetesClusterEntity_Call {
+	return &Client_GetKubernetesClusterEntity_Call{Call: _e.mock.On("GetKubernetesClusterEntity", ctx, kubeSystemUUID)}
+}
+
+func (_c *Client_GetKubernetesClusterEntity_Call) Run(run func(ctx context.Context, kubeSystemUUID string)) *Client_GetKubernetesClusterEntity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_GetKubernetesClusterEntity_Call) Return(kubernetesClusterEntity dynatrace.KubernetesClusterEntity, err error) *Client_GetKubernetesClusterEntity_Call {
+	_c.Call.Return(kubernetesClusterEntity, err)
+	return _c
+}
+
+func (_c *Client_GetKubernetesClusterEntity_Call) RunAndReturn(run func(ctx context.Context, kubeSystemUUID string) (dynatrace.KubernetesClusterEntity, error)) *Client_GetKubernetesClusterEntity_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetSettingsForLogModule provides a mock function for the type Client
 func (_mock *Client) GetSettingsForLogModule(ctx context.Context, monitoredEntity string) (dynatrace.GetLogMonSettingsResponse, error) {
 	ret := _mock.Called(ctx, monitoredEntity)
@@ -1437,7 +1435,7 @@ func (_c *Client_GetSettingsForLogModule_Call) RunAndReturn(run func(ctx context
 }
 
 // GetSettingsForMonitoredEntity provides a mock function for the type Client
-func (_mock *Client) GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity *dynatrace.MonitoredEntity, schemaID string) (dynatrace.GetSettingsResponse, error) {
+func (_mock *Client) GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity dynatrace.KubernetesClusterEntity, schemaID string) (dynatrace.GetSettingsResponse, error) {
 	ret := _mock.Called(ctx, monitoredEntity, schemaID)
 
 	if len(ret) == 0 {
@@ -1446,15 +1444,15 @@ func (_mock *Client) GetSettingsForMonitoredEntity(ctx context.Context, monitore
 
 	var r0 dynatrace.GetSettingsResponse
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *dynatrace.MonitoredEntity, string) (dynatrace.GetSettingsResponse, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, dynatrace.KubernetesClusterEntity, string) (dynatrace.GetSettingsResponse, error)); ok {
 		return returnFunc(ctx, monitoredEntity, schemaID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *dynatrace.MonitoredEntity, string) dynatrace.GetSettingsResponse); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, dynatrace.KubernetesClusterEntity, string) dynatrace.GetSettingsResponse); ok {
 		r0 = returnFunc(ctx, monitoredEntity, schemaID)
 	} else {
 		r0 = ret.Get(0).(dynatrace.GetSettingsResponse)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *dynatrace.MonitoredEntity, string) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, dynatrace.KubernetesClusterEntity, string) error); ok {
 		r1 = returnFunc(ctx, monitoredEntity, schemaID)
 	} else {
 		r1 = ret.Error(1)
@@ -1469,21 +1467,21 @@ type Client_GetSettingsForMonitoredEntity_Call struct {
 
 // GetSettingsForMonitoredEntity is a helper method to define mock.On call
 //   - ctx context.Context
-//   - monitoredEntity *dynatrace.MonitoredEntity
+//   - monitoredEntity dynatrace.KubernetesClusterEntity
 //   - schemaID string
 func (_e *Client_Expecter) GetSettingsForMonitoredEntity(ctx interface{}, monitoredEntity interface{}, schemaID interface{}) *Client_GetSettingsForMonitoredEntity_Call {
 	return &Client_GetSettingsForMonitoredEntity_Call{Call: _e.mock.On("GetSettingsForMonitoredEntity", ctx, monitoredEntity, schemaID)}
 }
 
-func (_c *Client_GetSettingsForMonitoredEntity_Call) Run(run func(ctx context.Context, monitoredEntity *dynatrace.MonitoredEntity, schemaID string)) *Client_GetSettingsForMonitoredEntity_Call {
+func (_c *Client_GetSettingsForMonitoredEntity_Call) Run(run func(ctx context.Context, monitoredEntity dynatrace.KubernetesClusterEntity, schemaID string)) *Client_GetSettingsForMonitoredEntity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *dynatrace.MonitoredEntity
+		var arg1 dynatrace.KubernetesClusterEntity
 		if args[1] != nil {
-			arg1 = args[1].(*dynatrace.MonitoredEntity)
+			arg1 = args[1].(dynatrace.KubernetesClusterEntity)
 		}
 		var arg2 string
 		if args[2] != nil {
@@ -1503,7 +1501,7 @@ func (_c *Client_GetSettingsForMonitoredEntity_Call) Return(getSettingsResponse 
 	return _c
 }
 
-func (_c *Client_GetSettingsForMonitoredEntity_Call) RunAndReturn(run func(ctx context.Context, monitoredEntity *dynatrace.MonitoredEntity, schemaID string) (dynatrace.GetSettingsResponse, error)) *Client_GetSettingsForMonitoredEntity_Call {
+func (_c *Client_GetSettingsForMonitoredEntity_Call) RunAndReturn(run func(ctx context.Context, monitoredEntity dynatrace.KubernetesClusterEntity, schemaID string) (dynatrace.GetSettingsResponse, error)) *Client_GetSettingsForMonitoredEntity_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-10641](https://dt-rnd.atlassian.net/browse/DAQ-10641)

Replace the `GetMonitoredEntitiesForKubeSystemUUID` that used the `entities.read` scope with `GetK8sClusterME` that uses `settings.read` scope to get the same thing.
- It lists the `builtin:cloud.kubernetes` settings, that have a `scope` which is the ID of the entity we are looking for
- Only 1 such setting exists per tenant per Kubernetes cluster, and the `label` of the setting is the Name of the entity 

`GetK8sClusterME` is bit hard to parse at first, I added all the docs strings to help with that.
- Writing `GetKubernetesClusterMonitoredEntity` was IMO way worse
- The term "ME" is a common Dynatrace term we already use it in the status, see `kubernetesClusterMEID`

`GetK8sClusterME` (as the rename suggest) assumes a few things:
- The only type of entity we care about is a `KUBERNETES_CLUSTER_...` entity (so calling it `MonitoredEntity` would be too generic)
- There can only be 1 `KUBERNETES_CLUSTER_...` entity (per tenant) for a Kubernetes cluster, this is why it doesn't return a list.
- We only care about the ID of it and Label/Name, so that is the only things we store.

The `GetK8sClusterME` function is only used in the `monitoredentities.Reconciler`, that now will check for the `settings.read` scope.
Also the `entities.read` scope has been fully removed from the code.

## How can this be tested?
The unittests are pretty extensive... (mainly because some of them feel like integration tests...)

Manual test:
1. Create an `apiToken`, normal in every way BUT without the `entities.read` scope.
2. Use this `apiToken` in your DynaKube, and start deploying things that want to know the Kubernetes cluster entityID
 - (standalone logmon for example) 

[DAQ-10641]: https://dt-rnd.atlassian.net/browse/DAQ-10641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ