### PR TITLE
Removes the github-token from the helm action as it is not needed

### DIFF
--- a/.github/actions/build-helm/action.yaml
+++ b/.github/actions/build-helm/action.yaml
@@ -4,9 +4,6 @@ inputs:
   version_without_prefix:
     description: The version of the operator that should be deployed without the leading 'v' character
     required: true
-  github-token:
-    description: Token used to fetch the current helm version
-    required: true
   secring:
     description: Contains the private key that is used to sign the helm packages
     required: true
@@ -25,7 +22,6 @@ runs:
       with:
         # usually we use latest, but 3.18.0 has bug https://github.com/helm/helm/issues/30890
         version: v3.17.3
-        token: ${{ inputs.github-token }}
     - name: Generate helm-package
       shell: bash
       run: hack/build/ci/generate-helm-package.sh "${{ inputs.secring }}" "${{ inputs.passphrase }}" "${{ inputs.output-dir }}" "${{ inputs.version_without_prefix }}"

--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -44,9 +44,6 @@ inputs:
   tenant2-dataingesttoken:
     description: The data ingest token of Tenant 2
     required: true
-  github-token:
-    description: The GitHub token
-    required: true
 outputs:
   cluster_status:
     description: Status of the cluster creation ['skipped'|'success']
@@ -74,7 +71,6 @@ runs:
       with:
         # usually we use latest, but 3.18.0 has bug https://github.com/helm/helm/issues/30890
         version: v3.17.3
-        token: ${{ inputs.github-token }}
     - name: Install gotestsum
       shell: bash
       run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -81,7 +81,6 @@ jobs:
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine cluster status
         id: cluster_creation_status
         if: failure()

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -43,7 +43,6 @@ jobs:
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine cluster status
         if: failure()
         run: |
@@ -78,7 +77,6 @@ jobs:
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine cluster status
         if: failure()
         run: |
@@ -113,7 +111,6 @@ jobs:
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine cluster status
         if: failure()
         run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -107,7 +107,6 @@ jobs:
         uses: ./.github/actions/build-helm
         with:
           version_without_prefix: ${{ env.HELM_PACKAGE_VERSION }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           secring: ${{ secrets.HELM_SECRING }}
           passphrase: ${{ secrets.HELM_PASSPHRASE }}
           output-dir: "./helm-pkg"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -252,7 +252,6 @@ jobs:
         uses: ./.github/actions/build-helm
         with:
           version_without_prefix: ${{ needs.prepare.outputs.version_without_prefix }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           secring: ${{ secrets.HELM_SECRING }}
           passphrase: ${{ secrets.HELM_PASSPHRASE }}
           output-dir: "./helm-pkg"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Just saw this on an e2e run

<img width="690" height="87" alt="image" src="https://github.com/user-attachments/assets/008b12f4-7d0a-4b16-9781-cce2f8a3e640" />


## How can this be tested?

Doing an e2e run based on this branch -> no warning