### PR TITLE
Improve RunAsNonRoot check

### DIFF
--- a/pkg/webhook/mutation/pod/config.go
+++ b/pkg/webhook/mutation/pod/config.go
@@ -15,4 +15,7 @@ const (
 
 	NoBootstrapperConfigReason = "NoBootstrapperConfig"
 	NoMutationNeededReason     = "NoMutationNeeded"
+
+	RootUser  int64 = 0
+	RootGroup int64 = 0
 )

--- a/pkg/webhook/mutation/pod/init_test.go
+++ b/pkg/webhook/mutation/pod/init_test.go
@@ -59,7 +59,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 
 		assert.Nil(t, initContainer.SecurityContext.SeccompProfile)
 	})
-	t.Run("do not take security context from user container", func(t *testing.T) {
+	t.Run("take security context from user container", func(t *testing.T) {
 		dk := getTestDynakube()
 		pod := getTestPod()
 		testUser := ptr.To(int64(420))
@@ -72,10 +72,10 @@ func TestCreateInitContainerBase(t *testing.T) {
 		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
 
 		require.NotNil(t, *initContainer.SecurityContext.RunAsUser)
-		assert.Equal(t, oacommon.DefaultUser, *initContainer.SecurityContext.RunAsUser)
+		assert.Equal(t, *testUser, *initContainer.SecurityContext.RunAsUser)
 
 		require.NotNil(t, *initContainer.SecurityContext.RunAsGroup)
-		assert.Equal(t, oacommon.DefaultGroup, *initContainer.SecurityContext.RunAsGroup)
+		assert.Equal(t, *testUser, *initContainer.SecurityContext.RunAsGroup)
 	})
 	t.Run("PodSecurityContext overrules defaults", func(t *testing.T) {
 		dk := getTestDynakube()
@@ -100,9 +100,10 @@ func TestCreateInitContainerBase(t *testing.T) {
 	t.Run("should set RunAsNonRoot if root user is used", func(t *testing.T) {
 		dk := getTestDynakube()
 		pod := getTestPod()
+		pod.Spec.Containers[0].SecurityContext = nil
 		pod.Spec.SecurityContext = &corev1.PodSecurityContext{}
-		pod.Spec.SecurityContext.RunAsUser = ptr.To(oacommon.RootGroup)
-		pod.Spec.SecurityContext.RunAsGroup = ptr.To(oacommon.RootGroup)
+		pod.Spec.SecurityContext.RunAsUser = ptr.To(RootUser)
+		pod.Spec.SecurityContext.RunAsGroup = ptr.To(RootGroup)
 
 		initContainer := wh.createInitContainerBase(pod, *dk)
 
@@ -110,10 +111,10 @@ func TestCreateInitContainerBase(t *testing.T) {
 		assert.False(t, *initContainer.SecurityContext.RunAsNonRoot)
 
 		require.NotNil(t, *initContainer.SecurityContext.RunAsUser)
-		assert.Equal(t, oacommon.RootGroup, *initContainer.SecurityContext.RunAsUser)
+		assert.Equal(t, RootUser, *initContainer.SecurityContext.RunAsUser)
 
 		require.NotNil(t, *initContainer.SecurityContext.RunAsGroup)
-		assert.Equal(t, oacommon.RootGroup, *initContainer.SecurityContext.RunAsGroup)
+		assert.Equal(t, RootGroup, *initContainer.SecurityContext.RunAsGroup)
 	})
 	t.Run("should set seccomp profile if feature flag is enabled", func(t *testing.T) {
 		dk := getTestDynakube()
@@ -199,48 +200,90 @@ func TestAddInitContainerToPod(t *testing.T) {
 
 func Test_combineSecurityContexts(t *testing.T) {
 	type testCase struct {
-		title       string
-		podSc       corev1.PodSecurityContext
-		containerSc corev1.SecurityContext
-		expectedOut corev1.SecurityContext
+		title            string
+		podSc            corev1.PodSecurityContext
+		firstContainerSc corev1.SecurityContext
+		initContainerSc  corev1.SecurityContext
+		expectedOut      corev1.SecurityContext
 	}
 
 	cases := []testCase{
 		{
-			title:       "root pod user",
-			podSc:       corev1.PodSecurityContext{RunAsUser: ptr.To(int64(0))},
-			containerSc: corev1.SecurityContext{},
-			expectedOut: corev1.SecurityContext{RunAsUser: ptr.To(int64(0)), RunAsNonRoot: ptr.To(false)},
+			title:            "root pod user",
+			podSc:            corev1.PodSecurityContext{RunAsUser: ptr.To(int64(0))},
+			firstContainerSc: corev1.SecurityContext{},
+			initContainerSc:  corev1.SecurityContext{},
+			expectedOut:      corev1.SecurityContext{RunAsUser: ptr.To(int64(0)), RunAsNonRoot: ptr.To(false)},
 		},
 		{
-			title:       "root pod group",
-			podSc:       corev1.PodSecurityContext{RunAsGroup: ptr.To(int64(0))},
-			containerSc: corev1.SecurityContext{},
-			expectedOut: corev1.SecurityContext{RunAsGroup: ptr.To(int64(0)), RunAsNonRoot: ptr.To(false)},
+			title:            "root pod group",
+			podSc:            corev1.PodSecurityContext{RunAsGroup: ptr.To(int64(0))},
+			firstContainerSc: corev1.SecurityContext{},
+			initContainerSc:  corev1.SecurityContext{},
+			expectedOut:      corev1.SecurityContext{RunAsGroup: ptr.To(int64(0)), RunAsNonRoot: ptr.To(false)},
 		},
 		{
-			title:       "non-root pod user",
-			podSc:       corev1.PodSecurityContext{RunAsUser: ptr.To(int64(10))},
-			containerSc: corev1.SecurityContext{},
-			expectedOut: corev1.SecurityContext{RunAsUser: ptr.To(int64(10)), RunAsNonRoot: ptr.To(true)},
+			title:            "non-root pod user",
+			podSc:            corev1.PodSecurityContext{RunAsUser: ptr.To(int64(10))},
+			firstContainerSc: corev1.SecurityContext{},
+			initContainerSc:  corev1.SecurityContext{},
+			expectedOut:      corev1.SecurityContext{RunAsUser: ptr.To(int64(10)), RunAsNonRoot: ptr.To(true)},
 		},
 		{
-			title:       "non-root pod group",
-			podSc:       corev1.PodSecurityContext{RunAsGroup: ptr.To(int64(10))},
-			containerSc: corev1.SecurityContext{},
-			expectedOut: corev1.SecurityContext{RunAsGroup: ptr.To(int64(10)), RunAsNonRoot: ptr.To(true)},
+			title:            "non-root pod group",
+			podSc:            corev1.PodSecurityContext{RunAsGroup: ptr.To(int64(10))},
+			firstContainerSc: corev1.SecurityContext{},
+			initContainerSc:  corev1.SecurityContext{},
+			expectedOut:      corev1.SecurityContext{RunAsGroup: ptr.To(int64(10)), RunAsNonRoot: ptr.To(true)},
 		},
 		{
-			title:       "default",
-			podSc:       corev1.PodSecurityContext{},
-			containerSc: corev1.SecurityContext{},
-			expectedOut: corev1.SecurityContext{RunAsNonRoot: ptr.To(true)},
+			title:            "default",
+			podSc:            corev1.PodSecurityContext{},
+			firstContainerSc: corev1.SecurityContext{},
+			initContainerSc:  corev1.SecurityContext{},
+			expectedOut:      corev1.SecurityContext{RunAsNonRoot: ptr.To(true)},
 		},
 		{
-			title:       "non-root user + root group",
-			podSc:       corev1.PodSecurityContext{RunAsUser: ptr.To(int64(10)), RunAsGroup: ptr.To(int64(0))},
-			containerSc: corev1.SecurityContext{RunAsUser: ptr.To(int64(55)), RunAsGroup: ptr.To(int64(55))},
-			expectedOut: corev1.SecurityContext{RunAsUser: ptr.To(int64(10)), RunAsGroup: ptr.To(int64(0)), RunAsNonRoot: ptr.To(true)}, // user takes precedence
+			title:            "non-root user + root group",
+			podSc:            corev1.PodSecurityContext{},
+			firstContainerSc: corev1.SecurityContext{RunAsUser: ptr.To(int64(10)), RunAsGroup: ptr.To(int64(0))},
+			initContainerSc:  corev1.SecurityContext{RunAsUser: ptr.To(int64(55)), RunAsGroup: ptr.To(int64(55))},
+			expectedOut:      corev1.SecurityContext{RunAsUser: ptr.To(int64(10)), RunAsGroup: ptr.To(int64(0)), RunAsNonRoot: ptr.To(true)}, // user takes precedence
+		},
+		{
+			title:            "root first container user",
+			podSc:            corev1.PodSecurityContext{},
+			firstContainerSc: corev1.SecurityContext{RunAsUser: ptr.To(int64(0))},
+			initContainerSc:  corev1.SecurityContext{},
+			expectedOut:      corev1.SecurityContext{RunAsUser: ptr.To(int64(0)), RunAsNonRoot: ptr.To(false)},
+		},
+		{
+			title:            "root first container group",
+			podSc:            corev1.PodSecurityContext{},
+			firstContainerSc: corev1.SecurityContext{RunAsGroup: ptr.To(int64(0))},
+			initContainerSc:  corev1.SecurityContext{},
+			expectedOut:      corev1.SecurityContext{RunAsGroup: ptr.To(int64(0)), RunAsNonRoot: ptr.To(false)},
+		},
+		{
+			title:            "non-root first container user",
+			podSc:            corev1.PodSecurityContext{},
+			firstContainerSc: corev1.SecurityContext{RunAsUser: ptr.To(int64(10))},
+			initContainerSc:  corev1.SecurityContext{},
+			expectedOut:      corev1.SecurityContext{RunAsUser: ptr.To(int64(10)), RunAsNonRoot: ptr.To(true)},
+		},
+		{
+			title:            "non-root first container group",
+			podSc:            corev1.PodSecurityContext{},
+			firstContainerSc: corev1.SecurityContext{RunAsGroup: ptr.To(int64(10))},
+			initContainerSc:  corev1.SecurityContext{},
+			expectedOut:      corev1.SecurityContext{RunAsGroup: ptr.To(int64(10)), RunAsNonRoot: ptr.To(true)},
+		},
+		{
+			title:            "first-container overrules pod",
+			podSc:            corev1.PodSecurityContext{RunAsUser: ptr.To(int64(10))},
+			firstContainerSc: corev1.SecurityContext{RunAsUser: ptr.To(int64(0))},
+			initContainerSc:  corev1.SecurityContext{},
+			expectedOut:      corev1.SecurityContext{RunAsUser: ptr.To(int64(0)), RunAsNonRoot: ptr.To(false)},
 		},
 	}
 
@@ -248,8 +291,14 @@ func Test_combineSecurityContexts(t *testing.T) {
 		t.Run(c.title, func(t *testing.T) {
 			pod := corev1.Pod{}
 			pod.Spec.SecurityContext = &c.podSc
+			pod.Spec.Containers = []corev1.Container{
+				{
+					Name:            "test",
+					SecurityContext: &c.firstContainerSc,
+				},
+			}
 
-			out := combineSecurityContexts(c.containerSc, pod)
+			out := combineSecurityContexts(c.initContainerSc, pod)
 			require.NotNil(t, out)
 
 			assert.Equal(t, c.expectedOut, *out)
@@ -429,4 +478,59 @@ func Test_securityContextForInitContainer(t *testing.T) {
 			assert.Equal(t, c.expectedOut, *out)
 		})
 	}
+}
+
+func Test_isNonRoot(t *testing.T) {
+	t.Run("root user", func(t *testing.T) {
+		sc := &corev1.SecurityContext{
+			RunAsUser:  ptr.To(int64(0)),
+			RunAsGroup: ptr.To(int64(0)),
+		}
+		assert.False(t, isNonRoot(sc))
+	})
+	t.Run("non-root user", func(t *testing.T) {
+		sc := &corev1.SecurityContext{
+			RunAsUser:  ptr.To(int64(1000)),
+			RunAsGroup: ptr.To(int64(1000)),
+		}
+		assert.True(t, isNonRoot(sc))
+	})
+	t.Run("root user and nil group (OCP case)", func(t *testing.T) {
+		sc := &corev1.SecurityContext{
+			RunAsUser:  ptr.To(int64(0)),
+			RunAsGroup: nil,
+		}
+		assert.False(t, isNonRoot(sc))
+	})
+	t.Run("root user and non-root group", func(t *testing.T) {
+		sc := &corev1.SecurityContext{
+			RunAsUser:  ptr.To(int64(0)),
+			RunAsGroup: ptr.To(int64(1000)),
+		}
+		assert.False(t, isNonRoot(sc))
+	})
+	t.Run("non-root user and nil group (OCP case)", func(t *testing.T) {
+		sc := &corev1.SecurityContext{
+			RunAsUser:  ptr.To(int64(1000)),
+			RunAsGroup: nil,
+		}
+		assert.True(t, isNonRoot(sc))
+	})
+	t.Run("nil user and root group (edge case)", func(t *testing.T) {
+		sc := &corev1.SecurityContext{
+			RunAsUser:  nil,
+			RunAsGroup: ptr.To(int64(0)),
+		}
+		assert.False(t, isNonRoot(sc))
+	})
+	t.Run("nil user and non-root group (edge case)", func(t *testing.T) {
+		sc := &corev1.SecurityContext{
+			RunAsUser:  nil,
+			RunAsGroup: ptr.To(int64(1000)),
+		}
+		assert.True(t, isNonRoot(sc))
+	})
+	t.Run("nil context", func(t *testing.T) {
+		assert.True(t, isNonRoot(nil))
+	})
 }

--- a/pkg/webhook/mutation/pod/mutator/oneagent/config.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/config.go
@@ -50,8 +50,6 @@ const (
 
 	DefaultUser  int64 = 1001
 	DefaultGroup int64 = 1001
-	RootUser     int64 = 0
-	RootGroup    int64 = 0
 
 	// DtStorageEnv is a temporary env we set on the containers injected with the OneAgent to control where it stores logs and such.
 	// This should be replaced by the `storage` property in the ruxitagentproc.conf

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init.go
@@ -115,13 +115,8 @@ func IsNonRoot(sc *corev1.SecurityContext) bool {
 		return true
 	}
 
-	if sc.RunAsUser != nil && *sc.RunAsUser != RootUser {
-		return true
-	}
+	notRootUser := sc.RunAsUser == nil || *sc.RunAsUser != RootUser
+	notRootGroup := sc.RunAsGroup == nil || *sc.RunAsGroup != RootGroup
 
-	if sc.RunAsGroup != nil && *sc.RunAsGroup != RootGroup {
-		return true
-	}
-
-	return false
+	return notRootGroup && notRootUser
 }

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init.go
@@ -101,23 +101,3 @@ func addInitArgs(pod corev1.Pod, initContainer *corev1.Container, dk dynakube.Dy
 func getTechnology(pod corev1.Pod, dk dynakube.DynaKube) string {
 	return maputils.GetField(pod.Annotations, AnnotationTechnologies, dk.FF().GetNodeImagePullTechnology())
 }
-
-func HasPodUserSet(psc *corev1.PodSecurityContext) bool {
-	return psc != nil && psc.RunAsUser != nil
-}
-
-func HasPodGroupSet(psc *corev1.PodSecurityContext) bool {
-	return psc != nil && psc.RunAsGroup != nil
-}
-
-func IsNonRoot(sc *corev1.SecurityContext) bool {
-	if sc == nil {
-		return true
-	}
-
-	if sc.RunAsUser != nil { // user takes precedence over group
-		return *sc.RunAsUser != RootUser
-	}
-
-	return sc.RunAsGroup == nil || *sc.RunAsGroup != RootGroup // if group is root, but no user is set, we are still "running as root"
-}

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init.go
@@ -115,8 +115,9 @@ func IsNonRoot(sc *corev1.SecurityContext) bool {
 		return true
 	}
 
-	notRootUser := sc.RunAsUser == nil || *sc.RunAsUser != RootUser
-	notRootGroup := sc.RunAsGroup == nil || *sc.RunAsGroup != RootGroup
+	if sc.RunAsUser != nil { // user takes precedence over group
+		return *sc.RunAsUser != RootUser
+	}
 
-	return notRootGroup && notRootUser
+	return sc.RunAsGroup == nil || *sc.RunAsGroup != RootGroup // if group is root, but no user is set, we are still "running as root"
 }

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init_test.go
@@ -435,6 +435,13 @@ func Test_isNonRoot(t *testing.T) {
 		}
 		assert.False(t, IsNonRoot(sc))
 	})
+	t.Run("root user and non-root group", func(t *testing.T) {
+		sc := &corev1.SecurityContext{
+			RunAsUser:  ptr.To(int64(0)),
+			RunAsGroup: ptr.To(int64(1000)),
+		}
+		assert.False(t, IsNonRoot(sc))
+	})
 	t.Run("non-root user and nil group (OCP case)", func(t *testing.T) {
 		sc := &corev1.SecurityContext{
 			RunAsUser:  ptr.To(int64(1000)),

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init_test.go
@@ -415,46 +415,46 @@ func TestGetTechnology(t *testing.T) {
 
 func Test_isNonRoot(t *testing.T) {
 	t.Run("root user", func(t *testing.T) {
-		ctx := &corev1.SecurityContext{
+		sc := &corev1.SecurityContext{
 			RunAsUser:  ptr.To(int64(0)),
 			RunAsGroup: ptr.To(int64(0)),
 		}
-		assert.False(t, IsNonRoot(ctx))
+		assert.False(t, IsNonRoot(sc))
 	})
 	t.Run("non-root user", func(t *testing.T) {
-		ctx := &corev1.SecurityContext{
+		sc := &corev1.SecurityContext{
 			RunAsUser:  ptr.To(int64(1000)),
 			RunAsGroup: ptr.To(int64(1000)),
 		}
-		assert.True(t, IsNonRoot(ctx))
+		assert.True(t, IsNonRoot(sc))
 	})
 	t.Run("root user and nil group (OCP case)", func(t *testing.T) {
-		ctx := &corev1.SecurityContext{
+		sc := &corev1.SecurityContext{
 			RunAsUser:  ptr.To(int64(0)),
 			RunAsGroup: nil,
 		}
-		assert.False(t, IsNonRoot(ctx))
+		assert.False(t, IsNonRoot(sc))
 	})
 	t.Run("non-root user and nil group (OCP case)", func(t *testing.T) {
-		ctx := &corev1.SecurityContext{
+		sc := &corev1.SecurityContext{
 			RunAsUser:  ptr.To(int64(1000)),
 			RunAsGroup: nil,
 		}
-		assert.True(t, IsNonRoot(ctx))
+		assert.True(t, IsNonRoot(sc))
 	})
 	t.Run("nil user and root group (edge case)", func(t *testing.T) {
-		ctx := &corev1.SecurityContext{
+		sc := &corev1.SecurityContext{
 			RunAsUser:  nil,
 			RunAsGroup: ptr.To(int64(0)),
 		}
-		assert.False(t, IsNonRoot(ctx))
+		assert.False(t, IsNonRoot(sc))
 	})
 	t.Run("nil user and non-root group (edge case)", func(t *testing.T) {
-		ctx := &corev1.SecurityContext{
+		sc := &corev1.SecurityContext{
 			RunAsUser:  nil,
 			RunAsGroup: ptr.To(int64(1000)),
 		}
-		assert.True(t, IsNonRoot(ctx))
+		assert.True(t, IsNonRoot(sc))
 	})
 	t.Run("nil context", func(t *testing.T) {
 		assert.True(t, IsNonRoot(nil))

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 )
 
 func TestMutateInitContainer(t *testing.T) {
@@ -411,59 +410,4 @@ func TestGetTechnology(t *testing.T) {
 			assert.Equal(t, test.expected, getTechnology(pod, dk))
 		})
 	}
-}
-
-func Test_isNonRoot(t *testing.T) {
-	t.Run("root user", func(t *testing.T) {
-		sc := &corev1.SecurityContext{
-			RunAsUser:  ptr.To(int64(0)),
-			RunAsGroup: ptr.To(int64(0)),
-		}
-		assert.False(t, IsNonRoot(sc))
-	})
-	t.Run("non-root user", func(t *testing.T) {
-		sc := &corev1.SecurityContext{
-			RunAsUser:  ptr.To(int64(1000)),
-			RunAsGroup: ptr.To(int64(1000)),
-		}
-		assert.True(t, IsNonRoot(sc))
-	})
-	t.Run("root user and nil group (OCP case)", func(t *testing.T) {
-		sc := &corev1.SecurityContext{
-			RunAsUser:  ptr.To(int64(0)),
-			RunAsGroup: nil,
-		}
-		assert.False(t, IsNonRoot(sc))
-	})
-	t.Run("root user and non-root group", func(t *testing.T) {
-		sc := &corev1.SecurityContext{
-			RunAsUser:  ptr.To(int64(0)),
-			RunAsGroup: ptr.To(int64(1000)),
-		}
-		assert.False(t, IsNonRoot(sc))
-	})
-	t.Run("non-root user and nil group (OCP case)", func(t *testing.T) {
-		sc := &corev1.SecurityContext{
-			RunAsUser:  ptr.To(int64(1000)),
-			RunAsGroup: nil,
-		}
-		assert.True(t, IsNonRoot(sc))
-	})
-	t.Run("nil user and root group (edge case)", func(t *testing.T) {
-		sc := &corev1.SecurityContext{
-			RunAsUser:  nil,
-			RunAsGroup: ptr.To(int64(0)),
-		}
-		assert.False(t, IsNonRoot(sc))
-	})
-	t.Run("nil user and non-root group (edge case)", func(t *testing.T) {
-		sc := &corev1.SecurityContext{
-			RunAsUser:  nil,
-			RunAsGroup: ptr.To(int64(1000)),
-		}
-		assert.True(t, IsNonRoot(sc))
-	})
-	t.Run("nil context", func(t *testing.T) {
-		assert.True(t, IsNonRoot(nil))
-	})
 }


### PR DESCRIPTION
## Description

[DAQ-13355](https://dt-rnd.atlassian.net/browse/DAQ-13355)

There was a bug found, when somehow setting the `podSecurityContext`'s user to `0` causes a problem, that we still think it is "non root", the unit tests make it look that everything is fine.

- Added a lot more unittests, on different levels
- Fixed the `IsNonRoot` check, to check what is actually kubernetes will check
   - If the `RunAsUser` is `0`, it is `RunAsNonRoot: false`
   - If the `RunAsUser` is anything but `0`, it will be `RunAsNonRoot: true`
     -   `RunAsGroup` has not effect, user takes precedence
   - Only `RunAsGroup` is set, and it is `0`,  it will be `RunAsNonRoot: true`


## How can this be tested?

Inject into a Pod with a PodSecurityContext like:
```
      securityContext:
        runAsUser: 0
```

[DAQ-13355]: https://dt-rnd.atlassian.net/browse/DAQ-13355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ