### PR TITLE
Validate install-path at injection time

### DIFF
--- a/pkg/webhook/mutation/pod/mutator/oneagent/config.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/config.go
@@ -19,6 +19,7 @@ const (
 
 	MissingTenantUUIDReason      = "MissingTenantUUID"
 	DynaKubeStatusNotReadyReason = "DynaKubeStatusNotReady"
+	InvalidInstallPathReason     = "InvalidInstallPath"
 
 	// AnnotationTechnologies can be set on a Pod to configure which code module technologies to download. It's set to
 	// "all" if not set.

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init.go
@@ -15,18 +15,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type CodeModulesStatusNotReadyErr struct {
+type codeModulesStatusNotReadyError struct {
 	dkName string
 }
 
-func (err CodeModulesStatusNotReadyErr) Error() string {
+func (err codeModulesStatusNotReadyError) Error() string {
 	return fmt.Sprintf("the dynakube's (%s) codemodules version status is not yet ready, skipping mutation", err.dkName)
 }
 
 func mutateInitContainer(mutationRequest *dtwebhook.MutationRequest, installPath string) error {
 	if !mutationRequest.DynaKube.IsCodeModulesStatusReady() {
 		return dtwebhook.MutatorError{
-			Err:      CodeModulesStatusNotReadyErr{dkName: mutationRequest.DynaKube.Name},
+			Err:      codeModulesStatusNotReadyError{dkName: mutationRequest.DynaKube.Name},
 			Annotate: setNotInjectedAnnotationFunc(DynaKubeStatusNotReadyReason),
 		}
 	}

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init_test.go
@@ -53,7 +53,7 @@ func TestMutateInitContainer(t *testing.T) {
 
 		err := mutateInitContainer(request, installPath)
 		require.ErrorAs(t, err, &webhook.MutatorError{})
-		require.ErrorAs(t, err, &CodeModulesStatusNotReadyErr{})
+		require.ErrorAs(t, err, &codeModulesStatusNotReadyError{})
 	})
 
 	t.Run("status not ready - no image", func(t *testing.T) {
@@ -75,7 +75,7 @@ func TestMutateInitContainer(t *testing.T) {
 
 		err := mutateInitContainer(request, installPath)
 		require.ErrorAs(t, err, &webhook.MutatorError{})
-		require.ErrorAs(t, err, &CodeModulesStatusNotReadyErr{})
+		require.ErrorAs(t, err, &codeModulesStatusNotReadyError{})
 	})
 
 	t.Run("status not ready - image set, version is needed", func(t *testing.T) {
@@ -97,7 +97,7 @@ func TestMutateInitContainer(t *testing.T) {
 
 		err := mutateInitContainer(request, installPath)
 		require.ErrorAs(t, err, &webhook.MutatorError{})
-		require.ErrorAs(t, err, &CodeModulesStatusNotReadyErr{})
+		require.ErrorAs(t, err, &codeModulesStatusNotReadyError{})
 	})
 
 	t.Run("status not ready - version set, image is needed", func(t *testing.T) {
@@ -120,7 +120,7 @@ func TestMutateInitContainer(t *testing.T) {
 
 		err := mutateInitContainer(request, installPath)
 		require.ErrorAs(t, err, &webhook.MutatorError{})
-		require.ErrorAs(t, err, &CodeModulesStatusNotReadyErr{})
+		require.ErrorAs(t, err, &codeModulesStatusNotReadyError{})
 	})
 
 	t.Run("csi-scenario -> custom init-resources", func(t *testing.T) {

--- a/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
@@ -20,11 +20,11 @@ const (
 	EphemeralVolumeType = "ephemeral"
 )
 
-type InvalidInstallPathErr struct {
+type invalidInstallPathError struct {
 	InstallPath string
 }
 
-func (err InvalidInstallPathErr) Error() string {
+func (err invalidInstallPathError) Error() string {
 	return fmt.Sprintf("the installPath (%s) must be clean, absolute and without whitespace and separators like ,:", err.InstallPath)
 }
 
@@ -82,7 +82,7 @@ func validateInstallPath(installPath string) error {
 		strings.ContainsAny(installPath, "\x00,:") ||
 		filepath.Clean(installPath) != installPath {
 		return dtwebhook.MutatorError{
-			Err:      InvalidInstallPathErr{installPath},
+			Err:      invalidInstallPathError{installPath},
 			Annotate: setNotInjectedAnnotationFunc(InvalidInstallPathReason),
 		}
 	}

--- a/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
@@ -2,6 +2,7 @@ package oneagent
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"unicode"
@@ -78,6 +79,7 @@ func (mut *Mutator) IsInjected(request *dtwebhook.BaseRequest) bool {
 
 func validateInstallPath(installPath string) error {
 	if !filepath.IsAbs(installPath) ||
+		installPath == string(os.PathSeparator) ||
 		strings.ContainsFunc(installPath, unicode.IsSpace) ||
 		strings.ContainsAny(installPath, "\x00,:") ||
 		filepath.Clean(installPath) != installPath {

--- a/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
@@ -1,6 +1,11 @@
 package oneagent
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode"
+
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8smount"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
@@ -14,6 +19,14 @@ const (
 	CSIVolumeType       = "csi"
 	EphemeralVolumeType = "ephemeral"
 )
+
+type InvalidInstallPathErr struct {
+	InstallPath string
+}
+
+func (err InvalidInstallPathErr) Error() string {
+	return fmt.Sprintf("the installPath (%s) must be clean, absolute and without whitespace and separators like ,:", err.InstallPath)
+}
 
 type Mutator struct{}
 
@@ -63,8 +76,26 @@ func (mut *Mutator) IsInjected(request *dtwebhook.BaseRequest) bool {
 	return maputils.GetFieldBool(request.Pod.Annotations, AnnotationInjected, false)
 }
 
+func validateInstallPath(installPath string) error {
+	if !filepath.IsAbs(installPath) ||
+		strings.ContainsFunc(installPath, unicode.IsSpace) ||
+		strings.ContainsAny(installPath, "\x00,:") ||
+		filepath.Clean(installPath) != installPath {
+		return dtwebhook.MutatorError{
+			Err:      InvalidInstallPathErr{installPath},
+			Annotate: setNotInjectedAnnotationFunc(InvalidInstallPathReason),
+		}
+	}
+
+	return nil
+}
+
 func (mut *Mutator) Mutate(request *dtwebhook.MutationRequest) error {
 	installPath := maputils.GetField(request.Pod.Annotations, AnnotationInstallPath, DefaultInstallPath)
+
+	if err := validateInstallPath(installPath); err != nil {
+		return err
+	}
 
 	err := mutateInitContainer(request, installPath)
 	if err != nil {
@@ -81,6 +112,9 @@ func (mut *Mutator) Mutate(request *dtwebhook.MutationRequest) error {
 
 func (mut *Mutator) Reinvoke(request *dtwebhook.ReinvocationRequest) bool {
 	installPath := maputils.GetField(request.Pod.Annotations, AnnotationInstallPath, DefaultInstallPath)
+	if err := validateInstallPath(installPath); err != nil {
+		return false
+	}
 
 	return mutateUserContainers(request.BaseRequest, installPath)
 }

--- a/pkg/webhook/mutation/pod/mutator/oneagent/mutator_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/mutator_test.go
@@ -286,6 +286,43 @@ func TestIsSelfExtractingImage(t *testing.T) {
 	}
 }
 
+func TestValidateInstallPath(t *testing.T) {
+	t.Run("relative install path is rejected", func(t *testing.T) {
+		require.Error(t, validateInstallPath("relative/path"))
+	})
+
+	t.Run("install path with separator is rejected", func(t *testing.T) {
+		for _, path := range []string{
+			"/valid/path,/injected/path",
+			"/valid/path:/other",
+			"/valid/path\x00/other",
+		} {
+			require.Error(t, validateInstallPath(path))
+		}
+	})
+
+	t.Run("install path with whitespace is rejected", func(t *testing.T) {
+		for _, path := range []string{
+			"/valid/path\n/injected/path",
+			"/valid/path\r/other",
+			"/valid/path\t/other",
+			"/valid/path\x00/other",
+		} {
+			require.Error(t, validateInstallPath(path))
+		}
+	})
+
+	t.Run("unclean install path is rejected", func(t *testing.T) {
+		require.Error(t, validateInstallPath("/valid/../path"))
+	})
+
+	// Valid but rejected: spaces in paths are indistinguishable from
+	// whitespace separators in ld.so.preload, so we treat them as invalid.
+	t.Run("path with space is rejected despite being a valid linux path", func(t *testing.T) {
+		require.Error(t, validateInstallPath("/opt/my agent/dynatrace"))
+	})
+}
+
 func TestMutate(t *testing.T) {
 	mut := NewMutator()
 
@@ -308,7 +345,7 @@ func TestMutate(t *testing.T) {
 		assert.True(t, mut.IsInjected(request.BaseRequest))
 	})
 	t.Run("install-path respected", func(t *testing.T) {
-		expectedInstallPath := "my-install"
+		expectedInstallPath := "/my-install"
 		request := createTestMutationRequestWithoutInjectedContainers()
 		request.Pod.Annotations = map[string]string{
 			AnnotationInstallPath: expectedInstallPath,
@@ -337,6 +374,28 @@ func TestMutate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, mut.IsInjected(request.BaseRequest))
+	})
+
+	t.Run("install-path with separator => error", func(t *testing.T) {
+		request := createTestMutationRequestWithoutInjectedContainers()
+		request.Pod.Annotations = map[string]string{
+			AnnotationInstallPath: "my:install",
+		}
+
+		err := mut.Mutate(request)
+		require.ErrorAs(t, err, new(dtwebhook.MutatorError))
+		assert.False(t, mut.IsInjected(request.BaseRequest))
+	})
+
+	t.Run("install-path with whitespace => error", func(t *testing.T) {
+		request := createTestMutationRequestWithoutInjectedContainers()
+		request.Pod.Annotations = map[string]string{
+			AnnotationInstallPath: "my install",
+		}
+
+		err := mut.Mutate(request)
+		require.ErrorAs(t, err, new(dtwebhook.MutatorError))
+		assert.False(t, mut.IsInjected(request.BaseRequest))
 	})
 
 	t.Run("no tenantUUID + cloudnative => error", func(t *testing.T) {
@@ -388,7 +447,7 @@ func TestReinvoke(t *testing.T) {
 	})
 
 	t.Run("install-path respected", func(t *testing.T) {
-		expectedInstallPath := "my-install"
+		expectedInstallPath := "/my-install"
 		request := createTestMutationRequestWithoutInjectedContainers()
 		request.Pod.Annotations = map[string]string{
 			AnnotationInstallPath: expectedInstallPath,
@@ -408,6 +467,16 @@ func TestReinvoke(t *testing.T) {
 		request := createTestMutationRequestWithoutInjectedContainers()
 		for i := range request.Pod.Spec.Containers {
 			addVolumeMounts(&request.Pod.Spec.Containers[i], "test")
+		}
+
+		updated := mut.Reinvoke(request.ToReinvocationRequest())
+		require.False(t, updated)
+	})
+
+	t.Run("incorrect install-path => no update", func(t *testing.T) {
+		request := createTestMutationRequestWithoutInjectedContainers()
+		request.Pod.Annotations = map[string]string{
+			AnnotationInstallPath: "my install",
 		}
 
 		updated := mut.Reinvoke(request.ToReinvocationRequest())

--- a/pkg/webhook/mutation/pod/mutator/oneagent/mutator_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/mutator_test.go
@@ -287,6 +287,10 @@ func TestIsSelfExtractingImage(t *testing.T) {
 }
 
 func TestValidateInstallPath(t *testing.T) {
+	t.Run("can't be just root", func(t *testing.T) {
+		require.Error(t, validateInstallPath("/"))
+	})
+
 	t.Run("relative install path is rejected", func(t *testing.T) {
 		require.Error(t, validateInstallPath("relative/path"))
 	})


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-4033](https://dt-rnd.atlassian.net/browse/ICP-4033)

Basically the same as https://github.com/Dynatrace/dynatrace-bootstrapper/pull/168, but at injection time.

Not validating the installPath properly can cause some weird volumeMounts as we just pass it to their. I was surprised the k8s even lets you do that.

Obvious questions:
- Why both here and in the bootstrapper? -> So that no security researcher can complain that it is exploitable in the boostrapper alone.
- Why not reuse the logic from the bootstrapper? -> Sharing logic between the 2 repos is a pain, that I would like to avoid.

## How can this be tested?

1. Default OA injection works as usual
2. Play around with `oneagent.dynatrace.com/install-path: "..."`, and try to break it.

[ICP-4033]: https://dt-rnd.atlassian.net/browse/ICP-4033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ