### PR TITLE
fix: remove EdgeConnect finalizer only after tenant cleanup succeeds

### DIFF
--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -151,13 +151,6 @@ func (controller *Controller) reconcileEdgeConnectDeletion(ctx context.Context, 
 		return err
 	}
 
-	ec.Finalizers = nil
-	if err := controller.client.Update(ctx, ec); err != nil {
-		log.Debug("updating the EdgeConnect object failed, couldn't remove the finalizers")
-
-		return errors.WithStack(err)
-	}
-
 	edgeConnectClient, err := controller.buildEdgeConnectClient(ctx, ec)
 	if err != nil {
 		log.Debug("building EdgeConnect client failed")
@@ -171,6 +164,24 @@ func (controller *Controller) reconcileEdgeConnectDeletion(ctx context.Context, 
 
 		return err
 	}
+
+	if err := controller.cleanupTenantEdgeConnect(ctx, edgeConnectClient, ec, tenantEdgeConnect, edgeConnectIDFromSecret); err != nil {
+		return err
+	}
+
+	if controllerutil.RemoveFinalizer(ec, finalizerName) {
+		if err := controller.client.Update(ctx, ec); err != nil {
+			log.Debug("updating the EdgeConnect object failed, couldn't remove the finalizers")
+
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
+func (controller *Controller) cleanupTenantEdgeConnect(ctx context.Context, edgeConnectClient edgeconnectClient.Client, ec *edgeconnect.EdgeConnect, tenantEdgeConnect edgeconnectClient.APIResponse, edgeConnectIDFromSecret string) error {
+	log := logd.FromContext(ctx)
 
 	switch {
 	case tenantEdgeConnect.ID == "":
@@ -190,8 +201,7 @@ func (controller *Controller) reconcileEdgeConnectDeletion(ctx context.Context, 
 	}
 
 	if ec.IsK8SAutomationEnabled() && ec.IsProvisionerModeEnabled() {
-		err = controller.deleteConnectionSetting(ctx, edgeConnectClient, ec)
-		if err != nil {
+		if err := controller.deleteConnectionSetting(ctx, edgeConnectClient, ec); err != nil {
 			log.Info("reconcile deletion: Deleting connection setting failed")
 
 			return err

--- a/pkg/controllers/edgeconnect/controller_test.go
+++ b/pkg/controllers/edgeconnect/controller_test.go
@@ -510,6 +510,56 @@ func TestReconcileProvisionerDelete(t *testing.T) {
 
 		edgeConnectClient.AssertNotCalled(t, "DeleteEdgeConnect", mock.Anything, testCreatedID)
 	})
+
+	t.Run("finalizer is kept when tenant cleanup fails", func(t *testing.T) {
+		ec := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
+
+		edgeConnectClient := edgeconnectmock.NewClient(t)
+
+		controller := createFakeClientAndReconcilerForProvisioner(
+			t,
+			ec,
+			mockNewEdgeConnectClientDeleteFails(edgeConnectClient),
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
+			createClientSecret(ec.ClientSecretName(), ec.Namespace),
+			createKubeSystemNamespace(),
+		)
+
+		_, err := controller.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+		})
+		require.Error(t, err)
+
+		edgeConnectCR, err := getEdgeConnectCR(controller.apiReader, ec.Name, ec.Namespace)
+		require.NoError(t, err)
+		require.Contains(t, edgeConnectCR.Finalizers, finalizerName)
+
+		edgeConnectClient.AssertCalled(t, "DeleteEdgeConnect", mock.Anything, testCreatedID)
+	})
+
+	t.Run("finalizer is kept when buildEdgeConnectClient fails", func(t *testing.T) {
+		ec := createEdgeConnectProvisionerCR([]string{finalizerName}, &metav1.Time{Time: time.Now()}, testHostPatterns)
+
+		controller := createFakeClientAndReconcilerForProvisioner(
+			t,
+			ec,
+			func(context.Context, *edgeconnect.EdgeConnect, oauthCredentialsType, []byte) (edgeconnectClient.Client, error) {
+				return nil, errors.New("oauth secret rotated")
+			},
+			createOauthSecret(ec.Spec.OAuth.ClientSecret, ec.Namespace),
+			createClientSecret(ec.ClientSecretName(), ec.Namespace),
+			createKubeSystemNamespace(),
+		)
+
+		_, err := controller.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+		})
+		require.Error(t, err)
+
+		edgeConnectCR, err := getEdgeConnectCR(controller.apiReader, ec.Name, ec.Namespace)
+		require.NoError(t, err)
+		require.Contains(t, edgeConnectCR.Finalizers, finalizerName)
+	})
 }
 
 func TestReconcileProvisionerUpdate(t *testing.T) {
@@ -952,6 +1002,28 @@ func mockNewEdgeConnectClientDelete(edgeConnectClient *edgeconnectmock.Client) f
 			nil,
 		)
 		edgeConnectClient.On("DeleteEdgeConnect", mock.Anything, testCreatedID).Return(nil)
+
+		return edgeConnectClient, nil
+	}
+}
+
+func mockNewEdgeConnectClientDeleteFails(edgeConnectClient *edgeconnectmock.Client) func(context.Context, *edgeconnect.EdgeConnect, oauthCredentialsType, []byte) (edgeconnectClient.Client, error) {
+	return func(ctx context.Context, ec *edgeconnect.EdgeConnect, oauthCredentials oauthCredentialsType, _ []byte) (edgeconnectClient.Client, error) {
+		edgeConnectClient.On("ListEdgeConnects", mock.Anything, testName).Return(
+			[]edgeconnectClient.APIResponse{
+				{
+					ID:                         testCreatedID,
+					Name:                       testName,
+					HostPatterns:               testHostPatterns,
+					OauthClientID:              testOauthClientID,
+					ManagedByDynatraceOperator: true,
+				},
+			},
+			nil,
+		)
+		edgeConnectClient.On("ListEnvironmentSettings", mock.Anything).Return([]edgeconnectClient.EnvironmentSetting{testEnvironmentSetting}, nil)
+		edgeConnectClient.On("DeleteEnvironmentSetting", mock.Anything, mock.Anything).Return(nil)
+		edgeConnectClient.On("DeleteEdgeConnect", mock.Anything, testCreatedID).Return(errors.New("tenant unreachable"))
 
 		return edgeConnectClient, nil
 	}


### PR DESCRIPTION
## description

`reconcileEdgeConnectDeletion` clears the finalizer and persists it BEFORE running tenant cleanup (`buildEdgeConnectClient`, `getEdgeConnectByName`, `deleteConnectionSetting`, `DeleteEdgeConnect`). if any step fails the k8s object has already lost its finalizer and gets garbage collected. tenant resource is orphaned forever

## root cause

been there since `8fa3f094d` ("Add edgeconnect provisioner mode") - no test for the failure path, no comment, no rationale

## fix

- run tenant cleanup first, only `controllerutil.RemoveFinalizer` after success
- pull tenant cleanup into a `cleanupTenantEdgeConnect` helper
- switch from `Finalizers = nil` to `controllerutil.RemoveFinalizer` so third-party finalizers don't get wiped

## how can this be tested?

existing edgeconnect tests pass

two new regression tests in `controller_test.go`:
- `finalizer is kept when DeleteEdgeConnect fails`
- `finalizer is kept when buildEdgeConnectClient fails`

both fail on main (object gets GC'd, finalizer gone) and pass on this branch

## note for operators

if the OAuth secret or `caCertsRef` configmap is deleted before the EdgeConnect CR, `buildEdgeConnectClient` fails and deletion gets retried indefinitely. recovery: recreate the secret/configmap or `kubectl patch` the finalizer off