### PR TITLE
Remove gke-autopilot file from github releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -235,7 +235,6 @@ jobs:
           make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}"
           make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}"
           make manifests/openshift IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}"
-          cp config/deploy/kubernetes/kubernetes.yaml config/deploy/kubernetes/gke-autopilot.yaml
       - name: Build helm packages
         uses: ./.github/actions/build-helm
         with:
@@ -311,7 +310,6 @@ jobs:
             tmp/cosign.pub
             config/deploy/dynatrace-operator-crd.yaml
             config/deploy/kubernetes/kubernetes.yaml
-            config/deploy/kubernetes/gke-autopilot.yaml
             config/deploy/openshift/openshift.yaml
             config/deploy/kubernetes/kubernetes-csi.yaml
             config/deploy/openshift/openshift-csi.yaml


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

As this file was never correct (it didn't contain the allow list synchronizer) and was not really used (max 17 downloads for 1 mayor release) it was decided to remove the file entirely from the releases.

[ICP-4003 gke-autopilot.yaml does not contain allowlistsynchronizer - Jira](https://dt-rnd.atlassian.net/browse/ICP-4003)
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- Look at the change, it is just 2 lines.
- Fork and run release job
<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->