### PR TITLE
Use dk.templates.logMonitoring.resources to set value of main and init container resources (#5065)

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
@@ -37,6 +37,7 @@ func getContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container {
 		ImagePullPolicy: corev1.PullAlways,
 		VolumeMounts:    getVolumeMounts(tenantUUID),
 		Env:             getEnvs(),
+		Resources:       dk.LogMonitoring().Template().Resources,
 		SecurityContext: &securityContext,
 	}
 
@@ -55,6 +56,7 @@ func getInitContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container 
 		Command:         []string{bootstrapCommand},
 		Env:             getInitEnvs(dk),
 		Args:            getInitArgs(dk),
+		Resources:       dk.LogMonitoring().Template().Resources,
 		SecurityContext: &securityContext,
 	}
 

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestGetContainer(t *testing.T) {
@@ -27,6 +29,7 @@ func TestGetContainer(t *testing.T) {
 		assert.Len(t, mainContainer.VolumeMounts, expectedMountLen)
 		assert.NotEmpty(t, mainContainer.Env)
 		assert.Len(t, mainContainer.Env, expectedBaseEnvLen)
+		assert.Empty(t, mainContainer.Resources)
 		assert.NotEmpty(t, mainContainer.SecurityContext)
 	})
 
@@ -45,6 +48,30 @@ func TestGetContainer(t *testing.T) {
 		require.NotEmpty(t, mainContainer)
 		assert.NotEmpty(t, mainContainer.Image)
 		assert.Equal(t, expectedRepo+":"+expectedTag, mainContainer.Image)
+	})
+
+	t.Run("resources are respected", func(t *testing.T) {
+		requests := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		}
+		limits := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}
+		dk := dynakube.DynaKube{}
+		dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{
+			Resources: corev1.ResourceRequirements{
+				Requests: requests,
+				Limits:   limits,
+			},
+		}
+		mainContainer := getContainer(dk, tenantUUID)
+
+		require.NotEmpty(t, mainContainer)
+		assert.NotEmpty(t, mainContainer.Resources)
+		assert.Equal(t, requests, mainContainer.Resources.Requests)
+		assert.Equal(t, limits, mainContainer.Resources.Limits)
 	})
 }
 
@@ -80,11 +107,34 @@ func TestGetInitContainer(t *testing.T) {
 				Tag:        expectedTag,
 			},
 		}
-		initContainer := getContainer(dk, tenantUUID)
+		initContainer := getInitContainer(dk, tenantUUID)
 
 		require.NotEmpty(t, initContainer)
 		assert.NotEmpty(t, initContainer.Image)
 		assert.Equal(t, expectedRepo+":"+expectedTag, initContainer.Image)
+	})
+	t.Run("resources are respected", func(t *testing.T) {
+		requests := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		}
+		limits := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}
+		dk := dynakube.DynaKube{}
+		dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{
+			Resources: corev1.ResourceRequirements{
+				Requests: requests,
+				Limits:   limits,
+			},
+		}
+		initContainer := getInitContainer(dk, tenantUUID)
+
+		require.NotEmpty(t, initContainer)
+		assert.NotEmpty(t, initContainer.Resources)
+		assert.Equal(t, requests, initContainer.Resources.Requests)
+		assert.Equal(t, limits, initContainer.Resources.Limits)
 	})
 }
 


### PR DESCRIPTION
Co-authored-by: Marcell Sevcsik <marcell.sevcsik@dynatrace.com>

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

same as https://github.com/Dynatrace/dynatrace-operator/pull/5065

## How can this be tested?

same as https://github.com/Dynatrace/dynatrace-operator/pull/5065