### PR TITLE
display each deprecated feature flag as a separate warning message

### DIFF
--- a/pkg/api/validation/dynakube/featureflag.go
+++ b/pkg/api/validation/dynakube/featureflag.go
@@ -3,7 +3,6 @@ package validation
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -13,21 +12,21 @@ const (
 	warningFeatureFlagDeprecated = `Feature flag %s is deprecated.`
 )
 
-var deprecatedFeatureFlags = []string{
+var deprecatedFeatureFlagKeys = []string{
 	exp.OAProxyIgnoredKey,   //nolint:staticcheck
 	exp.AGUpdatesKey,        //nolint:staticcheck
 	exp.AGDisableUpdatesKey, //nolint:staticcheck
 	exp.OAMaxUnavailableKey, //nolint:staticcheck
 }
 
-func deprecatedFeatureFlag(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	var results strings.Builder
+func deprecatedFeatureFlags(_ context.Context, _ *Validator, dk *dynakube.DynaKube) []string {
+	var results []string
 
-	for _, flag := range deprecatedFeatureFlags {
+	for _, flag := range deprecatedFeatureFlagKeys {
 		if dk.Annotations != nil && dk.Annotations[flag] != "" {
-			fmt.Fprintf(&results, warningFeatureFlagDeprecated, flag)
+			results = append(results, fmt.Sprintf(warningFeatureFlagDeprecated, flag))
 		}
 	}
 
-	return results.String()
+	return results
 }

--- a/pkg/api/validation/dynakube/featureflag.go
+++ b/pkg/api/validation/dynakube/featureflag.go
@@ -3,30 +3,35 @@ package validation
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 )
 
 const (
-	warningFeatureFlagDeprecated = `Feature flag %s is deprecated.`
+	warningFeatureFlagDeprecated = `Using deprecated feature flags: %s`
 )
 
-var deprecatedFeatureFlagKeys = []string{
+var deprecatedFeatureFlags = []string{
 	exp.OAProxyIgnoredKey,   //nolint:staticcheck
 	exp.AGUpdatesKey,        //nolint:staticcheck
 	exp.AGDisableUpdatesKey, //nolint:staticcheck
 	exp.OAMaxUnavailableKey, //nolint:staticcheck
 }
 
-func deprecatedFeatureFlags(_ context.Context, _ *Validator, dk *dynakube.DynaKube) []string {
+func deprecatedFeatureFlag(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	var results []string
 
-	for _, flag := range deprecatedFeatureFlagKeys {
+	for _, flag := range deprecatedFeatureFlags {
 		if dk.Annotations != nil && dk.Annotations[flag] != "" {
-			results = append(results, fmt.Sprintf(warningFeatureFlagDeprecated, flag))
+			results = append(results, flag)
 		}
 	}
 
-	return results
+	if len(results) > 0 {
+		return fmt.Sprintf(warningFeatureFlagDeprecated, strings.Join(results, ", "))
+	}
+
+	return ""
 }

--- a/pkg/api/validation/dynakube/featureflag.go
+++ b/pkg/api/validation/dynakube/featureflag.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
@@ -30,7 +29,7 @@ func deprecatedFeatureFlag(_ context.Context, _ *Validator, dk *dynakube.DynaKub
 	}
 
 	if len(results) > 0 {
-		return fmt.Sprintf(warningFeatureFlagDeprecated, strings.Join(results, ", "))
+		return warningFeatureFlagDeprecated + strings.Join(results, ", ")
 	}
 
 	return ""

--- a/pkg/api/validation/dynakube/featureflag.go
+++ b/pkg/api/validation/dynakube/featureflag.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	warningFeatureFlagDeprecated = `Using deprecated feature flags: %s`
+	warningFeatureFlagDeprecated = `Using deprecated feature flags: `
 )
 
 var deprecatedFeatureFlags = []string{

--- a/pkg/api/validation/dynakube/featureflag_test.go
+++ b/pkg/api/validation/dynakube/featureflag_test.go
@@ -1,7 +1,9 @@
 package validation
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -17,7 +19,7 @@ func TestDeprecatedFeatureFlag(t *testing.T) {
 }
 
 func DeprecatedFeatureFlagWithDeprecatedFlags(t *testing.T) {
-	for _, featureFlag := range deprecatedFeatureFlagKeys {
+	for _, featureFlag := range deprecatedFeatureFlags {
 		t.Run(featureFlag, func(t *testing.T) {
 			dk := &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
@@ -27,8 +29,8 @@ func DeprecatedFeatureFlagWithDeprecatedFlags(t *testing.T) {
 					},
 				},
 			}
-			expected := []string{fmt.Sprintf(warningFeatureFlagDeprecated, featureFlag)}
-			result := deprecatedFeatureFlags(t.Context(), nil, dk)
+			expected := fmt.Sprintf(warningFeatureFlagDeprecated, featureFlag)
+			result := deprecatedFeatureFlag(context.Background(), nil, dk)
 
 			assert.Equal(t, expected, result)
 		})
@@ -44,14 +46,14 @@ func DeprecatedFeatureFlagWithoutDeprecatedFlags(t *testing.T) {
 			},
 		},
 	}
-	result := deprecatedFeatureFlags(t.Context(), nil, dk)
+	result := deprecatedFeatureFlag(context.Background(), nil, dk)
 
 	assert.Empty(t, result)
 }
 
 func DeprecatedFeatureFlagWithNoAnnotations(t *testing.T) {
 	dk := &dynakube.DynaKube{}
-	result := deprecatedFeatureFlags(t.Context(), nil, dk)
+	result := deprecatedFeatureFlag(context.Background(), nil, dk)
 
 	assert.Empty(t, result)
 }
@@ -59,7 +61,7 @@ func DeprecatedFeatureFlagWithNoAnnotations(t *testing.T) {
 func DeprecatedFeatureFlagWithMultipleDeprecatedFlags(t *testing.T) {
 	annotations := map[string]string{}
 
-	for _, flag := range deprecatedFeatureFlagKeys {
+	for _, flag := range deprecatedFeatureFlags {
 		annotations[flag] = "true"
 	}
 
@@ -70,9 +72,7 @@ func DeprecatedFeatureFlagWithMultipleDeprecatedFlags(t *testing.T) {
 		},
 	}
 
-	result := deprecatedFeatureFlags(t.Context(), nil, dk)
-	assert.Len(t, result, len(deprecatedFeatureFlagKeys))
-	for _, flag := range deprecatedFeatureFlagKeys {
-		assert.Contains(t, result, fmt.Sprintf(warningFeatureFlagDeprecated, flag))
-	}
+	result := deprecatedFeatureFlag(t.Context(), nil, dk)
+	expected := fmt.Sprintf(warningFeatureFlagDeprecated, strings.Join(deprecatedFeatureFlags, ", "))
+	assert.Equal(t, expected, result)
 }

--- a/pkg/api/validation/dynakube/featureflag_test.go
+++ b/pkg/api/validation/dynakube/featureflag_test.go
@@ -1,8 +1,6 @@
 package validation
 
 import (
-	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -29,8 +27,8 @@ func DeprecatedFeatureFlagWithDeprecatedFlags(t *testing.T) {
 					},
 				},
 			}
-			expected := fmt.Sprintf(warningFeatureFlagDeprecated, featureFlag)
-			result := deprecatedFeatureFlag(context.Background(), nil, dk)
+			expected := warningFeatureFlagDeprecated + featureFlag
+			result := deprecatedFeatureFlag(t.Context(), nil, dk)
 
 			assert.Equal(t, expected, result)
 		})
@@ -46,14 +44,14 @@ func DeprecatedFeatureFlagWithoutDeprecatedFlags(t *testing.T) {
 			},
 		},
 	}
-	result := deprecatedFeatureFlag(context.Background(), nil, dk)
+	result := deprecatedFeatureFlag(t.Context(), nil, dk)
 
 	assert.Empty(t, result)
 }
 
 func DeprecatedFeatureFlagWithNoAnnotations(t *testing.T) {
 	dk := &dynakube.DynaKube{}
-	result := deprecatedFeatureFlag(context.Background(), nil, dk)
+	result := deprecatedFeatureFlag(t.Context(), nil, dk)
 
 	assert.Empty(t, result)
 }
@@ -73,6 +71,6 @@ func DeprecatedFeatureFlagWithMultipleDeprecatedFlags(t *testing.T) {
 	}
 
 	result := deprecatedFeatureFlag(t.Context(), nil, dk)
-	expected := fmt.Sprintf(warningFeatureFlagDeprecated, strings.Join(deprecatedFeatureFlags, ", "))
+	expected := warningFeatureFlagDeprecated + strings.Join(deprecatedFeatureFlags, ", ")
 	assert.Equal(t, expected, result)
 }

--- a/pkg/api/validation/dynakube/featureflag_test.go
+++ b/pkg/api/validation/dynakube/featureflag_test.go
@@ -17,7 +17,7 @@ func TestDeprecatedFeatureFlag(t *testing.T) {
 }
 
 func DeprecatedFeatureFlagWithDeprecatedFlags(t *testing.T) {
-	for _, featureFlag := range deprecatedFeatureFlags {
+	for _, featureFlag := range deprecatedFeatureFlagKeys {
 		t.Run(featureFlag, func(t *testing.T) {
 			dk := &dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
@@ -27,8 +27,8 @@ func DeprecatedFeatureFlagWithDeprecatedFlags(t *testing.T) {
 					},
 				},
 			}
-			expected := fmt.Sprintf(warningFeatureFlagDeprecated, featureFlag)
-			result := deprecatedFeatureFlag(context.Background(), nil, dk)
+			expected := []string{fmt.Sprintf(warningFeatureFlagDeprecated, featureFlag)}
+			result := deprecatedFeatureFlags(context.Background(), nil, dk)
 
 			assert.Equal(t, expected, result)
 		})
@@ -44,14 +44,14 @@ func DeprecatedFeatureFlagWithoutDeprecatedFlags(t *testing.T) {
 			},
 		},
 	}
-	result := deprecatedFeatureFlag(context.Background(), nil, dk)
+	result := deprecatedFeatureFlags(context.Background(), nil, dk)
 
 	assert.Empty(t, result)
 }
 
 func DeprecatedFeatureFlagWithNoAnnotations(t *testing.T) {
 	dk := &dynakube.DynaKube{}
-	result := deprecatedFeatureFlag(context.Background(), nil, dk)
+	result := deprecatedFeatureFlags(context.Background(), nil, dk)
 
 	assert.Empty(t, result)
 }

--- a/pkg/api/validation/dynakube/featureflag_test.go
+++ b/pkg/api/validation/dynakube/featureflag_test.go
@@ -1,7 +1,6 @@
 package validation
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -14,6 +13,7 @@ func TestDeprecatedFeatureFlag(t *testing.T) {
 	t.Run("Feature flag is deprecated", DeprecatedFeatureFlagWithDeprecatedFlags)
 	t.Run("Feature flag is not deprecated", DeprecatedFeatureFlagWithoutDeprecatedFlags)
 	t.Run("No annotations", DeprecatedFeatureFlagWithNoAnnotations)
+	t.Run("Multiple feature flags are deprecated", DeprecatedFeatureFlagWithMultipleDeprecatedFlags)
 }
 
 func DeprecatedFeatureFlagWithDeprecatedFlags(t *testing.T) {
@@ -28,7 +28,7 @@ func DeprecatedFeatureFlagWithDeprecatedFlags(t *testing.T) {
 				},
 			}
 			expected := []string{fmt.Sprintf(warningFeatureFlagDeprecated, featureFlag)}
-			result := deprecatedFeatureFlags(context.Background(), nil, dk)
+			result := deprecatedFeatureFlags(t.Context(), nil, dk)
 
 			assert.Equal(t, expected, result)
 		})
@@ -44,14 +44,35 @@ func DeprecatedFeatureFlagWithoutDeprecatedFlags(t *testing.T) {
 			},
 		},
 	}
-	result := deprecatedFeatureFlags(context.Background(), nil, dk)
+	result := deprecatedFeatureFlags(t.Context(), nil, dk)
 
 	assert.Empty(t, result)
 }
 
 func DeprecatedFeatureFlagWithNoAnnotations(t *testing.T) {
 	dk := &dynakube.DynaKube{}
-	result := deprecatedFeatureFlags(context.Background(), nil, dk)
+	result := deprecatedFeatureFlags(t.Context(), nil, dk)
 
 	assert.Empty(t, result)
+}
+
+func DeprecatedFeatureFlagWithMultipleDeprecatedFlags(t *testing.T) {
+	annotations := map[string]string{}
+
+	for _, flag := range deprecatedFeatureFlagKeys {
+		annotations[flag] = "true"
+	}
+
+	dk := &dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Annotations: annotations,
+		},
+	}
+
+	result := deprecatedFeatureFlags(t.Context(), nil, dk)
+	assert.Len(t, result, len(deprecatedFeatureFlagKeys))
+	for _, flag := range deprecatedFeatureFlagKeys {
+		assert.Contains(t, result, fmt.Sprintf(warningFeatureFlagDeprecated, flag))
+	}
 }

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -74,6 +74,7 @@ var (
 		conflictingMaxUnavailableAnnotationWithRollingUpdate,
 		deprecatedAutoUpdate,
 		deprecatedOneAgentVersionField,
+		deprecatedFeatureFlag,
 		ignoredLogMonitoringTemplate,
 		conflictingAPIURLForExtensions,
 		noMappedHostPaths,
@@ -86,9 +87,6 @@ var (
 		otlpResourceAttributesExceedsLimit,
 		deprecatedPaasToken,
 	}
-	validatorWarningsMultiFuncs = []multiValidatorFunc{
-		deprecatedFeatureFlags,
-	}
 	updateValidatorErrorFuncs = []updateValidatorFunc{
 		IsMutatedAPIURL,
 	}
@@ -96,7 +94,6 @@ var (
 
 type validatorFunc func(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string
 type updateValidatorFunc func(ctx context.Context, dv *Validator, oldDk *dynakube.DynaKube, newDk *dynakube.DynaKube) string
-type multiValidatorFunc func(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) []string
 
 func New(apiReader client.Reader) admission.Validator[runtime.Object] {
 	return &Validator{
@@ -112,7 +109,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (war
 	}
 
 	errMessages := v.runValidators(ctx, validatorErrorFuncs, dk)
-	warnings = append(v.runValidators(ctx, validatorWarningFuncs, dk), v.runMultiValidators(ctx, validatorWarningsMultiFuncs, dk)...)
+	warnings = v.runValidators(ctx, validatorWarningFuncs, dk)
 
 	if len(errMessages) != 0 {
 		err = errors.New(validation.SumErrors(errMessages, "DynaKube"))
@@ -133,7 +130,7 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	}
 
 	errMessages := v.runValidators(ctx, validatorErrorFuncs, newDK)
-	warnings = append(v.runValidators(ctx, validatorWarningFuncs, newDK), v.runMultiValidators(ctx, validatorWarningsMultiFuncs, newDK)...)
+	warnings = v.runValidators(ctx, validatorWarningFuncs, newDK)
 
 	errMessages = append(errMessages, v.runUpdateValidators(ctx, updateValidatorErrorFuncs, oldDK, newDK)...)
 
@@ -191,14 +188,4 @@ func getDynakube(obj runtime.Object) (dk *dynakube.DynaKube, err error) {
 	}
 
 	return
-}
-
-func (v *Validator) runMultiValidators(ctx context.Context, validators []multiValidatorFunc, dk *dynakube.DynaKube) []string {
-	results := []string{} //nolint:prealloc // each multiValidator returns a variable-length []string, so the total size is unknown upfront
-
-	for _, validate := range validators {
-		results = append(results, validate(ctx, v, dk)...)
-	}
-
-	return results
 }

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -74,7 +74,6 @@ var (
 		conflictingMaxUnavailableAnnotationWithRollingUpdate,
 		deprecatedAutoUpdate,
 		deprecatedOneAgentVersionField,
-		deprecatedFeatureFlag,
 		ignoredLogMonitoringTemplate,
 		conflictingAPIURLForExtensions,
 		noMappedHostPaths,
@@ -87,6 +86,9 @@ var (
 		otlpResourceAttributesExceedsLimit,
 		deprecatedPaasToken,
 	}
+	validatorWarningsMultiFuncs = []multiValidatorFunc{
+		deprecatedFeatureFlags,
+	}
 	updateValidatorErrorFuncs = []updateValidatorFunc{
 		IsMutatedAPIURL,
 	}
@@ -94,6 +96,7 @@ var (
 
 type validatorFunc func(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string
 type updateValidatorFunc func(ctx context.Context, dv *Validator, oldDk *dynakube.DynaKube, newDk *dynakube.DynaKube) string
+type multiValidatorFunc func(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) []string
 
 func New(apiReader client.Reader) admission.Validator[runtime.Object] {
 	return &Validator{
@@ -109,7 +112,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (war
 	}
 
 	errMessages := v.runValidators(ctx, validatorErrorFuncs, dk)
-	warnings = v.runValidators(ctx, validatorWarningFuncs, dk)
+	warnings = append(v.runValidators(ctx, validatorWarningFuncs, dk), v.runMultiValidators(ctx, validatorWarningsMultiFuncs, dk)...)
 
 	if len(errMessages) != 0 {
 		err = errors.New(validation.SumErrors(errMessages, "DynaKube"))
@@ -130,7 +133,7 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	}
 
 	errMessages := v.runValidators(ctx, validatorErrorFuncs, newDK)
-	warnings = v.runValidators(ctx, validatorWarningFuncs, newDK)
+	warnings = append(v.runValidators(ctx, validatorWarningFuncs, newDK), v.runMultiValidators(ctx, validatorWarningsMultiFuncs, newDK)...)
 
 	errMessages = append(errMessages, v.runUpdateValidators(ctx, updateValidatorErrorFuncs, oldDK, newDK)...)
 
@@ -188,4 +191,14 @@ func getDynakube(obj runtime.Object) (dk *dynakube.DynaKube, err error) {
 	}
 
 	return
+}
+
+func (v *Validator) runMultiValidators(ctx context.Context, validators []multiValidatorFunc, dk *dynakube.DynaKube) []string {
+	results := []string{} //nolint:prealloc // each multiValidator returns a variable-length []string, so the total size is unknown upfront
+
+	for _, validate := range validators {
+		results = append(results, validate(ctx, v, dk)...)
+	}
+
+	return results
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-2313

If multiple deprecated feature-flags are detected, each one is listed in one sentence instead of one sentence per ff

#### Before:
```
Warning: Feature flag feature.dynatrace.com/oneagent-ignore-proxy is deprecated.Feature flag feature.dynatrace.com/activegate-updates is deprecated.
```

#### After:
```
Warning: Using deprecated feature flags: feature.dynatrace.com/oneagent-ignore-proxy, feature.dynatrace.com/activegate-updates`

```


<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

`make go/test`

`make build && make deploy` and apply a DynaKube with deprecated FFs

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->