### PR TITLE
refactor dtpull secret

### DIFF
--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -94,7 +94,7 @@ func (r *Reconciler) reconcilePullSecret(ctx context.Context) error {
 		return errors.WithStack(err)
 	}
 
-	created, err := r.secrets.CreateOrUpdate(ctx, secret)
+	_, err = r.secrets.CreateOrUpdate(ctx, secret)
 	if err != nil {
 		log.Info("could not create or update secret", "name", secret.Name)
 		conditions.SetKubeAPIError(r.dk.Conditions(), PullSecretConditionType, errors.WithMessage(err, "failed to create or update secret"))
@@ -102,11 +102,7 @@ func (r *Reconciler) reconcilePullSecret(ctx context.Context) error {
 		return errors.WithMessage(err, "failed to create or update secret")
 	}
 
-	if created {
-		conditions.SetSecretCreated(r.dk.Conditions(), PullSecretConditionType, secret.Name)
-	}
-
-	conditions.SetSecretUpdated(r.dk.Conditions(), PullSecretConditionType, secret.Name)
+	conditions.SetSecretCreated(r.dk.Conditions(), PullSecretConditionType, secret.Name)
 
 	return nil
 }

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -97,7 +97,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 		err := r.Reconcile(context.Background())
 		require.Error(t, err)
-		assert.Equal(t, "failed to create or update secret: failed to create secret test-name-pull-secret: fake error", err.Error())
+		assert.Equal(t, "failed to create or update secret: fake error", err.Error())
 	})
 	t.Run("Create does not reconcile with custom pull secret", func(t *testing.T) {
 		dk := &dynakube.DynaKube{

--- a/pkg/util/conditions/secret.go
+++ b/pkg/util/conditions/secret.go
@@ -23,16 +23,6 @@ func SetSecretCreated(conditions *[]metav1.Condition, conditionType, name string
 	_ = meta.SetStatusCondition(conditions, condition)
 }
 
-func SetSecretUpdated(conditions *[]metav1.Condition, conditionType, name string) {
-	condition := metav1.Condition{
-		Type:    conditionType,
-		Status:  metav1.ConditionTrue,
-		Reason:  SecretUpdatedReason,
-		Message: appendUpdatedSuffix(name),
-	}
-	_ = meta.SetStatusCondition(conditions, condition)
-}
-
 func SetSecretCreatedOrUpdated(conditions *[]metav1.Condition, conditionType, name string) {
 	condition := metav1.Condition{
 		Type:    conditionType,

--- a/pkg/util/conditions/suffix.go
+++ b/pkg/util/conditions/suffix.go
@@ -13,10 +13,6 @@ func appendCreatedSuffix(name string) string {
 	return fmt.Sprintf("%s %s", name, createdSuffix)
 }
 
-func appendUpdatedSuffix(name string) string {
-	return fmt.Sprintf("%s %s", name, updatedSuffix)
-}
-
 func appendCreatedOrUpdatedSuffix(name string) string {
 	return fmt.Sprintf("%s %s", name, createdOrUpdatedSuffix)
 }


### PR DESCRIPTION
## Description

This PR refactors dtpull secret reconciler and resolves [DAQ-1457](https://dt-rnd.atlassian.net/browse/DAQ-1457)

## How can this be tested?

a) unit-tests
b) deploy operator and simple DK,

- find `<dk-name>-pull-secret` via:
```
k get secrets | grep "\-pull-secret"
dynakube-pull-secret                                 kubernetes.io/dockerconfigjson   1      8m19s
```
so make sure it;s created;

- Also, you can check the condition on DK, which we use to make sure it gets updated in time:

```
Last Transition Time:  2025-08-21T07:45:40Z                                                                                              │
│     Message:               dynakube-pull-secret updated                                                                                      │
│     Reason:                SecretUpdated                                                                                                     │
│     Status:                True 
```
- and check age (wait 15 mins default )

```
     Last Transition Time:  2025-08-21T08:00:42Z                                                                                              │
│     Message:               dynakube-pull-secret updated                                                                                      │
│     Reason:                SecretUpdated                                                                                                     │
│     Status:                True                                                                                                              │
│     Type:                  PullSecret`
```

🎉 

[DAQ-1457]: https://dt-rnd.atlassian.net/browse/DAQ-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ