### PR TITLE
Removes duplicate metrics-port in DaemonSet

### DIFF
--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -199,7 +199,7 @@ spec:
         ports:
           - name: livez
             containerPort: 10090
-          - name: provisioner-metrics
+          - name: prov-metrics
             containerPort: 8090
         resources:
           {{- include "csidriver.provisioner.resources" . | nindent 10 }}

--- a/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
+++ b/config/helm/chart/default/tests/Common/csi/daemonset_test.yaml
@@ -287,7 +287,7 @@ tests:
                   - containerPort: 10090
                     name: livez
                   - containerPort: 8090
-                    name: provisioner-metrics
+                    name: prov-metrics
                 resources:
                   requests:
                     cpu: 300m


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-12518](https://dt-rnd.atlassian.net/browse/DAQ-12518)

To avoid the following warning:
```
W0818 01:19:03.925355   24374 warnings.go:70] spec.template.spec.containers[1].ports[1]: duplicate port name "metrics" with spec.template.spec.containers[0].ports[0], services and probes that select ports by name will use spec.template.spec.containers[0].ports[0]
```

## How can this be tested?

Helm install the branch :D 

[DAQ-12518]: https://dt-rnd.atlassian.net/browse/DAQ-12518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ