### PR TITLE
Fix deprecation warning for azure/setup-helm

### DIFF
--- a/.github/actions/build-helm/action.yaml
+++ b/.github/actions/build-helm/action.yaml
@@ -25,7 +25,6 @@ runs:
       with:
         # usually we use latest, but 3.18.0 has bug https://github.com/helm/helm/issues/30890
         version: v3.17.3
-        token: ${{ inputs.github-token }}
     - name: Generate helm-package
       shell: bash
       run: hack/build/ci/generate-helm-package.sh "${{ inputs.secring }}" "${{ inputs.passphrase }}" "${{ inputs.output-dir }}" "${{ inputs.version_without_prefix }}"

--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -71,7 +71,6 @@ runs:
       with:
         # usually we use latest, but 3.18.0 has bug https://github.com/helm/helm/issues/30890
         version: v3.17.3
-        token: ${{ inputs.github-token }}
     - name: Install gotestsum
       shell: bash
       run: go install gotest.tools/gotestsum@latest


### PR DESCRIPTION
## Description

I see the following line in some workflow logs:

```
Warning: Input 'token' has been deprecated with message: GitHub token is no longer required
```

The source of this is the azure/setup-helm action.

## How can this be tested?

Run a workflow that includes the run-e2e or build-helm actions, e.g. `e2e-tests-ondemand.yaml` and check output.
