### PR TITLE
[main] Reintroduce “Mark for termination” event to improve graceful node shutdown detection for setups using autoscaling (#5426)

### DIFF
--- a/cmd/operator/manager.go
+++ b/cmd/operator/manager.go
@@ -6,9 +6,12 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/certificates"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/nodes"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/envvars"
 	"github.com/pkg/errors"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // important for running operator locally
 	"k8s.io/client-go/rest"
@@ -25,6 +28,10 @@ func getControllerAddFuncs(isOLM bool) []controllerSetupFunc {
 	funcs := []controllerSetupFunc{
 		dynakube.Add,
 		edgeconnect.Add,
+	}
+
+	if envvars.GetBool(consts.HostAvailabilityDetectionEnvVar, true) {
+		funcs = append(funcs, nodes.Add)
 	}
 
 	if !isOLM {

--- a/cmd/operator/manager_test.go
+++ b/cmd/operator/manager_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -10,10 +11,17 @@ func TestGetControllerAddFuncs(t *testing.T) {
 	t.Run("without OLM", func(t *testing.T) {
 		funcs := getControllerAddFuncs(false)
 
-		assert.Len(t, funcs, 3) // dk, ec, certs
+		assert.Len(t, funcs, 4) // dk, ec, nodes, certs
 	})
 
 	t.Run("with OLM", func(t *testing.T) {
+		funcs := getControllerAddFuncs(true)
+
+		assert.Len(t, funcs, 3) // dk, ec, nodes
+	})
+
+	t.Run("without HostAvailabilityDetectionEnvVar", func(t *testing.T) {
+		t.Setenv(consts.HostAvailabilityDetectionEnvVar, "false")
 		funcs := getControllerAddFuncs(true)
 
 		assert.Len(t, funcs, 2) // dk, ec

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -67,6 +67,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DT_HOST_AVAILABILITY_DETECTION
+              value: "{{ .Values.operator.hostAvailabilityDetection }}"
             {{- if .Values.debugLogs }}
             - name: LOG_LEVEL
               value: "debug"

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -86,6 +86,8 @@ tests:
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.name
+                  - name: DT_HOST_AVAILABILITY_DETECTION
+                    value: "true"
                   - name: modules.json
                     value: |
                       {
@@ -212,6 +214,17 @@ tests:
           value:
             test-key: test-value
 
+  - it: should have env var DT_HOST_AVAILABILITY_DETECTION if disabled
+    set:
+      platform: kubernetes
+      operator.hostAvailabilityDetection: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DT_HOST_AVAILABILITY_DETECTION
+            value: "false"
+
   - it: should not have imagePullSecrets defined in spec
     set:
       platform: kubernetes
@@ -267,6 +280,8 @@ tests:
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.name
+                  - name: DT_HOST_AVAILABILITY_DETECTION
+                    value: "true"
                   - name: modules.json
                     value: |
                       {

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -36,6 +36,7 @@ operator:
   labels: {}
   annotations: {}
   apparmor: false
+  hostAvailabilityDetection: true
   securityContext:
     privileged: false
     allowPrivilegeEscalation: false

--- a/pkg/clients/dynatrace/agent_version.go
+++ b/pkg/clients/dynatrace/agent_version.go
@@ -8,6 +8,23 @@ import (
 	"github.com/pkg/errors"
 )
 
+func (dtc *dynatraceClient) GetEntityIDForIP(ctx context.Context, ip string) (string, error) {
+	if len(ip) == 0 {
+		return "", errors.New("ip is invalid")
+	}
+
+	hostInfo, err := dtc.getHostInfoForIP(ctx, ip)
+	if err != nil {
+		return "", err
+	}
+
+	if hostInfo.entityID == "" {
+		return "", errors.New("entity id not set for host")
+	}
+
+	return hostInfo.entityID, nil
+}
+
 // TODO: the `arch` params should be removed and instead always the "github.com/Dynatrace/dynatrace-operator/pkg/arch" should be used
 
 // GetLatestAgent gets the latest agent package for the given OS and installer type.

--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -53,6 +53,13 @@ type Client interface {
 	// GetCommunicationHostForClient returns a CommunicationHost for the client's API URL. Or error, if failed to be parsed.
 	GetCommunicationHostForClient() (CommunicationHost, error)
 
+	// SendEvent posts events to dynatrace API
+	SendEvent(ctx context.Context, eventData *EventData) error
+
+	// GetEntityIDForIP returns the entity id for a given IP address.
+	// Returns an error in case the lookup failed.
+	GetEntityIDForIP(ctx context.Context, ip string) (string, error)
+
 	// GetTokenScopes returns the list of scopes assigned to a token if successful.
 	GetTokenScopes(ctx context.Context, token string) (TokenScopes, error)
 
@@ -116,6 +123,7 @@ const (
 // Relevant token scopes
 const (
 	TokenScopeInstallerDownload     = "InstallerDownload"
+	TokenScopeDataExport            = "DataExport"
 	TokenScopeMetricsIngest         = "metrics.ingest"
 	TokenScopeSettingsRead          = "settings.read"
 	TokenScopeSettingsWrite         = "settings.write"
@@ -162,6 +170,7 @@ func NewClient(url, apiToken, paasToken string, opts ...Option) (Client, error) 
 		apiToken:  apiToken,
 		paasToken: paasToken,
 
+		hostCache: make(map[string]hostInfo),
 		httpClient: &http.Client{
 			Transport: http.DefaultTransport.(*http.Transport).Clone(),
 			Timeout:   15 * time.Minute,

--- a/pkg/clients/dynatrace/client_test.go
+++ b/pkg/clients/dynatrace/client_test.go
@@ -125,6 +125,7 @@ func createTestDynatraceClient(dynatraceServer httptest.Server) dynatraceClient 
 		url:        dynatraceServer.URL,
 		apiToken:   apiToken,
 		paasToken:  paasToken,
+		hostCache:  nil,
 		httpClient: dynatraceServer.Client(),
 	}
 }

--- a/pkg/clients/dynatrace/dynatrace_client.go
+++ b/pkg/clients/dynatrace/dynatrace_client.go
@@ -19,6 +19,19 @@ import (
 
 const APITokenHeader = "Api-Token "
 
+type HostNotFoundErr struct {
+	IP string
+}
+
+func (e HostNotFoundErr) Error() string {
+	return fmt.Sprintf("host not found for ip: %v", e.IP)
+}
+
+type hostInfo struct {
+	version  string
+	entityID string
+}
+
 // client implements the Client interface.
 type dynatraceClient struct {
 
@@ -26,6 +39,8 @@ type dynatraceClient struct {
 	now time.Time
 
 	httpClient *http.Client
+
+	hostCache map[string]hostInfo
 
 	url       string
 	apiToken  string
@@ -198,4 +213,120 @@ func getMaxResponseLen() int {
 	}
 
 	return defaultMaxResponseLen
+}
+
+func (dtc *dynatraceClient) getHostInfoForIP(ctx context.Context, ip string) (*hostInfo, error) {
+	if len(dtc.hostCache) == 0 {
+		err := dtc.buildHostCache(ctx)
+		if err != nil {
+			return nil, errors.WithMessage(err, "error building host-cache from dynatrace cluster")
+		}
+	}
+
+	switch hostInfo, ok := dtc.hostCache[ip]; {
+	case !ok:
+		return nil, HostNotFoundErr{IP: ip}
+	default:
+		return &hostInfo, nil
+	}
+}
+
+func (dtc *dynatraceClient) buildHostCache(ctx context.Context) error {
+	resp, err := dtc.makeRequest(ctx, dtc.getHostsURL(), dynatraceAPIToken)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	defer utils.CloseBodyAfterRequest(resp)
+
+	responseData, err := dtc.getServerResponseData(resp)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = dtc.setHostCacheFromResponse(responseData)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+type hostInfoResponse struct {
+	AgentVersion *struct {
+		Timestamp string
+		Major     int
+		Minor     int
+		Revision  int
+	}
+	EntityID          string
+	NetworkZoneID     string
+	IPAddresses       []string
+	LastSeenTimestamp int64
+}
+
+func (dtc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
+	dtc.hostCache = make(map[string]hostInfo)
+
+	hostInfoResponses, err := dtc.extractHostInfoResponse(response)
+	if err != nil {
+		return err
+	}
+
+	now := dtc.now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	var inactive []string
+
+	for _, info := range hostInfoResponses {
+		// If we haven't seen this host in the last 30 minutes, ignore it.
+		if tm := time.Unix(info.LastSeenTimestamp/1000, 0).UTC(); tm.Before(now.Add(-30 * time.Minute)) {
+			inactive = append(inactive, info.EntityID)
+
+			continue
+		}
+
+		nz := info.NetworkZoneID
+
+		if (dtc.networkZone != "" && nz == dtc.networkZone) || (dtc.networkZone == "" && (nz == "default" || nz == "")) {
+			hostInfo := hostInfo{entityID: info.EntityID}
+
+			if v := info.AgentVersion; v != nil {
+				hostInfo.version = fmt.Sprintf("%d.%d.%d.%s", v.Major, v.Minor, v.Revision, v.Timestamp)
+			}
+
+			dtc.updateHostCache(info, hostInfo)
+		}
+	}
+
+	if len(inactive) > 0 {
+		log.Info("hosts cache: ignoring inactive hosts", "ids", inactive)
+	}
+
+	return nil
+}
+
+func (dtc *dynatraceClient) updateHostCache(info hostInfoResponse, hostInfo hostInfo) {
+	for _, ip := range info.IPAddresses {
+		if old, ok := dtc.hostCache[ip]; ok {
+			log.Info("hosts cache: replacing host", "ip", ip, "new", hostInfo.entityID, "old", old.entityID)
+		}
+
+		dtc.hostCache[ip] = hostInfo
+	}
+}
+
+func (dtc *dynatraceClient) extractHostInfoResponse(response []byte) ([]hostInfoResponse, error) {
+	var hostInfoResponses []hostInfoResponse
+
+	err := json.Unmarshal(response, &hostInfoResponses)
+	if err != nil {
+		log.Error(err, "error unmarshalling json response", "response", string(response))
+
+		return nil, errors.WithStack(err)
+	}
+
+	return hostInfoResponses, nil
 }

--- a/pkg/clients/dynatrace/dynatrace_client_test.go
+++ b/pkg/clients/dynatrace/dynatrace_client_test.go
@@ -45,6 +45,7 @@ func TestMakeRequest(t *testing.T) {
 		apiToken:  apiToken,
 		paasToken: paasToken,
 
+		hostCache:  make(map[string]hostInfo),
 		httpClient: http.DefaultClient,
 	}
 
@@ -76,6 +77,7 @@ func TestGetResponseOrServerError(t *testing.T) {
 		apiToken:  apiToken,
 		paasToken: paasToken,
 
+		hostCache:  make(map[string]hostInfo),
 		httpClient: http.DefaultClient,
 	}
 
@@ -139,6 +141,40 @@ func TestGetResponseOrServerError(t *testing.T) {
 	})
 }
 
+func TestBuildHostCache(t *testing.T) {
+	ctx := context.Background()
+
+	dynatraceServer := httptest.NewServer(dynatraceServerHandler(t))
+	defer dynatraceServer.Close()
+
+	dc := &dynatraceClient{
+		url:       dynatraceServer.URL,
+		paasToken: paasToken,
+		now:       time.Unix(1521540000, 0),
+
+		hostCache:  make(map[string]hostInfo),
+		httpClient: http.DefaultClient,
+	}
+
+	require.NotNil(t, dc)
+	t.Run("sad path", func(t *testing.T) {
+		dc.apiToken = ""
+		err := dc.buildHostCache(ctx)
+		require.Error(t, err, "error querying dynatrace server")
+		assert.Empty(t, dc.hostCache)
+	})
+	t.Run("happy path", func(t *testing.T) {
+		dc.apiToken = apiToken
+		err := dc.buildHostCache(ctx)
+		require.NoError(t, err)
+		assert.NotEmpty(t, dc.hostCache)
+		assert.ObjectsAreEqual(dc.hostCache, map[string]hostInfo{
+			"10.11.12.13": {version: "1.142.0.20180313-173634", entityID: "dynatraceSampleEntityId"},
+			"192.168.0.1": {version: "1.142.0.20180313-173634", entityID: "dynatraceSampleEntityId"},
+		})
+	})
+}
+
 func TestServerError(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		se := &ServerError{Code: 401, Message: "Unauthorized"}
@@ -173,6 +209,7 @@ func TestDynatraceClientWithServer(t *testing.T) {
 	testAgentVersionGetLatestAgentVersion(t, dtc)
 	testActiveGateVersionGetLatestActiveGateVersion(t, dtc)
 	testCommunicationHostsGetCommunicationHosts(t, dtc)
+	testSendEvent(t, dtc)
 	testGetTokenScopes(t, dtc)
 
 	testServerErrors(t)
@@ -185,12 +222,12 @@ func dynatraceServerHandler(t *testing.T) http.HandlerFunc {
 		if r.FormValue("Api-Token") == "" && r.Header.Get("Authorization") == "" {
 			writeError(w, http.StatusUnauthorized)
 		} else {
-			handleRequest(t, r, w)
+			handleRequest(r, w)
 		}
 	}
 }
 
-func handleRequest(t *testing.T, request *http.Request, writer http.ResponseWriter) {
+func handleRequest(request *http.Request, writer http.ResponseWriter) {
 	latestAgentVersion := fmt.Sprintf("/v1/deployment/installer/agent/%s/%s/latest/metainfo", OsUnix, InstallerTypePaaS)
 	latestActiveGateVersion := fmt.Sprintf("/v1/deployment/installer/gateway/%s/latest/metainfo", OsUnix)
 	agentVersions := fmt.Sprintf("/v1/deployment/installer/agent/versions/%s/%s", OsUnix, InstallerTypePaaS)
@@ -207,7 +244,7 @@ func handleRequest(t *testing.T, request *http.Request, writer http.ResponseWrit
 	case "/v1/deployment/installer/agent/connectioninfo":
 		handleCommunicationHosts(request, writer)
 	case "/v1/events":
-		t.Error("/v1/events endpoint should not be called")
+		handleSendEvent(request, writer)
 	case "/v2/apiTokens/lookup":
 		handleTokenScopes(request, writer)
 	default:
@@ -226,6 +263,53 @@ func writeError(w http.ResponseWriter, status int) {
 
 	w.WriteHeader(status)
 	_, _ = w.Write(result)
+}
+
+func TestIgnoreNonCurrentlySeenHosts(t *testing.T) {
+	ctx := context.Background()
+	// now:                         20/05/2020 10:10 AM UTC
+	// HOST-42 - lastSeenTimestamp: 20/05/2020 10:04 AM UTC
+	// HOST-84 - lastSeenTimestamp: 19/05/2020 01:49 AM UTC
+	c := dynatraceClient{
+		now: time.Unix(1589969400, 0).UTC(),
+	}
+
+	require.NoError(t, c.setHostCacheFromResponse([]byte(`[
+	{
+		"entityId": "HOST-42",
+		"displayName": "A",
+		"firstSeenTimestamp": 1589940921731,
+		"lastSeenTimestamp": 1589969061511,
+		"ipAddresses": [
+			"1.1.1.1"
+		],
+		"monitoringMode": "FULL_STACK",
+		"networkZoneId": "default",
+		"agentVersion": {
+			"major": 1,
+			"minor": 195,
+			"revision": 0,
+			"timestamp": "20200515-045253",
+			"sourceRevision": ""
+		}
+	},
+	{
+		"entityId": "HOST-84",
+		"displayName": "B",
+		"firstSeenTimestamp": 1589767448722,
+		"lastSeenTimestamp": 1589852948530,
+		"ipAddresses": [
+			"1.1.1.1"
+		],
+		"monitoringMode": "FULL_STACK",
+		"networkZoneId": "default"
+	}
+]`)))
+
+	info, err := c.getHostInfoForIP(ctx, "1.1.1.1")
+	require.NoError(t, err)
+	require.Equal(t, "HOST-42", info.entityID)
+	require.Equal(t, "1.195.0.20200515-045253", info.version)
 }
 
 func createTestDynatraceServer(t *testing.T, handler http.Handler, networkZoneName string) (*httptest.Server, Client) {

--- a/pkg/clients/dynatrace/endpoints.go
+++ b/pkg/clients/dynatrace/endpoints.go
@@ -53,6 +53,10 @@ func (dtc *dynatraceClient) getActiveGateConnectionInfoURL() string {
 	return dtc.url + "/v1/deployment/installer/gateway/connectioninfo"
 }
 
+func (dtc *dynatraceClient) getHostsURL() string {
+	return dtc.url + "/v1/entity/infrastructure/hosts?includeDetails=false"
+}
+
 func (dtc *dynatraceClient) getSettingsURL(validate bool) string {
 	validationQuery := ""
 	if !validate {
@@ -73,6 +77,10 @@ func (dtc *dynatraceClient) getEffectiveSettingsURL(validate bool) string {
 
 func (dtc *dynatraceClient) getProcessModuleConfigURL() string {
 	return dtc.url + "/v1/deployment/installer/agent/processmoduleconfig?sections=general,agentType"
+}
+
+func (dtc *dynatraceClient) getEventsURL() string {
+	return dtc.url + "/v1/events"
 }
 
 func (dtc *dynatraceClient) getTokensLookupURL() string {

--- a/pkg/clients/dynatrace/send_event.go
+++ b/pkg/clients/dynatrace/send_event.go
@@ -1,0 +1,63 @@
+package dynatrace
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/utils"
+	"github.com/pkg/errors"
+)
+
+const (
+	MarkedForTerminationEvent = "MARKED_FOR_TERMINATION"
+)
+
+// EventData struct which defines what event payload should contain
+type EventData struct {
+	EventType     string               `json:"eventType"`
+	Description   string               `json:"description"`
+	Source        string               `json:"source"`
+	AttachRules   EventDataAttachRules `json:"attachRules"`
+	StartInMillis uint64               `json:"start"`
+	EndInMillis   uint64               `json:"end"`
+}
+
+type EventDataAttachRules struct {
+	EntityIDs []string `json:"entityIds"`
+}
+
+func (dtc *dynatraceClient) SendEvent(ctx context.Context, eventData *EventData) error {
+	if eventData == nil {
+		return errors.New("no data found in eventData payload")
+	}
+
+	if eventData.EventType == "" {
+		return errors.New("no key set for eventType in eventData payload")
+	}
+
+	jsonStr, err := json.Marshal(eventData)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, dtc.getEventsURL(), bytes.NewBuffer(jsonStr))
+	if err != nil {
+		return errors.WithMessage(err, "error initializing http request")
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", APITokenHeader+dtc.apiToken)
+
+	response, err := dtc.httpClient.Do(req)
+	if err != nil {
+		return errors.WithMessage(err, "error making post request to dynatrace api")
+	}
+
+	defer utils.CloseBodyAfterRequest(response)
+
+	_, err = dtc.getServerResponseData(response)
+
+	return errors.WithStack(err)
+}

--- a/pkg/clients/dynatrace/send_event_test.go
+++ b/pkg/clients/dynatrace/send_event_test.go
@@ -1,0 +1,173 @@
+package dynatrace
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventDataMarshal(t *testing.T) {
+	testJSONInput := []byte(`{
+		"eventType": "MARKED_FOR_TERMINATION",
+		"start": 20,
+		"end": 20,
+		"description": "K8s node was marked unschedulable. Node is likely being drained",
+		"attachRules": {
+			"entityIds": [ "HOST-CA78D78BBC6687D3" ]
+		},
+		"source": "OneAgent Operator"
+	}`)
+
+	var testEventData EventData
+	err := json.Unmarshal(testJSONInput, &testEventData)
+	require.NoError(t, err)
+	assert.Equal(t, "MARKED_FOR_TERMINATION", testEventData.EventType)
+	assert.ElementsMatch(t, testEventData.AttachRules.EntityIDs, []string{"HOST-CA78D78BBC6687D3"})
+	assert.Equal(t, "OneAgent Operator", testEventData.Source)
+
+	jsonBuffer, err := json.Marshal(testEventData)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(jsonBuffer), string(testJSONInput))
+}
+
+func TestSendEvent(t *testing.T) {
+	ctx := context.Background()
+	empty := EventData{}
+	eventTypeOnly := EventData{
+		EventType: "abcd",
+	}
+
+	t.Run("SendEvent no event data", func(t *testing.T) {
+		dynatraceServer, dynatraceClient := createTestDynatraceServer(t, sendEventHandlerStub(), "")
+		defer dynatraceServer.Close()
+
+		err := dynatraceClient.SendEvent(ctx, nil)
+		require.Error(t, err)
+		assert.Equal(t, "no data found in eventData payload", err.Error())
+	})
+	t.Run("SendEvent incomplete event data", func(t *testing.T) {
+		dynatraceServer, dynatraceClient := createTestDynatraceServer(t, sendEventHandlerStub(), "")
+		defer dynatraceServer.Close()
+
+		err := dynatraceClient.SendEvent(ctx, &empty)
+		require.Error(t, err)
+		assert.Equal(t, "no key set for eventType in eventData payload", err.Error())
+
+		err = dynatraceClient.SendEvent(ctx, &eventTypeOnly)
+		require.NoError(t, err)
+	})
+	t.Run("SendEvent request error", func(t *testing.T) {
+		dynatraceServer, dynatraceClient := createTestDynatraceServer(t, sendEventHandlerError(), "")
+
+		err := dynatraceClient.SendEvent(ctx, &empty)
+		require.Error(t, err)
+		assert.Equal(t, "no key set for eventType in eventData payload", err.Error())
+
+		err = dynatraceClient.SendEvent(ctx, &eventTypeOnly)
+		require.Error(t, err)
+		assert.Equal(t, "dynatrace server error 500: error received from server", err.Error())
+
+		dynatraceServer.Close()
+
+		err = dynatraceClient.SendEvent(ctx, &eventTypeOnly)
+		require.Error(t, err)
+		assert.True(t,
+			// Reason differs between local tests and travis test, so only check main error message
+			strings.HasPrefix(err.Error(),
+				"error making post request to dynatrace api: Post \""+
+					dynatraceServer.URL+
+					"/v1/events\""))
+	})
+}
+
+func sendEventHandlerStub() http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {}
+}
+
+func sendEventHandlerError() http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		writeError(writer, http.StatusInternalServerError)
+	}
+}
+
+func testSendEvent(t *testing.T, dynatraceClient Client) {
+	ctx := context.Background()
+
+	t.Run("happy path", func(t *testing.T) {
+		testValidEventData := []byte(`{
+			"eventType": "MARKED_FOR_TERMINATION",
+			"start": 20,
+			"end": 20,
+			"description": "K8s node was marked unschedulable. Node is likely being drained",
+			"attachRules": {
+				"entityIds": [ "HOST-CA78D78BBC6687D3" ]
+			},
+			"source": "OneAgent Operator"
+		}`)
+
+		var testEventData EventData
+		err := json.Unmarshal(testValidEventData, &testEventData)
+		require.NoError(t, err)
+
+		err = dynatraceClient.SendEvent(ctx, &testEventData)
+		require.NoError(t, err)
+	})
+	t.Run("invalid event type sent -> error from API", func(t *testing.T) {
+		testInvalidEventData := []byte(`{
+			"start": 20,
+			"end": 20,
+			"description": "K8s node was marked unschedulable. Node is likely being drained",
+			"attachRules": {
+				"entityIds": [ "HOST-CA78D78BBC6687D3" ]
+			},
+			"source": "OneAgent Operator"
+		}`)
+
+		var testEventData EventData
+		err := json.Unmarshal(testInvalidEventData, &testEventData)
+		require.NoError(t, err)
+
+		err = dynatraceClient.SendEvent(ctx, &testEventData)
+		require.Error(t, err, "no eventType set")
+	})
+	t.Run("extra keys are ignored", func(t *testing.T) {
+		testExtraKeysEventData := []byte(`{
+			"eventType": "MARKED_FOR_TERMINATION",
+			"start": 20,
+			"end": 20,
+			"description": "K8s node was marked unschedulable. Node is likely being drained",
+			"attachRules": {
+				"entityIds": [ "HOST-CA78D78BBC6687D3" ]
+			},
+			"source": "OneAgent Operator",
+		 	"cat": "potato"
+		}`)
+
+		var testEventData EventData
+		err := json.Unmarshal(testExtraKeysEventData, &testEventData)
+		require.NoError(t, err)
+
+		err = dynatraceClient.SendEvent(ctx, &testEventData)
+		require.NoError(t, err)
+	})
+}
+
+func handleSendEvent(request *http.Request, writer http.ResponseWriter) {
+	eventPostResponse := []byte(`{
+		"storedEventIds": [1],
+		"storedIds": ["string"],
+		"storedCorrelationIds": ["string"]}`)
+
+	switch request.Method {
+	case http.MethodPost:
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write(eventPostResponse)
+	default:
+		writeError(writer, http.StatusMethodNotAllowed)
+	}
+}

--- a/pkg/consts/host_availability.go
+++ b/pkg/consts/host_availability.go
@@ -1,0 +1,3 @@
+package consts
+
+const HostAvailabilityDetectionEnvVar = "DT_HOST_AVAILABILITY_DETECTION"

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -296,6 +296,7 @@ func TestSetupTokensAndClient(t *testing.T) {
 
 		mockedDtc := dtclientmock.NewClient(t)
 		mockedDtc.On("GetTokenScopes", mock.Anything, "this is a token").Return(dtclient.TokenScopes{
+			dtclient.TokenScopeDataExport,
 			dtclient.TokenScopeSettingsRead,
 			dtclient.TokenScopeSettingsWrite,
 			dtclient.TokenScopeInstallerDownload,
@@ -441,6 +442,7 @@ func TestReconcileDynaKube(t *testing.T) {
 	fakeClient := fake.NewClient(baseDk, createAPISecret())
 	mockClient := dtclientmock.NewClient(t)
 	mockClient.On("GetTokenScopes", mock.Anything, testAPIToken).Return(dtclient.TokenScopes{
+		dtclient.TokenScopeDataExport,
 		dtclient.TokenScopeSettingsRead,
 		dtclient.TokenScopeSettingsWrite,
 		dtclient.TokenScopeInstallerDownload,
@@ -709,6 +711,7 @@ func TestTokenConditions(t *testing.T) {
 		})
 		mockClient := dtclientmock.NewClient(t)
 		mockClient.On("GetTokenScopes", mock.Anything, testAPIToken).Return(dtclient.TokenScopes{
+			dtclient.TokenScopeDataExport,
 			dtclient.TokenScopeSettingsRead,
 			dtclient.TokenScopeSettingsWrite,
 			dtclient.TokenScopeInstallerDownload,
@@ -916,6 +919,7 @@ func TestTokenConditionsOptionalScopes(t *testing.T) {
 		dk := createDynakubeWithK8SMonitoring()
 
 		controller := createFakeControllerAndClients(t, dtclient.TokenScopes{
+			dtclient.TokenScopeDataExport,
 			dtclient.TokenScopeSettingsRead,
 			dtclient.TokenScopeSettingsWrite,
 			dtclient.TokenScopeInstallerDownload,
@@ -936,6 +940,7 @@ func TestTokenConditionsOptionalScopes(t *testing.T) {
 		dk := createDynakubeWithK8SMonitoring()
 
 		controller := createFakeControllerAndClients(t, dtclient.TokenScopes{
+			dtclient.TokenScopeDataExport,
 			dtclient.TokenScopeSettingsRead,
 			dtclient.TokenScopeSettingsWrite,
 			dtclient.TokenScopeInstallerDownload,
@@ -956,6 +961,7 @@ func TestTokenConditionsOptionalScopes(t *testing.T) {
 		dk := createDynakubeWithK8SMonitoring()
 
 		controller := createFakeControllerAndClients(t, dtclient.TokenScopes{
+			dtclient.TokenScopeDataExport,
 			dtclient.TokenScopeInstallerDownload,
 			dtclient.TokenScopeActiveGateTokenCreate,
 		})

--- a/pkg/controllers/dynakube/token/feature.go
+++ b/pkg/controllers/dynakube/token/feature.go
@@ -3,6 +3,8 @@ package token
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/envvars"
 	"golang.org/x/exp/slices"
 )
 
@@ -41,6 +43,13 @@ func (feature *Feature) CollectOptionalScopes(availableScopes []string) map[stri
 
 func getFeaturesForAPIToken(paasTokenExists bool) []Feature {
 	return []Feature{
+		{
+			Name:           "Access problem and event feed, metrics, and topology",
+			RequiredScopes: []string{dtclient.TokenScopeDataExport},
+			IsEnabled: func(dk dynakube.DynaKube) bool {
+				return envvars.GetBool(consts.HostAvailabilityDetectionEnvVar, true)
+			},
+		},
 		{
 			Name: "Kubernetes API Monitoring",
 			OptionalScopes: []string{

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -19,6 +19,7 @@ import (
 
 func getAllScopesForAPIToken() dtclient.TokenScopes {
 	return []string{
+		dtclient.TokenScopeDataExport,
 		dtclient.TokenScopeSettingsRead,
 		dtclient.TokenScopeSettingsWrite,
 		dtclient.TokenScopeActiveGateTokenCreate,
@@ -85,7 +86,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
 
-		assert.Len(t, tokens.APIToken().Features, 6)
+		assert.Len(t, tokens.APIToken().Features, 7)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Empty(t, tokens.DataIngestToken().Features)
 		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Download Installer' is missing scope 'InstallerDownload']")
@@ -100,7 +101,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
 
-		assert.Len(t, tokens.APIToken().Features, 6)
+		assert.Len(t, tokens.APIToken().Features, 7)
 		assert.Len(t, tokens.PaasToken().Features, 1)
 		assert.Empty(t, tokens.DataIngestToken().Features)
 		assert.NoError(t, err)
@@ -113,7 +114,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
 
-		assert.Len(t, tokens.APIToken().Features, 6)
+		assert.Len(t, tokens.APIToken().Features, 7)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Empty(t, tokens.DataIngestToken().Features)
 		assert.NoError(t, err)
@@ -131,10 +132,10 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
 
-		assert.Len(t, tokens.APIToken().Features, 6)
+		assert.Len(t, tokens.APIToken().Features, 7)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Empty(t, tokens.DataIngestToken().Features)
-		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Automatic ActiveGate Token Creation' is missing scope 'activeGateTokenManagement.create' feature 'Download Installer' is missing scope 'InstallerDownload']")
+		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Access problem and event feed, metrics, and topology' is missing scope 'DataExport' feature 'Automatic ActiveGate Token Creation' is missing scope 'activeGateTokenManagement.create' feature 'Download Installer' is missing scope 'InstallerDownload']")
 	})
 	t.Run("data ingest enabled => dataingest token missing rights => fail", func(t *testing.T) {
 		dk := dynakube.DynaKube{}
@@ -149,7 +150,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
 
-		assert.Len(t, tokens.APIToken().Features, 6)
+		assert.Len(t, tokens.APIToken().Features, 7)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Len(t, tokens.DataIngestToken().Features, 1)
 		assert.EqualError(t, err, "token 'dataIngestToken' has scope errors: [feature 'Data Ingest' is missing scope 'metrics.ingest']")
@@ -164,7 +165,7 @@ func TestTokens(t *testing.T) {
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
 
-		assert.Len(t, tokens.APIToken().Features, 6)
+		assert.Len(t, tokens.APIToken().Features, 7)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Len(t, tokens.DataIngestToken().Features, 1)
 		assert.NoError(t, err)
@@ -198,6 +199,7 @@ func TestTokens_VerifyScopes(t *testing.T) {
 				},
 			},
 			availableScopes: dtclient.TokenScopes{
+				dtclient.TokenScopeDataExport,
 				dtclient.TokenScopeSettingsRead,
 				dtclient.TokenScopeSettingsWrite,
 				dtclient.TokenScopeInstallerDownload, // TODO: is this really necessary? I think this is only needed in case of appmon (when we download the zip)
@@ -226,6 +228,7 @@ func TestTokens_VerifyScopes(t *testing.T) {
 				},
 			},
 			availableScopes: dtclient.TokenScopes{
+				dtclient.TokenScopeDataExport,
 				dtclient.TokenScopeSettingsRead,
 				dtclient.TokenScopeSettingsWrite,
 				dtclient.TokenScopeInstallerDownload, // TODO: is this really necessary? I think this is only needed in case of appmon (when we download the zip)
@@ -253,6 +256,7 @@ func TestTokens_VerifyScopes(t *testing.T) {
 				},
 			},
 			availableScopes: dtclient.TokenScopes{
+				dtclient.TokenScopeDataExport,
 				dtclient.TokenScopeActiveGateTokenCreate,
 				dtclient.TokenScopeInstallerDownload, // TODO: is this really necessary? I think this is only needed in case of appmon (when we download the zip)
 			},
@@ -272,6 +276,7 @@ func TestTokens_VerifyScopes(t *testing.T) {
 				},
 			},
 			availableScopes: dtclient.TokenScopes{
+				dtclient.TokenScopeDataExport,
 				dtclient.TokenScopeSettingsRead,
 				dtclient.TokenScopeInstallerDownload, // TODO: is this really necessary? I think this is only needed in case of appmon (when we download the zip)
 			},
@@ -290,6 +295,7 @@ func TestTokens_VerifyScopes(t *testing.T) {
 				},
 			},
 			availableScopes: dtclient.TokenScopes{
+				dtclient.TokenScopeDataExport,
 				dtclient.TokenScopeSettingsRead,
 			},
 			expectedOptional: map[string]bool{
@@ -307,6 +313,7 @@ func TestTokens_VerifyScopes(t *testing.T) {
 				},
 			},
 			availableScopes: dtclient.TokenScopes{
+				dtclient.TokenScopeDataExport,
 				dtclient.TokenScopeInstallerDownload, // TODO: is this really necessary? I think this is only needed in case of appmon (when we download the zip)
 			},
 			expectedOptional: map[string]bool{
@@ -322,6 +329,7 @@ func TestTokens_VerifyScopes(t *testing.T) {
 				},
 			},
 			availableScopes: dtclient.TokenScopes{
+				dtclient.TokenScopeDataExport,
 				dtclient.TokenScopeSettingsRead,
 				dtclient.TokenScopeSettingsWrite,
 				dtclient.TokenScopeInstallerDownload, // TODO: is this really necessary? I think this is only needed in case of appmon (when we download the zip)
@@ -340,6 +348,7 @@ func TestTokens_VerifyScopes(t *testing.T) {
 				},
 			},
 			availableScopes: dtclient.TokenScopes{
+				dtclient.TokenScopeDataExport,
 				dtclient.TokenScopeInstallerDownload, // TODO: is this really necessary? I think this is only needed in case of appmon (when we download the zip)
 			},
 			expectedOptional: map[string]bool{

--- a/pkg/controllers/nodes/cache.go
+++ b/pkg/controllers/nodes/cache.go
@@ -1,0 +1,119 @@
+package nodes
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ErrNotFound is returned when entry hasn't been found on the cache.
+var ErrNotFound = errors.New("not found")
+
+// CacheEntry contains information about a Node.
+type CacheEntry struct {
+	LastSeen                 time.Time `json:"seen"`
+	LastMarkedForTermination time.Time `json:"marked"`
+	Instance                 string    `json:"instance"`
+	IPAddress                string    `json:"ip"`
+}
+
+// Cache manages information about Nodes.
+type Cache struct {
+	Obj          *corev1.ConfigMap
+	timeProvider *timeprovider.Provider
+	Create       bool
+	upd          bool
+}
+
+// Get returns the information about node, or error if not found or failed to unmarshall the data.
+func (cache *Cache) Get(node string) (CacheEntry, error) {
+	if cache.Obj.Data == nil {
+		return CacheEntry{}, ErrNotFound
+	}
+
+	raw, ok := cache.Obj.Data[node]
+	if !ok {
+		return CacheEntry{}, ErrNotFound
+	}
+
+	var out CacheEntry
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return CacheEntry{}, err
+	}
+
+	return out, nil
+}
+
+// Set updates the information about node, or error if failed to marshall the data.
+func (cache *Cache) Set(node string, entry CacheEntry) error {
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+
+	if cache.Obj.Data == nil {
+		cache.Obj.Data = map[string]string{}
+	}
+
+	cache.Obj.Data[node] = string(raw)
+	cache.upd = true
+
+	return nil
+}
+
+// Delete removes the node from the cache.
+func (cache *Cache) Delete(node string) {
+	if cache.Obj.Data != nil {
+		delete(cache.Obj.Data, node)
+		cache.upd = true
+	}
+}
+
+// Keys returns a list of node names on the cache.
+func (cache *Cache) Keys() []string {
+	if cache.Obj.Data == nil {
+		return []string{}
+	}
+
+	out := make([]string, 0, len(cache.Obj.Data))
+	for k := range cache.Obj.Data {
+		out = append(out, k)
+	}
+
+	return out
+}
+
+// Changed returns true if changes have been made to the cache instance.
+func (cache *Cache) Changed() bool {
+	return cache.Create || cache.upd
+}
+
+func (cache *Cache) IsCacheOutdated() bool {
+	if lastUpdated, ok := cache.Obj.Annotations[lastUpdatedCacheAnnotation]; ok {
+		if lastUpdatedTime, err := time.Parse(time.RFC3339, lastUpdated); err == nil {
+			return lastUpdatedTime.Add(cacheLifetime).Before(cache.timeProvider.Now().UTC())
+		} else {
+			return false
+		}
+	}
+
+	return true // Cache is not annotated -> outdated
+}
+
+func (cache *Cache) UpdateTimestamp() {
+	if cache.Obj.Annotations == nil {
+		cache.Obj.Annotations = make(map[string]string)
+	}
+
+	cache.Obj.Annotations[lastUpdatedCacheAnnotation] = cache.timeProvider.Now().Format(time.RFC3339)
+	cache.upd = true
+}
+
+func (cache *Cache) updateLastMarkedForTerminationTimestamp(nodeInfo CacheEntry, nodeName string) error {
+	nodeInfo.LastMarkedForTermination = cache.timeProvider.Now().UTC()
+
+	return cache.Set(nodeName, nodeInfo)
+}

--- a/pkg/controllers/nodes/cache_test.go
+++ b/pkg/controllers/nodes/cache_test.go
@@ -1,0 +1,57 @@
+package nodes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCache(t *testing.T) {
+	t.Run("get non-existing key", func(t *testing.T) {
+		cm := corev1.ConfigMap{}
+		nodesCache := &Cache{Obj: &cm}
+		_, err := nodesCache.Get("node1")
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("get non json key", func(t *testing.T) {
+		cm := corev1.ConfigMap{Data: map[string]string{"node1": "non-json-key"}}
+		nodesCache := &Cache{Obj: &cm}
+		_, err := nodesCache.Get("node1")
+		require.EqualError(t, err, "invalid character 'o' in literal null (expecting 'u')")
+	})
+
+	t.Run("set cache key if configmap data nil", func(t *testing.T) {
+		cm := corev1.ConfigMap{}
+		nodesCache := &Cache{Obj: &cm}
+		err := nodesCache.Set("node1", CacheEntry{
+			Instance:  "dynakube",
+			IPAddress: "10.128.0.48",
+		})
+		require.NoError(t, err)
+
+		entry, err := nodesCache.Get("node1")
+		require.NoError(t, err)
+
+		assert.Equal(t, CacheEntry{
+			Instance:  "dynakube",
+			IPAddress: "10.128.0.48",
+		}, entry)
+	})
+
+	t.Run("get all cache keys if configmap data nil", func(t *testing.T) {
+		cm := corev1.ConfigMap{}
+		nodesCache := &Cache{Obj: &cm}
+		keys := nodesCache.Keys()
+		assert.Equal(t, []string{}, keys)
+	})
+
+	t.Run("check if cache is not outdated", func(t *testing.T) {
+		cm := corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{lastUpdatedCacheAnnotation: ""}}}
+		nodesCache := &Cache{Obj: &cm}
+		assert.False(t, nodesCache.IsCacheOutdated())
+	})
+}

--- a/pkg/controllers/nodes/config.go
+++ b/pkg/controllers/nodes/config.go
@@ -1,0 +1,18 @@
+package nodes
+
+import (
+	"time"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+)
+
+const (
+	cacheName                  = "dynatrace-node-cache"
+	cacheLifetime              = 10 * time.Minute
+	lastUpdatedCacheAnnotation = "DTOperatorLastUpdated"
+)
+
+var (
+	log                 = logd.Get().WithName("nodes")
+	unschedulableTaints = []string{"ToBeDeletedByClusterAutoscaler"}
+)

--- a/pkg/controllers/nodes/nodes_controller.go
+++ b/pkg/controllers/nodes/nodes_controller.go
@@ -1,0 +1,359 @@
+package nodes
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceclient"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/deployment"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/env"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubesystem"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type Controller struct {
+	client                 client.Client
+	apiReader              client.Reader
+	dynatraceClientBuilder dynatraceclient.Builder
+	timeProvider           *timeprovider.Provider
+	podNamespace           string
+	runLocal               bool
+}
+
+type CachedNodeInfo struct {
+	cachedNode CacheEntry
+	nodeCache  *Cache
+	nodeName   string
+}
+
+func Add(mgr manager.Manager, _ string) error {
+	return NewController(mgr).SetupWithManager(mgr)
+}
+
+func (controller *Controller) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).
+		Named("nodes-controller").
+		Complete(controller)
+}
+
+func NewController(mgr manager.Manager) *Controller {
+	return &Controller{
+		client:                 mgr.GetClient(),
+		apiReader:              mgr.GetAPIReader(),
+		dynatraceClientBuilder: dynatraceclient.NewBuilder(mgr.GetAPIReader()),
+		runLocal:               kubesystem.IsRunLocally(),
+		podNamespace:           os.Getenv(env.PodNamespace),
+		timeProvider:           timeprovider.New(),
+	}
+}
+
+func (controller *Controller) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) { //nolint: revive
+	nodeName := request.Name
+	dk, err := controller.determineDynakubeForNode(nodeName)
+
+	log.Info("reconciling node name", "node", nodeName)
+
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	nodeCache, err := controller.getCache(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	var node corev1.Node
+	if err := controller.apiReader.Get(ctx, client.ObjectKey{Name: nodeName}, &node); err != nil {
+		if k8serrors.IsNotFound(err) {
+			// if there is no node it means it get deleted
+			return reconcile.Result{}, controller.reconcileNodeDeletion(ctx, nodeName)
+		}
+
+		return reconcile.Result{}, err
+	}
+
+	// Node is found in the cluster, add or update to cache
+	if dk != nil {
+		ipAddress := dk.Status.OneAgent.Instances[nodeName].IPAddress
+		cacheEntry := CacheEntry{
+			Instance:  dk.Name,
+			IPAddress: ipAddress,
+			LastSeen:  controller.timeProvider.Now().UTC(),
+		}
+
+		if cached, err := nodeCache.Get(nodeName); err == nil {
+			cacheEntry.LastMarkedForTermination = cached.LastMarkedForTermination
+		}
+
+		if err := nodeCache.Set(nodeName, cacheEntry); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// Handle unschedulable Nodes, if they have a OneAgent instance
+		if controller.isUnschedulable(&node) {
+			cachedNodeData := CachedNodeInfo{
+				cachedNode: cacheEntry,
+				nodeCache:  nodeCache,
+				nodeName:   nodeName,
+			}
+
+			if err := controller.markForTermination(ctx, dk, cachedNodeData); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+	}
+
+	// check node cache for outdated nodes and remove them, to keep cache clean
+	if nodeCache.IsCacheOutdated() {
+		if err := controller.handleOutdatedCache(ctx, nodeCache); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		nodeCache.UpdateTimestamp()
+	}
+
+	return reconcile.Result{}, controller.updateCache(ctx, nodeCache)
+}
+
+func (controller *Controller) reconcileNodeDeletion(ctx context.Context, nodeName string) error {
+	nodeCache, err := controller.getCache(ctx)
+	if err != nil {
+		return err
+	}
+
+	dynakube, err := controller.determineDynakubeForNode(nodeName)
+	if err != nil {
+		return err
+	}
+
+	cachedNodeInfo, err := nodeCache.Get(nodeName)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			// uncached node -> ignoring
+			return nil
+		}
+
+		return err
+	}
+
+	if dynakube != nil {
+		cachedNodeData := CachedNodeInfo{
+			cachedNode: cachedNodeInfo,
+			nodeCache:  nodeCache,
+			nodeName:   nodeName,
+		}
+
+		if err := controller.markForTermination(ctx, dynakube, cachedNodeData); err != nil {
+			return err
+		}
+	}
+
+	nodeCache.Delete(nodeName)
+
+	if err := controller.updateCache(ctx, nodeCache); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (controller *Controller) getCache(ctx context.Context) (*Cache, error) {
+	var cm corev1.ConfigMap
+
+	err := controller.apiReader.Get(ctx, client.ObjectKey{Name: cacheName, Namespace: controller.podNamespace}, &cm)
+	if err == nil {
+		return &Cache{Obj: &cm, timeProvider: controller.timeProvider}, nil
+	}
+
+	if k8serrors.IsNotFound(err) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cacheName,
+				Namespace: controller.podNamespace,
+			},
+			Data: map[string]string{},
+		}
+		// If running locally, don't set the controller.
+		if !controller.runLocal {
+			deploy, err := deployment.GetDeployment(controller.client, os.Getenv(env.PodName), controller.podNamespace)
+			if err != nil {
+				return nil, err
+			}
+
+			if err = controllerutil.SetControllerReference(deploy, cm, scheme.Scheme); err != nil {
+				return nil, err
+			}
+		}
+
+		return &Cache{Create: true, Obj: cm, timeProvider: controller.timeProvider}, nil
+	}
+
+	return nil, err
+}
+
+func (controller *Controller) updateCache(ctx context.Context, nodeCache *Cache) error {
+	if !nodeCache.Changed() {
+		return nil
+	}
+
+	if nodeCache.Create {
+		return controller.client.Create(ctx, nodeCache.Obj)
+	}
+
+	if err := controller.client.Update(ctx, nodeCache.Obj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (controller *Controller) handleOutdatedCache(ctx context.Context, nodeCache *Cache) error {
+	var nodeLst corev1.NodeList
+	if err := controller.client.List(ctx, &nodeLst); err != nil {
+		return err
+	}
+
+	for _, cachedNodeName := range nodeCache.Keys() {
+		cachedNodeInCluster := false
+
+		for _, clusterNode := range nodeLst.Items {
+			if clusterNode.Name == cachedNodeName {
+				// We ignore errors because we always ask ONLY existing key from the cache,
+				// because of the loop (range nodeCache.Keys()) in few lines early
+				cachedNodeInfo, _ := nodeCache.Get(cachedNodeName)
+				cachedNodeInCluster = true
+				// Check if node was seen less than an hour ago, otherwise do not remove from cache
+				controller.removeNodeFromCache(nodeCache, cachedNodeInfo, cachedNodeName)
+
+				break
+			}
+		}
+
+		// if node is not in cluster -> probably deleted
+		if !cachedNodeInCluster {
+			log.Info("Removing missing cached node from cluster", "node", cachedNodeName)
+
+			err := controller.reconcileNodeDeletion(ctx, cachedNodeName)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (controller *Controller) removeNodeFromCache(nodeCache *Cache, cachedNode CacheEntry, nodeName string) {
+	if controller.isNodeDeletable(cachedNode) {
+		nodeCache.Delete(nodeName)
+	}
+}
+
+func (controller *Controller) isNodeDeletable(cachedNode CacheEntry) bool {
+	if controller.timeProvider.Now().UTC().Sub(cachedNode.LastSeen).Hours() > 1 {
+		return true
+	} else if cachedNode.IPAddress == "" {
+		return true
+	}
+
+	return false
+}
+
+func (controller *Controller) sendMarkedForTermination(ctx context.Context, dk *dynakube.DynaKube, cachedNode CacheEntry) error {
+	tokenReader := token.NewReader(controller.apiReader, dk)
+
+	tokens, err := tokenReader.ReadTokens(ctx)
+	if err != nil {
+		return err
+	}
+
+	dynatraceClient, err := controller.dynatraceClientBuilder.
+		SetDynakube(*dk).
+		SetTokens(tokens).
+		Build(ctx)
+	if err != nil {
+		return err
+	}
+
+	entityID, err := dynatraceClient.GetEntityIDForIP(ctx, cachedNode.IPAddress)
+	if err != nil {
+		if errors.As(err, &dtclient.HostNotFoundErr{}) {
+			log.Info("skipping to send mark for termination event", "dynakube", dk.Name, "nodeIP", cachedNode.IPAddress, "reason", err.Error())
+
+			return nil
+		}
+
+		log.Info("failed to send mark for termination event",
+			"reason", "failed to determine entity id", "dynakube", dk.Name, "nodeIP", cachedNode.IPAddress, "cause", err)
+
+		return err
+	}
+
+	ts := uint64(cachedNode.LastSeen.Add(-10*time.Minute).UnixNano()) / uint64(time.Millisecond) //nolint:gosec
+
+	return dynatraceClient.SendEvent(ctx, &dtclient.EventData{
+		EventType:     dtclient.MarkedForTerminationEvent,
+		Source:        "Dynatrace Operator",
+		Description:   "Kubernetes node cordoned. Node might be drained or terminated.",
+		StartInMillis: ts,
+		EndInMillis:   ts,
+		AttachRules: dtclient.EventDataAttachRules{
+			EntityIDs: []string{entityID},
+		},
+	})
+}
+
+func (controller *Controller) markForTermination(ctx context.Context, dk *dynakube.DynaKube, cachedNodeData CachedNodeInfo) error {
+	if !controller.isMarkableForTermination(&cachedNodeData.cachedNode) {
+		return nil
+	}
+
+	if err := cachedNodeData.nodeCache.updateLastMarkedForTerminationTimestamp(cachedNodeData.cachedNode, cachedNodeData.nodeName); err != nil {
+		return err
+	}
+
+	log.Info("sending mark for termination event to dynatrace server", "dk", dk.Name, "ip", cachedNodeData.cachedNode.IPAddress,
+		"node", cachedNodeData.nodeName)
+
+	return controller.sendMarkedForTermination(ctx, dk, cachedNodeData.cachedNode)
+}
+
+func (controller *Controller) isUnschedulable(node *corev1.Node) bool {
+	return node.Spec.Unschedulable || controller.hasUnschedulableTaint(node)
+}
+
+func (controller *Controller) hasUnschedulableTaint(node *corev1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		for _, unschedulableTaint := range unschedulableTaints {
+			if taint.Key == unschedulableTaint {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// isMarkableForTermination checks if the timestamp from last mark is at least one hour old
+func (controller *Controller) isMarkableForTermination(nodeInfo *CacheEntry) bool {
+	// If the last mark was an hour ago, mark again
+	// Zero value for time.Time is 0001-01-01, so first mark is also executed
+	lastMarked := nodeInfo.LastMarkedForTermination
+
+	return lastMarked.UTC().Add(time.Hour).Before(controller.timeProvider.Now().UTC())
+}

--- a/pkg/controllers/nodes/nodes_controller_test.go
+++ b/pkg/controllers/nodes/nodes_controller_test.go
@@ -1,0 +1,324 @@
+package nodes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceclient"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	testNamespace = "dynatrace"
+	testAPIToken  = "test-api-token"
+)
+
+var testCacheKey = client.ObjectKey{Name: cacheName, Namespace: testNamespace}
+
+func TestReconcile(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Create node and then delete it", func(t *testing.T) {
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+
+		fakeClient := fake.NewClient(
+			node,
+			&dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{Name: "oneagent1", Namespace: testNamespace},
+				Status: dynakube.DynaKubeStatus{
+					OneAgent: oneagent.Status{
+						Instances: map[string]oneagent.Instance{node.Name: {IPAddress: "1.2.3.4"}},
+					},
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "oneagent1",
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					dtclient.APIToken: []byte(testAPIToken),
+				},
+			},
+		)
+
+		dtClient := createDTMockClient(t, "1.2.3.4", "HOST-42")
+		defer mock.AssertExpectationsForObjects(t, dtClient)
+
+		ctrl := createDefaultReconciler(fakeClient, dtClient)
+		result, err := ctrl.Reconcile(ctx, createReconcileRequest("node1"))
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+
+		// delete node from kube api
+		err = fakeClient.Delete(ctx, node)
+		require.NoError(t, err)
+
+		// run another request reconcile
+		result, err = ctrl.Reconcile(ctx, createReconcileRequest("node1"))
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+
+		var cm corev1.ConfigMap
+
+		require.NoError(t, fakeClient.Get(ctx, testCacheKey, &cm))
+		nodesCache := &Cache{Obj: &cm}
+
+		_, err = nodesCache.Get("node1")
+		require.Error(t, err)
+	})
+
+	t.Run("Create two nodes and then delete one", func(t *testing.T) {
+		node1 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+		fakeClient := createDefaultFakeClient()
+
+		dtClient := createDTMockClient(t, "1.2.3.4", "HOST-42")
+		defer mock.AssertExpectationsForObjects(t, dtClient)
+
+		ctrl := createDefaultReconciler(fakeClient, dtClient)
+		reconcileAllNodes(t, ctrl, fakeClient)
+
+		// delete node from kube api
+		err := fakeClient.Delete(ctx, node1)
+		require.NoError(t, err)
+
+		// run another request reconcile
+		result, err := ctrl.Reconcile(ctx, createReconcileRequest("node1"))
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+
+		var cm corev1.ConfigMap
+
+		require.NoError(t, fakeClient.Get(ctx, testCacheKey, &cm))
+		nodesCache := &Cache{Obj: &cm}
+
+		_, err = nodesCache.Get("node1")
+		require.Error(t, err)
+		_, err = nodesCache.Get("node2")
+		require.NoError(t, err)
+	})
+
+	t.Run("Node has taint", func(t *testing.T) {
+		fakeClient := createDefaultFakeClient()
+		dtClient := createDTMockClient(t, "1.2.3.4", "HOST-42")
+		ctrl := createDefaultReconciler(fakeClient, dtClient)
+
+		// Get node 1
+		node1 := &corev1.Node{}
+		err := fakeClient.Get(ctx, client.ObjectKey{Name: "node1"}, node1)
+		require.NoError(t, err)
+
+		reconcileAllNodes(t, ctrl, fakeClient)
+		// Add taint that makes it unschedulable
+		node1.Spec.Taints = []corev1.Taint{
+			{Key: "ToBeDeletedByClusterAutoscaler"},
+		}
+		err = fakeClient.Update(ctx, node1)
+		require.NoError(t, err)
+
+		result, err := ctrl.Reconcile(ctx, createReconcileRequest("node1"))
+		assert.NotNil(t, result)
+		require.NoError(t, err)
+
+		// Get node from cache
+		c, err := ctrl.getCache(ctx)
+		require.NoError(t, err)
+		assert.NotNil(t, c)
+
+		node, err := c.Get("node1")
+		require.NoError(t, err)
+		assert.NotNil(t, node)
+
+		// Check if LastMarkedForTermination Timestamp is set to current time
+		// Added one minute buffer to account for operation times
+		now := time.Now().UTC()
+		assert.True(t, node.LastMarkedForTermination.Add(time.Minute).After(now))
+	})
+
+	t.Run("Server error when removing node", func(t *testing.T) {
+		fakeClient := createDefaultFakeClient()
+
+		dtClient := dtclientmock.NewClient(t)
+		dtClient.On("GetEntityIDForIP", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return("", ErrNotFound)
+
+		ctrl := createDefaultReconciler(fakeClient, dtClient)
+
+		reconcileAllNodes(t, ctrl, fakeClient)
+
+		require.ErrorIs(t, ctrl.reconcileNodeDeletion(ctx, "node1"), ErrNotFound)
+	})
+
+	t.Run("Remove host from cache even if server error: host not found", func(t *testing.T) {
+		fakeClient := createDefaultFakeClient()
+
+		dtClient := dtclientmock.NewClient(t)
+		dtClient.On("GetEntityIDForIP", mock.AnythingOfType("context.backgroundCtx"), mock.Anything).Return("", dtclient.HostNotFoundErr{IP: "1.2.3.4"})
+
+		ctrl := createDefaultReconciler(fakeClient, dtClient)
+
+		reconcileAllNodes(t, ctrl, fakeClient)
+
+		require.NoError(t, ctrl.reconcileNodeDeletion(ctx, "node1"))
+
+		// Get node from cache
+		c, err := ctrl.getCache(ctx)
+		require.NoError(t, err)
+		assert.NotNil(t, c)
+
+		// should return not found for key inside configmap
+		_, err = c.Get("node1")
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("Handle outdated cache", func(t *testing.T) {
+		fakeClient := createDefaultFakeClient()
+
+		dtClient := createDTMockClient(t, "1.2.3.4", "HOST-42")
+		defer mock.AssertExpectationsForObjects(t, dtClient)
+
+		ctrl := createDefaultReconciler(fakeClient, dtClient)
+		// by doing this step we warm up cache by adding node1 and node2
+		reconcileAllNodes(t, ctrl, fakeClient)
+
+		// Emulate error by explicitly removing node1 from cache
+		var cm corev1.ConfigMap
+
+		require.NoError(t, fakeClient.Get(ctx, testCacheKey, &cm))
+		nodesCache := &Cache{Obj: &cm}
+
+		// delete node from kube api
+		node1 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+		err := fakeClient.Delete(ctx, node1)
+		require.NoError(t, err)
+
+		// run another request reconcile
+		require.NoError(t, ctrl.handleOutdatedCache(ctx, nodesCache))
+	})
+}
+
+func createReconcileRequest(nodeName string) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: nodeName},
+	}
+}
+
+type mockDynatraceClientBuilder struct {
+	dynatraceClient dtclient.Client
+}
+
+func (builder mockDynatraceClientBuilder) SetContext(context.Context) dynatraceclient.Builder {
+	return builder
+}
+
+func (builder mockDynatraceClientBuilder) SetDynakube(dynakube.DynaKube) dynatraceclient.Builder {
+	return builder
+}
+
+func (builder mockDynatraceClientBuilder) SetTokens(token.Tokens) dynatraceclient.Builder {
+	return builder
+}
+
+func (builder mockDynatraceClientBuilder) LastAPIProbeTimestamp() *metav1.Time {
+	return nil
+}
+
+func (builder mockDynatraceClientBuilder) Build(ctx context.Context) (dtclient.Client, error) {
+	return builder.dynatraceClient, nil
+}
+
+func (builder mockDynatraceClientBuilder) BuildWithTokenVerification(*dynakube.DynaKubeStatus) (dtclient.Client, error) {
+	return builder.dynatraceClient, nil
+}
+
+func createDefaultReconciler(fakeClient client.Client, dtClient *dtclientmock.Client) *Controller {
+	return &Controller{
+		client:    fakeClient,
+		apiReader: fakeClient,
+		dynatraceClientBuilder: &mockDynatraceClientBuilder{
+			dynatraceClient: dtClient,
+		},
+		podNamespace: testNamespace,
+		runLocal:     true,
+		timeProvider: timeprovider.New().Freeze(),
+	}
+}
+
+func createDTMockClient(t *testing.T, ip, host string) *dtclientmock.Client {
+	dtClient := dtclientmock.NewClient(t)
+	dtClient.On("GetEntityIDForIP", mock.AnythingOfType("context.backgroundCtx"), ip).Return(host, nil)
+	dtClient.On("SendEvent", mock.AnythingOfType("context.backgroundCtx"), mock.MatchedBy(func(e *dtclient.EventData) bool {
+		return e.EventType == "MARKED_FOR_TERMINATION"
+	})).Return(nil)
+
+	return dtClient
+}
+
+func reconcileAllNodes(t *testing.T, ctrl *Controller, fakeClient client.Client) {
+	ctx := context.Background()
+
+	var nodeList corev1.NodeList
+	err := fakeClient.List(ctx, &nodeList)
+
+	require.NoError(t, err)
+
+	for _, clusterNode := range nodeList.Items {
+		result, err := ctrl.Reconcile(ctx, createReconcileRequest(clusterNode.Name))
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+	}
+}
+
+func createDefaultFakeClient() client.Client {
+	return fake.NewClient(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+		&dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent1", Namespace: testNamespace},
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: oneagent.Status{
+					Instances: map[string]oneagent.Instance{"node1": {IPAddress: "1.2.3.4"}},
+				},
+			},
+		},
+		&dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent2", Namespace: testNamespace},
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: oneagent.Status{
+					Instances: map[string]oneagent.Instance{"node2": {IPAddress: "5.6.7.8"}},
+				},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oneagent1",
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				dtclient.APIToken: []byte(testAPIToken),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oneagent2",
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				dtclient.APIToken: []byte(testAPIToken),
+			},
+		})
+}

--- a/pkg/controllers/nodes/oneagent_dao.go
+++ b/pkg/controllers/nodes/oneagent_dao.go
@@ -1,0 +1,40 @@
+package nodes
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (controller *Controller) determineDynakubeForNode(nodeName string) (*dynakube.DynaKube, error) {
+	dks, err := controller.getDynakubeList()
+	if err != nil {
+		return nil, err
+	}
+
+	return controller.filterDynakubeFromList(dks, nodeName), nil
+}
+
+func (controller *Controller) getDynakubeList() (*dynakube.DynaKubeList, error) {
+	var dynakubeList dynakube.DynaKubeList
+
+	err := controller.apiReader.List(context.TODO(), &dynakubeList, client.InNamespace(controller.podNamespace))
+	if err != nil {
+		return nil, err
+	}
+
+	return &dynakubeList, nil
+}
+
+func (controller *Controller) filterDynakubeFromList(dkList *dynakube.DynaKubeList,
+	nodeName string) *dynakube.DynaKube {
+	for _, dk := range dkList.Items {
+		items := dk.Status.OneAgent.Instances
+		if _, ok := items[nodeName]; ok {
+			return &dk
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/envvars/envvars.go
+++ b/pkg/util/envvars/envvars.go
@@ -1,0 +1,20 @@
+package envvars
+
+import (
+	"os"
+	"strconv"
+)
+
+func GetBool(varName string, defaultValue bool) bool {
+	envValue := os.Getenv(varName)
+	if envValue != "" {
+		parsedValue, err := strconv.ParseBool(envValue)
+		if err != nil {
+			return defaultValue
+		}
+
+		return parsedValue
+	}
+
+	return defaultValue
+}

--- a/pkg/util/envvars/envvars_test.go
+++ b/pkg/util/envvars/envvars_test.go
@@ -1,0 +1,33 @@
+package envvars
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBool(t *testing.T) {
+	t.Run("env var is set to true and properly parsed to true", func(t *testing.T) {
+		t.Setenv(consts.HostAvailabilityDetectionEnvVar, "true")
+
+		assert.True(t, GetBool(consts.HostAvailabilityDetectionEnvVar, true))
+	})
+
+	t.Run("env var is set to false and properly parsed to false", func(t *testing.T) {
+		t.Setenv(consts.HostAvailabilityDetectionEnvVar, "false")
+
+		assert.False(t, GetBool(consts.HostAvailabilityDetectionEnvVar, true))
+	})
+
+	t.Run("env var is set to dummy and properly parsed to default value", func(t *testing.T) {
+		t.Setenv(consts.HostAvailabilityDetectionEnvVar, "dummy")
+
+		assert.True(t, GetBool(consts.HostAvailabilityDetectionEnvVar, true))
+	})
+
+	t.Run("env var is NOT set and fallback to default", func(t *testing.T) {
+		assert.True(t, GetBool(consts.HostAvailabilityDetectionEnvVar, true))
+		assert.False(t, GetBool(consts.HostAvailabilityDetectionEnvVar, false))
+	})
+}

--- a/test/features/supportarchive/files.go
+++ b/test/features/supportarchive/files.go
@@ -311,6 +311,14 @@ func (r requiredFiles) getRequiredConfigMapFiles() []string {
 			supportarchive.ManifestsDirectoryName,
 			r.dk.Namespace,
 			"configmap",
+			"dynatrace-node-cache",
+			supportarchive.ManifestsFileExtension))
+
+	requiredFiles = append(requiredFiles,
+		fmt.Sprintf("%s/%s/%s/%s%s",
+			supportarchive.ManifestsDirectoryName,
+			r.dk.Namespace,
+			"configmap",
 			"kube-root-ca.crt",
 			supportarchive.ManifestsFileExtension))
 

--- a/test/mocks/pkg/clients/dynatrace/client.go
+++ b/test/mocks/pkg/clients/dynatrace/client.go
@@ -685,6 +685,72 @@ func (_c *Client_GetCommunicationHostForClient_Call) RunAndReturn(run func() (dy
 	return _c
 }
 
+// GetEntityIDForIP provides a mock function for the type Client
+func (_mock *Client) GetEntityIDForIP(ctx context.Context, ip string) (string, error) {
+	ret := _mock.Called(ctx, ip)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEntityIDForIP")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return returnFunc(ctx, ip)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = returnFunc(ctx, ip)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, ip)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Client_GetEntityIDForIP_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityIDForIP'
+type Client_GetEntityIDForIP_Call struct {
+	*mock.Call
+}
+
+// GetEntityIDForIP is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ip string
+func (_e *Client_Expecter) GetEntityIDForIP(ctx interface{}, ip interface{}) *Client_GetEntityIDForIP_Call {
+	return &Client_GetEntityIDForIP_Call{Call: _e.mock.On("GetEntityIDForIP", ctx, ip)}
+}
+
+func (_c *Client_GetEntityIDForIP_Call) Run(run func(ctx context.Context, ip string)) *Client_GetEntityIDForIP_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_GetEntityIDForIP_Call) Return(s string, err error) *Client_GetEntityIDForIP_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *Client_GetEntityIDForIP_Call) RunAndReturn(run func(ctx context.Context, ip string) (string, error)) *Client_GetEntityIDForIP_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetK8sClusterME provides a mock function for the type Client
 func (_mock *Client) GetK8sClusterME(ctx context.Context, kubeSystemUUID string) (dynatrace.K8sClusterME, error) {
 	ret := _mock.Called(ctx, kubeSystemUUID)
@@ -1570,6 +1636,63 @@ func (_c *Client_GetTokenScopes_Call) Return(tokenScopes dynatrace.TokenScopes, 
 }
 
 func (_c *Client_GetTokenScopes_Call) RunAndReturn(run func(ctx context.Context, token string) (dynatrace.TokenScopes, error)) *Client_GetTokenScopes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SendEvent provides a mock function for the type Client
+func (_mock *Client) SendEvent(ctx context.Context, eventData *dynatrace.EventData) error {
+	ret := _mock.Called(ctx, eventData)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SendEvent")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *dynatrace.EventData) error); ok {
+		r0 = returnFunc(ctx, eventData)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Client_SendEvent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendEvent'
+type Client_SendEvent_Call struct {
+	*mock.Call
+}
+
+// SendEvent is a helper method to define mock.On call
+//   - ctx context.Context
+//   - eventData *dynatrace.EventData
+func (_e *Client_Expecter) SendEvent(ctx interface{}, eventData interface{}) *Client_SendEvent_Call {
+	return &Client_SendEvent_Call{Call: _e.mock.On("SendEvent", ctx, eventData)}
+}
+
+func (_c *Client_SendEvent_Call) Run(run func(ctx context.Context, eventData *dynatrace.EventData)) *Client_SendEvent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *dynatrace.EventData
+		if args[1] != nil {
+			arg1 = args[1].(*dynatrace.EventData)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_SendEvent_Call) Return(err error) *Client_SendEvent_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Client_SendEvent_Call) RunAndReturn(run func(ctx context.Context, eventData *dynatrace.EventData) error) *Client_SendEvent_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Description

same as https://github.com/Dynatrace/dynatrace-operator/pull/5426

## How can this be tested?

same as https://github.com/Dynatrace/dynatrace-operator/pull/5426