### PR TITLE
move apiToken paasToken dataIngestToken consts to pkg/controllers/dynakube/token

### DIFF
--- a/cmd/troubleshoot/dynakube.go
+++ b/cmd/troubleshoot/dynakube.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/installer"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dtpullsecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceclient"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
@@ -102,9 +102,9 @@ func checkIfDynatraceAPISecretHasAPIToken(ctx context.Context, baseLog logd.Logg
 		return nil, errors.Wrapf(err, "'%s:%s' secret is missing or invalid", dk.Namespace, dk.Tokens())
 	}
 
-	_, hasAPIToken := tokens[dtclient.APIToken]
+	_, hasAPIToken := tokens[consts.APIToken]
 	if !hasAPIToken {
-		return nil, errors.New(fmt.Sprintf("'%s' token is missing in '%s:%s' secret", dtclient.APIToken, dk.Namespace, dk.Tokens()))
+		return nil, errors.New(fmt.Sprintf("'%s' token is missing in '%s:%s' secret", consts.APIToken, dk.Namespace, dk.Tokens()))
 	}
 
 	logInfof(log, "secret token 'apiToken' exists")

--- a/cmd/troubleshoot/dynakube.go
+++ b/cmd/troubleshoot/dynakube.go
@@ -101,9 +101,9 @@ func checkIfDynatraceAPISecretHasAPIToken(ctx context.Context, baseLog logd.Logg
 		return nil, errors.Wrapf(err, "'%s:%s' secret is missing or invalid", dk.Namespace, dk.Tokens())
 	}
 
-	_, hasAPIToken := tokens[token.APIToken]
+	_, hasAPIToken := tokens[token.APIKey]
 	if !hasAPIToken {
-		return nil, errors.New(fmt.Sprintf("'%s' token is missing in '%s:%s' secret", token.APIToken, dk.Namespace, dk.Tokens()))
+		return nil, errors.New(fmt.Sprintf("'%s' token is missing in '%s:%s' secret", token.APIKey, dk.Namespace, dk.Tokens()))
 	}
 
 	logInfof(log, "secret token 'apiToken' exists")

--- a/cmd/troubleshoot/dynakube.go
+++ b/cmd/troubleshoot/dynakube.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/installer"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dtpullsecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceclient"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
@@ -102,9 +101,9 @@ func checkIfDynatraceAPISecretHasAPIToken(ctx context.Context, baseLog logd.Logg
 		return nil, errors.Wrapf(err, "'%s:%s' secret is missing or invalid", dk.Namespace, dk.Tokens())
 	}
 
-	_, hasAPIToken := tokens[consts.APIToken]
+	_, hasAPIToken := tokens[token.APIToken]
 	if !hasAPIToken {
-		return nil, errors.New(fmt.Sprintf("'%s' token is missing in '%s:%s' secret", consts.APIToken, dk.Namespace, dk.Tokens()))
+		return nil, errors.New(fmt.Sprintf("'%s' token is missing in '%s:%s' secret", token.APIToken, dk.Namespace, dk.Tokens()))
 	}
 
 	logInfof(log, "secret token 'apiToken' exists")

--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -12,12 +12,6 @@ import (
 	"golang.org/x/net/http/httpproxy"
 )
 
-const (
-	PaasToken       = "paasToken"
-	APIToken        = "apiToken"
-	DataIngestToken = "dataIngestToken"
-)
-
 // Client is the interface for the Dynatrace REST API client.
 type Client interface {
 	// AsV2 is a temporary adapter to gradually migrate to the v2 client.

--- a/pkg/consts/token.go
+++ b/pkg/consts/token.go
@@ -1,1 +1,0 @@
-package consts

--- a/pkg/consts/token.go
+++ b/pkg/consts/token.go
@@ -1,7 +1,1 @@
 package consts
-
-const (
-	PaasToken       = "paasToken"
-	APIToken        = "apiToken"
-	DataIngestToken = "dataIngestToken"
-)

--- a/pkg/consts/token.go
+++ b/pkg/consts/token.go
@@ -1,0 +1,7 @@
+package consts
+
+const (
+	PaasToken       = "paasToken"
+	APIToken        = "apiToken"
+	DataIngestToken = "dataIngestToken"
+)

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -406,7 +406,7 @@ func createToken(t *testing.T, dk *dynakube.DynaKube) *corev1.Secret {
 			Namespace: dk.Namespace,
 		},
 		Data: map[string][]byte{
-			token.APIToken: []byte("this is a token"),
+			token.APIKey: []byte("this is a token"),
 		},
 	}
 }

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	oneagentclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/provisioner/cleanup"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceclient"
@@ -405,7 +406,7 @@ func createToken(t *testing.T, dk *dynakube.DynaKube) *corev1.Secret {
 			Namespace: dk.Namespace,
 		},
 		Data: map[string][]byte{
-			dtclient.APIToken: []byte("this is a token"),
+			consts.APIToken: []byte("this is a token"),
 		},
 	}
 }

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	oneagentclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/provisioner/cleanup"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceclient"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/job"
@@ -406,7 +406,7 @@ func createToken(t *testing.T, dk *dynakube.DynaKube) *corev1.Secret {
 			Namespace: dk.Namespace,
 		},
 		Data: map[string][]byte{
-			consts.APIToken: []byte("this is a token"),
+			token.APIToken: []byte("this is a token"),
 		},
 	}
 }

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -15,6 +15,7 @@ import (
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/settings"
 	tokenclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	oaconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/injection"
@@ -243,7 +244,7 @@ func TestSetupTokensAndClient(t *testing.T) {
 				Namespace: dk.Namespace,
 			},
 			Data: map[string][]byte{
-				dtclient.APIToken: []byte("this is a token"),
+				consts.APIToken: []byte("this is a token"),
 			},
 		}
 		fakeClient := fake.NewClientWithIndex(dk, tokens)
@@ -275,7 +276,7 @@ func TestSetupTokensAndClient(t *testing.T) {
 				Namespace: dk.Namespace,
 			},
 			Data: map[string][]byte{
-				dtclient.APIToken: []byte("this is a token"),
+				consts.APIToken: []byte("this is a token"),
 			},
 		}
 		fakeClient := fake.NewClientWithIndex(dk, tokens)
@@ -669,7 +670,7 @@ func TestTokenConditions(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				dtclient.APIToken: []byte(testAPIToken),
+				consts.APIToken: []byte(testAPIToken),
 			},
 		})
 
@@ -711,7 +712,7 @@ func TestTokenConditions(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				dtclient.APIToken: []byte(testAPIToken),
+				consts.APIToken: []byte(testAPIToken),
 			},
 		})
 
@@ -960,7 +961,7 @@ func createAPISecret() *corev1.Secret {
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{
-			dtclient.APIToken: []byte(testAPIToken),
+			consts.APIToken: []byte(testAPIToken),
 		},
 	}
 }

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -15,7 +15,6 @@ import (
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/settings"
 	tokenclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
 	oaconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/injection"
@@ -244,7 +243,7 @@ func TestSetupTokensAndClient(t *testing.T) {
 				Namespace: dk.Namespace,
 			},
 			Data: map[string][]byte{
-				consts.APIToken: []byte("this is a token"),
+				token.APIToken: []byte("this is a token"),
 			},
 		}
 		fakeClient := fake.NewClientWithIndex(dk, tokens)
@@ -276,7 +275,7 @@ func TestSetupTokensAndClient(t *testing.T) {
 				Namespace: dk.Namespace,
 			},
 			Data: map[string][]byte{
-				consts.APIToken: []byte("this is a token"),
+				token.APIToken: []byte("this is a token"),
 			},
 		}
 		fakeClient := fake.NewClientWithIndex(dk, tokens)
@@ -670,7 +669,7 @@ func TestTokenConditions(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				consts.APIToken: []byte(testAPIToken),
+				token.APIToken: []byte(testAPIToken),
 			},
 		})
 
@@ -712,7 +711,7 @@ func TestTokenConditions(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				consts.APIToken: []byte(testAPIToken),
+				token.APIToken: []byte(testAPIToken),
 			},
 		})
 
@@ -961,7 +960,7 @@ func createAPISecret() *corev1.Secret {
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{
-			consts.APIToken: []byte(testAPIToken),
+			token.APIToken: []byte(testAPIToken),
 		},
 	}
 }

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -243,7 +243,7 @@ func TestSetupTokensAndClient(t *testing.T) {
 				Namespace: dk.Namespace,
 			},
 			Data: map[string][]byte{
-				token.APIToken: []byte("this is a token"),
+				token.APIKey: []byte("this is a token"),
 			},
 		}
 		fakeClient := fake.NewClientWithIndex(dk, tokens)
@@ -275,7 +275,7 @@ func TestSetupTokensAndClient(t *testing.T) {
 				Namespace: dk.Namespace,
 			},
 			Data: map[string][]byte{
-				token.APIToken: []byte("this is a token"),
+				token.APIKey: []byte("this is a token"),
 			},
 		}
 		fakeClient := fake.NewClientWithIndex(dk, tokens)
@@ -669,7 +669,7 @@ func TestTokenConditions(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				token.APIToken: []byte(testAPIToken),
+				token.APIKey: []byte(testAPIToken),
 			},
 		})
 
@@ -711,7 +711,7 @@ func TestTokenConditions(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				token.APIToken: []byte(testAPIToken),
+				token.APIKey: []byte(testAPIToken),
 			},
 		})
 
@@ -960,7 +960,7 @@ func createAPISecret() *corev1.Secret {
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{
-			token.APIToken: []byte(testAPIToken),
+			token.APIKey: []byte(testAPIToken),
 		},
 	}
 }

--- a/pkg/controllers/dynakube/dtpullsecret/generate_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,7 +49,7 @@ func TestReconciler_GenerateData(t *testing.T) {
 	r := &Reconciler{}
 
 	data, err := r.generateData(dk, token.Tokens{
-		consts.PaasToken: &token.Token{Value: testPaasToken},
+		token.PaasToken: &token.Token{Value: testPaasToken},
 	})
 
 	require.NoError(t, err)

--- a/pkg/controllers/dynakube/dtpullsecret/generate_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,7 +50,7 @@ func TestReconciler_GenerateData(t *testing.T) {
 	r := &Reconciler{}
 
 	data, err := r.generateData(dk, token.Tokens{
-		dtclient.PaasToken: &token.Token{Value: testPaasToken},
+		consts.PaasToken: &token.Token{Value: testPaasToken},
 	})
 
 	require.NoError(t, err)

--- a/pkg/controllers/dynakube/dtpullsecret/generate_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate_test.go
@@ -49,7 +49,7 @@ func TestReconciler_GenerateData(t *testing.T) {
 	r := &Reconciler{}
 
 	data, err := r.generateData(dk, token.Tokens{
-		token.PaasToken: &token.Token{Value: testPaasToken},
+		token.PaaSKey: &token.Token{Value: testPaasToken},
 	})
 
 	require.NoError(t, err)

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,7 +34,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			consts.APIToken: &token.Token{Value: testValue},
+			token.APIToken: &token.Token{Value: testValue},
 		})
 
 		require.NoError(t, err)
@@ -63,7 +62,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fake.NewClient(), fakeErrorClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			consts.APIToken: &token.Token{Value: testValue},
+			token.APIToken: &token.Token{Value: testValue},
 		})
 		require.ErrorIs(t, err, expectErr)
 	})
@@ -81,7 +80,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			consts.APIToken: &token.Token{Value: testValue},
+			token.APIToken: &token.Token{Value: testValue},
 		})
 		require.Error(t, err)
 	})
@@ -97,7 +96,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeErrorClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			consts.APIToken: &token.Token{Value: testValue},
+			token.APIToken: &token.Token{Value: testValue},
 		})
 		require.ErrorIs(t, err, expectErr)
 	})
@@ -122,7 +121,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			consts.APIToken: &token.Token{Value: testValue},
+			token.APIToken: &token.Token{Value: testValue},
 		})
 
 		require.NoError(t, err)
@@ -144,7 +143,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
-			consts.APIToken: &token.Token{Value: testValue},
+			token.APIToken: &token.Token{Value: testValue},
 		}
 
 		r := NewReconciler(fakeClient, fakeClient)
@@ -184,7 +183,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
-			consts.APIToken: &token.Token{Value: testValue},
+			token.APIToken: &token.Token{Value: testValue},
 		}
 
 		r := NewReconciler(fakeClient, fakeClient)
@@ -220,7 +219,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
-			consts.APIToken: &token.Token{Value: testValue},
+			token.APIToken: &token.Token{Value: testValue},
 		}
 
 		r := NewReconciler(fakeClient, fakeClient)

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,7 +35,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			dtclient.APIToken: &token.Token{Value: testValue},
+			consts.APIToken: &token.Token{Value: testValue},
 		})
 
 		require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fake.NewClient(), fakeErrorClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			dtclient.APIToken: &token.Token{Value: testValue},
+			consts.APIToken: &token.Token{Value: testValue},
 		})
 		require.ErrorIs(t, err, expectErr)
 	})
@@ -81,7 +81,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			dtclient.APIToken: &token.Token{Value: testValue},
+			consts.APIToken: &token.Token{Value: testValue},
 		})
 		require.Error(t, err)
 	})
@@ -97,7 +97,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeErrorClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			dtclient.APIToken: &token.Token{Value: testValue},
+			consts.APIToken: &token.Token{Value: testValue},
 		})
 		require.ErrorIs(t, err, expectErr)
 	})
@@ -122,7 +122,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			dtclient.APIToken: &token.Token{Value: testValue},
+			consts.APIToken: &token.Token{Value: testValue},
 		})
 
 		require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
-			dtclient.APIToken: &token.Token{Value: testValue},
+			consts.APIToken: &token.Token{Value: testValue},
 		}
 
 		r := NewReconciler(fakeClient, fakeClient)
@@ -184,7 +184,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
-			dtclient.APIToken: &token.Token{Value: testValue},
+			consts.APIToken: &token.Token{Value: testValue},
 		}
 
 		r := NewReconciler(fakeClient, fakeClient)
@@ -220,7 +220,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
-			dtclient.APIToken: &token.Token{Value: testValue},
+			consts.APIToken: &token.Token{Value: testValue},
 		}
 
 		r := NewReconciler(fakeClient, fakeClient)

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -34,7 +34,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			token.APIToken: &token.Token{Value: testValue},
+			token.APIKey: &token.Token{Value: testValue},
 		})
 
 		require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fake.NewClient(), fakeErrorClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			token.APIToken: &token.Token{Value: testValue},
+			token.APIKey: &token.Token{Value: testValue},
 		})
 		require.ErrorIs(t, err, expectErr)
 	})
@@ -80,7 +80,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			token.APIToken: &token.Token{Value: testValue},
+			token.APIKey: &token.Token{Value: testValue},
 		})
 		require.Error(t, err)
 	})
@@ -96,7 +96,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeErrorClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			token.APIToken: &token.Token{Value: testValue},
+			token.APIKey: &token.Token{Value: testValue},
 		})
 		require.ErrorIs(t, err, expectErr)
 	})
@@ -121,7 +121,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := NewReconciler(fakeClient, fakeClient)
 
 		err := r.Reconcile(t.Context(), dk, token.Tokens{
-			token.APIToken: &token.Token{Value: testValue},
+			token.APIKey: &token.Token{Value: testValue},
 		})
 
 		require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
-			token.APIToken: &token.Token{Value: testValue},
+			token.APIKey: &token.Token{Value: testValue},
 		}
 
 		r := NewReconciler(fakeClient, fakeClient)
@@ -183,7 +183,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
-			token.APIToken: &token.Token{Value: testValue},
+			token.APIKey: &token.Token{Value: testValue},
 		}
 
 		r := NewReconciler(fakeClient, fakeClient)
@@ -219,7 +219,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
-			token.APIToken: &token.Token{Value: testValue},
+			token.APIKey: &token.Token{Value: testValue},
 		}
 
 		r := NewReconciler(fakeClient, fakeClient)

--- a/pkg/controllers/dynakube/dynatraceclient/builder_test.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder_test.go
@@ -35,8 +35,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 		dynatraceClientBuilder := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				token.APIToken:  {Value: testValue},
-				token.PaasToken: {Value: testValueAlternative},
+				token.APIKey:  {Value: testValue},
+				token.PaaSKey: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -63,8 +63,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
 				// Simulate missing values
-				token.APIToken:  {Value: ""},
-				token.PaasToken: {Value: ""},
+				token.APIKey:  {Value: ""},
+				token.PaaSKey: {Value: ""},
 			},
 			dk: *dk,
 		}
@@ -97,8 +97,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 		dynatraceClientBuilder := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				token.APIToken:  {Value: testValue},
-				token.PaasToken: {Value: testValueAlternative},
+				token.APIKey:  {Value: testValue},
+				token.PaaSKey: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -121,8 +121,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 		dtf := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				token.APIToken:  {Value: testValue},
-				token.PaasToken: {Value: testValueAlternative},
+				token.APIKey:  {Value: testValue},
+				token.PaaSKey: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}

--- a/pkg/controllers/dynakube/dynatraceclient/builder_test.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,8 +35,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 		dynatraceClientBuilder := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				consts.APIToken:  {Value: testValue},
-				consts.PaasToken: {Value: testValueAlternative},
+				token.APIToken:  {Value: testValue},
+				token.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -64,8 +63,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
 				// Simulate missing values
-				consts.APIToken:  {Value: ""},
-				consts.PaasToken: {Value: ""},
+				token.APIToken:  {Value: ""},
+				token.PaasToken: {Value: ""},
 			},
 			dk: *dk,
 		}
@@ -98,8 +97,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 		dynatraceClientBuilder := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				consts.APIToken:  {Value: testValue},
-				consts.PaasToken: {Value: testValueAlternative},
+				token.APIToken:  {Value: testValue},
+				token.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -122,8 +121,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 		dtf := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				consts.APIToken:  {Value: testValue},
-				consts.PaasToken: {Value: testValueAlternative},
+				token.APIToken:  {Value: testValue},
+				token.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}

--- a/pkg/controllers/dynakube/dynatraceclient/builder_test.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,8 +36,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 		dynatraceClientBuilder := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				dtclient.APIToken:  {Value: testValue},
-				dtclient.PaasToken: {Value: testValueAlternative},
+				consts.APIToken:  {Value: testValue},
+				consts.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -64,8 +64,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
 				// Simulate missing values
-				dtclient.APIToken:  {Value: ""},
-				dtclient.PaasToken: {Value: ""},
+				consts.APIToken:  {Value: ""},
+				consts.PaasToken: {Value: ""},
 			},
 			dk: *dk,
 		}
@@ -98,8 +98,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 		dynatraceClientBuilder := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				dtclient.APIToken:  {Value: testValue},
-				dtclient.PaasToken: {Value: testValueAlternative},
+				consts.APIToken:  {Value: testValue},
+				consts.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -122,8 +122,8 @@ func TestBuildDynatraceClient(t *testing.T) {
 		dtf := builder{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				dtclient.APIToken:  {Value: testValue},
-				dtclient.PaasToken: {Value: testValueAlternative},
+				consts.APIToken:  {Value: testValue},
+				consts.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}

--- a/pkg/controllers/dynakube/dynatraceclient/builder_v2_test.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder_v2_test.go
@@ -27,8 +27,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 		dynatraceClientBuilder := builderV2{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				token.APIToken:  {Value: testValue},
-				token.PaasToken: {Value: testValueAlternative},
+				token.APIKey:  {Value: testValue},
+				token.PaaSKey: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -55,8 +55,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
 				// Simulate missing values
-				token.APIToken:  {Value: ""},
-				token.PaasToken: {Value: ""},
+				token.APIKey:  {Value: ""},
+				token.PaaSKey: {Value: ""},
 			},
 			dk: *dk,
 		}
@@ -89,8 +89,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 		dynatraceClientBuilder := builderV2{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				token.APIToken:  {Value: testValue},
-				token.PaasToken: {Value: testValueAlternative},
+				token.APIKey:  {Value: testValue},
+				token.PaaSKey: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -113,8 +113,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 		dtf := builderV2{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				token.APIToken:  {Value: testValue},
-				token.PaasToken: {Value: testValueAlternative},
+				token.APIKey:  {Value: testValue},
+				token.PaaSKey: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}

--- a/pkg/controllers/dynakube/dynatraceclient/builder_v2_test.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder_v2_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,8 +27,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 		dynatraceClientBuilder := builderV2{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				consts.APIToken:  {Value: testValue},
-				consts.PaasToken: {Value: testValueAlternative},
+				token.APIToken:  {Value: testValue},
+				token.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -56,8 +55,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
 				// Simulate missing values
-				consts.APIToken:  {Value: ""},
-				consts.PaasToken: {Value: ""},
+				token.APIToken:  {Value: ""},
+				token.PaasToken: {Value: ""},
 			},
 			dk: *dk,
 		}
@@ -90,8 +89,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 		dynatraceClientBuilder := builderV2{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				consts.APIToken:  {Value: testValue},
-				consts.PaasToken: {Value: testValueAlternative},
+				token.APIToken:  {Value: testValue},
+				token.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -114,8 +113,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 		dtf := builderV2{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				consts.APIToken:  {Value: testValue},
-				consts.PaasToken: {Value: testValueAlternative},
+				token.APIToken:  {Value: testValue},
+				token.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}

--- a/pkg/controllers/dynakube/dynatraceclient/builder_v2_test.go
+++ b/pkg/controllers/dynakube/dynatraceclient/builder_v2_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,8 +28,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 		dynatraceClientBuilder := builderV2{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				dtclient.APIToken:  {Value: testValue},
-				dtclient.PaasToken: {Value: testValueAlternative},
+				consts.APIToken:  {Value: testValue},
+				consts.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -56,8 +56,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
 				// Simulate missing values
-				dtclient.APIToken:  {Value: ""},
-				dtclient.PaasToken: {Value: ""},
+				consts.APIToken:  {Value: ""},
+				consts.PaasToken: {Value: ""},
 			},
 			dk: *dk,
 		}
@@ -90,8 +90,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 		dynatraceClientBuilder := builderV2{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				dtclient.APIToken:  {Value: testValue},
-				dtclient.PaasToken: {Value: testValueAlternative},
+				consts.APIToken:  {Value: testValue},
+				consts.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}
@@ -114,8 +114,8 @@ func TestBuildDynatraceClientV2(t *testing.T) {
 		dtf := builderV2{
 			apiReader: fakeClient,
 			tokens: map[string]*token.Token{
-				dtclient.APIToken:  {Value: testValue},
-				dtclient.PaasToken: {Value: testValueAlternative},
+				consts.APIToken:  {Value: testValue},
+				consts.PaasToken: {Value: testValueAlternative},
 			},
 			dk: *dk,
 		}

--- a/pkg/controllers/dynakube/injection/reconciler_test.go
+++ b/pkg/controllers/dynakube/injection/reconciler_test.go
@@ -14,9 +14,10 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	oneagentclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
+	tokenclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	versions "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/version"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/bootstrapperconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/mapper"
@@ -111,14 +112,14 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		}
-		k8sconditions.SetOptionalScopeAvailable(dk.Conditions(), token.ConditionTypeAPITokenSettingsRead, "available")
+		k8sconditions.SetOptionalScopeAvailable(dk.Conditions(), tokenclient.ConditionTypeAPITokenSettingsRead, "available")
 		clt := fake.NewClientWithIndex(
 			clientNotInjectedNamespace(testNamespace, testDynakube),
 			clientNotInjectedNamespace(testNamespace2, testDynakube2),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.APIToken:        []byte(testAPIToken),
-				consts.PaasToken:       []byte(testPaasToken),
-				consts.DataIngestToken: []byte(testDataIngestToken),
+				token.APIToken:        []byte(testAPIToken),
+				token.PaasToken:       []byte(testPaasToken),
+				token.DataIngestToken: []byte(testDataIngestToken),
 			}),
 			dk,
 		)
@@ -173,8 +174,8 @@ func TestReconciler(t *testing.T) {
 			clientSecret(consts.OTLPExporterSecretName, testNamespace, nil),
 			clientSecret(consts.OTLPExporterSecretName, testNamespace2, nil),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.APIToken:  []byte(testAPIToken),
-				consts.PaasToken: []byte(testPaasToken),
+				token.APIToken:  []byte(testAPIToken),
+				token.PaasToken: []byte(testPaasToken),
 			}),
 			dk,
 		)
@@ -385,8 +386,8 @@ func TestGenerateCorrectInitSecret(t *testing.T) {
 	}
 
 	tokenSecret := clientSecret(dkBase.Name, dkBase.Namespace, map[string][]byte{
-		consts.APIToken:  []byte("testAPIToken"),
-		consts.PaasToken: []byte("testPaasToken"),
+		token.APIToken:  []byte("testAPIToken"),
+		token.PaasToken: []byte("testPaasToken"),
 	})
 
 	tenantSecret := clientSecret(dkBase.OneAgent().GetTenantSecret(), dkBase.Namespace, map[string][]byte{
@@ -448,8 +449,8 @@ func TestGenerateCorrectCertInitSecret(t *testing.T) {
 	}
 
 	tokenSecret := clientSecret(dkBase.Name, dkBase.Namespace, map[string][]byte{
-		consts.APIToken:  []byte(testAPIToken),
-		consts.PaasToken: []byte(testPaasToken),
+		token.APIToken:  []byte(testAPIToken),
+		token.PaasToken: []byte(testPaasToken),
 	})
 
 	tenantSecret := clientSecret(dkBase.OneAgent().GetTenantSecret(), dkBase.Namespace, map[string][]byte{
@@ -537,9 +538,9 @@ func TestGenerateCorrectOTLPCertInitSecret(t *testing.T) {
 	}
 
 	tokenSecret := clientSecret(dkBase.Name, dkBase.Namespace, map[string][]byte{
-		consts.APIToken:        []byte(testAPIToken),
-		consts.PaasToken:       []byte(testPaasToken),
-		consts.DataIngestToken: []byte(testDataIngestToken),
+		token.APIToken:        []byte(testAPIToken),
+		token.PaasToken:       []byte(testPaasToken),
+		token.DataIngestToken: []byte(testDataIngestToken),
 	})
 
 	tenantSecret := clientSecret(dkBase.OneAgent().GetTenantSecret(), dkBase.Namespace, map[string][]byte{
@@ -706,8 +707,8 @@ func clientOneAgentInjection() client.Client {
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientInjectedNamespace(testNamespace2, testDynakube2),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			consts.APIToken:  []byte(testAPIToken),
-			consts.PaasToken: []byte(testPaasToken),
+			token.APIToken:  []byte(testAPIToken),
+			token.PaasToken: []byte(testPaasToken),
 		}),
 	)
 }
@@ -717,9 +718,9 @@ func clientEnrichmentInjection() client.Client {
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientInjectedNamespace(testNamespace2, testDynakube2),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			consts.APIToken:        []byte(testAPIToken),
-			consts.PaasToken:       []byte(testPaasToken),
-			consts.DataIngestToken: []byte(testDataIngestToken),
+			token.APIToken:        []byte(testAPIToken),
+			token.PaasToken:       []byte(testPaasToken),
+			token.DataIngestToken: []byte(testDataIngestToken),
 		}),
 	)
 }

--- a/pkg/controllers/dynakube/injection/reconciler_test.go
+++ b/pkg/controllers/dynakube/injection/reconciler_test.go
@@ -116,9 +116,9 @@ func TestReconciler(t *testing.T) {
 			clientNotInjectedNamespace(testNamespace, testDynakube),
 			clientNotInjectedNamespace(testNamespace2, testDynakube2),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.APIToken:        []byte(testAPIToken),
-				dtclient.PaasToken:       []byte(testPaasToken),
-				dtclient.DataIngestToken: []byte(testDataIngestToken),
+				consts.APIToken:        []byte(testAPIToken),
+				consts.PaasToken:       []byte(testPaasToken),
+				consts.DataIngestToken: []byte(testDataIngestToken),
 			}),
 			dk,
 		)
@@ -173,8 +173,8 @@ func TestReconciler(t *testing.T) {
 			clientSecret(consts.OTLPExporterSecretName, testNamespace, nil),
 			clientSecret(consts.OTLPExporterSecretName, testNamespace2, nil),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.APIToken:  []byte(testAPIToken),
-				dtclient.PaasToken: []byte(testPaasToken),
+				consts.APIToken:  []byte(testAPIToken),
+				consts.PaasToken: []byte(testPaasToken),
 			}),
 			dk,
 		)
@@ -385,8 +385,8 @@ func TestGenerateCorrectInitSecret(t *testing.T) {
 	}
 
 	tokenSecret := clientSecret(dkBase.Name, dkBase.Namespace, map[string][]byte{
-		dtclient.APIToken:  []byte("testAPIToken"),
-		dtclient.PaasToken: []byte("testPaasToken"),
+		consts.APIToken:  []byte("testAPIToken"),
+		consts.PaasToken: []byte("testPaasToken"),
 	})
 
 	tenantSecret := clientSecret(dkBase.OneAgent().GetTenantSecret(), dkBase.Namespace, map[string][]byte{
@@ -448,8 +448,8 @@ func TestGenerateCorrectCertInitSecret(t *testing.T) {
 	}
 
 	tokenSecret := clientSecret(dkBase.Name, dkBase.Namespace, map[string][]byte{
-		dtclient.APIToken:  []byte(testAPIToken),
-		dtclient.PaasToken: []byte(testPaasToken),
+		consts.APIToken:  []byte(testAPIToken),
+		consts.PaasToken: []byte(testPaasToken),
 	})
 
 	tenantSecret := clientSecret(dkBase.OneAgent().GetTenantSecret(), dkBase.Namespace, map[string][]byte{
@@ -537,9 +537,9 @@ func TestGenerateCorrectOTLPCertInitSecret(t *testing.T) {
 	}
 
 	tokenSecret := clientSecret(dkBase.Name, dkBase.Namespace, map[string][]byte{
-		dtclient.APIToken:        []byte(testAPIToken),
-		dtclient.PaasToken:       []byte(testPaasToken),
-		dtclient.DataIngestToken: []byte(testDataIngestToken),
+		consts.APIToken:        []byte(testAPIToken),
+		consts.PaasToken:       []byte(testPaasToken),
+		consts.DataIngestToken: []byte(testDataIngestToken),
 	})
 
 	tenantSecret := clientSecret(dkBase.OneAgent().GetTenantSecret(), dkBase.Namespace, map[string][]byte{
@@ -706,8 +706,8 @@ func clientOneAgentInjection() client.Client {
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientInjectedNamespace(testNamespace2, testDynakube2),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			dtclient.APIToken:  []byte(testAPIToken),
-			dtclient.PaasToken: []byte(testPaasToken),
+			consts.APIToken:  []byte(testAPIToken),
+			consts.PaasToken: []byte(testPaasToken),
 		}),
 	)
 }
@@ -717,9 +717,9 @@ func clientEnrichmentInjection() client.Client {
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientInjectedNamespace(testNamespace2, testDynakube2),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			dtclient.APIToken:        []byte(testAPIToken),
-			dtclient.PaasToken:       []byte(testPaasToken),
-			dtclient.DataIngestToken: []byte(testDataIngestToken),
+			consts.APIToken:        []byte(testAPIToken),
+			consts.PaasToken:       []byte(testPaasToken),
+			consts.DataIngestToken: []byte(testDataIngestToken),
 		}),
 	)
 }

--- a/pkg/controllers/dynakube/injection/reconciler_test.go
+++ b/pkg/controllers/dynakube/injection/reconciler_test.go
@@ -117,9 +117,9 @@ func TestReconciler(t *testing.T) {
 			clientNotInjectedNamespace(testNamespace, testDynakube),
 			clientNotInjectedNamespace(testNamespace2, testDynakube2),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.APIToken:        []byte(testAPIToken),
-				token.PaasToken:       []byte(testPaasToken),
-				token.DataIngestToken: []byte(testDataIngestToken),
+				token.APIKey:        []byte(testAPIToken),
+				token.PaaSKey:       []byte(testPaasToken),
+				token.DataIngestKey: []byte(testDataIngestToken),
 			}),
 			dk,
 		)
@@ -174,8 +174,8 @@ func TestReconciler(t *testing.T) {
 			clientSecret(consts.OTLPExporterSecretName, testNamespace, nil),
 			clientSecret(consts.OTLPExporterSecretName, testNamespace2, nil),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.APIToken:  []byte(testAPIToken),
-				token.PaasToken: []byte(testPaasToken),
+				token.APIKey:  []byte(testAPIToken),
+				token.PaaSKey: []byte(testPaasToken),
 			}),
 			dk,
 		)
@@ -386,8 +386,8 @@ func TestGenerateCorrectInitSecret(t *testing.T) {
 	}
 
 	tokenSecret := clientSecret(dkBase.Name, dkBase.Namespace, map[string][]byte{
-		token.APIToken:  []byte("testAPIToken"),
-		token.PaasToken: []byte("testPaasToken"),
+		token.APIKey:  []byte("testAPIToken"),
+		token.PaaSKey: []byte("testPaasToken"),
 	})
 
 	tenantSecret := clientSecret(dkBase.OneAgent().GetTenantSecret(), dkBase.Namespace, map[string][]byte{
@@ -449,8 +449,8 @@ func TestGenerateCorrectCertInitSecret(t *testing.T) {
 	}
 
 	tokenSecret := clientSecret(dkBase.Name, dkBase.Namespace, map[string][]byte{
-		token.APIToken:  []byte(testAPIToken),
-		token.PaasToken: []byte(testPaasToken),
+		token.APIKey:  []byte(testAPIToken),
+		token.PaaSKey: []byte(testPaasToken),
 	})
 
 	tenantSecret := clientSecret(dkBase.OneAgent().GetTenantSecret(), dkBase.Namespace, map[string][]byte{
@@ -538,9 +538,9 @@ func TestGenerateCorrectOTLPCertInitSecret(t *testing.T) {
 	}
 
 	tokenSecret := clientSecret(dkBase.Name, dkBase.Namespace, map[string][]byte{
-		token.APIToken:        []byte(testAPIToken),
-		token.PaasToken:       []byte(testPaasToken),
-		token.DataIngestToken: []byte(testDataIngestToken),
+		token.APIKey:        []byte(testAPIToken),
+		token.PaaSKey:       []byte(testPaasToken),
+		token.DataIngestKey: []byte(testDataIngestToken),
 	})
 
 	tenantSecret := clientSecret(dkBase.OneAgent().GetTenantSecret(), dkBase.Namespace, map[string][]byte{
@@ -707,8 +707,8 @@ func clientOneAgentInjection() client.Client {
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientInjectedNamespace(testNamespace2, testDynakube2),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			token.APIToken:  []byte(testAPIToken),
-			token.PaasToken: []byte(testPaasToken),
+			token.APIKey:  []byte(testAPIToken),
+			token.PaaSKey: []byte(testPaasToken),
 		}),
 	)
 }
@@ -718,9 +718,9 @@ func clientEnrichmentInjection() client.Client {
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientInjectedNamespace(testNamespace2, testDynakube2),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			token.APIToken:        []byte(testAPIToken),
-			token.PaasToken:       []byte(testPaasToken),
-			token.DataIngestToken: []byte(testDataIngestToken),
+			token.APIKey:        []byte(testAPIToken),
+			token.PaaSKey:       []byte(testPaasToken),
+			token.DataIngestKey: []byte(testDataIngestToken),
 		}),
 	)
 }

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -763,6 +763,6 @@ func createVersionReconcilerMock(t *testing.T) versionReconciler {
 
 func createTokens() token.Tokens {
 	return token.Tokens{
-		token.APIToken: &token.Token{Value: "sdfsdf"},
+		token.APIKey: &token.Token{Value: "sdfsdf"},
 	}
 }

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	oaconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
@@ -764,6 +764,6 @@ func createVersionReconcilerMock(t *testing.T) versionReconciler {
 
 func createTokens() token.Tokens {
 	return token.Tokens{
-		dtclient.APIToken: &token.Token{Value: "sdfsdf"},
+		consts.APIToken: &token.Token{Value: "sdfsdf"},
 	}
 }

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	oaconnectioninfo "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
@@ -764,6 +763,6 @@ func createVersionReconcilerMock(t *testing.T) versionReconciler {
 
 func createTokens() token.Tokens {
 	return token.Tokens{
-		consts.APIToken: &token.Token{Value: "sdfsdf"},
+		token.APIToken: &token.Token{Value: "sdfsdf"},
 	}
 }

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
@@ -10,8 +10,8 @@ import (
 	schemeFake "github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	globalConsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sconfigmap"
 	"github.com/stretchr/testify/assert"
@@ -37,7 +37,7 @@ func TestConfigMapCreation(t *testing.T) {
 		dk := createDynaKube(true)
 
 		testConfigMap, err := k8sconfigmap.Build(&dk, dk.Name, map[string]string{
-			globalConsts.APIToken: testAPIToken,
+			token.APIToken: testAPIToken,
 		})
 		require.NoError(t, err)
 

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
@@ -37,7 +37,7 @@ func TestConfigMapCreation(t *testing.T) {
 		dk := createDynaKube(true)
 
 		testConfigMap, err := k8sconfigmap.Build(&dk, dk.Name, map[string]string{
-			token.APIToken: testAPIToken,
+			token.APIKey: testAPIToken,
 		})
 		require.NoError(t, err)
 

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
@@ -10,7 +10,7 @@ import (
 	schemeFake "github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	globalConsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sconfigmap"
@@ -37,7 +37,7 @@ func TestConfigMapCreation(t *testing.T) {
 		dk := createDynaKube(true)
 
 		testConfigMap, err := k8sconfigmap.Build(&dk, dk.Name, map[string]string{
-			dtclient.APIToken: testAPIToken,
+			globalConsts.APIToken: testAPIToken,
 		})
 		require.NoError(t, err)
 

--- a/pkg/controllers/dynakube/otelc/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/reconciler_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	globalConsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/endpoint"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/statefulset"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sconfigmap"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
 	"github.com/stretchr/testify/assert"
@@ -65,8 +65,8 @@ func TestNoProxyConsistency(t *testing.T) {
 
 func createClient(t *testing.T, dk *dynakube.DynaKube) client.WithWatch {
 	testTokensSecret, err := k8ssecret.Build(dk, dk.Name, map[string][]byte{
-		globalConsts.APIToken:        []byte(testToken),
-		globalConsts.DataIngestToken: []byte(testToken),
+		token.APIToken:        []byte(testToken),
+		token.DataIngestToken: []byte(testToken),
 	})
 	require.NoError(t, err)
 

--- a/pkg/controllers/dynakube/otelc/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/reconciler_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	globalConsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/endpoint"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/statefulset"
@@ -65,8 +65,8 @@ func TestNoProxyConsistency(t *testing.T) {
 
 func createClient(t *testing.T, dk *dynakube.DynaKube) client.WithWatch {
 	testTokensSecret, err := k8ssecret.Build(dk, dk.Name, map[string][]byte{
-		dtclient.APIToken:        []byte(testToken),
-		dtclient.DataIngestToken: []byte(testToken),
+		globalConsts.APIToken:        []byte(testToken),
+		globalConsts.DataIngestToken: []byte(testToken),
 	})
 	require.NoError(t, err)
 

--- a/pkg/controllers/dynakube/otelc/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/reconciler_test.go
@@ -65,8 +65,8 @@ func TestNoProxyConsistency(t *testing.T) {
 
 func createClient(t *testing.T, dk *dynakube.DynaKube) client.WithWatch {
 	testTokensSecret, err := k8ssecret.Build(dk, dk.Name, map[string][]byte{
-		token.APIToken:        []byte(testToken),
-		token.DataIngestToken: []byte(testToken),
+		token.APIKey:        []byte(testToken),
+		token.DataIngestKey: []byte(testToken),
 	})
 	require.NoError(t, err)
 

--- a/pkg/controllers/dynakube/otelc/statefulset/env.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env.go
@@ -107,7 +107,7 @@ func getEnvs(dk *dynakube.DynaKube, replicas int32) []corev1.EnvVar {
 			corev1.EnvVar{Name: otelcConsts.EnvDataIngestToken, ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: dk.Tokens()},
-					Key:                  token.DataIngestToken,
+					Key:                  token.DataIngestKey,
 				},
 			}},
 		)

--- a/pkg/controllers/dynakube/otelc/statefulset/env.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/activegate"
 	otelcConsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -106,7 +107,7 @@ func getEnvs(dk *dynakube.DynaKube, replicas int32) []corev1.EnvVar {
 			corev1.EnvVar{Name: otelcConsts.EnvDataIngestToken, ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: dk.Tokens()},
-					Key:                  consts.DataIngestToken,
+					Key:                  token.DataIngestToken,
 				},
 			}},
 		)

--- a/pkg/controllers/dynakube/otelc/statefulset/env.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/activegate"
 	otelcConsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
@@ -107,7 +106,7 @@ func getEnvs(dk *dynakube.DynaKube, replicas int32) []corev1.EnvVar {
 			corev1.EnvVar{Name: otelcConsts.EnvDataIngestToken, ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: dk.Tokens()},
-					Key:                  dynatrace.DataIngestToken,
+					Key:                  consts.DataIngestToken,
 				},
 			}},
 		)

--- a/pkg/controllers/dynakube/otelc/statefulset/env_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	otelcConsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -111,7 +112,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Equal(t, corev1.EnvVar{Name: otelcConsts.EnvDataIngestToken, ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: dk.Tokens()},
-				Key:                  consts.DataIngestToken,
+				Key:                  token.DataIngestToken,
 			},
 		}}, statefulSet.Spec.Template.Spec.Containers[0].Env[11])
 	})

--- a/pkg/controllers/dynakube/otelc/statefulset/env_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/extensions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/telemetryingest"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	otelcConsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
 	"github.com/stretchr/testify/assert"
@@ -112,7 +111,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Equal(t, corev1.EnvVar{Name: otelcConsts.EnvDataIngestToken, ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: dk.Tokens()},
-				Key:                  dynatrace.DataIngestToken,
+				Key:                  consts.DataIngestToken,
 			},
 		}}, statefulSet.Spec.Template.Spec.Containers[0].Env[11])
 	})

--- a/pkg/controllers/dynakube/otelc/statefulset/env_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/env_test.go
@@ -112,7 +112,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Equal(t, corev1.EnvVar{Name: otelcConsts.EnvDataIngestToken, ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: dk.Tokens()},
-				Key:                  token.DataIngestToken,
+				Key:                  token.DataIngestKey,
 			},
 		}}, statefulSet.Spec.Template.Spec.Containers[0].Env[11])
 	})

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
@@ -524,8 +524,8 @@ func getTokens(name string, namespace string) corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			token.APIToken:        []byte("test"),
-			token.DataIngestToken: []byte("test"),
+			token.APIKey:        []byte("test"),
+			token.DataIngestKey: []byte("test"),
 		},
 	}
 }

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/extensions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	otelcconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
@@ -524,8 +523,8 @@ func getTokens(name string, namespace string) corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			dtclient.APIToken:        []byte("test"),
-			dtclient.DataIngestToken: []byte("test"),
+			consts.APIToken:        []byte("test"),
+			consts.DataIngestToken: []byte("test"),
 		},
 	}
 }

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	otelcconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8saffinity"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
@@ -523,8 +524,8 @@ func getTokens(name string, namespace string) corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			consts.APIToken:        []byte("test"),
-			consts.DataIngestToken: []byte("test"),
+			token.APIToken:        []byte("test"),
+			token.DataIngestToken: []byte("test"),
 		},
 	}
 }

--- a/pkg/controllers/dynakube/token/reader.go
+++ b/pkg/controllers/dynakube/token/reader.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,7 +58,7 @@ func (reader Reader) readTokens(ctx context.Context) (Tokens, error) {
 }
 
 func (reader Reader) verifyAPITokenExists(tokens Tokens) error {
-	apiToken, hasAPIToken := tokens[consts.APIToken]
+	apiToken, hasAPIToken := tokens[APIToken]
 
 	if !hasAPIToken || len(apiToken.Value) == 0 {
 		return errors.New(fmt.Sprintf("the API token is missing from the token secret '%s:%s'", reader.dk.Namespace, reader.dk.Tokens()))

--- a/pkg/controllers/dynakube/token/reader.go
+++ b/pkg/controllers/dynakube/token/reader.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,7 +59,7 @@ func (reader Reader) readTokens(ctx context.Context) (Tokens, error) {
 }
 
 func (reader Reader) verifyAPITokenExists(tokens Tokens) error {
-	apiToken, hasAPIToken := tokens[dtclient.APIToken]
+	apiToken, hasAPIToken := tokens[consts.APIToken]
 
 	if !hasAPIToken || len(apiToken.Value) == 0 {
 		return errors.New(fmt.Sprintf("the API token is missing from the token secret '%s:%s'", reader.dk.Namespace, reader.dk.Tokens()))

--- a/pkg/controllers/dynakube/token/reader.go
+++ b/pkg/controllers/dynakube/token/reader.go
@@ -58,7 +58,7 @@ func (reader Reader) readTokens(ctx context.Context) (Tokens, error) {
 }
 
 func (reader Reader) verifyAPITokenExists(tokens Tokens) error {
-	apiToken, hasAPIToken := tokens[APIToken]
+	apiToken, hasAPIToken := tokens[APIKey]
 
 	if !hasAPIToken || len(apiToken.Value) == 0 {
 		return errors.New(fmt.Sprintf("the API token is missing from the token secret '%s:%s'", reader.dk.Namespace, reader.dk.Tokens()))

--- a/pkg/controllers/dynakube/token/reader_test.go
+++ b/pkg/controllers/dynakube/token/reader_test.go
@@ -49,9 +49,9 @@ func testReadTokens(t *testing.T) {
 			},
 		}
 		testSecret, err := k8ssecret.Build(&dk, "dynakube", map[string][]byte{
-			APIToken:               []byte(testAPIToken),
-			PaasToken:              []byte(testPaasToken),
-			DataIngestToken:        []byte(testDataIngestToken),
+			APIKey:                 []byte(testAPIToken),
+			PaaSKey:                []byte(testPaasToken),
+			DataIngestKey:          []byte(testDataIngestToken),
 			testIrrelevantTokenKey: []byte(testIrrelevantToken),
 		})
 		require.NoError(t, err)
@@ -64,13 +64,13 @@ func testReadTokens(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Len(t, tokens, 4)
-		assert.Contains(t, tokens, APIToken)
-		assert.Contains(t, tokens, PaasToken)
-		assert.Contains(t, tokens, DataIngestToken)
+		assert.Contains(t, tokens, APIKey)
+		assert.Contains(t, tokens, PaaSKey)
+		assert.Contains(t, tokens, DataIngestKey)
 		assert.Contains(t, tokens, testIrrelevantTokenKey)
-		assert.Equal(t, testAPIToken, tokens[APIToken].Value)
-		assert.Equal(t, testPaasToken, tokens[PaasToken].Value)
-		assert.Equal(t, testDataIngestToken, tokens[DataIngestToken].Value)
+		assert.Equal(t, testAPIToken, tokens[APIKey].Value)
+		assert.Equal(t, testPaasToken, tokens[PaaSKey].Value)
+		assert.Equal(t, testDataIngestToken, tokens[DataIngestKey].Value)
 		assert.Equal(t, testIrrelevantToken, tokens[testIrrelevantTokenKey].Value)
 	})
 }
@@ -97,7 +97,7 @@ func testVerifyTokens(t *testing.T) {
 			testIrrelevantTokenKey: {
 				Value: testIrrelevantToken,
 			},
-			APIToken: {
+			APIKey: {
 				Value: testAPIToken,
 			},
 		})

--- a/pkg/controllers/dynakube/token/reader_test.go
+++ b/pkg/controllers/dynakube/token/reader_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,10 +50,10 @@ func testReadTokens(t *testing.T) {
 			},
 		}
 		testSecret, err := k8ssecret.Build(&dk, "dynakube", map[string][]byte{
-			dtclient.APIToken:        []byte(testAPIToken),
-			dtclient.PaasToken:       []byte(testPaasToken),
-			dtclient.DataIngestToken: []byte(testDataIngestToken),
-			testIrrelevantTokenKey:   []byte(testIrrelevantToken),
+			consts.APIToken:        []byte(testAPIToken),
+			consts.PaasToken:       []byte(testPaasToken),
+			consts.DataIngestToken: []byte(testDataIngestToken),
+			testIrrelevantTokenKey: []byte(testIrrelevantToken),
 		})
 		require.NoError(t, err)
 
@@ -65,13 +65,13 @@ func testReadTokens(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Len(t, tokens, 4)
-		assert.Contains(t, tokens, dtclient.APIToken)
-		assert.Contains(t, tokens, dtclient.PaasToken)
-		assert.Contains(t, tokens, dtclient.DataIngestToken)
+		assert.Contains(t, tokens, consts.APIToken)
+		assert.Contains(t, tokens, consts.PaasToken)
+		assert.Contains(t, tokens, consts.DataIngestToken)
 		assert.Contains(t, tokens, testIrrelevantTokenKey)
-		assert.Equal(t, testAPIToken, tokens[dtclient.APIToken].Value)
-		assert.Equal(t, testPaasToken, tokens[dtclient.PaasToken].Value)
-		assert.Equal(t, testDataIngestToken, tokens[dtclient.DataIngestToken].Value)
+		assert.Equal(t, testAPIToken, tokens[consts.APIToken].Value)
+		assert.Equal(t, testPaasToken, tokens[consts.PaasToken].Value)
+		assert.Equal(t, testDataIngestToken, tokens[consts.DataIngestToken].Value)
 		assert.Equal(t, testIrrelevantToken, tokens[testIrrelevantTokenKey].Value)
 	})
 }
@@ -98,7 +98,7 @@ func testVerifyTokens(t *testing.T) {
 			testIrrelevantTokenKey: {
 				Value: testIrrelevantToken,
 			},
-			dtclient.APIToken: {
+			consts.APIToken: {
 				Value: testAPIToken,
 			},
 		})

--- a/pkg/controllers/dynakube/token/reader_test.go
+++ b/pkg/controllers/dynakube/token/reader_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,9 +49,9 @@ func testReadTokens(t *testing.T) {
 			},
 		}
 		testSecret, err := k8ssecret.Build(&dk, "dynakube", map[string][]byte{
-			consts.APIToken:        []byte(testAPIToken),
-			consts.PaasToken:       []byte(testPaasToken),
-			consts.DataIngestToken: []byte(testDataIngestToken),
+			APIToken:               []byte(testAPIToken),
+			PaasToken:              []byte(testPaasToken),
+			DataIngestToken:        []byte(testDataIngestToken),
 			testIrrelevantTokenKey: []byte(testIrrelevantToken),
 		})
 		require.NoError(t, err)
@@ -65,13 +64,13 @@ func testReadTokens(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Len(t, tokens, 4)
-		assert.Contains(t, tokens, consts.APIToken)
-		assert.Contains(t, tokens, consts.PaasToken)
-		assert.Contains(t, tokens, consts.DataIngestToken)
+		assert.Contains(t, tokens, APIToken)
+		assert.Contains(t, tokens, PaasToken)
+		assert.Contains(t, tokens, DataIngestToken)
 		assert.Contains(t, tokens, testIrrelevantTokenKey)
-		assert.Equal(t, testAPIToken, tokens[consts.APIToken].Value)
-		assert.Equal(t, testPaasToken, tokens[consts.PaasToken].Value)
-		assert.Equal(t, testDataIngestToken, tokens[consts.DataIngestToken].Value)
+		assert.Equal(t, testAPIToken, tokens[APIToken].Value)
+		assert.Equal(t, testPaasToken, tokens[PaasToken].Value)
+		assert.Equal(t, testDataIngestToken, tokens[DataIngestToken].Value)
 		assert.Equal(t, testIrrelevantToken, tokens[testIrrelevantTokenKey].Value)
 	})
 }
@@ -98,7 +97,7 @@ func testVerifyTokens(t *testing.T) {
 			testIrrelevantTokenKey: {
 				Value: testIrrelevantToken,
 			},
-			consts.APIToken: {
+			APIToken: {
 				Value: testAPIToken,
 			},
 		})

--- a/pkg/controllers/dynakube/token/tokens.go
+++ b/pkg/controllers/dynakube/token/tokens.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	PaasToken       = "paasToken"
-	APIToken        = "apiToken"
-	DataIngestToken = "dataIngestToken"
+	PaaSKey       = "paasToken"
+	APIKey        = "apiToken"
+	DataIngestKey = "dataIngestToken"
 )
 
 type VerificationError struct {
@@ -28,15 +28,15 @@ func (v VerificationError) Error() string {
 type Tokens map[string]*Token
 
 func (tokens Tokens) APIToken() *Token {
-	return tokens.getToken(APIToken)
+	return tokens.getToken(APIKey)
 }
 
 func (tokens Tokens) PaasToken() *Token {
-	return tokens.getToken(PaasToken)
+	return tokens.getToken(PaaSKey)
 }
 
 func (tokens Tokens) DataIngestToken() *Token {
-	return tokens.getToken(DataIngestToken)
+	return tokens.getToken(DataIngestKey)
 }
 
 func (tokens Tokens) getToken(tokenName string) *Token {
@@ -49,15 +49,15 @@ func (tokens Tokens) getToken(tokenName string) *Token {
 }
 
 func (tokens Tokens) AddFeatureScopesToTokens() Tokens {
-	_, hasPaasToken := tokens[PaasToken]
+	_, hasPaasToken := tokens[PaaSKey]
 
 	for _, token := range tokens {
 		switch token.Type {
-		case APIToken:
+		case APIKey:
 			token.addFeatures(getFeaturesForAPIToken(hasPaasToken))
-		case PaasToken:
+		case PaaSKey:
 			token.addFeatures(getFeaturesForPaaSToken())
-		case DataIngestToken:
+		case DataIngestKey:
 			token.addFeatures(getFeaturesForDataIngest())
 		}
 	}
@@ -129,7 +129,7 @@ func concatErrors(errs []error) error {
 }
 
 func CheckForDataIngestToken(tokens Tokens) bool {
-	dataIngestToken, hasDataIngestToken := tokens[DataIngestToken]
+	dataIngestToken, hasDataIngestToken := tokens[DataIngestKey]
 
 	return hasDataIngestToken && len(dataIngestToken.Value) != 0
 }

--- a/pkg/controllers/dynakube/token/tokens.go
+++ b/pkg/controllers/dynakube/token/tokens.go
@@ -8,8 +8,13 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceapi"
+)
+
+const (
+	PaasToken       = "paasToken"
+	APIToken        = "apiToken"
+	DataIngestToken = "dataIngestToken"
 )
 
 type VerificationError struct {
@@ -23,15 +28,15 @@ func (v VerificationError) Error() string {
 type Tokens map[string]*Token
 
 func (tokens Tokens) APIToken() *Token {
-	return tokens.getToken(consts.APIToken)
+	return tokens.getToken(APIToken)
 }
 
 func (tokens Tokens) PaasToken() *Token {
-	return tokens.getToken(consts.PaasToken)
+	return tokens.getToken(PaasToken)
 }
 
 func (tokens Tokens) DataIngestToken() *Token {
-	return tokens.getToken(consts.DataIngestToken)
+	return tokens.getToken(DataIngestToken)
 }
 
 func (tokens Tokens) getToken(tokenName string) *Token {
@@ -44,15 +49,15 @@ func (tokens Tokens) getToken(tokenName string) *Token {
 }
 
 func (tokens Tokens) AddFeatureScopesToTokens() Tokens {
-	_, hasPaasToken := tokens[consts.PaasToken]
+	_, hasPaasToken := tokens[PaasToken]
 
 	for _, token := range tokens {
 		switch token.Type {
-		case consts.APIToken:
+		case APIToken:
 			token.addFeatures(getFeaturesForAPIToken(hasPaasToken))
-		case consts.PaasToken:
+		case PaasToken:
 			token.addFeatures(getFeaturesForPaaSToken())
-		case consts.DataIngestToken:
+		case DataIngestToken:
 			token.addFeatures(getFeaturesForDataIngest())
 		}
 	}
@@ -124,7 +129,7 @@ func concatErrors(errs []error) error {
 }
 
 func CheckForDataIngestToken(tokens Tokens) bool {
-	dataIngestToken, hasDataIngestToken := tokens[consts.DataIngestToken]
+	dataIngestToken, hasDataIngestToken := tokens[DataIngestToken]
 
 	return hasDataIngestToken && len(dataIngestToken.Value) != 0
 }

--- a/pkg/controllers/dynakube/token/tokens.go
+++ b/pkg/controllers/dynakube/token/tokens.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dynatraceapi"
 )
 
@@ -22,15 +23,15 @@ func (v VerificationError) Error() string {
 type Tokens map[string]*Token
 
 func (tokens Tokens) APIToken() *Token {
-	return tokens.getToken(dtclient.APIToken)
+	return tokens.getToken(consts.APIToken)
 }
 
 func (tokens Tokens) PaasToken() *Token {
-	return tokens.getToken(dtclient.PaasToken)
+	return tokens.getToken(consts.PaasToken)
 }
 
 func (tokens Tokens) DataIngestToken() *Token {
-	return tokens.getToken(dtclient.DataIngestToken)
+	return tokens.getToken(consts.DataIngestToken)
 }
 
 func (tokens Tokens) getToken(tokenName string) *Token {
@@ -43,15 +44,15 @@ func (tokens Tokens) getToken(tokenName string) *Token {
 }
 
 func (tokens Tokens) AddFeatureScopesToTokens() Tokens {
-	_, hasPaasToken := tokens[dtclient.PaasToken]
+	_, hasPaasToken := tokens[consts.PaasToken]
 
 	for _, token := range tokens {
 		switch token.Type {
-		case dtclient.APIToken:
+		case consts.APIToken:
 			token.addFeatures(getFeaturesForAPIToken(hasPaasToken))
-		case dtclient.PaasToken:
+		case consts.PaasToken:
 			token.addFeatures(getFeaturesForPaaSToken())
-		case dtclient.DataIngestToken:
+		case consts.DataIngestToken:
 			token.addFeatures(getFeaturesForDataIngest())
 		}
 	}
@@ -123,7 +124,7 @@ func concatErrors(errs []error) error {
 }
 
 func CheckForDataIngestToken(tokens Tokens) bool {
-	dataIngestToken, hasDataIngestToken := tokens[dtclient.DataIngestToken]
+	dataIngestToken, hasDataIngestToken := tokens[consts.DataIngestToken]
 
 	return hasDataIngestToken && len(dataIngestToken.Value) != 0
 }

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -120,9 +120,9 @@ func TestTokens(t *testing.T) {
 	}
 
 	t.Run("empty dynakube, all permissions in api token, but paas => should fail", func(t *testing.T) {
-		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissions)
+		apiToken := newToken(APIKey, fakeTokenAllAPITokenPermissions)
 		tokens := Tokens{
-			APIToken: &apiToken,
+			APIKey: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -135,11 +135,11 @@ func TestTokens(t *testing.T) {
 		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Download Installer' is missing scope 'InstallerDownload']")
 	})
 	t.Run("empty dynakube, all permissions in api token, but paas + paas token => should work", func(t *testing.T) {
-		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissions)
-		paasToken := newToken(PaasToken, fakeTokenPaas)
+		apiToken := newToken(APIKey, fakeTokenAllAPITokenPermissions)
+		paasToken := newToken(PaaSKey, fakeTokenPaas)
 		tokens := Tokens{
-			APIToken:  &apiToken,
-			PaasToken: &paasToken,
+			APIKey:  &apiToken,
+			PaaSKey: &paasToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -150,9 +150,9 @@ func TestTokens(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("empty dynakube, all permissions in api token => should work", func(t *testing.T) {
-		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		apiToken := newToken(APIKey, fakeTokenAllAPITokenPermissionsIncludingPaaS)
 		tokens := Tokens{
-			APIToken: &apiToken,
+			APIKey: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -168,9 +168,9 @@ func TestTokens(t *testing.T) {
 			activegate.KubeMonCapability.DisplayName,
 		}
 
-		apiToken := newToken(APIToken, fakeTokenNoPermissions)
+		apiToken := newToken(APIKey, fakeTokenNoPermissions)
 		tokens := Tokens{
-			APIToken: &apiToken,
+			APIKey: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -185,11 +185,11 @@ func TestTokens(t *testing.T) {
 		dk := dynakube.DynaKube{}
 		enableKubernetesMonitoringAndMetricsIngest(&dk)
 
-		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(DataIngestToken, fakeTokenNoPermissions)
+		apiToken := newToken(APIKey, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(DataIngestKey, fakeTokenNoPermissions)
 		tokens := Tokens{
-			APIToken:        &apiToken,
-			DataIngestToken: &dataingestToken,
+			APIKey:        &apiToken,
+			DataIngestKey: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -201,11 +201,11 @@ func TestTokens(t *testing.T) {
 		assert.EqualError(t, err, "token 'dataIngestToken' has scope errors: [feature 'Data Ingest' is missing scope 'metrics.ingest']")
 	})
 	t.Run("data ingest enabled => dataingest token has rights => success", func(t *testing.T) {
-		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(DataIngestToken, fakeTokenAllDataIngestPermissions)
+		apiToken := newToken(APIKey, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(DataIngestKey, fakeTokenAllDataIngestPermissions)
 		tokens := Tokens{
-			APIToken:        &apiToken,
-			DataIngestToken: &dataingestToken,
+			APIKey:        &apiToken,
+			DataIngestKey: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -228,11 +228,11 @@ func TestTokens(t *testing.T) {
 			},
 		}
 
-		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(DataIngestToken, fakeTokenNoPermissions)
+		apiToken := newToken(APIKey, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(DataIngestKey, fakeTokenNoPermissions)
 		tokens := Tokens{
-			APIToken:        &apiToken,
-			DataIngestToken: &dataingestToken,
+			APIKey:        &apiToken,
+			DataIngestKey: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -256,11 +256,11 @@ func TestTokens(t *testing.T) {
 			},
 		}
 
-		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(DataIngestToken, fakeTokenAllOTLPExporterPermissions)
+		apiToken := newToken(APIKey, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(DataIngestKey, fakeTokenAllOTLPExporterPermissions)
 		tokens := Tokens{
-			APIToken:        &apiToken,
-			DataIngestToken: &dataingestToken,
+			APIKey:        &apiToken,
+			DataIngestKey: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -468,9 +468,9 @@ func TestTokens_VerifyScopes(t *testing.T) {
 			fakeClient := dtclientmock.NewClient(t)
 			fakeClient.EXPECT().AsV2().Return(&dtclient.ClientV2{Token: mockedTokenClient})
 
-			apiToken := newToken(APIToken, tokenValue)
+			apiToken := newToken(APIKey, tokenValue)
 			tokens := Tokens{
-				APIToken: &apiToken,
+				APIKey: &apiToken,
 			}
 			tokens = tokens.AddFeatureScopesToTokens()
 			optionalScopes, err := tokens.VerifyScopes(t.Context(), fakeClient, c.dk)
@@ -482,14 +482,14 @@ func TestTokens_VerifyScopes(t *testing.T) {
 }
 
 func TestTokens_VerifyValues(t *testing.T) {
-	validToken := newToken(APIToken, "valid-value")
-	invalidToken := newToken(APIToken, " invalid-value ")
+	validToken := newToken(APIKey, "valid-value")
+	invalidToken := newToken(APIKey, " invalid-value ")
 
 	validTokens := Tokens{
-		APIToken: &validToken,
+		APIKey: &validToken,
 	}
 	invalidTokens := Tokens{
-		APIToken: &invalidToken,
+		APIKey: &invalidToken,
 	}
 
 	require.NoError(t, validTokens.VerifyValues())
@@ -579,7 +579,7 @@ func TestConcatErrors(t *testing.T) {
 func TestCheckForDataIngestToken(t *testing.T) {
 	t.Run("data ingest token is present, but empty", func(t *testing.T) {
 		tokens := Tokens{
-			DataIngestToken: &Token{},
+			DataIngestKey: &Token{},
 		}
 
 		assert.False(t, CheckForDataIngestToken(tokens))
@@ -587,7 +587,7 @@ func TestCheckForDataIngestToken(t *testing.T) {
 
 	t.Run("data ingest token is present and not empty", func(t *testing.T) {
 		tokens := Tokens{
-			DataIngestToken: &Token{
+			DataIngestKey: &Token{
 				Value: "token",
 			},
 		}

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	tokenclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	tokenclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/token"
 	"github.com/pkg/errors"
@@ -120,9 +121,9 @@ func TestTokens(t *testing.T) {
 	}
 
 	t.Run("empty dynakube, all permissions in api token, but paas => should fail", func(t *testing.T) {
-		apiToken := newToken(dtclient.APIToken, fakeTokenAllAPITokenPermissions)
+		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissions)
 		tokens := Tokens{
-			dtclient.APIToken: &apiToken,
+			consts.APIToken: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -135,11 +136,11 @@ func TestTokens(t *testing.T) {
 		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Download Installer' is missing scope 'InstallerDownload']")
 	})
 	t.Run("empty dynakube, all permissions in api token, but paas + paas token => should work", func(t *testing.T) {
-		apiToken := newToken(dtclient.APIToken, fakeTokenAllAPITokenPermissions)
-		paasToken := newToken(dtclient.PaasToken, fakeTokenPaas)
+		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissions)
+		paasToken := newToken(consts.PaasToken, fakeTokenPaas)
 		tokens := Tokens{
-			dtclient.APIToken:  &apiToken,
-			dtclient.PaasToken: &paasToken,
+			consts.APIToken:  &apiToken,
+			consts.PaasToken: &paasToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -150,9 +151,9 @@ func TestTokens(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("empty dynakube, all permissions in api token => should work", func(t *testing.T) {
-		apiToken := newToken(dtclient.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
 		tokens := Tokens{
-			dtclient.APIToken: &apiToken,
+			consts.APIToken: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -168,9 +169,9 @@ func TestTokens(t *testing.T) {
 			activegate.KubeMonCapability.DisplayName,
 		}
 
-		apiToken := newToken(dtclient.APIToken, fakeTokenNoPermissions)
+		apiToken := newToken(consts.APIToken, fakeTokenNoPermissions)
 		tokens := Tokens{
-			dtclient.APIToken: &apiToken,
+			consts.APIToken: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -185,11 +186,11 @@ func TestTokens(t *testing.T) {
 		dk := dynakube.DynaKube{}
 		enableKubernetesMonitoringAndMetricsIngest(&dk)
 
-		apiToken := newToken(dtclient.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(dtclient.DataIngestToken, fakeTokenNoPermissions)
+		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(consts.DataIngestToken, fakeTokenNoPermissions)
 		tokens := Tokens{
-			dtclient.APIToken:        &apiToken,
-			dtclient.DataIngestToken: &dataingestToken,
+			consts.APIToken:        &apiToken,
+			consts.DataIngestToken: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -201,11 +202,11 @@ func TestTokens(t *testing.T) {
 		assert.EqualError(t, err, "token 'dataIngestToken' has scope errors: [feature 'Data Ingest' is missing scope 'metrics.ingest']")
 	})
 	t.Run("data ingest enabled => dataingest token has rights => success", func(t *testing.T) {
-		apiToken := newToken(dtclient.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(dtclient.DataIngestToken, fakeTokenAllDataIngestPermissions)
+		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(consts.DataIngestToken, fakeTokenAllDataIngestPermissions)
 		tokens := Tokens{
-			dtclient.APIToken:        &apiToken,
-			dtclient.DataIngestToken: &dataingestToken,
+			consts.APIToken:        &apiToken,
+			consts.DataIngestToken: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -228,11 +229,11 @@ func TestTokens(t *testing.T) {
 			},
 		}
 
-		apiToken := newToken(dtclient.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(dtclient.DataIngestToken, fakeTokenNoPermissions)
+		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(consts.DataIngestToken, fakeTokenNoPermissions)
 		tokens := Tokens{
-			dtclient.APIToken:        &apiToken,
-			dtclient.DataIngestToken: &dataingestToken,
+			consts.APIToken:        &apiToken,
+			consts.DataIngestToken: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -256,11 +257,11 @@ func TestTokens(t *testing.T) {
 			},
 		}
 
-		apiToken := newToken(dtclient.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(dtclient.DataIngestToken, fakeTokenAllOTLPExporterPermissions)
+		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(consts.DataIngestToken, fakeTokenAllOTLPExporterPermissions)
 		tokens := Tokens{
-			dtclient.APIToken:        &apiToken,
-			dtclient.DataIngestToken: &dataingestToken,
+			consts.APIToken:        &apiToken,
+			consts.DataIngestToken: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -468,9 +469,9 @@ func TestTokens_VerifyScopes(t *testing.T) {
 			fakeClient := dtclientmock.NewClient(t)
 			fakeClient.EXPECT().AsV2().Return(&dtclient.ClientV2{Token: mockedTokenClient})
 
-			apiToken := newToken(dtclient.APIToken, tokenValue)
+			apiToken := newToken(consts.APIToken, tokenValue)
 			tokens := Tokens{
-				dtclient.APIToken: &apiToken,
+				consts.APIToken: &apiToken,
 			}
 			tokens = tokens.AddFeatureScopesToTokens()
 			optionalScopes, err := tokens.VerifyScopes(t.Context(), fakeClient, c.dk)
@@ -482,14 +483,14 @@ func TestTokens_VerifyScopes(t *testing.T) {
 }
 
 func TestTokens_VerifyValues(t *testing.T) {
-	validToken := newToken(dtclient.APIToken, "valid-value")
-	invalidToken := newToken(dtclient.APIToken, " invalid-value ")
+	validToken := newToken(consts.APIToken, "valid-value")
+	invalidToken := newToken(consts.APIToken, " invalid-value ")
 
 	validTokens := Tokens{
-		dtclient.APIToken: &validToken,
+		consts.APIToken: &validToken,
 	}
 	invalidTokens := Tokens{
-		dtclient.APIToken: &invalidToken,
+		consts.APIToken: &invalidToken,
 	}
 
 	require.NoError(t, validTokens.VerifyValues())
@@ -579,7 +580,7 @@ func TestConcatErrors(t *testing.T) {
 func TestCheckForDataIngestToken(t *testing.T) {
 	t.Run("data ingest token is present, but empty", func(t *testing.T) {
 		tokens := Tokens{
-			dtclient.DataIngestToken: &Token{},
+			consts.DataIngestToken: &Token{},
 		}
 
 		assert.False(t, CheckForDataIngestToken(tokens))
@@ -587,7 +588,7 @@ func TestCheckForDataIngestToken(t *testing.T) {
 
 	t.Run("data ingest token is present and not empty", func(t *testing.T) {
 		tokens := Tokens{
-			dtclient.DataIngestToken: &Token{
+			consts.DataIngestToken: &Token{
 				Value: "token",
 			},
 		}

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	tokenclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	tokenclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/token"
 	"github.com/pkg/errors"
@@ -121,9 +120,9 @@ func TestTokens(t *testing.T) {
 	}
 
 	t.Run("empty dynakube, all permissions in api token, but paas => should fail", func(t *testing.T) {
-		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissions)
+		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissions)
 		tokens := Tokens{
-			consts.APIToken: &apiToken,
+			APIToken: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -136,11 +135,11 @@ func TestTokens(t *testing.T) {
 		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Download Installer' is missing scope 'InstallerDownload']")
 	})
 	t.Run("empty dynakube, all permissions in api token, but paas + paas token => should work", func(t *testing.T) {
-		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissions)
-		paasToken := newToken(consts.PaasToken, fakeTokenPaas)
+		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissions)
+		paasToken := newToken(PaasToken, fakeTokenPaas)
 		tokens := Tokens{
-			consts.APIToken:  &apiToken,
-			consts.PaasToken: &paasToken,
+			APIToken:  &apiToken,
+			PaasToken: &paasToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -151,9 +150,9 @@ func TestTokens(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("empty dynakube, all permissions in api token => should work", func(t *testing.T) {
-		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
 		tokens := Tokens{
-			consts.APIToken: &apiToken,
+			APIToken: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -169,9 +168,9 @@ func TestTokens(t *testing.T) {
 			activegate.KubeMonCapability.DisplayName,
 		}
 
-		apiToken := newToken(consts.APIToken, fakeTokenNoPermissions)
+		apiToken := newToken(APIToken, fakeTokenNoPermissions)
 		tokens := Tokens{
-			consts.APIToken: &apiToken,
+			APIToken: &apiToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -186,11 +185,11 @@ func TestTokens(t *testing.T) {
 		dk := dynakube.DynaKube{}
 		enableKubernetesMonitoringAndMetricsIngest(&dk)
 
-		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(consts.DataIngestToken, fakeTokenNoPermissions)
+		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(DataIngestToken, fakeTokenNoPermissions)
 		tokens := Tokens{
-			consts.APIToken:        &apiToken,
-			consts.DataIngestToken: &dataingestToken,
+			APIToken:        &apiToken,
+			DataIngestToken: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -202,11 +201,11 @@ func TestTokens(t *testing.T) {
 		assert.EqualError(t, err, "token 'dataIngestToken' has scope errors: [feature 'Data Ingest' is missing scope 'metrics.ingest']")
 	})
 	t.Run("data ingest enabled => dataingest token has rights => success", func(t *testing.T) {
-		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(consts.DataIngestToken, fakeTokenAllDataIngestPermissions)
+		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(DataIngestToken, fakeTokenAllDataIngestPermissions)
 		tokens := Tokens{
-			consts.APIToken:        &apiToken,
-			consts.DataIngestToken: &dataingestToken,
+			APIToken:        &apiToken,
+			DataIngestToken: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dynakube.DynaKube{})
@@ -229,11 +228,11 @@ func TestTokens(t *testing.T) {
 			},
 		}
 
-		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(consts.DataIngestToken, fakeTokenNoPermissions)
+		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(DataIngestToken, fakeTokenNoPermissions)
 		tokens := Tokens{
-			consts.APIToken:        &apiToken,
-			consts.DataIngestToken: &dataingestToken,
+			APIToken:        &apiToken,
+			DataIngestToken: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -257,11 +256,11 @@ func TestTokens(t *testing.T) {
 			},
 		}
 
-		apiToken := newToken(consts.APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
-		dataingestToken := newToken(consts.DataIngestToken, fakeTokenAllOTLPExporterPermissions)
+		apiToken := newToken(APIToken, fakeTokenAllAPITokenPermissionsIncludingPaaS)
+		dataingestToken := newToken(DataIngestToken, fakeTokenAllOTLPExporterPermissions)
 		tokens := Tokens{
-			consts.APIToken:        &apiToken,
-			consts.DataIngestToken: &dataingestToken,
+			APIToken:        &apiToken,
+			DataIngestToken: &dataingestToken,
 		}
 		tokens = tokens.AddFeatureScopesToTokens()
 		_, err := tokens.VerifyScopes(t.Context(), createFakeClient(t), dk)
@@ -469,9 +468,9 @@ func TestTokens_VerifyScopes(t *testing.T) {
 			fakeClient := dtclientmock.NewClient(t)
 			fakeClient.EXPECT().AsV2().Return(&dtclient.ClientV2{Token: mockedTokenClient})
 
-			apiToken := newToken(consts.APIToken, tokenValue)
+			apiToken := newToken(APIToken, tokenValue)
 			tokens := Tokens{
-				consts.APIToken: &apiToken,
+				APIToken: &apiToken,
 			}
 			tokens = tokens.AddFeatureScopesToTokens()
 			optionalScopes, err := tokens.VerifyScopes(t.Context(), fakeClient, c.dk)
@@ -483,14 +482,14 @@ func TestTokens_VerifyScopes(t *testing.T) {
 }
 
 func TestTokens_VerifyValues(t *testing.T) {
-	validToken := newToken(consts.APIToken, "valid-value")
-	invalidToken := newToken(consts.APIToken, " invalid-value ")
+	validToken := newToken(APIToken, "valid-value")
+	invalidToken := newToken(APIToken, " invalid-value ")
 
 	validTokens := Tokens{
-		consts.APIToken: &validToken,
+		APIToken: &validToken,
 	}
 	invalidTokens := Tokens{
-		consts.APIToken: &invalidToken,
+		APIToken: &invalidToken,
 	}
 
 	require.NoError(t, validTokens.VerifyValues())
@@ -580,7 +579,7 @@ func TestConcatErrors(t *testing.T) {
 func TestCheckForDataIngestToken(t *testing.T) {
 	t.Run("data ingest token is present, but empty", func(t *testing.T) {
 		tokens := Tokens{
-			consts.DataIngestToken: &Token{},
+			DataIngestToken: &Token{},
 		}
 
 		assert.False(t, CheckForDataIngestToken(tokens))
@@ -588,7 +587,7 @@ func TestCheckForDataIngestToken(t *testing.T) {
 
 	t.Run("data ingest token is present and not empty", func(t *testing.T) {
 		tokens := Tokens{
-			consts.DataIngestToken: &Token{
+			DataIngestToken: &Token{
 				Value: "token",
 			},
 		}

--- a/pkg/controllers/nodes/nodes_controller_test.go
+++ b/pkg/controllers/nodes/nodes_controller_test.go
@@ -11,6 +11,7 @@ import (
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/hostevent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/nodes/cache"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
@@ -53,7 +54,7 @@ func TestReconcile(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
-					dtclient.APIToken: []byte(testAPIToken),
+					consts.APIToken: []byte(testAPIToken),
 				},
 			},
 		)
@@ -100,7 +101,7 @@ func TestReconcile(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
-					dtclient.APIToken: []byte(testAPIToken),
+					consts.APIToken: []byte(testAPIToken),
 				},
 			},
 		)
@@ -146,7 +147,7 @@ func TestReconcile(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
-					dtclient.APIToken: []byte(testAPIToken),
+					consts.APIToken: []byte(testAPIToken),
 				},
 			},
 		)
@@ -387,7 +388,7 @@ func createDefaultFakeClient() client.Client {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				dtclient.APIToken: []byte(testAPIToken),
+				consts.APIToken: []byte(testAPIToken),
 			},
 		},
 		&corev1.Secret{
@@ -396,7 +397,7 @@ func createDefaultFakeClient() client.Client {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				dtclient.APIToken: []byte(testAPIToken),
+				consts.APIToken: []byte(testAPIToken),
 			},
 		})
 }

--- a/pkg/controllers/nodes/nodes_controller_test.go
+++ b/pkg/controllers/nodes/nodes_controller_test.go
@@ -11,7 +11,6 @@ import (
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/hostevent"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/nodes/cache"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
@@ -54,7 +53,7 @@ func TestReconcile(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
-					consts.APIToken: []byte(testAPIToken),
+					token.APIToken: []byte(testAPIToken),
 				},
 			},
 		)
@@ -101,7 +100,7 @@ func TestReconcile(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
-					consts.APIToken: []byte(testAPIToken),
+					token.APIToken: []byte(testAPIToken),
 				},
 			},
 		)
@@ -147,7 +146,7 @@ func TestReconcile(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
-					consts.APIToken: []byte(testAPIToken),
+					token.APIToken: []byte(testAPIToken),
 				},
 			},
 		)
@@ -388,7 +387,7 @@ func createDefaultFakeClient() client.Client {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				consts.APIToken: []byte(testAPIToken),
+				token.APIToken: []byte(testAPIToken),
 			},
 		},
 		&corev1.Secret{
@@ -397,7 +396,7 @@ func createDefaultFakeClient() client.Client {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				consts.APIToken: []byte(testAPIToken),
+				token.APIToken: []byte(testAPIToken),
 			},
 		})
 }

--- a/pkg/controllers/nodes/nodes_controller_test.go
+++ b/pkg/controllers/nodes/nodes_controller_test.go
@@ -53,7 +53,7 @@ func TestReconcile(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
-					token.APIToken: []byte(testAPIToken),
+					token.APIKey: []byte(testAPIToken),
 				},
 			},
 		)
@@ -100,7 +100,7 @@ func TestReconcile(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
-					token.APIToken: []byte(testAPIToken),
+					token.APIKey: []byte(testAPIToken),
 				},
 			},
 		)
@@ -146,7 +146,7 @@ func TestReconcile(t *testing.T) {
 					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
-					token.APIToken: []byte(testAPIToken),
+					token.APIKey: []byte(testAPIToken),
 				},
 			},
 		)
@@ -387,7 +387,7 @@ func createDefaultFakeClient() client.Client {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				token.APIToken: []byte(testAPIToken),
+				token.APIKey: []byte(testAPIToken),
 			},
 		},
 		&corev1.Secret{
@@ -396,7 +396,7 @@ func createDefaultFakeClient() client.Client {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				token.APIToken: []byte(testAPIToken),
+				token.APIKey: []byte(testAPIToken),
 			},
 		})
 }

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
@@ -257,7 +257,7 @@ func (s *SecretGenerator) prepareDownloadConfig(ctx context.Context, dk *dynakub
 
 	downloadConfigJSON := download.Config{
 		URL:           dk.Spec.APIURL,
-		APIToken:      string(tokens.Data[token.APIToken]),
+		APIToken:      string(tokens.Data[token.APIKey]),
 		NoProxy:       dk.FF().GetNoProxy(),
 		NetworkZone:   dk.Spec.NetworkZone,
 		HostGroup:     dk.OneAgent().GetHostGroup(),

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/oneagent/pmc"
 	"github.com/Dynatrace/dynatrace-operator/cmd/bootstrapper/download"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
@@ -257,7 +256,7 @@ func (s *SecretGenerator) prepareDownloadConfig(ctx context.Context, dk *dynakub
 
 	downloadConfigJSON := download.Config{
 		URL:           dk.Spec.APIURL,
-		APIToken:      string(tokens.Data[dtclient.APIToken]),
+		APIToken:      string(tokens.Data[consts.APIToken]),
 		NoProxy:       dk.FF().GetNoProxy(),
 		NetworkZone:   dk.Spec.NetworkZone,
 		HostGroup:     dk.OneAgent().GetHostGroup(),

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
@@ -256,7 +257,7 @@ func (s *SecretGenerator) prepareDownloadConfig(ctx context.Context, dk *dynakub
 
 	downloadConfigJSON := download.Config{
 		URL:           dk.Spec.APIURL,
-		APIToken:      string(tokens.Data[consts.APIToken]),
+		APIToken:      string(tokens.Data[token.APIToken]),
 		NoProxy:       dk.FF().GetNoProxy(),
 		NetworkZone:   dk.Spec.NetworkZone,
 		HostGroup:     dk.OneAgent().GetHostGroup(),

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig_test.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/metadataenrichment"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	oneagentclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
@@ -90,8 +89,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.APIToken:  []byte(testAPIToken),
-				dtclient.PaasToken: []byte(testPaasToken),
+				consts.APIToken:  []byte(testAPIToken),
+				consts.PaasToken: []byte(testPaasToken),
 			}),
 			clientSecret(dk.OneAgent().GetTenantSecret(), testNamespaceDynatrace, map[string][]byte{
 				"tenant-token": []byte(testTenantToken),
@@ -155,8 +154,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.APIToken:  []byte(testAPIToken),
-				dtclient.PaasToken: []byte(testPaasToken),
+				consts.APIToken:  []byte(testAPIToken),
+				consts.PaasToken: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -253,8 +252,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.APIToken:  []byte(testAPIToken),
-				dtclient.PaasToken: []byte(testPaasToken),
+				consts.APIToken:  []byte(testAPIToken),
+				consts.PaasToken: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -332,8 +331,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			clientInjectedNamespace(testNamespace, testDynakube),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.APIToken:  []byte(testAPIToken),
-				dtclient.PaasToken: []byte(testPaasToken),
+				consts.APIToken:  []byte(testAPIToken),
+				consts.PaasToken: []byte(testPaasToken),
 			}),
 		)
 
@@ -380,8 +379,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.APIToken:  []byte(testAPIToken),
-				dtclient.PaasToken: []byte(testPaasToken),
+				consts.APIToken:  []byte(testAPIToken),
+				consts.PaasToken: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -443,8 +442,8 @@ func TestGenerateForDynakube(t *testing.T) {
 		failClient := createConfigFailClient(dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.APIToken:  []byte(testAPIToken),
-				dtclient.PaasToken: []byte(testPaasToken),
+				consts.APIToken:  []byte(testAPIToken),
+				consts.PaasToken: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -502,8 +501,8 @@ func TestCleanup(t *testing.T) {
 		dk,
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			dtclient.APIToken:  []byte(testAPIToken),
-			dtclient.PaasToken: []byte(testPaasToken),
+			consts.APIToken:  []byte(testAPIToken),
+			consts.PaasToken: []byte(testPaasToken),
 		}),
 		clientSecret(dk.OneAgent().GetTenantSecret(), testNamespaceDynatrace, map[string][]byte{
 			"tenant-token": []byte(testTenantToken),

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig_test.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	oneagentclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	oneagentclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/oneagent"
 	"github.com/stretchr/testify/assert"
@@ -89,8 +90,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.APIToken:  []byte(testAPIToken),
-				consts.PaasToken: []byte(testPaasToken),
+				token.APIToken:  []byte(testAPIToken),
+				token.PaasToken: []byte(testPaasToken),
 			}),
 			clientSecret(dk.OneAgent().GetTenantSecret(), testNamespaceDynatrace, map[string][]byte{
 				"tenant-token": []byte(testTenantToken),
@@ -154,8 +155,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.APIToken:  []byte(testAPIToken),
-				consts.PaasToken: []byte(testPaasToken),
+				token.APIToken:  []byte(testAPIToken),
+				token.PaasToken: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -252,8 +253,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.APIToken:  []byte(testAPIToken),
-				consts.PaasToken: []byte(testPaasToken),
+				token.APIToken:  []byte(testAPIToken),
+				token.PaasToken: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -331,8 +332,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			clientInjectedNamespace(testNamespace, testDynakube),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.APIToken:  []byte(testAPIToken),
-				consts.PaasToken: []byte(testPaasToken),
+				token.APIToken:  []byte(testAPIToken),
+				token.PaasToken: []byte(testPaasToken),
 			}),
 		)
 
@@ -379,8 +380,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.APIToken:  []byte(testAPIToken),
-				consts.PaasToken: []byte(testPaasToken),
+				token.APIToken:  []byte(testAPIToken),
+				token.PaasToken: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -442,8 +443,8 @@ func TestGenerateForDynakube(t *testing.T) {
 		failClient := createConfigFailClient(dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.APIToken:  []byte(testAPIToken),
-				consts.PaasToken: []byte(testPaasToken),
+				token.APIToken:  []byte(testAPIToken),
+				token.PaasToken: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -501,8 +502,8 @@ func TestCleanup(t *testing.T) {
 		dk,
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			consts.APIToken:  []byte(testAPIToken),
-			consts.PaasToken: []byte(testPaasToken),
+			token.APIToken:  []byte(testAPIToken),
+			token.PaasToken: []byte(testPaasToken),
 		}),
 		clientSecret(dk.OneAgent().GetTenantSecret(), testNamespaceDynatrace, map[string][]byte{
 			"tenant-token": []byte(testTenantToken),

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig_test.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig_test.go
@@ -90,8 +90,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.APIToken:  []byte(testAPIToken),
-				token.PaasToken: []byte(testPaasToken),
+				token.APIKey:  []byte(testAPIToken),
+				token.PaaSKey: []byte(testPaasToken),
 			}),
 			clientSecret(dk.OneAgent().GetTenantSecret(), testNamespaceDynatrace, map[string][]byte{
 				"tenant-token": []byte(testTenantToken),
@@ -155,8 +155,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.APIToken:  []byte(testAPIToken),
-				token.PaasToken: []byte(testPaasToken),
+				token.APIKey:  []byte(testAPIToken),
+				token.PaaSKey: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -253,8 +253,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.APIToken:  []byte(testAPIToken),
-				token.PaasToken: []byte(testPaasToken),
+				token.APIKey:  []byte(testAPIToken),
+				token.PaaSKey: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -332,8 +332,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			clientInjectedNamespace(testNamespace, testDynakube),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.APIToken:  []byte(testAPIToken),
-				token.PaasToken: []byte(testPaasToken),
+				token.APIKey:  []byte(testAPIToken),
+				token.PaaSKey: []byte(testPaasToken),
 			}),
 		)
 
@@ -380,8 +380,8 @@ func TestGenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.APIToken:  []byte(testAPIToken),
-				token.PaasToken: []byte(testPaasToken),
+				token.APIKey:  []byte(testAPIToken),
+				token.PaaSKey: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -443,8 +443,8 @@ func TestGenerateForDynakube(t *testing.T) {
 		failClient := createConfigFailClient(dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.APIToken:  []byte(testAPIToken),
-				token.PaasToken: []byte(testPaasToken),
+				token.APIKey:  []byte(testAPIToken),
+				token.PaaSKey: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.ServerCertKey: []byte("test-cert-value"),
@@ -502,8 +502,8 @@ func TestCleanup(t *testing.T) {
 		dk,
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			token.APIToken:  []byte(testAPIToken),
-			token.PaasToken: []byte(testPaasToken),
+			token.APIKey:  []byte(testAPIToken),
+			token.PaaSKey: []byte(testPaasToken),
 		}),
 		clientSecret(dk.OneAgent().GetTenantSecret(), testNamespaceDynatrace, map[string][]byte{
 			"tenant-token": []byte(testTenantToken),

--- a/pkg/injection/namespace/bootstrapperconfig/endpoints.go
+++ b/pkg/injection/namespace/bootstrapperconfig/endpoints.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,8 +51,8 @@ func (s *SecretGenerator) prepareFieldsForEndpoints(ctx context.Context, dk *dyn
 		return nil, errors.WithMessage(err, "failed to query tokens")
 	}
 
-	if token, ok := tokens.Data[consts.DataIngestToken]; ok {
-		fields[MetricsTokenSecretField] = string(token)
+	if dataIngestToken, ok := tokens.Data[token.DataIngestToken]; ok {
+		fields[MetricsTokenSecretField] = string(dataIngestToken)
 	} else {
 		log.Info("data ingest token not found in secret", "dk", dk.Name)
 	}

--- a/pkg/injection/namespace/bootstrapperconfig/endpoints.go
+++ b/pkg/injection/namespace/bootstrapperconfig/endpoints.go
@@ -51,7 +51,7 @@ func (s *SecretGenerator) prepareFieldsForEndpoints(ctx context.Context, dk *dyn
 		return nil, errors.WithMessage(err, "failed to query tokens")
 	}
 
-	if dataIngestToken, ok := tokens.Data[token.DataIngestToken]; ok {
+	if dataIngestToken, ok := tokens.Data[token.DataIngestKey]; ok {
 		fields[MetricsTokenSecretField] = string(dataIngestToken)
 	} else {
 		log.Info("data ingest token not found in secret", "dk", dk.Name)

--- a/pkg/injection/namespace/bootstrapperconfig/endpoints.go
+++ b/pkg/injection/namespace/bootstrapperconfig/endpoints.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/pkg/errors"
@@ -51,7 +51,7 @@ func (s *SecretGenerator) prepareFieldsForEndpoints(ctx context.Context, dk *dyn
 		return nil, errors.WithMessage(err, "failed to query tokens")
 	}
 
-	if token, ok := tokens.Data[dtclient.DataIngestToken]; ok {
+	if token, ok := tokens.Data[consts.DataIngestToken]; ok {
 		fields[MetricsTokenSecretField] = string(token)
 	} else {
 		log.Info("data ingest token not found in secret", "dk", dk.Name)

--- a/pkg/injection/otlp/exporterconfig/secret_generator.go
+++ b/pkg/injection/otlp/exporterconfig/secret_generator.go
@@ -112,14 +112,14 @@ func (s *SecretGenerator) generateConfig(ctx context.Context, dk *dynakube.DynaK
 		return nil, errors.WithMessage(err, "failed to query tokens")
 	}
 
-	if _, ok := tokens.Data[token.DataIngestToken]; !ok {
+	if _, ok := tokens.Data[token.DataIngestKey]; !ok {
 		err := errors.New("data ingest token not found in tokens secret")
 		k8sconditions.SetKubeAPIError(dk.Conditions(), ConfigConditionType, err)
 
 		return nil, err
 	}
 
-	data[token.DataIngestToken] = tokens.Data[token.DataIngestToken]
+	data[token.DataIngestKey] = tokens.Data[token.DataIngestKey]
 
 	return data, nil
 }

--- a/pkg/injection/otlp/exporterconfig/secret_generator.go
+++ b/pkg/injection/otlp/exporterconfig/secret_generator.go
@@ -111,14 +111,14 @@ func (s *SecretGenerator) generateConfig(ctx context.Context, dk *dynakube.DynaK
 		return nil, errors.WithMessage(err, "failed to query tokens")
 	}
 
-	if _, ok := tokens.Data[dtclient.DataIngestToken]; !ok {
+	if _, ok := tokens.Data[consts.DataIngestToken]; !ok {
 		err := errors.New("data ingest token not found in tokens secret")
 		k8sconditions.SetKubeAPIError(dk.Conditions(), ConfigConditionType, err)
 
 		return nil, err
 	}
 
-	data[dtclient.DataIngestToken] = tokens.Data[dtclient.DataIngestToken]
+	data[consts.DataIngestToken] = tokens.Data[consts.DataIngestToken]
 
 	return data, nil
 }

--- a/pkg/injection/otlp/exporterconfig/secret_generator.go
+++ b/pkg/injection/otlp/exporterconfig/secret_generator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
@@ -111,14 +112,14 @@ func (s *SecretGenerator) generateConfig(ctx context.Context, dk *dynakube.DynaK
 		return nil, errors.WithMessage(err, "failed to query tokens")
 	}
 
-	if _, ok := tokens.Data[consts.DataIngestToken]; !ok {
+	if _, ok := tokens.Data[token.DataIngestToken]; !ok {
 		err := errors.New("data ingest token not found in tokens secret")
 		k8sconditions.SetKubeAPIError(dk.Conditions(), ConfigConditionType, err)
 
 		return nil, err
 	}
 
-	data[consts.DataIngestToken] = tokens.Data[consts.DataIngestToken]
+	data[token.DataIngestToken] = tokens.Data[token.DataIngestToken]
 
 	return data, nil
 }

--- a/pkg/injection/otlp/exporterconfig/secret_generator_test.go
+++ b/pkg/injection/otlp/exporterconfig/secret_generator_test.go
@@ -59,7 +59,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			clientInjectedNamespace(testNamespace, testDynakube),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.DataIngestToken: []byte(testDataIngestToken),
+				token.DataIngestKey: []byte(testDataIngestToken),
 			}),
 		)
 
@@ -94,7 +94,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.DataIngestToken: []byte(testDataIngestToken),
+				token.DataIngestKey: []byte(testDataIngestToken),
 			}),
 		)
 
@@ -127,7 +127,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.DataIngestToken: []byte(testDataIngestToken),
+				token.DataIngestKey: []byte(testDataIngestToken),
 			}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.TLSCertKey: []byte(testCrt),
@@ -146,7 +146,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		require.Equal(t, consts.OTLPExporterSecretName, secret.Name)
 		assert.NotEmpty(t, secret.Data)
 
-		assert.Equal(t, testDataIngestToken, string(secret.Data[token.DataIngestToken]))
+		assert.Equal(t, testDataIngestToken, string(secret.Data[token.DataIngestKey]))
 
 		var sourceSecret corev1.Secret
 		err = clt.Get(t.Context(), client.ObjectKey{Name: GetSourceConfigSecretName(dk.Name), Namespace: dk.Namespace}, &sourceSecret)
@@ -195,16 +195,16 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				token.DataIngestToken: []byte(testDataIngestToken),
+				token.DataIngestKey: []byte(testDataIngestToken),
 			}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.TLSCertKey: []byte(testCrt),
 			}),
 			clientSecret(consts.OTLPExporterSecretName, testNamespace, map[string][]byte{
-				token.DataIngestToken: []byte(oldDataIngestToken),
+				token.DataIngestKey: []byte(oldDataIngestToken),
 			}),
 			clientSecret(GetSourceConfigSecretName(dk.Name), dk.Namespace, map[string][]byte{
-				token.DataIngestToken: []byte(oldDataIngestToken),
+				token.DataIngestKey: []byte(oldDataIngestToken),
 			}),
 			clientSecret(consts.OTLPExporterCertsSecretName, testNamespace, map[string][]byte{
 				ActiveGateCertDataName: []byte(oldTestCert),
@@ -226,7 +226,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		require.Equal(t, consts.OTLPExporterSecretName, secret.Name)
 		assert.NotEmpty(t, secret.Data)
 
-		assert.Equal(t, testDataIngestToken, string(secret.Data[token.DataIngestToken]))
+		assert.Equal(t, testDataIngestToken, string(secret.Data[token.DataIngestKey]))
 
 		var sourceSecret corev1.Secret
 		err = clt.Get(t.Context(), client.ObjectKey{Name: GetSourceConfigSecretName(dk.Name), Namespace: dk.Namespace}, &sourceSecret)
@@ -304,7 +304,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			namespace1,
 			namespace2,
 			terminatingNS,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestKey: []byte(testDataIngestToken)}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{dynakube.TLSCertKey: []byte(testCrt)}),
 		)
 
@@ -366,7 +366,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		clt := fake.NewClientWithIndex(
 			dk,
 			nonInjected,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestKey: []byte(testDataIngestToken)}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{dynakube.TLSCertKey: []byte(testCrt)}),
 		)
 
@@ -403,7 +403,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		clt := fake.NewClientWithIndex(
 			dk,
 			namespace,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestKey: []byte(testDataIngestToken)}),
 		)
 
 		sg := NewSecretGenerator(clt, clt, dtclientmock.NewClient(t))
@@ -435,7 +435,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		clt := fake.NewClientWithIndex(
 			dk,
 			namespace,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestKey: []byte(testDataIngestToken)}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{"unknown": []byte("value")}),
 		)
 
@@ -468,7 +468,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			trustedCAConfigMap,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestKey: []byte(testDataIngestToken)}),
 		)
 
 		mockDTClient := dtclientmock.NewClient(t)
@@ -516,7 +516,7 @@ func TestCleanup(t *testing.T) {
 		dk,
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			token.DataIngestToken: []byte(testDataIngestToken),
+			token.DataIngestKey: []byte(testDataIngestToken),
 		}),
 		clientSecret(consts.OTLPExporterSecretName, testNamespace, nil),
 		clientSecret(consts.OTLPExporterSecretName, testNamespace2, nil),

--- a/pkg/injection/otlp/exporterconfig/secret_generator_test.go
+++ b/pkg/injection/otlp/exporterconfig/secret_generator_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
@@ -59,7 +58,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			clientInjectedNamespace(testNamespace, testDynakube),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.DataIngestToken: []byte(testDataIngestToken),
+				consts.DataIngestToken: []byte(testDataIngestToken),
 			}),
 		)
 
@@ -94,7 +93,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.DataIngestToken: []byte(testDataIngestToken),
+				consts.DataIngestToken: []byte(testDataIngestToken),
 			}),
 		)
 
@@ -127,7 +126,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.DataIngestToken: []byte(testDataIngestToken),
+				consts.DataIngestToken: []byte(testDataIngestToken),
 			}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.TLSCertKey: []byte(testCrt),
@@ -146,7 +145,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		require.Equal(t, consts.OTLPExporterSecretName, secret.Name)
 		assert.NotEmpty(t, secret.Data)
 
-		assert.Equal(t, testDataIngestToken, string(secret.Data[dtclient.DataIngestToken]))
+		assert.Equal(t, testDataIngestToken, string(secret.Data[consts.DataIngestToken]))
 
 		var sourceSecret corev1.Secret
 		err = clt.Get(t.Context(), client.ObjectKey{Name: GetSourceConfigSecretName(dk.Name), Namespace: dk.Namespace}, &sourceSecret)
@@ -195,16 +194,16 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				dtclient.DataIngestToken: []byte(testDataIngestToken),
+				consts.DataIngestToken: []byte(testDataIngestToken),
 			}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.TLSCertKey: []byte(testCrt),
 			}),
 			clientSecret(consts.OTLPExporterSecretName, testNamespace, map[string][]byte{
-				dtclient.DataIngestToken: []byte(oldDataIngestToken),
+				consts.DataIngestToken: []byte(oldDataIngestToken),
 			}),
 			clientSecret(GetSourceConfigSecretName(dk.Name), dk.Namespace, map[string][]byte{
-				dtclient.DataIngestToken: []byte(oldDataIngestToken),
+				consts.DataIngestToken: []byte(oldDataIngestToken),
 			}),
 			clientSecret(consts.OTLPExporterCertsSecretName, testNamespace, map[string][]byte{
 				ActiveGateCertDataName: []byte(oldTestCert),
@@ -226,7 +225,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		require.Equal(t, consts.OTLPExporterSecretName, secret.Name)
 		assert.NotEmpty(t, secret.Data)
 
-		assert.Equal(t, testDataIngestToken, string(secret.Data[dtclient.DataIngestToken]))
+		assert.Equal(t, testDataIngestToken, string(secret.Data[consts.DataIngestToken]))
 
 		var sourceSecret corev1.Secret
 		err = clt.Get(t.Context(), client.ObjectKey{Name: GetSourceConfigSecretName(dk.Name), Namespace: dk.Namespace}, &sourceSecret)
@@ -304,7 +303,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			namespace1,
 			namespace2,
 			terminatingNS,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{dtclient.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{consts.DataIngestToken: []byte(testDataIngestToken)}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{dynakube.TLSCertKey: []byte(testCrt)}),
 		)
 
@@ -366,7 +365,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		clt := fake.NewClientWithIndex(
 			dk,
 			nonInjected,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{dtclient.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{consts.DataIngestToken: []byte(testDataIngestToken)}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{dynakube.TLSCertKey: []byte(testCrt)}),
 		)
 
@@ -403,7 +402,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		clt := fake.NewClientWithIndex(
 			dk,
 			namespace,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{dtclient.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{consts.DataIngestToken: []byte(testDataIngestToken)}),
 		)
 
 		sg := NewSecretGenerator(clt, clt, dtclientmock.NewClient(t))
@@ -435,7 +434,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		clt := fake.NewClientWithIndex(
 			dk,
 			namespace,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{dtclient.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{consts.DataIngestToken: []byte(testDataIngestToken)}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{"unknown": []byte("value")}),
 		)
 
@@ -468,7 +467,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			trustedCAConfigMap,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{dtclient.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{consts.DataIngestToken: []byte(testDataIngestToken)}),
 		)
 
 		mockDTClient := dtclientmock.NewClient(t)
@@ -516,7 +515,7 @@ func TestCleanup(t *testing.T) {
 		dk,
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			dtclient.DataIngestToken: []byte(testDataIngestToken),
+			consts.DataIngestToken: []byte(testDataIngestToken),
 		}),
 		clientSecret(consts.OTLPExporterSecretName, testNamespace, nil),
 		clientSecret(consts.OTLPExporterSecretName, testNamespace2, nil),

--- a/pkg/injection/otlp/exporterconfig/secret_generator_test.go
+++ b/pkg/injection/otlp/exporterconfig/secret_generator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	dtclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace"
 	"github.com/stretchr/testify/assert"
@@ -58,7 +59,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			clientInjectedNamespace(testNamespace, testDynakube),
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.DataIngestToken: []byte(testDataIngestToken),
+				token.DataIngestToken: []byte(testDataIngestToken),
 			}),
 		)
 
@@ -93,7 +94,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.DataIngestToken: []byte(testDataIngestToken),
+				token.DataIngestToken: []byte(testDataIngestToken),
 			}),
 		)
 
@@ -126,7 +127,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.DataIngestToken: []byte(testDataIngestToken),
+				token.DataIngestToken: []byte(testDataIngestToken),
 			}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.TLSCertKey: []byte(testCrt),
@@ -145,7 +146,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		require.Equal(t, consts.OTLPExporterSecretName, secret.Name)
 		assert.NotEmpty(t, secret.Data)
 
-		assert.Equal(t, testDataIngestToken, string(secret.Data[consts.DataIngestToken]))
+		assert.Equal(t, testDataIngestToken, string(secret.Data[token.DataIngestToken]))
 
 		var sourceSecret corev1.Secret
 		err = clt.Get(t.Context(), client.ObjectKey{Name: GetSourceConfigSecretName(dk.Name), Namespace: dk.Namespace}, &sourceSecret)
@@ -194,16 +195,16 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-				consts.DataIngestToken: []byte(testDataIngestToken),
+				token.DataIngestToken: []byte(testDataIngestToken),
 			}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{
 				dynakube.TLSCertKey: []byte(testCrt),
 			}),
 			clientSecret(consts.OTLPExporterSecretName, testNamespace, map[string][]byte{
-				consts.DataIngestToken: []byte(oldDataIngestToken),
+				token.DataIngestToken: []byte(oldDataIngestToken),
 			}),
 			clientSecret(GetSourceConfigSecretName(dk.Name), dk.Namespace, map[string][]byte{
-				consts.DataIngestToken: []byte(oldDataIngestToken),
+				token.DataIngestToken: []byte(oldDataIngestToken),
 			}),
 			clientSecret(consts.OTLPExporterCertsSecretName, testNamespace, map[string][]byte{
 				ActiveGateCertDataName: []byte(oldTestCert),
@@ -225,7 +226,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		require.Equal(t, consts.OTLPExporterSecretName, secret.Name)
 		assert.NotEmpty(t, secret.Data)
 
-		assert.Equal(t, testDataIngestToken, string(secret.Data[consts.DataIngestToken]))
+		assert.Equal(t, testDataIngestToken, string(secret.Data[token.DataIngestToken]))
 
 		var sourceSecret corev1.Secret
 		err = clt.Get(t.Context(), client.ObjectKey{Name: GetSourceConfigSecretName(dk.Name), Namespace: dk.Namespace}, &sourceSecret)
@@ -303,7 +304,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			namespace1,
 			namespace2,
 			terminatingNS,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{consts.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestToken: []byte(testDataIngestToken)}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{dynakube.TLSCertKey: []byte(testCrt)}),
 		)
 
@@ -365,7 +366,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		clt := fake.NewClientWithIndex(
 			dk,
 			nonInjected,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{consts.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestToken: []byte(testDataIngestToken)}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{dynakube.TLSCertKey: []byte(testCrt)}),
 		)
 
@@ -402,7 +403,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		clt := fake.NewClientWithIndex(
 			dk,
 			namespace,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{consts.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestToken: []byte(testDataIngestToken)}),
 		)
 
 		sg := NewSecretGenerator(clt, clt, dtclientmock.NewClient(t))
@@ -434,7 +435,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 		clt := fake.NewClientWithIndex(
 			dk,
 			namespace,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{consts.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestToken: []byte(testDataIngestToken)}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{"unknown": []byte("value")}),
 		)
 
@@ -467,7 +468,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			namespace,
 			trustedCAConfigMap,
-			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{consts.DataIngestToken: []byte(testDataIngestToken)}),
+			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestToken: []byte(testDataIngestToken)}),
 		)
 
 		mockDTClient := dtclientmock.NewClient(t)
@@ -515,7 +516,7 @@ func TestCleanup(t *testing.T) {
 		dk,
 		clientInjectedNamespace(testNamespace, testDynakube),
 		clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{
-			consts.DataIngestToken: []byte(testDataIngestToken),
+			token.DataIngestToken: []byte(testDataIngestToken),
 		}),
 		clientSecret(consts.OTLPExporterSecretName, testNamespace, nil),
 		clientSecret(consts.OTLPExporterSecretName, testNamespace2, nil),

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
@@ -113,7 +113,7 @@ func (m Mutator) mutate(request *dtwebhook.BaseRequest) (bool, error) {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: consts.OTLPExporterSecretName,
 				},
-				Key: token.DataIngestToken,
+				Key: token.DataIngestKey,
 			},
 		},
 	}

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/endpoint"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
@@ -113,7 +112,7 @@ func (m Mutator) mutate(request *dtwebhook.BaseRequest) (bool, error) {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: consts.OTLPExporterSecretName,
 				},
-				Key: dynatrace.DataIngestToken,
+				Key: consts.DataIngestToken,
 			},
 		},
 	}

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/endpoint"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8smount"
@@ -112,7 +113,7 @@ func (m Mutator) mutate(request *dtwebhook.BaseRequest) (bool, error) {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: consts.OTLPExporterSecretName,
 				},
-				Key: consts.DataIngestToken,
+				Key: token.DataIngestToken,
 			},
 		},
 	}

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	otelcactivegate "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/activegate"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	"github.com/stretchr/testify/assert"
@@ -782,7 +783,7 @@ func assertTokenEnvVarIsSet(t *testing.T, containerEnvVars []corev1.EnvVar) {
 	require.NotNil(t, dtTokenVar.ValueFrom)
 	require.NotNil(t, dtTokenVar.ValueFrom.SecretKeyRef)
 	assert.Equal(t, consts.OTLPExporterSecretName, dtTokenVar.ValueFrom.SecretKeyRef.Name)
-	assert.Equal(t, consts.DataIngestToken, dtTokenVar.ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, token.DataIngestToken, dtTokenVar.ValueFrom.SecretKeyRef.Key)
 }
 
 func TestMutator_Reinvoke(t *testing.T) {

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	otelcactivegate "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
@@ -783,7 +782,7 @@ func assertTokenEnvVarIsSet(t *testing.T, containerEnvVars []corev1.EnvVar) {
 	require.NotNil(t, dtTokenVar.ValueFrom)
 	require.NotNil(t, dtTokenVar.ValueFrom.SecretKeyRef)
 	assert.Equal(t, consts.OTLPExporterSecretName, dtTokenVar.ValueFrom.SecretKeyRef.Name)
-	assert.Equal(t, dynatrace.DataIngestToken, dtTokenVar.ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, consts.DataIngestToken, dtTokenVar.ValueFrom.SecretKeyRef.Key)
 }
 
 func TestMutator_Reinvoke(t *testing.T) {

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
@@ -783,7 +783,7 @@ func assertTokenEnvVarIsSet(t *testing.T, containerEnvVars []corev1.EnvVar) {
 	require.NotNil(t, dtTokenVar.ValueFrom)
 	require.NotNil(t, dtTokenVar.ValueFrom.SecretKeyRef)
 	assert.Equal(t, consts.OTLPExporterSecretName, dtTokenVar.ValueFrom.SecretKeyRef.Name)
-	assert.Equal(t, token.DataIngestToken, dtTokenVar.ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, token.DataIngestKey, dtTokenVar.ValueFrom.SecretKeyRef.Key)
 }
 
 func TestMutator_Reinvoke(t *testing.T) {

--- a/pkg/webhook/mutation/pod/webhook_integration_test.go
+++ b/pkg/webhook/mutation/pod/webhook_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	agconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook"
@@ -435,7 +436,7 @@ func TestOTLPWebhook(t *testing.T) {
 		require.NotNil(t, dtTokenEnv.ValueFrom)
 		require.NotNil(t, dtTokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, dtTokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, consts.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, token.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
 
 		// Headers env vars should reference DT_API_TOKEN via authorization header literal
 		assert.Contains(t, appContainer.Env, corev1.EnvVar{Name: exporter.OTLPMetricsHeadersEnv, Value: exporter.OTLPAuthorizationHeader})
@@ -570,7 +571,7 @@ func TestOTLPWebhook(t *testing.T) {
 		require.NotNil(t, dtTokenEnv.ValueFrom)
 		require.NotNil(t, dtTokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, dtTokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, consts.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, token.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
 
 		raEnv := k8senv.Find(appContainer.Env, resourceattributes.OTELResourceAttributesEnv)
 		require.NotNil(t, raEnv, "OTEL_RESOURCE_ATTRIBUTES missing")
@@ -669,8 +670,8 @@ func TestOTLPWebhook(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				consts.APIToken:        []byte(dataIngestToken),
-				consts.DataIngestToken: []byte(dataIngestToken),
+				token.APIToken:        []byte(dataIngestToken),
+				token.DataIngestToken: []byte(dataIngestToken),
 			},
 		}
 		createObject(t, clt, apiTokenSecret)
@@ -701,7 +702,7 @@ func TestOTLPWebhook(t *testing.T) {
 		require.NotNil(t, dtTokenEnv.ValueFrom)
 		require.NotNil(t, dtTokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, dtTokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, consts.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, token.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
 
 		expectedService := fmt.Sprintf("%s-%s.%s", dk.Name, agconsts.MultiActiveGateName, testNamespace)
 		expectedBase := fmt.Sprintf("https://%s/e/%s/api/v2/otlp", expectedService, tenantUUID)
@@ -760,8 +761,8 @@ func TestOTLPWebhook(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				consts.APIToken:        []byte(dataIngestToken),
-				consts.DataIngestToken: []byte(dataIngestToken),
+				token.APIToken:        []byte(dataIngestToken),
+				token.DataIngestToken: []byte(dataIngestToken),
 			},
 		}
 		createObject(t, clt, apiTokenSecret)
@@ -1094,8 +1095,8 @@ func getOTLPExporterSecret(namespace string) *corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			consts.APIToken:        []byte(dataIngestToken),
-			consts.DataIngestToken: []byte(dataIngestToken),
+			token.APIToken:        []byte(dataIngestToken),
+			token.DataIngestToken: []byte(dataIngestToken),
 		},
 	}
 }

--- a/pkg/webhook/mutation/pod/webhook_integration_test.go
+++ b/pkg/webhook/mutation/pod/webhook_integration_test.go
@@ -436,7 +436,7 @@ func TestOTLPWebhook(t *testing.T) {
 		require.NotNil(t, dtTokenEnv.ValueFrom)
 		require.NotNil(t, dtTokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, dtTokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, token.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, token.DataIngestKey, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
 
 		// Headers env vars should reference DT_API_TOKEN via authorization header literal
 		assert.Contains(t, appContainer.Env, corev1.EnvVar{Name: exporter.OTLPMetricsHeadersEnv, Value: exporter.OTLPAuthorizationHeader})
@@ -571,7 +571,7 @@ func TestOTLPWebhook(t *testing.T) {
 		require.NotNil(t, dtTokenEnv.ValueFrom)
 		require.NotNil(t, dtTokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, dtTokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, token.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, token.DataIngestKey, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
 
 		raEnv := k8senv.Find(appContainer.Env, resourceattributes.OTELResourceAttributesEnv)
 		require.NotNil(t, raEnv, "OTEL_RESOURCE_ATTRIBUTES missing")
@@ -670,8 +670,8 @@ func TestOTLPWebhook(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				token.APIToken:        []byte(dataIngestToken),
-				token.DataIngestToken: []byte(dataIngestToken),
+				token.APIKey:        []byte(dataIngestToken),
+				token.DataIngestKey: []byte(dataIngestToken),
 			},
 		}
 		createObject(t, clt, apiTokenSecret)
@@ -702,7 +702,7 @@ func TestOTLPWebhook(t *testing.T) {
 		require.NotNil(t, dtTokenEnv.ValueFrom)
 		require.NotNil(t, dtTokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, dtTokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, token.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, token.DataIngestKey, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
 
 		expectedService := fmt.Sprintf("%s-%s.%s", dk.Name, agconsts.MultiActiveGateName, testNamespace)
 		expectedBase := fmt.Sprintf("https://%s/e/%s/api/v2/otlp", expectedService, tenantUUID)
@@ -761,8 +761,8 @@ func TestOTLPWebhook(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				token.APIToken:        []byte(dataIngestToken),
-				token.DataIngestToken: []byte(dataIngestToken),
+				token.APIKey:        []byte(dataIngestToken),
+				token.DataIngestKey: []byte(dataIngestToken),
 			},
 		}
 		createObject(t, clt, apiTokenSecret)
@@ -1095,8 +1095,8 @@ func getOTLPExporterSecret(namespace string) *corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			token.APIToken:        []byte(dataIngestToken),
-			token.DataIngestToken: []byte(dataIngestToken),
+			token.APIKey:        []byte(dataIngestToken),
+			token.DataIngestKey: []byte(dataIngestToken),
 		},
 	}
 }

--- a/pkg/webhook/mutation/pod/webhook_integration_test.go
+++ b/pkg/webhook/mutation/pod/webhook_integration_test.go
@@ -18,7 +18,6 @@ import (
 	otlpspec "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	agconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
@@ -436,7 +435,7 @@ func TestOTLPWebhook(t *testing.T) {
 		require.NotNil(t, dtTokenEnv.ValueFrom)
 		require.NotNil(t, dtTokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, dtTokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, dynatrace.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, consts.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
 
 		// Headers env vars should reference DT_API_TOKEN via authorization header literal
 		assert.Contains(t, appContainer.Env, corev1.EnvVar{Name: exporter.OTLPMetricsHeadersEnv, Value: exporter.OTLPAuthorizationHeader})
@@ -571,7 +570,7 @@ func TestOTLPWebhook(t *testing.T) {
 		require.NotNil(t, dtTokenEnv.ValueFrom)
 		require.NotNil(t, dtTokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, dtTokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, dynatrace.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, consts.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
 
 		raEnv := k8senv.Find(appContainer.Env, resourceattributes.OTELResourceAttributesEnv)
 		require.NotNil(t, raEnv, "OTEL_RESOURCE_ATTRIBUTES missing")
@@ -670,8 +669,8 @@ func TestOTLPWebhook(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				dynatrace.APIToken:        []byte(dataIngestToken),
-				dynatrace.DataIngestToken: []byte(dataIngestToken),
+				consts.APIToken:        []byte(dataIngestToken),
+				consts.DataIngestToken: []byte(dataIngestToken),
 			},
 		}
 		createObject(t, clt, apiTokenSecret)
@@ -702,7 +701,7 @@ func TestOTLPWebhook(t *testing.T) {
 		require.NotNil(t, dtTokenEnv.ValueFrom)
 		require.NotNil(t, dtTokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, dtTokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, dynatrace.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, consts.DataIngestToken, dtTokenEnv.ValueFrom.SecretKeyRef.Key)
 
 		expectedService := fmt.Sprintf("%s-%s.%s", dk.Name, agconsts.MultiActiveGateName, testNamespace)
 		expectedBase := fmt.Sprintf("https://%s/e/%s/api/v2/otlp", expectedService, tenantUUID)
@@ -761,8 +760,8 @@ func TestOTLPWebhook(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				dynatrace.APIToken:        []byte(dataIngestToken),
-				dynatrace.DataIngestToken: []byte(dataIngestToken),
+				consts.APIToken:        []byte(dataIngestToken),
+				consts.DataIngestToken: []byte(dataIngestToken),
 			},
 		}
 		createObject(t, clt, apiTokenSecret)
@@ -1095,8 +1094,8 @@ func getOTLPExporterSecret(namespace string) *corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			dynatrace.APIToken:        []byte(dataIngestToken),
-			dynatrace.DataIngestToken: []byte(dataIngestToken),
+			consts.APIToken:        []byte(dataIngestToken),
+			consts.DataIngestToken: []byte(dataIngestToken),
 		},
 	}
 }

--- a/test/benchmarks/nodes_controller/helpers_test.go
+++ b/test/benchmarks/nodes_controller/helpers_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
-	dtclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -93,7 +93,7 @@ func createSecret(tb testing.TB, clt client.Client, index int) *corev1.Secret {
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{
-			dtclient.APIToken: []byte(testAPIToken),
+			consts.APIToken: []byte(testAPIToken),
 		},
 	}
 

--- a/test/benchmarks/nodes_controller/helpers_test.go
+++ b/test/benchmarks/nodes_controller/helpers_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
-	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -93,7 +93,7 @@ func createSecret(tb testing.TB, clt client.Client, index int) *corev1.Secret {
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{
-			consts.APIToken: []byte(testAPIToken),
+			token.APIToken: []byte(testAPIToken),
 		},
 	}
 

--- a/test/benchmarks/nodes_controller/helpers_test.go
+++ b/test/benchmarks/nodes_controller/helpers_test.go
@@ -93,7 +93,7 @@ func createSecret(tb testing.TB, clt client.Client, index int) *corev1.Secret {
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{
-			token.APIToken: []byte(testAPIToken),
+			token.APIKey: []byte(testAPIToken),
 		},
 	}
 

--- a/test/e2e/features/applicationmonitoring/otlp_exporter_configuration.go
+++ b/test/e2e/features/applicationmonitoring/otlp_exporter_configuration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator/otlp/exporter"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes"
@@ -195,7 +196,7 @@ func assertOTLPEnvVarsPresent(t *testing.T, pod *corev1.Pod, expectedBase string
 		require.NotNil(t, tokenEnv.ValueFrom)
 		require.NotNil(t, tokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, tokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, consts.DataIngestToken, tokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, token.DataIngestToken, tokenEnv.ValueFrom.SecretKeyRef.Key)
 	}
 }
 

--- a/test/e2e/features/applicationmonitoring/otlp_exporter_configuration.go
+++ b/test/e2e/features/applicationmonitoring/otlp_exporter_configuration.go
@@ -196,7 +196,7 @@ func assertOTLPEnvVarsPresent(t *testing.T, pod *corev1.Pod, expectedBase string
 		require.NotNil(t, tokenEnv.ValueFrom)
 		require.NotNil(t, tokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, tokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, token.DataIngestToken, tokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, token.DataIngestKey, tokenEnv.ValueFrom.SecretKeyRef.Key)
 	}
 }
 

--- a/test/e2e/features/applicationmonitoring/otlp_exporter_configuration.go
+++ b/test/e2e/features/applicationmonitoring/otlp_exporter_configuration.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator/otlp/exporter"
@@ -196,7 +195,7 @@ func assertOTLPEnvVarsPresent(t *testing.T, pod *corev1.Pod, expectedBase string
 		require.NotNil(t, tokenEnv.ValueFrom)
 		require.NotNil(t, tokenEnv.ValueFrom.SecretKeyRef)
 		assert.Equal(t, consts.OTLPExporterSecretName, tokenEnv.ValueFrom.SecretKeyRef.Name)
-		assert.Equal(t, dynatrace.DataIngestToken, tokenEnv.ValueFrom.SecretKeyRef.Key)
+		assert.Equal(t, consts.DataIngestToken, tokenEnv.ValueFrom.SecretKeyRef.Key)
 	}
 }
 


### PR DESCRIPTION
## Description

As part of ICP-2063
old dtclient was imported in bunch of places just to import the token consts.

Two places have conflict with version  so variables and imports for client were renamed 
- `pkg/injection/namespace/bootstrapperconfig/endpoints.go`
- `pkg/controllers/dynakube/injection/reconciler_test.go`

## How can this be tested?
`make go/test`