### PR TITLE
bugfix(otelc): telemetry ingest endpoint config map is not updated (#…

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler.go
@@ -24,6 +24,7 @@ const (
 	tenantTokenKey  = "TenantToken"
 	hostIDSourceKey = "HostIdSource"
 	serverKey       = "Server"
+	networkZoneKey  = "Location"
 )
 
 type Reconciler struct {
@@ -126,6 +127,10 @@ func (r *Reconciler) getSecretData(ctx context.Context) (map[string][]byte, erro
 		tenantKey:       tenantUUID,
 		tenantTokenKey:  tenantToken,
 		hostIDSourceKey: "k8s-node-name",
+	}
+
+	if r.dk.Spec.NetworkZone != "" {
+		deploymentConfigContent[networkZoneKey] = r.dk.Spec.NetworkZone
 	}
 
 	var content strings.Builder

--- a/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler_test.go
@@ -72,6 +72,7 @@ func TestReconcile(t *testing.T) {
 		require.NotEmpty(t, oldTransitionTime)
 		assert.Equal(t, conditions.SecretCreatedReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		reconciler.dk.Spec.NetworkZone = "test-zone"
 
 		err = reconciler.Reconcile(context.Background())
 
@@ -132,6 +133,10 @@ func checkSecretForValue(t *testing.T, k8sClient client.Client, dk *dynakube.Dyn
 		tenantKey + "=" + tenantUUID,
 		tenantTokenKey + "=" + tokenValue,
 		hostIDSourceKey + "=k8s-node-name",
+	}
+
+	if dk.Spec.NetworkZone != "" {
+		expectedLines = append(expectedLines, networkZoneKey+"="+dk.Spec.NetworkZone)
 	}
 
 	split := strings.Split(strings.Trim(string(deploymentConfig), "\n"), "\n")


### PR DESCRIPTION
## Description

[DAQ-13040](https://dt-rnd.atlassian.net/browse/DAQ-13040)

The networkzone is not passed to the standalone logmonitoring DaemonSet

## How can this be tested?

Use DynaKube features:
- kubernetes monitoring
- routing
- standalone log module
- strict network zone with fallback mode NONE

Observe standalone log module logs about connection attempts ([comm  ]) to endpoints.