### PR TITLE
Fix metadataEnrichment not adding prefixed pod annotations to enrichment files

### DIFF
--- a/pkg/webhook/mutation/pod/common/metadata/annotations.go
+++ b/pkg/webhook/mutation/pod/common/metadata/annotations.go
@@ -32,7 +32,7 @@ func copyAccordingToPrefix(pod *corev1.Pod, namespace corev1.Namespace) map[stri
 
 	for key, value := range pod.Annotations {
 		if strings.HasPrefix(key, dynakube.MetadataPrefix) {
-			addedAnnotations[key] = value //add all annotations that are on the pod and that are copied from namespace
+			addedAnnotations[key] = value
 		}
 	}
 

--- a/pkg/webhook/mutation/pod/common/metadata/annotations.go
+++ b/pkg/webhook/mutation/pod/common/metadata/annotations.go
@@ -22,21 +22,21 @@ func CopyMetadataFromNamespace(pod *corev1.Pod, namespace corev1.Namespace, dk d
 }
 
 func copyAccordingToPrefix(pod *corev1.Pod, namespace corev1.Namespace) map[string]string {
-	addedAnnotations := make(map[string]string)
+	metadataAnnotations := make(map[string]string)
 
 	for key, value := range namespace.Annotations {
 		if strings.HasPrefix(key, dynakube.MetadataPrefix) {
-			setPodAnnotationIfNotExists(pod, key, value)
+			_ = setPodAnnotationIfNotExists(pod, key, value)
 		}
 	}
 
 	for key, value := range pod.Annotations {
 		if strings.HasPrefix(key, dynakube.MetadataPrefix) {
-			addedAnnotations[key] = value
+			metadataAnnotations[key] = value
 		}
 	}
 
-	return addedAnnotations
+	return metadataAnnotations
 }
 
 func copyAccordingToCustomRules(pod *corev1.Pod, namespace corev1.Namespace, dk dynakube.DynaKube) map[string]string {
@@ -76,7 +76,7 @@ func setPodMetadataJsonAnnotation(pod *corev1.Pod, annotations map[string]string
 		log.Error(err, "failed to marshal annotations to map", "annotations", annotations)
 	}
 
-	setPodAnnotationIfNotExists(pod, dynakube.MetadataAnnotation, string(marshaledAnnotations))
+	_ = setPodAnnotationIfNotExists(pod, dynakube.MetadataAnnotation, string(marshaledAnnotations))
 }
 
 func setPodAnnotationIfNotExists(pod *corev1.Pod, key, value string) bool {

--- a/pkg/webhook/mutation/pod/common/metadata/annotations.go
+++ b/pkg/webhook/mutation/pod/common/metadata/annotations.go
@@ -26,11 +26,13 @@ func copyAccordingToPrefix(pod *corev1.Pod, namespace corev1.Namespace) map[stri
 
 	for key, value := range namespace.Annotations {
 		if strings.HasPrefix(key, dynakube.MetadataPrefix) {
-			added := setPodAnnotationIfNotExists(pod, key, value)
+			setPodAnnotationIfNotExists(pod, key, value)
+		}
+	}
 
-			if added {
-				addedAnnotations[key] = value
-			}
+	for key, value := range pod.Annotations {
+		if strings.HasPrefix(key, dynakube.MetadataPrefix) {
+			addedAnnotations[key] = value //add all annotations that are on the pod and that are copied from namespace
 		}
 	}
 

--- a/pkg/webhook/mutation/pod/common/metadata/annotations_test.go
+++ b/pkg/webhook/mutation/pod/common/metadata/annotations_test.go
@@ -175,7 +175,7 @@ func TestCopyMetadataFromNamespace(t *testing.T) {
 		annotations := CopyMetadataFromNamespace(request.Pod, request.Namespace, request.DynaKube)
 
 		require.Len(t, annotations, 2)
-		require.Len(t, request.Pod.Annotations, 3) //2 annotations + json annotation
+		require.Len(t, request.Pod.Annotations, 3)
 
 		require.Equal(t, "do-not-overwrite", request.Pod.Annotations[dynakube.MetadataPrefix+"someannotation"])
 


### PR DESCRIPTION
Ticket: https://dt-rnd.atlassian.net/browse/DAQ-12297

## Description
Currently the operator is not copying all annotations with "metadata.dynatrace.com/" prefix from the pod to the enrichment file, only the ones that are copied from the namespace (either with prefix or by specified rule). Example: If there is a pod that has metadata.dynatrace.com/someannotation: annotation set when its scheduled, this will not land in the enrichment file, even though it is expected land there.


## How can this be tested?

Deploy a `DynaKube` without or with NodeImagePull enabled (both should work), aswell as metadataEnrichment enabled.

```
metadataEnrichment:
    enabled: true
```

Schedule a pod within a namespace that has an annotation set with prefix "metadata.dynatrace.com/", check if this annotation incl. value is ending up in the enrichment file