### PR TITLE
Add K8S 1.33 and 1.34 pipelines to on-demand tests.

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -36,6 +36,10 @@ jobs:
             platform: k8s
           - version: 1-32
             platform: k8s
+          - version: 1-33
+            platform: k8s
+          - version: 1-34
+            platform: k8s
           - version: 4-12
             platform: ocp
           - version: 4-13


### PR DESCRIPTION
## Description

Make sure latest K8s versions are tested.

## How can this be tested?
n/a