### PR TITLE
Implement webhook integration test base

### DIFF
--- a/cmd/webhook/cmd.go
+++ b/cmd/webhook/cmd.go
@@ -5,12 +5,6 @@ import (
 	"os"
 
 	"github.com/Dynatrace/dynatrace-operator/cmd/webhook/certificates"
-	dynakubelatest "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	edgeconnectv1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
-	edgeconnectv1alpha2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
-	dynakubev1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
-	dynakubev1beta4 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
-	dynakubev1beta5 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta5/dynakube"
 	dynakubevalidation "github.com/Dynatrace/dynatrace-operator/pkg/api/validation/dynakube"
 	edgeconnectvalidation "github.com/Dynatrace/dynatrace-operator/pkg/api/validation/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
@@ -116,12 +110,12 @@ func run() func(*cobra.Command, []string) error {
 			return err
 		}
 
-		err = setupDynakubeValidation(webhookManager)
+		err = dynakubevalidation.SetupWebhookWithManager(webhookManager)
 		if err != nil {
 			return err
 		}
 
-		err = setupEdgeconnectValidation(webhookManager)
+		err = edgeconnectvalidation.SetupWebhookWithManager(webhookManager)
 		if err != nil {
 			return err
 		}
@@ -146,48 +140,6 @@ func startCertificateWatcher(webhookManager manager.Manager, namespace string, p
 		}
 
 		watcher.WaitForCertificates()
-	}
-
-	return nil
-}
-
-func setupDynakubeValidation(webhookManager manager.Manager) error {
-	dkValidator := dynakubevalidation.New(webhookManager.GetAPIReader(), webhookManager.GetConfig())
-
-	err := dynakubev1beta3.SetupWebhookWithManager(webhookManager, dkValidator)
-	if err != nil {
-		return err
-	}
-
-	err = dynakubev1beta4.SetupWebhookWithManager(webhookManager, dkValidator)
-	if err != nil {
-		return err
-	}
-
-	err = dynakubev1beta5.SetupWebhookWithManager(webhookManager, dkValidator)
-	if err != nil {
-		return err
-	}
-
-	err = dynakubelatest.SetupWebhookWithManager(webhookManager, dkValidator)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func setupEdgeconnectValidation(webhookManager manager.Manager) error {
-	ecValidator := edgeconnectvalidation.New(webhookManager.GetAPIReader(), webhookManager.GetConfig())
-
-	err := edgeconnectv1alpha1.SetupWebhookWithManager(webhookManager, ecValidator)
-	if err != nil {
-		return err
-	}
-
-	err = edgeconnectv1alpha2.SetupWebhookWithManager(webhookManager, ecValidator)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/api/validation/dynakube/testdata/latest-default.yaml
+++ b/pkg/api/validation/dynakube/testdata/latest-default.yaml
@@ -1,0 +1,276 @@
+apiVersion: dynatrace.com/v1beta6
+kind: DynaKube
+metadata:
+  annotations:
+    feature.dynatrace.com/activegate-ignore-proxy: "true"
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
+  labels:
+    label: label-value
+  name: dynakube
+  namespace: default
+spec:
+  activeGate:
+    annotations:
+      activegate-annotation-key: activegate-annotation-value
+    capabilities:
+    - dynatrace-api
+    - kubernetes-monitoring
+    - metrics-ingest
+    customProperties:
+      value: activegate-custom-property-value
+      valueFrom: activegate-custom-property-value-from
+    dnsPolicy: ClusterFirstWithHostNet
+    env:
+    - name: activegate-env-1
+      value: activegate-env-value-1
+      valueFrom:
+        configMapKeyRef:
+          key: activegate-env-from-1
+          name: activegate-env-configmap
+    - name: activegate-env-2
+      value: activegate-env-value-2
+      valueFrom:
+        configMapKeyRef:
+          key: activegate-env-from-2
+          name: activegate-env-configmap
+    group: activegate-group
+    image: activegate-image
+    labels:
+      activegate-label-key: activegate-label-value
+    nodeSelector:
+      activegate-node-selector-key: activegate-node-selector-value
+    priorityClassName: activegate-priority-class-name
+    replicas: 2
+    resources:
+      limits:
+        cpu: "3"
+      requests:
+        cpu: "3"
+    tlsSecretName: activegate-tls-secret-name
+    tolerations:
+    - key: activegate-toleration-key
+      operator: In
+      value: activegate-toleration-value
+    topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+  apiUrl: https://url/api
+  customPullSecret: pull-secret
+  dynatraceApiRequestThreshold: 42
+  enableIstio: true
+  extensions:
+    prometheus: {}
+  logMonitoring:
+    ingestRuleMatchers:
+    - attribute: attribute1
+      values:
+      - matcher1
+      - matcher2
+      - matcher3
+    - attribute: attribute2
+      values:
+      - matcher1
+      - matcher2
+      - matcher3
+    - attribute: attribute3
+      values:
+      - matcher1
+      - matcher2
+      - matcher3
+  metadataEnrichment:
+    enabled: false
+    namespaceSelector: {}
+  networkZone: network-zone
+  oneAgent:
+    hostGroup: hostgroup-value
+    hostMonitoring:
+      annotations:
+        host-inject-annotation-key: host-inject-annotation-value
+      args:
+      - host-inject-arg-1
+      - host-inject-arg-2
+      autoUpdate: false
+      dnsPolicy: ClusterFirstWithHostNet
+      env:
+      - name: host-inject-env-1
+        value: host-inject-env-value-1
+        valueFrom:
+          configMapKeyRef:
+            key: host-inject-env-from-1
+            name: host-inject-env-configmap
+      - name: host-inject-env-2
+        value: host-inject-env-value-2
+        valueFrom:
+          configMapKeyRef:
+            key: host-inject-env-from-2
+            name: host-inject-env-configmap
+      image: host-inject-image
+      labels:
+        host-inject-label-key: host-inject-label-value
+      nodeSelector:
+        host-inject-node-selector-key: host-inject-node-selector-value
+      oneAgentResources:
+        limits:
+          cpu: "1"
+      priorityClassName: host-inject-priority-class
+      secCompProfile: seccomp
+      tolerations:
+      - key: host-inject-toleration-key
+        operator: In
+        value: host-inject-toleration-value
+      version: 1.0.0.20240101-000000
+  proxy:
+    value: proxy-value
+    valueFrom: proxy-from
+  skipCertCheck: true
+  templates:
+    databaseExecutor:
+      imageRef: {}
+    extensionExecutionController:
+      annotations:
+        eec-annotation-key1: eec-annotation-value1
+        eec-annotation-key2: eec-annotation-value2
+      customConfig: custom-eec-config
+      customExtensionCertificates: custom-eec-certificate
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      labels:
+        eec-label-key1: eec-label-value1
+        eec-label-key2: eec-label-value2
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tlsRefName: tls-ref-name
+      tolerations:
+      - key: otelc-toleration-key
+        operator: In
+        value: otelc-toleration-value
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      useEphemeralVolume: true
+    kspmNodeConfigurationCollector:
+      annotations:
+        ncc-annotation-key1: ncc-annotation-value1
+        ncc-annotation-key2: ncc-annotation-value2
+      args:
+      - --log-level
+      - debug
+      - --log-format
+      - json
+      env:
+      - name: ENV1
+        value: VAL1
+      - name: ENV2
+        value: VAL2
+      - name: ENV3
+        value: VAL3
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      labels:
+        ncc-label-key1: ncc-label-value1
+        ncc-label-key2: ncc-label-value2
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: node-selector-match-key
+              operator: In
+              values:
+              - node-match-value1
+              - node-match-value2
+            matchFields:
+            - key: node-selector-field-key
+              operator: In
+              values:
+              - node-field-value1
+              - node-field-value2
+      nodeSelector:
+        selector1: node1
+        selector2: node2
+      priorityClassName: priority-class-name
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tolerations:
+      - key: otelc-toleration-key
+        operator: In
+        value: otelc-toleration-value
+      updateStrategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 50%
+        type: RollingUpdate
+    logMonitoring:
+      annotations:
+        logagent-annotation-key1: logagent-annotation-value1
+        logagent-annotation-key2: logagent-annotation-value2
+      args:
+      - --log-level
+      - debug
+      - --log-format
+      - json
+      dnsPolicy: ClusterFirstWithHostNet
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      labels:
+        logagent-label-key1: logagent-label-value1
+        logagent-label-key2: logagent-label-value2
+      nodeSelector:
+        selector1: node1
+        selector2: node2
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      secCompProfile: seccomp
+      tolerations:
+      - key: otelc-toleration-key
+        operator: In
+        value: otelc-toleration-value
+    otelCollector:
+      annotations:
+        otelc-annotation-key1: otelc-annotation-value1
+        otelc-annotation-key2: otelc-annotation-value2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      labels:
+        otelc-label-key1: otelc-label-value1
+        otelc-label-key2: otelc-label-value2
+      replicas: 2
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tlsRefName: tls-ref-name
+      tolerations:
+      - key: otelc-toleration-key
+        operator: In
+        value: otelc-toleration-value
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+  tokens: token
+  trustedCAs: trusted-ca
+status:
+  activeGate:
+    connectionInfoStatus: {}
+  codeModules: {}
+  dynatraceApi: {}
+  kspm: {}
+  metadataEnrichment: {}
+  oneAgent:
+    connectionInfoStatus: {}

--- a/pkg/api/validation/dynakube/testdata/latest-default.yaml
+++ b/pkg/api/validation/dynakube/testdata/latest-default.yaml
@@ -58,7 +58,6 @@ spec:
   apiUrl: https://url/api
   customPullSecret: pull-secret
   dynatraceApiRequestThreshold: 42
-  enableIstio: true
   extensions:
     prometheus: {}
   logMonitoring:

--- a/pkg/api/validation/dynakube/testdata/v1beta3-default.yaml
+++ b/pkg/api/validation/dynakube/testdata/v1beta3-default.yaml
@@ -1,0 +1,271 @@
+apiVersion: dynatrace.com/v1beta3
+kind: DynaKube
+metadata:
+  name: dynakube
+  namespace: default
+  annotations:
+    feature.dynatrace.com/activegate-ignore-proxy: "true"
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
+  labels:
+    label: label-value
+spec:
+  apiUrl: https://url/api
+  tokens: token
+  customPullSecret: pull-secret
+  enableIstio: true
+  skipCertCheck: true
+  proxy:
+    value: proxy-value
+    valueFrom: proxy-from
+  trustedCAs: trusted-ca
+  networkZone: network-zone
+  dynatraceApiRequestThreshold: 42
+  metadataEnrichment:
+    enabled: false
+
+  activeGate:
+    dnsPolicy: ClusterFirstWithHostNet
+    annotations:
+      activegate-annotation-key: activegate-annotation-value
+    tlsSecretName: activegate-tls-secret-name
+    priorityClassName: activegate-priority-class-name
+    capabilities:
+      - dynatrace-api
+      - kubernetes-monitoring
+      - metrics-ingest
+    labels:
+      activegate-label-key: activegate-label-value
+    env:
+      - name: activegate-env-1
+        value: activegate-env-value-1
+        valueFrom:
+          configMapKeyRef:
+            key: activegate-env-from-1
+            name: activegate-env-configmap
+      - name: activegate-env-2
+        value: activegate-env-value-2
+        valueFrom:
+          configMapKeyRef:
+            key: activegate-env-from-2
+            name: activegate-env-configmap
+    nodeSelector:
+      activegate-node-selector-key: activegate-node-selector-value
+    image: activegate-image
+    replicas: 2
+    group: activegate-group
+    customProperties:
+      value: activegate-custom-property-value
+      valueFrom: activegate-custom-property-value-from
+    resources:
+      limits:
+        cpu: "3"
+      requests:
+        cpu: "3"
+    tolerations:
+      - key: activegate-toleration-key
+        operator: In
+        value: activegate-toleration-value
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+
+  oneAgent:
+    hostGroup: hostgroup-value
+    hostMonitoring:
+      version: 1.0.0.20240101-000000
+      image: host-inject-image
+      tolerations:
+        - key: host-inject-toleration-key
+          operator: In
+          value: host-inject-toleration-value
+      autoUpdate: false
+      dnsPolicy: ClusterFirstWithHostNet
+      annotations:
+        host-inject-annotation-key: host-inject-annotation-value
+      labels:
+        host-inject-label-key: host-inject-label-value
+      env:
+        - name: host-inject-env-1
+          value: host-inject-env-value-1
+          valueFrom:
+            configMapKeyRef:
+              name: host-inject-env-configmap
+              key: host-inject-env-from-1
+        - name: host-inject-env-2
+          value: host-inject-env-value-2
+          valueFrom:
+            configMapKeyRef:
+              name: host-inject-env-configmap
+              key: host-inject-env-from-2
+      nodeSelector:
+        host-inject-node-selector-key: host-inject-node-selector-value
+      priorityClassName: host-inject-priority-class
+      args:
+        - host-inject-arg-1
+        - host-inject-arg-2
+      oneAgentResources:
+        limits:
+          cpu: "1"
+      secCompProfile: seccomp
+
+  logMonitoring:
+    ingestRuleMatchers:
+      - attribute: attribute1
+        values:
+          - matcher1
+          - matcher2
+          - matcher3
+      - attribute: attribute2
+        values:
+          - matcher1
+          - matcher2
+          - matcher3
+      - attribute: attribute3
+        values:
+          - matcher1
+          - matcher2
+          - matcher3
+
+  extensions: {}
+
+  templates:
+    logMonitoring:
+      labels:
+        logagent-label-key1: logagent-label-value1
+        logagent-label-key2: logagent-label-value2
+      annotations:
+        logagent-annotation-key1: logagent-annotation-value1
+        logagent-annotation-key2: logagent-annotation-value2
+      nodeSelector:
+        selector1: node1
+        selector2: node2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      dnsPolicy: ClusterFirstWithHostNet
+      secCompProfile: seccomp
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      args:
+        - --log-level
+        - debug
+        - --log-format
+        - json
+
+    otelCollector:
+      labels:
+        otelc-label-key1: otelc-label-value1
+        otelc-label-key2: otelc-label-value2
+      annotations:
+        otelc-annotation-key1: otelc-annotation-value1
+        otelc-annotation-key2: otelc-annotation-value2
+      replicas: 2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      tlsRefName: tls-ref-name
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+
+    extensionExecutionController:
+      labels:
+        eec-label-key1: eec-label-value1
+        eec-label-key2: eec-label-value2
+      annotations:
+        eec-annotation-key1: eec-annotation-value1
+        eec-annotation-key2: eec-annotation-value2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      tlsRefName: tls-ref-name
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      customConfig: custom-eec-config
+      customExtensionCertificates: custom-eec-certificate
+      useEphemeralVolume: true
+
+    kspmNodeConfigurationCollector:
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 50%
+          maxSurge: 1
+      labels:
+        ncc-label-key1: ncc-label-value1
+        ncc-label-key2: ncc-label-value2
+      annotations:
+        ncc-annotation-key1: ncc-annotation-value1
+        ncc-annotation-key2: ncc-annotation-value2
+      nodeSelector:
+        selector1: node1
+        selector2: node2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      priorityClassName: priority-class-name
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node-selector-match-key
+                  operator: In
+                  values:
+                    - node-match-value1
+                    - node-match-value2
+              matchFields:
+                - key: node-selector-field-key
+                  operator: In
+                  values:
+                    - node-field-value1
+                    - node-field-value2
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      args:
+        - --log-level
+        - debug
+        - --log-format
+        - json
+      env:
+        - name: ENV1
+          value: VAL1
+        - name: ENV2
+          value: VAL2
+        - name: ENV3
+          value: VAL3

--- a/pkg/api/validation/dynakube/testdata/v1beta3-default.yaml
+++ b/pkg/api/validation/dynakube/testdata/v1beta3-default.yaml
@@ -12,7 +12,7 @@ spec:
   apiUrl: https://url/api
   tokens: token
   customPullSecret: pull-secret
-  enableIstio: true
+  # enableIstio: true  # needs istio CRD setup
   skipCertCheck: true
   proxy:
     value: proxy-value

--- a/pkg/api/validation/dynakube/testdata/v1beta4-default.yaml
+++ b/pkg/api/validation/dynakube/testdata/v1beta4-default.yaml
@@ -1,0 +1,271 @@
+apiVersion: dynatrace.com/v1beta4
+kind: DynaKube
+metadata:
+  name: dynakube
+  namespace: default
+  annotations:
+    feature.dynatrace.com/activegate-ignore-proxy: "true"
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
+  labels:
+    label: label-value
+spec:
+  apiUrl: https://url/api
+  tokens: token
+  customPullSecret: pull-secret
+  enableIstio: true
+  skipCertCheck: true
+  proxy:
+    value: proxy-value
+    valueFrom: proxy-from
+  trustedCAs: trusted-ca
+  networkZone: network-zone
+  dynatraceApiRequestThreshold: 42
+  metadataEnrichment:
+    enabled: false
+
+  activeGate:
+    dnsPolicy: ClusterFirstWithHostNet
+    annotations:
+      activegate-annotation-key: activegate-annotation-value
+    tlsSecretName: activegate-tls-secret-name
+    priorityClassName: activegate-priority-class-name
+    capabilities:
+      - dynatrace-api
+      - kubernetes-monitoring
+      - metrics-ingest
+    labels:
+      activegate-label-key: activegate-label-value
+    env:
+      - name: activegate-env-1
+        value: activegate-env-value-1
+        valueFrom:
+          configMapKeyRef:
+            key: activegate-env-from-1
+            name: activegate-env-configmap
+      - name: activegate-env-2
+        value: activegate-env-value-2
+        valueFrom:
+          configMapKeyRef:
+            key: activegate-env-from-2
+            name: activegate-env-configmap
+    nodeSelector:
+      activegate-node-selector-key: activegate-node-selector-value
+    image: activegate-image
+    replicas: 2
+    group: activegate-group
+    customProperties:
+      value: activegate-custom-property-value
+      valueFrom: activegate-custom-property-value-from
+    resources:
+      limits:
+        cpu: "3"
+      requests:
+        cpu: "3"
+    tolerations:
+      - key: activegate-toleration-key
+        operator: In
+        value: activegate-toleration-value
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+
+  oneAgent:
+    hostGroup: hostgroup-value
+    hostMonitoring:
+      version: 1.0.0.20240101-000000
+      image: host-inject-image
+      tolerations:
+        - key: host-inject-toleration-key
+          operator: In
+          value: host-inject-toleration-value
+      autoUpdate: false
+      dnsPolicy: ClusterFirstWithHostNet
+      annotations:
+        host-inject-annotation-key: host-inject-annotation-value
+      labels:
+        host-inject-label-key: host-inject-label-value
+      env:
+        - name: host-inject-env-1
+          value: host-inject-env-value-1
+          valueFrom:
+            configMapKeyRef:
+              name: host-inject-env-configmap
+              key: host-inject-env-from-1
+        - name: host-inject-env-2
+          value: host-inject-env-value-2
+          valueFrom:
+            configMapKeyRef:
+              name: host-inject-env-configmap
+              key: host-inject-env-from-2
+      nodeSelector:
+        host-inject-node-selector-key: host-inject-node-selector-value
+      priorityClassName: host-inject-priority-class
+      args:
+        - host-inject-arg-1
+        - host-inject-arg-2
+      oneAgentResources:
+        limits:
+          cpu: "1"
+      secCompProfile: seccomp
+
+  logMonitoring:
+    ingestRuleMatchers:
+      - attribute: attribute1
+        values:
+          - matcher1
+          - matcher2
+          - matcher3
+      - attribute: attribute2
+        values:
+          - matcher1
+          - matcher2
+          - matcher3
+      - attribute: attribute3
+        values:
+          - matcher1
+          - matcher2
+          - matcher3
+
+  extensions: {}
+
+  templates:
+    logMonitoring:
+      labels:
+        logagent-label-key1: logagent-label-value1
+        logagent-label-key2: logagent-label-value2
+      annotations:
+        logagent-annotation-key1: logagent-annotation-value1
+        logagent-annotation-key2: logagent-annotation-value2
+      nodeSelector:
+        selector1: node1
+        selector2: node2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      dnsPolicy: ClusterFirstWithHostNet
+      secCompProfile: seccomp
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      args:
+        - --log-level
+        - debug
+        - --log-format
+        - json
+
+    otelCollector:
+      labels:
+        otelc-label-key1: otelc-label-value1
+        otelc-label-key2: otelc-label-value2
+      annotations:
+        otelc-annotation-key1: otelc-annotation-value1
+        otelc-annotation-key2: otelc-annotation-value2
+      replicas: 2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      tlsRefName: tls-ref-name
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+
+    extensionExecutionController:
+      labels:
+        eec-label-key1: eec-label-value1
+        eec-label-key2: eec-label-value2
+      annotations:
+        eec-annotation-key1: eec-annotation-value1
+        eec-annotation-key2: eec-annotation-value2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      tlsRefName: tls-ref-name
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      customConfig: custom-eec-config
+      customExtensionCertificates: custom-eec-certificate
+      useEphemeralVolume: true
+
+    kspmNodeConfigurationCollector:
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 50%
+          maxSurge: 1
+      labels:
+        ncc-label-key1: ncc-label-value1
+        ncc-label-key2: ncc-label-value2
+      annotations:
+        ncc-annotation-key1: ncc-annotation-value1
+        ncc-annotation-key2: ncc-annotation-value2
+      nodeSelector:
+        selector1: node1
+        selector2: node2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      priorityClassName: priority-class-name
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node-selector-match-key
+                  operator: In
+                  values:
+                    - node-match-value1
+                    - node-match-value2
+              matchFields:
+                - key: node-selector-field-key
+                  operator: In
+                  values:
+                    - node-field-value1
+                    - node-field-value2
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      args:
+        - --log-level
+        - debug
+        - --log-format
+        - json
+      env:
+        - name: ENV1
+          value: VAL1
+        - name: ENV2
+          value: VAL2
+        - name: ENV3
+          value: VAL3

--- a/pkg/api/validation/dynakube/testdata/v1beta4-default.yaml
+++ b/pkg/api/validation/dynakube/testdata/v1beta4-default.yaml
@@ -12,7 +12,7 @@ spec:
   apiUrl: https://url/api
   tokens: token
   customPullSecret: pull-secret
-  enableIstio: true
+  # enableIstio: true  # needs istio CRD setup
   skipCertCheck: true
   proxy:
     value: proxy-value

--- a/pkg/api/validation/dynakube/testdata/v1beta5-default.yaml
+++ b/pkg/api/validation/dynakube/testdata/v1beta5-default.yaml
@@ -12,7 +12,7 @@ spec:
   apiUrl: https://url/api
   tokens: token
   customPullSecret: pull-secret
-  enableIstio: true
+  # enableIstio: true  # needs istio CRD setup
   skipCertCheck: true
   proxy:
     value: proxy-value

--- a/pkg/api/validation/dynakube/testdata/v1beta5-default.yaml
+++ b/pkg/api/validation/dynakube/testdata/v1beta5-default.yaml
@@ -1,0 +1,271 @@
+apiVersion: dynatrace.com/v1beta5
+kind: DynaKube
+metadata:
+  name: dynakube
+  namespace: default
+  annotations:
+    feature.dynatrace.com/activegate-ignore-proxy: "true"
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
+  labels:
+    label: label-value
+spec:
+  apiUrl: https://url/api
+  tokens: token
+  customPullSecret: pull-secret
+  enableIstio: true
+  skipCertCheck: true
+  proxy:
+    value: proxy-value
+    valueFrom: proxy-from
+  trustedCAs: trusted-ca
+  networkZone: network-zone
+  dynatraceApiRequestThreshold: 42
+  metadataEnrichment:
+    enabled: false
+
+  activeGate:
+    dnsPolicy: ClusterFirstWithHostNet
+    annotations:
+      activegate-annotation-key: activegate-annotation-value
+    tlsSecretName: activegate-tls-secret-name
+    priorityClassName: activegate-priority-class-name
+    capabilities:
+      - dynatrace-api
+      - kubernetes-monitoring
+      - metrics-ingest
+    labels:
+      activegate-label-key: activegate-label-value
+    env:
+      - name: activegate-env-1
+        value: activegate-env-value-1
+        valueFrom:
+          configMapKeyRef:
+            key: activegate-env-from-1
+            name: activegate-env-configmap
+      - name: activegate-env-2
+        value: activegate-env-value-2
+        valueFrom:
+          configMapKeyRef:
+            key: activegate-env-from-2
+            name: activegate-env-configmap
+    nodeSelector:
+      activegate-node-selector-key: activegate-node-selector-value
+    image: activegate-image
+    replicas: 2
+    group: activegate-group
+    customProperties:
+      value: activegate-custom-property-value
+      valueFrom: activegate-custom-property-value-from
+    resources:
+      limits:
+        cpu: "3"
+      requests:
+        cpu: "3"
+    tolerations:
+      - key: activegate-toleration-key
+        operator: In
+        value: activegate-toleration-value
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+
+  oneAgent:
+    hostGroup: hostgroup-value
+    hostMonitoring:
+      version: 1.0.0.20240101-000000
+      image: host-inject-image
+      tolerations:
+        - key: host-inject-toleration-key
+          operator: In
+          value: host-inject-toleration-value
+      autoUpdate: false
+      dnsPolicy: ClusterFirstWithHostNet
+      annotations:
+        host-inject-annotation-key: host-inject-annotation-value
+      labels:
+        host-inject-label-key: host-inject-label-value
+      env:
+        - name: host-inject-env-1
+          value: host-inject-env-value-1
+          valueFrom:
+            configMapKeyRef:
+              name: host-inject-env-configmap
+              key: host-inject-env-from-1
+        - name: host-inject-env-2
+          value: host-inject-env-value-2
+          valueFrom:
+            configMapKeyRef:
+              name: host-inject-env-configmap
+              key: host-inject-env-from-2
+      nodeSelector:
+        host-inject-node-selector-key: host-inject-node-selector-value
+      priorityClassName: host-inject-priority-class
+      args:
+        - host-inject-arg-1
+        - host-inject-arg-2
+      oneAgentResources:
+        limits:
+          cpu: "1"
+      secCompProfile: seccomp
+
+  logMonitoring:
+    ingestRuleMatchers:
+      - attribute: attribute1
+        values:
+          - matcher1
+          - matcher2
+          - matcher3
+      - attribute: attribute2
+        values:
+          - matcher1
+          - matcher2
+          - matcher3
+      - attribute: attribute3
+        values:
+          - matcher1
+          - matcher2
+          - matcher3
+
+  extensions: {}
+
+  templates:
+    logMonitoring:
+      labels:
+        logagent-label-key1: logagent-label-value1
+        logagent-label-key2: logagent-label-value2
+      annotations:
+        logagent-annotation-key1: logagent-annotation-value1
+        logagent-annotation-key2: logagent-annotation-value2
+      nodeSelector:
+        selector1: node1
+        selector2: node2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      dnsPolicy: ClusterFirstWithHostNet
+      secCompProfile: seccomp
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      args:
+        - --log-level
+        - debug
+        - --log-format
+        - json
+
+    otelCollector:
+      labels:
+        otelc-label-key1: otelc-label-value1
+        otelc-label-key2: otelc-label-value2
+      annotations:
+        otelc-annotation-key1: otelc-annotation-value1
+        otelc-annotation-key2: otelc-annotation-value2
+      replicas: 2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      tlsRefName: tls-ref-name
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+
+    extensionExecutionController:
+      labels:
+        eec-label-key1: eec-label-value1
+        eec-label-key2: eec-label-value2
+      annotations:
+        eec-annotation-key1: eec-annotation-value1
+        eec-annotation-key2: eec-annotation-value2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      tlsRefName: tls-ref-name
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      customConfig: custom-eec-config
+      customExtensionCertificates: custom-eec-certificate
+      useEphemeralVolume: true
+
+    kspmNodeConfigurationCollector:
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 50%
+          maxSurge: 1
+      labels:
+        ncc-label-key1: ncc-label-value1
+        ncc-label-key2: ncc-label-value2
+      annotations:
+        ncc-annotation-key1: ncc-annotation-value1
+        ncc-annotation-key2: ncc-annotation-value2
+      nodeSelector:
+        selector1: node1
+        selector2: node2
+      imageRef:
+        repository: image.repo
+        tag: 1.2.3
+      priorityClassName: priority-class-name
+      resources:
+        limits:
+          cpu: "3"
+        requests:
+          cpu: "3"
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node-selector-match-key
+                  operator: In
+                  values:
+                    - node-match-value1
+                    - node-match-value2
+              matchFields:
+                - key: node-selector-field-key
+                  operator: In
+                  values:
+                    - node-field-value1
+                    - node-field-value2
+      tolerations:
+        - key: otelc-toleration-key
+          operator: In
+          value: otelc-toleration-value
+      args:
+        - --log-level
+        - debug
+        - --log-format
+        - json
+      env:
+        - name: ENV1
+          value: VAL1
+        - name: ENV2
+          value: VAL2
+        - name: ENV3
+          value: VAL3

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	v1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
@@ -161,28 +162,25 @@ func (v *Validator) runUpdateValidators(ctx context.Context, updateValidators []
 	return results
 }
 
-func getDynakube(obj runtime.Object) (*dynakube.DynaKube, error) {
-	dk := &dynakube.DynaKube{}
+func getDynakube(obj runtime.Object) (dk *dynakube.DynaKube, err error) {
+	dk = &dynakube.DynaKube{}
 
 	switch v := obj.(type) {
 	case *dynakube.DynaKube:
 		dk = v
 	case *v1beta5.DynaKube:
-		err := v.ConvertTo(dk)
-		if err != nil {
-			return dk, err
-		}
+		err = v.ConvertTo(dk)
 	case *v1beta4.DynaKube:
-		err := v.ConvertTo(dk)
-		if err != nil {
-			return dk, err
-		}
+		err = v.ConvertTo(dk)
 	case *v1beta3.DynaKube:
-		err := v.ConvertTo(dk)
-		if err != nil {
-			return dk, err
+		err = v.ConvertTo(dk)
+	default:
+		if gvk := obj.GetObjectKind().GroupVersionKind(); !gvk.Empty() {
+			return nil, fmt.Errorf("unknown object %s", gvk)
 		}
+
+		return nil, fmt.Errorf("unknown object %T", obj)
 	}
 
-	return dk, nil
+	return
 }

--- a/pkg/api/validation/dynakube/webhook.go
+++ b/pkg/api/validation/dynakube/webhook.go
@@ -1,0 +1,27 @@
+package validation
+
+import (
+	latest "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	v1beta3 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta3/dynakube"
+	v1beta4 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
+	v1beta5 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta5/dynakube"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	validator := New(mgr.GetAPIReader(), mgr.GetConfig())
+
+	if err := v1beta3.SetupWebhookWithManager(mgr, validator); err != nil {
+		return err
+	}
+
+	if err := v1beta4.SetupWebhookWithManager(mgr, validator); err != nil {
+		return err
+	}
+
+	if err := v1beta5.SetupWebhookWithManager(mgr, validator); err != nil {
+		return err
+	}
+
+	return latest.SetupWebhookWithManager(mgr, validator)
+}

--- a/pkg/api/validation/dynakube/webhook_integration_test.go
+++ b/pkg/api/validation/dynakube/webhook_integration_test.go
@@ -1,0 +1,84 @@
+package validation_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	validation "github.com/Dynatrace/dynatrace-operator/pkg/api/validation/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/integrationtests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/yaml"
+)
+
+func TestWebhook(t *testing.T) {
+	clt := integrationtests.SetupWebhookTestEnvironment(t,
+		envtest.WebhookInstallOptions{},
+		validation.SetupWebhookWithManager,
+	)
+
+	versions := []string{
+		"v1beta3",
+		"v1beta4",
+		"v1beta5",
+	}
+	seenGVKs := sets.New[string]()
+
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			compareWebhookResult(t, clt, version, "default", seenGVKs)
+		})
+	}
+}
+
+func compareWebhookResult(t *testing.T, clt client.Client, version, name string, seen sets.Set[string]) {
+	t.Helper()
+	oldData, err := os.ReadFile(filepath.Join("testdata", version+"-"+name+".yaml"))
+	require.NoError(t, err)
+
+	// Use unstructured to
+	// a) not duplicate conversion code and
+	// b) simulate external tools like kubectl
+	oldObj := &unstructured.Unstructured{}
+	require.NoError(t, yaml.Unmarshal(oldData, &oldObj.Object))
+
+	require.NoError(t, clt.Create(t.Context(), oldObj))
+	t.Cleanup(func() {
+		// t.Context is no longer valid during cleanup
+		assert.NoError(t, clt.Delete(context.Background(), oldObj))
+	})
+
+	expectData, err := os.ReadFile(filepath.Join("testdata", "latest-"+name+".yaml"))
+	require.NoError(t, err)
+
+	expectObj := &unstructured.Unstructured{}
+	require.NoError(t, yaml.Unmarshal(expectData, &expectObj.Object))
+
+	// Sanity checks to reduce chances of human error
+	require.NotEqual(t, expectObj.GroupVersionKind(), oldObj.GroupVersionKind())
+	require.NotContains(t, seen, oldObj.GroupVersionKind().String(), "duplicate entry")
+	seen.Insert(oldObj.GroupVersionKind().String())
+
+	gotObj := &unstructured.Unstructured{}
+	gotObj.SetGroupVersionKind(expectObj.GroupVersionKind())
+
+	require.NoError(t, clt.Get(t.Context(), client.ObjectKeyFromObject(oldObj), gotObj))
+	// Clear server-side fields for comparison
+	gotObj.SetCreationTimestamp(metav1.Time{})
+	gotObj.SetGeneration(0)
+	gotObj.SetResourceVersion("")
+	gotObj.SetUID("")
+	gotObj.SetManagedFields(nil)
+
+	gotData, err := yaml.Marshal(gotObj)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expectData), string(gotData))
+}

--- a/pkg/api/validation/dynakube/webhook_integration_test.go
+++ b/pkg/api/validation/dynakube/webhook_integration_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/integrationtests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/yaml"
@@ -20,7 +22,118 @@ import (
 
 func TestWebhook(t *testing.T) {
 	clt := integrationtests.SetupWebhookTestEnvironment(t,
-		envtest.WebhookInstallOptions{},
+		envtest.WebhookInstallOptions{
+			// TODO(avorima): Load this from a file using Paths
+			ValidatingWebhooks: []*admissionv1.ValidatingWebhookConfiguration{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dynatrace-webhook",
+					},
+					Webhooks: []admissionv1.ValidatingWebhook{
+						{
+							Name: "v1beta3.dynakube.webhook.dynatrace.com",
+							ClientConfig: admissionv1.WebhookClientConfig{
+								Service: &admissionv1.ServiceReference{
+									Path: ptr.To("/validate-dynatrace-com-v1beta3-dynakube"),
+								},
+							},
+							Rules: []admissionv1.RuleWithOperations{
+								{
+									Operations: []admissionv1.OperationType{
+										admissionv1.Create,
+										admissionv1.Update,
+									},
+									Rule: admissionv1.Rule{
+										APIGroups:   []string{"dynatrace.com"},
+										APIVersions: []string{"v1beta3"},
+										Resources:   []string{"dynakubes"},
+									},
+								},
+							},
+							MatchPolicy:             ptr.To(admissionv1.Exact),
+							SideEffects:             ptr.To(admissionv1.SideEffectClassNone),
+							TimeoutSeconds:          ptr.To[int32](10),
+							AdmissionReviewVersions: []string{"v1"},
+						},
+						{
+							Name: "v1beta4.dynakube.webhook.dynatrace.com",
+							ClientConfig: admissionv1.WebhookClientConfig{
+								Service: &admissionv1.ServiceReference{
+									Path: ptr.To("/validate-dynatrace-com-v1beta4-dynakube"),
+								},
+							},
+							Rules: []admissionv1.RuleWithOperations{
+								{
+									Operations: []admissionv1.OperationType{
+										admissionv1.Create,
+										admissionv1.Update,
+									},
+									Rule: admissionv1.Rule{
+										APIGroups:   []string{"dynatrace.com"},
+										APIVersions: []string{"v1beta4"},
+										Resources:   []string{"dynakubes"},
+									},
+								},
+							},
+							MatchPolicy:             ptr.To(admissionv1.Exact),
+							SideEffects:             ptr.To(admissionv1.SideEffectClassNone),
+							TimeoutSeconds:          ptr.To[int32](10),
+							AdmissionReviewVersions: []string{"v1"},
+						},
+						{
+							Name: "v1beta5.dynakube.webhook.dynatrace.com",
+							ClientConfig: admissionv1.WebhookClientConfig{
+								Service: &admissionv1.ServiceReference{
+									Path: ptr.To("/validate-dynatrace-com-v1beta5-dynakube"),
+								},
+							},
+							Rules: []admissionv1.RuleWithOperations{
+								{
+									Operations: []admissionv1.OperationType{
+										admissionv1.Create,
+										admissionv1.Update,
+									},
+									Rule: admissionv1.Rule{
+										APIGroups:   []string{"dynatrace.com"},
+										APIVersions: []string{"v1beta5"},
+										Resources:   []string{"dynakubes"},
+									},
+								},
+							},
+							MatchPolicy:             ptr.To(admissionv1.Exact),
+							SideEffects:             ptr.To(admissionv1.SideEffectClassNone),
+							TimeoutSeconds:          ptr.To[int32](10),
+							AdmissionReviewVersions: []string{"v1"},
+						},
+						{
+							Name: "v1beta6.dynakube.webhook.dynatrace.com",
+							ClientConfig: admissionv1.WebhookClientConfig{
+								Service: &admissionv1.ServiceReference{
+									Path: ptr.To("/validate-dynatrace-com-v1beta6-dynakube"),
+								},
+							},
+							Rules: []admissionv1.RuleWithOperations{
+								{
+									Operations: []admissionv1.OperationType{
+										admissionv1.Create,
+										admissionv1.Update,
+									},
+									Rule: admissionv1.Rule{
+										APIGroups:   []string{"dynatrace.com"},
+										APIVersions: []string{"v1beta6"},
+										Resources:   []string{"dynakubes"},
+									},
+								},
+							},
+							MatchPolicy:             ptr.To(admissionv1.Exact),
+							SideEffects:             ptr.To(admissionv1.SideEffectClassNone),
+							TimeoutSeconds:          ptr.To[int32](10),
+							AdmissionReviewVersions: []string{"v1"},
+						},
+					},
+				},
+			},
+		},
 		validation.SetupWebhookWithManager,
 	)
 

--- a/pkg/api/validation/edgeconnect/testdata/latest-default.yaml
+++ b/pkg/api/validation/edgeconnect/testdata/latest-default.yaml
@@ -1,0 +1,60 @@
+apiVersion: dynatrace.com/v1alpha2
+kind: EdgeConnect
+metadata:
+  annotations:
+    edgeconnect-annotation-key: edgeconnect-annotation-value
+  labels:
+    edgeconnect-label-key: edgeconnect-label-value
+  name: edgeconnect
+  namespace: default
+spec:
+  annotations:
+    edgeconnect-annotation-key: edgeconnect-annotation-value
+  apiServer: foo.dev.apps.dynatracelabs.com
+  autoUpdate: true
+  caCertsRef: ca-certs
+  customPullSecret: custom-pull-secret
+  env:
+  - name: ENV1
+    value: VALUE1
+  hostPatterns:
+  - foo.bar.baz
+  hostRestrictions:
+  - foo
+  - bar
+  imageRef:
+    repository: image.repo
+    tag: 1.2.3
+  kubernetesAutomation:
+    enabled: true
+  labels:
+    edgeconnect-label-key: edgeconnect-label-value
+  nodeSelector:
+    kubernetes.io/os: linux
+  oauth:
+    clientSecret: secret
+    endpoint: https://url
+    provisioner: true
+    resource: resource
+  proxy:
+    authRef: baz
+    host: foo
+    noProxy: bar
+    port: 12345
+  replicas: 1
+  resources:
+    limits:
+      cpu: "2"
+    requests:
+      cpu: "1"
+  serviceAccountName: default
+  tolerations:
+  - key: edgeconnect-toleration-key
+    operator: In
+    value: edgeconnect-toleration-value
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+status:
+  version: {}

--- a/pkg/api/validation/edgeconnect/testdata/v1alpha1-default.yaml
+++ b/pkg/api/validation/edgeconnect/testdata/v1alpha1-default.yaml
@@ -1,0 +1,56 @@
+apiVersion: dynatrace.com/v1alpha1
+kind: EdgeConnect
+metadata:
+  name: edgeconnect
+  namespace: default
+  labels:
+    edgeconnect-label-key: edgeconnect-label-value
+  annotations:
+    edgeconnect-annotation-key: edgeconnect-annotation-value
+spec:
+  labels:
+    edgeconnect-label-key: edgeconnect-label-value
+  annotations:
+    edgeconnect-annotation-key: edgeconnect-annotation-value
+  replicas: 1
+  nodeSelector:
+    kubernetes.io/os: linux
+  kubernetesAutomation:
+    enabled: true
+  proxy:
+    host: foo
+    noProxy: bar
+    authRef: baz
+    port: 12345
+  imageRef:
+    repository: image.repo
+    tag: 1.2.3
+  apiServer: foo.dev.apps.dynatracelabs.com
+  hostRestrictions: foo,bar
+  customPullSecret: custom-pull-secret
+  caCertsRef: ca-certs
+  serviceAccountName: default
+  oauth:
+    clientSecret: secret
+    endpoint: https://url
+    resource: resource
+    provisioner: true
+  resources:
+    limits:
+      cpu: "2"
+    requests:
+      cpu: "1"
+  env:
+    - name: ENV1
+      value: VALUE1
+  tolerations:
+    - key: edgeconnect-toleration-key
+      operator: In
+      value: edgeconnect-toleration-value
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+  hostPatterns:
+    - foo.bar.baz
+  autoUpdate: true

--- a/pkg/api/validation/edgeconnect/validation.go
+++ b/pkg/api/validation/edgeconnect/validation.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"context"
+	"fmt"
 
 	v1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
@@ -94,9 +95,12 @@ func getEdgeConnect(obj runtime.Object) (ec *edgeconnect.EdgeConnect, err error)
 		ec = v
 	case *v1alpha1.EdgeConnect:
 		err = v.ConvertTo(ec)
-		if err != nil {
-			return
+	default:
+		if gvk := obj.GetObjectKind().GroupVersionKind(); !gvk.Empty() {
+			return nil, fmt.Errorf("unknown object %s", gvk)
 		}
+
+		return nil, fmt.Errorf("unknown object %T", obj)
 	}
 
 	return

--- a/pkg/api/validation/edgeconnect/webhook.go
+++ b/pkg/api/validation/edgeconnect/webhook.go
@@ -1,0 +1,17 @@
+package validation
+
+import (
+	v1alpha1 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/edgeconnect"
+	v1alpha2 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	validator := New(mgr.GetAPIReader(), mgr.GetConfig())
+
+	if err := v1alpha1.SetupWebhookWithManager(mgr, validator); err != nil {
+		return err
+	}
+
+	return v1alpha2.SetupWebhookWithManager(mgr, validator)
+}

--- a/pkg/api/validation/edgeconnect/webhook_integration_test.go
+++ b/pkg/api/validation/edgeconnect/webhook_integration_test.go
@@ -1,0 +1,82 @@
+package validation_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	validation "github.com/Dynatrace/dynatrace-operator/pkg/api/validation/edgeconnect"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/integrationtests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/yaml"
+)
+
+func TestWebhook(t *testing.T) {
+	clt := integrationtests.SetupWebhookTestEnvironment(t,
+		envtest.WebhookInstallOptions{},
+		validation.SetupWebhookWithManager,
+	)
+
+	versions := []string{
+		"v1alpha1",
+	}
+	seenGVKs := sets.New[string]()
+
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			compareWebhookResult(t, clt, version, "default", seenGVKs)
+		})
+	}
+}
+
+func compareWebhookResult(t *testing.T, clt client.Client, version, name string, seen sets.Set[string]) {
+	t.Helper()
+	oldData, err := os.ReadFile(filepath.Join("testdata", version+"-"+name+".yaml"))
+	require.NoError(t, err)
+
+	// Use unstructured to
+	// a) not duplicate conversion code and
+	// b) simulate external tools like kubectl
+	oldObj := &unstructured.Unstructured{}
+	require.NoError(t, yaml.Unmarshal(oldData, &oldObj.Object))
+
+	require.NoError(t, clt.Create(t.Context(), oldObj))
+	t.Cleanup(func() {
+		// t.Context is no longer valid during cleanup
+		assert.NoError(t, clt.Delete(context.Background(), oldObj))
+	})
+
+	expectData, err := os.ReadFile(filepath.Join("testdata", "latest-"+name+".yaml"))
+	require.NoError(t, err)
+
+	expectObj := &unstructured.Unstructured{}
+	require.NoError(t, yaml.Unmarshal(expectData, &expectObj.Object))
+
+	// Sanity checks to reduce chances of human error
+	require.NotEqual(t, expectObj.GroupVersionKind(), oldObj.GroupVersionKind())
+	require.NotContains(t, seen, oldObj.GroupVersionKind().String(), "duplicate entry")
+	seen.Insert(oldObj.GroupVersionKind().String())
+
+	gotObj := &unstructured.Unstructured{}
+	gotObj.SetGroupVersionKind(expectObj.GroupVersionKind())
+
+	require.NoError(t, clt.Get(t.Context(), client.ObjectKeyFromObject(oldObj), gotObj))
+	// Clear server-side fields for comparison
+	gotObj.SetCreationTimestamp(metav1.Time{})
+	gotObj.SetGeneration(0)
+	gotObj.SetResourceVersion("")
+	gotObj.SetUID("")
+	gotObj.SetManagedFields(nil)
+
+	gotData, err := yaml.Marshal(gotObj)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expectData), string(gotData))
+}

--- a/pkg/util/integrationtests/environment.go
+++ b/pkg/util/integrationtests/environment.go
@@ -24,6 +24,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -79,7 +80,6 @@ func SetupWebhookTestEnvironment(t *testing.T, webhookOptions envtest.WebhookIns
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
-		Logger: logd.Get().WithName("manager").Logger,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Host:    webhookInstallOptions.LocalServingHost,
 			Port:    webhookInstallOptions.LocalServingPort,
@@ -150,6 +150,8 @@ func setupBaseTestEnv(t *testing.T) {
 	if err := addScheme(testEnv); err != nil {
 		t.Fatal(err)
 	}
+
+	logf.SetLogger(logd.Get().Logger)
 }
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.


### PR DESCRIPTION
## Description

Implement basic webhook integration tests for EdgeConnect and DynaKube conversion.
The tests are meant to be similar to how a user would interact with these resources, e.g. with kubectl. They load files from disk, apply the using the envtest client and then compare the result.
Only resource create happy path is covered, but the code can easily be extended as needed.

In order to ensure that the integration tests use the same setup as the live binary I moved the webhook setup functions into the respective validation packages. The test code is basically duplicated apart from the webhook code and could be moved to a separate package (together with the webhook setup) at a later point.

Add default cases to conversion type switches as a fly-by.

[Jira](https://dt-rnd.atlassian.net/browse/DAQ-13997)

## How can this be tested?

Run go tests:

```
make go/test
```
