### PR TITLE
Write e2e test logs to file instead of stdout

### DIFF
--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -139,3 +139,15 @@ runs:
       with:
         files: target/results/*.xml
       if: always()
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+      with:
+        files: target/results/*.xml
+    - name: Upload logs
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: e2e-test-logs
+        path: target/results/*.log
+        if-no-files-found: ignore
+        retention-days: 7

--- a/test/e2e/helpers/logs/logs.go
+++ b/test/e2e/helpers/logs/logs.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -20,15 +22,23 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-// WriteOperatorLog fetches the operator pod logs and writes the to the testing log sink.
-func WriteOperatorLog(ctx context.Context, envConfig *envconf.Config, t *testing.T) {
+const operatorLogFileSuffix = "_operator.log"
+
+// WriteOperatorLogToFile fetches the operator pod logs and writes them to a file in the test/e2e directory.
+// The filename is generated from the test name and has the suffix "_operator.log",
+func WriteOperatorLogToFile(ctx context.Context, envConfig *envconf.Config, t *testing.T) {
 	resources := envConfig.Client().Resources()
 
 	clientset, err := kubernetes.NewForConfig(resources.GetConfig())
 	require.NoError(t, err)
 
+	resultsDir := filepath.Join(findProjectRoot(t), "results")
+	require.NoError(t, os.MkdirAll(resultsDir, 0755))
+	logFile, err := os.Create(filepath.Join(resultsDir, t.Name()+operatorLogFileSuffix))
+	require.NoError(t, err)
+
 	err = k8sdeployment.NewQuery(ctx, resources, client.ObjectKey{Name: operator.DeploymentName, Namespace: operator.DefaultNamespace}).ForEachPod(func(pod corev1.Pod) {
-		err = copyLogStream(ctx, clientset, t.Output(), logParams{
+		err = copyLogStream(ctx, clientset, logFile, logParams{
 			namespace:     pod.Namespace,
 			podName:       pod.Name,
 			containerName: operator.ContainerName,
@@ -101,4 +111,23 @@ func copyLogStream(ctx context.Context, clientset kubernetes.Interface, w io.Wri
 	_, err = io.Copy(w, logStream)
 
 	return err
+}
+
+func findProjectRoot(t *testing.T) string {
+	path := "."
+
+	for {
+		var err error
+		path, err = filepath.Abs(path)
+		require.NoError(t, err)
+
+		require.NotEqual(t, "/", path, "reached filesystem root")
+		require.NotEqual(t, os.Getenv("HOME"), path, "reached user home directory")
+
+		if _, err := os.Stat(filepath.Join(path, "PROJECT")); err == nil {
+			return path
+		}
+
+		path = filepath.Join(path, "..")
+	}
 }

--- a/test/e2e/scenarios/istio/istio_test.go
+++ b/test/e2e/scenarios/istio/istio_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, c *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, c, t)
-			logs.WriteOperatorLog(ctx, c, t)
+			logs.WriteOperatorLogToFile(ctx, c, t)
 		}
 
 		return ctx, nil

--- a/test/e2e/scenarios/nocsi/no_csi_test.go
+++ b/test/e2e/scenarios/nocsi/no_csi_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, c *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, c, t)
-			logs.WriteOperatorLog(ctx, c, t)
+			logs.WriteOperatorLogToFile(ctx, c, t)
 		}
 
 		return ctx, nil

--- a/test/e2e/scenarios/release/release_test.go
+++ b/test/e2e/scenarios/release/release_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, envConfig *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, envConfig, t)
-			logs.WriteOperatorLog(ctx, envConfig, t)
+			logs.WriteOperatorLogToFile(ctx, envConfig, t)
 		}
 
 		// If we cleaned up during a fail-fast (aka.: /debug) it wouldn't be possible to investigate the error.

--- a/test/e2e/scenarios/standard/standard_test.go
+++ b/test/e2e/scenarios/standard/standard_test.go
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 	testEnv.AfterEachTest(func(ctx context.Context, c *envconf.Config, t *testing.T) (context.Context, error) {
 		if t.Failed() {
 			events.LogEvents(ctx, c, t)
-			logs.WriteOperatorLog(ctx, c, t)
+			logs.WriteOperatorLogToFile(ctx, c, t)
 		}
 
 		return ctx, nil


### PR DESCRIPTION
## Description

The logs can be quite noisy so to make the output more readable again write it to a file instead of stdout.
In CI the log files are uploaded as artifacts.

## How can this be tested?

Break a test and check the CI artifacts

Test run: https://github.com/Dynatrace/dynatrace-operator/actions/runs/25557432815
