### PR TITLE
Remove `post-delete` from AllowlistSynchronizer

### DIFF
--- a/config/helm/chart/default/templates/Common/operator/allowlistsynchronizer.yaml
+++ b/config/helm/chart/default/templates/Common/operator/allowlistsynchronizer.yaml
@@ -17,7 +17,7 @@ kind: AllowlistSynchronizer
 metadata:
   name: dynatrace-operator
   annotations:
-    "helm.sh/hook": pre-install, post-delete, pre-upgrade, pre-rollback
+    "helm.sh/hook": pre-install, pre-upgrade, pre-rollback
 spec:
   allowlistPaths:
   - Dynatrace/csidriver/{{ .Chart.AppVersion }}/*


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

`post-delete` will cause the manifest to be reinstalled AFTER you delete the Operator which makes 0 sense.

The `post-delete` hook makes sense for cleanup Jobs and such, not for creating some random resource.

> [!WARNING]
> This will not fix the "`AllowlistSynchronizer` is leftover after uninstall" issue. [That is present due to resources created by hooks are not really managed by Helm.](https://helm.sh/docs/topics/charts_hooks/#hook-resources-are-not-managed-with-corresponding-releases)

## How can this be tested?

1. Get Autopilot cluster
2. Deploy via HELM
3. *Remove manually the AllowlistSynchronizer*
4. Undeploy via HELM
5. See that AllowlistSynchronizer is not re added due to `post-delete` hook