### PR TITLE
cherry-pick: Fix wrong init-container runAsNonRoot value on OCP (#5308)

### DIFF
--- a/pkg/webhook/mutation/pod/init_test.go
+++ b/pkg/webhook/mutation/pod/init_test.go
@@ -101,8 +101,8 @@ func TestCreateInitContainerBase(t *testing.T) {
 		dk := getTestDynakube()
 		pod := getTestPod()
 		pod.Spec.SecurityContext = &corev1.PodSecurityContext{}
-		pod.Spec.SecurityContext.RunAsUser = ptr.To(oacommon.RootUserGroup)
-		pod.Spec.SecurityContext.RunAsGroup = ptr.To(oacommon.RootUserGroup)
+		pod.Spec.SecurityContext.RunAsUser = ptr.To(oacommon.RootGroup)
+		pod.Spec.SecurityContext.RunAsGroup = ptr.To(oacommon.RootGroup)
 
 		initContainer := wh.createInitContainerBase(pod, *dk)
 
@@ -110,10 +110,10 @@ func TestCreateInitContainerBase(t *testing.T) {
 		assert.False(t, *initContainer.SecurityContext.RunAsNonRoot)
 
 		require.NotNil(t, *initContainer.SecurityContext.RunAsUser)
-		assert.Equal(t, oacommon.RootUserGroup, *initContainer.SecurityContext.RunAsUser)
+		assert.Equal(t, oacommon.RootGroup, *initContainer.SecurityContext.RunAsUser)
 
 		require.NotNil(t, *initContainer.SecurityContext.RunAsGroup)
-		assert.Equal(t, oacommon.RootUserGroup, *initContainer.SecurityContext.RunAsGroup)
+		assert.Equal(t, oacommon.RootGroup, *initContainer.SecurityContext.RunAsGroup)
 	})
 	t.Run("should set seccomp profile if feature flag is enabled", func(t *testing.T) {
 		dk := getTestDynakube()

--- a/pkg/webhook/mutation/pod/mutator/oneagent/config.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/config.go
@@ -48,9 +48,10 @@ const (
 	ReleaseStageEnv        = "DT_RELEASE_STAGE"
 	ReleaseBuildVersionEnv = "DT_RELEASE_BUILD_VERSION"
 
-	DefaultUser   int64 = 1001
-	DefaultGroup  int64 = 1001
-	RootUserGroup int64 = 0
+	DefaultUser  int64 = 1001
+	DefaultGroup int64 = 1001
+	RootUser     int64 = 0
+	RootGroup    int64 = 0
 
 	// DtStorageEnv is a temporary env we set on the containers injected with the OneAgent to control where it stores logs and such.
 	// This should be replaced by the `storage` property in the ruxitagentproc.conf

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init.go
@@ -86,16 +86,26 @@ func getTechnology(pod corev1.Pod, dk dynakube.DynaKube) string {
 	return maputils.GetField(pod.Annotations, AnnotationTechnologies, dk.FF().GetNodeImagePullTechnology())
 }
 
-func HasPodUserSet(ctx *corev1.PodSecurityContext) bool {
-	return ctx != nil && ctx.RunAsUser != nil
+func HasPodUserSet(psc *corev1.PodSecurityContext) bool {
+	return psc != nil && psc.RunAsUser != nil
 }
 
-func HasPodGroupSet(ctx *corev1.PodSecurityContext) bool {
-	return ctx != nil && ctx.RunAsGroup != nil
+func HasPodGroupSet(psc *corev1.PodSecurityContext) bool {
+	return psc != nil && psc.RunAsGroup != nil
 }
 
-func IsNonRoot(ctx *corev1.SecurityContext) bool {
-	return ctx != nil &&
-		(ctx.RunAsUser != nil && *ctx.RunAsUser != RootUserGroup) &&
-		(ctx.RunAsGroup != nil && *ctx.RunAsGroup != RootUserGroup)
+func IsNonRoot(sc *corev1.SecurityContext) bool {
+	if sc == nil {
+		return true
+	}
+
+	if sc.RunAsUser != nil && *sc.RunAsUser != RootUser {
+		return true
+	}
+
+	if sc.RunAsGroup != nil && *sc.RunAsGroup != RootGroup {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/DAQ-13021

## How can this be tested?

Same as #5308