### PR TITLE
Remove spec.preserveUnknownFields from CRD spec

### DIFF
--- a/config/crd/patches/webhook_in_dynakubes.yaml
+++ b/config/crd/patches/webhook_in_dynakubes.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   name: dynakubes.dynatrace.com
 spec:
-  preserveUnknownFields: false # needed when upgrading CRD from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1
   conversion:
     strategy: Webhook
     webhook:

--- a/config/crd/patches/webhook_in_edgeconnects.yaml
+++ b/config/crd/patches/webhook_in_edgeconnects.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   name: edgeconnects.dynatrace.com
 spec:
-  preserveUnknownFields: false # needed when upgrading CRD from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1
   conversion:
     strategy: Webhook
     webhook:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -28,7 +28,6 @@ spec:
     - dk
     - dks
     singular: dynakube
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -7993,7 +7992,6 @@ spec:
     - ec
     - ecs
     singular: edgeconnect
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:


### PR DESCRIPTION
## Description

Remove deprecated preserveUnknownFields spec field from CRD to prevent Out-of-sync status in ArgoCD v3.0+.

[DAQ-11001](https://dt-rnd.atlassian.net/browse/DAQ-11001)

## How can this be tested?

Requires ArgoCD 3.0+ to be installed. See: https://argo-cd.readthedocs.io/en/stable/operator-manual/core/#installing

* Push helm chart to a registry and use it as source for an ArgoCD Application, e.g.:

```yaml
project: default
source:
  repoURL: https://chart.repo/
  targetRevision: someversion
  chart: dynatrace-operator
destination:
  server: https://kubernetes.default.svc
  namespace: default
syncPolicy:
  automated: {}
```

The status of the EdgeConnect and Dynakube CRDs should be green (Synced).

I pushed test charts to https://avorima.github.io/chartrepo. Version 0.1.0 was built from main and 0.2.0 from this branch.


[DAQ-11001]: https://dt-rnd.atlassian.net/browse/DAQ-11001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ