### PR TITLE
Deprecate pass token

### DIFF
--- a/cmd/troubleshoot/dynakube.go
+++ b/cmd/troubleshoot/dynakube.go
@@ -96,7 +96,7 @@ func checkIfDynatraceAPISecretHasAPIToken(ctx context.Context, baseLog logd.Logg
 
 	tokenReader := token.NewReader(apiReader, dk)
 
-	tokens, err := tokenReader.ReadTokens(ctx)
+	tokens, err := tokenReader.ReadAndVerifyTokens(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "'%s:%s' secret is missing or invalid", dk.Namespace, dk.Tokens())
 	}

--- a/pkg/api/validation/dynakube/paastoken.go
+++ b/pkg/api/validation/dynakube/paastoken.go
@@ -1,0 +1,35 @@
+package validation
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
+)
+
+const (
+	warningPaasTokenNotUsed = "The '" + token.PaaSKey + "' token in the spec.tokens secret is deprecated. It will be ignored because the '" + token.APIKey + "' field in the secret contains a platform token, which will be used for authentication."
+	warningPaasTokenUsed    = "The '" + token.PaaSKey + "' token in the spec.tokens secret is deprecated. It will be used for authentication because the '" + token.APIKey + "' field in the secret does not contain a platform token."
+)
+
+func deprecatedPaasToken(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	tokenReader := token.NewReader(dv.apiReader, dk)
+
+	tokens, err := tokenReader.ReadTokens(ctx)
+	if err != nil {
+		log.Info("error occurred while reading the tokens secret", "err", err.Error())
+
+		return ""
+	}
+
+	if tokens.PaasToken().Value != "" {
+		if dttoken.IsPlatform(tokens.APIToken().Value) {
+			return warningPaasTokenNotUsed
+		}
+
+		return warningPaasTokenUsed
+	}
+
+	return ""
+}

--- a/pkg/api/validation/dynakube/paastoken_test.go
+++ b/pkg/api/validation/dynakube/paastoken_test.go
@@ -1,0 +1,92 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDeprecatedPaasToken(t *testing.T) {
+	t.Run("gen2 token without paasToken", func(t *testing.T) {
+		assertAllowedWithoutWarnings(t,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultDynakubeObjectMeta.Name,
+					Namespace: defaultDynakubeObjectMeta.Namespace,
+				},
+				Data: map[string][]byte{
+					token.APIKey: []byte("test-api-token"),
+				},
+				Type: corev1.SecretTypeOpaque,
+			})
+	})
+	t.Run("platform token without paasToken", func(t *testing.T) {
+		assertAllowedWithoutWarnings(t,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultDynakubeObjectMeta.Name,
+					Namespace: defaultDynakubeObjectMeta.Namespace,
+				},
+				Data: map[string][]byte{
+					token.APIKey: []byte(dttoken.PlatformPrefix + "test-platform-token"),
+				},
+				Type: corev1.SecretTypeOpaque,
+			})
+	})
+	t.Run("gen2 token with paasToken", func(t *testing.T) {
+		assertAllowedWithWarnings(t, 1,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultDynakubeObjectMeta.Name,
+					Namespace: defaultDynakubeObjectMeta.Namespace,
+				},
+				Data: map[string][]byte{
+					token.APIKey:  []byte("test-api-token"),
+					token.PaaSKey: []byte("test-paas-token"),
+				},
+				Type: corev1.SecretTypeOpaque,
+			})
+	})
+	t.Run("platform token with paasToken", func(t *testing.T) {
+		assertAllowedWithWarnings(t, 1,
+			&dynakube.DynaKube{
+				ObjectMeta: defaultDynakubeObjectMeta,
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultDynakubeObjectMeta.Name,
+					Namespace: defaultDynakubeObjectMeta.Namespace,
+				},
+				Data: map[string][]byte{
+					token.APIKey:  []byte(dttoken.PlatformPrefix + "test-platform-token"),
+					token.PaaSKey: []byte("test-paas-token"),
+				},
+				Type: corev1.SecretTypeOpaque,
+			})
+	})
+}

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -85,6 +85,7 @@ var (
 		globalResourceAttributesExceedsLimit,
 		oneAgentResourceAttributesExceedsLimit,
 		otlpResourceAttributesExceedsLimit,
+		deprecatedPaasToken,
 	}
 	updateValidatorErrorFuncs = []updateValidatorFunc{
 		IsMutatedAPIURL,

--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/settings"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/version"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	operatorversion "github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/pkg/errors"
 	"golang.org/x/net/http/httpproxy"
@@ -67,7 +68,7 @@ func NewClient(options ...Option) (*Client, error) {
 		return nil, errors.New("tokens are empty")
 	}
 
-	if config.PaasToken == "" {
+	if dttoken.IsPlatform(config.APIToken) || config.PaasToken == "" {
 		config.PaasToken = config.APIToken
 	}
 

--- a/pkg/clients/dynatrace/client_test.go
+++ b/pkg/clients/dynatrace/client_test.go
@@ -4,14 +4,23 @@ import (
 	"crypto/tls"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	operatorversion "github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2/clientcredentials"
+)
+
+const (
+	testPaasToken      = "test-paas-token"
+	testAPIToken       = "test-api-token"
+	testPlatformToken  = dttoken.PlatformPrefix + ".test-api-token"
+	testConnectionInfo = `{"tenantUUID":"test-tenant","tenantToken":"test-tenant-token","communicationEndpoints":""}`
 )
 
 func TestNewClient(t *testing.T) {
@@ -359,3 +368,48 @@ zWDF6rXZJXT6MJUcf740v4MOLlIWcrNj/igI9VQP9cBrhvJzthHJ0gMEjNqKJPgk
 APj12zaRa05OBW3H3Ng+1MmdtrU4gAu+xwLAOz1cxT6q8LUGBGDCBYVcFXvomhKL
 kHUfKUp2W9zOWWDlwSB65QuJ3wAQSCVs4g==
 -----END CERTIFICATE-----`
+
+func TestNewClientPaasToken(t *testing.T) {
+	handlerFunc := func(token string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			authToken := r.Header.Get("Authorization")
+			assert.Equal(t, "Api-Token "+token, authToken)
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(testConnectionInfo))
+		}
+	}
+
+	t.Run("gen2 apiToken, no paasToken", func(t *testing.T) {
+		srv := httptest.NewServer(handlerFunc(testAPIToken))
+		defer srv.Close()
+
+		clt, err := NewClient(WithHTTPClient(srv.Client()), WithBaseURL(srv.URL), WithAPIToken(testAPIToken))
+		require.NoError(t, err)
+		connectionInfo, err := clt.ActiveGate.GetConnectionInfo(t.Context())
+		require.NoError(t, err)
+		assert.NotNil(t, connectionInfo)
+	})
+
+	t.Run("gen2 apiToken and paasToken", func(t *testing.T) {
+		srv := httptest.NewServer(handlerFunc(testPaasToken))
+		defer srv.Close()
+
+		clt, err := NewClient(WithHTTPClient(srv.Client()), WithBaseURL(srv.URL), WithAPIToken(testAPIToken), WithPaasToken(testPaasToken))
+		require.NoError(t, err)
+		connectionInfo, err := clt.ActiveGate.GetConnectionInfo(t.Context())
+		require.NoError(t, err)
+		assert.NotNil(t, connectionInfo)
+	})
+
+	t.Run("platform token and paasToken", func(t *testing.T) {
+		srv := httptest.NewServer(handlerFunc(testPlatformToken))
+		defer srv.Close()
+
+		clt, err := NewClient(WithHTTPClient(srv.Client()), WithBaseURL(srv.URL), WithAPIToken(testPlatformToken), WithPaasToken(testPaasToken))
+		require.NoError(t, err)
+		connectionInfo, err := clt.ActiveGate.GetConnectionInfo(t.Context())
+		require.NoError(t, err)
+		assert.NotNil(t, connectionInfo)
+	})
+}

--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -184,7 +184,7 @@ func (provisioner *OneAgentProvisioner) setupFileSystem(dk dynakube.DynaKube) er
 func buildDtc(provisioner *OneAgentProvisioner, ctx context.Context, dk dynakube.DynaKube) (*dynatrace.Client, error) {
 	tokenReader := token.NewReader(provisioner.apiReader, &dk)
 
-	tokens, err := tokenReader.ReadTokens(ctx)
+	tokens, err := tokenReader.ReadAndVerifyTokens(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/dynakube/controller.go
+++ b/pkg/controllers/dynakube/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/mapper"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
@@ -325,7 +326,7 @@ func (controller *Controller) reconcileDynaKube(ctx context.Context, dk *dynakub
 func (controller *Controller) setupTokensAndClient(ctx context.Context, dk *dynakube.DynaKube) (*dynatrace.Client, error) {
 	tokenReader := token.NewReader(controller.apiReader, dk)
 
-	tokens, err := tokenReader.ReadTokens(ctx)
+	tokens, err := tokenReader.ReadAndVerifyTokens(ctx)
 	if err != nil {
 		controller.setConditionTokenError(dk, err)
 
@@ -344,6 +345,8 @@ func (controller *Controller) setupTokensAndClient(ctx context.Context, dk *dyna
 
 		return nil, err
 	}
+
+	controller.warnAboutDeprecatedTokens()
 
 	err = controller.verifyTokens(ctx, dtClient.Token, dk)
 	if err != nil {
@@ -451,6 +454,16 @@ func (controller *Controller) createDynakubeMapper(ctx context.Context, dk *dyna
 	dkMapper := mapper.NewDynakubeMapper(ctx, controller.client, controller.apiReader, controller.operatorNamespace, dk)
 
 	return &dkMapper
+}
+
+func (controller *Controller) warnAboutDeprecatedTokens() {
+	if controller.tokens.PaasToken().Value != "" {
+		if dttoken.IsPlatform(controller.tokens.APIToken().Value) {
+			log.Info("The '" + token.PaaSKey + "' token in the spec.tokens secret is deprecated. It will be ignored because the '" + token.APIKey + "' field in the secret contains a platform token, which will be used for authentication.")
+		} else {
+			log.Info("The '" + token.PaaSKey + "' token in the spec.tokens secret is deprecated. It will be used for authentication because the '" + token.APIKey + "' field in the secret does not contain a platform token.")
+		}
+	}
 }
 
 func (controller *Controller) verifyTokens(ctx context.Context, dtClient tokenclient.APIClient, dk *dynakube.DynaKube) error {

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -213,7 +213,7 @@ func (r *Reconciler) calculateConfigMapHash(ctx context.Context, configMapName s
 func (r *Reconciler) checkDataIngestTokenExists(ctx context.Context, dk *dynakube.DynaKube) bool {
 	tokenReader := token.NewReader(r.apiReader, dk)
 
-	tokens, err := tokenReader.ReadTokens(ctx)
+	tokens, err := tokenReader.ReadAndVerifyTokens(ctx)
 	if err != nil {
 		return false
 	}

--- a/pkg/controllers/dynakube/token/reader.go
+++ b/pkg/controllers/dynakube/token/reader.go
@@ -26,7 +26,7 @@ func NewReader(apiReader client.Reader, dk *dynakube.DynaKube) Reader {
 // HasPlatformToken inspects the token secret and checks if the apiToken is a platform token.
 // Returns an error if reading the secret fails.
 func (reader Reader) HasPlatformToken(ctx context.Context) (bool, error) {
-	tokens, err := reader.readTokens(ctx)
+	tokens, err := reader.ReadTokens(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -39,8 +39,8 @@ func (reader Reader) HasPlatformToken(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func (reader Reader) ReadTokens(ctx context.Context) (Tokens, error) {
-	tokens, err := reader.readTokens(ctx)
+func (reader Reader) ReadAndVerifyTokens(ctx context.Context) (Tokens, error) {
+	tokens, err := reader.ReadTokens(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (reader Reader) ReadTokens(ctx context.Context) (Tokens, error) {
 	return tokens, nil
 }
 
-func (reader Reader) readTokens(ctx context.Context) (Tokens, error) {
+func (reader Reader) ReadTokens(ctx context.Context) (Tokens, error) {
 	var tokenSecret corev1.Secret
 
 	result := make(Tokens)

--- a/pkg/controllers/dynakube/token/reader_test.go
+++ b/pkg/controllers/dynakube/token/reader_test.go
@@ -37,7 +37,7 @@ func testReadTokens(t *testing.T) {
 		dk := dynakube.DynaKube{}
 		reader := NewReader(clt, &dk)
 
-		_, err := reader.readTokens(context.Background())
+		_, err := reader.ReadTokens(context.Background())
 
 		require.Error(t, err)
 		assert.True(t, k8serrors.IsNotFound(err))
@@ -61,7 +61,7 @@ func testReadTokens(t *testing.T) {
 
 		reader := NewReader(clt, &dk)
 
-		tokens, err := reader.readTokens(context.Background())
+		tokens, err := reader.ReadTokens(context.Background())
 
 		require.NoError(t, err)
 		assert.Len(t, tokens, 4)

--- a/pkg/controllers/nodes/nodes_controller.go
+++ b/pkg/controllers/nodes/nodes_controller.go
@@ -173,7 +173,7 @@ func (controller *Controller) reconcileNodeDeletion(ctx context.Context, nodeCac
 func (controller *Controller) sendMarkedForTermination(ctx context.Context, dk *dynakube.DynaKube, cachedNode *cache.Entry) error {
 	tokenReader := token.NewReader(controller.apiReader, dk)
 
-	tokens, err := tokenReader.ReadTokens(ctx)
+	tokens, err := tokenReader.ReadAndVerifyTokens(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-3228)

## Description

1) New warning message is printed by validation webhook if the `tokens` secret contains `paasToken` field.

2) The same messages are printed to log in the runtime.

3) Platform token is always used instead of PaaS token.

## How can this be tested?
unittests

1)  
create spec.tokens secret containing
- `apiToken` - set to `<gen2 prefix>.test`

apply any dk
no warning
check the operator log - no related message in the operator log 

2)  
create spec.tokens secret containing
- `apiToken` - set to `<gen2 prefix>.test`
- `paasToken` - set to `test`

apply any dk
check the warning
check the message in the operator log 

3)
create spec.tokens secret containing
- `apiToken` - set to `<platform token prefix>.test`
- `paasToken` - set to `test`

apply any dk
check the warning 
check the message in the operator log 
