### PR TITLE
Remove dynatrace.com/updated-via-operator annotation

### DIFF
--- a/pkg/controllers/dynakube/injection/reconciler_test.go
+++ b/pkg/controllers/dynakube/injection/reconciler_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	versions "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/version"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/bootstrapperconfig"
-	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/mapper"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/otlp/exporterconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
@@ -270,8 +269,6 @@ func TestRemoveAppInjection(t *testing.T) {
 	err = clt.Get(t.Context(), client.ObjectKey{Name: testNamespace, Namespace: ""}, &namespace)
 	require.NoError(t, err)
 	assert.Nil(t, namespace.Labels)
-	require.NotNil(t, namespace.Annotations)
-	assert.Equal(t, "true", namespace.Annotations[mapper.UpdatedViaDynakubeAnnotation])
 
 	err = clt.Get(t.Context(), client.ObjectKey{Name: testNamespace2, Namespace: ""}, &namespace)
 	require.NoError(t, err)

--- a/pkg/injection/namespace/mapper/config.go
+++ b/pkg/injection/namespace/mapper/config.go
@@ -5,11 +5,8 @@ import (
 )
 
 const (
-	UpdatedViaDynakubeAnnotation = "dynatrace.com/updated-via-operator"
-	ErrorConflictingNamespace    = "namespace matches two or more DynaKubes which is unsupported. " +
+	ErrorConflictingNamespace = "namespace matches two or more DynaKubes which is unsupported. " +
 		"refine the labels on your namespace metadata or DynaKube/CodeModules specification"
 )
 
-var (
-	log = logd.Get().WithName("namespace-mapper")
-)
+var log = logd.Get().WithName("namespace-mapper")

--- a/pkg/injection/namespace/mapper/dynakubes.go
+++ b/pkg/injection/namespace/mapper/dynakubes.go
@@ -2,6 +2,7 @@ package mapper
 
 import (
 	"context"
+	goerrors "errors"
 	"slices"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -51,8 +52,10 @@ func (dm *DynakubeMapper) MapFromDynakube() error {
 		return err
 	}
 
-	if err := dm.updateNamespaces(modifiedNs); err != nil {
-		return err
+	for _, ns := range modifiedNs {
+		if err := dm.client.Update(dm.ctx, ns); err != nil {
+			return err
+		}
 	}
 
 	oaActive := dm.dk.OneAgent().IsAppInjectionNeeded()
@@ -80,31 +83,16 @@ func (dm *DynakubeMapper) MatchingNamespaces() ([]*corev1.Namespace, error) {
 }
 
 func (dm *DynakubeMapper) UnmapFromDynaKube(namespaces []corev1.Namespace) error {
-	for i, ns := range namespaces {
+	for _, ns := range namespaces {
 		delete(ns.Labels, dtwebhook.InjectionInstanceLabel)
-		setUpdatedViaDynakubeAnnotation(&namespaces[i])
 
-		if err := dm.client.Update(dm.ctx, &namespaces[i]); err != nil {
-			return errors.WithMessagef(err, "failed to remove label %s from namespace %s", dtwebhook.InjectionInstanceLabel, ns.Name)
-		}
-
-		err := dm.secrets.DeleteForNamespace(dm.ctx, consts.BootstrapperInitSecretName, ns.Name)
-		if err != nil {
-			return err
-		}
-
-		err = dm.secrets.DeleteForNamespace(dm.ctx, consts.BootstrapperInitCertsSecretName, ns.Name)
-		if err != nil {
-			return err
-		}
-
-		err = dm.secrets.DeleteForNamespace(dm.ctx, consts.OTLPExporterSecretName, ns.Name)
-		if err != nil {
-			return err
-		}
-
-		err = dm.secrets.DeleteForNamespace(dm.ctx, consts.OTLPExporterCertsSecretName, ns.Name)
-		if err != nil {
+		if err := goerrors.Join(
+			errors.WithMessagef(dm.client.Update(dm.ctx, &ns), "failed to remove label %s from namespace %s", dtwebhook.InjectionInstanceLabel, ns.Name),
+			dm.secrets.DeleteForNamespace(dm.ctx, consts.BootstrapperInitSecretName, ns.Name),
+			dm.secrets.DeleteForNamespace(dm.ctx, consts.BootstrapperInitCertsSecretName, ns.Name),
+			dm.secrets.DeleteForNamespace(dm.ctx, consts.OTLPExporterSecretName, ns.Name),
+			dm.secrets.DeleteForNamespace(dm.ctx, consts.OTLPExporterCertsSecretName, ns.Name),
+		); err != nil {
 			return err
 		}
 	}
@@ -169,16 +157,4 @@ func (dm *DynakubeMapper) mapFromDynakube(nsList *corev1.NamespaceList, dkList *
 	slices.Sort(dm.matchedOTLPNamespaces)
 
 	return modifiedNs, nil
-}
-
-func (dm *DynakubeMapper) updateNamespaces(modifiedNs []*corev1.Namespace) error {
-	for _, ns := range modifiedNs {
-		setUpdatedViaDynakubeAnnotation(ns)
-
-		if err := dm.client.Update(dm.ctx, ns); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/pkg/injection/namespace/mapper/dynakubes.go
+++ b/pkg/injection/namespace/mapper/dynakubes.go
@@ -86,8 +86,11 @@ func (dm *DynakubeMapper) UnmapFromDynaKube(namespaces []corev1.Namespace) error
 	for _, ns := range namespaces {
 		delete(ns.Labels, dtwebhook.InjectionInstanceLabel)
 
+		if err := dm.client.Update(dm.ctx, &ns); err != nil {
+			return errors.WithMessagef(err, "failed to remove label %s from namespace %s", dtwebhook.InjectionInstanceLabel, ns.Name)
+		}
+
 		if err := goerrors.Join(
-			errors.WithMessagef(dm.client.Update(dm.ctx, &ns), "failed to remove label %s from namespace %s", dtwebhook.InjectionInstanceLabel, ns.Name),
 			dm.secrets.DeleteForNamespace(dm.ctx, consts.BootstrapperInitSecretName, ns.Name),
 			dm.secrets.DeleteForNamespace(dm.ctx, consts.BootstrapperInitCertsSecretName, ns.Name),
 			dm.secrets.DeleteForNamespace(dm.ctx, consts.OTLPExporterSecretName, ns.Name),

--- a/pkg/injection/namespace/mapper/dynakubes_test.go
+++ b/pkg/injection/namespace/mapper/dynakubes_test.go
@@ -34,7 +34,6 @@ func TestMapFromDynakube(t *testing.T) {
 		err = clt.Get(t.Context(), types.NamespacedName{Name: namespace.Name}, &ns)
 		require.NoError(t, err)
 		assert.Len(t, ns.Labels, 2)
-		assert.Len(t, ns.Annotations, 1)
 	})
 	t.Run("Overwrite stale entry in labels", func(t *testing.T) {
 		nsLabels := map[string]string{
@@ -53,7 +52,6 @@ func TestMapFromDynakube(t *testing.T) {
 		err = clt.Get(t.Context(), types.NamespacedName{Name: namespace.Name}, &ns)
 		require.NoError(t, err)
 		assert.Len(t, ns.Labels, 2)
-		assert.Len(t, ns.Annotations, 1)
 	})
 	t.Run("Remove stale dynakube entry for no longer matching ns", func(t *testing.T) {
 		movedDK := createDynakubeWithAppInject("moved-dk", convertToLabelSelector(labels))
@@ -72,7 +70,6 @@ func TestMapFromDynakube(t *testing.T) {
 		err = clt.Get(t.Context(), types.NamespacedName{Name: namespace.Name}, &ns)
 		require.NoError(t, err)
 		assert.Empty(t, ns.Labels)
-		assert.Len(t, ns.Annotations, 1)
 	})
 	t.Run("Throw error in case of conflicting Dynakubes", func(t *testing.T) {
 		conflictingDK := createDynakubeWithAppInject("conflicting-dk", convertToLabelSelector(labels))
@@ -102,7 +99,6 @@ func TestMapFromDynakube(t *testing.T) {
 		err = clt.Get(t.Context(), types.NamespacedName{Name: namespace.Name}, &ns)
 		require.NoError(t, err)
 		assert.Empty(t, ns.Labels)
-		assert.Empty(t, ns.Annotations)
 	})
 
 	t.Run("Ignore openshift namespaces", func(t *testing.T) {
@@ -119,7 +115,6 @@ func TestMapFromDynakube(t *testing.T) {
 		err = clt.Get(t.Context(), types.NamespacedName{Name: namespace.Name}, &ns)
 		require.NoError(t, err)
 		assert.Empty(t, ns.Labels)
-		assert.Empty(t, ns.Annotations)
 	})
 	t.Run("ComponentFeature flag for monitoring system namespaces", func(t *testing.T) {
 		dk := createDynakubeWithAppInject("appMonitoring", metav1.LabelSelector{})
@@ -138,7 +133,6 @@ func TestMapFromDynakube(t *testing.T) {
 		err = clt.Get(t.Context(), types.NamespacedName{Name: namespace.Name}, &ns)
 		require.NoError(t, err)
 		assert.Len(t, ns.Labels, 1)
-		assert.Len(t, ns.Annotations, 1)
 	})
 }
 
@@ -179,11 +173,9 @@ func TestUnmapFromDynaKube(t *testing.T) {
 		err = clt.Get(t.Context(), types.NamespacedName{Name: namespace.Name}, &ns)
 		require.NoError(t, err)
 		assert.Empty(t, ns.Labels)
-		assert.Len(t, ns.Annotations, 1)
 		err = clt.Get(t.Context(), types.NamespacedName{Name: namespace2.Name}, &ns)
 		require.NoError(t, err)
 		assert.Empty(t, ns.Labels)
-		assert.Len(t, ns.Annotations, 1)
 	})
 	t.Run("Remove "+consts.BootstrapperInitSecretName+", "+consts.BootstrapperInitCertsSecretName+" and "+consts.OTLPExporterSecretName+" secrets"+" and "+consts.OTLPExporterCertsSecretName+" secrets", func(t *testing.T) {
 		clt := fake.NewClient(namespace, namespace2)

--- a/pkg/injection/namespace/mapper/mapper.go
+++ b/pkg/injection/namespace/mapper/mapper.go
@@ -68,14 +68,6 @@ func addNamespaceInjectLabel(dkName string, ns *corev1.Namespace) {
 	ns.Labels[dtwebhook.InjectionInstanceLabel] = dkName
 }
 
-func setUpdatedViaDynakubeAnnotation(ns *corev1.Namespace) {
-	if ns.Annotations == nil {
-		ns.Annotations = make(map[string]string)
-	}
-
-	ns.Annotations[UpdatedViaDynakubeAnnotation] = "true"
-}
-
 func match(dk *dynakube.DynaKube, namespace *corev1.Namespace) (matchResult, error) {
 	var result matchResult
 

--- a/pkg/webhook/mutation/namespace/webhook.go
+++ b/pkg/webhook/mutation/namespace/webhook.go
@@ -3,6 +3,7 @@ package namespace
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
@@ -26,9 +27,10 @@ func AddWebhookToManager(manager ctrl.Manager, namespace string) error {
 
 // webhook adds the necessary label to namespaces that match a dynakubes namespace selector
 type webhook struct {
-	client    client.Client
-	apiReader client.Reader
-	namespace string
+	client         client.Client
+	apiReader      client.Reader
+	namespace      string
+	serviceAccount string
 }
 
 // Handle does the mapping between the namespace and dynakube from the namespace's side.
@@ -39,24 +41,23 @@ type webhook struct {
 //     but from the dynakube's side (during dynakube reconcile) and we don't want to repeat ourselves. So we just remove the annotation.
 func (wh *webhook) Handle(ctx context.Context, request admission.Request) admission.Response {
 	if wh.namespace == request.Namespace {
-		return admission.Patched("")
+		return admission.Allowed("")
 	}
 
-	log.Info("namespace request", "namespace", request.Name, "operation", request.Operation)
+	logger := log.WithValues("namespace", request.Name, "operator", request.Operation)
+
+	if request.UserInfo.Username == wh.serviceAccount {
+		logger.Info("ignoring change from operator", "serviceAccount", wh.serviceAccount)
+
+		return admission.Allowed("")
+	}
+
+	log.Info("namespace request")
 
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: request.Namespace}}
 	if err := decodeRequestToNamespace(request, &ns); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-
-	if _, ok := ns.Annotations[mapper.UpdatedViaDynakubeAnnotation]; ok {
-		log.Info("checking namespace labels not necessary", "namespace", request.Name)
-		delete(ns.Annotations, mapper.UpdatedViaDynakubeAnnotation)
-
-		return getResponseForNamespace(&ns, &request)
-	}
-
-	log.Info("checking namespace labels", "namespace", request.Name)
 
 	nsMapper := mapper.NewNamespaceMapper(wh.client, wh.apiReader, wh.namespace, &ns)
 
@@ -66,10 +67,10 @@ func (wh *webhook) Handle(ctx context.Context, request admission.Request) admiss
 	}
 
 	if !updatedNamespace {
-		return admission.Patched("")
+		return admission.Allowed("")
 	}
 
-	log.Info("namespace", "labels", ns.Labels)
+	log.Info("updated labels", "labels", ns.Labels)
 
 	return getResponseForNamespace(&ns, &request)
 }
@@ -87,9 +88,10 @@ func decodeRequestToNamespace(request admission.Request, namespace *corev1.Names
 
 func newNamespaceMutator(client client.Client, apiReader client.Reader, namespace string) admission.Handler {
 	return &webhook{
-		apiReader: apiReader,
-		namespace: namespace,
-		client:    client,
+		apiReader:      apiReader,
+		client:         client,
+		namespace:      namespace,
+		serviceAccount: fmt.Sprintf("system:serviceaccount:%s:dynatrace-operator", namespace),
 	}
 }
 

--- a/pkg/webhook/mutation/namespace/webhook.go
+++ b/pkg/webhook/mutation/namespace/webhook.go
@@ -33,18 +33,18 @@ type webhook struct {
 	serviceAccount string
 }
 
-// Handle does the mapping between the namespace and dynakube from the namespace's side.
+// Handle does the mapping between the namespace and DynaKube from the namespace's side.
 // There are 2 special cases:
 //  1. ignore the webhook's namespace: this is necessary because if we want to monitor the whole cluster
 //     we would tag our own namespace which would cause the podInjector webhook to inject into our pods which can cause issues. (infra-monitoring pod injected into == bad)
-//  2. if the namespace was updated by the operator => don't do the mapping: we detect this using an annotation, we do this because the operator also does the mapping
-//     but from the dynakube's side (during dynakube reconcile) and we don't want to repeat ourselves. So we just remove the annotation.
+//  2. if the namespace was updated by the operator => don't do the mapping: we do this because the operator also does the mapping
+//     but from the DynaKube's side (during DynaKube reconcile) and we don't want to repeat ourselves
 func (wh *webhook) Handle(ctx context.Context, request admission.Request) admission.Response {
 	if wh.namespace == request.Namespace {
 		return admission.Allowed("")
 	}
 
-	logger := log.WithValues("namespace", request.Name, "operator", request.Operation)
+	logger := log.WithValues("namespace", request.Name, "operation", request.Operation)
 
 	if request.UserInfo.Username == wh.serviceAccount {
 		logger.Info("ignoring change from operator", "serviceAccount", wh.serviceAccount)

--- a/pkg/webhook/mutation/namespace/webhook_test.go
+++ b/pkg/webhook/mutation/namespace/webhook_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,11 +46,7 @@ func TestInjection(t *testing.T) {
 		},
 	}
 	clt := fake.NewClient(dk)
-	inj := &webhook{
-		client:    clt,
-		apiReader: clt,
-		namespace: "dynatrace",
-	}
+	inj := newNamespaceMutator(clt, clt, "dynatrace").(*webhook)
 
 	t.Run("Don't inject into operator ns", func(t *testing.T) {
 		baseNs := &corev1.Namespace{
@@ -214,5 +211,27 @@ func TestInjection(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, dk.Name, dkName)
 		assert.Len(t, updNs.Labels, 2)
+	})
+
+	t.Run("skip operator", func(t *testing.T) {
+		baseNsBytes, err := json.Marshal(&baseNs)
+		require.NoError(t, err)
+
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Object:    runtime.RawExtension{Raw: baseNsBytes},
+				Name:      baseNs.Name,
+				Namespace: baseNs.Name,
+				Operation: admissionv1.Create,
+				UserInfo: authenticationv1.UserInfo{
+					Username: inj.serviceAccount,
+				},
+			},
+		}
+
+		resp := inj.Handle(context.Background(), req)
+		require.NoError(t, resp.Complete(req))
+		assert.True(t, resp.Allowed)
+		assert.Empty(t, resp.Patch)
 	})
 }


### PR DESCRIPTION
## Description

The operator sets the `dynatrace.com/updated-via-operator` on namespaces to prevent the webhook from doing duplicate work when it marks a namespace as monitored.
The webhook looks for this annotation and deletes it via admission patch response.
This round trip can be replaced by inspecting the user info from the admission request. No additional handling on the operator side needed and in the webhook it's also clearer why the request is skipped.

Also refactored UnmapFromDynaKube to not fail early in case of an error. This aligns with the rest of our injection cleanup.

ICP-4253

## How can this be tested?

* Deploy operator
* Create a sample app: `kubectl create deploy nginx --image nginx`
* Create DynaKube

```yaml
apiVersion: dynatrace.com/v1beta6
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  oneAgent:
    applicationMonitoring:
      namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: default
```
* Check that bootstrapper secret is created
* Delete DynaKube
* Check that bootstrapper secret is deleted
* Webhook logs should contain 2 entries of "ignoring change from operator"
