### PR TITLE
Do not treat ServerError struct as error

### DIFF
--- a/pkg/clients/dynatrace/core/error.go
+++ b/pkg/clients/dynatrace/core/error.go
@@ -23,26 +23,6 @@ type ConstraintViolation struct {
 	Path              string `json:"path"`
 }
 
-func (e *ServerError) Error() string {
-	if len(e.Message) == 0 && e.Code == 0 {
-		return "unknown server error"
-	}
-
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "dynatrace server error %d: %s", e.Code, e.Message)
-
-	for _, v := range e.ConstraintViolations {
-		// Fprintf scales allocations linearly with the amount of items.
-		// WriteString only allocates when backing slice needs more space.
-		sb.WriteString("\n\t- ")
-		sb.WriteString(v.Path)
-		sb.WriteString(": ")
-		sb.WriteString(v.Message)
-	}
-
-	return sb.String()
-}
-
 // HTTPError represents an HTTP error that includes status code, response body, and parsed server errors
 type HTTPError struct {
 	Body         string        `json:"body"`
@@ -60,7 +40,7 @@ func (e *HTTPError) Error() string {
 				sb.WriteString("; ")
 			}
 
-			sb.WriteString(serverErr.Error())
+			sb.WriteString(formatServerError(&serverErr))
 		}
 
 		return fmt.Sprintf("HTTP %d: %s", e.StatusCode, sb.String())
@@ -103,4 +83,24 @@ func StatusCode(err error) int {
 	}
 
 	return httpErr.StatusCode
+}
+
+func formatServerError(e *ServerError) string {
+	if len(e.Message) == 0 && e.Code == 0 {
+		return "unknown server error"
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "dynatrace server error %d: %s", e.Code, e.Message)
+
+	for _, v := range e.ConstraintViolations {
+		// Fprintf scales allocations linearly with the amount of items.
+		// WriteString only allocates when backing slice needs more space.
+		sb.WriteString("\n\t- ")
+		sb.WriteString(v.Path)
+		sb.WriteString(": ")
+		sb.WriteString(v.Message)
+	}
+
+	return sb.String()
 }

--- a/pkg/clients/dynatrace/core/error_test.go
+++ b/pkg/clients/dynatrace/core/error_test.go
@@ -7,15 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestServerError(t *testing.T) {
+func TestFormatServerError(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		serverErr := &ServerError{}
-		assert.EqualError(t, serverErr, "unknown server error")
+		assert.Equal(t, "unknown server error", formatServerError(&ServerError{}))
 	})
 
 	t.Run("simple", func(t *testing.T) {
 		serverErr := &ServerError{Code: 404, Message: "not found"}
-		assert.EqualError(t, serverErr, "dynatrace server error 404: not found")
+		assert.Equal(t, "dynatrace server error 404: not found", formatServerError(serverErr))
 	})
 
 	t.Run("single constraint", func(t *testing.T) {
@@ -32,7 +31,7 @@ func TestServerError(t *testing.T) {
 				},
 			},
 		}
-		assert.EqualError(t, serverErr, "dynatrace server error 422: invalid\n\t- test path: test message")
+		assert.Equal(t, "dynatrace server error 422: invalid\n\t- test path: test message", formatServerError(serverErr))
 	})
 
 	t.Run("multiple constraints", func(t *testing.T) {
@@ -44,7 +43,7 @@ func TestServerError(t *testing.T) {
 				{Message: "message2", Path: "path2"},
 			},
 		}
-		assert.EqualError(t, serverErr, "dynatrace server error 422: invalid\n\t- path1: message1\n\t- path2: message2")
+		assert.Equal(t, "dynatrace server error 422: invalid\n\t- path1: message1\n\t- path2: message2", formatServerError(serverErr))
 	})
 }
 


### PR DESCRIPTION
## Description

Having the `ServerError` struct be an `error` is confusing, since it's never actually returned by the core client.
The struct is always part of the `HTTPError`.

## How can this be tested?

Run unit tests
