### PR TITLE
Make metadata/rules reconciler ready for optional scopes in MetadaEnrichment mode (no AG)

### DIFF
--- a/pkg/controllers/dynakube/token/feature.go
+++ b/pkg/controllers/dynakube/token/feature.go
@@ -63,6 +63,13 @@ func getFeaturesForAPIToken(paasTokenExists bool) []Feature {
 				return !paasTokenExists
 			},
 		},
+		{
+			Name:           "MetadataEnrichment Rules",
+			OptionalScopes: []string{dtclient.TokenScopeSettingsRead},
+			IsEnabled: func(dk dynakube.DynaKube) bool {
+				return dk.MetadataEnrichmentEnabled() || dk.FF().IsNodeImagePull()
+			},
+		},
 	}
 }
 

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func getAllScopesForAPIToken() dtclient.TokenScopes {
@@ -75,7 +76,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynakube.DynaKube{})
 
-		assert.Len(t, tokens.APIToken().Features, 3)
+		assert.Len(t, tokens.APIToken().Features, 4)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Empty(t, tokens.DataIngestToken().Features)
 		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Download Installer' is missing scope 'InstallerDownload']")
@@ -90,7 +91,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynakube.DynaKube{})
 
-		assert.Len(t, tokens.APIToken().Features, 3)
+		assert.Len(t, tokens.APIToken().Features, 4)
 		assert.Len(t, tokens.PaasToken().Features, 1)
 		assert.Empty(t, tokens.DataIngestToken().Features)
 		assert.NoError(t, err)
@@ -103,7 +104,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynakube.DynaKube{})
 
-		assert.Len(t, tokens.APIToken().Features, 3)
+		assert.Len(t, tokens.APIToken().Features, 4)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Empty(t, tokens.DataIngestToken().Features)
 		assert.NoError(t, err)
@@ -121,7 +122,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dk)
 
-		assert.Len(t, tokens.APIToken().Features, 3)
+		assert.Len(t, tokens.APIToken().Features, 4)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Empty(t, tokens.DataIngestToken().Features)
 		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Automatic ActiveGate Token Creation' is missing scope 'activeGateTokenManagement.create' feature 'Download Installer' is missing scope 'InstallerDownload']")
@@ -139,7 +140,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dk)
 
-		assert.Len(t, tokens.APIToken().Features, 3)
+		assert.Len(t, tokens.APIToken().Features, 4)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Len(t, tokens.DataIngestToken().Features, 1)
 		assert.EqualError(t, err, "token 'dataIngestToken' has scope errors: [feature 'Data Ingest' is missing scope 'metrics.ingest']")
@@ -154,7 +155,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(context.Background(), createFakeClient(t), dynakube.DynaKube{})
 
-		assert.Len(t, tokens.APIToken().Features, 3)
+		assert.Len(t, tokens.APIToken().Features, 4)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Len(t, tokens.DataIngestToken().Features, 1)
 		assert.NoError(t, err)
@@ -162,7 +163,7 @@ func TestTokens(t *testing.T) {
 }
 
 func TestOptionalTokens(t *testing.T) {
-	t.Run("optional scope is missing", func(t *testing.T) {
+	t.Run("optional scope is missing - kubernetes-monitoring enabled", func(t *testing.T) {
 		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -179,8 +180,9 @@ func TestOptionalTokens(t *testing.T) {
 		}
 
 		apiTokenNoMissingScopes := "api-token-value1"
-		apiTokenMissingEntitiesRead := "api-token-value2"
-		apiTokenMissingEntitiesReadSettingsRead := "api-token-value3"
+		apiTokenMissingSettingsRead := "api-token-value2"
+		apiTokenMissingSettingsWrite := "api-token-value3"
+		apiTokenMissingSettingsReadWrite := "api-token-value4"
 
 		fakeClient := dtclientmock.NewClient(t)
 		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenNoMissingScopes).Return(dtclient.TokenScopes{
@@ -189,39 +191,144 @@ func TestOptionalTokens(t *testing.T) {
 			dtclient.TokenScopeInstallerDownload,
 			dtclient.TokenScopeActiveGateTokenCreate,
 		}, nil).Maybe()
-		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenMissingEntitiesRead).Return(dtclient.TokenScopes{
-			dtclient.TokenScopeSettingsRead,
+		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenMissingSettingsRead).Return(dtclient.TokenScopes{
 			dtclient.TokenScopeSettingsWrite,
 			dtclient.TokenScopeInstallerDownload,
 			dtclient.TokenScopeActiveGateTokenCreate,
 		}, nil).Maybe()
-		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenMissingEntitiesReadSettingsRead).Return(dtclient.TokenScopes{
-			dtclient.TokenScopeSettingsWrite,
+		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenMissingSettingsWrite).Return(dtclient.TokenScopes{
+			dtclient.TokenScopeSettingsRead,
+			dtclient.TokenScopeInstallerDownload,
+			dtclient.TokenScopeActiveGateTokenCreate,
+		}, nil).Maybe()
+		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenMissingSettingsReadWrite).Return(dtclient.TokenScopes{
 			dtclient.TokenScopeInstallerDownload,
 			dtclient.TokenScopeActiveGateTokenCreate,
 		}, nil).Maybe()
 
 		missingScopes := map[string][]string{
-			apiTokenNoMissingScopes:     {},
-			apiTokenMissingEntitiesRead: {},
-			apiTokenMissingEntitiesReadSettingsRead: {
+			apiTokenNoMissingScopes: {},
+			apiTokenMissingSettingsRead: {
 				dtclient.TokenScopeSettingsRead,
+			},
+			apiTokenMissingSettingsWrite: {
+				dtclient.TokenScopeSettingsWrite,
+			},
+			apiTokenMissingSettingsReadWrite: {
+				dtclient.TokenScopeSettingsRead,
+				dtclient.TokenScopeSettingsWrite,
+			},
+		}
+		assertOptionalScopes(t, fakeClient, dk, missingScopes)
+	})
+	t.Run("optional scope is missing - metadataEnrichment enabled", func(t *testing.T) {
+		dk := dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				MetadataEnrichment: dynakube.MetadataEnrichment{
+					Enabled: ptr.To(true),
+				},
 			},
 		}
 
-		for tokenValue, scopes := range missingScopes {
-			apiToken := newToken(dtclient.APIToken, tokenValue)
-			tokens := Tokens{
-				dtclient.APIToken: &apiToken,
-			}
-			tokens = tokens.AddFeatureScopesToTokens()
-			missingOptionalScopes, err := tokens.VerifyScopes(context.Background(), fakeClient, dk)
+		apiTokenNoMissingScopes := "api-token-value1"
+		apiTokenMissingSettingsRead := "api-token-value2"
 
-			assert.Len(t, tokens.APIToken().Features, 3, tokenValue)
-			assert.Equal(t, scopes, missingOptionalScopes, tokenValue)
-			assert.NoError(t, err, tokenValue)
+		fakeClient := dtclientmock.NewClient(t)
+		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenNoMissingScopes).Return(dtclient.TokenScopes{
+			dtclient.TokenScopeSettingsRead,
+			dtclient.TokenScopeInstallerDownload,
+			dtclient.TokenScopeActiveGateTokenCreate,
+		}, nil).Maybe()
+		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenMissingSettingsRead).Return(dtclient.TokenScopes{
+			dtclient.TokenScopeInstallerDownload,
+			dtclient.TokenScopeActiveGateTokenCreate,
+		}, nil).Maybe()
+
+		missingScopes := map[string][]string{
+			apiTokenNoMissingScopes: {},
+			apiTokenMissingSettingsRead: {
+				dtclient.TokenScopeSettingsRead,
+			},
 		}
+		assertOptionalScopes(t, fakeClient, dk, missingScopes)
 	})
+	t.Run("optional scope is missing - kubernetes-monitoring and metadataEnrichment enabled", func(t *testing.T) {
+		dk := dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"feature.dynatrace.com/automatic-kubernetes-api-monitoring": "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.KubeMonCapability.DisplayName,
+					},
+				},
+				MetadataEnrichment: dynakube.MetadataEnrichment{
+					Enabled: ptr.To(true),
+				},
+			},
+		}
+
+		apiTokenNoMissingScopes := "api-token-value1"
+		apiTokenMissingSettingsRead := "api-token-value2"
+		apiTokenMissingSettingsWrite := "api-token-value3"
+		apiTokenMissingSettingsReadWrite := "api-token-value4"
+
+		fakeClient := dtclientmock.NewClient(t)
+		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenNoMissingScopes).Return(dtclient.TokenScopes{
+			dtclient.TokenScopeSettingsRead,
+			dtclient.TokenScopeSettingsWrite,
+			dtclient.TokenScopeInstallerDownload,
+			dtclient.TokenScopeActiveGateTokenCreate,
+		}, nil).Maybe()
+		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenMissingSettingsRead).Return(dtclient.TokenScopes{
+			dtclient.TokenScopeSettingsWrite,
+			dtclient.TokenScopeInstallerDownload,
+			dtclient.TokenScopeActiveGateTokenCreate,
+		}, nil).Maybe()
+		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenMissingSettingsWrite).Return(dtclient.TokenScopes{
+			dtclient.TokenScopeSettingsRead,
+			dtclient.TokenScopeInstallerDownload,
+			dtclient.TokenScopeActiveGateTokenCreate,
+		}, nil).Maybe()
+		fakeClient.On("GetTokenScopes", mock.Anything, apiTokenMissingSettingsReadWrite).Return(dtclient.TokenScopes{
+			dtclient.TokenScopeInstallerDownload,
+			dtclient.TokenScopeActiveGateTokenCreate,
+		}, nil).Maybe()
+
+		missingScopes := map[string][]string{
+			apiTokenNoMissingScopes: {},
+			apiTokenMissingSettingsRead: {
+				dtclient.TokenScopeSettingsRead,
+			},
+			apiTokenMissingSettingsWrite: {
+				dtclient.TokenScopeSettingsWrite,
+			},
+			apiTokenMissingSettingsReadWrite: {
+				dtclient.TokenScopeSettingsRead,
+				dtclient.TokenScopeSettingsWrite,
+			},
+		}
+
+		assertOptionalScopes(t, fakeClient, dk, missingScopes)
+	})
+}
+
+func assertOptionalScopes(t *testing.T, fakeClient dtclient.Client, dk dynakube.DynaKube, missingScopes map[string][]string) {
+	for tokenValue, scopes := range missingScopes {
+		apiToken := newToken(dtclient.APIToken, tokenValue)
+		tokens := Tokens{
+			dtclient.APIToken: &apiToken,
+		}
+		tokens = tokens.AddFeatureScopesToTokens()
+		missingOptionalScopes, err := tokens.VerifyScopes(context.Background(), fakeClient, dk)
+
+		assert.Len(t, tokens.APIToken().Features, 4, tokenValue)
+		assert.Equal(t, scopes, missingOptionalScopes, tokenValue)
+		assert.NoError(t, err, tokenValue)
+	}
 }
 
 func enableKubernetesMonitoringAndMetricsIngest(dk *dynakube.DynaKube) *dynakube.DynaKube {


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-11413)

## Description
It's a fix for [Makes settings.read/write, entities.read scopes optional PR](https://github.com/Dynatrace/dynatrace-operator/pull/5119).

MetadataEnrichmentRules should be also downloaded when MetadataEnrichment mode is enabled only (no kubernetes-monitoring).

New feature is added to the ApiToken because it is used by [GetRulesSettings](https://github.com/Dynatrace/dynatrace-operator/blob/main/pkg/clients/dynatrace/settings_enrichment.go#L45) for authorization.

## How can this be tested?
1) unittests
2) deploy dk with MetadataEnrichment and K8S monitoring (without and with `settings.read` scope)
```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  annotations:
    feature.dynatrace.com/k8s-app-enabled: "true"
    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://<tenant>.dev.dynatracelabs.com/api
  activeGate:
    capabilities:
    - kubernetes-monitoring
  metadataEnrichment:
    enabled: true
  oneAgent:
    cloudNativeFullStack: {}    
```

3) deploy dk with MetadataEnrichment (without and with `settings.read` scope)
```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://<tenant>.dev.dynatracelabs.com/api
  metadataEnrichment:
    enabled: true
  activeGate: {}
  oneAgent:
    cloudNativeFullStack: {}
```
4) deploy dk with node-pull-image (without and with `settings.read` scope)
```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  annotations:
    feature.dynatrace.com/node-image-pull: "true"   
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://<tenant>.dev.dynatracelabs.com/api
  activeGate: {}
  oneAgent:
    cloudNativeFullStack: {}
```
