### PR TITLE
Remove unused request interface methods

### DIFF
--- a/pkg/clients/dynatrace/core/client.go
+++ b/pkg/clients/dynatrace/core/client.go
@@ -36,8 +36,6 @@ type APIRequest interface {
 	WithRawQueryParams(params url.Values) APIRequest
 	// WithJSONBody sets the request body as JSON
 	WithJSONBody(body any) APIRequest
-	// WithRawBody sets the request body as raw bytes
-	WithRawBody(body []byte) APIRequest
 	// WithPaasToken sets the token type to PaaS
 	WithPaasToken() APIRequest
 	// WithoutToken explicitly disables authentication for the request
@@ -46,8 +44,6 @@ type APIRequest interface {
 	WithHeader(key, value string) APIRequest
 	// Execute executes the request and unmarshals the response into the provided model
 	Execute(model any) error
-	// ExecuteRaw executes the request and returns the raw response data
-	ExecuteRaw() ([]byte, error)
 	// ExecuteWriter executes the request and writes the response body to the provided writer
 	ExecuteWriter(writer io.Writer) error
 }
@@ -177,20 +173,6 @@ func (r *Request) WithJSONBody(body any) APIRequest {
 	return r
 }
 
-// WithRawBody sets the request body as raw bytes
-func (r *Request) WithRawBody(body []byte) APIRequest {
-	r.body = body
-
-	return r
-}
-
-// WithTokenType sets the token type to use for authentication
-func (r *Request) WithTokenType(tokenType TokenType) APIRequest {
-	r.tokenType = tokenType
-
-	return r
-}
-
 // WithPaasToken sets the token type to PaaS
 func (r *Request) WithPaasToken() APIRequest {
 	r.tokenType = TokenTypePaaS
@@ -226,11 +208,6 @@ func (r *Request) Execute(model any) error {
 	}
 
 	return nil
-}
-
-// ExecuteRaw executes the request and returns the raw response data
-func (r *Request) ExecuteRaw() ([]byte, error) {
-	return r.doRequest()
 }
 
 // ExecuteWriter executes the request and writes the response body to the provided writer.

--- a/pkg/clients/dynatrace/core/client_test.go
+++ b/pkg/clients/dynatrace/core/client_test.go
@@ -49,9 +49,6 @@ func TestClient_Headers(t *testing.T) {
 
 	c := NewClient(Config{BaseURL: must(url.Parse(s.URL)).JoinPath("/api/"), UserAgent: "my-user-agent"})
 	require.NoError(t, c.GET(t.Context(), "test").Execute(nil))
-
-	expectContentType = "application/json"
-	require.NoError(t, c.POST(t.Context(), "test").WithRawBody([]byte("test")).Execute(nil))
 }
 
 func TestClient_WithHeader(t *testing.T) {
@@ -63,9 +60,9 @@ func TestClient_WithHeader(t *testing.T) {
 		defer s.Close()
 
 		c := NewClient(Config{BaseURL: must(url.Parse(s.URL))})
-		_, err := c.GET(t.Context(), "/test").
+		err := c.GET(t.Context(), "/test").
 			WithHeader("Accept", "application/octet-stream").
-			ExecuteRaw()
+			Execute(nil)
 		require.NoError(t, err)
 	})
 
@@ -77,9 +74,9 @@ func TestClient_WithHeader(t *testing.T) {
 		defer s.Close()
 
 		c := NewClient(Config{BaseURL: must(url.Parse(s.URL))})
-		_, err := c.GET(t.Context(), "/test").
+		err := c.GET(t.Context(), "/test").
 			WithHeader("X-Custom", "custom-value").
-			ExecuteRaw()
+			Execute(nil)
 		require.NoError(t, err)
 	})
 
@@ -90,9 +87,9 @@ func TestClient_WithHeader(t *testing.T) {
 		defer s.Close()
 
 		c := NewClient(Config{BaseURL: must(url.Parse(s.URL))})
-		_, err := c.GET(t.Context(), "/test").
+		err := c.GET(t.Context(), "/test").
 			WithHeader("X-Empty", "").
-			ExecuteRaw()
+			Execute(nil)
 		require.NoError(t, err)
 	})
 }
@@ -178,33 +175,6 @@ func TestClient_Execute(t *testing.T) {
 		err := c.GET(t.Context(), "/fail").Execute(&model)
 		require.Error(t, err)
 		assert.Empty(t, model.Foo)
-	})
-}
-
-func TestClient_ExecuteRaw(t *testing.T) {
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/fail" {
-			w.WriteHeader(http.StatusTeapot)
-			_, _ = w.Write([]byte(`{"error":{}}`))
-
-			return
-		}
-		_, _ = w.Write([]byte("response"))
-	}))
-	defer s.Close()
-
-	c := NewClient(Config{BaseURL: must(url.Parse(s.URL))})
-
-	t.Run("ok", func(t *testing.T) {
-		body, err := c.GET(t.Context(), "/test").ExecuteRaw()
-		require.NoError(t, err)
-		assert.Equal(t, "response", string(body))
-	})
-
-	t.Run("fail", func(t *testing.T) {
-		body, err := c.GET(t.Context(), "/fail").ExecuteRaw()
-		require.Error(t, err)
-		assert.JSONEq(t, `{"error":{}}`, string(body))
 	})
 }
 

--- a/test/mocks/pkg/clients/dynatrace/core/api_request.go
+++ b/test/mocks/pkg/clients/dynatrace/core/api_request.go
@@ -90,61 +90,6 @@ func (_c *APIRequest_Execute_Call) RunAndReturn(run func(model any) error) *APIR
 	return _c
 }
 
-// ExecuteRaw provides a mock function for the type APIRequest
-func (_mock *APIRequest) ExecuteRaw() ([]byte, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for ExecuteRaw")
-	}
-
-	var r0 []byte
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]byte, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() []byte); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]byte)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// APIRequest_ExecuteRaw_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecuteRaw'
-type APIRequest_ExecuteRaw_Call struct {
-	*mock.Call
-}
-
-// ExecuteRaw is a helper method to define mock.On call
-func (_e *APIRequest_Expecter) ExecuteRaw() *APIRequest_ExecuteRaw_Call {
-	return &APIRequest_ExecuteRaw_Call{Call: _e.mock.On("ExecuteRaw")}
-}
-
-func (_c *APIRequest_ExecuteRaw_Call) Run(run func()) *APIRequest_ExecuteRaw_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *APIRequest_ExecuteRaw_Call) Return(bytes []byte, err error) *APIRequest_ExecuteRaw_Call {
-	_c.Call.Return(bytes, err)
-	return _c
-}
-
-func (_c *APIRequest_ExecuteRaw_Call) RunAndReturn(run func() ([]byte, error)) *APIRequest_ExecuteRaw_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // ExecuteWriter provides a mock function for the type APIRequest
 func (_mock *APIRequest) ExecuteWriter(writer io.Writer) error {
 	ret := _mock.Called(writer)
@@ -465,59 +410,6 @@ func (_c *APIRequest_WithQueryParams_Call) Return(aPIRequest core.APIRequest) *A
 }
 
 func (_c *APIRequest_WithQueryParams_Call) RunAndReturn(run func(params map[string]string) core.APIRequest) *APIRequest_WithQueryParams_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// WithRawBody provides a mock function for the type APIRequest
-func (_mock *APIRequest) WithRawBody(body []byte) core.APIRequest {
-	ret := _mock.Called(body)
-
-	if len(ret) == 0 {
-		panic("no return value specified for WithRawBody")
-	}
-
-	var r0 core.APIRequest
-	if returnFunc, ok := ret.Get(0).(func([]byte) core.APIRequest); ok {
-		r0 = returnFunc(body)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(core.APIRequest)
-		}
-	}
-	return r0
-}
-
-// APIRequest_WithRawBody_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithRawBody'
-type APIRequest_WithRawBody_Call struct {
-	*mock.Call
-}
-
-// WithRawBody is a helper method to define mock.On call
-//   - body []byte
-func (_e *APIRequest_Expecter) WithRawBody(body interface{}) *APIRequest_WithRawBody_Call {
-	return &APIRequest_WithRawBody_Call{Call: _e.mock.On("WithRawBody", body)}
-}
-
-func (_c *APIRequest_WithRawBody_Call) Run(run func(body []byte)) *APIRequest_WithRawBody_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []byte
-		if args[0] != nil {
-			arg0 = args[0].([]byte)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *APIRequest_WithRawBody_Call) Return(aPIRequest core.APIRequest) *APIRequest_WithRawBody_Call {
-	_c.Call.Return(aPIRequest)
-	return _c
-}
-
-func (_c *APIRequest_WithRawBody_Call) RunAndReturn(run func(body []byte) core.APIRequest) *APIRequest_WithRawBody_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Description

Remove unused "raw" request interface methods. In practice, we do not use them.
The `ExecuteRaw` method could also be implemented in terms of `ExecuteWriter(new(bytes.Buffer))`.

ICP-2063

## How can this be tested?

Unit tests
