### PR TITLE
Fix failing test/e2e/release test (failing if launched locally).

### DIFF
--- a/test/features/logmonitoring/logmonitoring.go
+++ b/test/features/logmonitoring/logmonitoring.go
@@ -117,7 +117,7 @@ func WithOptionalScopes(t *testing.T) features.Feature {
 
 	testDynakube := *componentDynakube.New(options...)
 
-	componentDynakube.Install(builder, helpers.LevelAssess, &secretConfig, testDynakube)
+	componentDynakube.InstallWithoutSettingsScopes(builder, helpers.LevelAssess, &secretConfig, testDynakube)
 
 	builder.Assess("active gate pod is running", checkActiveGateContainer(&testDynakube))
 
@@ -125,8 +125,7 @@ func WithOptionalScopes(t *testing.T) features.Feature {
 
 	builder.Assess("log monitoring conditions with disabled scopes", checkConditions(testDynakube.Name, testDynakube.Namespace, false))
 
-	secretConfig.APITokenNoSettings = ""
-	builder.Assess("update token secret", tenant.CreateTenantSecret(secretConfig, testDynakube.Name, testDynakube.Namespace))
+	builder.Assess("update token secret", tenant.CreateTenantSecret(secretConfig.APIToken, secretConfig.DataIngestToken, testDynakube.Name, testDynakube.Namespace))
 
 	builder.Assess("trigger reconcile", triggerDaemonSetReconcile(testDynakube))
 

--- a/test/helpers/components/dynakube/dynakube.go
+++ b/test/helpers/components/dynakube/dynakube.go
@@ -28,18 +28,23 @@ const (
 )
 
 func Install(builder *features.FeatureBuilder, level features.Level, secretConfig *tenant.Secret, dk dynakube.DynaKube) {
-	Create(builder, level, secretConfig, dk)
+	Create(builder, level, secretConfig.APIToken, secretConfig.DataIngestToken, dk)
+	VerifyStartup(builder, level, dk)
+}
+
+func InstallWithoutSettingsScopes(builder *features.FeatureBuilder, level features.Level, secretConfig *tenant.Secret, dk dynakube.DynaKube) {
+	Create(builder, level, secretConfig.APITokenNoSettings, secretConfig.DataIngestToken, dk)
 	VerifyStartup(builder, level, dk)
 }
 
 func InstallPreviousVersion(builder *features.FeatureBuilder, level features.Level, secretConfig *tenant.Secret, prevDk prevDynakube.DynaKube) {
-	CreatePreviousVersion(builder, level, secretConfig, prevDk)
+	CreatePreviousVersion(builder, level, secretConfig.APIToken, secretConfig.DataIngestToken, prevDk)
 	VerifyStartupPreviousVersion(builder, level, prevDk)
 }
 
-func Create(builder *features.FeatureBuilder, level features.Level, secretConfig *tenant.Secret, testDynakube dynakube.DynaKube) {
-	if secretConfig != nil {
-		builder.WithStep("created tenant secret", level, tenant.CreateTenantSecret(*secretConfig, testDynakube.Name, testDynakube.Namespace))
+func Create(builder *features.FeatureBuilder, level features.Level, apiToken string, dataIngestToken string, testDynakube dynakube.DynaKube) {
+	if apiToken != "" || dataIngestToken != "" {
+		builder.WithStep("created tenant secret", level, tenant.CreateTenantSecret(apiToken, dataIngestToken, testDynakube.Name, testDynakube.Namespace))
 	}
 	builder.WithStep(
 		fmt.Sprintf("'%s' dynakube created", testDynakube.Name),
@@ -51,9 +56,9 @@ func Update(builder *features.FeatureBuilder, level features.Level, testDynakube
 	builder.WithStep("dynakube updated", level, update(testDynakube))
 }
 
-func CreatePreviousVersion(builder *features.FeatureBuilder, level features.Level, secretConfig *tenant.Secret, prevDk prevDynakube.DynaKube) {
-	if secretConfig != nil {
-		builder.WithStep("created tenant secret", level, tenant.CreateTenantSecret(*secretConfig, prevDk.Name, prevDk.Namespace))
+func CreatePreviousVersion(builder *features.FeatureBuilder, level features.Level, apiToken string, dataIngestToken string, prevDk prevDynakube.DynaKube) {
+	if apiToken != "" || dataIngestToken != "" {
+		builder.WithStep("created tenant secret", level, tenant.CreateTenantSecret(apiToken, dataIngestToken, prevDk.Name, prevDk.Namespace))
 	}
 	builder.WithStep(
 		fmt.Sprintf("'%s' dynakube created", prevDk.Name),

--- a/test/helpers/components/dynakube/dynakube.go
+++ b/test/helpers/components/dynakube/dynakube.go
@@ -42,7 +42,7 @@ func InstallPreviousVersion(builder *features.FeatureBuilder, level features.Lev
 	VerifyStartupPreviousVersion(builder, level, prevDk)
 }
 
-func Create(builder *features.FeatureBuilder, level features.Level, apiToken string, dataIngestToken string, testDynakube dynakube.DynaKube) {
+func Create(builder *features.FeatureBuilder, level features.Level, apiToken, dataIngestToken string, testDynakube dynakube.DynaKube) {
 	if apiToken != "" || dataIngestToken != "" {
 		builder.WithStep("created tenant secret", level, tenant.CreateTenantSecret(apiToken, dataIngestToken, testDynakube.Name, testDynakube.Namespace))
 	}
@@ -56,7 +56,7 @@ func Update(builder *features.FeatureBuilder, level features.Level, testDynakube
 	builder.WithStep("dynakube updated", level, update(testDynakube))
 }
 
-func CreatePreviousVersion(builder *features.FeatureBuilder, level features.Level, apiToken string, dataIngestToken string, prevDk prevDynakube.DynaKube) {
+func CreatePreviousVersion(builder *features.FeatureBuilder, level features.Level, apiToken, dataIngestToken string, prevDk prevDynakube.DynaKube) {
 	if apiToken != "" || dataIngestToken != "" {
 		builder.WithStep("created tenant secret", level, tenant.CreateTenantSecret(apiToken, dataIngestToken, prevDk.Name, prevDk.Namespace))
 	}

--- a/test/helpers/tenant/secrets.go
+++ b/test/helpers/tenant/secrets.go
@@ -107,13 +107,8 @@ func GetEdgeConnectTenantSecret(t *testing.T) EdgeConnectSecret {
 	return result
 }
 
-func CreateTenantSecret(secretConfig Secret, name, namespace string) features.Func {
+func CreateTenantSecret(apiToken string, dataIngestToken string, name, namespace string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		apiToken := secretConfig.APIToken
-		if secretConfig.APITokenNoSettings != "" {
-			apiToken = secretConfig.APITokenNoSettings
-		}
-
 		defaultSecret := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -127,8 +122,8 @@ func CreateTenantSecret(secretConfig Secret, name, namespace string) features.Fu
 			},
 		}
 
-		if secretConfig.DataIngestToken != "" {
-			defaultSecret.Data["dataIngestToken"] = []byte(secretConfig.DataIngestToken)
+		if dataIngestToken != "" {
+			defaultSecret.Data["dataIngestToken"] = []byte(dataIngestToken)
 		}
 
 		err := envConfig.Client().Resources().Create(ctx, &defaultSecret)

--- a/test/helpers/tenant/secrets.go
+++ b/test/helpers/tenant/secrets.go
@@ -107,7 +107,7 @@ func GetEdgeConnectTenantSecret(t *testing.T) EdgeConnectSecret {
 	return result
 }
 
-func CreateTenantSecret(apiToken string, dataIngestToken string, name, namespace string) features.Func {
+func CreateTenantSecret(apiToken, dataIngestToken, name, namespace string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		defaultSecret := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/testdata/secrets-samples/single-tenant.yaml
+++ b/test/testdata/secrets-samples/single-tenant.yaml
@@ -1,3 +1,4 @@
 tenantUid: abc1234
 apiUrl: https://abc1234.dev.dynatracelabs.com/api
 apiToken: <apiToken>
+apiTokenNoSettings: <apiToken without settings scopes>


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-13598)

## Description

PR adds functions to install dynakube and/or apiToken without settings scopes.

All tests use normal apiToken which has `settings` scopes granted.

The `logmonitoring.WithOptionalScopes` test first install dynakube and ApiToken without optional scopes. Next the token secret is updated and following steps are performed.

`ApiTokenNoSettings` token shouldn't have the following scopes:
- settings.read
- settings.write
- entities.read

We can remove `entities.read` from the official `ApiTokenNoSettings` token after this fix is back-ported to all branches that are still tested and use this [logic](https://github.com/Dynatrace/dynatrace-operator/blob/v1.7.0/test/helpers/tenant/secrets.go#L113).

## How can this be tested?
Create testdata/secrets/single-tenant.yaml
```
tenantUid: <tenant>
apiUrl: https:// <tenant>.dev.dynatracelabs.com/api
apiToken: dt...
apiTokenNoSettings: dt...
dataIngestToken: dt...
```
Launch tests
```
make test/e2e
```

I checked :
```
make test/e2e/no-csi
make test/e2e/release
make test/e2e/standard
```