### PR TITLE
Use default HTTP transport

### DIFF
--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -270,7 +270,7 @@ func getConfig(options ...Option) (*Config, error) {
 		}
 	}
 
-	t := &http.Transport{}
+	t := http.DefaultTransport.(*http.Transport).Clone()
 
 	if config.HTTPClient == nil {
 		config.HTTPClient = &http.Client{


### PR DESCRIPTION
## Description

Fixes a small regression that was introduced in #6482. The client previously cloned the default transport, which has some fields set like timeouts and proxy from environment.

ICP-2063

## How can this be tested?

Run e2e tests
