### PR TITLE
Print istio version in e2e tests

### DIFF
--- a/test/e2e/helpers/istio/install.go
+++ b/test/e2e/helpers/istio/install.go
@@ -59,6 +59,10 @@ func AssertIstiodDeployment() func(ctx context.Context, envConfig *envconf.Confi
 			return ctx, nil
 		}
 
+		if version := deployment.Labels["app.kubernetes.io/version"]; version != "" {
+			t.Logf("detected istio control plane version %s", version)
+		}
+
 		return ctx, errors.WithStack(err)
 	}
 }


### PR DESCRIPTION
## Description

To not have to guess what istio version is installed in our CI environments.
