### PR TITLE
Propagate resource attributes via `-p` args for standalone log module

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -2,6 +2,8 @@ package daemonset
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 )
@@ -24,8 +26,9 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 		baseArgs = append(baseArgs, fmt.Sprintf("-p k8s.cluster.name=$(%s)", clusterNameEnv), fmt.Sprintf("-p dt.entity.kubernetes_cluster=$(%s)", entityEnv))
 	}
 
-	for key, value := range dk.GetResourceAttributes() {
-		baseArgs = append(baseArgs, fmt.Sprintf("-p %s=%s", key, value))
+	attrs := dk.GetResourceAttributes()
+	for _, key := range slices.Sorted(maps.Keys(attrs)) {
+		baseArgs = append(baseArgs, fmt.Sprintf("-p %s=%s", key, attrs[key]))
 	}
 
 	return append(baseArgs, dk.LogMonitoring().Template().Args...)

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -26,12 +26,10 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 		baseArgs = append(baseArgs, fmt.Sprintf("-p k8s.cluster.name=$(%s)", clusterNameEnv), fmt.Sprintf("-p dt.entity.kubernetes_cluster=$(%s)", entityEnv))
 	}
 
-	baseArgs = append(baseArgs, dk.LogMonitoring().Template().Args...)
-
 	attrs := dk.GetResourceAttributes()
 	for _, key := range slices.Sorted(maps.Keys(attrs)) {
 		baseArgs = append(baseArgs, fmt.Sprintf("-p %s=%s", key, attrs[key]))
 	}
 
-	return baseArgs
+	return append(baseArgs, dk.LogMonitoring().Template().Args...)
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -26,10 +26,12 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 		baseArgs = append(baseArgs, fmt.Sprintf("-p k8s.cluster.name=$(%s)", clusterNameEnv), fmt.Sprintf("-p dt.entity.kubernetes_cluster=$(%s)", entityEnv))
 	}
 
+	baseArgs = append(baseArgs, dk.LogMonitoring().Template().Args...)
+
 	attrs := dk.GetResourceAttributes()
 	for _, key := range slices.Sorted(maps.Keys(attrs)) {
 		baseArgs = append(baseArgs, fmt.Sprintf("-p %s=%s", key, attrs[key]))
 	}
 
-	return append(baseArgs, dk.LogMonitoring().Template().Args...)
+	return baseArgs
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -24,5 +24,9 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 		baseArgs = append(baseArgs, fmt.Sprintf("-p k8s.cluster.name=$(%s)", clusterNameEnv), fmt.Sprintf("-p dt.entity.kubernetes_cluster=$(%s)", entityEnv))
 	}
 
+	for key, value := range dk.GetResourceAttributes() {
+		baseArgs = append(baseArgs, fmt.Sprintf("-p %s=%s", key, value))
+	}
+
 	return append(baseArgs, dk.LogMonitoring().Template().Args...)
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
@@ -77,9 +77,14 @@ func Test_getInitArgs(t *testing.T) {
 
 		assert.Len(t, args, expectedBaseInitArgsLenWithoutMEID+len(dk.Spec.ResourceAttributes))
 
-		assert.Contains(t, args, "-p env=staging")
-		assert.Contains(t, args, "-p service=logmodule")
-		assert.Contains(t, args, "-p team=platform")
+		// Verify resourceAttributes are in sorted order
+		attrArgs := args[len(args)-len(dk.Spec.ResourceAttributes):]
+		expectedAttrs := []string{
+			"-p env=staging",
+			"-p service=logmodule",
+			"-p team=platform",
+		}
+		assert.Equal(t, expectedAttrs, attrArgs)
 	})
 
 	t.Run("propagate spec.resourceAttributes as -p args together with MEID args", func(t *testing.T) {
@@ -87,9 +92,9 @@ func Test_getInitArgs(t *testing.T) {
 		dk.Status.KubernetesClusterMEID = "test-me-id"
 		dk.Status.KubernetesClusterName = "test-cluster-name"
 		dk.Spec.ResourceAttributes = map[string]string{
+			"service": "logmodule",
 			"team":    "platform",
 			"env":     "staging",
-			"service": "logmodule",
 		}
 
 		args := getInitArgs(dk)
@@ -98,8 +103,14 @@ func Test_getInitArgs(t *testing.T) {
 
 		assert.Contains(t, args, "-p k8s.cluster.name=$(K8S_CLUSTER_NAME)")
 		assert.Contains(t, args, "-p dt.entity.kubernetes_cluster=$(DT_ENTITY_KUBERNETES_CLUSTER)")
-		assert.Contains(t, args, "-p env=staging")
-		assert.Contains(t, args, "-p service=logmodule")
-		assert.Contains(t, args, "-p team=platform")
+
+		// Verify resourceAttributes are in sorted order
+		attrArgs := args[len(args)-len(dk.Spec.ResourceAttributes):]
+		expectedAttrs := []string{
+			"-p env=staging",
+			"-p service=logmodule",
+			"-p team=platform",
+		}
+		assert.Equal(t, expectedAttrs, attrArgs)
 	})
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
@@ -13,13 +13,19 @@ const (
 	expectedBaseInitArgsLenWithoutMEID = 10
 )
 
-func TestGetInitArgs(t *testing.T) {
-	t.Run("get base init args", func(t *testing.T) {
+func Test_getInitArgs(t *testing.T) {
+	newDk := func() dynakube.DynaKube {
 		dk := dynakube.DynaKube{}
+		dk.Name = "dk-name-test"
+
+		return dk
+	}
+
+	t.Run("get base init args", func(t *testing.T) {
+		dk := newDk()
 		dk.Status.KubernetesClusterMEID = "test-me-id"
 		dk.Status.KubernetesClusterName = "test-cluster-name"
 
-		dk.Name = "dk-name-test"
 		args := getInitArgs(dk)
 
 		assert.Len(t, args, expectedBaseInitArgsLen)
@@ -30,11 +36,9 @@ func TestGetInitArgs(t *testing.T) {
 	})
 
 	t.Run("add user defined args to existing init args", func(t *testing.T) {
-		dk := dynakube.DynaKube{}
-		dk.Name = "dk-name-test"
+		dk := newDk()
 		dk.Status.KubernetesClusterMEID = "test-me-id"
 		dk.Status.KubernetesClusterName = "test-cluster-name"
-
 		dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{
 			Args: []string{
 				"customArg1",
@@ -51,8 +55,8 @@ func TestGetInitArgs(t *testing.T) {
 	})
 
 	t.Run("get base init args when no MEID or not all necessary scopes are set", func(t *testing.T) {
-		dk := dynakube.DynaKube{}
-		dk.Name = "dk-name-test"
+		dk := newDk()
+
 		args := getInitArgs(dk)
 
 		assert.Len(t, args, expectedBaseInitArgsLenWithoutMEID)
@@ -60,5 +64,42 @@ func TestGetInitArgs(t *testing.T) {
 		for _, arg := range args {
 			assert.NotEmpty(t, arg)
 		}
+	})
+
+	t.Run("propagate spec.resourceAttributes as -p args", func(t *testing.T) {
+		dk := newDk()
+		dk.Spec.ResourceAttributes = map[string]string{
+			"team":    "platform",
+			"env":     "staging",
+			"service": "logmodule",
+		}
+		args := getInitArgs(dk)
+
+		assert.Len(t, args, expectedBaseInitArgsLenWithoutMEID+len(dk.Spec.ResourceAttributes))
+
+		assert.Contains(t, args, "-p env=staging")
+		assert.Contains(t, args, "-p service=logmodule")
+		assert.Contains(t, args, "-p team=platform")
+	})
+
+	t.Run("propagate spec.resourceAttributes as -p args together with MEID args", func(t *testing.T) {
+		dk := newDk()
+		dk.Status.KubernetesClusterMEID = "test-me-id"
+		dk.Status.KubernetesClusterName = "test-cluster-name"
+		dk.Spec.ResourceAttributes = map[string]string{
+			"team":    "platform",
+			"env":     "staging",
+			"service": "logmodule",
+		}
+
+		args := getInitArgs(dk)
+
+		assert.Len(t, args, expectedBaseInitArgsLen+len(dk.Spec.ResourceAttributes))
+
+		assert.Contains(t, args, "-p k8s.cluster.name=$(K8S_CLUSTER_NAME)")
+		assert.Contains(t, args, "-p dt.entity.kubernetes_cluster=$(DT_ENTITY_KUBERNETES_CLUSTER)")
+		assert.Contains(t, args, "-p env=staging")
+		assert.Contains(t, args, "-p service=logmodule")
+		assert.Contains(t, args, "-p team=platform")
 	})
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
@@ -13,10 +13,11 @@ const (
 	expectedBaseInitArgsLenWithoutMEID = 10
 )
 
-func assertResourceAttrArgsAreSorted(t *testing.T, args []string, attrs map[string]string, expectedAttrs []string) {
+func assertResourceAttrArgsAreSorted(t *testing.T, args []string, attrs map[string]string, templateArgs []string, expectedAttrs []string) {
 	t.Helper()
 
-	attrArgs := args[len(args)-len(attrs):]
+	offset := len(templateArgs)
+	attrArgs := args[len(args)-len(attrs)-offset : len(args)-offset]
 	assert.Equal(t, expectedAttrs, attrArgs)
 }
 
@@ -132,7 +133,7 @@ func Test_getInitArgs(t *testing.T) {
 			}
 
 			if tt.expectedAttrArgs != nil {
-				assertResourceAttrArgsAreSorted(t, args, tt.resourceAttrs, tt.expectedAttrArgs)
+				assertResourceAttrArgsAreSorted(t, args, tt.resourceAttrs, tt.templateArgs, tt.expectedAttrArgs)
 			}
 		})
 	}

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
@@ -21,125 +21,119 @@ func assertResourceAttrArgsAreSorted(t *testing.T, args []string, attrs map[stri
 }
 
 func Test_getInitArgs(t *testing.T) {
-	newDK := func() dynakube.DynaKube {
-		dk := dynakube.DynaKube{}
-		dk.Name = "dk-name-test"
-
-		return dk
+	tests := []struct {
+		name             string
+		meID             string
+		clusterName      string
+		templateArgs     []string
+		resourceAttrs    map[string]string
+		expectedLen      int
+		mustContain      []string
+		expectedAttrArgs []string
+	}{
+		{
+			name:        "base args with MEID",
+			meID:        "test-me-id",
+			clusterName: "test-cluster-name",
+			expectedLen: expectedBaseInitArgsLen,
+		},
+		{
+			name:        "base args without MEID",
+			expectedLen: expectedBaseInitArgsLenWithoutMEID,
+		},
+		{
+			name:        "user-defined template args appended",
+			meID:        "test-me-id",
+			clusterName: "test-cluster-name",
+			templateArgs: []string{
+				"customArg1",
+				"customArg2",
+			},
+			expectedLen: expectedBaseInitArgsLen + 2,
+			mustContain: []string{
+				"customArg1",
+				"customArg2",
+			},
+		},
+		{
+			name: "resourceAttributes propagated as sorted -p args",
+			resourceAttrs: map[string]string{
+				"team":    "platform",
+				"env":     "staging",
+				"service": "logmodule",
+			},
+			expectedLen: expectedBaseInitArgsLenWithoutMEID + 3,
+			expectedAttrArgs: []string{
+				"-p env=staging",
+				"-p service=logmodule",
+				"-p team=platform",
+			},
+		},
+		{
+			name: "user-defined template args and resourceAttributes combined",
+			templateArgs: []string{
+				"customArg1",
+				"customArg2",
+			},
+			resourceAttrs: map[string]string{
+				"team": "platform",
+				"env":  "staging",
+			},
+			expectedLen: expectedBaseInitArgsLenWithoutMEID + 2 + 2,
+			mustContain: []string{
+				"customArg1",
+				"customArg2",
+			},
+			expectedAttrArgs: []string{
+				"-p env=staging",
+				"-p team=platform",
+			},
+		},
+		{
+			name:        "resourceAttributes and MEID args combined",
+			meID:        "test-me-id",
+			clusterName: "test-cluster-name",
+			resourceAttrs: map[string]string{
+				"service": "logmodule",
+				"team":    "platform",
+				"env":     "staging",
+			},
+			expectedLen: expectedBaseInitArgsLen + 3,
+			mustContain: []string{
+				"-p k8s.cluster.name=$(K8S_CLUSTER_NAME)",
+				"-p dt.entity.kubernetes_cluster=$(DT_ENTITY_KUBERNETES_CLUSTER)",
+			},
+			expectedAttrArgs: []string{
+				"-p env=staging",
+				"-p service=logmodule",
+				"-p team=platform",
+			},
+		},
 	}
 
-	t.Run("get base init args", func(t *testing.T) {
-		dk := newDK()
-		dk.Status.KubernetesClusterMEID = "test-me-id"
-		dk.Status.KubernetesClusterName = "test-cluster-name"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dk := dynakube.DynaKube{}
+			dk.Name = "dk-name-test"
+			dk.Status.KubernetesClusterMEID = tt.meID
+			dk.Status.KubernetesClusterName = tt.clusterName
+			dk.Spec.ResourceAttributes = tt.resourceAttrs
 
-		args := getInitArgs(dk)
+			if tt.templateArgs != nil {
+				dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{Args: tt.templateArgs}
+			}
 
-		assert.Len(t, args, expectedBaseInitArgsLen)
+			args := getInitArgs(dk)
 
-		for _, arg := range args {
-			assert.NotEmpty(t, arg)
-		}
-	})
+			assert.Len(t, args, tt.expectedLen)
 
-	t.Run("add user defined args to existing init args", func(t *testing.T) {
-		dk := newDK()
-		dk.Status.KubernetesClusterMEID = "test-me-id"
-		dk.Status.KubernetesClusterName = "test-cluster-name"
-		dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{
-			Args: []string{
-				"customArg1",
-				"customArg2",
-			},
-		}
-		args := getInitArgs(dk)
+			for _, arg := range tt.mustContain {
+				assert.Contains(t, args, arg)
+			}
 
-		assert.Len(t, args, expectedBaseInitArgsLen+len(dk.LogMonitoring().Args))
-
-		for _, customArg := range dk.LogMonitoring().Args {
-			assert.Contains(t, args, customArg)
-		}
-	})
-
-	t.Run("get base init args when no MEID or not all necessary scopes are set", func(t *testing.T) {
-		dk := newDK()
-
-		args := getInitArgs(dk)
-
-		assert.Len(t, args, expectedBaseInitArgsLenWithoutMEID)
-
-		for _, arg := range args {
-			assert.NotEmpty(t, arg)
-		}
-	})
-
-	t.Run("propagate spec.resourceAttributes as -p args", func(t *testing.T) {
-		dk := newDK()
-		dk.Spec.ResourceAttributes = map[string]string{
-			"team":    "platform",
-			"env":     "staging",
-			"service": "logmodule",
-		}
-		args := getInitArgs(dk)
-
-		assert.Len(t, args, expectedBaseInitArgsLenWithoutMEID+len(dk.Spec.ResourceAttributes))
-
-		// Verify resourceAttributes are in sorted order
-		assertResourceAttrArgsAreSorted(t, args, dk.Spec.ResourceAttributes, []string{
-			"-p env=staging",
-			"-p service=logmodule",
-			"-p team=platform",
+			if tt.expectedAttrArgs != nil {
+				assertResourceAttrArgsAreSorted(t, args, tt.resourceAttrs, tt.expectedAttrArgs)
+			}
 		})
-	})
-
-	t.Run("propagate spec.resourceAttributes as -p args together with user-defined args", func(t *testing.T) {
-		dk := newDK()
-		dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{
-			Args: []string{
-				"customArg1",
-				"customArg2",
-			},
-		}
-		dk.Spec.ResourceAttributes = map[string]string{
-			"team": "platform",
-			"env":  "staging",
-		}
-
-		args := getInitArgs(dk)
-
-		assert.Len(t, args, expectedBaseInitArgsLenWithoutMEID+len(dk.LogMonitoring().Args)+len(dk.Spec.ResourceAttributes))
-
-		for _, customArg := range dk.LogMonitoring().Args {
-			assert.Contains(t, args, customArg)
-		}
-
-		assertResourceAttrArgsAreSorted(t, args, dk.Spec.ResourceAttributes, []string{
-			"-p env=staging",
-			"-p team=platform",
-		})
-	})
-
-	t.Run("propagate spec.resourceAttributes as -p args together with MEID args", func(t *testing.T) {
-		dk := newDK()
-		dk.Status.KubernetesClusterMEID = "test-me-id"
-		dk.Status.KubernetesClusterName = "test-cluster-name"
-		dk.Spec.ResourceAttributes = map[string]string{
-			"service": "logmodule",
-			"team":    "platform",
-			"env":     "staging",
-		}
-
-		args := getInitArgs(dk)
-
-		assert.Len(t, args, expectedBaseInitArgsLen+len(dk.Spec.ResourceAttributes))
-
-		assert.Contains(t, args, "-p k8s.cluster.name=$(K8S_CLUSTER_NAME)")
-		assert.Contains(t, args, "-p dt.entity.kubernetes_cluster=$(DT_ENTITY_KUBERNETES_CLUSTER)")
-
-		assertResourceAttrArgsAreSorted(t, args, dk.Spec.ResourceAttributes, []string{
-			"-p env=staging",
-			"-p service=logmodule",
-			"-p team=platform",
-		})
-	})
+	}
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
@@ -14,7 +14,7 @@ const (
 )
 
 func Test_getInitArgs(t *testing.T) {
-	newDk := func() dynakube.DynaKube {
+	newDK := func() dynakube.DynaKube {
 		dk := dynakube.DynaKube{}
 		dk.Name = "dk-name-test"
 
@@ -22,7 +22,7 @@ func Test_getInitArgs(t *testing.T) {
 	}
 
 	t.Run("get base init args", func(t *testing.T) {
-		dk := newDk()
+		dk := newDK()
 		dk.Status.KubernetesClusterMEID = "test-me-id"
 		dk.Status.KubernetesClusterName = "test-cluster-name"
 
@@ -36,7 +36,7 @@ func Test_getInitArgs(t *testing.T) {
 	})
 
 	t.Run("add user defined args to existing init args", func(t *testing.T) {
-		dk := newDk()
+		dk := newDK()
 		dk.Status.KubernetesClusterMEID = "test-me-id"
 		dk.Status.KubernetesClusterName = "test-cluster-name"
 		dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{
@@ -55,7 +55,7 @@ func Test_getInitArgs(t *testing.T) {
 	})
 
 	t.Run("get base init args when no MEID or not all necessary scopes are set", func(t *testing.T) {
-		dk := newDk()
+		dk := newDK()
 
 		args := getInitArgs(dk)
 
@@ -67,7 +67,7 @@ func Test_getInitArgs(t *testing.T) {
 	})
 
 	t.Run("propagate spec.resourceAttributes as -p args", func(t *testing.T) {
-		dk := newDk()
+		dk := newDK()
 		dk.Spec.ResourceAttributes = map[string]string{
 			"team":    "platform",
 			"env":     "staging",
@@ -83,7 +83,7 @@ func Test_getInitArgs(t *testing.T) {
 	})
 
 	t.Run("propagate spec.resourceAttributes as -p args together with MEID args", func(t *testing.T) {
-		dk := newDk()
+		dk := newDK()
 		dk.Status.KubernetesClusterMEID = "test-me-id"
 		dk.Status.KubernetesClusterName = "test-cluster-name"
 		dk.Spec.ResourceAttributes = map[string]string{

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
@@ -13,6 +13,13 @@ const (
 	expectedBaseInitArgsLenWithoutMEID = 10
 )
 
+func assertResourceAttrArgsAreSorted(t *testing.T, args []string, attrs map[string]string, expectedAttrs []string) {
+	t.Helper()
+
+	attrArgs := args[len(args)-len(attrs):]
+	assert.Equal(t, expectedAttrs, attrArgs)
+}
+
 func Test_getInitArgs(t *testing.T) {
 	newDK := func() dynakube.DynaKube {
 		dk := dynakube.DynaKube{}
@@ -78,13 +85,38 @@ func Test_getInitArgs(t *testing.T) {
 		assert.Len(t, args, expectedBaseInitArgsLenWithoutMEID+len(dk.Spec.ResourceAttributes))
 
 		// Verify resourceAttributes are in sorted order
-		attrArgs := args[len(args)-len(dk.Spec.ResourceAttributes):]
-		expectedAttrs := []string{
+		assertResourceAttrArgsAreSorted(t, args, dk.Spec.ResourceAttributes, []string{
 			"-p env=staging",
 			"-p service=logmodule",
 			"-p team=platform",
+		})
+	})
+
+	t.Run("propagate spec.resourceAttributes as -p args together with user-defined args", func(t *testing.T) {
+		dk := newDK()
+		dk.Spec.Templates.LogMonitoring = &logmonitoring.TemplateSpec{
+			Args: []string{
+				"customArg1",
+				"customArg2",
+			},
 		}
-		assert.Equal(t, expectedAttrs, attrArgs)
+		dk.Spec.ResourceAttributes = map[string]string{
+			"team": "platform",
+			"env":  "staging",
+		}
+
+		args := getInitArgs(dk)
+
+		assert.Len(t, args, expectedBaseInitArgsLenWithoutMEID+len(dk.LogMonitoring().Args)+len(dk.Spec.ResourceAttributes))
+
+		for _, customArg := range dk.LogMonitoring().Args {
+			assert.Contains(t, args, customArg)
+		}
+
+		assertResourceAttrArgsAreSorted(t, args, dk.Spec.ResourceAttributes, []string{
+			"-p env=staging",
+			"-p team=platform",
+		})
 	})
 
 	t.Run("propagate spec.resourceAttributes as -p args together with MEID args", func(t *testing.T) {
@@ -104,13 +136,10 @@ func Test_getInitArgs(t *testing.T) {
 		assert.Contains(t, args, "-p k8s.cluster.name=$(K8S_CLUSTER_NAME)")
 		assert.Contains(t, args, "-p dt.entity.kubernetes_cluster=$(DT_ENTITY_KUBERNETES_CLUSTER)")
 
-		// Verify resourceAttributes are in sorted order
-		attrArgs := args[len(args)-len(dk.Spec.ResourceAttributes):]
-		expectedAttrs := []string{
+		assertResourceAttrArgsAreSorted(t, args, dk.Spec.ResourceAttributes, []string{
 			"-p env=staging",
 			"-p service=logmodule",
 			"-p team=platform",
-		}
-		assert.Equal(t, expectedAttrs, attrArgs)
+		})
 	})
 }


### PR DESCRIPTION
## Description

ICP-3792

## How can this be tested?
`make go/test`

manually
deployed dk with 
```yaml
  logMonitoring: {}
  resourceAttributes:
    fookey: foovalue
```
verified logmon yaml that `-p fookey=foovalue` was added