### PR TITLE
Skip flaky test

### DIFF
--- a/test/features/cloudnative/codemodules/codemodules.go
+++ b/test/features/cloudnative/codemodules/codemodules.go
@@ -330,6 +330,8 @@ func WithProxyAndAutomaticAGCert(t *testing.T, proxySpec *value.Source) features
 }
 
 func WithProxyCAAndAGCert(t *testing.T, proxySpec *value.Source) features.Feature {
+	t.Skip("skipping test, as it has inconsistent behavior, will be investigated/fixed in DAQ-12605")
+
 	builder := features.New("codemodules-with-proxy-custom-ca-ag-cert")
 	secretConfigs := tenant.GetMultiTenantSecret(t)
 	require.Len(t, secretConfigs, 2)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-12605](https://dt-rnd.atlassian.net/browse/DAQ-12605)

Skips the test that is currently inconsistent between envs.
We need to look into it more deeply, and maybe rework the tests in general.

## How can this be tested?

`make test/e2e/cloudnative/codemodules-with-proxy-custom-ca-ag-cert` is skipped
`make test/e2e/istio` runs through (expect the one above, should be still skipped)