### PR TITLE
Adapt LogMonitoring to optional scope handling

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -6,12 +6,11 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 )
 
-func getInitArgs(dk dynakube.DynaKube) []string {
+func getInitArgs(dk dynakube.DynaKube, useMetadata bool) []string {
 	baseArgs := []string{
 		fmt.Sprintf("-p k8s.cluster.name=$(%s)", clusterNameEnv),
 		fmt.Sprintf("-p k8s.cluster.uid=$(%s)", clusterUIDEnv),
 		fmt.Sprintf("-p k8s.node.name=$(%s)", nodeNameEnv),
-		fmt.Sprintf("-p dt.entity.kubernetes_cluster=$(%s)", entityEnv),
 		fmt.Sprintf("-c k8s_fullpodname $(%s)", podNameEnv),
 		fmt.Sprintf("-c k8s_poduid $(%s)", podUIDEnv),
 		fmt.Sprintf("-c k8s_basepodname $(%s)", basePodNameEnv),
@@ -20,6 +19,10 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 		fmt.Sprintf("-c k8s_cluster_id $(%s)", clusterUIDEnv),
 		"-c k8s_containername " + containerName,
 		"-l " + dtLogVolumeMountPath,
+	}
+
+	if useMetadata {
+		baseArgs = append(baseArgs, fmt.Sprintf("-p dt.entity.kubernetes_cluster=$(%s)", entityEnv))
 	}
 
 	return append(baseArgs, dk.LogMonitoring().Template().Args...)

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
@@ -9,14 +9,15 @@ import (
 )
 
 const (
-	expectedBaseInitArgsLen = 12
+	expectedBaseInitArgsLen            = 12
+	expectedBaseInitArgsLenWithoutMEID = 11
 )
 
 func TestGetInitArgs(t *testing.T) {
 	t.Run("get base init args", func(t *testing.T) {
 		dk := dynakube.DynaKube{}
 		dk.Name = "dk-name-test"
-		args := getInitArgs(dk)
+		args := getInitArgs(dk, true)
 
 		assert.Len(t, args, expectedBaseInitArgsLen)
 
@@ -34,12 +35,23 @@ func TestGetInitArgs(t *testing.T) {
 				"customArg2",
 			},
 		}
-		args := getInitArgs(dk)
+		args := getInitArgs(dk, true)
 
 		assert.Len(t, args, expectedBaseInitArgsLen+len(dk.LogMonitoring().Args))
 
 		for _, customArg := range dk.LogMonitoring().Args {
 			assert.Contains(t, args, customArg)
+		}
+	})
+	t.Run("get base init args when no MEID or not all necessary scopes are set", func(t *testing.T) {
+		dk := dynakube.DynaKube{}
+		dk.Name = "dk-name-test"
+		args := getInitArgs(dk, false)
+
+		assert.Len(t, args, expectedBaseInitArgsLenWithoutMEID)
+
+		for _, arg := range args {
+			assert.NotEmpty(t, arg)
 		}
 	})
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
@@ -2,6 +2,7 @@ package daemonset
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )
@@ -44,7 +45,7 @@ func getContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container {
 	return container
 }
 
-func getInitContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container {
+func getInitContainer(dk dynakube.DynaKube, tenantUUID string, useMetadata bool) corev1.Container {
 	securityContext := getBaseSecurityContext(dk)
 	securityContext.Capabilities.Add = neededInitCapabilities
 
@@ -54,8 +55,8 @@ func getInitContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container 
 		ImagePullPolicy: corev1.PullAlways,
 		VolumeMounts:    []corev1.VolumeMount{getDTVolumeMounts(tenantUUID)},
 		Command:         []string{bootstrapCommand},
-		Env:             getInitEnvs(dk),
-		Args:            getInitArgs(dk),
+		Env:             getInitEnvs(dk, useMetadata),
+		Args:            getInitArgs(dk, useMetadata),
 		Resources:       dk.LogMonitoring().Template().Resources,
 		SecurityContext: &securityContext,
 	}

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container_test.go
@@ -80,7 +80,7 @@ func TestGetInitContainer(t *testing.T) {
 
 	t.Run("get main container", func(t *testing.T) {
 		dk := dynakube.DynaKube{}
-		initContainer := getInitContainer(dk, tenantUUID)
+		initContainer := getInitContainer(dk, tenantUUID, true)
 
 		require.NotEmpty(t, initContainer)
 
@@ -107,7 +107,7 @@ func TestGetInitContainer(t *testing.T) {
 				Tag:        expectedTag,
 			},
 		}
-		initContainer := getInitContainer(dk, tenantUUID)
+		initContainer := getInitContainer(dk, tenantUUID, true)
 
 		require.NotEmpty(t, initContainer)
 		assert.NotEmpty(t, initContainer.Image)
@@ -129,12 +129,23 @@ func TestGetInitContainer(t *testing.T) {
 				Limits:   limits,
 			},
 		}
-		initContainer := getInitContainer(dk, tenantUUID)
+		initContainer := getInitContainer(dk, tenantUUID, true)
 
 		require.NotEmpty(t, initContainer)
 		assert.NotEmpty(t, initContainer.Resources)
 		assert.Equal(t, requests, initContainer.Resources.Requests)
 		assert.Equal(t, limits, initContainer.Resources.Limits)
+	})
+	t.Run("get main container without the use of metadata", func(t *testing.T) {
+		dk := dynakube.DynaKube{}
+		initContainer := getInitContainer(dk, tenantUUID, false)
+
+		require.NotEmpty(t, initContainer)
+
+		assert.NotEmpty(t, initContainer.Args)
+		assert.Len(t, initContainer.Args, expectedBaseInitArgsLen-1)
+		assert.NotEmpty(t, initContainer.Env)
+		assert.Len(t, initContainer.Env, expectedBaseInitEnvLen-1)
 	})
 }
 
@@ -175,7 +186,7 @@ func TestSecurityContext(t *testing.T) {
 
 	t.Run("main and init container securityContext differ only in capabilities", func(t *testing.T) {
 		dk := dynakube.DynaKube{}
-		initContainer := getInitContainer(dk, tenantUUID)
+		initContainer := getInitContainer(dk, tenantUUID, false)
 		mainContainer := getContainer(dk, tenantUUID)
 
 		require.NotNil(t, initContainer)

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/env.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/env.go
@@ -27,8 +27,8 @@ const (
 	ruxitConfigPath = "/var/lib/dynatrace/oneagent/agent/config/ruxitagentproc.conf"
 )
 
-func getInitEnvs(dk dynakube.DynaKube) []corev1.EnvVar {
-	return []corev1.EnvVar{
+func getInitEnvs(dk dynakube.DynaKube, useMetadata bool) []corev1.EnvVar {
+	envs := []corev1.EnvVar{
 		{
 			Name: nodeNameEnv,
 			ValueFrom: &corev1.EnvVarSource{
@@ -70,14 +70,19 @@ func getInitEnvs(dk dynakube.DynaKube) []corev1.EnvVar {
 			Value: dk.Status.KubernetesClusterName,
 		},
 		{
-			Name:  entityEnv,
-			Value: dk.Status.KubernetesClusterMEID,
-		},
-		{
 			Name:  basePodNameEnv,
 			Value: dk.LogMonitoring().GetDaemonSetName(),
 		},
 	}
+
+	if useMetadata {
+		envs = append(envs, corev1.EnvVar{
+			Name:  entityEnv,
+			Value: dk.Status.KubernetesClusterMEID,
+		})
+	}
+
+	return envs
 }
 
 func GetKubeletEnvs() []corev1.EnvVar {

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/env_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/env_test.go
@@ -22,12 +22,29 @@ func TestGetInitEnvs(t *testing.T) {
 		dk.Status.KubernetesClusterMEID = "test-me-id"
 		dk.Status.KubernetesClusterName = "test-cluster-name"
 
-		envs := getInitEnvs(dk)
+		envs := getInitEnvs(dk, true)
 
 		assert.Len(t, envs, expectedBaseInitEnvLen)
 
 		for _, env := range envs {
 			hasValueOrFieldPath(t, env)
+		}
+	})
+	t.Run("get base init envs without MEID but all scopes set", func(t *testing.T) {
+		dk := dynakube.DynaKube{}
+		dk.Name = "dk-name-test"
+		dk.Status.KubeSystemUUID = "test-cluster-uuid"
+		dk.Status.KubernetesClusterMEID = ""
+		dk.Status.KubernetesClusterName = "test-cluster-name"
+
+		envs := getInitEnvs(dk, false)
+
+		assert.Len(t, envs, expectedBaseInitEnvLen-1)
+
+		for _, env := range envs {
+			if env.Name == "DT_ENTITY_KUBERNETES_CLUSTER" {
+				require.Empty(t, env.Value)
+			}
 		}
 	})
 }

--- a/pkg/controllers/dynakube/logmonitoring/logmonsettings/conditions.go
+++ b/pkg/controllers/dynakube/logmonitoring/logmonsettings/conditions.go
@@ -6,11 +6,22 @@ import (
 )
 
 const (
-	settingsExistReason = "LogMonSettingsExist"
-	settingsErrorReason = "LogMonSettingsError"
+	settingsExistReason   = "LogMonSettingsExist"
+	settingsErrorReason   = "LogMonSettingsError"
+	settingsCreatedReason = "LogMonSettingsCreated"
 
 	ConditionType = "LogMonitoringSettings"
 )
+
+func setLogMonitoringSettingCreated(conditions *[]metav1.Condition, conditionType string) {
+	condition := metav1.Condition{
+		Type:    conditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  settingsCreatedReason,
+		Message: "LogMonitoring settings have been created.",
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
+}
 
 func setLogMonitoringSettingExists(conditions *[]metav1.Condition, conditionType string) {
 	condition := metav1.Condition{


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

With this the LogModule rollout is adapted to the optional scopes.

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-10495)

For the LogModuleSettings Reconciler:

- if the `settings.read` scope is there - `GetSettingsForLogModule` can be performed
- if the `settings.write` scope is there - `CreateLogMonitoringSetting` can be performed

Conditions are set respectively if one of those scopes are missing.

For the LogModule DaemonSet reconciler:

- if all scopes are there the reconciler waits for the `ClusterMEID` is set - to avoid unnecessary restart
- otherwise if one of the scopes is missing the DaemonSet is still created but without certain metadata -> without the ClusterMEID (field: `dt.entity.kubernetes_cluster`) set in the args of the init container of the LogModule pods! If you then use a token with necessary scopes the change in the manifest (e.g. the arg is added) will trigger the pods to restart.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- create tokens in different variations (with scopes, only with read, only with write, without scopes) and deploy the operator + dynakube with LogMon enabled. Check the Conditions, check that the DaemonSet is still rolled out, check the restart triggering by first using a token without some scopes and then using a token with all scopes -> after some time the logmon pods should restart
- unit tests
- e2e tests

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->