### PR TITLE
Remove incorrect app version labels

### DIFF
--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -157,10 +157,7 @@ func (r *reconciler) buildTemplateAnnotations(ctx context.Context) (map[string]s
 }
 
 func buildAppLabels(dynakubeName string) *labels.AppLabels {
-	// TODO: when version is available
-	version := "0.0.0"
-
-	return labels.NewAppLabels(labels.ExtensionComponentLabel, dynakubeName, labels.ExtensionComponentLabel, version)
+	return labels.NewAppLabels(labels.ExtensionComponentLabel, dynakubeName, labels.ExtensionComponentLabel, "")
 }
 
 func buildAffinity() corev1.Affinity {

--- a/pkg/controllers/dynakube/extension/service.go
+++ b/pkg/controllers/dynakube/extension/service.go
@@ -62,7 +62,6 @@ func (r *reconciler) createOrUpdateService(ctx context.Context) error {
 
 func (r *reconciler) buildService() (*corev1.Service, error) {
 	coreLabels := labels.NewCoreLabels(r.dk.Name, labels.ExtensionComponentLabel)
-	// TODO: add proper version later on
 	appLabels := labels.NewAppLabels(labels.ExtensionComponentLabel, r.dk.Name, labels.ExtensionComponentLabel, "")
 
 	svcPorts := []corev1.ServicePort{

--- a/pkg/controllers/dynakube/otelc/service/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/service/reconciler.go
@@ -121,7 +121,6 @@ func (r *Reconciler) createOrUpdateService(ctx context.Context) error {
 
 func (r *Reconciler) buildService() (*corev1.Service, error) {
 	coreLabels := labels.NewCoreLabels(r.dk.Name, labels.OtelCComponentLabel)
-	// TODO: add proper version later on
 	appLabels := labels.NewAppLabels(labels.OtelCComponentLabel, r.dk.Name, labels.OtelCComponentLabel, "")
 
 	return service.Build(r.dk,

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -246,10 +246,7 @@ func buildPodSecurityContext() *corev1.PodSecurityContext {
 }
 
 func buildAppLabels(dkName string) *labels.AppLabels {
-	// TODO: when version is available
-	version := ""
-
-	return labels.NewAppLabels(labels.OtelCComponentLabel, dkName, labels.OtelCComponentLabel, version)
+	return labels.NewAppLabels(labels.OtelCComponentLabel, dkName, labels.OtelCComponentLabel, "")
 }
 
 func buildAffinity() corev1.Affinity {

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -247,7 +247,7 @@ func buildPodSecurityContext() *corev1.PodSecurityContext {
 
 func buildAppLabels(dkName string) *labels.AppLabels {
 	// TODO: when version is available
-	version := "0.0.0"
+	version := ""
 
 	return labels.NewAppLabels(labels.OtelCComponentLabel, dkName, labels.OtelCComponentLabel, version)
 }


### PR DESCRIPTION
## 📝 Description
Currently, `app.kubernetes.io/version` is set to `0.0.0` for the EEC + OTelC components, which can be misleading.

☑️ Addresses [DAQ-12251](https://dt-rnd.atlassian.net/browse/DAQ-12251)

## How can this be tested?
Unit tests

[DAQ-12251]: https://dt-rnd.atlassian.net/browse/DAQ-12251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ