### PR TITLE
Output operator logs on e2e test failure

### DIFF
--- a/test/e2e/helpers/logs/logs.go
+++ b/test/e2e/helpers/logs/logs.go
@@ -5,6 +5,7 @@ package logs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -18,17 +19,22 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-func FetchOperatorLog(ctx context.Context, envConfig *envconf.Config, t *testing.T) string {
+// WriteOperatorLog fetches the operator pod logs and writes the to the testing log sink.
+func WriteOperatorLog(ctx context.Context, envConfig *envconf.Config, t *testing.T) {
 	resources := envConfig.Client().Resources()
 
-	var operatorLog string
-
-	err := k8sdeployment.NewQuery(ctx, resources, client.ObjectKey{Name: "dynatrace-operator", Namespace: "dynatrace"}).ForEachPod(func(pod corev1.Pod) {
-		operatorLog = ReadLog(ctx, t, envConfig, pod.Namespace, pod.Name, "operator")
-	})
+	clientset, err := kubernetes.NewForConfig(resources.GetConfig())
 	require.NoError(t, err)
 
-	return operatorLog
+	err = k8sdeployment.NewQuery(ctx, resources, client.ObjectKey{Name: "dynatrace-operator", Namespace: "dynatrace"}).ForEachPod(func(pod corev1.Pod) {
+		err = copyLogStream(ctx, clientset, t.Output(), logParams{
+			namespace:     pod.Namespace,
+			podName:       pod.Name,
+			containerName: "operator",
+		})
+		require.NoError(t, err)
+	})
+	require.NoError(t, err)
 }
 
 func ReadLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, namespace, podName, containerName string) string { //nolint:revive
@@ -40,17 +46,12 @@ func ReadLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, names
 	clientset, err := kubernetes.NewForConfig(resources.GetConfig())
 	require.NoError(t, err)
 
-	logStream, err := clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
-		Container: containerName,
-	}).Stream(ctx)
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, logStream.Close())
-	}()
-
 	buffer := new(bytes.Buffer)
-	_, err = io.Copy(buffer, logStream)
+	err = copyLogStream(ctx, clientset, buffer, logParams{
+		namespace:     namespace,
+		podName:       podName,
+		containerName: containerName,
+	})
 	require.NoError(t, err)
 
 	return buffer.String()
@@ -73,4 +74,30 @@ func FindLineContainingText(log, searchText string) string {
 	}
 
 	return ""
+}
+
+type logParams struct {
+	namespace     string
+	podName       string
+	containerName string
+}
+
+func copyLogStream(ctx context.Context, clientset kubernetes.Interface, w io.Writer, params logParams) (err error) {
+	logStream, err := clientset.CoreV1().Pods(params.namespace).GetLogs(params.podName, &corev1.PodLogOptions{
+		Container: params.containerName,
+	}).Stream(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		errClose := logStream.Close()
+		if errClose != nil {
+			err = errors.Join(err, errClose)
+		}
+	}()
+
+	_, err = io.Copy(w, logStream)
+
+	return err
 }

--- a/test/e2e/helpers/logs/logs.go
+++ b/test/e2e/helpers/logs/logs.go
@@ -9,12 +9,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sdeployment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
+
+func FetchOperatorLog(ctx context.Context, envConfig *envconf.Config, t *testing.T) string {
+	resources := envConfig.Client().Resources()
+
+	var operatorLog string
+
+	err := k8sdeployment.NewQuery(ctx, resources, client.ObjectKey{Name: "dynatrace-operator", Namespace: "dynatrace"}).ForEachPod(func(pod corev1.Pod) {
+		operatorLog = ReadLog(ctx, t, envConfig, pod.Namespace, pod.Name, "operator")
+	})
+	require.NoError(t, err)
+
+	return operatorLog
+}
 
 func ReadLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, namespace, podName, containerName string) string { //nolint:revive
 	resources := envConfig.Client().Resources()
@@ -29,6 +44,10 @@ func ReadLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, names
 		Container: containerName,
 	}).Stream(ctx)
 	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, logStream.Close())
+	}()
 
 	buffer := new(bytes.Buffer)
 	_, err = io.Copy(buffer, logStream)

--- a/test/e2e/helpers/logs/logs.go
+++ b/test/e2e/helpers/logs/logs.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sdeployment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,11 +27,11 @@ func WriteOperatorLog(ctx context.Context, envConfig *envconf.Config, t *testing
 	clientset, err := kubernetes.NewForConfig(resources.GetConfig())
 	require.NoError(t, err)
 
-	err = k8sdeployment.NewQuery(ctx, resources, client.ObjectKey{Name: "dynatrace-operator", Namespace: "dynatrace"}).ForEachPod(func(pod corev1.Pod) {
+	err = k8sdeployment.NewQuery(ctx, resources, client.ObjectKey{Name: operator.DeploymentName, Namespace: operator.DefaultNamespace}).ForEachPod(func(pod corev1.Pod) {
 		err = copyLogStream(ctx, clientset, t.Output(), logParams{
 			namespace:     pod.Namespace,
 			podName:       pod.Name,
-			containerName: "operator",
+			containerName: operator.ContainerName,
 		})
 		require.NoError(t, err)
 	})

--- a/test/e2e/scenarios/istio/istio_test.go
+++ b/test/e2e/scenarios/istio/istio_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, c *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, c, t)
-			t.Log(logs.FetchOperatorLog(ctx, c, t))
+			logs.WriteOperatorLog(ctx, c, t)
 		}
 
 		return ctx, nil

--- a/test/e2e/scenarios/istio/istio_test.go
+++ b/test/e2e/scenarios/istio/istio_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/istio"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/environment"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8snamespace"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/logs"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/proxy"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -48,6 +49,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, c *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, c, t)
+			t.Log(logs.FetchOperatorLog(ctx, c, t))
 		}
 
 		return ctx, nil

--- a/test/e2e/scenarios/nocsi/no_csi_test.go
+++ b/test/e2e/scenarios/nocsi/no_csi_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/events"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/environment"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/logs"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
@@ -46,6 +47,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, c *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, c, t)
+			t.Log(logs.FetchOperatorLog(ctx, c, t))
 		}
 
 		return ctx, nil

--- a/test/e2e/scenarios/nocsi/no_csi_test.go
+++ b/test/e2e/scenarios/nocsi/no_csi_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, c *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, c, t)
-			t.Log(logs.FetchOperatorLog(ctx, c, t))
+			logs.WriteOperatorLog(ctx, c, t)
 		}
 
 		return ctx, nil

--- a/test/e2e/scenarios/release/release_test.go
+++ b/test/e2e/scenarios/release/release_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/events"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/environment"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/logs"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
@@ -38,6 +39,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, envConfig *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, envConfig, t)
+			t.Log(logs.FetchOperatorLog(ctx, envConfig, t))
 		}
 
 		// If we cleaned up during a fail-fast (aka.: /debug) it wouldn't be possible to investigate the error.

--- a/test/e2e/scenarios/release/release_test.go
+++ b/test/e2e/scenarios/release/release_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, envConfig *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, envConfig, t)
-			t.Log(logs.FetchOperatorLog(ctx, envConfig, t))
+			logs.WriteOperatorLog(ctx, envConfig, t)
 		}
 
 		// If we cleaned up during a fail-fast (aka.: /debug) it wouldn't be possible to investigate the error.

--- a/test/e2e/scenarios/standard/standard_test.go
+++ b/test/e2e/scenarios/standard/standard_test.go
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, c *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, c, t)
-			t.Log(logs.FetchOperatorLog(ctx, c, t))
+			logs.WriteOperatorLog(ctx, c, t)
 		}
 
 		return ctx, nil

--- a/test/e2e/scenarios/standard/standard_test.go
+++ b/test/e2e/scenarios/standard/standard_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/events"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/environment"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/logs"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
@@ -42,6 +43,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, c *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, c, t)
+			t.Log(logs.FetchOperatorLog(ctx, c, t))
 		}
 
 		return ctx, nil


### PR DESCRIPTION
## Description

We had this e2e test failure, which had limited info on why it failed.
https://github.com/Dynatrace/dynatrace-operator/actions/runs/24445236212

Include the operator in the output if a test failed to improve this.

ICP-2268

## How can this be tested?

Break an e2e test and check the output
