### PR TITLE
Make WithPath additive

### DIFF
--- a/pkg/clients/dynatrace/core/client.go
+++ b/pkg/clients/dynatrace/core/client.go
@@ -28,8 +28,8 @@ type APIClient interface {
 
 // APIRequest provides a fluent interface for building and executing HTTP requests
 type APIRequest interface {
-	// WithPath sets the path for the request
-	WithPath(path string) APIRequest
+	// WithPath sets the path for the request. Path parts will be joined, ignoring leading or trailing slashes.
+	WithPath(path ...string) APIRequest
 	// WithQueryParams adds multiple query parameters to the request, overwriting existing keys if they exist
 	WithQueryParams(params map[string]string) APIRequest
 	// WithRawQueryParams adds multiple query parameters to the request
@@ -128,9 +128,9 @@ func (c *Client) DELETE(ctx context.Context, path string) APIRequest {
 	return c.newRequest(ctx).withMethod(http.MethodDelete).WithPath(path)
 }
 
-// WithPath sets the path for the request
-func (r *Request) WithPath(path string) APIRequest {
-	r.path = path
+// WithPath sets the path for the request. Path parts will be joined, ignoring leading or trailing slashes
+func (r *Request) WithPath(path ...string) APIRequest {
+	r.path = (&url.URL{Path: r.path}).JoinPath(path...).Path
 
 	return r
 }

--- a/pkg/clients/dynatrace/core/client_test.go
+++ b/pkg/clients/dynatrace/core/client_test.go
@@ -26,15 +26,15 @@ func (m brokenModel) MarshalJSON() ([]byte, error) {
 
 func TestClient_Verbs(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/"+r.Method, r.URL.Path)
+		assert.Equal(t, "/api/test/"+r.Method, r.URL.Path)
 	}))
 	defer s.Close()
 
 	c := NewClient(Config{BaseURL: must(url.Parse(s.URL)).JoinPath("/api/")})
-	require.NoError(t, c.GET(t.Context(), http.MethodGet).Execute(nil))
-	require.NoError(t, c.POST(t.Context(), http.MethodPost).Execute(nil))
-	require.NoError(t, c.PUT(t.Context(), http.MethodPut).Execute(nil))
-	require.NoError(t, c.DELETE(t.Context(), http.MethodDelete).Execute(nil))
+	require.NoError(t, c.GET(t.Context(), "/").WithPath("/test//", http.MethodGet).Execute(nil))
+	require.NoError(t, c.POST(t.Context(), "/").WithPath("/test//", http.MethodPost).Execute(nil))
+	require.NoError(t, c.PUT(t.Context(), "/").WithPath("/test//", http.MethodPut).Execute(nil))
+	require.NoError(t, c.DELETE(t.Context(), "/").WithPath("/test//", http.MethodDelete).Execute(nil))
 }
 
 func TestClient_Headers(t *testing.T) {
@@ -48,10 +48,10 @@ func TestClient_Headers(t *testing.T) {
 	defer s.Close()
 
 	c := NewClient(Config{BaseURL: must(url.Parse(s.URL)).JoinPath("/api/"), UserAgent: "my-user-agent"})
-	require.NoError(t, c.GET(t.Context(), "/test").Execute(nil))
+	require.NoError(t, c.GET(t.Context(), "test").Execute(nil))
 
 	expectContentType = "application/json"
-	require.NoError(t, c.POST(t.Context(), "/test").WithRawBody([]byte("test")).Execute(nil))
+	require.NoError(t, c.POST(t.Context(), "test").WithRawBody([]byte("test")).Execute(nil))
 }
 
 func TestClient_WithHeader(t *testing.T) {

--- a/pkg/clients/dynatrace/edgeconnect/edgeconnect.go
+++ b/pkg/clients/dynatrace/edgeconnect/edgeconnect.go
@@ -10,9 +10,7 @@ import (
 
 // EdgeConnect API
 const (
-	edgeConnectAPIPath  = "/platform/app-engine/edge-connect/v1"
-	edgeConnectsAPIPath = edgeConnectAPIPath + "/edge-connects"
-	edgeConnectPath     = edgeConnectsAPIPath + "/"
+	edgeConnectsPath = "/platform/app-engine/edge-connect/v1/edge-connects"
 )
 
 var errNoEdgeConnectID = errors.New("no EdgeConnect ID given")
@@ -65,7 +63,7 @@ func (c *Client) GetEdgeConnect(ctx context.Context, id string) (APIResponse, er
 
 	var response APIResponse
 
-	err := c.apiClient.GET(ctx, edgeConnectPath+id).WithoutToken().Execute(&response)
+	err := c.apiClient.GET(ctx, edgeConnectsPath).WithPath(id).WithoutToken().Execute(&response)
 	if err != nil {
 		return APIResponse{}, errors.Wrap(err, "failed to get EdgeConnect")
 	}
@@ -77,7 +75,7 @@ func (c *Client) GetEdgeConnect(ctx context.Context, id string) (APIResponse, er
 func (c *Client) CreateEdgeConnect(ctx context.Context, request *Request) (APIResponse, error) {
 	var response APIResponse
 
-	err := c.apiClient.POST(ctx, edgeConnectsAPIPath).WithoutToken().WithJSONBody(request).Execute(&response)
+	err := c.apiClient.POST(ctx, edgeConnectsPath).WithoutToken().WithJSONBody(request).Execute(&response)
 	if err != nil {
 		return APIResponse{}, errors.Wrap(err, "failed to create EdgeConnect")
 	}
@@ -91,7 +89,7 @@ func (c *Client) UpdateEdgeConnect(ctx context.Context, id string, request *Requ
 		return errNoEdgeConnectID
 	}
 
-	err := c.apiClient.PUT(ctx, edgeConnectPath+id).WithoutToken().WithJSONBody(request).Execute(nil)
+	err := c.apiClient.PUT(ctx, edgeConnectsPath).WithPath(id).WithoutToken().WithJSONBody(request).Execute(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to update EdgeConnect")
 	}
@@ -108,7 +106,7 @@ func (c *Client) ListEdgeConnects(ctx context.Context, name string) ([]APIRespon
 		"filter":     fmt.Sprintf("name='%s'", name),
 	}
 
-	err := c.apiClient.GET(ctx, edgeConnectsAPIPath).WithoutToken().WithQueryParams(qp).Execute(&response)
+	err := c.apiClient.GET(ctx, edgeConnectsPath).WithoutToken().WithQueryParams(qp).Execute(&response)
 	if err != nil {
 		return []APIResponse{}, errors.Wrap(err, "failed to get EdgeConnects")
 	}
@@ -122,7 +120,7 @@ func (c *Client) DeleteEdgeConnect(ctx context.Context, id string) error {
 		return errNoEdgeConnectID
 	}
 
-	err := c.apiClient.DELETE(ctx, edgeConnectPath+id).WithoutToken().Execute(nil)
+	err := c.apiClient.DELETE(ctx, edgeConnectsPath).WithPath(id).WithoutToken().Execute(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete EdgeConnect")
 	}

--- a/pkg/clients/dynatrace/edgeconnect/edgeconnect_test.go
+++ b/pkg/clients/dynatrace/edgeconnect/edgeconnect_test.go
@@ -14,7 +14,7 @@ const edgeConnectID = "test-id"
 func TestGetEdgeConnect(t *testing.T) {
 	t.Run("get EdgeConnect", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectGET(t, apiClient, request, edgeConnectPath+edgeConnectID)
+		expectGET(t, apiClient, request, edgeConnectsPath, edgeConnectID)
 		request.EXPECT().Execute(new(APIResponse)).Run(func(obj any) {
 			obj.(*APIResponse).Name = "test-name"
 		}).Return(nil).Once()
@@ -26,7 +26,7 @@ func TestGetEdgeConnect(t *testing.T) {
 
 	t.Run("fail to get EdgeConnect", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectGET(t, apiClient, request, edgeConnectPath+edgeConnectID)
+		expectGET(t, apiClient, request, edgeConnectsPath, edgeConnectID)
 		request.EXPECT().Execute(new(APIResponse)).Return(errTest).Once()
 		got, err := mockClient.GetEdgeConnect(t.Context(), edgeConnectID)
 		require.ErrorIs(t, err, errTest)
@@ -42,11 +42,11 @@ func TestGetEdgeConnect(t *testing.T) {
 }
 
 func TestCreateEdgeConnect(t *testing.T) {
-	var edgeConnectCreateRequest = NewCreateRequest("InternalServices", []string{"*.internal.org"}, []edgeconnect.HostMapping{})
+	edgeConnectCreateRequest := NewCreateRequest("InternalServices", []string{"*.internal.org"}, []edgeconnect.HostMapping{})
 
 	t.Run("create EdgeConnect", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectPOST(t, apiClient, request, edgeConnectsAPIPath, edgeConnectCreateRequest)
+		expectPOST(t, apiClient, request, edgeConnectsPath, edgeConnectCreateRequest)
 		request.EXPECT().Execute(new(APIResponse)).Run(func(obj any) {
 			obj.(*APIResponse).Name = edgeConnectCreateRequest.Name
 		}).Return(nil).Once()
@@ -58,7 +58,7 @@ func TestCreateEdgeConnect(t *testing.T) {
 
 	t.Run("fail to create EdgeConnect", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectPOST(t, apiClient, request, edgeConnectsAPIPath, edgeConnectCreateRequest)
+		expectPOST(t, apiClient, request, edgeConnectsPath, edgeConnectCreateRequest)
 		request.EXPECT().Execute(new(APIResponse)).Return(errTest).Once()
 		got, err := mockClient.CreateEdgeConnect(t.Context(), edgeConnectCreateRequest)
 		require.ErrorIs(t, err, errTest)
@@ -67,11 +67,11 @@ func TestCreateEdgeConnect(t *testing.T) {
 }
 
 func TestUpdateEdgeConnect(t *testing.T) {
-	var edgeConnectUpdateRequest = NewUpdateRequest("InternalServices", []string{"*.internal.org"}, []edgeconnect.HostMapping{}, "dt0s02.AIOUP56P")
+	edgeConnectUpdateRequest := NewUpdateRequest("InternalServices", []string{"*.internal.org"}, []edgeconnect.HostMapping{}, "dt0s02.AIOUP56P")
 
 	t.Run("update EdgeConnect", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectPUT(t, apiClient, request, edgeConnectPath+edgeConnectID, edgeConnectUpdateRequest)
+		expectPUT(t, apiClient, request, edgeConnectsPath, edgeConnectID, edgeConnectUpdateRequest)
 		request.EXPECT().Execute(nil).Return(nil).Once()
 		err := mockClient.UpdateEdgeConnect(t.Context(), edgeConnectID, edgeConnectUpdateRequest)
 		require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestUpdateEdgeConnect(t *testing.T) {
 
 	t.Run("fail to update EdgeConnect", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectPUT(t, apiClient, request, edgeConnectPath+edgeConnectID, edgeConnectUpdateRequest)
+		expectPUT(t, apiClient, request, edgeConnectsPath, edgeConnectID, edgeConnectUpdateRequest)
 		request.EXPECT().Execute(nil).Return(errTest).Once()
 		err := mockClient.UpdateEdgeConnect(t.Context(), edgeConnectID, edgeConnectUpdateRequest)
 		require.ErrorIs(t, err, errTest)
@@ -102,7 +102,7 @@ func TestListEdgeConnects(t *testing.T) {
 
 	t.Run("get EdgeConnects", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectGET(t, apiClient, request, edgeConnectsAPIPath)
+		expectGET(t, apiClient, request, edgeConnectsPath, "")
 		request.EXPECT().WithQueryParams(ecQp).Return(request).Once()
 		request.EXPECT().Execute(new(listResponse)).Run(func(obj any) {
 			obj.(*listResponse).EdgeConnects = []APIResponse{
@@ -117,7 +117,7 @@ func TestListEdgeConnects(t *testing.T) {
 
 	t.Run("fail to get EdgeConnects", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectGET(t, apiClient, request, edgeConnectsAPIPath)
+		expectGET(t, apiClient, request, edgeConnectsPath, "")
 		request.EXPECT().WithQueryParams(ecQp).Return(request).Once()
 		request.EXPECT().Execute(new(listResponse)).Return(errTest).Once()
 		got, err := mockClient.ListEdgeConnects(t.Context(), name)
@@ -129,7 +129,7 @@ func TestListEdgeConnects(t *testing.T) {
 func TestDeleteEdgeConnect(t *testing.T) {
 	t.Run("delete EdgeConnect", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectDELETE(t, apiClient, request, edgeConnectPath+edgeConnectID)
+		expectDELETE(t, apiClient, request, edgeConnectsPath, edgeConnectID)
 		request.EXPECT().Execute(nil).Return(nil).Once()
 		err := mockClient.DeleteEdgeConnect(t.Context(), edgeConnectID)
 		require.NoError(t, err)
@@ -137,7 +137,7 @@ func TestDeleteEdgeConnect(t *testing.T) {
 
 	t.Run("fail to delete EdgeConnect", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectDELETE(t, apiClient, request, edgeConnectPath+edgeConnectID)
+		expectDELETE(t, apiClient, request, edgeConnectsPath, edgeConnectID)
 		request.EXPECT().Execute(nil).Return(errTest).Once()
 		err := mockClient.DeleteEdgeConnect(t.Context(), edgeConnectID)
 		require.ErrorIs(t, err, errTest)
@@ -158,9 +158,12 @@ func newTestSetup(t *testing.T) (*coremock.APIClient, *coremock.APIRequest, *Cli
 	return apiClient, request, NewClient(apiClient)
 }
 
-func expectGET(t *testing.T, apiClient *coremock.APIClient, request *coremock.APIRequest, path string) {
+func expectGET(t *testing.T, apiClient *coremock.APIClient, request *coremock.APIRequest, path, id string) {
 	t.Helper()
 	request.EXPECT().WithoutToken().Return(request).Once()
+	if id != "" {
+		request.EXPECT().WithPath([]string{id}).Return(request).Once()
+	}
 	apiClient.EXPECT().GET(t.Context(), path).Return(request).Once()
 }
 
@@ -171,16 +174,18 @@ func expectPOST(t *testing.T, apiClient *coremock.APIClient, request *coremock.A
 	apiClient.EXPECT().POST(t.Context(), path).Return(request).Once()
 }
 
-func expectPUT(t *testing.T, apiClient *coremock.APIClient, request *coremock.APIRequest, path string, body any) {
+func expectPUT(t *testing.T, apiClient *coremock.APIClient, request *coremock.APIRequest, path, id string, body any) {
 	t.Helper()
 	request.EXPECT().WithoutToken().Return(request).Once()
 	request.EXPECT().WithJSONBody(body).Return(request).Once()
+	request.EXPECT().WithPath([]string{id}).Return(request).Once()
 	apiClient.EXPECT().PUT(t.Context(), path).Return(request).Once()
 }
 
 // expectDELETE sets up WithoutToken and DELETE mock expectations for the given path.
-func expectDELETE(t *testing.T, apiClient *coremock.APIClient, request *coremock.APIRequest, path string) {
+func expectDELETE(t *testing.T, apiClient *coremock.APIClient, request *coremock.APIRequest, path, id string) {
 	t.Helper()
 	request.EXPECT().WithoutToken().Return(request).Once()
+	request.EXPECT().WithPath([]string{id}).Return(request).Once()
 	apiClient.EXPECT().DELETE(t.Context(), path).Return(request).Once()
 }

--- a/pkg/clients/dynatrace/edgeconnect/environment_settings.go
+++ b/pkg/clients/dynatrace/edgeconnect/environment_settings.go
@@ -8,9 +8,7 @@ import (
 
 // Environment API
 const (
-	environmentAPIPath    = "/platform/classic/environment-api/v2"
-	settingsObjectsPath   = environmentAPIPath + "/settings/objects"
-	settingsObjectsIDPath = settingsObjectsPath + "/"
+	settingsObjectsPath = "/platform/classic/environment-api/v2/settings/objects"
 )
 
 const (
@@ -71,7 +69,7 @@ func (c *Client) UpdateEnvironmentSetting(ctx context.Context, es EnvironmentSet
 		return errNoEnvSettingObjectID
 	}
 
-	err := c.apiClient.PUT(ctx, settingsObjectsIDPath+es.ObjectID).WithoutToken().WithJSONBody(es).Execute(nil)
+	err := c.apiClient.PUT(ctx, settingsObjectsPath).WithPath(es.ObjectID).WithoutToken().WithJSONBody(es).Execute(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to update environment setting")
 	}
@@ -85,7 +83,7 @@ func (c *Client) DeleteEnvironmentSetting(ctx context.Context, objectID string) 
 		return errNoEnvSettingObjectID
 	}
 
-	err := c.apiClient.DELETE(ctx, settingsObjectsIDPath+objectID).WithoutToken().Execute(nil)
+	err := c.apiClient.DELETE(ctx, settingsObjectsPath).WithPath(objectID).WithoutToken().Execute(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete environment setting")
 	}

--- a/pkg/clients/dynatrace/edgeconnect/environment_settings_test.go
+++ b/pkg/clients/dynatrace/edgeconnect/environment_settings_test.go
@@ -31,7 +31,7 @@ var errTest = errors.New("test-error")
 func TestListEnvironmentSettings(t *testing.T) {
 	t.Run("Server response OK", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectGET(t, apiClient, request, settingsObjectsPath)
+		expectGET(t, apiClient, request, settingsObjectsPath, "")
 		request.EXPECT().WithQueryParams(qp).Return(request).Once()
 		request.EXPECT().Execute(new(environmentSettingsResponse)).Run(func(obj any) {
 			obj.(*environmentSettingsResponse).Items = []EnvironmentSetting{
@@ -47,7 +47,7 @@ func TestListEnvironmentSettings(t *testing.T) {
 
 	t.Run("Server response NOK", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectGET(t, apiClient, request, settingsObjectsPath)
+		expectGET(t, apiClient, request, settingsObjectsPath, "")
 		request.EXPECT().WithQueryParams(qp).Return(request).Once()
 		request.EXPECT().Execute(new(environmentSettingsResponse)).Return(errTest).Once()
 		got, err := mockClient.ListEnvironmentSettings(t.Context())
@@ -77,7 +77,7 @@ func TestCreateEnvironmentSetting(t *testing.T) {
 func TestUpdateEnvironmentSetting(t *testing.T) {
 	t.Run("Server response OK", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectPUT(t, apiClient, request, settingsObjectsIDPath+testObjectID, testEnvironmentSetting)
+		expectPUT(t, apiClient, request, settingsObjectsPath, testObjectID, testEnvironmentSetting)
 		request.EXPECT().Execute(nil).Return(nil).Once()
 		err := mockClient.UpdateEnvironmentSetting(t.Context(), testEnvironmentSetting)
 		require.NoError(t, err)
@@ -85,7 +85,7 @@ func TestUpdateEnvironmentSetting(t *testing.T) {
 
 	t.Run("Server response NOK", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectPUT(t, apiClient, request, settingsObjectsIDPath+testObjectID, testEnvironmentSetting)
+		expectPUT(t, apiClient, request, settingsObjectsPath, testObjectID, testEnvironmentSetting)
 		request.EXPECT().Execute(nil).Return(errTest).Once()
 		err := mockClient.UpdateEnvironmentSetting(t.Context(), testEnvironmentSetting)
 		require.ErrorIs(t, err, errTest)
@@ -107,7 +107,7 @@ func TestUpdateEnvironmentSetting(t *testing.T) {
 func TestDeleteEnvironmentSetting(t *testing.T) {
 	t.Run("Server response OK", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectDELETE(t, apiClient, request, settingsObjectsIDPath+testObjectID)
+		expectDELETE(t, apiClient, request, settingsObjectsPath, testObjectID)
 		request.EXPECT().Execute(nil).Return(nil).Once()
 		err := mockClient.DeleteEnvironmentSetting(t.Context(), testEnvironmentSetting.ObjectID)
 		require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestDeleteEnvironmentSetting(t *testing.T) {
 
 	t.Run("Server response NOK", func(t *testing.T) {
 		apiClient, request, mockClient := newTestSetup(t)
-		expectDELETE(t, apiClient, request, settingsObjectsIDPath+testObjectID)
+		expectDELETE(t, apiClient, request, settingsObjectsPath, testObjectID)
 		request.EXPECT().Execute(nil).Return(errTest).Once()
 		err := mockClient.DeleteEnvironmentSetting(t.Context(), testEnvironmentSetting.ObjectID)
 		require.ErrorIs(t, err, errTest)

--- a/pkg/clients/dynatrace/oneagent/version.go
+++ b/pkg/clients/dynatrace/oneagent/version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
+	goerrors "errors"
 	"io"
 	"net/url"
 	"strconv"
@@ -14,6 +14,10 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/installer"
 	"github.com/pkg/errors"
 )
+
+const agentDeploymentPath = "/v1/deployment/installer/agent"
+
+var errEmptyOSOrInstallerType = goerrors.New("OS or installerType is empty")
 
 type GetParams struct {
 	OS            string
@@ -27,10 +31,11 @@ type GetParams struct {
 // Get gets the agent package for the given OS, installer type, flavor, arch and version.
 func (c *Client) Get(ctx context.Context, args GetParams, writer io.Writer) error {
 	if len(args.OS) == 0 || len(args.InstallerType) == 0 {
-		return errors.New("os or installerType is empty")
+		return errEmptyOSOrInstallerType
 	}
 
-	apiRequest := c.apiClient.GET(ctx, getURL(args.OS, args.InstallerType, args.Version)).
+	apiRequest := c.apiClient.GET(ctx, agentDeploymentPath).
+		WithPath(args.OS, args.InstallerType, "version", args.Version).
 		WithPaasToken().
 		WithQueryParams(map[string]string{
 			"flavor":       args.Flavor,
@@ -51,10 +56,11 @@ func (c *Client) Get(ctx context.Context, args GetParams, writer io.Writer) erro
 // GetLatest gets the latest agent package for the given OS, installer type, flavor and arch.
 func (c *Client) GetLatest(ctx context.Context, args GetParams, writer io.Writer) error {
 	if len(args.OS) == 0 || len(args.InstallerType) == 0 {
-		return errors.New("os or installerType is empty")
+		return errEmptyOSOrInstallerType
 	}
 
-	apiRequest := c.apiClient.GET(ctx, getLatestURL(args.OS, args.InstallerType)).
+	apiRequest := c.apiClient.GET(ctx, agentDeploymentPath).
+		WithPath(args.OS, args.InstallerType, "latest").
 		WithPaasToken().
 		WithQueryParams(map[string]string{
 			"flavor":       args.Flavor,
@@ -79,7 +85,7 @@ type versionsResponse struct {
 // GetVersions gets available agent versions for the given OS, installer type and flavor.
 func (c *Client) GetVersions(ctx context.Context, args GetParams) ([]string, error) {
 	if len(args.OS) == 0 || len(args.InstallerType) == 0 {
-		return nil, errors.New("os or installerType is empty")
+		return nil, errEmptyOSOrInstallerType
 	}
 
 	var resp versionsResponse
@@ -93,7 +99,8 @@ func (c *Client) GetVersions(ctx context.Context, args GetParams) ([]string, err
 		params["arch"] = oaArch
 	}
 
-	err := c.apiClient.GET(ctx, getVersionsURL(args.OS, args.InstallerType)).
+	err := c.apiClient.GET(ctx, agentDeploymentPath).
+		WithPath("versions", args.OS, args.InstallerType).
 		WithQueryParams(params).
 		WithPaasToken().
 		Execute(&resp)
@@ -126,18 +133,6 @@ func makeRequestForBinary(req core.APIRequest, writer io.Writer) (string, error)
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), nil
-}
-
-func getURL(os, installerType, version string) string {
-	return fmt.Sprintf("/v1/deployment/installer/agent/%s/%s/version/%s", os, installerType, version)
-}
-
-func getLatestURL(os, installerType string) string {
-	return fmt.Sprintf("/v1/deployment/installer/agent/%s/%s/latest", os, installerType)
-}
-
-func getVersionsURL(os, installerType string) string {
-	return fmt.Sprintf("/v1/deployment/installer/agent/versions/%s/%s", os, installerType)
 }
 
 func technologiesQueryParams(technologies []string) url.Values {

--- a/pkg/clients/dynatrace/oneagent/version.go
+++ b/pkg/clients/dynatrace/oneagent/version.go
@@ -17,7 +17,10 @@ import (
 
 const agentDeploymentPath = "/v1/deployment/installer/agent"
 
-var errEmptyOSOrInstallerType = goerrors.New("OS or installerType is empty")
+var (
+	errEmptyOS            = goerrors.New("OS is empty")
+	errEmptyInstallerType = goerrors.New("installerType is empty")
+)
 
 type GetParams struct {
 	OS            string
@@ -30,8 +33,12 @@ type GetParams struct {
 
 // Get gets the agent package for the given OS, installer type, flavor, arch and version.
 func (c *Client) Get(ctx context.Context, args GetParams, writer io.Writer) error {
-	if len(args.OS) == 0 || len(args.InstallerType) == 0 {
-		return errEmptyOSOrInstallerType
+	if len(args.OS) == 0 {
+		return errEmptyOS
+	}
+
+	if len(args.InstallerType) == 0 {
+		return errEmptyInstallerType
 	}
 
 	apiRequest := c.apiClient.GET(ctx, agentDeploymentPath).
@@ -55,8 +62,12 @@ func (c *Client) Get(ctx context.Context, args GetParams, writer io.Writer) erro
 
 // GetLatest gets the latest agent package for the given OS, installer type, flavor and arch.
 func (c *Client) GetLatest(ctx context.Context, args GetParams, writer io.Writer) error {
-	if len(args.OS) == 0 || len(args.InstallerType) == 0 {
-		return errEmptyOSOrInstallerType
+	if len(args.OS) == 0 {
+		return errEmptyOS
+	}
+
+	if len(args.InstallerType) == 0 {
+		return errEmptyInstallerType
 	}
 
 	apiRequest := c.apiClient.GET(ctx, agentDeploymentPath).
@@ -84,8 +95,12 @@ type versionsResponse struct {
 
 // GetVersions gets available agent versions for the given OS, installer type and flavor.
 func (c *Client) GetVersions(ctx context.Context, args GetParams) ([]string, error) {
-	if len(args.OS) == 0 || len(args.InstallerType) == 0 {
-		return nil, errEmptyOSOrInstallerType
+	if len(args.OS) == 0 {
+		return nil, errEmptyOS
+	}
+
+	if len(args.InstallerType) == 0 {
+		return nil, errEmptyInstallerType
 	}
 
 	var resp versionsResponse

--- a/pkg/clients/dynatrace/oneagent/version_test.go
+++ b/pkg/clients/dynatrace/oneagent/version_test.go
@@ -70,6 +70,11 @@ func TestGetLatest(t *testing.T) {
 		err := oaClient.GetLatest(t.Context(), args, file)
 		require.Error(t, err)
 	})
+
+	t.Run("missing params", func(t *testing.T) {
+		require.ErrorIs(t, (&Client{}).GetLatest(t.Context(), GetParams{InstallerType: installer.TypePaaS}, nil), errEmptyOS)
+		require.ErrorIs(t, (&Client{}).GetLatest(t.Context(), GetParams{OS: installer.OsUnix}, nil), errEmptyInstallerType)
+	})
 }
 
 func TestGet(t *testing.T) {
@@ -123,6 +128,11 @@ func TestGet(t *testing.T) {
 
 		require.True(t, core.IsNotFound(err))
 	})
+
+	t.Run("missing params", func(t *testing.T) {
+		require.ErrorIs(t, (&Client{}).Get(t.Context(), GetParams{InstallerType: installer.TypePaaS}, nil), errEmptyOS)
+		require.ErrorIs(t, (&Client{}).Get(t.Context(), GetParams{OS: installer.OsUnix}, nil), errEmptyInstallerType)
+	})
 }
 
 func TestGetVersions(t *testing.T) {
@@ -172,5 +182,12 @@ func TestGetVersions(t *testing.T) {
 		require.Empty(t, availableVersions)
 		require.Error(t, err)
 		require.True(t, core.IsBadRequest(err))
+	})
+
+	t.Run("missing params", func(t *testing.T) {
+		_, err := (&Client{}).GetVersions(t.Context(), GetParams{InstallerType: installer.TypePaaS})
+		require.ErrorIs(t, err, errEmptyOS)
+		_, err = (&Client{}).GetVersions(t.Context(), GetParams{OS: installer.OsUnix})
+		require.ErrorIs(t, err, errEmptyInstallerType)
 	})
 }

--- a/pkg/clients/dynatrace/oneagent/version_test.go
+++ b/pkg/clients/dynatrace/oneagent/version_test.go
@@ -39,6 +39,7 @@ func TestGetLatest(t *testing.T) {
 		multiWriter := io.MultiWriter(file, hash)
 
 		req := coremock.NewAPIRequest(t)
+		req.EXPECT().WithPath([]string{args.OS, args.InstallerType, "latest"}).Return(req).Once()
 		req.EXPECT().WithPaasToken().Return(req).Once()
 		req.EXPECT().WithQueryParams(mock.Anything).Return(req).Once()
 		req.EXPECT().WithRawQueryParams(mock.Anything).Return(req).Once()
@@ -49,7 +50,7 @@ func TestGetLatest(t *testing.T) {
 		}).Return(rawErr).Once()
 
 		client := coremock.NewAPIClient(t)
-		client.EXPECT().GET(t.Context(), getLatestURL(installer.OsUnix, installer.TypePaaS)).Return(req).Once()
+		client.EXPECT().GET(t.Context(), agentDeploymentPath).Return(req).Once()
 
 		return NewClient(client, "", ""), file
 	}
@@ -75,7 +76,7 @@ func TestGet(t *testing.T) {
 	args := GetParams{
 		OS:            installer.OsUnix,
 		InstallerType: installer.TypePaaS,
-		Version:       "",
+		Version:       "1.2.3",
 		Flavor:        "",
 		Technologies:  nil,
 		SkipMetadata:  false,
@@ -90,6 +91,7 @@ func TestGet(t *testing.T) {
 		multiWriter := io.MultiWriter(file, hash)
 
 		req := coremock.NewAPIRequest(t)
+		req.EXPECT().WithPath([]string{args.OS, args.InstallerType, "version", args.Version}).Return(req).Once()
 		req.EXPECT().WithPaasToken().Return(req).Once()
 		req.EXPECT().WithQueryParams(mock.Anything).Return(req).Once()
 		req.EXPECT().WithRawQueryParams(mock.Anything).Return(req).Once()
@@ -100,7 +102,7 @@ func TestGet(t *testing.T) {
 		}).Return(rawErr).Once()
 
 		client := coremock.NewAPIClient(t)
-		client.EXPECT().GET(t.Context(), getURL(installer.OsUnix, installer.TypePaaS, "")).Return(req).Once()
+		client.EXPECT().GET(t.Context(), agentDeploymentPath).Return(req).Once()
 
 		return NewClient(client, "", ""), file
 	}
@@ -129,12 +131,13 @@ func TestGetVersions(t *testing.T) {
 		InstallerType: installer.TypePaaS,
 		Flavor:        "",
 	}
-	var responseString = []string{"1.123.1", "1.123.2", "1.123.3", "1.123.4"}
+	responseString := []string{"1.123.1", "1.123.2", "1.123.3", "1.123.4"}
 
 	setupClient := func(t *testing.T, execErr error) *Client {
 		var resp versionsResponse
 
 		req := coremock.NewAPIRequest(t)
+		req.EXPECT().WithPath([]string{"versions", args.OS, args.InstallerType}).Return(req).Once()
 		req.EXPECT().WithQueryParams(mock.Anything).Return(req).Once()
 		req.EXPECT().WithPaasToken().Return(req).Once()
 		req.EXPECT().Execute(&resp).Run(func(model any) {
@@ -145,7 +148,7 @@ func TestGetVersions(t *testing.T) {
 		}).Return(execErr).Once()
 
 		client := coremock.NewAPIClient(t)
-		client.EXPECT().GET(t.Context(), getVersionsURL(installer.OsUnix, installer.TypePaaS)).Return(req).Once()
+		client.EXPECT().GET(t.Context(), agentDeploymentPath).Return(req).Once()
 
 		return NewClient(client, "", "")
 	}

--- a/pkg/clients/dynatrace/version/activegate.go
+++ b/pkg/clients/dynatrace/version/activegate.go
@@ -2,27 +2,24 @@ package version
 
 import (
 	"context"
-	"fmt"
+	goerrors "errors"
 
 	"github.com/pkg/errors"
 )
 
+var errEmptyOS = goerrors.New("OS is empty")
+
 // GetLatestActiveGateVersion gets the latest gateway version for the given OS and arch configured on the Tenant.
 func (c *Client) GetLatestActiveGateVersion(ctx context.Context, os string) (string, error) {
 	if len(os) == 0 {
-		return "", errors.New("os is empty")
+		return "", errEmptyOS
 	}
 
 	response := struct {
 		LatestGatewayVersion string `json:"latestGatewayVersion"`
 	}{}
 
-	url := getLatestActiveGateVersionPath(os)
-	err := c.apiClient.GET(ctx, url).WithPaasToken().Execute(&response)
+	err := c.apiClient.GET(ctx, "/v1/deployment/installer/gateway").WithPath(os, "latest/metainfo").WithPaasToken().Execute(&response)
 
 	return response.LatestGatewayVersion, errors.WithStack(err)
-}
-
-func getLatestActiveGateVersionPath(os string) string {
-	return fmt.Sprintf("/v1/deployment/installer/gateway/%s/latest/metainfo", os)
 }

--- a/pkg/clients/dynatrace/version/activegate_test.go
+++ b/pkg/clients/dynatrace/version/activegate_test.go
@@ -13,9 +13,8 @@ import (
 func TestGetLatestActiveGateVersion(t *testing.T) {
 	setupMockedClient := func(t *testing.T, os string, err error) *Client {
 		req := coremock.NewAPIRequest(t)
-		req.EXPECT().
-			WithPaasToken().
-			Return(req).Once()
+		req.EXPECT().WithPath([]string{os, "latest/metainfo"}).Return(req).Once()
+		req.EXPECT().WithPaasToken().Return(req).Once()
 		req.EXPECT().
 			Execute(new(struct {
 				LatestGatewayVersion string `json:"latestGatewayVersion"`
@@ -28,7 +27,7 @@ func TestGetLatestActiveGateVersion(t *testing.T) {
 			}).
 			Return(err).Once()
 		client := coremock.NewAPIClient(t)
-		client.EXPECT().GET(t.Context(), getLatestActiveGateVersionPath(os)).Return(req).Once()
+		client.EXPECT().GET(t.Context(), "/v1/deployment/installer/gateway").Return(req).Once()
 
 		return NewClient(client)
 	}
@@ -45,7 +44,7 @@ func TestGetLatestActiveGateVersion(t *testing.T) {
 		client := NewClient(nil)
 
 		_, err := client.GetLatestActiveGateVersion(t.Context(), "")
-		assert.Error(t, err, "os is empty")
+		assert.ErrorIs(t, err, errEmptyOS)
 	})
 
 	t.Run("server error", func(t *testing.T) {

--- a/pkg/clients/dynatrace/version/agent.go
+++ b/pkg/clients/dynatrace/version/agent.go
@@ -2,24 +2,24 @@ package version
 
 import (
 	"context"
-	"fmt"
+	goerrors "errors"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/installer"
 	"github.com/pkg/errors"
 )
 
+var errEmptyOSOrInstallerType = goerrors.New("OS or installerType is empty")
+
 // GetLatestAgentVersion gets the latest agent version for the given OS and installer type configured on the Tenant.
 func (c *Client) GetLatestAgentVersion(ctx context.Context, os, installerType string) (string, error) {
 	if len(os) == 0 || len(installerType) == 0 {
-		return "", errors.New("os or installerType is empty")
+		return "", errEmptyOSOrInstallerType
 	}
 
 	response := struct {
 		LatestAgentVersion string `json:"latestAgentVersion"`
 	}{}
-
-	path := getLatestAgentVersionPath(os, installerType)
 
 	queryParams := map[string]string{
 		"bitness": "64",
@@ -30,14 +30,12 @@ func (c *Client) GetLatestAgentVersion(ctx context.Context, os, installerType st
 		queryParams["arch"] = determineArch(installerType)
 	}
 
-	err := c.apiClient.GET(ctx, path).WithPaasToken().WithQueryParams(queryParams).Execute(&response)
+	err := c.apiClient.GET(ctx, "/v1/deployment/installer/agent").
+		WithPath(os, installerType, "latest/metainfo").
+		WithPaasToken().
+		WithQueryParams(queryParams).Execute(&response)
 
 	return response.LatestAgentVersion, errors.WithStack(err)
-}
-
-func getLatestAgentVersionPath(os string, installerType string) string {
-	return fmt.Sprintf("/v1/deployment/installer/agent/%s/%s/latest/metainfo",
-		os, installerType)
 }
 
 // determineArch gives you the proper arch value, because the OSAgent and ActiveGate images on the tenant-image-registry only have AMD images.

--- a/pkg/clients/dynatrace/version/agent_test.go
+++ b/pkg/clients/dynatrace/version/agent_test.go
@@ -12,14 +12,11 @@ import (
 )
 
 func TestGetLatestAgentVersion(t *testing.T) {
-	setupMockedClient := func(t *testing.T, os string, installerType string, queryParams map[string]string, err error) *Client {
+	setupMockedClient := func(t *testing.T, os, installerType string, queryParams map[string]string, err error) *Client {
 		req := coremock.NewAPIRequest(t)
-		req.EXPECT().
-			WithQueryParams(queryParams).
-			Return(req).Once()
-		req.EXPECT().
-			WithPaasToken().
-			Return(req).Once()
+		req.EXPECT().WithPath([]string{os, installerType, "latest/metainfo"}).Return(req).Once()
+		req.EXPECT().WithQueryParams(queryParams).Return(req).Once()
+		req.EXPECT().WithPaasToken().Return(req).Once()
 		req.EXPECT().
 			Execute(new(struct {
 				LatestAgentVersion string `json:"latestAgentVersion"`
@@ -32,7 +29,7 @@ func TestGetLatestAgentVersion(t *testing.T) {
 			}).
 			Return(err).Once()
 		client := coremock.NewAPIClient(t)
-		client.EXPECT().GET(t.Context(), getLatestAgentVersionPath(os, installerType)).Return(req).Once()
+		client.EXPECT().GET(t.Context(), "/v1/deployment/installer/agent").Return(req).Once()
 
 		return NewClient(client)
 	}
@@ -66,14 +63,14 @@ func TestGetLatestAgentVersion(t *testing.T) {
 		client := NewClient(nil)
 
 		_, err := client.GetLatestAgentVersion(t.Context(), "", installer.TypeDefault)
-		assert.Error(t, err, "os is empty")
+		assert.ErrorIs(t, err, errEmptyOSOrInstallerType)
 	})
 
 	t.Run("empty installerType", func(t *testing.T) {
 		client := NewClient(nil)
 
 		_, err := client.GetLatestAgentVersion(t.Context(), installer.OsUnix, "")
-		assert.Error(t, err, "os is empty")
+		assert.ErrorIs(t, err, errEmptyOSOrInstallerType)
 	})
 
 	t.Run("server error", func(t *testing.T) {

--- a/test/mocks/pkg/clients/dynatrace/core/api_request.go
+++ b/test/mocks/pkg/clients/dynatrace/core/api_request.go
@@ -355,16 +355,22 @@ func (_c *APIRequest_WithPaasToken_Call) RunAndReturn(run func() core.APIRequest
 }
 
 // WithPath provides a mock function for the type APIRequest
-func (_mock *APIRequest) WithPath(path string) core.APIRequest {
-	ret := _mock.Called(path)
+func (_mock *APIRequest) WithPath(path ...string) core.APIRequest {
+	var tmpRet mock.Arguments
+	if len(path) > 0 {
+		tmpRet = _mock.Called(path)
+	} else {
+		tmpRet = _mock.Called()
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for WithPath")
 	}
 
 	var r0 core.APIRequest
-	if returnFunc, ok := ret.Get(0).(func(string) core.APIRequest); ok {
-		r0 = returnFunc(path)
+	if returnFunc, ok := ret.Get(0).(func(...string) core.APIRequest); ok {
+		r0 = returnFunc(path...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(core.APIRequest)
@@ -379,19 +385,22 @@ type APIRequest_WithPath_Call struct {
 }
 
 // WithPath is a helper method to define mock.On call
-//   - path string
-func (_e *APIRequest_Expecter) WithPath(path interface{}) *APIRequest_WithPath_Call {
-	return &APIRequest_WithPath_Call{Call: _e.mock.On("WithPath", path)}
+//   - path ...string
+func (_e *APIRequest_Expecter) WithPath(path ...interface{}) *APIRequest_WithPath_Call {
+	return &APIRequest_WithPath_Call{Call: _e.mock.On("WithPath",
+		append([]interface{}{}, path...)...)}
 }
 
-func (_c *APIRequest_WithPath_Call) Run(run func(path string)) *APIRequest_WithPath_Call {
+func (_c *APIRequest_WithPath_Call) Run(run func(path ...string)) *APIRequest_WithPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+		var arg0 []string
+		var variadicArgs []string
+		if len(args) > 0 {
+			variadicArgs = args[0].([]string)
 		}
+		arg0 = variadicArgs
 		run(
-			arg0,
+			arg0...,
 		)
 	})
 	return _c
@@ -402,7 +411,7 @@ func (_c *APIRequest_WithPath_Call) Return(aPIRequest core.APIRequest) *APIReque
 	return _c
 }
 
-func (_c *APIRequest_WithPath_Call) RunAndReturn(run func(path string) core.APIRequest) *APIRequest_WithPath_Call {
+func (_c *APIRequest_WithPath_Call) RunAndReturn(run func(path ...string) core.APIRequest) *APIRequest_WithPath_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Description

Extend the WithPath request method to be additive instead of always overwriting the path. It also uses url.JoinPath which obsoletes the use of string formatting to build a path.
Since this interface change makes the mocks expect a slice, I decided to only keep this behavior change in the WithPath method to keep the change focused on the packages that actually make use of this feature.

I overlooked this initially, because all the paths I was working with were static. Now that we're finishing up the refactoring we can revisit the interfaces and improve on them.

Having `WithPath(string)` be additive would be enough, but I changed it to varargs for ease of use.

ICP-2063

## How can this be tested?

Run activegate, edgeconnect and bootstrapper e2e tests
