### PR TITLE
Skip go installs on E2E executions

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -8,6 +8,10 @@ test/e2e/%/publish:
 test/e2e/%/debug:
 	@make SKIPCLEANUP="--fail-fast" $(@D)
 
+## Start a test and generate CRD for it
+test/e2e/%/gen-crd: manifests/crd/helm
+	@make $(@D)
+
 ## Run standard, no-csi, istio and release e2e tests
 test/e2e:
 	RC=0; \
@@ -27,156 +31,156 @@ test/e2e-publish:
 	exit $$RC
 
 ## Run standard e2e test only
-test/e2e/standard: manifests/crd/helm
+test/e2e/standard:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 200m -count=1 ./test/scenarios/standard -args $(SKIPCLEANUP)
 
 ## Run istio e2e test only
-test/e2e/istio: manifests/crd/helm
+test/e2e/istio:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 200m -count=1 ./test/scenarios/istio -args $(SKIPCLEANUP)
 
 ## Run no-csi e2e test only
-test/e2e/no-csi: manifests/crd/helm
+test/e2e/no-csi:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 200m -count=1 ./test/scenarios/nocsi -args $(SKIPCLEANUP)
 
 ## Run release e2e test only
-test/e2e/release: manifests/crd/helm
+test/e2e/release:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1 ./test/scenarios/release -args $(SKIPCLEANUP)
 
 ## Runs ActiveGate e2e test only
-test/e2e/activegate: manifests/crd/helm
+test/e2e/activegate:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "activegate" -args $(SKIPCLEANUP)
 
 ## Runs ActiveGate proxy e2e test only
-test/e2e/activegate/proxy: manifests/crd/helm
+test/e2e/activegate/proxy:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -run "activegate" -args $(SKIPCLEANUP)
 
 ## Runs ClassicFullStack e2e test only
-test/e2e/classic: manifests/crd/helm
+test/e2e/classic:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "classic" -args  $(SKIPCLEANUP)
 
 ## Runs ClassicFullStack switch mode e2e test only
-test/e2e/classic/switchmodes: manifests/crd/helm
+test/e2e/classic/switchmodes:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -run "classic_to_cloudnative" -args  $(SKIPCLEANUP)
 
 ## Runs CloudNative codemodules e2e test only
-test/e2e/cloudnative/codemodules: manifests/crd/helm
+test/e2e/cloudnative/codemodules:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -run "cloudnative_codemodules_image" -args $(SKIPCLEANUP)
 
 ## Runs CloudNative codemodules-with-proxy e2e test only
-test/e2e/cloudnative/codemodules-with-proxy: manifests/crd/helm
+test/e2e/cloudnative/codemodules-with-proxy:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -run "codemodules_with_proxy_no_certs" -args $(SKIPCLEANUP)
 
 ## Runs CloudNative codemodules e2e test with proxy and AG custom certificate
-test/e2e/cloudnative/codemodules-with-proxy-and-ag-cert: manifests/crd/helm
+test/e2e/cloudnative/codemodules-with-proxy-and-ag-cert:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -run "codemodules_with_proxy_and_ag_cert" -args $(SKIPCLEANUP)
 
 ## Runs CloudNative codemodules e2e test with proxy and automatically created AG certificate
-test/e2e/cloudnative/codemodules-with-proxy-and-auto-ag-cert: manifests/crd/helm
+test/e2e/cloudnative/codemodules-with-proxy-and-auto-ag-cert:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -run "codemodules_with_proxy_and_auto_ag_cert" -args $(SKIPCLEANUP)
 
 ## Runs CloudNative codemodules e2e test with proxy and AG custom certificates
-test/e2e/cloudnative/codemodules-with-proxy-custom-ca-ag-cert: manifests/crd/helm
+test/e2e/cloudnative/codemodules-with-proxy-custom-ca-ag-cert:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -run "codemodules_with_proxy_custom_ca_ag_cert" -args  $(SKIPCLEANUP)
 
 ## Runs CloudNative codemodules e2e test with proxy and automatically created AG certificates
-test/e2e/cloudnative/codemodules-with-proxy-custom-ca-auto-ag-cert: manifests/crd/helm
+test/e2e/cloudnative/codemodules-with-proxy-custom-ca-auto-ag-cert:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -run "codemodules_with_proxy_custom_ca_auto_ag_cert" -args $(SKIPCLEANUP)
 
 ## Runs CloudNative automatic injection disabled e2e test only
-test/e2e/cloudnative/disabledautoinjection: manifests/crd/helm
+test/e2e/cloudnative/disabledautoinjection:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -run "cloudnative_disabled_auto_inject" -args $(SKIPCLEANUP)
 
 ## Runs CloudNative default e2e test only
-test/e2e/cloudnative/default: manifests/crd/helm
+test/e2e/cloudnative/default:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -run "cloudnative" -args $(SKIPCLEANUP)
 
 ## Runs CloudNative istio e2e test only
-test/e2e/cloudnative/istio: manifests/crd/helm
+test/e2e/cloudnative/istio:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -run "cloudnative" -args $(SKIPCLEANUP)
 
 ## Runs CloudNative network problem e2e test only
-test/e2e/cloudnative/resilience: manifests/crd/helm
+test/e2e/cloudnative/resilience:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/istio -run "cloudnative_csi_resilience" -args $(SKIPCLEANUP)
 
 ## Runs Classic/CloudNative mode switching tests
-test/e2e/cloudnative/switchmodes: manifests/crd/helm
+test/e2e/cloudnative/switchmodes:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -run "cloudnative_to_classic" -args $(SKIPCLEANUP)
 
 ## Runs CloudNative upgrade e2e test only
-test/e2e/cloudnative/upgrade: manifests/crd/helm
+test/e2e/cloudnative/upgrade:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/release -run "cloudnative_upgrade" -args $(SKIPCLEANUP)
 
 ## Runs Application Monitoring metadata-enrichment e2e test only
-test/e2e/applicationmonitoring/metadataenrichment: manifests/crd/helm
+test/e2e/applicationmonitoring/metadataenrichment:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "metadata_enrichment" -args $(SKIPCLEANUP)
 
 ## Runs Application Monitoring label versio detection e2e test only
-test/e2e/applicationmonitoring/labelversion: manifests/crd/helm
+test/e2e/applicationmonitoring/labelversion:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "label_version" -args $(SKIPCLEANUP)
 
 ## Runs Application Monitoring readonly csi-volume e2e test only
-test/e2e/applicationmonitoring/readonlycsivolume: manifests/crd/helm
+test/e2e/applicationmonitoring/readonlycsivolume:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -run "app_read_only_csi_volume" -args $(SKIPCLEANUP)
 
 ## Runs Application Monitoring without CSI e2e test only
-test/e2e/applicationmonitoring/withoutcsi: manifests/crd/helm
+test/e2e/applicationmonitoring/withoutcsi:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "app_monitoring_without_csi" -args $(SKIPCLEANUP)
 
 ## Runs Application Monitoring bootstrapper with CSI e2e test only
-test/e2e/applicationmonitoring/bootstrapper-csi: manifests/crd/helm
+test/e2e/applicationmonitoring/bootstrapper-csi:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -run "node_image_pull_with_csi" -args $(SKIPCLEANUP)
 
 ## Runs Application Monitoring bootstrapper with no CSI e2e test only
-test/e2e/applicationmonitoring/bootstrapper-no-csi: manifests/crd/helm
+test/e2e/applicationmonitoring/bootstrapper-no-csi:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "node_image_pull_with_no_csi" -args $(SKIPCLEANUP)
 
 ## Runs public registry images e2e test only
-test/e2e/publicregistry: manifests/crd/helm
+test/e2e/publicregistry:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -run "public_registry_images" -args $(SKIPCLEANUP)
 
 ## Runs SupportArchive e2e test only
-test/e2e/supportarchive: manifests/crd/helm
+test/e2e/supportarchive:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -run "support_archive" -args $(SKIPCLEANUP)
 
 ## Runs Edgeconnect e2e test only
-test/e2e/edgeconnect: manifests/crd/helm
+test/e2e/edgeconnect:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "edgeconnect" -args  $(SKIPCLEANUP)
 
 ## Runs e2e tests on gke-autopilot
-test/e2e/gke-autopilot: manifests/crd/helm
+test/e2e/gke-autopilot:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/standard -run "app_metadata_enrichment|app_read_only_csi_volume|app_read_only_csi_volume|app_without_csi|activegate" -args $(SKIPCLEANUP)
 
 ## Runs extensions related e2e tests
-test/e2e/extensions: manifests/crd/helm
+test/e2e/extensions:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "extensions" -args $(SKIPCLEANUP)
 
 ## Runs LogMonitoring related e2e tests
-test/e2e/logmonitoring: manifests/crd/helm
+test/e2e/logmonitoring:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "logmonitoring.*" -args $(SKIPCLEANUP)
 
-test/e2e/logmonitoring/optionalscopes: manifests/crd/helm
+test/e2e/logmonitoring/optionalscopes:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "logmonitoring_with_optional_scopes.*" -args $(SKIPCLEANUP)
 
 ## Runs Host Monitoring without CSI e2e test only
-test/e2e/hostmonitoring/withoutcsi: manifests/crd/helm
+test/e2e/hostmonitoring/withoutcsi:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "host_monitoring_without_csi" -args $(SKIPCLEANUP)
 
 ## Runs CloudNative default e2e test only
-test/e2e/cloudnative/withoutcsi: manifests/crd/helm
+test/e2e/cloudnative/withoutcsi:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "cloudnative" -args $(SKIPCLEANUP)
 
 ## Runs TelemetryIngest related e2e tests
-test/e2e/telemetryingest: manifests/crd/helm
+test/e2e/telemetryingest:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "telemetryingest_.*" -args $(SKIPCLEANUP)
 
-test/e2e/telemetryingest/public-active-gate: manifests/crd/helm
+test/e2e/telemetryingest/public-active-gate:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "telemetryingest_w_public_ag" -args $(SKIPCLEANUP)
 
-test/e2e/telemetryingest/local-active-gate-and-cleanup: manifests/crd/helm
+test/e2e/telemetryingest/local-active-gate-and-cleanup:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "telemetryingest_w_local_ag_and_cleanup_after" -args $(SKIPCLEANUP)
 
-test/e2e/telemetryingest/otel-collector-endpoint-tls: manifests/crd/helm
+test/e2e/telemetryingest/otel-collector-endpoint-tls:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "telemetryingest_w_otel_collector_endpoint_tls" -args $(SKIPCLEANUP)
 
-test/e2e/telemetryingest/otel-collector-config-udpate: manifests/crd/helm
+test/e2e/telemetryingest/otel-collector-config-udpate:
 	$(GOTESTCMD) -v -tags "$(shell ./hack/build/create_go_build_tags.sh true)" -timeout 20m -count=1  ./test/scenarios/nocsi -run "telemetryingest_configuration_update" -args $(SKIPCLEANUP)


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/DAQ-12535

We want to get rid of go install calls on E2E executions (which caused the linked bug). They were called to build the CRD, but now we don't need it anymore since we use the nightly helm chart.

I still added a subcommand to build the CRD in case someone misses to do it all in one command.

## How can this be tested?

make test/e2e/standard/gen-crd --> go install calls
make test/e2e/standard --> no go install
