### PR TITLE
Adds EdgeConnect oauth.endpoint validation

### DIFF
--- a/pkg/api/validation/edgeconnect/api_server_test.go
+++ b/pkg/api/validation/edgeconnect/api_server_test.go
@@ -24,7 +24,7 @@ func TestApiServer(t *testing.T) {
 					APIServer: "tenantid" + suffix,
 					OAuth: edgeconnect.OAuthSpec{
 						ClientSecret: "secret",
-						Endpoint:     "endpoint",
+						Endpoint:     testValidOAuthEndpoint,
 						Resource:     "resource",
 					},
 				},

--- a/pkg/api/validation/edgeconnect/host_patterns_test.go
+++ b/pkg/api/validation/edgeconnect/host_patterns_test.go
@@ -18,7 +18,7 @@ func TestHostPatternsRequired(t *testing.T) {
 				APIServer: "tenantid-test.dev.apps.dynatracelabs.com",
 				OAuth: edgeconnect.OAuthSpec{
 					ClientSecret: "secret",
-					Endpoint:     "endpoint",
+					Endpoint:     testValidOAuthEndpoint,
 					Resource:     "resource",
 				},
 			},

--- a/pkg/api/validation/edgeconnect/name_test.go
+++ b/pkg/api/validation/edgeconnect/name_test.go
@@ -48,6 +48,9 @@ func TestNameTooLong(t *testing.T) {
 				},
 				Spec: edgeconnect.EdgeConnectSpec{
 					APIServer: "id." + allowedSuffix[0],
+					OAuth: edgeconnect.OAuthSpec{
+						Endpoint: testValidOAuthEndpoint,
+					},
 				},
 			}
 			if test.allow {

--- a/pkg/api/validation/edgeconnect/oauth.go
+++ b/pkg/api/validation/edgeconnect/oauth.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/url"
 	"slices"
-	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
 )
@@ -51,7 +50,7 @@ func checkSSOServerProtocol(ctx context.Context, _ *Validator, ec *edgeconnect.E
 		return ""
 	}
 
-	if strings.ToLower(url.Scheme) != "https" {
+	if url.Scheme != "https" {
 		return errorProtocolIsMissingOauthEndpoint
 	}
 
@@ -64,7 +63,7 @@ func isAllowedSSOServer(ctx context.Context, _ *Validator, ec *edgeconnect.EdgeC
 		return ""
 	}
 
-	if !slices.Contains(allowedSSODomains, strings.ToLower(url.Host)) {
+	if !slices.Contains(allowedSSODomains, url.Host) {
 		return errorUnknownSSOServer
 	}
 

--- a/pkg/api/validation/edgeconnect/oauth.go
+++ b/pkg/api/validation/edgeconnect/oauth.go
@@ -1,0 +1,72 @@
+package validation
+
+import (
+	"context"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+)
+
+const (
+	errorInvalidOauthEndpoint = `The EdgeConnect's specification has an invalid oauth.endpoint value set.
+	Make sure you correctly specify the endpoint in your custom resource.
+	`
+
+	errorProtocolIsMissingOauthEndpoint = `The EdgeConnect's specification has an invalid oauth.endpoint value set.
+	Should include 'https' protocol.
+	Make sure you correctly specify the oauth.endpoint in your custom resource.
+	`
+
+	errorUnknownSSOServer = `The EdgeConnect's specification has an invalid oauth.endpoint value set.
+	Example valid values:
+	-  For prod: "sso.dynatrace.com"
+	-  For dev: "sso-dev.dynatracelabs.com",
+	-  For sprint: "sso.sprint.dynatracelabs.com"
+	Make sure you correctly specify the endpoint in your custom resource.
+	`
+)
+
+var (
+	allowedSSODomains = []string{
+		"sso-dev.dynatracelabs.com",
+		"sso.sprint.dynatracelabs.com",
+		"sso.dynatrace.com",
+	}
+)
+
+func isValidSSOServerURL(ctx context.Context, _ *Validator, ec *edgeconnect.EdgeConnect) string {
+	_, err := url.Parse(ec.Spec.OAuth.Endpoint)
+	if err != nil {
+		return errorInvalidOauthEndpoint
+	}
+
+	return ""
+}
+
+func checkSSOServerProtocol(ctx context.Context, _ *Validator, ec *edgeconnect.EdgeConnect) string {
+	url, err := url.Parse(ec.Spec.OAuth.Endpoint)
+	if err != nil {
+		return ""
+	}
+
+	if strings.ToLower(url.Scheme) != "https" {
+		return errorProtocolIsMissingOauthEndpoint
+	}
+
+	return ""
+}
+
+func isAllowedSSOServer(ctx context.Context, _ *Validator, ec *edgeconnect.EdgeConnect) string {
+	url, err := url.Parse(ec.Spec.OAuth.Endpoint)
+	if err != nil {
+		return ""
+	}
+
+	if !slices.Contains(allowedSSODomains, strings.ToLower(url.Host)) {
+		return errorUnknownSSOServer
+	}
+
+	return ""
+}

--- a/pkg/api/validation/edgeconnect/oauth_test.go
+++ b/pkg/api/validation/edgeconnect/oauth_test.go
@@ -1,0 +1,112 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+)
+
+const (
+	testAPIServer          = "tenantid.apps.dynatrace.com"
+	testValidOAuthEndpoint = "https://sso.dynatrace.com/endpoint"
+)
+
+func TestOauthEndpoint(t *testing.T) {
+	t.Run("happy apiServer", func(t *testing.T) {
+		for _, domain := range allowedSSODomains {
+			ec := &edgeconnect.EdgeConnect{
+				Spec: edgeconnect.EdgeConnectSpec{
+					APIServer: testAPIServer,
+					OAuth: edgeconnect.OAuthSpec{
+						ClientSecret: "secret",
+						Endpoint:     "https://" + domain + "/endpoint",
+						Resource:     "resource",
+					},
+				},
+			}
+			assertAllowed(t, ec)
+		}
+	})
+
+	t.Run("invalid ouath.endpoint (missing protocol)", func(t *testing.T) {
+		for _, domain := range allowedSSODomains {
+			ec := &edgeconnect.EdgeConnect{
+				Spec: edgeconnect.EdgeConnectSpec{
+					APIServer: testAPIServer,
+					OAuth: edgeconnect.OAuthSpec{
+						ClientSecret: "secret",
+						Endpoint:     domain + "/endpoint",
+						Resource:     "resource",
+					},
+				},
+			}
+
+			assertDenied(t, []string{errorProtocolIsMissingOauthEndpoint}, ec)
+		}
+	})
+
+	t.Run("invalid oauth.endpoint (wrong protocol)", func(t *testing.T) {
+		assertDenied(t, []string{errorProtocolIsMissingOauthEndpoint}, &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				APIServer: testAPIServer,
+				OAuth: edgeconnect.OAuthSpec{
+					ClientSecret: "secret",
+					Endpoint:     "http://sso.dynatrace.com/endpoint",
+					Resource:     "resource",
+				},
+			},
+		})
+	})
+
+	t.Run("invalid oauth.endpoint (wrong domain)", func(t *testing.T) {
+		assertDenied(t, []string{errorUnknownSSOServer}, &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				APIServer: testAPIServer,
+				OAuth: edgeconnect.OAuthSpec{
+					ClientSecret: "secret",
+					Endpoint:     "https://my-sso-server/endpoint",
+					Resource:     "resource",
+				},
+			},
+		})
+	})
+
+	t.Run("invalid oauth.endpoint (url should NOT be empty string)", func(t *testing.T) {
+		assertDenied(t, []string{errorProtocolIsMissingOauthEndpoint, errorUnknownSSOServer}, &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				APIServer: testAPIServer,
+				OAuth: edgeconnect.OAuthSpec{
+					ClientSecret: "secret",
+					Endpoint:     "",
+					Resource:     "resource",
+				},
+			},
+		})
+	})
+
+	t.Run("invalid oauth.endpoint (url.Parse fails)", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidOauthEndpoint}, &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				APIServer: testAPIServer,
+				OAuth: edgeconnect.OAuthSpec{
+					ClientSecret: "secret",
+					Endpoint:     "https://sso-dev.dynatracelabs.com( )/sso/oauth2/token",
+					Resource:     "resource",
+				},
+			},
+		})
+	})
+
+	t.Run("invalid oauth.endpoint (protocol and domain)", func(t *testing.T) {
+		assertDenied(t, []string{errorProtocolIsMissingOauthEndpoint, errorUnknownSSOServer}, &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				APIServer: testAPIServer,
+				OAuth: edgeconnect.OAuthSpec{
+					ClientSecret: "secret",
+					Endpoint:     "http://my-sso-dev.dynatracelabs.com/sso/oauth2/token",
+					Resource:     "resource",
+				},
+			},
+		})
+	})
+}

--- a/pkg/api/validation/edgeconnect/service_account_test.go
+++ b/pkg/api/validation/edgeconnect/service_account_test.go
@@ -23,6 +23,9 @@ func TestServiceAccountName(t *testing.T) {
 		ec := &edgeconnect.EdgeConnect{
 			Spec: edgeconnect.EdgeConnectSpec{
 				APIServer: "tenant.apps.dynatrace.com",
+				OAuth: edgeconnect.OAuthSpec{
+					Endpoint: testValidOAuthEndpoint,
+				},
 			},
 		}
 		assertAllowed(t, ec)

--- a/pkg/api/validation/edgeconnect/testdata/latest-default.yaml
+++ b/pkg/api/validation/edgeconnect/testdata/latest-default.yaml
@@ -33,7 +33,7 @@ spec:
     kubernetes.io/os: linux
   oauth:
     clientSecret: secret
-    endpoint: https://url
+    endpoint: https://sso.dynatrace.com/url
     provisioner: true
     resource: resource
   proxy:

--- a/pkg/api/validation/edgeconnect/testdata/v1alpha1-default.yaml
+++ b/pkg/api/validation/edgeconnect/testdata/v1alpha1-default.yaml
@@ -32,7 +32,7 @@ spec:
   serviceAccountName: default
   oauth:
     clientSecret: secret
-    endpoint: https://url
+    endpoint: https://sso.dynatrace.com/url
     resource: resource
     provisioner: true
   resources:

--- a/pkg/api/validation/edgeconnect/validation.go
+++ b/pkg/api/validation/edgeconnect/validation.go
@@ -32,6 +32,9 @@ var validatorErrorFuncs = []validatorFunc{
 	checkHostPatternsValue,
 	isInvalidServiceName,
 	automationRequiresProvisionerValidation,
+	isValidSSOServerURL,
+	checkSSOServerProtocol,
+	isAllowedSSOServer,
 }
 
 func New(apiReader client.Reader, cfg *rest.Config) admission.Validator[runtime.Object] {


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-4364)

## Description



## How can this be tested?

unittests

try to deploy an EC with invalid `oauth.endpoint` values
