### PR TITLE
Use errors.Join instead of custom error concat

### DIFF
--- a/pkg/controllers/dynakube/conditions.go
+++ b/pkg/controllers/dynakube/conditions.go
@@ -1,7 +1,6 @@
 package dynakube
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -21,22 +20,8 @@ const (
 func (controller *Controller) setConditionTokenError(dk *dynakube.DynaKube, err error) {
 	msg := TokenVerificationFailedConditionMessage
 
-	var e token.VerificationError
-	if errors.As(err, &e) {
-		if len(e.Errs) > 0 {
-			missingScopes := make([]string, 0)
-
-			for _, scopeErr := range e.Errs {
-				var se token.ScopeError
-				if errors.As(scopeErr, &se) {
-					missingScopes = append(missingScopes, se.MissingScopes...)
-				}
-			}
-
-			if len(missingScopes) > 0 {
-				msg = fmt.Sprintf(TokenScopesMissingConditionMessage, strings.Join(missingScopes, ", "))
-			}
-		}
+	if missingScopes := token.GetMissingScopes(err); len(missingScopes) > 0 {
+		msg = fmt.Sprintf(TokenScopesMissingConditionMessage, strings.Join(missingScopes, ", "))
 	}
 
 	tokenErrorCondition := metav1.Condition{

--- a/pkg/controllers/dynakube/token/tokens.go
+++ b/pkg/controllers/dynakube/token/tokens.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 	"maps"
-	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
 )
 
@@ -15,17 +13,7 @@ const (
 	PaaSKey       = "paasToken"
 	APIKey        = "apiToken"
 	DataIngestKey = "dataIngestToken"
-
-	noError = 0
 )
-
-type VerificationError struct {
-	Errs []error
-}
-
-func (v VerificationError) Error() string {
-	return concatErrors(v.Errs).Error()
-}
 
 type Tokens map[string]*Token
 
@@ -68,75 +56,61 @@ func (tokens Tokens) AddFeatureScopesToTokens() Tokens {
 }
 
 func (tokens Tokens) VerifyScopes(ctx context.Context, dtClient token.APIClient, dk dynakube.DynaKube) (map[string]bool, error) {
-	collectedScopeErrors := make([]error, 0)
+	var err error
+
 	collectedMissingOptionalScopes := map[string]bool{}
 
 	for _, token := range tokens {
 		missingOptionalScopes, scopeError := token.verifyScopes(ctx, dtClient, dk)
 		if scopeError != nil {
-			collectedScopeErrors = append(collectedScopeErrors, scopeError)
+			err = errors.Join(err, scopeError)
 		}
 
 		maps.Insert(collectedMissingOptionalScopes, maps.All(missingOptionalScopes))
 	}
 
-	if len(collectedScopeErrors) == 0 {
-		return collectedMissingOptionalScopes, nil
-	}
-
-	return collectedMissingOptionalScopes, VerificationError{Errs: collectedScopeErrors}
+	return collectedMissingOptionalScopes, err
 }
 
-func (tokens Tokens) VerifyValues() error {
-	valueErrors := make([]error, 0)
-
+func (tokens Tokens) VerifyValues() (err error) {
 	for _, token := range tokens {
-		err := token.verifyValue()
-		if err != nil {
-			valueErrors = append(valueErrors, err)
+		verifyErr := token.verifyValue()
+		if verifyErr != nil {
+			err = errors.Join(err, verifyErr)
 		}
 	}
 
-	return concatErrors(valueErrors)
-}
-
-func concatErrors(errs []error) error {
-	if len(errs) == 0 {
-		return nil
-	}
-
-	apiStatus := noError
-
-	var concatenatedError strings.Builder
-	for index, err := range errs {
-		concatenatedError.WriteString(err.Error())
-
-		if index < len(errs)-1 {
-			concatenatedError.WriteString("\n\t")
-		}
-
-		if apiStatus == noError && core.IsUnreachable(err) {
-			apiStatus = core.StatusCode(err)
-		}
-	}
-
-	if apiStatus != noError {
-		return &core.HTTPError{
-			StatusCode: apiStatus,
-			ServerErrors: []core.ServerError{
-				{
-					Code:    apiStatus,
-					Message: concatenatedError.String(),
-				},
-			},
-		}
-	}
-
-	return errors.New(concatenatedError.String())
+	return
 }
 
 func CheckForDataIngestToken(tokens Tokens) bool {
 	dataIngestToken, hasDataIngestToken := tokens[DataIngestKey]
 
 	return hasDataIngestToken && len(dataIngestToken.Value) != 0
+}
+
+// GetMissingScopes inspects the provided error for ScopeError values and extracts their missing scopes.
+// Returns a nil slice if no ScopeError is encountered.
+func GetMissingScopes(err error) []string {
+	if err == nil {
+		return nil
+	}
+
+	var errs []error
+
+	if unwrap, ok := err.(interface{ Unwrap() []error }); !ok {
+		errs = []error{err}
+	} else {
+		errs = unwrap.Unwrap()
+	}
+
+	var missingScopes []string
+
+	for _, err := range errs {
+		if scopeErr := new(ScopeError); errors.As(err, scopeErr) {
+			missingScopes = append(missingScopes, scopeErr.MissingScopes...)
+		}
+	}
+
+	return missingScopes
 }

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -1,7 +1,7 @@
 package token
 
 import (
-	"net/http"
+	"errors"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -9,10 +9,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/metadataenrichment"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	tokenclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
 	tokenclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/token"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +37,7 @@ func getAllScopesForDataIngest() []string {
 		tokenclient.ScopeMetricsIngest,
 	}
 }
+
 func getAllScopesForTelemetryIngest() []string {
 	return []string{
 		tokenclient.ScopeMetricsIngest,
@@ -53,24 +52,6 @@ func getAllScopesForOTLPExporter() []string {
 		tokenclient.ScopeOpenTelemetryTraceIngest,
 		tokenclient.ScopeLogsIngest,
 	}
-}
-
-func extractMissingScopesFromError(err error) []string {
-	var verificationErr VerificationError
-	if errors.As(err, &verificationErr) {
-		missingScopes := make([]string, 0)
-
-		for _, scopeErr := range verificationErr.Errs {
-			var se ScopeError
-			if errors.As(scopeErr, &se) {
-				missingScopes = append(missingScopes, se.MissingScopes...)
-			}
-		}
-
-		return missingScopes
-	}
-
-	return nil
 }
 
 func TestTokens(t *testing.T) {
@@ -128,7 +109,7 @@ func TestTokens(t *testing.T) {
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Empty(t, tokens.DataIngestToken().Features)
 
-		assert.Equal(t, []string{"InstallerDownload"}, extractMissingScopesFromError(err))
+		assert.Equal(t, []string{"InstallerDownload"}, GetMissingScopes(err))
 		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Download Installer' is missing scope 'InstallerDownload']")
 	})
 	t.Run("empty dynakube, all permissions in api token, but paas + paas token => should work", func(t *testing.T) {
@@ -175,7 +156,7 @@ func TestTokens(t *testing.T) {
 		assert.Len(t, tokens.APIToken().Features, 10)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Empty(t, tokens.DataIngestToken().Features)
-		assert.Equal(t, []string{"DataExport", "activeGateTokenManagement.create", "InstallerDownload"}, extractMissingScopesFromError(err))
+		assert.Equal(t, []string{"DataExport", "activeGateTokenManagement.create", "InstallerDownload"}, GetMissingScopes(err))
 		assert.EqualError(t, err, "token 'apiToken' has scope errors: [feature 'Access problem and event feed, metrics, and topology' is missing scope 'DataExport' feature 'Automatic ActiveGate Token Creation' is missing scope 'activeGateTokenManagement.create' feature 'Download Installer' is missing scope 'InstallerDownload']")
 	})
 	t.Run("data ingest enabled => dataingest token missing rights => fail", func(t *testing.T) {
@@ -194,7 +175,7 @@ func TestTokens(t *testing.T) {
 		assert.Len(t, tokens.APIToken().Features, 10)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Len(t, tokens.DataIngestToken().Features, 8)
-		assert.Equal(t, []string{"metrics.ingest"}, extractMissingScopesFromError(err))
+		assert.Equal(t, []string{"metrics.ingest"}, GetMissingScopes(err))
 		assert.EqualError(t, err, "token 'dataIngestToken' has scope errors: [feature 'Data Ingest' is missing scope 'metrics.ingest']")
 	})
 	t.Run("data ingest enabled => dataingest token has rights => success", func(t *testing.T) {
@@ -237,7 +218,7 @@ func TestTokens(t *testing.T) {
 		assert.Len(t, tokens.APIToken().Features, 10)
 		assert.Empty(t, tokens.PaasToken().Features)
 		assert.Len(t, tokens.DataIngestToken().Features, 8)
-		assert.Equal(t, []string{"openTelemetryTrace.ingest", "logs.ingest", "metrics.ingest"}, extractMissingScopesFromError(err))
+		assert.Equal(t, []string{"openTelemetryTrace.ingest", "logs.ingest", "metrics.ingest"}, GetMissingScopes(err))
 		assert.EqualError(t, err, "token 'dataIngestToken' has scope errors: [feature 'OTLP trace exporter configuration' is missing scope 'openTelemetryTrace.ingest' feature 'OTLP logs exporter configuration' is missing scope 'logs.ingest' feature 'OTLP metrics exporter configuration' is missing scope 'metrics.ingest']")
 	})
 	t.Run("otlp exporter configuration enabled => dataingest token has rights => success", func(t *testing.T) {
@@ -490,96 +471,6 @@ func TestTokens_VerifyValues(t *testing.T) {
 	require.EqualError(t, invalidTokens.VerifyValues(), "token 'apiToken' contains leading or trailing whitespaces")
 }
 
-func TestConcatErrors(t *testing.T) {
-	stringError1 := errors.New("error 1")
-	stringError2 := errors.New("error 2")
-	serviceUnavailableError := &core.HTTPError{
-		ServerErrors: []core.ServerError{
-			{
-				Code:    http.StatusServiceUnavailable,
-				Message: "ServiceUnavailable",
-			},
-		},
-		StatusCode: http.StatusServiceUnavailable,
-	}
-	tooManyRequestsError := &core.HTTPError{
-		ServerErrors: []core.ServerError{
-			{
-				Code:    http.StatusTooManyRequests,
-				Message: "TooManyRequests",
-			},
-		},
-		StatusCode: http.StatusTooManyRequests,
-	}
-
-	type concatErrorsTestCase struct {
-		name              string
-		encounteredErrors []error
-		message           string
-	}
-
-	testCases := []concatErrorsTestCase{
-		{
-			name:              "no errors -> no error",
-			encounteredErrors: []error{},
-		},
-		{
-			name: "string errors",
-			encounteredErrors: []error{
-				stringError1,
-				stringError2,
-			},
-			message: "error 1\n\terror 2",
-		},
-		{
-			name: "string + ServiceUnavailable errors",
-			encounteredErrors: []error{
-				stringError1,
-				serviceUnavailableError,
-			},
-			message: "HTTP 503: dynatrace server error 503: error 1\n\tHTTP 503: dynatrace server error 503: ServiceUnavailable",
-		},
-		{
-			name: "string + TooManyRequests errors",
-			encounteredErrors: []error{
-				stringError1,
-				tooManyRequestsError,
-			},
-			message: "HTTP 429: dynatrace server error 429: error 1\n\tHTTP 429: dynatrace server error 429: TooManyRequests",
-		},
-		{
-			name: "string + ServiceUnavailable + TooManyRequests errors",
-			encounteredErrors: []error{
-				stringError1,
-				serviceUnavailableError,
-				tooManyRequestsError,
-			},
-			message: "HTTP 503: dynatrace server error 503: error 1\n\tHTTP 503: dynatrace server error 503: ServiceUnavailable\n\tHTTP 429: dynatrace server error 429: TooManyRequests",
-		},
-		{
-			name: "string + TooManyRequests + ServiceUnavailable errors",
-			encounteredErrors: []error{
-				stringError1,
-				tooManyRequestsError,
-				serviceUnavailableError,
-			},
-			message: "HTTP 429: dynatrace server error 429: error 1\n\tHTTP 429: dynatrace server error 429: TooManyRequests\n\tHTTP 503: dynatrace server error 503: ServiceUnavailable",
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			err := concatErrors(testCase.encounteredErrors)
-
-			if len(testCase.encounteredErrors) == 0 {
-				require.NoError(t, err)
-			} else {
-				require.EqualError(t, err, testCase.message)
-			}
-		})
-	}
-}
-
 func TestCheckForDataIngestToken(t *testing.T) {
 	t.Run("data ingest token is present, but empty", func(t *testing.T) {
 		tokens := Tokens{
@@ -604,4 +495,78 @@ func TestCheckForDataIngestToken(t *testing.T) {
 
 		assert.False(t, CheckForDataIngestToken(tokens))
 	})
+}
+
+func TestGetMissingScopes(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{
+			name: "nil error returns nil",
+			err:  nil,
+			want: nil,
+		},
+		{
+			name: "single ScopeError returns its missing scopes",
+			err: ScopeError{
+				Token:         APIKey,
+				MissingScopes: []string{"DataExport", "InstallerDownload"},
+			},
+			want: []string{"DataExport", "InstallerDownload"},
+		},
+		{
+			name: "single ScopeError with no missing scopes returns nil",
+			err: ScopeError{
+				Token:         APIKey,
+				MissingScopes: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "non-ScopeError returns nil",
+			err:  errors.New("some error"),
+			want: nil,
+		},
+		{
+			name: "joined ScopeErrors returns all missing scopes",
+			err: errors.Join(
+				ScopeError{
+					Token:         APIKey,
+					MissingScopes: []string{"DataExport"},
+				},
+				ScopeError{
+					Token:         PaaSKey,
+					MissingScopes: []string{"InstallerDownload"},
+				},
+			),
+			want: []string{"DataExport", "InstallerDownload"},
+		},
+		{
+			name: "joined non-ScopeErrors returns nil",
+			err: errors.Join(
+				errors.New("some error"),
+				errors.New("another error"),
+			),
+			want: nil,
+		},
+		{
+			name: "joined mixed errors returns only ScopeError missing scopes",
+			err: errors.Join(
+				ScopeError{
+					Token:         APIKey,
+					MissingScopes: []string{"DataExport"},
+				},
+				errors.New("some non-scope error"),
+			),
+			want: []string{"DataExport"},
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, GetMissingScopes(c.err))
+		})
+	}
 }


### PR DESCRIPTION
## Description

We have some custom error concatenation in place for the scope validation, but we could just as well use the stdlib.
Export the function that extracts the missing scopes from the unit tests to share the logic with the conditions.

Unit tests were written with the help of AI.

ICP-2063

## How can this be tested?

Run unit tests.
Deploy a DynaKube with missing scopes and check the logs and condition.
