### PR TITLE
Fix release manifest generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -231,10 +231,10 @@ jobs:
         run: |
           make manifests/crd/release CHART_VERSION="${VERSION_WITHOUT_PREFIX}"
 
-          make manifests/kubernetes/olm IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${DIGEST}"
-          make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}@${DIGEST}"
-          make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${DIGEST}"
-          make manifests/openshift IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}@${DIGEST}"
+          make manifests/kubernetes/olm IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}"
+          make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}"
+          make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}"
+          make manifests/openshift IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}"
           cp config/deploy/kubernetes/kubernetes.yaml config/deploy/kubernetes/gke-autopilot.yaml
       - name: Build helm packages
         uses: ./.github/actions/build-helm


### PR DESCRIPTION
## Description

The release workflow set the digest in the env and also in the TAG. The logic in our makefiles appends the DIGEST if it's set, causing a duplicate SHA in our manifests.

Compare the output of 

```
DIGEST=sha256:8b06ad33d17c0ae132e4d6d034a2f2075635eb609043e5c8ed32f676b4c2f484 make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="v1.9.0@sha256:8b06ad33d17c0ae132e4d6d034a2f2075635eb609043e5c8ed32f676b4c2f484"
```

and 

```
DIGEST=sha256:8b06ad33d17c0ae132e4d6d034a2f2075635eb609043e5c8ed32f676b4c2f484 make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="v1.9.0"
```