### PR TITLE
Fix EdgeConnect e2e subtest scope

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -185,7 +185,7 @@ test/e2e/edgeconnect/normal:
 
 ## Runs Edgeconnect e2e proxy test cases
 test/e2e/edgeconnect/proxy:
-	$(GOTESTCMD) -timeout 20m  ./test/e2e/scenarios/nocsi -run "TestNoCSI_edgeconnect_install_proxy" $(SKIPCLEANUP)
+	$(GOTESTCMD) -timeout 20m  ./test/e2e/scenarios/nocsi -run "TestNoCSI_edgeconnect_proxy" $(SKIPCLEANUP)
 
 ## Runs EdgeConnect scaling e2e test only
 test/e2e/edgeconnect/scaling:

--- a/test/e2e/features/edgeconnect/edgeconnect.go
+++ b/test/e2e/features/edgeconnect/edgeconnect.go
@@ -107,7 +107,7 @@ func ProvisionerModeFeature(t *testing.T) features.Feature {
 }
 
 func WithHTTPProxy(t *testing.T) features.Feature {
-	builder := features.New("edgeconnect-install-http-proxy")
+	builder := features.New("edgeconnect-proxy-http")
 
 	builder.Setup(func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		ctx, err := istio.AssertIstioNamespace()(ctx, envConfig, t)
@@ -160,7 +160,7 @@ func WithHTTPProxy(t *testing.T) features.Feature {
 }
 
 func WithHTTPSProxy(t *testing.T) features.Feature {
-	builder := features.New("edgeconnect-install-https-proxy")
+	builder := features.New("edgeconnect-proxy-https")
 
 	builder.Setup(func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		ctx, err := istio.AssertIstioNamespace()(ctx, envConfig, t)

--- a/test/e2e/helpers/logs/logs.go
+++ b/test/e2e/helpers/logs/logs.go
@@ -30,6 +30,10 @@ func ReadLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, names
 	}).Stream(ctx)
 	require.NoError(t, err)
 
+	defer func() {
+		require.NoError(t, logStream.Close())
+	}()
+
 	buffer := new(bytes.Buffer)
 	_, err = io.Copy(buffer, logStream)
 	require.NoError(t, err)

--- a/test/e2e/helpers/logs/logs.go
+++ b/test/e2e/helpers/logs/logs.go
@@ -30,10 +30,6 @@ func ReadLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, names
 	}).Stream(ctx)
 	require.NoError(t, err)
 
-	defer func() {
-		require.NoError(t, logStream.Close())
-	}()
-
 	buffer := new(bytes.Buffer)
 	_, err = io.Copy(buffer, logStream)
 	require.NoError(t, err)

--- a/test/e2e/scenarios/nocsi/no_csi_test.go
+++ b/test/e2e/scenarios/nocsi/no_csi_test.go
@@ -97,15 +97,15 @@ func TestNoCSI_edgeconnect_install_provisioner(t *testing.T) {
 	testEnv.Test(t, edgeconnect.ProvisionerModeFeature(t))
 }
 
-func TestNoCSI_edgeconnect_install_proxy_http(t *testing.T) {
+func TestNoCSI_edgeconnect_proxy_http(t *testing.T) {
 	testEnv.Test(t, edgeconnect.WithHTTPProxy(t))
 }
 
-func TestNoCSI_edgeconnect_install_proxy_https(t *testing.T) {
+func TestNoCSI_edgeconnect_proxy_https(t *testing.T) {
 	testEnv.Test(t, edgeconnect.WithHTTPSProxy(t))
 }
 
-func TestNoCSI_custom_edgeconnect(t *testing.T) {
+func TestNoCSI_edgeconnect_custom(t *testing.T) {
 	testEnv.Test(t, edgeconnect.AutomationModeFeature(t))
 }
 


### PR DESCRIPTION
## Description

The `test/e2e/edgeconnect/normal` didn't just run the normal installation tests, but also the proxy tests. There also was the k8s automation tests which wasn't covered by any make target.
Fix this by renaming some functions and changing the -run flag.

## How can this be tested?

Run different edgeconnect e2e test make targets and check that the correct tests are run.

To quickly verify that the correct tests are invoked you can set the following in the TestMain

```go
cfg.WithSkipFeatureRegex(".*")
```
