### PR TITLE
Use a safe struct to log edgeconnect configs

### DIFF
--- a/pkg/controllers/edgeconnect/secret/secret.go
+++ b/pkg/controllers/edgeconnect/secret/secret.go
@@ -79,11 +79,55 @@ func PrepareConfigFile(ctx context.Context, ec *edgeconnect.EdgeConnect, apiRead
 
 // Replace client secret with stars for debug logs
 func safeEdgeConnectCfg(cfg config.EdgeConnect) string {
-	if cfg.OAuth.ClientSecret != "" {
-		cfg.OAuth.ClientSecret = "****"
+	type safeOAuth struct {
+		ClientID string `yaml:"client_id,omitempty"`
+		Endpoint string `yaml:"endpoint,omitempty"`
+		Resource string `yaml:"resource,omitempty"`
 	}
 
-	safe, _ := yaml.Marshal(cfg)
+	type safeProxy struct {
+		Server     string `yaml:"server,omitempty"`
+		Port       uint32 `yaml:"port,omitempty"`
+		Exceptions string `yaml:"exceptions,omitempty"`
+	}
+
+	type safeSecrets struct {
+		Name            string   `yaml:"name,omitempty"`
+		RestrictHostsTo []string `yaml:"restrict_hosts_to,omitempty"`
+	}
+
+	type safeConfig struct {
+		Name                 string        `yaml:"name,omitempty"`
+		APIEndpointHost      string        `yaml:"api_endpoint_host,omitempty"`
+		OAuth                safeOAuth     `yaml:"oauth,omitempty"`
+		Proxy                safeProxy     `yaml:"proxy,omitempty"`
+		RootCertificatePaths []string      `yaml:"root_certificate_paths,omitempty"`
+		RestrictHostsTo      []string      `yaml:"restrict_hosts_to,omitempty"`
+		Secrets              []safeSecrets `yaml:"secrets,omitempty"`
+	}
+
+	safeCfg := safeConfig{
+		Name:            cfg.Name,
+		APIEndpointHost: cfg.APIEndpointHost,
+		OAuth: safeOAuth{
+			ClientID: cfg.OAuth.ClientID,
+			Endpoint: cfg.OAuth.Endpoint,
+			Resource: cfg.OAuth.Resource,
+		},
+		Proxy: safeProxy{
+			Server:     cfg.Proxy.Server,
+			Port:       cfg.Proxy.Port,
+			Exceptions: cfg.Proxy.Exceptions,
+		},
+		RootCertificatePaths: cfg.RootCertificatePaths,
+		RestrictHostsTo:      cfg.RestrictHostsTo,
+	}
+
+	for _, s := range cfg.Secrets {
+		safeCfg.Secrets = append(safeCfg.Secrets, safeSecrets{Name: s.Name, RestrictHostsTo: s.RestrictHostsTo})
+	}
+
+	safe, _ := yaml.Marshal(safeCfg)
 
 	return string(safe)
 }

--- a/pkg/controllers/edgeconnect/secret/secret.go
+++ b/pkg/controllers/edgeconnect/secret/secret.go
@@ -80,15 +80,16 @@ func PrepareConfigFile(ctx context.Context, ec *edgeconnect.EdgeConnect, apiRead
 // Replace client secret with stars for debug logs
 func safeEdgeConnectCfg(cfg config.EdgeConnect) string {
 	type safeOAuth struct {
-		ClientID string `yaml:"client_id,omitempty"`
 		Endpoint string `yaml:"endpoint,omitempty"`
+		ClientID string `yaml:"client_id,omitempty"`
 		Resource string `yaml:"resource,omitempty"`
 	}
 
 	type safeProxy struct {
+		User       string `yaml:"user,omitempty"`
 		Server     string `yaml:"server,omitempty"`
-		Port       uint32 `yaml:"port,omitempty"`
 		Exceptions string `yaml:"exceptions,omitempty"`
+		Port       uint32 `yaml:"port,omitempty"`
 	}
 
 	type safeSecrets struct {
@@ -100,9 +101,9 @@ func safeEdgeConnectCfg(cfg config.EdgeConnect) string {
 		Name                 string        `yaml:"name,omitempty"`
 		APIEndpointHost      string        `yaml:"api_endpoint_host,omitempty"`
 		OAuth                safeOAuth     `yaml:"oauth,omitempty"`
-		Proxy                safeProxy     `yaml:"proxy,omitempty"`
-		RootCertificatePaths []string      `yaml:"root_certificate_paths,omitempty"`
 		RestrictHostsTo      []string      `yaml:"restrict_hosts_to,omitempty"`
+		RootCertificatePaths []string      `yaml:"root_certificate_paths,omitempty"`
+		Proxy                safeProxy     `yaml:"proxy,omitempty"`
 		Secrets              []safeSecrets `yaml:"secrets,omitempty"`
 	}
 
@@ -115,6 +116,7 @@ func safeEdgeConnectCfg(cfg config.EdgeConnect) string {
 			Resource: cfg.OAuth.Resource,
 		},
 		Proxy: safeProxy{
+			User:       cfg.Proxy.Auth.User,
 			Server:     cfg.Proxy.Server,
 			Port:       cfg.Proxy.Port,
 			Exceptions: cfg.Proxy.Exceptions,

--- a/pkg/controllers/edgeconnect/secret/secret_test.go
+++ b/pkg/controllers/edgeconnect/secret/secret_test.go
@@ -165,16 +165,50 @@ secrets:
 			Name:            "test",
 			APIEndpointHost: "test",
 			OAuth: config.OAuth{
+				Endpoint:     "endpoint",
+				ClientID:     "id",
 				ClientSecret: "super secret",
+				Resource:     "resource",
+			},
+			RestrictHostsTo:      []string{"host"},
+			RootCertificatePaths: []string{"path"},
+			Proxy: config.Proxy{
+				Server:     "server",
+				Exceptions: "exception",
+				Port:       2,
+				Auth: config.Auth{
+					User:     "user",
+					Password: "password",
+				},
+			},
+			Secrets: []config.Secret{
+				{
+					Name:            "secret",
+					Token:           "token",
+					FromFile:        "file",
+					RestrictHostsTo: []string{"hosts"},
+				},
 			},
 		}
 		expected := `name: test
 api_endpoint_host: test
 oauth:
-    endpoint: ""
-    client_id: ""
-    client_secret: '****'
-    resource: ""
+    endpoint: endpoint
+    client_id: id
+    resource: resource
+restrict_hosts_to:
+    - host
+root_certificate_paths:
+    - path
+proxy:
+    user: user
+    server: server
+    exceptions: exception
+    port: 2
+secrets:
+    - name: secret
+      restrict_hosts_to:
+        - hosts
 `
 		assert.Equal(t, expected, safeEdgeConnectCfg(cfg))
 	})


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
The logged edgeconnect config has some sensitive data. This PR hides all sensitive data from the log by mapping the config to a safe struct before logging.
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?
Create a regular edgeconnect and look in the logs if the log is safe. (Or run a similar e2e test and check the logs)
<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->