### PR TITLE
e2e: increase wait for dk status

### DIFF
--- a/test/helpers/components/dynakube/dynakube.go
+++ b/test/helpers/components/dynakube/dynakube.go
@@ -95,7 +95,7 @@ func WaitForPhase(dk dynakube.DynaKube, phase status.DeploymentPhase) features.F
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
 
-		const timeout = 5 * time.Minute
+		const timeout = 8 * time.Minute
 		err := wait.For(conditions.New(resources).ResourceMatch(&dk, func(object k8s.Object) bool {
 			dynakube, isDynakube := object.(*dynakube.DynaKube)
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

resolves https://dt-rnd.atlassian.net/browse/DAQ-11804

`WaitForPhase ` waits 5 mins before this PR and fails from time to time because we wait for OneAgent to start to set phase to running.

my experiment shows that we achieve it faster in 2 mins or so ( status running i mean) but because we can't control that OneAgent will start quickly ( or even we don't know how fast) I extend default value to 8 mins. Also on CI in logs it takes more than 5 mins (300 seconds) .

```
NAMESPACE   NAME       APIURL                                       STATUS    AGE
dynatrace   dynakube   https://hbc47170.dev.dynatracelabs.com/api   Running   117s
NAMESPACE   NAME       APIURL                                       STATUS    AGE
dynatrace   dynakube   https://hbc47170.dev.dynatracelabs.com/api   Running   2m
NAMESPACE   NAME       APIURL                                       STATUS    AGE
dynatrace   dynakube   https://hbc47170.dev.dynatracelabs.com/api   Running   2m3s
```

## How can this be tested?

```
make test/e2e/classic
```