### PR TITLE
WIP: Create secret containing DataIngest token for OTLP exporter configuration

### DIFF
--- a/pkg/consts/otlp.go
+++ b/pkg/consts/otlp.go
@@ -1,0 +1,5 @@
+package consts
+
+const (
+	OTLPExporterSecretName = "dynatrace-otlp-exporter-config"
+)

--- a/pkg/controllers/dynakube/otlp/conditions.go
+++ b/pkg/controllers/dynakube/otlp/conditions.go
@@ -1,0 +1,5 @@
+package otlp
+
+const (
+	otlpExporterConfigurationConditionType = "OTLPExporterConfiguration"
+)

--- a/pkg/controllers/dynakube/otlp/config.go
+++ b/pkg/controllers/dynakube/otlp/config.go
@@ -1,0 +1,9 @@
+package otlp
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+)
+
+var (
+	log = logd.Get().WithName("dynakube-otlp")
+)

--- a/pkg/controllers/dynakube/otlp/reconciler.go
+++ b/pkg/controllers/dynakube/otlp/reconciler.go
@@ -1,0 +1,99 @@
+package otlp
+
+import (
+	"context"
+	goerrors "errors"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
+	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/mapper"
+	"github.com/Dynatrace/dynatrace-operator/pkg/otlp/exporterconfig"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Reconciler struct {
+	client          client.Client
+	apiReader       client.Reader
+	dynatraceClient dynatrace.Client
+	dk              *dynakube.DynaKube
+}
+
+type ReconcilerBuilder func(
+	client client.Client,
+	apiReader client.Reader,
+	dynatraceClient dynatrace.Client,
+	dk *dynakube.DynaKube,
+) controllers.Reconciler
+
+//nolint:revive
+func NewReconciler(
+	client client.Client,
+	apiReader client.Reader,
+	dynatraceClient dynatrace.Client,
+	dk *dynakube.DynaKube,
+) controllers.Reconciler {
+	return &Reconciler{
+		client:          client,
+		apiReader:       apiReader,
+		dynatraceClient: dynatraceClient,
+		dk:              dk,
+	}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context) error {
+	var setupErrors []error
+
+	if r.dk.Spec.OTLPExporterConfiguration == nil {
+		defer r.cleanup(ctx)
+	} else {
+		dkMapper := r.createDynakubeMapper(ctx)
+		if err := dkMapper.MapFromDynakube(); err != nil {
+			log.Info("update of a map of namespaces failed")
+
+			setupErrors = append(setupErrors, err)
+		}
+
+		err := r.generateSecret(ctx)
+		if err != nil {
+			setupErrors = append(setupErrors, err)
+		}
+	}
+
+	if len(setupErrors) > 0 {
+		return goerrors.Join(setupErrors...)
+	}
+
+	log.Info("OTLP exporter configuration reconciled")
+
+	return nil
+}
+
+func (r *Reconciler) cleanup(ctx context.Context) {
+	namespaces, err := mapper.GetNamespacesForDynakube(ctx, r.apiReader, r.dk.Name)
+	if err != nil {
+		log.Error(err, "failed to list namespaces for dynakube", "dkName", r.dk.Name)
+	}
+
+	err = exporterconfig.Cleanup(ctx, r.client, r.apiReader, namespaces, r.dk)
+}
+
+func (r *Reconciler) createDynakubeMapper(ctx context.Context) *mapper.DynakubeMapper {
+	operatorNamespace := r.dk.GetNamespace()
+	dkMapper := mapper.NewDynakubeMapper(ctx, r.client, r.apiReader, operatorNamespace, r.dk)
+
+	return &dkMapper
+}
+
+func (r *Reconciler) generateSecret(ctx context.Context) error {
+	err := exporterconfig.NewSecretGenerator(r.client, r.apiReader, r.dynatraceClient).GenerateForDynakube(ctx, r.dk)
+	if err != nil {
+		if conditions.IsKubeAPIError(err) {
+			conditions.SetKubeAPIError(r.dk.Conditions(), otlpExporterConfigurationConditionType, err)
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controllers/dynakube/otlp/reconciler_test.go
+++ b/pkg/controllers/dynakube/otlp/reconciler_test.go
@@ -1,0 +1,120 @@
+package otlp
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlpexporterconfiguration"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+const (
+	testDataIngestToken = "test-ingest-token"
+
+	testDynakube   = "test-dynakube"
+	testDynakube2  = "test-dynakube2"
+	testNamespace  = "test-namespace"
+	testNamespace2 = "test-namespace2"
+
+	testNamespaceSelectorLabel = "namespaceSelector"
+
+	testNamespaceDynatrace = "dynatrace"
+)
+
+func TestReconciler_Reconcile(t *testing.T) {
+	t.Run("reconcile OTLP exporter configuration", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testDynakube,
+				Namespace: testNamespaceDynatrace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				OTLPExporterConfiguration: &otlpexporterconfiguration.Spec{},
+			},
+		}
+
+		clt := fake.NewClientWithIndex(
+			clientInjectedNamespace(testNamespace, testDynakube),
+			clientNotInjectedNamespace(testNamespace2, testDynakube2),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
+				dtclient.DataIngestToken: []byte(testDataIngestToken),
+			}),
+			dk,
+		)
+		dtClient := dtclientmock.NewClient(t)
+
+		rec := NewReconciler(clt, clt, dtClient, dk)
+
+		err := rec.Reconcile(t.Context())
+		require.NoError(t, err)
+
+		assertSecretFound(t, clt, consts.OTLPExporterSecretName, testNamespace)
+		assertSecretNotFound(t, clt, consts.OTLPExporterSecretName, testNamespace2)
+	})
+}
+
+func assertSecretFound(t *testing.T, clt client.Client, secretName string, secretNamespace string) {
+	var secret corev1.Secret
+	err := clt.Get(t.Context(), client.ObjectKey{Name: secretName, Namespace: secretNamespace}, &secret)
+	require.NoError(t, err, "%s.%s secret not found, error: %s", secretName, secretNamespace, err)
+}
+
+func assertSecretNotFound(t *testing.T, clt client.Client, secretName string, secretNamespace string) {
+	var secret corev1.Secret
+	err := clt.Get(t.Context(), client.ObjectKey{Name: secretName, Namespace: secretNamespace}, &secret)
+	require.Error(t, err, "%s.%s secret found, error: %s ", secretName, secretNamespace, err)
+	assert.True(t, k8serrors.IsNotFound(err), "%s.%s secret, unexpected error: %s", secretName, secretNamespace, err)
+}
+
+func clientInjectedNamespace(namespaceName string, dynakubeName string) *corev1.Namespace {
+	return &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "corev1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespaceName,
+			Labels: map[string]string{
+				dtwebhook.InjectionInstanceLabel: dynakubeName,
+			},
+		},
+	}
+}
+
+func clientNotInjectedNamespace(namespaceName string, dynakubeName string) *corev1.Namespace {
+	return &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "corev1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespaceName,
+			Labels: map[string]string{
+				testNamespaceSelectorLabel: dynakubeName,
+			},
+		},
+	}
+}
+
+func clientSecret(secretName string, namespaceName string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "core/v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespaceName,
+		},
+		Data: data,
+	}
+}

--- a/pkg/otlp/exporterconfig/conditions.go
+++ b/pkg/otlp/exporterconfig/conditions.go
@@ -1,0 +1,3 @@
+package exporterconfig
+
+const ConfigConditionType = "OTLPExporterConfig"

--- a/pkg/otlp/exporterconfig/config.go
+++ b/pkg/otlp/exporterconfig/config.go
@@ -3,5 +3,5 @@ package exporterconfig
 import "github.com/Dynatrace/dynatrace-operator/pkg/logd"
 
 var (
-	log = logd.Get().WithName("bootstrapper-config")
+	log = logd.Get().WithName("otlp-exporter-configuration")
 )

--- a/pkg/otlp/exporterconfig/config.go
+++ b/pkg/otlp/exporterconfig/config.go
@@ -1,0 +1,7 @@
+package exporterconfig
+
+import "github.com/Dynatrace/dynatrace-operator/pkg/logd"
+
+var (
+	log = logd.Get().WithName("bootstrapper-config")
+)

--- a/pkg/otlp/exporterconfig/replicate.go
+++ b/pkg/otlp/exporterconfig/replicate.go
@@ -1,0 +1,11 @@
+package exporterconfig
+
+import "fmt"
+
+const (
+	sourceSecretTemplate = "%s-otlp-exporter-config"
+)
+
+func GetSourceConfigSecretName(dkName string) string {
+	return fmt.Sprintf(sourceSecretTemplate, dkName)
+}

--- a/pkg/otlp/exporterconfig/secret_generator.go
+++ b/pkg/otlp/exporterconfig/secret_generator.go
@@ -1,0 +1,136 @@
+package exporterconfig
+
+import (
+	"context"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/mapper"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/conditions"
+	k8slabels "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/labels"
+	k8ssecret "github.com/Dynatrace/dynatrace-operator/pkg/util/kubeobjects/secret"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SecretGenerator manages the OTLP exporter secret secret generation for the user namespaces.
+type SecretGenerator struct {
+	client       client.Client
+	dtClient     dtclient.Client
+	apiReader    client.Reader
+	timeProvider *timeprovider.Provider
+	secrets      k8ssecret.QueryObject
+}
+
+func NewSecretGenerator(client client.Client, apiReader client.Reader, dtClient dtclient.Client) *SecretGenerator {
+	return &SecretGenerator{
+		client:       client,
+		dtClient:     dtClient,
+		apiReader:    apiReader,
+		timeProvider: timeprovider.New(),
+		secrets:      k8ssecret.Query(client, apiReader, log),
+	}
+}
+
+// GenerateForDynakube creates/updates the init secret for EVERY namespace for the given dynakube.
+// Used by the dynakube controller during reconcile.
+func (s *SecretGenerator) GenerateForDynakube(ctx context.Context, dk *dynakube.DynaKube) error {
+	log.Info("reconciling namespace bootstrapper init secret for", "dynakube", dk.Name)
+
+	data, err := s.generateConfig(ctx, dk)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	nsList, err := mapper.GetNamespacesForDynakube(ctx, s.apiReader, dk.Name)
+	if err != nil {
+		conditions.SetKubeAPIError(dk.Conditions(), ConfigConditionType, err)
+
+		return errors.WithStack(err)
+	}
+
+	if len(data) != 0 {
+		err = s.createSourceForWebhook(ctx, dk, GetSourceConfigSecretName(dk.Name), ConfigConditionType, data)
+		if err != nil {
+			return err
+		}
+
+		err = s.createSecretForNSlist(ctx, consts.OTLPExporterSecretName, ConfigConditionType, nsList, dk, data)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
+func (s *SecretGenerator) generateConfig(ctx context.Context, dk *dynakube.DynaKube) (map[string][]byte, error) {
+	data := map[string][]byte{}
+
+	if dk.Spec.OTLPExporterConfiguration == nil {
+		return data, nil
+	}
+
+	var tokens corev1.Secret
+	if err := s.client.Get(ctx, client.ObjectKey{Name: dk.Tokens(), Namespace: dk.Namespace}, &tokens); err != nil {
+		conditions.SetKubeAPIError(dk.Conditions(), ConfigConditionType, err)
+
+		return nil, errors.WithMessage(err, "failed to query tokens")
+	}
+
+	data["apiToken"] = tokens.Data[dtclient.APIToken]
+
+	return data, nil
+}
+
+func (s *SecretGenerator) createSecretForNSlist( //nolint:revive // argument-limit
+	ctx context.Context,
+	secretName string,
+	conditionType string,
+	nsList []corev1.Namespace,
+	dk *dynakube.DynaKube,
+	data map[string][]byte,
+) error {
+	coreLabels := k8slabels.NewCoreLabels(dk.Name, k8slabels.WebhookComponentLabel)
+
+	secret, err := k8ssecret.BuildForNamespace(secretName, "", data, k8ssecret.SetLabels(coreLabels.BuildLabels()))
+	if err != nil {
+		conditions.SetSecretGenFailed(dk.Conditions(), conditionType, err)
+
+		return err
+	}
+
+	err = s.secrets.CreateOrUpdateForNamespaces(ctx, secret, nsList)
+	if err != nil {
+		conditions.SetKubeAPIError(dk.Conditions(), conditionType, err)
+
+		return err
+	}
+
+	log.Info("done updating OTLP exporter secrets")
+	conditions.SetSecretCreatedOrUpdated(dk.Conditions(), conditionType, consts.OTLPExporterSecretName)
+
+	return nil
+}
+
+func (s *SecretGenerator) createSourceForWebhook(ctx context.Context, dk *dynakube.DynaKube, secretName, conditionType string, data map[string][]byte) error {
+	coreLabels := k8slabels.NewCoreLabels(dk.Name, k8slabels.WebhookComponentLabel)
+
+	secret, err := k8ssecret.BuildForNamespace(secretName, dk.Namespace, data, k8ssecret.SetLabels(coreLabels.BuildLabels()))
+	if err != nil {
+		conditions.SetSecretGenFailed(dk.Conditions(), conditionType, err)
+
+		return err
+	}
+
+	_, err = s.secrets.WithOwner(dk).CreateOrUpdate(ctx, secret)
+	if err != nil {
+		conditions.SetKubeAPIError(dk.Conditions(), conditionType, err)
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/otlp/exporterconfig/secret_generator_test.go
+++ b/pkg/otlp/exporterconfig/secret_generator_test.go
@@ -1,0 +1,293 @@
+package exporterconfig
+
+import (
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlpexporterconfiguration"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
+	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+const (
+	testDataIngestToken = "test-ingest-token"
+	oldDataIngestToken  = "old-data-ingest-token"
+
+	testDynakube   = "test-dynakube"
+	testNamespace  = "test-namespace"
+	testNamespace2 = "test-namespace2"
+
+	testNamespaceDynatrace = "dynatrace"
+)
+
+func TestNewSecretGenerator(t *testing.T) {
+	client := fake.NewClient()
+	mockDTClient := dtclientmock.NewClient(t)
+
+	secretGenerator := NewSecretGenerator(client, client, mockDTClient)
+	assert.NotNil(t, secretGenerator)
+
+	assert.Equal(t, client, secretGenerator.client)
+	assert.Equal(t, client, secretGenerator.apiReader)
+	assert.Equal(t, mockDTClient, secretGenerator.dtClient)
+}
+
+func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
+	t.Run("no OTLP exporter config enabled - do not create secret", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      testDynakube,
+				Namespace: testNamespaceDynatrace,
+			},
+		}
+
+		clt := fake.NewClientWithIndex(
+			dk,
+			clientInjectedNamespace(testNamespace, testDynakube),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
+				dtclient.DataIngestToken: []byte(testDataIngestToken),
+			}),
+		)
+
+		mockDTClient := dtclientmock.NewClient(t)
+
+		secretGenerator := NewSecretGenerator(clt, clt, mockDTClient)
+		err := secretGenerator.GenerateForDynakube(t.Context(), dk)
+		require.NoError(t, err)
+
+		var secret corev1.Secret
+		err = clt.Get(t.Context(), client.ObjectKey{Name: consts.OTLPExporterSecretName, Namespace: testNamespace}, &secret)
+		require.True(t, errors.IsNotFound(err))
+
+		var sourceSecret corev1.Secret
+		err = clt.Get(t.Context(), client.ObjectKey{Name: GetSourceConfigSecretName(dk.Name), Namespace: dk.Namespace}, &sourceSecret)
+		require.True(t, errors.IsNotFound(err))
+	})
+	t.Run("successfully generate config secret for dynakube", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      testDynakube,
+				Namespace: testNamespaceDynatrace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				OTLPExporterConfiguration: &otlpexporterconfiguration.Spec{
+					Signals: otlpexporterconfiguration.SignalConfiguration{},
+				},
+			},
+		}
+
+		clt := fake.NewClientWithIndex(
+			dk,
+			clientInjectedNamespace(testNamespace, testDynakube),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
+				dtclient.DataIngestToken: []byte(testDataIngestToken),
+			}),
+		)
+
+		mockDTClient := dtclientmock.NewClient(t)
+
+		secretGenerator := NewSecretGenerator(clt, clt, mockDTClient)
+		err := secretGenerator.GenerateForDynakube(t.Context(), dk)
+		require.NoError(t, err)
+
+		var secret corev1.Secret
+		err = clt.Get(t.Context(), client.ObjectKey{Name: consts.OTLPExporterSecretName, Namespace: testNamespace}, &secret)
+		require.NoError(t, err)
+		require.Equal(t, consts.OTLPExporterSecretName, secret.Name)
+		assert.NotEmpty(t, secret.Data)
+
+		assert.Equal(t, testDataIngestToken, string(secret.Data[dtclient.DataIngestToken]))
+
+		var sourceSecret corev1.Secret
+		err = clt.Get(t.Context(), client.ObjectKey{Name: GetSourceConfigSecretName(dk.Name), Namespace: dk.Namespace}, &sourceSecret)
+		require.NoError(t, err)
+
+		require.Equal(t, GetSourceConfigSecretName(dk.Name), sourceSecret.Name)
+		assert.Equal(t, secret.Data, sourceSecret.Data)
+
+		c := meta.FindStatusCondition(*dk.Conditions(), ConfigConditionType)
+		require.NotNil(t, c)
+		assert.Equal(t, metav1.ConditionTrue, c.Status)
+	})
+	t.Run("update existing secret", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      testDynakube,
+				Namespace: testNamespaceDynatrace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				OTLPExporterConfiguration: &otlpexporterconfiguration.Spec{
+					Signals: otlpexporterconfiguration.SignalConfiguration{},
+				},
+			},
+		}
+
+		clt := fake.NewClientWithIndex(
+			dk,
+			clientInjectedNamespace(testNamespace, testDynakube),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
+				dtclient.DataIngestToken: []byte(testDataIngestToken),
+			}),
+			clientSecret(consts.OTLPExporterSecretName, testNamespace, map[string][]byte{
+				dtclient.DataIngestToken: []byte(oldDataIngestToken),
+			}),
+			clientSecret(GetSourceConfigSecretName(dk.Name), dk.Namespace, map[string][]byte{
+				dtclient.DataIngestToken: []byte(oldDataIngestToken),
+			}),
+		)
+
+		mockDTClient := dtclientmock.NewClient(t)
+
+		secretGenerator := NewSecretGenerator(clt, clt, mockDTClient)
+		err := secretGenerator.GenerateForDynakube(t.Context(), dk)
+		require.NoError(t, err)
+
+		var secret corev1.Secret
+		err = clt.Get(t.Context(), client.ObjectKey{Name: consts.OTLPExporterSecretName, Namespace: testNamespace}, &secret)
+		require.NoError(t, err)
+		require.Equal(t, consts.OTLPExporterSecretName, secret.Name)
+		assert.NotEmpty(t, secret.Data)
+
+		assert.Equal(t, testDataIngestToken, string(secret.Data[dtclient.DataIngestToken]))
+
+		var sourceSecret corev1.Secret
+		err = clt.Get(t.Context(), client.ObjectKey{Name: GetSourceConfigSecretName(dk.Name), Namespace: dk.Namespace}, &sourceSecret)
+		require.NoError(t, err)
+
+		require.Equal(t, GetSourceConfigSecretName(dk.Name), sourceSecret.Name)
+		assert.Equal(t, secret.Data, sourceSecret.Data)
+
+		c := meta.FindStatusCondition(*dk.Conditions(), ConfigConditionType)
+		require.NotNil(t, c)
+		assert.Equal(t, metav1.ConditionTrue, c.Status)
+	})
+	t.Run("fail while generating secret for dynakube - secret in dynatrace namespace not found", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      testDynakube,
+				Namespace: testNamespaceDynatrace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				OTLPExporterConfiguration: &otlpexporterconfiguration.Spec{
+					Signals: otlpexporterconfiguration.SignalConfiguration{},
+				},
+			},
+		}
+
+		clt := fake.NewClientWithIndex(
+			dk,
+			clientInjectedNamespace(testNamespace, testDynakube),
+		)
+
+		mockDTClient := dtclientmock.NewClient(t)
+
+		secretGenerator := NewSecretGenerator(clt, clt, mockDTClient)
+		err := secretGenerator.GenerateForDynakube(t.Context(), dk)
+		require.Error(t, err)
+
+		c := meta.FindStatusCondition(*dk.Conditions(), ConfigConditionType)
+		require.NotNil(t, c)
+		assert.Equal(t, metav1.ConditionFalse, c.Status)
+	})
+}
+
+func TestCleanup(t *testing.T) {
+	dk := &dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testDynakube,
+			Namespace: testNamespaceDynatrace,
+		},
+		Spec: dynakube.DynaKubeSpec{},
+		Status: dynakube.DynaKubeStatus{
+			Conditions: []metav1.Condition{
+				{Type: ConfigConditionType},
+				{Type: "other"},
+			},
+		},
+	}
+
+	clt := fake.NewClientWithIndex(
+		dk,
+		clientInjectedNamespace(testNamespace, testDynakube),
+		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
+			dtclient.DataIngestToken: []byte(testDataIngestToken),
+		}),
+		clientSecret(consts.OTLPExporterSecretName, testNamespace, nil),
+		clientSecret(consts.OTLPExporterSecretName, testNamespace2, nil),
+		clientSecret(GetSourceConfigSecretName(dk.Name), dk.Namespace, nil),
+	)
+	namespaces := []corev1.Namespace{
+		{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}},
+		{ObjectMeta: metav1.ObjectMeta{Name: testNamespace2}},
+	}
+
+	var secretNS1 corev1.Secret
+	err := clt.Get(t.Context(), client.ObjectKey{Name: consts.OTLPExporterSecretName, Namespace: testNamespace}, &secretNS1)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, secretNS1)
+	assert.Equal(t, consts.OTLPExporterSecretName, secretNS1.Name)
+
+	var secretNS2 corev1.Secret
+	err = clt.Get(t.Context(), client.ObjectKey{Name: consts.OTLPExporterSecretName, Namespace: testNamespace}, &secretNS2)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, secretNS2)
+	assert.Equal(t, consts.OTLPExporterSecretName, secretNS2.Name)
+
+	err = Cleanup(t.Context(), clt, clt, namespaces, dk)
+	require.NoError(t, err)
+
+	var deleted corev1.Secret
+	err = clt.Get(t.Context(), client.ObjectKey{Name: consts.OTLPExporterSecretName, Namespace: testNamespace}, &deleted)
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+
+	err = clt.Get(t.Context(), client.ObjectKey{Name: consts.OTLPExporterSecretName, Namespace: testNamespace2}, &deleted)
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+
+	err = clt.Get(t.Context(), client.ObjectKey{Name: GetSourceConfigSecretName(dk.Name), Namespace: dk.Namespace}, &deleted)
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+	require.Nil(t, meta.FindStatusCondition(*dk.Conditions(), ConfigConditionType))
+}
+
+func clientSecret(secretName string, namespaceName string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "core/v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespaceName,
+		},
+		Data: data,
+	}
+}
+
+func clientInjectedNamespace(namespaceName string, dynakubeName string) *corev1.Namespace {
+	return &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "corev1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespaceName,
+			Labels: map[string]string{
+				dtwebhook.InjectionInstanceLabel: dynakubeName,
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

This PR adds an OTLP reconciler which is responsible for creating the secret containing the DataIngest token required for the OTLP exporter auto configuration. 

Fixes https://dt-rnd.atlassian.net/browse/DAQ-13778

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

- Unit tests