### PR TITLE
Fix `triggerDaemonSetReconcile`

### DIFF
--- a/test/e2e/features/logmonitoring/logmonitoring.go
+++ b/test/e2e/features/logmonitoring/logmonitoring.go
@@ -173,8 +173,10 @@ func triggerDaemonSetReconcile(dk dynakube.DynaKube) features.Func {
 		// Force reconciliation by simulating the passage of time
 		expireLastTransitionTime(&dk, "MonitoredEntity")
 		expireLastTransitionTime(&dk, logmonsettings.ConditionType)
-		dk.Spec.DynatraceAPIRequestThreshold = ptr.To(uint16(0))
 		require.NoError(t, resources.UpdateStatus(ctx, &dk))
+
+		dk.Spec.DynatraceAPIRequestThreshold = ptr.To(uint16(0))
+		require.NoError(t, resources.Update(ctx, &dk))
 
 		// Verify that the operator picked up the update
 		err = wait.For(func(ctx context.Context) (bool, error) {

--- a/test/e2e/features/logmonitoring/logmonitoring.go
+++ b/test/e2e/features/logmonitoring/logmonitoring.go
@@ -171,9 +171,9 @@ func triggerDaemonSetReconcile(dk dynakube.DynaKube) features.Func {
 
 		require.NoError(t, resources.Get(ctx, dk.Name, dk.Namespace, &dk))
 		// Force reconciliation by simulating the passage of time
-		dk.Spec.DynatraceAPIRequestThreshold = ptr.To(uint16(0))
 		expireLastTransitionTime(&dk, "MonitoredEntity")
 		expireLastTransitionTime(&dk, logmonsettings.ConditionType)
+		dk.Spec.DynatraceAPIRequestThreshold = ptr.To(uint16(0))
 		require.NoError(t, resources.UpdateStatus(ctx, &dk))
 
 		// Verify that the operator picked up the update


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-4242

@aorcholski found this, and I stole it 🥷 

The issue: `expireLastTransitionTime` uses `DynatraceAPIRequestThreshold`, and setting it to nothing, will make them do nothing
```
dk.Spec.DynatraceAPIRequestThreshold = ptr.To(uint16(0))     <--- first idea should be put AFTER expireLastTransitionTime() calls
expireLastTransitionTime(&dk, "MonitoredEntity")             <--- because now: -2 * dk.APIRequestThreshold() = ZERO
expireLastTransitionTime(&dk, logmonsettings.ConditionType)
```

➕  setting `dk.Spec.DynatraceAPIRequestThreshold` is useless unless you actually update the dk

## How can this be tested?

`make test/e2e/logmonitoring/optionalscopes` should pass