### PR TITLE
Do not serve v1beta1 and v1beta2

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1377,7 +1377,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2434,7 +2434,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -1388,7 +1388,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2445,7 +2445,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/pkg/api/v1beta1/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta1/dynakube/dynakube_types.go
@@ -37,6 +37,7 @@ type DynaKubeValueSource struct { //nolint:revive
 // DynaKube is the Schema for the DynaKube API
 // +k8s:openapi-gen=true
 // +kubebuilder:deprecatedversion:warning="This dynakube API version is deprecated and will be removed in a future operator version. Please visit our documentation for details and timeline."
+// +kubebuilder:unservedversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=dynakubes,scope=Namespaced,categories=dynatrace,shortName={dk,dks}

--- a/pkg/api/v1beta2/dynakube/dynakube_types.go
+++ b/pkg/api/v1beta2/dynakube/dynakube_types.go
@@ -37,6 +37,7 @@ type DynaKubeValueSource struct { //nolint:revive
 // DynaKube is the Schema for the DynaKube API
 // +k8s:openapi-gen=true
 // +kubebuilder:deprecatedversion:warning="This dynakube API version is deprecated and will be removed in a future operator version. Please visit our documentation for details and timeline."
+// +kubebuilder:unservedversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=dynakubes,scope=Namespaced,categories=dynatrace,shortName={dk,dks}


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/DAQ-12588

v1beta1 and v1beta2 are no longer served.

## How can this be tested?

- Apply a Dynakube with either v1beta1 or v1beta2
- You should see:
```sh
❯ k apply -f ~/dev/playground/dynakubes/beta2-CNFS.yaml
error: resource mapping not found for name: "dynakube" namespace: "dynatrace" from "/home/local_albertogildedios/dev/playground/dynakubes/beta2-CNFS.yaml": no matches for kind "DynaKube" in version "dynatrace.com/v1beta2"
ensure CRDs are installed first
```