### PR TITLE
Set k8s recommended labels

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	agclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -113,9 +114,12 @@ func (r *Reconciler) getActiveGateAuthToken(ctx context.Context, dk *dynakube.Dy
 func (r *Reconciler) createSecret(ctx context.Context, dk *dynakube.DynaKube, secretData map[string][]byte) error {
 	secretName := dk.ActiveGate().GetAuthTokenSecretName()
 
+	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.ActiveGateComponentLabel)
+
 	secret, err := k8ssecret.Build(dk,
 		secretName,
-		secretData)
+		secretData,
+		k8ssecret.SetLabels(coreLabels.BuildLabels()))
 	if err != nil {
 		k8sconditions.SetKubeAPIError(dk.Conditions(), ActiveGateAuthTokenSecretConditionType, err)
 

--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/istio"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/version"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sconfigmap"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/pkg/errors"
@@ -158,9 +159,12 @@ func (r *Reconciler) createActiveGateTenantConnectionInfoConfigMap(ctx context.C
 
 	configMapData := extractPublicData(dk)
 
+	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.ActiveGateComponentLabel)
+
 	configMap, err := k8sconfigmap.Build(dk,
 		dk.ActiveGate().GetConnectionInfoConfigMapName(),
 		configMapData,
+		k8sconfigmap.SetLabels(coreLabels.BuildLabels()),
 	)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/controllers/dynakube/connectioninfo/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/activegate/reconciler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/pkg/errors"
@@ -113,7 +114,7 @@ func (r *Reconciler) setDynakubeStatus(dk *dynakube.DynaKube, connectionInfo agc
 }
 
 func (r *Reconciler) createTenantTokenSecret(ctx context.Context, dk *dynakube.DynaKube, secretName string, connectionInfo agclient.ConnectionInfo) error {
-	secret, err := connectioninfo.BuildTenantSecret(dk, secretName, connectionInfo.TenantToken)
+	secret, err := connectioninfo.BuildTenantSecret(dk, k8slabel.ActiveGateComponentLabel, secretName, connectionInfo.TenantToken)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pkg/controllers/dynakube/connectioninfo/common.go
+++ b/pkg/controllers/dynakube/connectioninfo/common.go
@@ -3,11 +3,12 @@ package connectioninfo
 import (
 	"context"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -40,10 +41,12 @@ func IsTenantSecretPresent(ctx context.Context, secrets k8ssecret.QueryObject, s
 	return true, nil
 }
 
-func BuildTenantSecret(owner metav1.Object, secretName string, tenantToken string) (*corev1.Secret, error) {
+func BuildTenantSecret(dk *dynakube.DynaKube, componentName string, secretName string, tenantToken string) (*corev1.Secret, error) {
 	secretData := ExtractSensitiveData(tenantToken)
 
-	return k8ssecret.Build(owner, secretName, secretData)
+	coreLabels := k8slabel.NewCoreLabels(dk.Name, componentName)
+
+	return k8ssecret.Build(dk, secretName, secretData, k8ssecret.SetLabels(coreLabels.BuildLabels()))
 }
 
 func ExtractSensitiveData(tenantToken string) map[string][]byte {

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/pkg/errors"
@@ -135,7 +136,7 @@ func (r *reconciler) setDynakubeStatus(connectionInfo oneagent.ConnectionInfo) {
 }
 
 func (r *reconciler) createTenantTokenSecret(ctx context.Context, secretName string, connectionInfo oneagent.ConnectionInfo) error {
-	secret, err := connectioninfo.BuildTenantSecret(r.dk, secretName, connectionInfo.TenantToken)
+	secret, err := connectioninfo.BuildTenantSecret(r.dk, k8slabel.OneAgentComponentLabel, secretName, connectionInfo.TenantToken)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sconfigmap"
 	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/pkg/errors"
@@ -57,9 +58,12 @@ func (r *Reconciler) addOperatorVersionInfo(dk *dynakube.DynaKube, configMapData
 }
 
 func (r *Reconciler) maintainMetadataConfigMap(ctx context.Context, dk *dynakube.DynaKube, configMapData map[string]string) error {
+	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.WebhookComponentLabel)
+
 	configMap, err := k8sconfigmap.Build(dk,
 		GetDeploymentMetadataConfigMapName(dk.Name),
 		configMapData,
+		k8sconfigmap.SetLabels(coreLabels.BuildLabels()),
 	)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
@@ -58,7 +58,7 @@ func (r *Reconciler) addOperatorVersionInfo(dk *dynakube.DynaKube, configMapData
 }
 
 func (r *Reconciler) maintainMetadataConfigMap(ctx context.Context, dk *dynakube.DynaKube, configMapData map[string]string) error {
-	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.WebhookComponentLabel)
+	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.OperatorComponentLabel)
 
 	configMap, err := k8sconfigmap.Build(dk,
 		GetDeploymentMetadataConfigMapName(dk.Name),

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/pkg/errors"
@@ -80,9 +81,12 @@ func (r *Reconciler) reconcilePullSecret(ctx context.Context, dk *dynakube.DynaK
 		return errors.WithMessage(err, "could not generate pull secret data")
 	}
 
+	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.WebhookComponentLabel)
+
 	secret, err := k8ssecret.Build(dk,
 		extendWithPullSecretSuffix(dk.Name), pullSecretData,
 		k8ssecret.SetType(corev1.SecretTypeDockerConfigJson),
+		k8ssecret.SetLabels(coreLabels.BuildLabels()),
 	)
 	if err != nil {
 		k8sconditions.SetKubeAPIError(dk.Conditions(), PullSecretConditionType, err)

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -81,7 +81,7 @@ func (r *Reconciler) reconcilePullSecret(ctx context.Context, dk *dynakube.DynaK
 		return errors.WithMessage(err, "could not generate pull secret data")
 	}
 
-	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.WebhookComponentLabel)
+	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.OperatorComponentLabel)
 
 	secret, err := k8ssecret.Build(dk,
 		extendWithPullSecretSuffix(dk.Name), pullSecretData,

--- a/pkg/controllers/dynakube/extension/secret.go
+++ b/pkg/controllers/dynakube/extension/secret.go
@@ -8,6 +8,7 @@ import (
 	eecConsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -99,7 +100,9 @@ func (r *Reconciler) buildSecret(eecToken dttoken.Token, otelcToken dttoken.Toke
 		consts.DatasourceTokenSecretKey: []byte(otelcToken.String()),
 	}
 
-	return k8ssecret.Build(dk, r.getSecretName(dk), secretData)
+	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.ExtensionComponentLabel)
+
+	return k8ssecret.Build(dk, r.getSecretName(dk), secretData, k8ssecret.SetLabels(coreLabels.BuildLabels()))
 }
 
 func (r *Reconciler) getSecretName(dk *dynakube.DynaKube) string {

--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
@@ -75,7 +75,7 @@ func (r *Reconciler) generateDaemonSet(dk *dynakube.DynaKube) (*appsv1.DaemonSet
 		return nil, err
 	}
 
-	labels := k8slabel.NewCoreLabels(dk.Name, k8slabel.KSPMComponentLabel)
+	labels := k8slabel.NewAppLabels(k8slabel.KSPMComponentLabel, dk.Name, k8slabel.KSPMComponentLabel, dk.Spec.Templates.KSPMNodeConfigurationCollector.ImageRef.Tag)
 	templateAnnotations := map[string]string{tokenSecretHashAnnotation: dk.KSPM().TokenSecretHash}
 	maps.Copy(templateAnnotations, k8ssecuritycontext.RemoveAppArmorAnnotation(dk.KSPM().Annotations, containerName))
 

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
@@ -77,7 +77,12 @@ func (r *Reconciler) generateDaemonSet(dk *dynakube.DynaKube) (*appsv1.DaemonSet
 		return nil, err
 	}
 
-	labels := k8slabel.NewAppLabels(k8slabel.LogMonitoringComponentLabel, dk.Name, k8slabel.LogMonitoringComponentLabel, dk.Spec.Templates.LogMonitoring.ImageRef.Tag)
+	tag := ""
+	if dk.Spec.Templates.LogMonitoring != nil {
+		tag = dk.Spec.Templates.LogMonitoring.ImageRef.Tag
+	}
+
+	labels := k8slabel.NewAppLabels(k8slabel.LogMonitoringComponentLabel, dk.Name, k8slabel.LogMonitoringComponentLabel, tag)
 
 	ds, err := k8sdaemonset.Build(dk, dk.LogMonitoring().GetDaemonSetName(), getContainer(*dk, tenantUUID),
 		k8sdaemonset.SetInitContainer(getInitContainer(*dk, tenantUUID)),

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
@@ -77,7 +77,7 @@ func (r *Reconciler) generateDaemonSet(dk *dynakube.DynaKube) (*appsv1.DaemonSet
 		return nil, err
 	}
 
-	labels := k8slabel.NewCoreLabels(dk.Name, k8slabel.LogMonitoringComponentLabel)
+	labels := k8slabel.NewAppLabels(k8slabel.LogMonitoringComponentLabel, dk.Name, k8slabel.LogMonitoringComponentLabel, dk.Spec.Templates.LogMonitoring.ImageRef.Tag)
 
 	ds, err := k8sdaemonset.Build(dk, dk.LogMonitoring().GetDaemonSetName(), getContainer(*dk, tenantUUID),
 		k8sdaemonset.SetInitContainer(getInitContainer(*dk, tenantUUID)),

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler_test.go
@@ -98,6 +98,7 @@ func TestReconcile(t *testing.T) {
 
 	t.Run("Create and update works with ME not set", func(t *testing.T) {
 		dk := createDynakube(true)
+
 		dk.Status.KubernetesClusterMEID = ""
 
 		mockK8sClient := fake.NewClient()
@@ -454,6 +455,9 @@ func createDynakube(isEnabled bool) *dynakube.DynaKube {
 		Spec: dynakube.DynaKubeSpec{
 			APIURL:        "test-url",
 			LogMonitoring: logMonitoring,
+			Templates: dynakube.TemplatesSpec{
+				LogMonitoring: &logmonitoring.TemplateSpec{},
+			},
 		},
 		Status: dynakube.DynaKubeStatus{
 			OneAgent: oneagent.Status{

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler.go
@@ -196,9 +196,12 @@ func (r *Reconciler) updateInstancesStatus(ctx context.Context, dk *dynakube.Dyn
 func (r *Reconciler) createOneAgentTenantConnectionInfoConfigMap(ctx context.Context, dk *dynakube.DynaKube) error {
 	configMapData := extractPublicData(dk)
 
+	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.OneAgentComponentLabel)
+
 	configMap, err := k8sconfigmap.Build(dk,
 		dk.OneAgent().GetConnectionInfoConfigMapName(),
 		configMapData,
+		k8sconfigmap.SetLabels(coreLabels.BuildLabels()),
 	)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/controllers/nodes/cache/cache.go
+++ b/pkg/controllers/nodes/cache/cache.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
+	"github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -71,10 +73,13 @@ func New(ctx context.Context, apiReader client.Reader, ns string, owner client.O
 	}
 
 	if k8serrors.IsNotFound(err) {
+		coreLabels := k8slabel.NewCoreLabels(version.AppName, k8slabel.NodeControllerLabel)
+
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ConfigMapName,
 				Namespace: ns,
+				Labels:    coreLabels.BuildLabels(),
 			},
 			Data: map[string]string{},
 		}

--- a/pkg/util/kubernetes/fields/k8slabel/labels.go
+++ b/pkg/util/kubernetes/fields/k8slabel/labels.go
@@ -25,6 +25,7 @@ const (
 	ExtensionComponentLabel     = "dynatrace-extension-controller"
 	OtelCComponentLabel         = "dynatrace-otel-collector"
 	DatabaseSQLExecutorLabel    = "dynatrace-sql-extension-executor"
+	NodeControllerLabel         = "node-controller"
 )
 
 type AppMatchLabels struct {

--- a/pkg/util/kubernetes/fields/k8slabel/labels.go
+++ b/pkg/util/kubernetes/fields/k8slabel/labels.go
@@ -26,6 +26,7 @@ const (
 	OtelCComponentLabel         = "dynatrace-otel-collector"
 	DatabaseSQLExecutorLabel    = "dynatrace-sql-extension-executor"
 	NodeControllerLabel         = "node-controller"
+	OperatorComponentLabel      = "operator"
 )
 
 type AppMatchLabels struct {


### PR DESCRIPTION
[ICP-3699](https://dt-rnd.atlassian.net/browse/ICP-3699)

## Description

Changes LogMonitoring daemonset and KSPM daemonset labels from CoreLabels to AppLabels.
Adds CoreLables to Secrets and ConfigMaps if not exist.

## How can this be tested?

Deploy all components. Check if labels are used the same way for workloads and secrets,configmaps,services.

[ICP-3699]: https://dt-rnd.atlassian.net/browse/ICP-3699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ