### PR TITLE
bugfix(otelc): telemetry ingest endpoint config map is not updated

### DIFF
--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
@@ -8,130 +8,112 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	k8sconfigmap "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/configmap"
 	k8slabels "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Reconciler struct {
-	client    client.Client
-	apiReader client.Reader
-	dk        *dynakube.DynaKube
+	dk         *dynakube.DynaKube
+	configMaps k8sconfigmap.QueryObject
 }
 
 type ReconcilerBuilder func(client client.Client, apiReader client.Reader, dk *dynakube.DynaKube) *Reconciler
 
 func NewReconciler(client client.Client, apiReader client.Reader, dk *dynakube.DynaKube) *Reconciler {
 	return &Reconciler{
-		client:    client,
-		dk:        dk,
-		apiReader: apiReader,
+		dk:         dk,
+		configMaps: k8sconfigmap.Query(client, apiReader, log),
 	}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	if r.dk.TelemetryIngest().IsEnabled() {
-		return r.ensureOtlpAPIEndpointConfigMap(ctx)
+	if !r.dk.TelemetryIngest().IsEnabled() {
+		if meta.FindStatusCondition(*r.dk.Conditions(), configMapConditionType) == nil {
+			return nil // no condition == nothing is there to clean up
+		}
+
+		defer meta.RemoveStatusCondition(r.dk.Conditions(), configMapConditionType)
+
+		configMap, _ := k8sconfigmap.Build(r.dk,
+			consts.OtlpAPIEndpointConfigMapName,
+			nil,
+			k8sconfigmap.SetLabels(k8slabels.NewCoreLabels(r.dk.Name, k8slabels.OtelCComponentLabel).BuildLabels()),
+		)
+
+		_ = r.deleteConfigMap(ctx, configMap)
+
+		return nil
 	}
 
-	return r.removeOtlpAPIEndpointConfigMap(ctx)
+	return r.reconcileConfigMap(ctx)
 }
 
-func (r *Reconciler) ensureOtlpAPIEndpointConfigMap(ctx context.Context) error {
-	query := k8sconfigmap.Query(r.client, r.apiReader, log)
+func (r *Reconciler) deleteConfigMap(ctx context.Context, configMap *corev1.ConfigMap) error {
+	log.Info("deleting configmap", "name", configMap.Name)
 
-	_, err := query.Get(ctx, types.NamespacedName{Name: consts.OtlpAPIEndpointConfigMapName, Namespace: r.dk.Namespace})
-	if err != nil && k8serrors.IsNotFound(err) {
-		log.Info("creating new config map for telemetry api endpoint")
+	err := r.configMaps.Delete(ctx, configMap)
 
-		configMap, err := r.generateOtlpAPIEndpointConfigMap(consts.OtlpAPIEndpointConfigMapName)
-		if err != nil {
-			conditions.SetConfigMapGenFailed(r.dk.Conditions(), configMapConditionType, err)
-
-			return err
-		}
-
-		_, err = hasher.GenerateHash(configMap.Data)
-		if err != nil {
-			conditions.SetConfigMapGenFailed(r.dk.Conditions(), configMapConditionType, err)
-
-			return err
-		}
-
-		err = query.Create(ctx, configMap)
-		if err != nil {
-			log.Info("could not create secret for telemetry api credentials", "name", configMap.Name)
-			conditions.SetKubeAPIError(r.dk.Conditions(), configMapConditionType, err)
-
-			return err
-		}
-
-		conditions.SetConfigMapCreatedOrUpdated(r.dk.Conditions(), configMapConditionType, consts.OtlpAPIEndpointConfigMapName)
-	} else if err != nil {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		conditions.SetKubeAPIError(r.dk.Conditions(), configMapConditionType, err)
 
-		return err
+		return errors.WithMessagef(err, "failed to delete configMap %s", configMap.Name)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) getDtEndpoint() (string, error) {
+func (r *Reconciler) reconcileConfigMap(ctx context.Context) error {
+	configMapData, err := r.generateData()
+	if err != nil {
+		return errors.WithMessage(err, "could not generate config map data")
+	}
+
+	configMap, err := k8sconfigmap.Build(r.dk,
+		consts.OtlpAPIEndpointConfigMapName,
+		configMapData,
+		k8sconfigmap.SetLabels(k8slabels.NewCoreLabels(r.dk.Name, k8slabels.OtelCComponentLabel).BuildLabels()),
+	)
+	if err != nil {
+		conditions.SetKubeAPIError(r.dk.Conditions(), configMapConditionType, err)
+
+		return errors.WithStack(err)
+	}
+
+	_, err = r.configMaps.CreateOrUpdate(ctx, configMap)
+	if err != nil {
+		log.Info("could not create or update config map", "name", configMap.Name)
+		conditions.SetKubeAPIError(r.dk.Conditions(), configMapConditionType, errors.WithMessage(err, "failed to create or update config map"))
+
+		return errors.WithMessage(err, "failed to create or update config map")
+	}
+
+	conditions.SetConfigMapCreatedOrUpdated(r.dk.Conditions(), configMapConditionType, configMap.Name)
+
+	return nil
+}
+
+func (r *Reconciler) generateData() (map[string]string, error) {
+	data := make(map[string]string)
+
+	dtEndpoint := r.dk.APIURL() + "/v2/otlp"
+
 	if r.dk.ActiveGate().IsEnabled() {
 		tenantUUID, err := r.dk.TenantUUID()
 		if err != nil {
-			return "", err
+			return data, err
 		}
 
 		serviceFQDN := capability.BuildServiceName(r.dk.Name) + "." + r.dk.Namespace + ".svc"
 
-		return fmt.Sprintf("https://%s/e/%s/api/v2/otlp", serviceFQDN, tenantUUID), nil
-	}
-
-	return r.dk.APIURL() + "/v2/otlp", nil
-}
-
-func (r *Reconciler) generateOtlpAPIEndpointConfigMap(name string) (secret *corev1.ConfigMap, err error) {
-	data := make(map[string]string)
-
-	dtEndpoint, err := r.getDtEndpoint()
-	if err != nil {
-		return nil, err
+		dtEndpoint = fmt.Sprintf("https://%s/e/%s/api/v2/otlp", serviceFQDN, tenantUUID)
 	}
 
 	data["DT_ENDPOINT"] = dtEndpoint
 
-	configMap, err := k8sconfigmap.Build(r.dk,
-		name,
-		data,
-		k8sconfigmap.SetLabels(k8slabels.NewCoreLabels(r.dk.Name, k8slabels.OtelCComponentLabel).BuildLabels()),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return configMap, nil
-}
-
-func (r *Reconciler) removeOtlpAPIEndpointConfigMap(ctx context.Context) error {
-	if meta.FindStatusCondition(*r.dk.Conditions(), configMapConditionType) == nil {
-		return nil // no condition == nothing is there to clean up
-	}
-
-	query := k8sconfigmap.Query(r.client, r.apiReader, log)
-
-	err := query.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: consts.OtlpAPIEndpointConfigMapName, Namespace: r.dk.Namespace}})
-	if err != nil {
-		log.Error(err, "could not delete apiEndpoint config map", "name", consts.OtlpAPIEndpointConfigMapName)
-	}
-
-	meta.RemoveStatusCondition(r.dk.Conditions(), configMapConditionType)
-
-	return nil
+	return data, nil
 }

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
@@ -42,7 +42,6 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		configMap, _ := k8sconfigmap.Build(r.dk,
 			consts.OtlpAPIEndpointConfigMapName,
 			nil,
-			k8sconfigmap.SetLabels(k8slabels.NewCoreLabels(r.dk.Name, k8slabels.OtelCComponentLabel).BuildLabels()),
 		)
 
 		_ = r.deleteConfigMap(ctx, configMap)

--- a/pkg/util/kubeobjects/configmap/query.go
+++ b/pkg/util/kubeobjects/configmap/query.go
@@ -9,24 +9,30 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Query(kubeClient client.Client, kubeReader client.Reader, log logd.Logger) query.Generic[*corev1.ConfigMap, *corev1.ConfigMapList] {
-	return query.Generic[*corev1.ConfigMap, *corev1.ConfigMapList]{
-		Target:     &corev1.ConfigMap{},
-		ListTarget: &corev1.ConfigMapList{},
-		ToList: func(cml *corev1.ConfigMapList) []*corev1.ConfigMap {
-			out := []*corev1.ConfigMap{}
-			for _, cm := range cml.Items {
-				out = append(out, &cm)
-			}
+type QueryObject struct {
+	query.Generic[*corev1.ConfigMap, *corev1.ConfigMapList]
+}
 
-			return out
+func Query(kubeClient client.Client, kubeReader client.Reader, log logd.Logger) QueryObject {
+	return QueryObject{
+		query.Generic[*corev1.ConfigMap, *corev1.ConfigMapList]{
+			Target:     &corev1.ConfigMap{},
+			ListTarget: &corev1.ConfigMapList{},
+			ToList: func(cml *corev1.ConfigMapList) []*corev1.ConfigMap {
+				out := []*corev1.ConfigMap{}
+				for _, cm := range cml.Items {
+					out = append(out, &cm)
+				}
+
+				return out
+			},
+			IsEqual:      isEqual,
+			MustRecreate: func(_, _ *corev1.ConfigMap) bool { return false },
+
+			KubeClient: kubeClient,
+			KubeReader: kubeReader,
+			Log:        log,
 		},
-		IsEqual:      isEqual,
-		MustRecreate: func(_, _ *corev1.ConfigMap) bool { return false },
-
-		KubeClient: kubeClient,
-		KubeReader: kubeReader,
-		Log:        log,
 	}
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR resolves https://dt-rnd.atlassian.net/browse/DAQ-12249 by refactoring `./otelc/endpoint/reconciler.go` the way we want all similar reconcilers to work, except it's configmap and not a secret.

## How can this be tested?

a) unit tests or

b) deploy dk like in official docu:

```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://****.dev.dynatracelabs.com/api
  activeGate:
    capabilities:
    - kubernetes-monitoring
    replicas: 1
    resources:
      requests:
        cpu: 500m
        memory: 1.5Gi
      limits:
        cpu: 1000m
        memory: 1.5Gi
  telemetryIngest:
    protocols:
      - jaeger
      - zipkin
      - otlp
      - statsd
  templates:
    otelCollector:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-otel-collector
        tag: 0.34.0

```

- check the content of the configmap: 
```
k get configmaps dynatrace-otlp-api-endpoint -o yaml | yq '.data'
DT_ENDPOINT: https://dynakube-activegate.dynatrace.svc/e/hbc47170/api/v2/otlp
```

- update dk by removing AG section:
```
apiVersion: dynatrace.com/v1beta4
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://hbc47170.dev.dynatracelabs.com/api
  customPullSecret: devregistry
  telemetryIngest:
    protocols:
      - jaeger
      - zipkin
      - otlp
      - statsd
  templates:
    otelCollector:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-otel-collector
        tag: 0.34.0
```

check updated configmap:
```
k get configmaps dynatrace-otlp-api-endpoint -o yaml | yq '.data'
DT_ENDPOINT: https://****.dev.dynatracelabs.com/api/v2/otlp
```

Bonus check conditions:
```
Last Transition Time:  2025-08-25T09:38:44Z                                                                                              │
│     Message:               dynatrace-otlp-api-endpoint created/updated                                                                       │
│     Reason:                ConfigMapCreatedOrUpdated                                                                                         │
│     Status:                True                                                                                                              │
│     Type:                  OtelpApiEndpointConfigMap
```