### PR TITLE
Move release-related secrets to `Release` environment

### DIFF
--- a/.github/workflows/self-update-on-new-release-version.yaml
+++ b/.github/workflows/self-update-on-new-release-version.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   self-update-on-new-release:
     name: Self update when new release branch has been created
+    environment: Release
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Description
The secrets have already been migrated to the`Release` environment.