### PR TITLE
Add liveness probe config of csi daemonset in helm values

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -107,17 +107,17 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        {{- if not .Values.debug }}
+        {{- if and (not .Values.debug) .Values.csidriver.server.livenessProbe.enabled }}
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: {{ .Values.csidriver.server.livenessProbe.failureThreshold }}
           httpGet:
             path: /healthz
             port: 9808
             scheme: HTTP
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          successThreshold: 1
-          timeoutSeconds: 10
+          initialDelaySeconds: {{ .Values.csidriver.server.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.csidriver.server.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.csidriver.server.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.csidriver.server.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: 8080
@@ -242,6 +242,7 @@ spec:
           name: registration-dir
         # Used to make a gRPC request (Probe()) to the driver to check if its running
         # - Needs access to the csi socket, needs to read/write to it, needs root permissions to do so.
+      {{- if .Values.csidriver.server.livenessProbe.enabled }}
       - name: liveness-probe
         image: {{ include "dynatrace-operator.image" . }}
         imagePullPolicy: Always
@@ -267,6 +268,7 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -396,6 +396,49 @@ tests:
                   type: DirectoryOrCreate
                 name: mountpoint-dir
 
+  - it: should use correct values for livenessprobe for server provided by the operator
+    set:
+      platform: kubernetes
+      image: image-name
+      csidriver.enabled: true
+      csidriver.server.livenessProbe.failureThreshold: 2
+      csidriver.server.livenessProbe.initialDelaySeconds: 2
+      csidriver.server.livenessProbe.periodSeconds: 2
+      csidriver.server.livenessProbe.successThreshold: 2
+      csidriver.server.livenessProbe.timeoutSeconds: 2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            failureThreshold: 2
+            httpGet:
+              path: /healthz
+              port: 9808
+              scheme: HTTP
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            successThreshold: 2
+            timeoutSeconds: 2
+
+  - it: should not use livenessProbe when it's disabled
+    set:
+      platform: kubernetes
+      image: image-name
+      csidriver.enabled: true
+      csidriver.server.livenessProbe.enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].livenessProbe
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 3
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: liveness-probe
+          count: 1
+          any: true
+
   - it: should use livenessprobe and csi-node-driver-registrar commands provided by the operator if they are preferred
     set:
       platform: kubernetes

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -154,6 +154,13 @@ csidriver:
       limits:
         cpu: 50m
         memory: 100Mi
+    livenessProbe:
+      enabled: true
+      failureThreshold: 5
+      initialDelaySeconds: 15
+      periodSeconds: 15
+      successThreshold: 1
+      timeoutSeconds: 10
   provisioner:
     securityContext:
       runAsUser: 0


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR resolves https://dt-rnd.atlassian.net/browse/DAQ-11106

It is mostly based on https://github.com/Dynatrace/dynatrace-operator/pull/5072, but it does not allow configuration (it requires some extra work and updates, so it will be done in future PRs if necessary).

```
- --probe-timeout={{- .Values.csidriver.livenessprobe.probeTimeout }}
```

kudos to @oihanitrz 

## How can this be tested?

unit-tests