### PR TITLE
Add platform token handling for dtpullsecret

### DIFF
--- a/pkg/controllers/dynakube/dtpullsecret/generate.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/pkg/errors"
 )
 
@@ -46,7 +47,7 @@ func (r *Reconciler) generateData(dk *dynakube.DynaKube, tokens token.Tokens) (m
 	}
 
 	switch {
-	case tokens.PaasToken().Value != "":
+	case tokens.PaasToken().Value != "" && !dttoken.IsPlatform(tokens.APIToken().Value):
 		registryToken = tokens.PaasToken().Value
 	case tokens.APIToken().Value != "":
 		registryToken = tokens.APIToken().Value

--- a/pkg/controllers/dynakube/dtpullsecret/generate_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate_test.go
@@ -48,29 +48,58 @@ func TestReconciler_GenerateData(t *testing.T) {
 	}
 	r := &Reconciler{}
 
-	data, err := r.generateData(dk, token.Tokens{
-		token.PaaSKey: &token.Token{Value: testPaasToken},
-	})
-
-	require.NoError(t, err)
-	assert.NotNil(t, data)
-	assert.NotEmpty(t, data)
-
-	auth := fmt.Sprintf("%s:%s", testTenant, testPaasToken)
-	expected := dockerConfig{
-		Auths: map[string]dockerAuthentication{
-			testAPIURLHost: {
-				Username: testTenant,
-				Password: testPaasToken,
-				Auth:     b64.StdEncoding.EncodeToString([]byte(auth)),
+	tests := []struct {
+		name        string
+		tokens      token.Tokens
+		expectToken string
+	}{
+		{
+			"use paas token",
+			token.Tokens{
+				token.PaaSKey: &token.Token{Value: testPaasToken},
 			},
+			testPaasToken,
+		},
+		{
+			"use api token",
+			token.Tokens{
+				token.APIKey: &token.Token{Value: testAPIToken},
+			},
+			testAPIToken,
+		},
+		{
+			"prefer platform token",
+			token.Tokens{
+				token.PaaSKey: &token.Token{Value: testPaasToken},
+				token.APIKey:  &token.Token{Value: testPlatformToken},
+			},
+			testPlatformToken,
 		},
 	}
 
-	var actual dockerConfig
-	err = json.Unmarshal(data[DockerConfigJSON], &actual)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := r.generateData(dk, test.tokens)
 
-	require.NoError(t, err)
-	assert.NotNil(t, actual)
-	assert.Equal(t, expected, actual)
+			require.NoError(t, err)
+			assert.NotEmpty(t, data)
+
+			auth := fmt.Sprintf("%s:%s", testTenant, test.expectToken)
+			expected := dockerConfig{
+				Auths: map[string]dockerAuthentication{
+					testAPIURLHost: {
+						Username: testTenant,
+						Password: test.expectToken,
+						Auth:     b64.StdEncoding.EncodeToString([]byte(auth)),
+					},
+				},
+			}
+
+			var actual dockerConfig
+			err = json.Unmarshal(data[DockerConfigJSON], &actual)
+
+			require.NoError(t, err)
+			assert.Equal(t, expected, actual)
+		})
+	}
 }

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -21,10 +22,12 @@ import (
 )
 
 const (
-	testPaasToken = "test-paas-token"
-	testName      = "test-name"
-	testNamespace = "test-namespace"
-	testValue     = "test-value"
+	testPaasToken     = "test-paas-token"
+	testAPIToken      = "test-api-token"
+	testPlatformToken = dttoken.PlatformPrefix + "test-platform-token"
+	testName          = "test-name"
+	testNamespace     = "test-namespace"
+	testValue         = "test-value"
 )
 
 func TestReconciler_Reconcile(t *testing.T) {
@@ -108,7 +111,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			Spec: dynakube.DynaKubeSpec{
 				CustomPullSecret: testValue,
-			}}
+			},
+		}
 		r := NewReconciler(nil, nil)
 		err := r.Reconcile(t.Context(), dk, nil)
 


### PR DESCRIPTION
## Description

Follow-up of #6499

The dtpullsecret reconciler should use the apiToken if it contains a platform token.

ICP-3228

## How can this be tested?

Run unit tests.
Deploy DynaKube that uses tenant registry and change fields in the token secret.
