### PR TITLE
Fix dynakube configuration so that AG auto-tls-cert is created by the operator

### DIFF
--- a/test/e2e/features/cloudnative/codemodules/codemodules.go
+++ b/test/e2e/features/cloudnative/codemodules/codemodules.go
@@ -405,7 +405,6 @@ func WithProxyCAAndAutomaticAGCert(t *testing.T, proxySpec *value.Source) featur
 		dynakubeComponents.WithCloudNativeSpec(codeModulesCloudNativeSpec(t)),
 		dynakubeComponents.WithCustomCAs(configMapName),
 		dynakubeComponents.WithActiveGate(),
-		dynakubeComponents.WithActiveGateTLSSecret(agSecretName),
 		dynakubeComponents.WithIstioIntegration(),
 		dynakubeComponents.WithProxy(proxySpec),
 	)


### PR DESCRIPTION
## Description

Fixes `WithProxyCAAndAutomaticAGCert`.

Dynakube is correctly configured in `WithProxyAndAutomaticAGCert`.

## How can this be tested?

make test/e2e/istio