### PR TITLE
Decouple update-csv-bundles workflow from release workflow

### DIFF
--- a/.github/actions/update-csv-bundles/action.yml
+++ b/.github/actions/update-csv-bundles/action.yml
@@ -11,6 +11,10 @@ inputs:
   changelog-path:
     description: "Path to the changelog file"
     required: true
+  dry-run:
+    description: "Generate bundles without creating a PR (uploads artifact instead)"
+    required: false
+    default: "false"
   app-id:
     description: "GitHub App ID for creating release PR"
     required: true
@@ -103,12 +107,14 @@ runs:
       run: |
         make bundle
     - name: Create GitHub app token
+      if: ${{ inputs.dry-run != 'true' }}
       uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: create-github-app-token
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}
     - name: Create CSV update PR
+      if: ${{ inputs.dry-run != 'true' }}
       uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
       with:
         base: release-${{ steps.vars.outputs.major_minor }}
@@ -126,3 +132,15 @@ runs:
         title: "[Automatic] Update OLM CSV bundles for v${{ inputs.version }}"
         body: |
             This PR updates the OLM bundles/CSVs on `release-${{ steps.vars.outputs.major_minor }}` for version `v${{ inputs.version }}`.
+    - name: Upload generated bundles as artifact
+      if: ${{ inputs.dry-run == 'true' }}
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: csv-bundles-${{ inputs.version }}
+        path: |
+          config/olm/
+          config/deploy/kubernetes/kustomization.yaml
+          config/deploy/openshift/kustomization.yaml
+          config/manifests/bases/
+          config/helm/
+        if-no-files-found: error

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -319,12 +319,6 @@ jobs:
           prerelease: false
           draft: true
           fail_on_unmatched_files: true
-      - name: Upload Changelog as artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: changelog
-          path: CHANGELOG.md
-          if-no-files-found: warn
       - name: Update index helm file
         if: ${{ !contains(github.ref, '-rc.') }}
         env:
@@ -359,27 +353,3 @@ jobs:
             ## Checklist
             - [x] PR is labeled accordingly
 
-  update-csv-bundles:
-    name: Update Operatorhub Bundles
-    needs: [release, prepare, build-push]
-    runs-on: ubuntu-24.04
-    if: ${{ !contains(github.ref, '-rc.') }}
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-          persist-credentials: false
-    - name: Download changelog
-      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-      with:
-        name: changelog
-        path: changelog_artifact
-    - uses: ./.github/actions/update-csv-bundles
-      with:
-        digest: ${{ needs.build-push.outputs.digest }}
-        version: ${{ needs.prepare.outputs.version_without_prefix }}
-        changelog-path: ./changelog_artifact/CHANGELOG.md
-        app-id: ${{ secrets.RELEASE_APP_ID }}
-        private-key: ${{ secrets.RELEASE_APP_KEY }}

--- a/.github/workflows/update-csv-bundles.yaml
+++ b/.github/workflows/update-csv-bundles.yaml
@@ -49,6 +49,7 @@ jobs:
           echo "dry-run=${DRY_RUN}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ steps.vars.outputs.tag }}
           persist-credentials: false
       - name: Fetch image digest
         id: digest

--- a/.github/workflows/update-csv-bundles.yaml
+++ b/.github/workflows/update-csv-bundles.yaml
@@ -50,6 +50,10 @@ jobs:
           DIGEST=$(docker buildx imagetools inspect \
             "public.ecr.aws/dynatrace/dynatrace-operator:${TAG}" \
             --format '{{.Manifest.Digest}}')
+          if [ -z "$DIGEST" ]; then
+            echo "Failed to fetch digest for ${TAG} — image may not exist on public.ecr.aws"
+            exit 1
+          fi
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
       - name: Generate release notes
         env:

--- a/.github/workflows/update-csv-bundles.yaml
+++ b/.github/workflows/update-csv-bundles.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   update-csv-bundles:
     name: Update Operatorhub Bundles
+    environment: Release
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     permissions:
@@ -21,11 +22,19 @@ jobs:
     steps:
       - name: Resolve tag and version
         id: vars
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_INPUT_TAG: ${{ inputs.tag }}
+          GH_RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ "$GH_EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$GH_INPUT_TAG"
           else
-            TAG="${{ github.event.release.tag_name }}"
+            TAG="$GH_RELEASE_TAG"
+          fi
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
+            echo "Invalid tag format: $TAG"
+            exit 1
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-csv-bundles.yaml
+++ b/.github/workflows/update-csv-bundles.yaml
@@ -50,10 +50,6 @@ jobs:
           DIGEST=$(docker buildx imagetools inspect \
             "public.ecr.aws/dynatrace/dynatrace-operator:${TAG}" \
             --format '{{.Manifest.Digest}}')
-          if [ -z "$DIGEST" ]; then
-            echo "Failed to fetch digest for ${TAG} — image may not exist on public.ecr.aws"
-            exit 1
-          fi
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
       - name: Generate release notes
         env:

--- a/.github/workflows/update-csv-bundles.yaml
+++ b/.github/workflows/update-csv-bundles.yaml
@@ -1,0 +1,56 @@
+name: Update CSV Bundles
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v1.2.3)"
+        required: true
+        type: string
+
+jobs:
+  update-csv-bundles:
+    name: Update Operatorhub Bundles
+    runs-on: ubuntu-24.04
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Resolve tag and version
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.vars.outputs.tag }}
+          persist-credentials: false
+      - name: Fetch image digest
+        id: digest
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
+        run: |
+          DIGEST=$(docker buildx imagetools inspect \
+            "public.ecr.aws/dynatrace/dynatrace-operator:${TAG}" \
+            --format '{{.Manifest.Digest}}')
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+      - name: Generate release notes
+        env:
+          GITHUB_REF_NAME: ${{ steps.vars.outputs.tag }}
+        run: |
+          hack/build/ci/generate-release-notes.sh
+      - uses: ./.github/actions/update-csv-bundles
+        with:
+          digest: ${{ steps.digest.outputs.digest }}
+          version: ${{ steps.vars.outputs.version }}
+          changelog-path: ./CHANGELOG.md
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}

--- a/.github/workflows/update-csv-bundles.yaml
+++ b/.github/workflows/update-csv-bundles.yaml
@@ -9,28 +9,36 @@ on:
         description: "Release tag (e.g. v1.2.3)"
         required: true
         type: string
+      dry-run:
+        description: "Generate bundles without creating a PR (outputs an artifact instead)"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   update-csv-bundles:
     name: Update Operatorhub Bundles
     environment: Release
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: Resolve tag and version
+      - name: Resolve tag, version and dry-run mode
         id: vars
         env:
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_INPUT_TAG: ${{ inputs.tag }}
           GH_RELEASE_TAG: ${{ github.event.release.tag_name }}
+          GH_IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          GH_INPUT_DRY_RUN: ${{ inputs.dry-run }}
         run: |
           if [ "$GH_EVENT_NAME" = "workflow_dispatch" ]; then
             TAG="$GH_INPUT_TAG"
+            DRY_RUN="$GH_INPUT_DRY_RUN"
           else
             TAG="$GH_RELEASE_TAG"
+            DRY_RUN="$GH_IS_PRERELEASE"
           fi
           if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
             echo "Invalid tag format: $TAG"
@@ -38,6 +46,7 @@ jobs:
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "dry-run=${DRY_RUN}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.vars.outputs.tag }}
@@ -61,5 +70,6 @@ jobs:
           digest: ${{ steps.digest.outputs.digest }}
           version: ${{ steps.vars.outputs.version }}
           changelog-path: ./CHANGELOG.md
+          dry-run: ${{ steps.vars.outputs.dry-run }}
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_KEY }}

--- a/.github/workflows/update-csv-bundles.yaml
+++ b/.github/workflows/update-csv-bundles.yaml
@@ -49,7 +49,6 @@ jobs:
           echo "dry-run=${DRY_RUN}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ steps.vars.outputs.tag }}
           persist-credentials: false
       - name: Fetch image digest
         id: digest


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-3777](https://dt-rnd.atlassian.net/browse/ICP-3777)

Previously the `update-csv-bundles` workflow was triggered by pushing a tag -> in other words triggering the whole release. The workflow was then dependent by all prior steps, which made it close to impossible to re run the step if something failed. And in reality the step has nothing to do with the release workflow.

With this it now listens to:

- the release being published
- workflow dispatch with tag as input parameter (for re runs should it fail)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[ICP-3777]: https://dt-rnd.atlassian.net/browse/ICP-3777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ