### PR TITLE
Move NewProcessModuleConfig into bootstrapperconfig

### DIFF
--- a/pkg/clients/dynatrace/oneagent/processmoduleconfig.go
+++ b/pkg/clients/dynatrace/oneagent/processmoduleconfig.go
@@ -2,7 +2,6 @@ package oneagent
 
 import (
 	"context"
-	"encoding/json"
 	"slices"
 	"strings"
 
@@ -176,23 +175,6 @@ func (c *Client) GetProcessModuleConfig(ctx context.Context) (*ProcessModuleConf
 
 	if len(resp.Properties) == 0 {
 		return &ProcessModuleConfig{}, errors.New("no properties available")
-	}
-
-	return &resp, nil
-}
-
-func NewProcessModuleConfig(response []byte) (*ProcessModuleConfig, error) {
-	resp := ProcessModuleConfig{}
-
-	err := json.Unmarshal(response, &resp)
-	if err != nil {
-		log.Error(err, "error unmarshalling processmoduleconfig response", "response", string(response))
-
-		return nil, err
-	}
-
-	if len(resp.Properties) == 0 {
-		return nil, errors.New("no properties available")
 	}
 
 	return &resp, nil

--- a/pkg/injection/namespace/bootstrapperconfig/pmc.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pmc.go
@@ -3,6 +3,7 @@ package bootstrapperconfig
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/oneagent/pmc"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -111,12 +112,29 @@ func (s *SecretGenerator) getCachedPMC(ctx context.Context, dk *dynakube.DynaKub
 
 			return nil, err
 		} else if err == nil && source.Data[pmc.InputFileName] != nil {
-			pmConfig, err = oneagentclient.NewProcessModuleConfig(source.Data[pmc.InputFileName])
+			inputData := source.Data[pmc.InputFileName]
+
+			pmConfig, err = configFromBytes(inputData)
 			if err != nil {
-				log.Error(err, "could not unmarshal process module config from source secret, will recreate")
+				log.Error(err, "could not unmarshal process module config from source secret, will recreate", pmc.InputFileName, string(inputData))
 			}
 		}
 	}
 
 	return pmConfig, nil
+}
+
+func configFromBytes(response []byte) (*oneagentclient.ProcessModuleConfig, error) {
+	var resp oneagentclient.ProcessModuleConfig
+
+	err := json.Unmarshal(response, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.Properties) == 0 {
+		return nil, errors.New("no properties available")
+	}
+
+	return &resp, nil
 }


### PR DESCRIPTION
## Description

This function just unmarshals a public struct, so it doesn't need to be part of the package API.
It's also only used in one place, so just move it there.

Having the error producer close to the error consumer also makes it obvious that some text was duplicated.

Goal is also to remove one exception from #6474 

## How can this be tested?

Unit tests
