### PR TITLE
Add missing httpsProxy setting to istio tests

### DIFF
--- a/test/scenarios/istio/istio_test.go
+++ b/test/scenarios/istio/istio_test.go
@@ -80,13 +80,9 @@ func TestIstio_codemodules_with_proxy_and_auto_ag_cert(t *testing.T) {
 }
 
 func TestIstio_codemodules_with_proxy_custom_ca_ag_cert(t *testing.T) {
-	t.Skip("skipping test, as it has inconsistent behavior, will be investigated/fixed in DAQ-12605")
-
-	testEnv.Test(t, codemodules.WithProxyCAAndAGCert(t, proxy.ProxySpec))
+	testEnv.Test(t, codemodules.WithProxyCAAndAGCert(t, proxy.HTTPSProxySpec))
 }
 
 func TestIstio_codemodules_with_proxy_custom_ca_auto_ag_cert(t *testing.T) {
-	t.Skip("skipping test, as it has inconsistent behavior, will be investigated/fixed in DAQ-12605")
-
-	testEnv.Test(t, codemodules.WithProxyCAAndAutomaticAGCert(t, proxy.ProxySpec))
+	testEnv.Test(t, codemodules.WithProxyCAAndAutomaticAGCert(t, proxy.HTTPSProxySpec))
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
This PR fixes [DAQ-12605](https://dt-rnd.atlassian.net/browse/DAQ-12605)

some leftovers after https://github.com/Dynatrace/dynatrace-operator/pull/5196/files#diff-2f7cca8cafba0692289e73986528a8e6794530308949a9a1390c383054afe155L58-L59

## How can this be tested?

`make test/e2e/cloudnative/codemodules-with-proxy-custom-ca-auto-ag-cert`

[DAQ-12605]: https://dt-rnd.atlassian.net/browse/DAQ-12605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ