### PR TITLE
Don't keep stale client in AG reconcile

### DIFF
--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -113,11 +113,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, dtCli
 		return err
 	}
 
-	if r.versionReconciler == nil {
-		r.versionReconciler = version.NewReconciler(r.apiReader, dtClient.Version, timeprovider.New().Freeze())
+	versionReconciler := r.versionReconciler
+	if versionReconciler == nil {
+		versionReconciler = version.NewReconciler(r.apiReader, dtClient.Version, timeprovider.New().Freeze())
 	}
 
-	err = r.versionReconciler.ReconcileActiveGate(ctx, dk)
+	err = versionReconciler.ReconcileActiveGate(ctx, dk)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

AI assisted in both debugging and creating the PR description

DAQ-23796

---

### Problem

The activegate.Reconciler was storing the initialized versionReconciler back to its own field on first use:

```
if r.versionReconciler == nil {
    r.versionReconciler = version.NewReconciler(r.apiReader, dtClient.Version, ...)
}

err = r.versionReconciler.ReconcileActiveGate(ctx, dk)
```

Because activegate.Reconciler lives for the entire operator lifetime (created once in controller.go), this caused the versionReconciler — and its embedded DT HTTP client — to be frozen after the first reconciliation cycle. Any subsequent cycle received a fresh dtClient (e.g. with updated TLS configuration after a CA cert rotation), but the versionReconciler kept using the original client.

This was surfaced as crypto/rsa: verification error in the HTTPS proxy + custom CA e2e tests: the second test run regenerated the proxy TLS cert, but the version reconciler still held the HTTP client from the first run's cert.

### Fix

Use a local variable instead of writing back to the field, matching the existing pattern in oneagent and injection reconcilers:

```
versionReconciler := r.versionReconciler
if versionReconciler == nil {
    versionReconciler = version.NewReconciler(r.apiReader, dtClient.Version, ...)
}
err = versionReconciler.ReconcileActiveGate(ctx, dk)
```

The r.versionReconciler field is still supported for test injection (set explicitly in tests); production code always creates a fresh reconciler per cycle.

## How can this be tested?

Run istio proxy e2e tests
