### PR TITLE
Use path/filepath for filesystem paths

### DIFF
--- a/doc/coding-style-guide.md
+++ b/doc/coding-style-guide.md
@@ -35,7 +35,7 @@
 - Avoid returning responses (e.g., reconcile.Result, admission.Patched) in anything but Reconcile or Handle functions.
 - Run the linters locally before opening a PR, it will save you time.
   - There is a pre-commit hook that you can configure via `make prerequisites/setup-pre-commit`
-- Avoid using the `path` package for operations on filesystem paths.
+- Avoid using the `path` package for operations on filesystem paths. Use "path/filepath" package.
 
 ## Function Parameter and Return-Value Order
 

--- a/doc/coding-style-guide.md
+++ b/doc/coding-style-guide.md
@@ -35,6 +35,7 @@
 - Avoid returning responses (e.g., reconcile.Result, admission.Patched) in anything but Reconcile or Handle functions.
 - Run the linters locally before opening a PR, it will save you time.
   - There is a pre-commit hook that you can configure via `make prerequisites/setup-pre-commit`
+- Avoid using the `path` package for operations on filesystem paths.
 
 ## Function Parameter and Return-Value Order
 

--- a/doc/coding-style-guide.md
+++ b/doc/coding-style-guide.md
@@ -428,7 +428,7 @@ So here are some basic guidelines:
 
 ## Code Review
 
-[Common guidelines](https://github.com/golang/go/wiki/CodeReview)
+[Common guidelines](https://go.dev/wiki/CodeReviewComments)
 
 - (🧑‍🤝‍🧑) 2 approvals per PR is preferred
 - (✅) Resolving a comment is the duty of the commenter. (after the comment was addressed)

--- a/pkg/injection/codemodule/installer/image/unpack.go
+++ b/pkg/injection/codemodule/installer/image/unpack.go
@@ -3,7 +3,6 @@ package image
 import (
 	"context"
 	"encoding/base64"
-	"path"
 	"path/filepath"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
@@ -76,7 +75,7 @@ func (installer *Installer) pullOCIimage(image containerv1.Image, imageName stri
 
 	// ref.String() is consistent with what the user gave, ref.Name() could add some prefix depending on the situation.
 	// It doesn't really matter here as it's only for a temporary dir, but it's still better be consistent.
-	imageCachePath := path.Join(imageCacheDir, base64.StdEncoding.EncodeToString([]byte(ref.String())))
+	imageCachePath := filepath.Join(imageCacheDir, base64.StdEncoding.EncodeToString([]byte(ref.String())))
 	if err := crane.SaveOCI(image, imageCachePath); err != nil {
 		log.Info("saving v1.Image img as an OCI Image Layout at path", imageCacheDir, err)
 

--- a/pkg/injection/codemodule/installer/symlink/symlink_test.go
+++ b/pkg/injection/codemodule/installer/symlink/symlink_test.go
@@ -2,7 +2,6 @@ package symlink
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -48,7 +47,7 @@ func TestRemove(t *testing.T) {
 		err = Remove(fs, testPath)
 		require.NoError(t, err)
 
-		entries, err := afero.Afero{Fs: fs}.ReadDir(path.Dir(testPath))
+		entries, err := afero.Afero{Fs: fs}.ReadDir(filepath.Dir(testPath))
 		require.NoError(t, err)
 		require.Empty(t, entries)
 	})
@@ -64,11 +63,11 @@ func TestRemove(t *testing.T) {
 		fs := afero.NewOsFs()
 
 		// Create dir to be symlinked
-		missingDir := path.Join(base, "dir")
+		missingDir := filepath.Join(base, "dir")
 		require.NoError(t, os.MkdirAll(missingDir, os.ModePerm))
 
 		// Create symlink to dir
-		danglingLink := path.Join(base, "link")
+		danglingLink := filepath.Join(base, "link")
 		require.NoError(t, os.Symlink(missingDir, danglingLink))
 
 		// Remove dir where the symlink was pointing to -> create dangling symlink

--- a/test/features/cloudnative/codemodules/codemodules.go
+++ b/test/features/cloudnative/codemodules/codemodules.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -227,9 +227,9 @@ func WithProxyAndAGCert(t *testing.T, proxySpec *value.Source) features.Feature 
 
 	// Add ActiveGate TLS secret
 	// public certificate for OneAgents
-	agCrt, _ := os.ReadFile(path.Join(project.TestDataDir(), agCertificate))
+	agCrt, _ := os.ReadFile(filepath.Join(project.TestDataDir(), agCertificate))
 	// public certificate and private key for ActiveGate server
-	agP12, _ := os.ReadFile(path.Join(project.TestDataDir(), agCertificateAndPrivateKey))
+	agP12, _ := os.ReadFile(filepath.Join(project.TestDataDir(), agCertificateAndPrivateKey))
 	agSecret := secret.New(agSecretName, cloudNativeDynakube.Namespace,
 		map[string][]byte{
 			dynakube.TLSCertKey:             agCrt,
@@ -355,9 +355,9 @@ func WithProxyCAAndAGCert(t *testing.T, proxySpec *value.Source) features.Featur
 
 	// Add ActiveGate TLS secret
 	// public certificate for OneAgents
-	agCrt, _ := os.ReadFile(path.Join(project.TestDataDir(), agCertificate))
+	agCrt, _ := os.ReadFile(filepath.Join(project.TestDataDir(), agCertificate))
 	// public certificate and private key for ActiveGate server
-	agP12, _ := os.ReadFile(path.Join(project.TestDataDir(), agCertificateAndPrivateKey))
+	agP12, _ := os.ReadFile(filepath.Join(project.TestDataDir(), agCertificateAndPrivateKey))
 	agSecret := secret.New(agSecretName, cloudNativeDynakube.Namespace,
 		map[string][]byte{
 			dynakube.TLSCertKey:             agCrt,

--- a/test/features/cloudnative/networkproblems/network_problems.go
+++ b/test/features/cloudnative/networkproblems/network_problems.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	csiNetworkPolicy = path.Join(project.TestDataDir(), "network/csi-denial.yaml")
+	csiNetworkPolicy = filepath.Join(project.TestDataDir(), "network/csi-denial.yaml")
 )
 
 // Prerequisites: istio service mesh

--- a/test/features/edgeconnect/edgeconnect.go
+++ b/test/features/edgeconnect/edgeconnect.go
@@ -5,7 +5,7 @@ package edgeconnect
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -107,7 +107,7 @@ func ProvisionerModeFeature(t *testing.T) features.Feature {
 }
 
 var (
-	customServiceAccount = path.Join(project.TestDataDir(), "edgeconnect/custom-service-account.yaml")
+	customServiceAccount = filepath.Join(project.TestDataDir(), "edgeconnect/custom-service-account.yaml")
 )
 
 func AutomationModeFeature(t *testing.T) features.Feature {

--- a/test/features/extensions/extensions.go
+++ b/test/features/extensions/extensions.go
@@ -5,7 +5,7 @@ package extensions
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -39,10 +39,10 @@ func Feature(t *testing.T) features.Feature {
 
 	testDynakube := *componentDynakube.New(options...)
 
-	agCrt, err := os.ReadFile(path.Join(project.TestDataDir(), consts.AgCertificate))
+	agCrt, err := os.ReadFile(filepath.Join(project.TestDataDir(), consts.AgCertificate))
 	require.NoError(t, err)
 
-	agP12, err := os.ReadFile(path.Join(project.TestDataDir(), consts.AgCertificateAndPrivateKey))
+	agP12, err := os.ReadFile(filepath.Join(project.TestDataDir(), consts.AgCertificateAndPrivateKey))
 	require.NoError(t, err)
 
 	agSecret := secret.New(consts.AgSecretName, testDynakube.Namespace,

--- a/test/features/logmonitoring/logmonitoring.go
+++ b/test/features/logmonitoring/logmonitoring.go
@@ -5,7 +5,7 @@ package logmonitoring
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -61,10 +61,10 @@ func Feature(t *testing.T) features.Feature {
 
 	testDynakube := *componentDynakube.New(options...)
 
-	agCrt, err := os.ReadFile(path.Join(project.TestDataDir(), consts.AgCertificate))
+	agCrt, err := os.ReadFile(filepath.Join(project.TestDataDir(), consts.AgCertificate))
 	require.NoError(t, err)
 
-	agP12, err := os.ReadFile(path.Join(project.TestDataDir(), consts.AgCertificateAndPrivateKey))
+	agP12, err := os.ReadFile(filepath.Join(project.TestDataDir(), consts.AgCertificateAndPrivateKey))
 	require.NoError(t, err)
 
 	agSecret := secret.New(consts.AgSecretName, testDynakube.Namespace,

--- a/test/features/supportarchive/support_archive.go
+++ b/test/features/supportarchive/support_archive.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -95,10 +95,10 @@ func Feature(t *testing.T) features.Feature {
 	builder.Assess("deploy injected namespace", namespace.Create(*namespace.New(testAppNameInjected, namespace.WithLabels(injectLabels))))
 	builder.Assess("deploy NOT injected namespace", namespace.Create(*namespace.New(testAppNameNotInjected)))
 
-	agCrt, err := os.ReadFile(path.Join(project.TestDataDir(), consts.AgCertificate))
+	agCrt, err := os.ReadFile(filepath.Join(project.TestDataDir(), consts.AgCertificate))
 	require.NoError(t, err)
 
-	agP12, err := os.ReadFile(path.Join(project.TestDataDir(), consts.AgCertificateAndPrivateKey))
+	agP12, err := os.ReadFile(filepath.Join(project.TestDataDir(), consts.AgCertificateAndPrivateKey))
 	require.NoError(t, err)
 
 	agSecret := secret.New(consts.AgSecretName, testDynakube.Namespace,

--- a/test/features/telemetryingest/telemetryingest.go
+++ b/test/features/telemetryingest/telemetryingest.go
@@ -5,7 +5,7 @@ package telemetryingest
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -408,12 +408,12 @@ func waitForShutdown(name string, namespace string) features.Func {
 }
 
 func createAgTLSSecret(namespace string) (corev1.Secret, error) {
-	agCrt, err := os.ReadFile(path.Join(project.TestDataDir(), consts.AgCertificate))
+	agCrt, err := os.ReadFile(filepath.Join(project.TestDataDir(), consts.AgCertificate))
 	if err != nil {
 		return corev1.Secret{}, err
 	}
 
-	agP12, err := os.ReadFile(path.Join(project.TestDataDir(), consts.AgCertificateAndPrivateKey))
+	agP12, err := os.ReadFile(filepath.Join(project.TestDataDir(), consts.AgCertificateAndPrivateKey))
 	if err != nil {
 		return corev1.Secret{}, err
 	}

--- a/test/helpers/components/oneagent/uninstall.go
+++ b/test/helpers/components/oneagent/uninstall.go
@@ -5,7 +5,7 @@ package oneagent
 import (
 	"bytes"
 	"context"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	uninstallOneAgentDaemonSetPath = path.Join(project.TestDataDir(), "oneagent/uninstall-oneagent.yaml")
+	uninstallOneAgentDaemonSetPath = filepath.Join(project.TestDataDir(), "oneagent/uninstall-oneagent.yaml")
 )
 
 func RunClassicUninstall(builder *features.FeatureBuilder, level features.Level, testDynakube dynakube.DynaKube) {

--- a/test/helpers/kubeobjects/namespace/istio.go
+++ b/test/helpers/kubeobjects/namespace/istio.go
@@ -4,7 +4,7 @@ package namespace
 
 import (
 	"context"
-	"path"
+	"path/filepath"
 
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/manifests"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/platform"
@@ -19,7 +19,7 @@ const (
 	InjectionEnabledValue = "enabled"
 )
 
-var networkAttachmentPath = path.Join(project.TestDataDir(), "network/ocp-istio-cni.yaml")
+var networkAttachmentPath = filepath.Join(project.TestDataDir(), "network/ocp-istio-cni.yaml")
 
 func AddIstioNetworkAttachment(namespace corev1.Namespace) func(ctx context.Context, envConfig *envconf.Config) (context.Context, error) {
 	return func(ctx context.Context, envConfig *envconf.Config) (context.Context, error) {

--- a/test/helpers/proxy/proxy.go
+++ b/test/helpers/proxy/proxy.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -47,12 +46,12 @@ const (
 )
 
 var (
-	dynatraceNetworkPolicy = path.Join(project.TestDataDir(), "network/dynatrace-denial.yaml")
+	dynatraceNetworkPolicy = filepath.Join(project.TestDataDir(), "network/dynatrace-denial.yaml")
 
-	proxyDeploymentPath                      = path.Join(project.TestDataDir(), "network/proxy.yaml")
-	proxyWithCustomCADeploymentPath          = path.Join(project.TestDataDir(), "network/proxy-ssl.yaml")
-	proxyNamespaceWithCustomCADeploymentPath = path.Join(project.TestDataDir(), "network/proxy-ssl-namespace.yaml")
-	proxySCCPath                             = path.Join(project.TestDataDir(), "network/proxy-scc.yaml")
+	proxyDeploymentPath                      = filepath.Join(project.TestDataDir(), "network/proxy.yaml")
+	proxyWithCustomCADeploymentPath          = filepath.Join(project.TestDataDir(), "network/proxy-ssl.yaml")
+	proxyNamespaceWithCustomCADeploymentPath = filepath.Join(project.TestDataDir(), "network/proxy-ssl-namespace.yaml")
+	proxySCCPath                             = filepath.Join(project.TestDataDir(), "network/proxy-scc.yaml")
 
 	ProxySpec = &value.Source{
 		Value: "http://squid.proxy.svc.cluster.local:3128",

--- a/test/helpers/sample/app.go
+++ b/test/helpers/sample/app.go
@@ -5,7 +5,7 @@ package sample
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -37,10 +37,10 @@ import (
 
 var (
 	defaultNameTemplate        = "sample-%s"
-	podTemplatePath            = path.Join(project.TestDataDir(), "sample-app/pod-base.yaml")
-	serviceAccountTemplatePath = path.Join(project.TestDataDir(), "sample-app/serviceaccount.yaml")
-	clusterRolePath            = path.Join(project.TestDataDir(), "sample-app/clusterrole.yaml")
-	bindingPath                = path.Join(project.TestDataDir(), "sample-app/binding.yaml")
+	podTemplatePath            = filepath.Join(project.TestDataDir(), "sample-app/pod-base.yaml")
+	serviceAccountTemplatePath = filepath.Join(project.TestDataDir(), "sample-app/serviceaccount.yaml")
+	clusterRolePath            = filepath.Join(project.TestDataDir(), "sample-app/clusterrole.yaml")
+	bindingPath                = filepath.Join(project.TestDataDir(), "sample-app/binding.yaml")
 )
 
 type App struct {

--- a/test/helpers/tenant/secrets.go
+++ b/test/helpers/tenant/secrets.go
@@ -4,7 +4,7 @@ package tenant
 
 import (
 	"context"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/test/project"
@@ -20,9 +20,9 @@ import (
 )
 
 var (
-	defaultSingleTenant      = path.Join(project.TestDataDir(), "secrets/single-tenant.yaml")
-	defaultMultiTenant       = path.Join(project.TestDataDir(), "secrets/multi-tenant.yaml")
-	defaultEdgeConnectTenant = path.Join(project.TestDataDir(), "secrets/edgeconnect-tenant.yaml")
+	defaultSingleTenant      = filepath.Join(project.TestDataDir(), "secrets/single-tenant.yaml")
+	defaultMultiTenant       = filepath.Join(project.TestDataDir(), "secrets/multi-tenant.yaml")
+	defaultEdgeConnectTenant = filepath.Join(project.TestDataDir(), "secrets/edgeconnect-tenant.yaml")
 )
 
 type Secrets struct {

--- a/test/helpers/tenant/secrets_test.go
+++ b/test/helpers/tenant/secrets_test.go
@@ -4,7 +4,7 @@ package tenant
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -20,13 +20,13 @@ func TestNewFromConfig(t *testing.T) {
 
 	require.NoError(t, err)
 
-	secretsPath := path.Join(workingDir, "..", "testdata", "Secrets")
+	secretsPath := filepath.Join(workingDir, "..", "testdata", "Secrets")
 	require.NoError(t, fs.MkdirAll(secretsPath, 0655))
 
-	require.NoError(t, afero.WriteFile(fs, path.Join(secretsPath, "Secrets-test.yaml"),
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(secretsPath, "Secrets-test.yaml"),
 		[]byte(testSecretFileContent), 0755))
 
-	tenantSecrets, err := newFromConfig(fs, path.Join(secretsPath, "Secrets-test.yaml"))
+	tenantSecrets, err := newFromConfig(fs, filepath.Join(secretsPath, "Secrets-test.yaml"))
 
 	require.NoError(t, err)
 	assert.Equal(t, "apiUrl", tenantSecrets.APIURL)

--- a/test/helpers/tls/tls.go
+++ b/test/helpers/tls/tls.go
@@ -4,7 +4,7 @@ package tls
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 
 	operatorconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers/kubeobjects/secret"
@@ -13,12 +13,12 @@ import (
 )
 
 func CreateTestdataTLSSecret(namespace string, name string, keyFile string, crtFile string) (corev1.Secret, error) {
-	tlsCrt, err := os.ReadFile(path.Join(project.TestDataDir(), crtFile))
+	tlsCrt, err := os.ReadFile(filepath.Join(project.TestDataDir(), crtFile))
 	if err != nil {
 		return corev1.Secret{}, err
 	}
 
-	tlsKey, err := os.ReadFile(path.Join(project.TestDataDir(), keyFile))
+	tlsKey, err := os.ReadFile(filepath.Join(project.TestDataDir(), keyFile))
 	if err != nil {
 		return corev1.Secret{}, err
 	}

--- a/test/project/project.go
+++ b/test/project/project.go
@@ -4,7 +4,7 @@ package project
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 )
 
 var rootDir string
@@ -14,7 +14,7 @@ func RootDir() string {
 }
 
 func TestDataDir() string {
-	return path.Join(rootDir, "test", "testdata")
+	return filepath.Join(rootDir, "test", "testdata")
 }
 
 func init() {
@@ -26,13 +26,13 @@ func init() {
 	}
 
 	for dir != "" {
-		goModPath := path.Join(dir, "go.mod")
+		goModPath := filepath.Join(dir, "go.mod")
 		if _, err := os.Stat(goModPath); err == nil {
 			rootDir = dir
 
 			return
 		}
 
-		dir = path.Dir(dir)
+		dir = filepath.Dir(dir)
 	}
 }


### PR DESCRIPTION
## Description

Outcome of discussion [here](https://github.com/Dynatrace/dynatrace-operator/pull/5335#discussion_r2315838554)

* Use `path/filepath` for all filesystem path operations. Turns out `path` was use in a lot of places.
* Mention this guideline in the docs
* fly-by: Fix outdated link in the docs

## How can this be tested?

The behavior is unchanged for Linux/OSX, so unit tests should suffice.
Windows may need to run e2e tests to properly verify.
