### PR TITLE
Remove k8sentity info log throttling

### DIFF
--- a/pkg/controllers/dynakube/k8sentity/reconciler.go
+++ b/pkg/controllers/dynakube/k8sentity/reconciler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
@@ -178,9 +177,7 @@ func (r *Reconciler) createK8sAppSettingIfAbsent(ctx context.Context, dtClient s
 				return errors.WithMessage(err, "error trying to check if app setting exists")
 			}
 
-			if shouldLogMissingAppTransitionSchema(k8sEntity.ID) {
-				log.Info("skipping app-transition creation due to missing schema", "kubernetesClusterMEID", k8sEntity.ID, "schemaID", settings.AppTransitionSchemaID)
-			}
+			log.Info("skipping app-transition creation due to missing schema", "kubernetesClusterMEID", k8sEntity.ID, "schemaID", settings.AppTransitionSchemaID)
 
 			return nil
 		}
@@ -201,27 +198,4 @@ func (r *Reconciler) createK8sAppSettingIfAbsent(ctx context.Context, dtClient s
 	}
 
 	return nil
-}
-
-const logCacheTimeout = 5 * time.Minute
-
-var logCache = make(map[string]time.Time)
-var timeNow = time.Now
-
-// NOT THREAD-SAFE!!!
-func shouldLogMissingAppTransitionSchema(meID string) bool {
-	// Limit cache size to prevent excessive memory usage at the cost of potentially spamming the logs.
-	const maxCacheSize = 100
-	if len(logCache) >= maxCacheSize {
-		return true
-	}
-
-	lastLog, exists := logCache[meID]
-	if !exists || timeNow().Sub(lastLog) > logCacheTimeout {
-		logCache[meID] = timeNow()
-
-		return true
-	}
-
-	return false
 }

--- a/pkg/controllers/dynakube/k8sentity/reconciler_test.go
+++ b/pkg/controllers/dynakube/k8sentity/reconciler_test.go
@@ -3,9 +3,7 @@ package k8sentity
 import (
 	"context"
 	"errors"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -436,40 +434,5 @@ func TestCreateK8sAppSettingIfAbsent(t *testing.T) {
 
 		err := r.createK8sAppSettingIfAbsent(t.Context(), dtClient, dk)
 		require.NoError(t, err)
-	})
-}
-
-func Test_logCache(t *testing.T) {
-	reset := func() {
-		logCache = make(map[string]time.Time)
-	}
-
-	t.Run("lookup", func(t *testing.T) {
-		t.Cleanup(reset)
-
-		fixedTime := time.Now()
-		timeNow = func() time.Time { return fixedTime }
-
-		assert.True(t, shouldLogMissingAppTransitionSchema("test"))
-		assert.False(t, shouldLogMissingAppTransitionSchema("test"))
-
-		// advance time to just before timeout
-		fixedTime = fixedTime.Add(logCacheTimeout)
-		assert.False(t, shouldLogMissingAppTransitionSchema("test"))
-		// advance time to after timeout
-		fixedTime = fixedTime.Add(1 * time.Second)
-		assert.True(t, shouldLogMissingAppTransitionSchema("test"))
-	})
-
-	t.Run("limit size", func(t *testing.T) {
-		t.Cleanup(reset)
-
-		for i := range 101 {
-			require.True(t, shouldLogMissingAppTransitionSchema(strconv.Itoa(i)))
-		}
-
-		require.Len(t, logCache, 100)
-		require.Contains(t, logCache, "99")
-		require.NotContains(t, logCache, "100")
 	})
 }


### PR DESCRIPTION
## Description

Throttling the logs was an interesting idea, but it was never actually requested or required.
We don't want this pattern to propagate without any actual value.

## How can this be tested?

Run unit tests
