### PR TITLE
Add cache middleware for the dtclient

### DIFF
--- a/cmd/operator/cmd.go
+++ b/cmd/operator/cmd.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/middleware"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/certificates"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
@@ -59,7 +60,10 @@ func runInPod(kubeCfg *rest.Config) error {
 		return err
 	}
 
-	return errors.WithStack(operatorManager.Start(ctrl.SetupSignalHandler()))
+	signalHandler := ctrl.SetupSignalHandler()
+	go middleware.RunPeriodicCacheCleanup(signalHandler, k8senv.GetDTClientCacheCleanInterval(log))
+
+	return errors.WithStack(operatorManager.Start(signalHandler))
 }
 
 func runLocally(ctx context.Context, kubeCfg *rest.Config) error {

--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/hostevent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/middleware"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/settings"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
@@ -51,6 +52,7 @@ type Config struct {
 	NoProxy           string
 	Timeout           time.Duration
 	DisableKeepAlives bool
+	CacheEntryTTL     time.Duration
 }
 
 // Option is a functional option for configuring the client
@@ -62,6 +64,8 @@ func NewClient(options ...Option) (*Client, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client config")
 	}
+
+	addCacheMiddleware(config)
 
 	if len(config.APIToken) == 0 && len(config.PaasToken) == 0 {
 		return nil, errors.New("tokens are empty")
@@ -99,6 +103,8 @@ func NewOAuthClient(credentials clientcredentials.Config, options ...Option) (*O
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get oauth config")
 	}
+
+	addCacheMiddleware(config)
 
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, config.HTTPClient)
 
@@ -256,6 +262,18 @@ func WithCerts(certs []byte) Option {
 
 		return nil
 	}
+}
+
+func WithCacheTTL(ttl time.Duration) Option {
+	return func(c *Config) error {
+		c.CacheEntryTTL = ttl
+
+		return nil
+	}
+}
+
+func addCacheMiddleware(config *Config) {
+	config.HTTPClient.Transport = middleware.NewCacheRoundTripper(config.HTTPClient.Transport, config.CacheEntryTTL)
 }
 
 func getConfig(options ...Option) (*Config, error) {

--- a/pkg/clients/dynatrace/core/client.go
+++ b/pkg/clients/dynatrace/core/client.go
@@ -42,6 +42,8 @@ type APIRequest interface {
 	WithoutToken() APIRequest
 	// WithHeader sets a custom header for the request, overriding any default value
 	WithHeader(key, value string) APIRequest
+	// WithSkipCache bypasses the in-memory cache for this request and evicts any existing cached entry
+	WithSkipCache() APIRequest
 	// Execute executes the request and unmarshals the response into the provided model
 	Execute(model any) error
 	// ExecuteWriter executes the request and writes the response body to the provided writer
@@ -192,6 +194,11 @@ func (r *Request) WithHeader(key, value string) APIRequest {
 	r.headers.Set(key, value)
 
 	return r
+}
+
+// WithSkipCache bypasses the in-memory cache for this request and evicts any existing cached entry
+func (r *Request) WithSkipCache() APIRequest {
+	return r.WithHeader(CacheSkipHeader, "true")
 }
 
 // Execute executes the request and unmarshals the response into the provided model

--- a/pkg/clients/dynatrace/core/client.go
+++ b/pkg/clients/dynatrace/core/client.go
@@ -287,13 +287,7 @@ func (r *Request) doRequestStream(writer io.Writer) (err error) {
 		}
 	}()
 
-	// Legacy client only checked by 200-201, but DELETE requests are only handled by v2 client.
-	statusCodeThreshold := 201
-	if r.method == http.MethodDelete {
-		statusCodeThreshold = 299
-	}
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode > statusCodeThreshold {
+	if !IsSuccessResponse(resp) {
 		body, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			return fmt.Errorf("read error response body: %w", readErr)
@@ -360,13 +354,7 @@ func (r *Request) doRequest() (body []byte, err error) {
 
 	log.Debug("API request", loggerArgs(resp, body)...)
 
-	// Legacy client only checked by 200-201, but DELETE requests are only handled by v2 client.
-	statusCodeThreshold := 201
-	if r.method == http.MethodDelete {
-		statusCodeThreshold = 299
-	}
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode > statusCodeThreshold {
+	if !IsSuccessResponse(resp) {
 		err = handleErrorResponse(resp, body)
 	}
 
@@ -428,6 +416,18 @@ func handleErrorResponse(resp *http.Response, body []byte) error {
 	}
 
 	return httpErr
+}
+
+// IsSuccessResponse returns true when the HTTP response status code indicates
+// a successful operation. DELETE requests accept 200-299; all other methods
+// accept 200-201 (matching the legacy client behavior).
+func IsSuccessResponse(resp *http.Response) bool {
+	statusCodeThreshold := 201
+	if resp.Request != nil && resp.Request.Method == http.MethodDelete {
+		statusCodeThreshold = 299
+	}
+
+	return resp.StatusCode >= http.StatusOK && resp.StatusCode <= statusCodeThreshold
 }
 
 func isJSONList(body []byte) bool {

--- a/pkg/clients/dynatrace/core/logger.go
+++ b/pkg/clients/dynatrace/core/logger.go
@@ -28,6 +28,10 @@ const (
 	// CacheHitHeader is set on responses served from the in-memory cache so that
 	// the core client can include a "cached" field in its log output.
 	CacheHitHeader = "X-DT-Cache"
+
+	// CacheSkipHeader can be set on a request to bypass the in-memory cache for
+	// that specific request. Any non-empty value disables both cache reads and writes.
+	CacheSkipHeader = "X-DT-Cache-Skip"
 )
 
 var logLevel = getLogLevel()

--- a/pkg/clients/dynatrace/core/logger.go
+++ b/pkg/clients/dynatrace/core/logger.go
@@ -20,9 +20,15 @@ const (
 	levelFull     // full
 )
 
-// LogLevelEnv controls the verbosity of the Dynatrace API client.
-// The value will only be used when the LOG_LEVEL variable is set to "debug".
-const LogLevelEnv = "DT_CLIENT_LOG_LEVEL"
+const (
+	// LogLevelEnv controls the verbosity of the Dynatrace API client.
+	// The value will only be used when the LOG_LEVEL variable is set to "debug".
+	LogLevelEnv = "DT_CLIENT_LOG_LEVEL"
+
+	// CacheHitHeader is set on responses served from the in-memory cache so that
+	// the core client can include a "cached" field in its log output.
+	CacheHitHeader = "X-DT-Cache"
+)
 
 var logLevel = getLogLevel()
 
@@ -66,6 +72,7 @@ func createLoggerArgs(requestBody []byte) func(resp *http.Response, responseBody
 			"query", dumpValues(resp.Request.URL.Query(), false),
 			"status_code", resp.StatusCode,
 			"duration", duration.String(),
+			"cached", resp.Header.Get(CacheHitHeader) != "",
 		}
 
 		if logLevel >= levelFull {

--- a/pkg/clients/dynatrace/core/logger_test.go
+++ b/pkg/clients/dynatrace/core/logger_test.go
@@ -76,6 +76,7 @@ func Test_loggerArgs(t *testing.T) {
 			levelDefault,
 			[]any{
 				"method", "GET", "host", "host.test", "path", "/path-foo", "query", `{"query-foo":"query-bar"}`, "status_code", 200, "duration", "1s",
+				"cached", false,
 			},
 		},
 		{
@@ -83,7 +84,7 @@ func Test_loggerArgs(t *testing.T) {
 			levelRequest,
 			[]any{
 				"method", "GET", "host", "host.test", "path", "/path-foo", "query", `{"query-foo":"query-bar"}`, "status_code", 200, "duration", "1s",
-				"request_body", "request " + "Bearer " + "eya.eyb.***" + " " + publicPart + ".***rest",
+				"cached", false, "request_body", "request " + "Bearer " + "eya.eyb.***" + " " + publicPart + ".***rest",
 			},
 		},
 		{
@@ -91,7 +92,7 @@ func Test_loggerArgs(t *testing.T) {
 			levelResponse,
 			[]any{
 				"method", "GET", "host", "host.test", "path", "/path-foo", "query", `{"query-foo":"query-bar"}`, "status_code", 200, "duration", "1s",
-				"request_body", "request " + "Bearer " + "eya.eyb.***" + " " + publicPart + ".***rest",
+				"cached", false, "request_body", "request " + "Bearer " + "eya.eyb.***" + " " + publicPart + ".***rest",
 				"response_body", "response " + "Bearer " + "eya.eyb.***" + " " + publicPart + ".***rest",
 			},
 		},
@@ -100,10 +101,19 @@ func Test_loggerArgs(t *testing.T) {
 			levelFull,
 			[]any{
 				"method", "GET", "host", "host.test", "path", "/path-foo", "query", `{"query-foo":"query-bar"}`, "status_code", 200, "duration", "1s",
+				"cached", false,
 				"request_headers", `{"Authorization":"Bearer eya.eyb.***","Request-Foo":"request-` + publicPart + `.***"}`,
 				"response_headers", `{"Response-Foo":"response-` + publicPart + `.***"}`,
 				"request_body", "request " + "Bearer " + "eya.eyb.***" + " " + publicPart + ".***rest",
 				"response_body", "response " + "Bearer " + "eya.eyb.***" + " " + publicPart + ".***rest",
+			},
+		},
+		{
+			"default/cached",
+			levelDefault,
+			[]any{
+				"method", "GET", "host", "host.test", "path", "/path-foo", "query", `{"query-foo":"query-bar"}`, "status_code", 200, "duration", "1s",
+				"cached", true,
 			},
 		},
 	}
@@ -121,11 +131,19 @@ func Test_loggerArgs(t *testing.T) {
 				timeNow = time.Now
 			})
 
+			resp := response
+			if tt.name == "default/cached" {
+				cached := *response
+				cached.Header = response.Header.Clone()
+				cached.Header.Set(CacheHitHeader, "true")
+				resp = &cached
+			}
+
 			get := createLoggerArgs(requestBody)
 			// Advance time to always get duration=1s
 			fixedTime = fixedTime.Add(1 * time.Second)
 
-			assert.Equal(t, tt.want, get(response, responseBody))
+			assert.Equal(t, tt.want, get(resp, responseBody))
 		})
 	}
 }

--- a/pkg/clients/dynatrace/middleware/cache.go
+++ b/pkg/clients/dynatrace/middleware/cache.go
@@ -1,0 +1,149 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"maps"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+)
+
+var (
+	log = logd.Get().WithName("dynatraceapi-cache")
+
+	cache = newCache()
+)
+
+// cacheEntry holds all relevant info for a cached response.
+// The only not obvious part is that the `body` has to be stored separate from the actual `response`.
+// The reason for this is that the `Body` part of the `http.Response` is an `io.ReadCloser`.
+// This means the you may only read the body once, which is not good if we would like to reuse the `http.Response`
+// To combat this we read the `Body` while creating the `cacheEntry` and store it inside this new entry.
+// We always "recreate"(put it into a new Reader) the `Body` in the affected `http.Response` or when we returned the cached `http.Response`.
+type cacheEntry struct {
+	response     *http.Response
+	body         []byte
+	creationTime time.Time
+	ttl          time.Duration
+}
+
+func (ce *cacheEntry) isOutdated() bool {
+	return time.Since(ce.creationTime) > ce.ttl
+}
+
+type responseCache struct {
+	entries map[string]*cacheEntry
+	mu      sync.Mutex
+}
+
+func (rc *responseCache) get(key string) *http.Response {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	entry, ok := rc.entries[key]
+	if !ok {
+		return nil
+	}
+
+	if entry.isOutdated() {
+		log.Debug("outdated entry found, removing", "url", entry.response.Request.URL)
+
+		delete(rc.entries, key)
+
+		return nil
+	}
+
+	// Reconstruct a fresh response so every caller gets a full, open body and
+	// an independent header map (shallow copy shares the underlying map).
+	resp := *entry.response
+	resp.Header = entry.response.Header.Clone()
+	resp.Body = io.NopCloser(bytes.NewReader(entry.body))
+
+	return &resp
+}
+
+func (rc *responseCache) remove(key string) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	delete(rc.entries, key)
+}
+
+func (rc *responseCache) set(key string, response *http.Response, ttl time.Duration) error {
+	if response == nil {
+		return nil
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		response.Body.Close()
+
+		return err
+	}
+
+	response.Body.Close()
+
+	// Restore body for the current caller so they can still read it.
+	response.Body = io.NopCloser(bytes.NewReader(body))
+
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	rc.entries[key] = &cacheEntry{
+		response:     response,
+		body:         body,
+		creationTime: time.Now(),
+		ttl:          ttl,
+	}
+
+	return nil
+}
+
+func (rc *responseCache) cleanup() {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	maps.DeleteFunc(rc.entries, func(key string, value *cacheEntry) bool {
+		isOutdated := value.isOutdated()
+		if isOutdated {
+			log.Debug("outdated entry found, removing", "url", value.response.Request.URL)
+		}
+
+		return isOutdated
+	})
+}
+
+func newCache() *responseCache {
+	return &responseCache{
+		entries: make(map[string]*cacheEntry),
+		mu:      sync.Mutex{},
+	}
+}
+
+// RunPeriodicCacheCleanup will remove all expired entries from the dtclient cache once every period.
+// This is necessary because if the user changes tokens, disables features etc., some entries will never be hit again,
+// so we can't clean them up during normal reconciles.
+// This only makes sense to use in the Operator Pod.
+// - The bootstrap command only runs once, and can only download a ~700MB archive. (can be less or more, depending on the technologies present in the archive)
+// - The csidriver (mainly `provisioner` container) does not make "in-memory cacheable" requests, it only downloads +700MB archives, that we "cache" on the node.
+// - The webhook (and any other not listed command) does not use the dtclient.
+func RunPeriodicCacheCleanup(ctx context.Context, period time.Duration) {
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
+
+	log.Debug("periodic cache cleanup routine setup", "period", period)
+
+	for {
+		select {
+		case <-ticker.C:
+			log.Debug("periodic cache cleanup started")
+			cache.cleanup()
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/pkg/clients/dynatrace/middleware/cache_test.go
+++ b/pkg/clients/dynatrace/middleware/cache_test.go
@@ -1,0 +1,180 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// freshCache returns a new responseCache and replaces the package-level one,
+// preventing state from leaking between tests.
+func freshCache(t *testing.T) *responseCache {
+	t.Helper()
+	c := newCache()
+	cache = c
+
+	return c
+}
+
+func fakeResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		Request:    &http.Request{URL: &url.URL{Host: "example.com"}},
+	}
+}
+
+func TestResponseCache_SetAndGet(t *testing.T) {
+	t.Run("miss on empty cache", func(t *testing.T) {
+		c := freshCache(t)
+		assert.Nil(t, c.get("anykey"))
+	})
+
+	t.Run("hit after store within TTL", func(t *testing.T) {
+		c := freshCache(t)
+		require.NoError(t, c.set("key", fakeResponse("hello"), time.Minute))
+
+		resp := c.get("key")
+		require.NotNil(t, resp)
+		body, _ := io.ReadAll(resp.Body)
+		require.NoError(t, resp.Body.Close())
+		assert.Equal(t, "hello", string(body))
+	})
+	t.Run("expired entry is evicted on get and is a miss", func(t *testing.T) {
+		c := freshCache(t)
+
+		synctest.Test(t, func(t *testing.T) {
+			require.NoError(t, c.set("key", fakeResponse("data"), time.Minute))
+			time.Sleep(time.Minute + time.Second)
+
+			entry := c.get("key") // triggers eviction
+			assert.Nil(t, entry, "expired entry must be treated as a miss")
+		})
+
+		assert.NotContains(t, c.entries, "key")
+	})
+
+	t.Run("nil response is not stored", func(t *testing.T) {
+		c := freshCache(t)
+		require.NoError(t, c.set("key", nil, time.Minute))
+		assert.Nil(t, c.get("key"))
+	})
+
+	t.Run("body can be read multiple times from cached response", func(t *testing.T) {
+		c := freshCache(t)
+		require.NoError(t, c.set("key", fakeResponse("body-content"), time.Minute))
+
+		resp1 := c.get("key")
+		require.NotNil(t, resp1)
+		body1, _ := io.ReadAll(resp1.Body)
+		require.NoError(t, resp1.Body.Close())
+
+		resp2 := c.get("key")
+		require.NotNil(t, resp2)
+		body2, _ := io.ReadAll(resp2.Body)
+		require.NoError(t, resp2.Body.Close())
+
+		assert.Equal(t, "body-content", string(body1))
+		assert.Equal(t, "body-content", string(body2))
+	})
+
+	t.Run("caller's original response body is restored after store", func(t *testing.T) {
+		c := freshCache(t)
+		resp := fakeResponse("original")
+		require.NoError(t, c.set("key", resp, time.Minute))
+
+		body, _ := io.ReadAll(resp.Body)
+		assert.Equal(t, "original", string(body))
+	})
+
+	t.Run("returns error and does not cache when reading body fails", func(t *testing.T) {
+		c := freshCache(t)
+		readErr := errors.New("read error")
+		body := &ioErrReader{err: readErr}
+		resp := fakeResponse("")
+		resp.Body = body
+
+		err := c.set("key", resp, time.Minute)
+
+		require.ErrorIs(t, err, readErr)
+		assert.Nil(t, c.get("key"))
+		assert.True(t, body.closed, "body must be closed when reading fails")
+	})
+}
+
+func TestResponseCache_Cleanup(t *testing.T) {
+	t.Run("removes expired entries, keeps fresh ones", func(t *testing.T) {
+		c := freshCache(t)
+
+		synctest.Test(t, func(t *testing.T) {
+			require.NoError(t, c.set("expired", fakeResponse("old"), time.Minute))
+			require.NoError(t, c.set("fresh", fakeResponse("new"), 3*time.Minute))
+			time.Sleep(2 * time.Minute)
+
+			c.cleanup()
+		})
+
+		assert.NotContains(t, c.entries, "expired")
+		assert.Contains(t, c.entries, "fresh")
+	})
+
+	t.Run("does nothing on empty cache", func(t *testing.T) {
+		c := freshCache(t)
+		assert.NotPanics(t, cache.cleanup)
+		assert.Empty(t, c.entries)
+	})
+}
+
+func TestRunPeriodicCacheCleanup(t *testing.T) {
+	t.Run("evicts expired entries after a tick", func(t *testing.T) {
+		c := freshCache(t)
+
+		synctest.Test(t, func(t *testing.T) {
+			require.NoError(t, c.set("key", fakeResponse("data"), time.Minute))
+
+			go RunPeriodicCacheCleanup(t.Context(), 2*time.Minute)
+
+			time.Sleep(4 * time.Minute)
+
+			synctest.Wait()
+		})
+
+		assert.Empty(t, c.entries)
+	})
+
+	t.Run("goroutine exits when context is canceled", func(t *testing.T) {
+		freshCache(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		assert.NotPanics(t, func() {
+			go RunPeriodicCacheCleanup(ctx, time.Hour)
+			cancel()
+		})
+	})
+}
+
+// ioErrReader is a ReadCloser that always returns the configured error on Read
+// and tracks whether Close was called.
+type ioErrReader struct {
+	err    error
+	closed bool
+}
+
+func (r *ioErrReader) Read(_ []byte) (int, error) {
+	return 0, r.err
+}
+
+func (r *ioErrReader) Close() error {
+	r.closed = true
+
+	return nil
+}

--- a/pkg/clients/dynatrace/middleware/roundtripper.go
+++ b/pkg/clients/dynatrace/middleware/roundtripper.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (rt roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	if rt == nil {
+		panic("empty roundTripperFunc used")
+	}
+
+	return rt(r)
+}
+
+func NewCacheRoundTripper(next http.RoundTripper, ttl time.Duration) http.RoundTripper {
+	return roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodGet ||
+			r.Header.Get("Accept") == "application/octet-stream" {
+			return next.RoundTrip(r)
+		}
+
+		cacheKey := buildCacheKey(r)
+
+		if ttl == 0 {
+			log.Debug("cache ttl is 0, no cache will be used")
+
+			// if the caching was turned off intermittently, those entries should be removed
+			cache.remove(cacheKey)
+
+			return next.RoundTrip(r)
+		}
+
+		cachedResponse := cache.get(cacheKey)
+		if cachedResponse != nil {
+			cachedResponse.Header.Set(core.CacheHitHeader, "true")
+			cachedResponse.Request = r
+
+			return cachedResponse, nil
+		}
+
+		// send the actual request
+		resp, err := next.RoundTrip(r)
+		if err == nil && core.IsSuccessResponse(resp) {
+			// err is ignored, as cache.set can only error due to failing to read the body, which will cause an error down the line anyway
+			// adding extra logs will just repeat the same, adding no value
+			_ = cache.set(cacheKey, resp, ttl)
+
+			return resp, nil
+		}
+
+		return resp, err
+	})
+}
+
+func buildCacheKey(r *http.Request) string {
+	h := sha256.New()
+
+	fmt.Fprint(h, r.URL.String())
+	fmt.Fprint(h, r.Header.Get("Authorization"))
+
+	if r.Body != nil {
+		body, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		h.Write(body)
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/pkg/clients/dynatrace/middleware/roundtripper.go
+++ b/pkg/clients/dynatrace/middleware/roundtripper.go
@@ -31,9 +31,7 @@ func NewCacheRoundTripper(next http.RoundTripper, ttl time.Duration) http.RoundT
 
 		cacheKey := buildCacheKey(r)
 
-		if ttl == 0 {
-			log.Debug("cache ttl is 0, no cache will be used")
-
+		if ttl == 0 || r.Header.Get(core.CacheSkipHeader) != "" {
 			// if the caching was turned off intermittently, those entries should be removed
 			cache.remove(cacheKey)
 

--- a/pkg/clients/dynatrace/middleware/roundtripper_test.go
+++ b/pkg/clients/dynatrace/middleware/roundtripper_test.go
@@ -78,6 +78,31 @@ func TestNewCacheRoundTripper(t *testing.T) {
 		assert.Equal(t, 2, *calls, "POST must always reach backend")
 	})
 
+	t.Run("CacheSkipHeader bypasses cache and evicts existing entry", func(t *testing.T) {
+		rt, calls := makeCachedRT(t, time.Minute,
+			fakeResponse("r1"),
+			fakeResponse("r2"),
+			fakeResponse("r3"),
+		)
+
+		// Populate cache
+		_, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, 1, *calls)
+
+		// Call with skip header — evicts cached entry and calls backend
+		req2 := newRequest(t, http.MethodGet, endpoint)
+		req2.Header.Set(core.CacheSkipHeader, "true")
+		_, err = rt.RoundTrip(req2)
+		require.NoError(t, err)
+		assert.Equal(t, 2, *calls, "skip header must bypass the cache")
+
+		// Next call without skip — cache was evicted, backend is called again
+		_, err = rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, 3, *calls, "evicted entry must not be served from cache")
+	})
+
 	t.Run("zero TTL disables caching", func(t *testing.T) {
 		rt, calls := makeCachedRT(t, 0,
 			fakeResponse("r1"),

--- a/pkg/clients/dynatrace/middleware/roundtripper_test.go
+++ b/pkg/clients/dynatrace/middleware/roundtripper_test.go
@@ -1,0 +1,392 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCacheRoundTripper(t *testing.T) {
+	const endpoint = "http://api.example.com/v1/resource"
+
+	newRequest := func(t *testing.T, method, rawURL string) *http.Request {
+		t.Helper()
+		r, err := http.NewRequest(method, rawURL, nil)
+		require.NoError(t, err)
+
+		return r
+	}
+
+	makeCachedRT := func(t *testing.T, ttl time.Duration, responses ...*http.Response) (http.RoundTripper, *int) {
+		t.Helper()
+		_ = freshCache(t) // reset global cache, cleaned up after test
+
+		calls := 0
+		idx := 0
+
+		fake := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			calls++
+			resp := responses[idx]
+			if idx < len(responses)-1 {
+				idx++
+			}
+			resp.Request = r
+
+			return resp, nil
+		})
+
+		return NewCacheRoundTripper(fake, ttl), &calls
+	}
+
+	t.Run("GET response is served from cache on second call", func(t *testing.T) {
+		rt, calls := makeCachedRT(t, time.Minute,
+			fakeResponse("hello"),
+		)
+
+		resp1, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		body1, _ := io.ReadAll(resp1.Body)
+		assert.Equal(t, "hello", string(body1))
+		assert.Equal(t, 1, *calls)
+
+		resp2, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		body2, _ := io.ReadAll(resp2.Body)
+		assert.Equal(t, "hello", string(body2))
+		assert.Equal(t, 1, *calls, "second call must hit cache, not backend")
+	})
+
+	t.Run("non-GET requests bypass cache", func(t *testing.T) {
+		rt, calls := makeCachedRT(t, time.Minute,
+			fakeResponse("r1"),
+			fakeResponse("r2"),
+		)
+
+		_, err := rt.RoundTrip(newRequest(t, http.MethodPost, endpoint))
+		require.NoError(t, err)
+		_, err = rt.RoundTrip(newRequest(t, http.MethodPost, endpoint))
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, *calls, "POST must always reach backend")
+	})
+
+	t.Run("zero TTL disables caching", func(t *testing.T) {
+		rt, calls := makeCachedRT(t, 0,
+			fakeResponse("r1"),
+			fakeResponse("r2"),
+		)
+
+		_, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		_, err = rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, *calls, "zero TTL must bypass cache")
+	})
+
+	t.Run("octet-stream Accept header bypasses cache", func(t *testing.T) {
+		rt, calls := makeCachedRT(t, time.Minute,
+			fakeResponse("bin1"),
+			fakeResponse("bin2"),
+		)
+
+		req1 := newRequest(t, http.MethodGet, endpoint)
+		req1.Header.Set("Accept", "application/octet-stream")
+		_, err := rt.RoundTrip(req1)
+		require.NoError(t, err)
+
+		req2 := newRequest(t, http.MethodGet, endpoint)
+		req2.Header.Set("Accept", "application/octet-stream")
+		_, err = rt.RoundTrip(req2)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, *calls, "octet-stream requests must bypass cache")
+	})
+
+	t.Run("different URLs have separate cache entries", func(t *testing.T) {
+		rt, calls := makeCachedRT(t, time.Minute,
+			fakeResponse("url-a"),
+			fakeResponse("url-b"),
+		)
+
+		resp1, err := rt.RoundTrip(newRequest(t, http.MethodGet, "http://api.example.com/v1/a"))
+		require.NoError(t, err)
+		body1, _ := io.ReadAll(resp1.Body)
+
+		resp2, err := rt.RoundTrip(newRequest(t, http.MethodGet, "http://api.example.com/v1/b"))
+		require.NoError(t, err)
+		body2, _ := io.ReadAll(resp2.Body)
+
+		assert.Equal(t, "url-a", string(body1))
+		assert.Equal(t, "url-b", string(body2))
+		assert.Equal(t, 2, *calls)
+	})
+
+	t.Run("different Authorization headers produce separate cache entries", func(t *testing.T) {
+		rt, calls := makeCachedRT(t, time.Minute,
+			fakeResponse("token-abc"),
+			fakeResponse("token-xyz"),
+		)
+
+		req1 := newRequest(t, http.MethodGet, endpoint)
+		req1.Header.Set("Authorization", "Api-Token abc")
+		resp1, err := rt.RoundTrip(req1)
+		require.NoError(t, err)
+		body1, _ := io.ReadAll(resp1.Body)
+
+		req2 := newRequest(t, http.MethodGet, endpoint)
+		req2.Header.Set("Authorization", "Api-Token xyz")
+		resp2, err := rt.RoundTrip(req2)
+		require.NoError(t, err)
+		body2, _ := io.ReadAll(resp2.Body)
+
+		assert.Equal(t, "token-abc", string(body1))
+		assert.Equal(t, "token-xyz", string(body2))
+		assert.Equal(t, 2, *calls)
+	})
+
+	t.Run("expired cache entry triggers a fresh backend call", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			rt, calls := makeCachedRT(t, time.Minute,
+				fakeResponse("first"),
+				fakeResponse("second"),
+			)
+
+			_, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+			require.NoError(t, err)
+
+			time.Sleep(time.Minute + time.Second)
+
+			resp2, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+			require.NoError(t, err)
+			body2, _ := io.ReadAll(resp2.Body)
+
+			assert.Equal(t, "second", string(body2))
+			assert.Equal(t, 2, *calls)
+		})
+	})
+
+	t.Run("cached response body can be read independently on each call", func(t *testing.T) {
+		rt, _ := makeCachedRT(t, time.Minute, fakeResponse("body-content"))
+
+		resp1, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		body1, _ := io.ReadAll(resp1.Body)
+
+		resp2, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		body2, _ := io.ReadAll(resp2.Body)
+
+		assert.Equal(t, "body-content", string(body1))
+		assert.Equal(t, "body-content", string(body2))
+	})
+
+	t.Run("cache-hit response has CacheHitHeader set + request copied", func(t *testing.T) {
+		rt, _ := makeCachedRT(t, time.Minute, fakeResponse("data"))
+
+		// First call — backend response, header must NOT be set
+		req1 := newRequest(t, http.MethodGet, endpoint)
+		resp1, err := rt.RoundTrip(req1)
+		require.NoError(t, err)
+		assert.Empty(t, resp1.Header.Get(core.CacheHitHeader), "first (uncached) response must not have cache-hit header")
+		assert.Same(t, req1, resp1.Request)
+
+		// Second call — served from cache, header must be set + its Request must point to req2, not req1
+		req2 := newRequest(t, http.MethodGet, endpoint)
+		resp2, err := rt.RoundTrip(req2)
+		require.NoError(t, err)
+		assert.Equal(t, "true", resp2.Header.Get(core.CacheHitHeader), "cached response must have cache-hit header")
+		assert.Same(t, req2, resp2.Request, "cached response must carry the request that triggered the cache hit")
+		assert.NotSame(t, req1, resp2.Request, "cached response must not carry the original request that populated the cache")
+	})
+
+	t.Run("setting CacheHitHeader on cached response does not affect stored entry", func(t *testing.T) {
+		rt, _ := makeCachedRT(t, time.Minute, fakeResponse("data"))
+
+		// Populate cache
+		_, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+
+		// Two independent cache-hit responses should each have the header
+		resp2, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, "true", resp2.Header.Get(core.CacheHitHeader))
+
+		resp3, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, "true", resp3.Header.Get(core.CacheHitHeader))
+	})
+
+	t.Run("zero TTL removes a previously cached entry", func(t *testing.T) {
+		_ = freshCache(t)
+
+		calls := 0
+		fake := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			calls++
+			resp := fakeResponse("data")
+			resp.Request = r
+
+			return resp, nil
+		})
+
+		// First: cache the response with a non-zero TTL
+		rtWithTTL := NewCacheRoundTripper(fake, time.Minute)
+		_, err := rtWithTTL.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls)
+
+		// Second call hits cache, not backend
+		_, err = rtWithTTL.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls, "second call must hit cache")
+
+		// Now use zero TTL — the cached entry must be removed and the backend must be called
+		rtNoTTL := NewCacheRoundTripper(fake, 0)
+		_, err = rtNoTTL.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, 2, calls, "zero TTL must remove cached entry and call backend")
+
+		// Restore a non-zero TTL; since the entry was removed, the backend is called again
+		_, err = rtWithTTL.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, 3, calls, "after removal, next non-zero TTL call must hit backend again")
+	})
+
+	t.Run("cache.set error does not prevent response from being returned", func(t *testing.T) {
+		_ = freshCache(t)
+
+		readErr := errors.New("read error")
+
+		fake := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			badResp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(&ioErrReader{err: readErr}),
+			}
+			badResp.Request = r
+
+			return badResp, nil
+		})
+
+		rt := NewCacheRoundTripper(fake, time.Minute)
+		resp, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err, "round trip must not return an error even if caching fails")
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Entry must NOT have been cached; a second call must reach the backend
+		calls := 0
+		fake2 := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			calls++
+			resp := fakeResponse("ok")
+			resp.Request = r
+
+			return resp, nil
+		})
+		rt2 := NewCacheRoundTripper(fake2, time.Minute)
+		// populate fresh cache for same key
+		_, err = rt2.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls, "backend must be called because previous set failed")
+	})
+
+	t.Run("error responses are not cached", func(t *testing.T) {
+		_ = freshCache(t)
+
+		calls := 0
+		errorResp := &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewBufferString("error")),
+		}
+		successResp := fakeResponse("ok")
+
+		fake := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			calls++
+			errorResp.Request = r
+			successResp.Request = r
+			if calls == 1 {
+				return errorResp, nil
+			}
+
+			return successResp, nil
+		})
+
+		rt := NewCacheRoundTripper(fake, time.Minute)
+
+		resp1, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, resp1.StatusCode)
+
+		resp2, err := rt.RoundTrip(newRequest(t, http.MethodGet, endpoint))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp2.StatusCode)
+
+		assert.Equal(t, 2, calls, "error response must not be cached; second call must reach backend")
+	})
+}
+func TestBuildCacheKey(t *testing.T) {
+	makeReq := func(t *testing.T, rawURL, auth string, body []byte) *http.Request {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet, rawURL, bytes.NewReader(body))
+		require.NoError(t, err)
+
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+
+		return req
+	}
+
+	const base = "http://api.example.com/v1/endpoint"
+
+	t.Run("same request produces same key", func(t *testing.T) {
+		req := makeReq(t, base, "token", nil)
+		assert.Equal(t, buildCacheKey(req), buildCacheKey(makeReq(t, base, "token", nil)))
+	})
+
+	t.Run("different URL produces different key", func(t *testing.T) {
+		assert.NotEqual(t,
+			buildCacheKey(makeReq(t, base+"/a", "", nil)),
+			buildCacheKey(makeReq(t, base+"/b", "", nil)),
+		)
+	})
+
+	t.Run("different Authorization produces different key", func(t *testing.T) {
+		assert.NotEqual(t,
+			buildCacheKey(makeReq(t, base, "token-a", nil)),
+			buildCacheKey(makeReq(t, base, "token-b", nil)),
+		)
+	})
+
+	t.Run("body is included in key", func(t *testing.T) {
+		assert.NotEqual(t,
+			buildCacheKey(makeReq(t, base, "", []byte("payload-a"))),
+			buildCacheKey(makeReq(t, base, "", []byte("payload-b"))),
+		)
+	})
+
+	t.Run("body can still be read after key is computed", func(t *testing.T) {
+		req := makeReq(t, base, "", []byte("my-body"))
+		_ = buildCacheKey(req)
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "my-body", string(body))
+	})
+}
+
+func TestRoundTripperFunc(t *testing.T) {
+	t.Run("nil roundTripperFunc causes panic, as it should never happen", func(t *testing.T) {
+		var rt roundTripperFunc // nil
+
+		assert.Panics(t, func() {
+			_, _ = rt.RoundTrip(nil)
+		})
+	})
+}

--- a/pkg/clients/dynatrace/oneagent/connection_info.go
+++ b/pkg/clients/dynatrace/oneagent/connection_info.go
@@ -32,6 +32,7 @@ func (c *Client) GetConnectionInfo(ctx context.Context) (ConnectionInfo, error) 
 	err := c.apiClient.GET(ctx, connectionInfoPath).
 		WithQueryParams(params).
 		WithPaasToken().
+		WithSkipCache().
 		Execute(&resp)
 
 	if core.IsBadRequest(err) {

--- a/pkg/clients/dynatrace/oneagent/connection_info.go
+++ b/pkg/clients/dynatrace/oneagent/connection_info.go
@@ -23,17 +23,21 @@ type ConnectionInfo struct {
 func (c *Client) GetConnectionInfo(ctx context.Context) (ConnectionInfo, error) {
 	var resp ConnectionInfo
 
+	req := c.apiClient.GET(ctx, connectionInfoPath).WithPaasToken()
+
 	params := map[string]string{}
 	if c.networkZone != "" {
 		params["networkZone"] = c.networkZone
 		params["defaultZoneFallback"] = "true"
+
+		// Skip the cache: when a network zone is set, the API may return empty Endpoints while
+		// the ActiveGate that owns the zone is still being deployed. The client treats an empty Endpoints response
+		// as valid, so only the reconciler detects the missing endpoints, by then the empty result has been cached
+		// which would cause repeated no-ops until the TTL expires.
+		req = req.WithSkipCache()
 	}
 
-	err := c.apiClient.GET(ctx, connectionInfoPath).
-		WithQueryParams(params).
-		WithPaasToken().
-		WithSkipCache().
-		Execute(&resp)
+	err := req.WithQueryParams(params).Execute(&resp)
 
 	if core.IsBadRequest(err) {
 		log.Info("server could not find the network zone or deliver default fallback config, is there an ActiveGate configured for the network zone?")

--- a/pkg/clients/dynatrace/oneagent/connection_info_test.go
+++ b/pkg/clients/dynatrace/oneagent/connection_info_test.go
@@ -36,7 +36,9 @@ func Test_GetConnectionInfo(t *testing.T) {
 		req := coremock.NewAPIRequest(t)
 		req.EXPECT().WithPaasToken().Return(req).Once()
 		req.EXPECT().WithQueryParams(params).Return(req).Once()
-		req.EXPECT().WithSkipCache().Return(req).Once()
+		if networkZone != "" {
+			req.EXPECT().WithSkipCache().Return(req).Once()
+		}
 		req.EXPECT().
 			Execute(&ConnectionInfo{}).
 			Run(func(model any) {

--- a/pkg/clients/dynatrace/oneagent/connection_info_test.go
+++ b/pkg/clients/dynatrace/oneagent/connection_info_test.go
@@ -36,6 +36,7 @@ func Test_GetConnectionInfo(t *testing.T) {
 		req := coremock.NewAPIRequest(t)
 		req.EXPECT().WithPaasToken().Return(req).Once()
 		req.EXPECT().WithQueryParams(params).Return(req).Once()
+		req.EXPECT().WithSkipCache().Return(req).Once()
 		req.EXPECT().
 			Execute(&ConnectionInfo{}).
 			Run(func(model any) {

--- a/pkg/controllers/dynakube/dynatraceclient/builder.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder.go
@@ -84,6 +84,7 @@ func (dynatraceClientBuilder builder) Build(ctx context.Context) (*dynatrace.Cli
 
 	opts.Opts = append(opts.Opts, dynatrace.WithAPIToken(apiToken))
 	opts.Opts = append(opts.Opts, dynatrace.WithPaasToken(paasToken))
+	opts.Opts = append(opts.Opts, dynatrace.WithCacheTTL(dynatraceClientBuilder.dk.APIRequestThreshold()))
 
 	return dynatrace.NewClient(opts.Opts...)
 }

--- a/pkg/controllers/nodes/nodes_controller.go
+++ b/pkg/controllers/nodes/nodes_controller.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -177,6 +178,12 @@ func (controller *Controller) sendMarkedForTermination(ctx context.Context, dk *
 	if err != nil {
 		return err
 	}
+
+	// NOTE: The dtclient in-memory cache is intentionally disabled here.
+	// `GetEntityIDForIP` fetches ALL host entities for the entire tenant, not just those belonging to this Kubernetes cluster.
+	// Which means a single call can pull in data from every cluster and environment reporting to the same tenant.
+	// Mark-for-termination events are rare, caching this possibly large dataset would waste memory with no meaningful benefit.
+	dk.Spec.DynatraceAPIRequestThreshold = ptr.To(uint16(0))
 
 	dtClient, err := controller.dynatraceClientBuilder.
 		SetDynakube(*dk).

--- a/pkg/util/kubernetes/fields/k8senv/env.go
+++ b/pkg/util/kubernetes/fields/k8senv/env.go
@@ -3,7 +3,9 @@ package k8senv
 import (
 	"os"
 	"strings"
+	"time"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -16,6 +18,11 @@ const (
 	DTOperatorPullSecretEnvName = "DT_OPERATOR_PULL_SECRET"
 	OLMOperatorNamespaceEnv     = "OLM_OPERATOR_NAMESPACE"
 	AppVersion                  = "APP_VERSION"
+
+	DTClientCacheCleanInterval        = "DT_CLIENT_CACHE_CLEAN_INTERVAL"
+	defaultDTClientCacheCleanInterval = time.Hour
+	minDTClientCacheCleanInterval     = 5 * time.Minute
+	maxDTClientCacheCleanInterval     = 100 * time.Hour
 )
 
 func Find(envVars []corev1.EnvVar, name string) *corev1.EnvVar {
@@ -92,4 +99,28 @@ func GetNodeName() string {
 
 func GetCSIDataDir() string {
 	return os.Getenv(CSIDataDir)
+}
+
+func GetDTClientCacheCleanInterval(log logd.Logger) time.Duration {
+	rawDuration := os.Getenv(DTClientCacheCleanInterval)
+	if rawDuration == "" {
+		log.Debug("no custom env set, using default", "env", DTClientCacheCleanInterval, "default", defaultDTClientCacheCleanInterval)
+
+		return defaultDTClientCacheCleanInterval
+	}
+
+	parsedDuration, err := time.ParseDuration(rawDuration)
+	if err != nil {
+		log.Info("couldn't parse time.Duration from env", "env", DTClientCacheCleanInterval, "value", rawDuration, "err", err)
+
+		return defaultDTClientCacheCleanInterval
+	}
+
+	if parsedDuration < minDTClientCacheCleanInterval || parsedDuration > maxDTClientCacheCleanInterval {
+		log.Info("parsed time.Duration from env is not in the allowed range", "env", DTClientCacheCleanInterval, "value", parsedDuration, "min", minDTClientCacheCleanInterval, "max", maxDTClientCacheCleanInterval)
+
+		return defaultDTClientCacheCleanInterval
+	}
+
+	return parsedDuration
 }

--- a/pkg/util/kubernetes/fields/k8senv/env_test.go
+++ b/pkg/util/kubernetes/fields/k8senv/env_test.go
@@ -2,7 +2,9 @@ package k8senv
 
 import (
 	"testing"
+	"time"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -171,6 +173,57 @@ func TestFindCaseInsensitive(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, FindCaseInsensitive(tt.args.envVars, tt.args.name), "FindCaseInsensitive(%v, %v)", tt.args.envVars, tt.args.name)
+		})
+	}
+}
+
+func TestGetDTClientCacheCleanInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     time.Duration
+	}{
+		{
+			name:     "valid duration returns parsed value",
+			envValue: "10m",
+			want:     10 * time.Minute,
+		},
+		{
+			name:     "empty env var returns default",
+			envValue: "",
+			want:     defaultDTClientCacheCleanInterval,
+		},
+		{
+			name:     "invalid duration returns default",
+			envValue: "not-a-duration",
+			want:     defaultDTClientCacheCleanInterval,
+		},
+		{
+			name:     "duration below minimum returns default",
+			envValue: "1m",
+			want:     defaultDTClientCacheCleanInterval,
+		},
+		{
+			name:     "duration above maximum returns default",
+			envValue: "200h",
+			want:     defaultDTClientCacheCleanInterval,
+		},
+		{
+			name:     "duration at minimum boundary returns parsed value",
+			envValue: "5m",
+			want:     minDTClientCacheCleanInterval,
+		},
+		{
+			name:     "duration at maximum boundary returns parsed value",
+			envValue: "100h",
+			want:     maxDTClientCacheCleanInterval,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(DTClientCacheCleanInterval, tt.envValue)
+			assert.Equal(t, tt.want, GetDTClientCacheCleanInterval(logd.Logger{}))
 		})
 	}
 }

--- a/test/mocks/pkg/clients/dynatrace/core/api_request.go
+++ b/test/mocks/pkg/clients/dynatrace/core/api_request.go
@@ -467,6 +467,52 @@ func (_c *APIRequest_WithRawQueryParams_Call) RunAndReturn(run func(params url.V
 	return _c
 }
 
+// WithSkipCache provides a mock function for the type APIRequest
+func (_mock *APIRequest) WithSkipCache() core.APIRequest {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithSkipCache")
+	}
+
+	var r0 core.APIRequest
+	if returnFunc, ok := ret.Get(0).(func() core.APIRequest); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(core.APIRequest)
+		}
+	}
+	return r0
+}
+
+// APIRequest_WithSkipCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithSkipCache'
+type APIRequest_WithSkipCache_Call struct {
+	*mock.Call
+}
+
+// WithSkipCache is a helper method to define mock.On call
+func (_e *APIRequest_Expecter) WithSkipCache() *APIRequest_WithSkipCache_Call {
+	return &APIRequest_WithSkipCache_Call{Call: _e.mock.On("WithSkipCache")}
+}
+
+func (_c *APIRequest_WithSkipCache_Call) Run(run func()) *APIRequest_WithSkipCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *APIRequest_WithSkipCache_Call) Return(aPIRequest core.APIRequest) *APIRequest_WithSkipCache_Call {
+	_c.Call.Return(aPIRequest)
+	return _c
+}
+
+func (_c *APIRequest_WithSkipCache_Call) RunAndReturn(run func() core.APIRequest) *APIRequest_WithSkipCache_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // WithoutToken provides a mock function for the type APIRequest
 func (_mock *APIRequest) WithoutToken() core.APIRequest {
 	ret := _mock.Called()


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-1115 (kinda incorrect, will need to update it)

Adds a little cache middleware to the dtclient.

It only caches GET requests that are not binary downloads
The TTL of each cache entry is the `spec.dynatraceApiRequestThreshold`
The key for each cache entry is the URL + body + tokens hashed:
- So if anything relevant changes in the DynaKube, this key should change

There is also a simple goroutine that keeps this cache clean.
- This is necessary due to the precious cache entry key
   - example: The user changes tokens, the old cache entry for this will never be hit again, so it wont be "auto" fixed
- Also necessary because users can turn off features, so they will stop making calls to certain APIs

~Rips out any and all previous dtclient throttling (or just misused throttling) from the code:~
- Moved to https://github.com/Dynatrace/dynatrace-operator/pull/6460

## How can this be tested?

~Just try it :D~ 

Now the part where it is actively used is https://github.com/Dynatrace/dynatrace-operator/pull/6460 (where nothing is in the way)