### PR TITLE
feat: logging: add context logger helpers

### DIFF
--- a/doc/coding-style-guide.md
+++ b/doc/coding-style-guide.md
@@ -495,34 +495,15 @@ Use `"github.com/Dynatrace/dynatrace-operator/pkg/logd"` (alias `logd`) for all 
   ctx = logd.IntoContext(ctx, myLogger)
   ```
 
-- **Utility functions that emit logs should accept `log logd.Logger` as a parameter** rather than closing over a package-level `log`.
-  This makes the function independently testable, its output attributable to the right component, and avoids hidden coupling to the package global.
+- **Utility functions that emit logs should accept `ctx context.Context` as a parameter** rather than using a package-level `log`.
 
   ```go
   // ✓
-  func printKubernetesVersion(log logd.Logger, kubeConfig *rest.Config) {
-      log.Info("kubernetes version", "version", ...)
-  }
-
-  // ✗ hidden dependency on package-level log
-  func printKubernetesVersion(kubeConfig *rest.Config) {
+  func printKubernetesVersion(ctx context.Context, kubeConfig *rest.Config) {
+      log := logd.FromContext(ctx)
       log.Info("kubernetes version", "version", ...)
   }
   ```
-
-- Include **enough context fields** in log messages to be useful during troubleshooting.
-  Reviewers frequently ask for additional fields (e.g. Go version, resource name, namespace). When in doubt, add more rather than less.
-
-### Exceptions
-
-`cmd/` packages and functions that have no `context.Context` parameter (e.g. background singletons, startup helpers) may keep a package-level logger declared with `logd.Get().WithName(...)`. Document the exception with a comment:
-
-```go
-// log is kept as a package-level logger because GetMinorVersion is a background singleton
-// cache with no context.Context parameter. This is an intentional exception to the
-// context-logger pattern.
-var log = logd.Get().WithName("k8sversion")
-```
 
 ### Don'ts
 

--- a/doc/coding-style-guide.md
+++ b/doc/coding-style-guide.md
@@ -463,15 +463,39 @@ import (
 
 ## Logging
 
+Use `"github.com/Dynatrace/dynatrace-operator/pkg/logd"` (alias `logd`) for all logging.
+
 ### Do's
 
-- Use a package global `logger` (1 per package), should be named `log` and be declared in the `config.go` of the package. (temporary solution)
-  - In case of larger packages it's advisable to introduce separate loggers for different parts of the package, these sub-loggers should still be derived from the main logger of the package and given a name.
-    - Example: in webhook/mutation `var nsLog = log.WithName("namespace")` (the name of this logger is `mutation-webhook.namespace`)
-- Use the logger defined in the `dynatrace-operator/src/logger` and always give it a name.
-  - The name of the logger (given via `.WithName("...")`) should use `-` to divide longer names.
-  - Example: `var log = logger.Get().WithName("mutation-webhook")`
-- **Utility functions that emit logs should accept `log logd.Logger` as a parameter** rather than closing over the package-level `log`.
+- **Extract the logger from context at the entry point** of any function that receives `context.Context`, using `logd.NewFromContext`. This derives a named logger, stores it back into the context, and returns both:
+
+  ```go
+  import logd "github.com/Dynatrace/dynatrace-operator/pkg/logd"
+
+  func Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+      ctx, log := logd.NewFromContext(ctx, "my-controller", "name", req.Name, "namespace", req.Namespace)
+      // ctx now carries log; downstream helpers can retrieve it with logd.FromContext(ctx)
+      ...
+  }
+  ```
+
+- **Use `logd.FromContext(ctx)` in downstream helpers** within the same package that receive the already-seeded context:
+
+  ```go
+  func (r *Reconciler) syncStatus(ctx context.Context, obj *myv1.MyKind) error {
+      log := logd.FromContext(ctx)
+      log.Info("syncing status", "name", obj.Name)
+      ...
+  }
+  ```
+
+- **Use `logd.IntoContext(ctx, log)` when explicitly seeding a logger** into a context (e.g. in tests or when constructing a sub-context manually):
+
+  ```go
+  ctx = logd.IntoContext(ctx, myLogger)
+  ```
+
+- **Utility functions that emit logs should accept `log logd.Logger` as a parameter** rather than closing over a package-level `log`.
   This makes the function independently testable, its output attributable to the right component, and avoids hidden coupling to the package global.
 
   ```go
@@ -488,6 +512,17 @@ import (
 
 - Include **enough context fields** in log messages to be useful during troubleshooting.
   Reviewers frequently ask for additional fields (e.g. Go version, resource name, namespace). When in doubt, add more rather than less.
+
+### Exceptions
+
+`cmd/` packages and functions that have no `context.Context` parameter (e.g. background singletons, startup helpers) may keep a package-level logger declared with `logd.Get().WithName(...)`. Document the exception with a comment:
+
+```go
+// log is kept as a package-level logger because GetMinorVersion is a background singleton
+// cache with no context.Context parameter. This is an intentional exception to the
+// context-logger pattern.
+var log = logd.Get().WithName("k8sversion")
+```
 
 ### Don'ts
 
@@ -537,15 +572,15 @@ if len(ecs.EdgeConnects) > 1 {
 
 ```go
 func (controller *Controller) reconcileEdgeConnectDeletion(ctx context.Context, edgeConnect *edgeconnectv1alpha1.EdgeConnect) error {
-    _log := log.WithValues("namespace", edgeConnect.Namespace, "name", edgeConnect.Name)
+    ctx, log := logd.NewFromContext(ctx, "deletion", "namespace", edgeConnect.Namespace, "name", edgeConnect.Name)
 
     ...
-    _log.Debug("foobar happened")
+    log.Debug("foobar happened")
 
-    _log = _log.WithValues("foobarReason", "hurga")
+    log = log.WithValues("foobarReason", "hurga")
 
     ...
-    _log.Debug("foobar happened again")
+    log.Debug("foobar happened again")
     ...
 }
 

--- a/doc/coding-style-guide.md
+++ b/doc/coding-style-guide.md
@@ -495,7 +495,7 @@ Use `"github.com/Dynatrace/dynatrace-operator/pkg/logd"` (alias `logd`) for all 
   ctx = logd.IntoContext(ctx, myLogger)
   ```
 
-- **Utility functions that emit logs should accept `ctx context.Context` as a parameter** rather than using a package-level `log`.
+- **Utility functions that emit logs should accept `ctx context.Context` as a parameter** rather than using a package-level `log`. This includes background callbacks, sync.Once initializers, and other singleton-style helpers — if they can receive a ctx, they should.
 
   ```go
   // ✓
@@ -505,8 +505,11 @@ Use `"github.com/Dynatrace/dynatrace-operator/pkg/logd"` (alias `logd`) for all 
   }
   ```
 
+- **A good rule of thumb**: a package should only rely on a package-level logger (i.e. not receive one from context) if it is a `cmd/` entrypoint (i.e. `main`). Every other package that logs should receive `ctx` and derive its logger from it.
+
 ### Don'ts
 
+- Don't declare `var log = logd.Get().WithName("...")` at the package level outside of `cmd/` packages. Instead, call `logd.NewFromContext(ctx, "name")` at the function entry point.
 - Don't use `fmt.Sprintf` for creating log messages, the values you wish to replace via `Sprintf` should be provided to the logger as key-value pairs.
   - Example: `log.Info("deleted volume info", "ID", volume.VolumeID, "PodUID", volume.PodName, "Version", volume.Version, "TenantUUID", volume.TenantUUID)`
 - Don't start a log message with uppercase characters, unless it's a name of an exact proper noun.

--- a/pkg/logd/context.go
+++ b/pkg/logd/context.go
@@ -1,0 +1,34 @@
+package logd
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+func NewFromContext(ctx context.Context, name string, keysAndValues ...any) (context.Context, Logger) {
+	log := FromContext(ctx).WithName(name).WithValues(keysAndValues...)
+
+	return logr.NewContext(ctx, log.Logger), log
+}
+
+func FromContext(ctx context.Context) Logger {
+	if ctx == nil {
+		return Get()
+	}
+
+	logger, err := logr.FromContext(ctx)
+	if logger.GetSink() == nil || err != nil {
+		return Get()
+	}
+
+	return Logger{logger}
+}
+
+// IntoContext stores the given Logger into ctx and returns the new context.
+// Use this when explicitly seeding or replacing the logger in a context.
+//
+//	ctx = logd.IntoContext(ctx, myLogger)
+func IntoContext(ctx context.Context, log Logger) context.Context {
+	return logr.NewContext(ctx, log.Logger)
+}

--- a/pkg/logd/context.go
+++ b/pkg/logd/context.go
@@ -18,7 +18,7 @@ func FromContext(ctx context.Context) Logger {
 	}
 
 	logger, err := logr.FromContext(ctx)
-	if logger.GetSink() == nil || err != nil {
+	if err != nil {
 		return Get()
 	}
 

--- a/pkg/logd/context_test.go
+++ b/pkg/logd/context_test.go
@@ -9,6 +9,12 @@ import (
 )
 
 func TestFromContext(t *testing.T) {
+	t.Run("returns fallback logger when ctx is nil", func(t *testing.T) {
+		log := logd.FromContext(nil) //nolint:staticcheck
+
+		assert.NotNil(t, log.GetSink())
+	})
+
 	t.Run("returns fallback logger when context has no logger", func(t *testing.T) {
 		log := logd.FromContext(t.Context())
 

--- a/pkg/logd/context_test.go
+++ b/pkg/logd/context_test.go
@@ -1,0 +1,68 @@
+package logd_test
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromContext(t *testing.T) {
+	t.Run("returns fallback logger when context has no logger", func(t *testing.T) {
+		log := logd.FromContext(t.Context())
+
+		assert.NotNil(t, log.GetSink())
+	})
+
+	t.Run("returns injected logger when context carries one", func(t *testing.T) {
+		injected := logd.Get().WithName("test")
+		ctx := logr.NewContext(t.Context(), injected.Logger)
+
+		log := logd.FromContext(ctx)
+
+		assert.Equal(t, injected.Logger, log.Logger)
+	})
+}
+
+func TestNewFromContext(t *testing.T) {
+	t.Run("falls back to logd.Get() when context has no logger", func(t *testing.T) {
+		ctx, log := logd.NewFromContext(t.Context(), "myname")
+
+		assert.NotNil(t, log.GetSink())
+		// The returned context must carry the derived logger.
+		fromCtx := logd.FromContext(ctx)
+		assert.NotNil(t, fromCtx.GetSink())
+	})
+
+	t.Run("derives from existing logger in context", func(t *testing.T) {
+		base := logd.Get().WithName("base")
+		ctx := logr.NewContext(t.Context(), base.Logger)
+
+		newCtx, log := logd.NewFromContext(ctx, "child", "key", "value")
+
+		assert.NotNil(t, log.GetSink())
+		// The new context must carry the derived logger.
+		fromCtx := logd.FromContext(newCtx)
+		assert.NotNil(t, fromCtx.GetSink())
+	})
+
+	t.Run("stores derived logger back into context", func(t *testing.T) {
+		ctx, derived := logd.NewFromContext(t.Context(), "stored")
+
+		retrieved := logd.FromContext(ctx)
+
+		assert.Equal(t, derived.Logger, retrieved.Logger)
+	})
+}
+
+func TestIntoContext(t *testing.T) {
+	t.Run("stores logger into context and retrieves it", func(t *testing.T) {
+		log := logd.Get().WithName("into-test")
+		ctx := logd.IntoContext(t.Context(), log)
+
+		retrieved := logd.FromContext(ctx)
+
+		assert.Equal(t, log.Logger, retrieved.Logger)
+	})
+}


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/ICP-2916

- adds three helpers to `pkg/logd/context.go` to thread the controller-runtime–seeded logger through `context.Context`:
  - `NewFromContext(ctx, name, keysAndValues...)` — call at package entry points; appends a name and stores the enriched logger back into ctx
  - `FromContext(ctx)` — call in downstream helpers within the same package; falls back to `logd.Get()` when no logger is in ctx
  - `IntoContext(ctx, log)` — explicitly seed or replace a logger in ctx
- updates `doc/coding-style-guide.md` with the new pattern: `NewFromContext` at package boundaries, `FromContext` inside, `var log` globals only in `cmd/`

### Stack
- **PR 1 (this):** https://github.com/Dynatrace/dynatrace-operator/pull/6472
- PR 2: https://github.com/Dynatrace/dynatrace-operator/pull/6473
- PR 3: https://github.com/Dynatrace/dynatrace-operator/pull/6474

## How can this be tested?
`make go/test`