### PR TITLE
Fix version in OCP bundles

### DIFF
--- a/config/olm/openshift/1.9.0/manifests/dynatrace-operator.clusterserviceversion.yaml
+++ b/config/olm/openshift/1.9.0/manifests/dynatrace-operator.clusterserviceversion.yaml
@@ -1047,7 +1047,7 @@ spec:
       - label:
           app.kubernetes.io/component: operator
           app.kubernetes.io/name: dynatrace-operator
-          app.kubernetes.io/version: 0.0.0-snapshot
+          app.kubernetes.io/version: 1.9.0
           dynatrace.com/install-source: operatorhub
         name: dynatrace-operator
         spec:
@@ -1065,7 +1065,7 @@ spec:
               labels:
                 app.kubernetes.io/component: operator
                 app.kubernetes.io/name: dynatrace-operator
-                app.kubernetes.io/version: 0.0.0-snapshot
+                app.kubernetes.io/version: 1.9.0
                 name: dynatrace-operator
             spec:
               affinity:
@@ -1114,7 +1114,7 @@ spec:
                 - name: GOMEMLIMIT
                   value: 116MiB
                 - name: APP_VERSION
-                  value: 0.0.0-snapshot
+                  value: 1.9.0
                 image: registry.connect.redhat.com/dynatrace/dynatrace-operator:v1.9.0
                 livenessProbe:
                   httpGet:
@@ -1176,7 +1176,7 @@ spec:
       - label:
           app.kubernetes.io/component: webhook
           app.kubernetes.io/name: dynatrace-operator
-          app.kubernetes.io/version: 0.0.0-snapshot
+          app.kubernetes.io/version: 1.9.0
         name: dynatrace-webhook
         spec:
           replicas: 2
@@ -1195,7 +1195,7 @@ spec:
               labels:
                 app.kubernetes.io/component: webhook
                 app.kubernetes.io/name: dynatrace-operator
-                app.kubernetes.io/version: 0.0.0-snapshot
+                app.kubernetes.io/version: 1.9.0
                 internal.dynatrace.com/app: webhook
                 internal.dynatrace.com/component: webhook
             spec:

--- a/config/olm/openshift/1.9.0/manifests/dynatrace-webhook_policy_v1_poddisruptionbudget.yaml
+++ b/config/olm/openshift/1.9.0/manifests/dynatrace-webhook_policy_v1_poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: 0.0.0-snapshot
+    app.kubernetes.io/version: 1.9.0
   name: dynatrace-webhook
 spec:
   minAvailable: 1

--- a/config/olm/openshift/1.9.0/manifests/dynatrace-webhook_v1_service.yaml
+++ b/config/olm/openshift/1.9.0/manifests/dynatrace-webhook_v1_service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: 0.0.0-snapshot
+    app.kubernetes.io/version: 1.9.0
   name: dynatrace-webhook
 spec:
   ports:
@@ -15,6 +15,6 @@ spec:
   selector:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: 0.0.0-snapshot
+    app.kubernetes.io/version: 1.9.0
 status:
   loadBalancer: {}

--- a/config/olm/openshift/1.9.0/manifests/dynatrace.com_dynakubes.yaml
+++ b/config/olm/openshift/1.9.0/manifests/dynatrace.com_dynakubes.yaml
@@ -6,7 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: 0.0.0-snapshot
+    app.kubernetes.io/version: 1.9.0
   name: dynakubes.dynatrace.com
 spec:
   conversion:

--- a/config/olm/openshift/1.9.0/manifests/dynatrace.com_edgeconnects.yaml
+++ b/config/olm/openshift/1.9.0/manifests/dynatrace.com_edgeconnects.yaml
@@ -6,7 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: dynatrace-operator
-    app.kubernetes.io/version: 0.0.0-snapshot
+    app.kubernetes.io/version: 1.9.0
   name: edgeconnects.dynatrace.com
 spec:
   conversion:


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

For some reason when generating the bundles for OCP a wrong version was set. I had to fix that by hand for [community-operators-prod](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/9375/changes#diff-304f67e25e5b6af4fe1ce74fabf9c90c903a65d285660d533c7f396375d4eeec)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->