### PR TITLE
fix: validate EdgeConnect CRD CA bundle in webhook cert controller

### DIFF
--- a/pkg/controllers/certificates/webhook_cert_controller.go
+++ b/pkg/controllers/certificates/webhook_cert_controller.go
@@ -140,7 +140,7 @@ func (controller *WebhookCertificateController) Reconcile(ctx context.Context, r
 
 	mutatingWebhookConfiguration, validatingWebhookConfiguration := controller.getWebhooksConfigurations(ctx)
 
-	crd, err := controller.getCRD(ctx)
+	crds, err := controller.getCRDs(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -157,7 +157,7 @@ func (controller *WebhookCertificateController) Reconcile(ctx context.Context, r
 	mutatingWebhookClientConfigs := getClientConfigsFromMutatingWebhook(mutatingWebhookConfiguration)
 	validatingWebhookConfigConfigs := getClientConfigsFromValidatingWebhook(validatingWebhookConfiguration)
 
-	if controller.isUpToDate(certSecret, mutatingWebhookClientConfigs, validatingWebhookConfigConfigs, crd) {
+	if controller.isUpToDate(certSecret, mutatingWebhookClientConfigs, validatingWebhookConfigConfigs, crds) {
 		log.Info("secret for certificates up to date, skipping update")
 
 		return ctrl.Result{RequeueAfter: controller.requeueAfter}, nil
@@ -193,15 +193,24 @@ func (controller *WebhookCertificateController) Reconcile(ctx context.Context, r
 	return ctrl.Result{RequeueAfter: controller.requeueAfter}, nil
 }
 
-func (controller *WebhookCertificateController) isUpToDate(certSecret *certificateSecret, mutatingWebhookClientConfigs []*admissionregistrationv1.WebhookClientConfig, validatingWebhookConfigConfigs []*admissionregistrationv1.WebhookClientConfig, crd *apiextensionsv1.CustomResourceDefinition) bool {
+func (controller *WebhookCertificateController) isUpToDate(certSecret *certificateSecret, mutatingWebhookClientConfigs []*admissionregistrationv1.WebhookClientConfig, validatingWebhookConfigConfigs []*admissionregistrationv1.WebhookClientConfig, crds []*apiextensionsv1.CustomResourceDefinition) bool {
 	areMutatingWebhookConfigsValid := certSecret.areWebhookConfigsValid(mutatingWebhookClientConfigs)
 	areValidatingWebhookConfigsValid := certSecret.areWebhookConfigsValid(validatingWebhookConfigConfigs)
-	isCRDConversionConfigValid := certSecret.isCRDConversionValid(crd)
+
+	areCRDConversionConfigsValid := true
+
+	for _, crd := range crds {
+		if !certSecret.isCRDConversionValid(crd) {
+			areCRDConversionConfigsValid = false
+
+			break
+		}
+	}
 
 	isUpToDate := certSecret.isRecent() &&
 		areMutatingWebhookConfigsValid &&
 		areValidatingWebhookConfigsValid &&
-		isCRDConversionConfigValid
+		areCRDConversionConfigsValid
 
 	return isUpToDate
 }
@@ -260,13 +269,20 @@ func (controller *WebhookCertificateController) getValidatingWebhookConfiguratio
 	return &mutatingWebhook, nil
 }
 
-func (controller *WebhookCertificateController) getCRD(ctx context.Context) (*apiextensionsv1.CustomResourceDefinition, error) {
-	var crd apiextensionsv1.CustomResourceDefinition
-	if err := controller.apiReader.Get(ctx, types.NamespacedName{Name: k8scrd.DynaKubeName}, &crd); err != nil {
-		return nil, fmt.Errorf("get CRD: %w", err)
+func (controller *WebhookCertificateController) getCRDs(ctx context.Context) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+	crdNames := []string{k8scrd.DynaKubeName, k8scrd.EdgeConnectName}
+	crds := make([]*apiextensionsv1.CustomResourceDefinition, 0, len(crdNames))
+
+	for _, name := range crdNames {
+		var crd apiextensionsv1.CustomResourceDefinition
+		if err := controller.apiReader.Get(ctx, types.NamespacedName{Name: name}, &crd); err != nil {
+			return nil, fmt.Errorf("get CRD %s: %w", name, err)
+		}
+
+		crds = append(crds, &crd)
 	}
 
-	return &crd, nil
+	return crds, nil
 }
 
 func (controller *WebhookCertificateController) updateClientConfigurations(ctx context.Context, bundle []byte,

--- a/pkg/controllers/certificates/webhook_cert_controller_test.go
+++ b/pkg/controllers/certificates/webhook_cert_controller_test.go
@@ -223,6 +223,45 @@ func TestReconcile(t *testing.T) {
 		assert.Equal(t, expectedBundle, actualCrd.Spec.Conversion.Webhook.ClientConfig.CABundle)
 	})
 
+	t.Run("edgeconnect crd ca bundle is fixed even if dynakube crd is already valid", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      webhook.DeploymentName,
+				Namespace: testNamespace,
+			},
+		}
+		// First, run a full reconcile to seed the secret and both CRDs
+		fakeClient := fake.NewClient(dkCrd.DeepCopy(), ecCrd.DeepCopy(), deployment)
+		controller, request := prepareController(t, fakeClient)
+		_, err := controller.Reconcile(t.Context(), request)
+		require.NoError(t, err)
+
+		// Capture the expected bundle that should now be on every CRD
+		secret := &corev1.Secret{}
+		require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: expectedSecretName, Namespace: testNamespace}, secret))
+
+		expectedBundle := append([]byte{}, secret.Data[RootCert]...)
+
+		dynaKubeAfter := &apiextensionsv1.CustomResourceDefinition{}
+		require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: k8scrd.DynaKubeName}, dynaKubeAfter))
+		require.Equal(t, expectedBundle, dynaKubeAfter.Spec.Conversion.Webhook.ClientConfig.CABundle)
+
+		// Simulate someone reinstalling the EdgeConnect CRD with an empty CA bundle.
+		// DynaKube CRD stays valid, so the old isUpToDate would short-circuit and
+		// EdgeConnect CRD's CA bundle would never get repaired.
+		ecAfter := &apiextensionsv1.CustomResourceDefinition{}
+		require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: k8scrd.EdgeConnectName}, ecAfter))
+		ecAfter.Spec.Conversion.Webhook.ClientConfig.CABundle = nil
+		require.NoError(t, fakeClient.Update(t.Context(), ecAfter))
+
+		_, err = controller.Reconcile(t.Context(), request)
+		require.NoError(t, err)
+
+		ecRepaired := &apiextensionsv1.CustomResourceDefinition{}
+		require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: k8scrd.EdgeConnectName}, ecRepaired))
+		assert.Equal(t, expectedBundle, ecRepaired.Spec.Conversion.Webhook.ClientConfig.CABundle)
+	})
+
 	// Generation must not be skipped because webhook startup routine listens for the secret
 	// See cmd/operator/manager.go and cmd/operator/watcher.go
 	t.Run("do not skip certificates generation if no configuration exists", func(t *testing.T) {


### PR DESCRIPTION
## description

the cert controller updates the CA bundle on both the DynaKube CRD and the EdgeConnect CRD in `Reconcile`, but `getCRD` only fetches DynaKube and `isUpToDate` only validates that one. if the EC CRD's CA bundle is stale while DynaKube's is fine, `isUpToDate` returns true, the reconciler short-circuits with `RequeueAfter: 3h`, and EC's conversion webhook stays broken until secret rotation or operator restart

## root cause

PR #3543 (Aug 2024) added the EC CRD update calls but didn't extend the validation. existing `updateCRDConfiguration(ctx, k8scrd.EdgeConnectName, ...)` already requires EC CRD to exist so this PR doesn't introduce any new "EC must exist" assumption

## fix

- rename `getCRD` -> `getCRDs`, return both DynaKube and EdgeConnect CRDs
- `isUpToDate` validates the bundle on each returned CRD

## how can this be tested?

existing `pkg/controllers/certificates/...` tests pass

new regression test `edgeconnect_crd_ca_bundle_is_fixed_even_if_dynakube_crd_is_already_valid` seeds both CRDs, wipes only the EC CRD's CA bundle, asserts the reconcile fixes it. fails on main passes on this branch