### PR TITLE
Remove HTTP client from config

### DIFF
--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -48,11 +48,9 @@ type Config struct {
 	UserAgent   string
 
 	BaseURL           *url.URL
-	HTTPClient        *http.Client
 	TLSConfig         *tls.Config
 	Proxy             string
 	NoProxy           string
-	Timeout           time.Duration
 	DisableKeepAlives bool
 	CacheEntryTTL     time.Duration
 }
@@ -62,12 +60,12 @@ type Option func(*Config) error
 
 // NewClient creates a new Dynatrace API client
 func NewClient(options ...Option) (*Client, error) {
-	config, err := getConfig(options...)
+	httpClient, config, err := getClientAndConfig(options...)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client config")
 	}
 
-	addCacheMiddleware(config)
+	addCacheMiddleware(httpClient, config)
 
 	if len(config.APIToken) == 0 && len(config.PaasToken) == 0 {
 		return nil, errors.New("tokens are empty")
@@ -85,7 +83,7 @@ func NewClient(options ...Option) (*Client, error) {
 
 	apiClient := core.NewClient(core.Config{
 		BaseURL:    config.BaseURL,
-		HTTPClient: config.HTTPClient,
+		HTTPClient: httpClient,
 		UserAgent:  config.UserAgent,
 		APIToken:   config.APIToken,
 		PaasToken:  config.PaasToken,
@@ -103,14 +101,14 @@ func NewClient(options ...Option) (*Client, error) {
 
 // NewOAuthClient creates a new Dynatrace API OAuth client
 func NewOAuthClient(credentials clientcredentials.Config, options ...Option) (*OAuthClient, error) {
-	config, err := getConfig(options...)
+	httpClient, config, err := getClientAndConfig(options...)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get oauth config")
 	}
 
-	addCacheMiddleware(config)
+	addCacheMiddleware(httpClient, config)
 
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, config.HTTPClient)
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
 
 	oAuthHTTPClient := credentials.Client(ctx)
 
@@ -185,15 +183,6 @@ func WithUserAgentSuffix(suffix string) Option {
 		if suffix != "" {
 			c.UserAgent += " " + suffix
 		}
-
-		return nil
-	}
-}
-
-// WithHTTPClient sets a custom HTTP client
-func WithHTTPClient(httpClient *http.Client) Option {
-	return func(c *Config) error {
-		c.HTTPClient = httpClient
 
 		return nil
 	}
@@ -276,43 +265,30 @@ func WithCacheTTL(ttl time.Duration) Option {
 	}
 }
 
-func addCacheMiddleware(config *Config) {
-	config.HTTPClient.Transport = middleware.NewCacheRoundTripper(config.HTTPClient.Transport, config.CacheEntryTTL)
+func addCacheMiddleware(httpClient *http.Client, config *Config) {
+	httpClient.Transport = middleware.NewCacheRoundTripper(httpClient.Transport, config.CacheEntryTTL)
 }
 
-func getConfig(options ...Option) (*Config, error) {
+func getClientAndConfig(options ...Option) (*http.Client, *Config, error) {
 	config := Config{
 		UserAgent: operatorversion.UserAgent(),
-		Timeout:   30 * time.Second,
 	}
 
 	for _, opt := range options {
 		if err := opt(&config); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	t := http.DefaultTransport.(*http.Transport).Clone()
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 
-	if config.HTTPClient == nil {
-		config.HTTPClient = &http.Client{
-			Transport: t,
-		}
-	} else {
-		var ok bool
-
-		t, ok = config.HTTPClient.Transport.(*http.Transport)
-		if !ok {
-			return nil, errors.New("unexpected transport type")
-		}
-	}
-
-	t.TLSClientConfig = config.TLSConfig
+	transport.TLSClientConfig = config.TLSConfig
+	transport.DisableKeepAlives = config.DisableKeepAlives
 
 	if config.Proxy != "" {
 		proxyURL, err := url.Parse(config.Proxy)
 		if err != nil {
-			return nil, errors.Wrap(err, "invalid proxy URL")
+			return nil, nil, errors.Wrap(err, "invalid proxy URL")
 		}
 
 		proxyConfig := httpproxy.Config{
@@ -320,18 +296,13 @@ func getConfig(options ...Option) (*Config, error) {
 			HTTPSProxy: proxyURL.String(),
 			NoProxy:    config.NoProxy,
 		}
-		t.Proxy = proxyWrapper(proxyConfig)
+		transport.Proxy = proxyWrapper(proxyConfig)
 	}
 
-	if config.DisableKeepAlives {
-		t.DisableKeepAlives = true
-	}
-
-	if config.Timeout > 0 {
-		config.HTTPClient.Timeout = config.Timeout
-	}
-
-	return &config, nil
+	return &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second,
+	}, &config, nil
 }
 
 func proxyWrapper(proxyConfig httpproxy.Config) func(req *http.Request) (*url.URL, error) {

--- a/pkg/clients/dynatrace/client_test.go
+++ b/pkg/clients/dynatrace/client_test.go
@@ -2,7 +2,6 @@ package dynatrace
 
 import (
 	"crypto/tls"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -125,13 +124,6 @@ func TestWithUserAgentSuffix(t *testing.T) {
 	})
 }
 
-func TestWithHTTPClient(t *testing.T) {
-	existing := &http.Client{Transport: &http.Transport{}}
-	cfg := &Config{}
-	require.NoError(t, WithHTTPClient(existing)(cfg))
-	assert.Same(t, existing, cfg.HTTPClient)
-}
-
 func TestWithProxy(t *testing.T) {
 	cfg := &Config{}
 	require.NoError(t, WithProxy("http://p.example.com", "no.proxy")(cfg))
@@ -201,17 +193,17 @@ func TestWithCerts(t *testing.T) {
 	})
 }
 
-func TestGetConfig(t *testing.T) {
+func TestGetClientAndConfig(t *testing.T) {
 	t.Run("default, a config with client default timeout and user agent", func(t *testing.T) {
-		c, err := getConfig()
+		httpClient, config, err := getClientAndConfig()
 		require.NoError(t, err)
-		require.NotNil(t, c)
-		assert.Equal(t, 30*time.Second, c.HTTPClient.Timeout)
-		assert.Equal(t, operatorversion.UserAgent(), c.UserAgent)
+		require.NotNil(t, config)
+		assert.Equal(t, 30*time.Second, httpClient.Timeout)
+		assert.Equal(t, operatorversion.UserAgent(), config.UserAgent)
 	})
 
 	t.Run("with different options", func(t *testing.T) {
-		c, err := getConfig(
+		_, config, err := getClientAndConfig(
 			WithAPIToken("apitoken"),
 			WithPaasToken("paastoken"),
 			WithNetworkZone("network"),
@@ -222,21 +214,21 @@ func TestGetConfig(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Equal(t, "apitoken", c.APIToken)
-		assert.Equal(t, "paastoken", c.PaasToken)
-		assert.Equal(t, "network", c.NetworkZone)
-		assert.Equal(t, "hostgroup", c.HostGroup)
-		assert.False(t, c.DisableKeepAlives)
-		assert.Equal(t, operatorversion.UserAgent()+" useragent", c.UserAgent)
+		assert.Equal(t, "apitoken", config.APIToken)
+		assert.Equal(t, "paastoken", config.PaasToken)
+		assert.Equal(t, "network", config.NetworkZone)
+		assert.Equal(t, "hostgroup", config.HostGroup)
+		assert.False(t, config.DisableKeepAlives)
+		assert.Equal(t, operatorversion.UserAgent()+" useragent", config.UserAgent)
 	})
 
 	t.Run("WithProxy configures transport proxy", func(t *testing.T) {
-		c, err := getConfig(WithProxy("http://proxy.example.com:8080", ""))
+		httpClient, config, err := getClientAndConfig(WithProxy("http://proxy.example.com:8080", ""))
 		require.NoError(t, err)
-		require.NotNil(t, c)
-		assert.Equal(t, "http://proxy.example.com:8080", c.Proxy)
+		require.NotNil(t, config)
+		assert.Equal(t, "http://proxy.example.com:8080", config.Proxy)
 
-		transport, ok := c.HTTPClient.Transport.(*http.Transport)
+		transport, ok := httpClient.Transport.(*http.Transport)
 		require.True(t, ok)
 		require.NotNil(t, transport.Proxy)
 
@@ -246,11 +238,11 @@ func TestGetConfig(t *testing.T) {
 	})
 
 	t.Run("WithProxy excludes matching no proxy hosts", func(t *testing.T) {
-		c, err := getConfig(WithProxy("http://proxy.example.com:8080", "excluded.host"))
+		httpClient, config, err := getClientAndConfig(WithProxy("http://proxy.example.com:8080", "excluded.host"))
 		require.NoError(t, err)
-		assert.Equal(t, "excluded.host", c.NoProxy)
+		assert.Equal(t, "excluded.host", config.NoProxy)
 
-		transport, ok := c.HTTPClient.Transport.(*http.Transport)
+		transport, ok := httpClient.Transport.(*http.Transport)
 		require.True(t, ok)
 
 		noProxyURL, err := transport.Proxy(&http.Request{URL: mustParseURL(t, "https://excluded.host/path")})
@@ -263,69 +255,55 @@ func TestGetConfig(t *testing.T) {
 	})
 
 	t.Run("WithProxy invalid URL returns error", func(t *testing.T) {
-		_, err := getConfig(WithProxy("://bad-proxy", ""))
+		_, _, err := getClientAndConfig(WithProxy("://bad-proxy", ""))
 		require.Error(t, err)
 	})
 
 	t.Run("WithSkipCertificateValidation true sets InsecureSkipVerify", func(t *testing.T) {
-		c, err := getConfig(WithSkipCertificateValidation(true))
+		httpClient, _, err := getClientAndConfig(WithSkipCertificateValidation(true))
 		require.NoError(t, err)
 
-		transport, ok := c.HTTPClient.Transport.(*http.Transport)
+		transport, ok := httpClient.Transport.(*http.Transport)
 		require.True(t, ok)
 		require.NotNil(t, transport.TLSClientConfig)
 		assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
 	})
 
 	t.Run("WithSkipCertificateValidation false is no-op", func(t *testing.T) {
-		c, err := getConfig(WithSkipCertificateValidation(false))
+		httpClient, _, err := getClientAndConfig(WithSkipCertificateValidation(false))
 		require.NoError(t, err)
 
-		transport, ok := c.HTTPClient.Transport.(*http.Transport)
+		transport, ok := httpClient.Transport.(*http.Transport)
 		require.True(t, ok)
 		assert.Nil(t, transport.TLSClientConfig)
 	})
 
 	t.Run("WithTLSConfig sets TLS config on transport", func(t *testing.T) {
 		tlsCfg := &tls.Config{MinVersion: tls.VersionTLS13}
-		c, err := getConfig(WithTLSConfig(tlsCfg))
+		httpClient, _, err := getClientAndConfig(WithTLSConfig(tlsCfg))
 		require.NoError(t, err)
 
-		transport, ok := c.HTTPClient.Transport.(*http.Transport)
+		transport, ok := httpClient.Transport.(*http.Transport)
 		require.True(t, ok)
 		assert.Equal(t, tlsCfg, transport.TLSClientConfig)
 	})
 
 	t.Run("WithKeepAlive false disables keep-alives", func(t *testing.T) {
-		c, err := getConfig(WithKeepAlive(false))
+		httpClient, _, err := getClientAndConfig(WithKeepAlive(false))
 		require.NoError(t, err)
 
-		transport, ok := c.HTTPClient.Transport.(*http.Transport)
+		transport, ok := httpClient.Transport.(*http.Transport)
 		require.True(t, ok)
 		assert.True(t, transport.DisableKeepAlives)
 	})
 
 	t.Run("WithKeepAlive true keeps keep-alives enabled", func(t *testing.T) {
-		c, err := getConfig(WithKeepAlive(true))
+		httpClient, _, err := getClientAndConfig(WithKeepAlive(true))
 		require.NoError(t, err)
 
-		transport, ok := c.HTTPClient.Transport.(*http.Transport)
+		transport, ok := httpClient.Transport.(*http.Transport)
 		require.True(t, ok)
 		assert.False(t, transport.DisableKeepAlives)
-	})
-
-	t.Run("WithHTTPClient uses provided client", func(t *testing.T) {
-		existing := &http.Client{Transport: &http.Transport{}}
-		c, err := getConfig(WithHTTPClient(existing))
-		require.NoError(t, err)
-		assert.Same(t, existing, c.HTTPClient)
-	})
-
-	t.Run("WithHTTPClient with unexpected transport type returns error", func(t *testing.T) {
-		bad := &http.Client{Transport: &badTransport{}}
-		_, err := getConfig(WithHTTPClient(bad))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unexpected transport type")
 	})
 }
 
@@ -404,12 +382,6 @@ func TestNewClientAppendAPIPath(t *testing.T) {
 	}
 }
 
-type badTransport struct{}
-
-func (b *badTransport) RoundTrip(*http.Request) (*http.Response, error) {
-	return nil, errors.New("bad transport")
-}
-
 func mustParseURL(t *testing.T, raw string) *url.URL {
 	t.Helper()
 	u, err := url.Parse(raw)
@@ -460,7 +432,7 @@ func TestNewClientPaasToken(t *testing.T) {
 		srv := httptest.NewServer(handlerFunc(testAPIToken))
 		defer srv.Close()
 
-		clt, err := NewClient(WithHTTPClient(srv.Client()), WithBaseURL(srv.URL), WithAPIToken(testAPIToken))
+		clt, err := NewClient(WithBaseURL(srv.URL), WithAPIToken(testAPIToken))
 		require.NoError(t, err)
 		connectionInfo, err := clt.ActiveGate.GetConnectionInfo(t.Context())
 		require.NoError(t, err)
@@ -471,7 +443,7 @@ func TestNewClientPaasToken(t *testing.T) {
 		srv := httptest.NewServer(handlerFunc(testPaasToken))
 		defer srv.Close()
 
-		clt, err := NewClient(WithHTTPClient(srv.Client()), WithBaseURL(srv.URL), WithAPIToken(testAPIToken), WithPaasToken(testPaasToken))
+		clt, err := NewClient(WithBaseURL(srv.URL), WithAPIToken(testAPIToken), WithPaasToken(testPaasToken))
 		require.NoError(t, err)
 		connectionInfo, err := clt.ActiveGate.GetConnectionInfo(t.Context())
 		require.NoError(t, err)
@@ -482,7 +454,7 @@ func TestNewClientPaasToken(t *testing.T) {
 		srv := httptest.NewServer(handlerFunc(testPlatformToken))
 		defer srv.Close()
 
-		clt, err := NewClient(WithHTTPClient(srv.Client()), WithBaseURL(srv.URL), WithAPIToken(testPlatformToken), WithPaasToken(testPaasToken))
+		clt, err := NewClient(WithBaseURL(srv.URL), WithAPIToken(testPlatformToken), WithPaasToken(testPaasToken))
 		require.NoError(t, err)
 		connectionInfo, err := clt.ActiveGate.GetConnectionInfo(t.Context())
 		require.NoError(t, err)


### PR DESCRIPTION
## Description

Remove the HTTP client from the client Config struct along with the option to set it.
The option was only used together with a httptest.Server, but for this use case setting the base URL works just as well.
Also remove the Timeout field from the Config struct. The corresponding option was already removed previously.

ICP-2063

## How can this be tested?

Unit tests
