### PR TITLE
Adapt to fixed eTag handling on server side.

### DIFF
--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 )
@@ -51,5 +50,5 @@ func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClu
 		return "", err
 	}
 
-	return strings.ReplaceAll(headers.Get(responseHeaderEtag), "\"", ""), nil
+	return headers.Get(responseHeaderEtag), nil
 }

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
@@ -14,11 +14,10 @@ import (
 )
 
 const (
-	testCBORData        = "\x81\x01" // minimal CBOR: array of one integer
-	testETag            = `"abc123"`
-	testResponseETag    = "def456"
-	testResponseETagRaw = `"` + testResponseETag + `"`
-	testClusterID       = "my-cluster"
+	testCBORData     = "\x81\x01" // minimal CBOR: array of one integer
+	testETag         = `"abc123"`
+	testResponseETag = `"def456"`
+	testClusterID    = "my-cluster"
 )
 
 // setupMockedProcessGroupingClient builds a client backed by a mock core.Client.
@@ -70,7 +69,7 @@ func setupMockedProcessGroupingClient(
 func TestGetProcessGroupingConfig(t *testing.T) {
 	t.Run("success_200_with_etag", func(t *testing.T) {
 		var buf bytes.Buffer
-		respHeaders := http.Header{"Etag": []string{testResponseETagRaw}}
+		respHeaders := http.Header{"Etag": []string{testResponseETag}}
 
 		client := setupMockedProcessGroupingClient(t,
 			map[string]string{},
@@ -90,7 +89,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 
 	t.Run("success_200_without_etag", func(t *testing.T) {
 		var buf bytes.Buffer
-		respHeaders := http.Header{"Etag": []string{testResponseETagRaw}}
+		respHeaders := http.Header{"Etag": []string{testResponseETag}}
 
 		client := setupMockedProcessGroupingClient(t,
 			map[string]string{},
@@ -128,7 +127,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 
 	t.Run("with_kubernetes_cluster_id", func(t *testing.T) {
 		var buf bytes.Buffer
-		respHeaders := http.Header{"Etag": []string{testResponseETagRaw}}
+		respHeaders := http.Header{"Etag": []string{testResponseETag}}
 
 		client := setupMockedProcessGroupingClient(t,
 			map[string]string{"kubernetesClusterId": testClusterID},
@@ -145,7 +144,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 
 	t.Run("without_kubernetes_cluster_id", func(t *testing.T) {
 		var buf bytes.Buffer
-		respHeaders := http.Header{"Etag": []string{testResponseETagRaw}}
+		respHeaders := http.Header{"Etag": []string{testResponseETag}}
 
 		client := setupMockedProcessGroupingClient(t,
 			map[string]string{},

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
@@ -161,7 +161,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 
 	t.Run("server_error", func(t *testing.T) {
 		var buf bytes.Buffer
-		serverErr := &core.HTTPError{StatusCode: 500, Message: "internal server error"}
+		serverErr := &core.HTTPError{StatusCode: http.StatusInternalServerError, Message: "internal server error"}
 
 		client := setupMockedProcessGroupingClient(t,
 			map[string]string{},
@@ -173,7 +173,27 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 
 		returnedETag, err := client.GetProcessGroupingConfig(t.Context(), "", "", &buf)
 		require.Error(t, err)
-		require.False(t, core.HasStatusCode(err, http.StatusNotModified))
+		require.True(t, core.HasStatusCode(err, http.StatusInternalServerError))
+		assert.Empty(t, returnedETag)
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("bad_request", func(t *testing.T) {
+		const badETag = "bad_etag"
+		var buf bytes.Buffer
+		serverErr := &core.HTTPError{StatusCode: http.StatusBadRequest, Message: "bad request"}
+
+		client := setupMockedProcessGroupingClient(t,
+			map[string]string{},
+			map[string]string{"If-None-Match": badETag},
+			nil,
+			nil,
+			serverErr,
+		)
+
+		returnedETag, err := client.GetProcessGroupingConfig(t.Context(), "", badETag, &buf)
+		require.Error(t, err)
+		require.True(t, core.HasStatusCode(err, http.StatusBadRequest))
 		assert.Empty(t, returnedETag)
 		assert.Empty(t, buf.String())
 	})


### PR DESCRIPTION
## Description

Server-side eTag handling is now done according to RFC spec. We need to adapt the handling on our end.

[JIRA](https://dt-rnd.atlassian.net/browse/ICP-1849)
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-4081)

## How can this be tested?

```
export DT_API_URL='https://<tenant>.dev.dynatracelabs.com/api'
export DT_API_TOKEN='dt0c01.....'
export DT_CLUSTER_ID="${1:-}"

go test -v -run TestGetProcessGroupingConfig_Integration ./pkg/clients/dynatrace/oneagent/
```
