### PR TITLE
Fix GitHub Action used for updating CSV bundles

### DIFF
--- a/.github/actions/update-csv-bundles/action.yml
+++ b/.github/actions/update-csv-bundles/action.yml
@@ -113,7 +113,7 @@ runs:
       with:
         base: release-${{ steps.vars.outputs.major_minor }}
         branch: csv-${{ steps.vars.outputs.major_minor}}
-        token: ${{ steps.create-github-app-token.token }}
+        token: ${{ steps.create-github-app-token.outputs.token }}
         delete-branch: true
         add-paths: |
           config/olm/**


### PR DESCRIPTION
## Description
The GitHub App token is an output of the `create-github-app-token` step.

Fixes https://github.com/Dynatrace/dynatrace-operator/actions/runs/24331752934/job/71040769488#step:4:820