### PR TITLE
Store nsSelector matching namespaces in conditions

### DIFF
--- a/pkg/controllers/dynakube/injection/conditions.go
+++ b/pkg/controllers/dynakube/injection/conditions.go
@@ -1,17 +1,31 @@
 package injection
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
+	namespacesMonitoredConditionType = "NamespacesMonitored"
+
+	oneAgentNamespacesMonitoredConditionType           = "OneAgentNamespacesMonitored"
+	metadataEnrichmentNamespacesMonitoredConditionType = "MetadataEnrichmentNamespacesMonitored"
+
 	metaDataEnrichmentConditionType   = "MetadataEnrichment"
 	codeModulesInjectionConditionType = "CodeModulesInjection"
+
+	matchesFoundReason          = "MatchesFound"
+	noMatchesReason             = "NoMatches"
+	selectorNotConfiguredReason = "SelectorNotConfigured"
 
 	secretsCreatedReason  = "SecretsCreated"
 	secretsCreatedMessage = "Namespaces mapped and secrets created"
 )
+
+const maxNamesInMsg = 10
 
 func setMetadataEnrichmentCreatedCondition(conditions *[]metav1.Condition) {
 	condition := metav1.Condition{
@@ -31,4 +45,83 @@ func setCodeModulesInjectionCreatedCondition(conditions *[]metav1.Condition) {
 		Message: secretsCreatedMessage,
 	}
 	_ = meta.SetStatusCondition(conditions, condition)
+}
+
+func setNamespacesMonitoredSelectorCondition(conditions *[]metav1.Condition, selectorType string, configured bool, names []string) {
+	var condType string
+
+	switch selectorType {
+	case "OneAgent":
+		condType = oneAgentNamespacesMonitoredConditionType
+	case "MetadataEnrichment":
+		condType = metadataEnrichmentNamespacesMonitoredConditionType
+	default:
+		condType = namespacesMonitoredConditionType
+	}
+
+	cond := metav1.Condition{Type: condType}
+
+	switch {
+	case !configured:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = selectorNotConfiguredReason
+		cond.Message = "Selector not configured"
+	case len(names) == 0:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = noMatchesReason
+		cond.Message = "0 namespaces match"
+	default:
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = matchesFoundReason
+		msg := formatMatchMessage(names, maxNamesInMsg)
+		cond.Message = msg
+	}
+
+	cond.LastTransitionTime = metav1.Now()
+	_ = meta.SetStatusCondition(conditions, cond)
+}
+
+func updateCollectedNamespacesMonitoredCondition(conditions *[]metav1.Condition) {
+	oa := meta.FindStatusCondition(*conditions, oneAgentNamespacesMonitoredConditionType)
+	me := meta.FindStatusCondition(*conditions, metadataEnrichmentNamespacesMonitoredConditionType)
+
+	collected := metav1.Condition{
+		Type:               namespacesMonitoredConditionType,
+		LastTransitionTime: metav1.Now(),
+	}
+
+	if oa != nil && oa.Status == metav1.ConditionTrue || me != nil && me.Status == metav1.ConditionTrue {
+		collected.Status = metav1.ConditionFalse
+		collected.Reason = noMatchesReason
+		collected.Message = "No namespaces match the configured selectors"
+		_ = meta.SetStatusCondition(conditions, collected)
+
+		return
+	}
+
+	if oa != nil && oa.Reason == selectorNotConfiguredReason && me != nil && me.Reason == selectorNotConfiguredReason {
+		collected.Status = metav1.ConditionFalse
+		collected.Reason = selectorNotConfiguredReason
+		collected.Message = "No selectors configured"
+		_ = meta.SetStatusCondition(conditions, collected)
+
+		return
+	}
+
+	collected.Status = metav1.ConditionFalse
+	collected.Reason = noMatchesReason
+	collected.Message = "No namespaces match the configured selectors"
+	meta.SetStatusCondition(conditions, collected)
+}
+
+func formatMatchMessage(names []string, limit int) string {
+	if len(names) == 0 {
+		return "no namespaces match"
+	}
+
+	if len(names) > limit {
+		return fmt.Sprintf("%d namespaces match: %s (at most %d shown)", len(names), strings.Join(names[:limit], ", "), limit)
+	}
+
+	return fmt.Sprintf("%d namespaces match: %s", len(names), strings.Join(names, ", "))
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[JIRA](https://dt-rnd.atlassian.net/browse/DAQ-11997)

With this we want to improve trouble shooting. This introduces a check of which namespace matches the respective namespace selector (split by metadataEnrichment and oneAgent ns selector!)

We store all namespaces into the dk status and list at most 10 namespaces in order to avoid unreadable long lists. We also log how many namespaces are matching (again up to 10 at most)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Test out a DK with both namespaces selectors enabled (metadataEnrichment and oneAgent)

Try out different scenarios:
- a lot of namespaces match the metadataEnrichment namespaceSelector
- a lot of namespaces match the oneAgent namespaceSelector
- a lot of namespaces match both
- little to no namespace match either of them or both

just play around and see how we react to it.

sample logs:

```
{"level":"info","ts":"2025-10-02T13:39:22.247Z","logger":"dynakube-injection","msg":"namespaces monitored","selector":"OneAgent","count (at most 10 are shown)":10,"namespaces":["bh-day-ns10","bh-day-ns11","bh-day-ns2","bh-day-ns3","bh-day-ns4","bh-day-ns5","bh-day-ns6","
h-day-ns7","bh-day-ns8","bh-day-ns9"[]}                                                                                                                                                                                                                                        
{"level":"info","ts":"2025-10-02T13:39:22.247Z","logger":"dynakube-injection","msg":"namespaces monitored","selector":"MetadataEnrichment","count (at most 10 are shown)":2,"namespaces":["bh-day-ns","default"]} 
```

sample status:

```
    Last Transition Time:  2025-10-02T12:10:52Z                                                                                                                                                                                                                                
    Message:               10 namespaces match: bh-day-ns10, bh-day-ns11, bh-day-ns2, bh-day-ns3, bh-day-ns4, bh-day-ns5, bh-day-ns6, bh-day-ns7, bh-day-ns8, bh-day-ns9                                                                                                       
    Reason:                MatchesFound                                                                                                                                                                                                                                        
    Status:                True                                                                                                                                                                                                                                                
    Type:                  OneAgentNamespacesMonitored                                                                                                                                                                                                                         
    Last Transition Time:  2025-10-02T12:10:52Z                                                                                                                                                                                                                                
    Message:               2 namespaces match: bh-day-ns, default                                                                                                                                                                                                              
    Reason:                MatchesFound                                                                                                                                                                                                                                        
    Status:                True                                                                                                                                                                                                                                                
    Type:                  MetadataEnrichmentNamespacesMonitored                                                                                                                                                                                                               
    Last Transition Time:  2025-10-02T12:09:06Z                                                                                                                                                                                                                                
    Message:               No namespaces match the configured selectors                                                                                                                                                                                                        
    Reason:                NoMatches                                                                                                                                                                                                                                           
    Status:                False                                                                                                                                                                                                                                               
    Type:                  NamespacesMonitored                                                                                                                                                                                                                                 
    Last Transition Time:  2025-10-02T13:39:21Z  
```

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->