### PR TITLE
Extend ActiveGate ClusterRole permissions

### DIFF
--- a/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
+++ b/config/helm/chart/default/templates/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring.yaml
@@ -32,6 +32,8 @@ rules:
       - nodes/proxy
       - nodes/metrics
       - services
+      - persistentvolumeclaims
+      - persistentvolumes
     verbs:
       - list
       - watch
@@ -76,6 +78,24 @@ rules:
       - dynatrace.com
     resources:
       - dynakubes
+      - edgeconnects
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
     verbs:
       - list
       - watch

--- a/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/kubernetes-monitoring/clusterrole-kubernetes-monitoring_test.yaml
@@ -30,6 +30,8 @@ tests:
               - nodes/proxy
               - nodes/metrics
               - services
+              - persistentvolumeclaims
+              - persistentvolumes
             verbs:
               - list
               - watch
@@ -89,6 +91,30 @@ tests:
               - dynatrace.com
             resources:
               - dynakubes
+              - edgeconnects
+            verbs:
+              - list
+              - watch
+              - get
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apiextensions.k8s.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - list
+              - watch
+              - get
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - networking.k8s.io
+            resources:
+              - ingresses
+              - networkpolicies
             verbs:
               - list
               - watch


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Kubernetes monitoring Activegate requires additional permissions for the K8s smartscape feature and for this I updated respective ClusterRole.

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-11915)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Helm unittests

Deploy the operator and check the `clusterrole` (`dynatrace-kubernetes-monitoring`)

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->