### PR TITLE
Propagate resource attributes to `deployment.properties` for ActiveGate

### DIFF
--- a/pkg/api/latest/dynakube/activegate/props.go
+++ b/pkg/api/latest/dynakube/activegate/props.go
@@ -11,12 +11,12 @@ import (
 )
 
 const (
-	TenantSecretSuffix                    = "-activegate-tenant-secret"
-	TLSSecretSuffix                       = "-activegate-tls-secret"
-	ConnectionInfoConfigMapSuffix         = "-activegate-connection-info"
-	DeploymentPropertiesConfigMapSuffix   = "-activegate-deployment-properties"
-	AuthTokenSecretSuffix                 = "-activegate-authtoken-secret"
-	DefaultImageRegistrySubPath           = "/linux/activegate"
+	TenantSecretSuffix                  = "-activegate-tenant-secret"
+	TLSSecretSuffix                     = "-activegate-tls-secret"
+	ConnectionInfoConfigMapSuffix       = "-activegate-connection-info"
+	DeploymentPropertiesConfigMapSuffix = "-activegate-deployment-properties"
+	AuthTokenSecretSuffix               = "-activegate-authtoken-secret"
+	DefaultImageRegistrySubPath         = "/linux/activegate"
 )
 
 func (ag *Spec) SetAPIURL(apiURL string) {

--- a/pkg/api/latest/dynakube/activegate/props.go
+++ b/pkg/api/latest/dynakube/activegate/props.go
@@ -11,11 +11,12 @@ import (
 )
 
 const (
-	TenantSecretSuffix            = "-activegate-tenant-secret"
-	TLSSecretSuffix               = "-activegate-tls-secret"
-	ConnectionInfoConfigMapSuffix = "-activegate-connection-info"
-	AuthTokenSecretSuffix         = "-activegate-authtoken-secret"
-	DefaultImageRegistrySubPath   = "/linux/activegate"
+	TenantSecretSuffix                    = "-activegate-tenant-secret"
+	TLSSecretSuffix                       = "-activegate-tls-secret"
+	ConnectionInfoConfigMapSuffix         = "-activegate-connection-info"
+	DeploymentPropertiesConfigMapSuffix   = "-activegate-deployment-properties"
+	AuthTokenSecretSuffix                 = "-activegate-authtoken-secret"
+	DefaultImageRegistrySubPath           = "/linux/activegate"
 )
 
 func (ag *Spec) SetAPIURL(apiURL string) {
@@ -126,6 +127,10 @@ func (ag *Spec) GetAutoTLSSecretName() string {
 
 func (ag *Spec) GetConnectionInfoConfigMapName() string {
 	return ag.name + ConnectionInfoConfigMapSuffix
+}
+
+func (ag *Spec) GetDeploymentPropertiesConfigMapName() string {
+	return ag.name + DeploymentPropertiesConfigMapSuffix
 }
 
 // GetDefaultImage provides the image reference for the ActiveGate from tenant registry.

--- a/pkg/controllers/dynakube/activegate/consts/consts.go
+++ b/pkg/controllers/dynakube/activegate/consts/consts.go
@@ -20,6 +20,10 @@ const (
 	AuthTokenSecretVolumeName = "ag-authtoken-secret"
 	AuthTokenMountPoint       = connectioninfo.TokenBasePath + "/auth-token"
 
+	DeploymentPropertiesVolumeName = "deployment-properties"
+	DeploymentPropertiesFileName   = "deployment.properties"
+	DeploymentPropertiesBasePath   = "/var/lib/dynatrace/secrets/config"
+
 	EnvDTCapabilities    = "DT_CAPABILITIES"
 	EnvDTIDSeedNamespace = "DT_ID_SEED_NAMESPACE"
 	EnvDTIDSeedClusterID = "DT_ID_SEED_K8S_CLUSTER_ID"

--- a/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties.go
+++ b/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties.go
@@ -1,0 +1,26 @@
+package deploymentproperties
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func BuildContent(attrs map[string]string) string {
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	var sb strings.Builder
+
+	sb.WriteString("[resource_attributes]\n")
+
+	for _, k := range keys {
+		fmt.Fprintf(&sb, "%s = %s\n", k, attrs[k])
+	}
+
+	return sb.String()
+}

--- a/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties.go
+++ b/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties.go
@@ -2,7 +2,7 @@ package deploymentproperties
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -12,7 +12,7 @@ func BuildContent(attrs map[string]string) string {
 		keys = append(keys, k)
 	}
 
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	var sb strings.Builder
 

--- a/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties.go
+++ b/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties.go
@@ -2,16 +2,17 @@ package deploymentproperties
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 )
 
 func BuildContent(attrs map[string]string) string {
-	keys := make([]string, 0, len(attrs))
-	for k := range attrs {
-		keys = append(keys, k)
+	if len(attrs) == 0 {
+		return ""
 	}
 
+	keys := slices.Collect(maps.Keys(attrs))
 	slices.Sort(keys)
 
 	var sb strings.Builder

--- a/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties_test.go
+++ b/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties_test.go
@@ -1,0 +1,34 @@
+package deploymentproperties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildContent(t *testing.T) {
+	t.Run("nil map produces empty section", func(t *testing.T) {
+		content := BuildContent(nil)
+		assert.Equal(t, "[resource_attributes]\n", content)
+	})
+
+	t.Run("empty map produces empty section", func(t *testing.T) {
+		content := BuildContent(map[string]string{})
+		assert.Equal(t, "[resource_attributes]\n", content)
+	})
+
+	t.Run("single entry", func(t *testing.T) {
+		content := BuildContent(map[string]string{"foo": "bar"})
+		assert.Equal(t, "[resource_attributes]\nfoo = bar\n", content)
+	})
+
+	t.Run("multiple entries are sorted by key", func(t *testing.T) {
+		attrs := map[string]string{
+			"zzz": "last",
+			"aaa": "first",
+			"mmm": "middle",
+		}
+		content := BuildContent(attrs)
+		assert.Equal(t, "[resource_attributes]\naaa = first\nmmm = middle\nzzz = last\n", content)
+	})
+}

--- a/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties_test.go
+++ b/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestBuildContent(t *testing.T) {
-	t.Run("nil map produces empty section", func(t *testing.T) {
+	t.Run("nil map produces empty string", func(t *testing.T) {
 		content := BuildContent(nil)
-		assert.Equal(t, "[resource_attributes]\n", content)
+		assert.Empty(t, content)
 	})
 
-	t.Run("empty map produces empty section", func(t *testing.T) {
+	t.Run("empty map produces empty string", func(t *testing.T) {
 		content := BuildContent(map[string]string{})
-		assert.Equal(t, "[resource_attributes]\n", content)
+		assert.Empty(t, content)
 	})
 
 	t.Run("single entry", func(t *testing.T) {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/config.go
@@ -32,6 +32,7 @@ func GenerateAllModifiers(dk dynakube.DynaKube, capability capability.Capability
 		NewSSLVolumeModifier(dk),
 		NewCertificatesModifier(dk),
 		NewTrustedCAsVolumeModifier(dk),
+		NewDeploymentPropertiesModifier(dk),
 		NewCustomPropertiesModifier(dk, capability),
 		NewProxyModifier(dk),
 		NewRawImageModifier(dk, agBaseContainerEnvMap),

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties.go
@@ -26,7 +26,7 @@ type DeploymentPropertiesModifier struct {
 }
 
 func (mod DeploymentPropertiesModifier) Enabled() bool {
-	return true
+	return len(mod.dk.GetResourceAttributes()) > 0
 }
 
 func (mod DeploymentPropertiesModifier) Modify(sts *appsv1.StatefulSet) error {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties.go
@@ -1,0 +1,74 @@
+package modifiers
+
+import (
+	"path"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8scontainer"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ volumeModifier = DeploymentPropertiesModifier{}
+var _ volumeMountModifier = DeploymentPropertiesModifier{}
+var _ builder.Modifier = DeploymentPropertiesModifier{}
+
+func NewDeploymentPropertiesModifier(dk dynakube.DynaKube) DeploymentPropertiesModifier {
+	return DeploymentPropertiesModifier{
+		dk: dk,
+	}
+}
+
+type DeploymentPropertiesModifier struct {
+	dk dynakube.DynaKube
+}
+
+func (mod DeploymentPropertiesModifier) Enabled() bool {
+	return true
+}
+
+func (mod DeploymentPropertiesModifier) Modify(sts *appsv1.StatefulSet) error {
+	baseContainer := k8scontainer.FindInPodSpec(&sts.Spec.Template.Spec, consts.ActiveGateContainerName)
+	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, mod.getVolumes()...)
+	baseContainer.VolumeMounts = append(baseContainer.VolumeMounts, mod.getVolumeMounts()...)
+
+	return nil
+}
+
+func (mod DeploymentPropertiesModifier) getVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: consts.DeploymentPropertiesVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: mod.dk.ActiveGate().GetDeploymentPropertiesConfigMapName(),
+					},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  consts.DeploymentPropertiesFileName,
+							Path: consts.DeploymentPropertiesFileName,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (mod DeploymentPropertiesModifier) getVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			ReadOnly:  true,
+			Name:      consts.DeploymentPropertiesVolumeName,
+			MountPath: getMountPath(),
+			SubPath:   consts.DeploymentPropertiesFileName,
+		},
+	}
+}
+
+func getMountPath() string {
+	return path.Join(consts.DeploymentPropertiesBasePath, consts.DeploymentPropertiesFileName)
+}

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties.go
@@ -1,7 +1,7 @@
 package modifiers
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
@@ -70,5 +70,5 @@ func (mod DeploymentPropertiesModifier) getVolumeMounts() []corev1.VolumeMount {
 }
 
 func getMountPath() string {
-	return path.Join(consts.DeploymentPropertiesBasePath, consts.DeploymentPropertiesFileName)
+	return filepath.Join(consts.DeploymentPropertiesBasePath, consts.DeploymentPropertiesFileName)
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties_test.go
@@ -10,10 +10,17 @@ import (
 )
 
 func TestDeploymentPropertiesModifierEnabled(t *testing.T) {
-	t.Run("always enabled", func(t *testing.T) {
+	t.Run("enabled when resource attributes are set", func(t *testing.T) {
 		dk := getBaseDynakube()
+		dk.Spec.ResourceAttributes = map[string]string{"key": "value"}
 		mod := NewDeploymentPropertiesModifier(dk)
 		assert.True(t, mod.Enabled())
+	})
+
+	t.Run("disabled without resource attributes", func(t *testing.T) {
+		dk := getBaseDynakube()
+		mod := NewDeploymentPropertiesModifier(dk)
+		assert.False(t, mod.Enabled())
 	})
 }
 
@@ -21,6 +28,7 @@ func TestDeploymentPropertiesModifierModify(t *testing.T) {
 	t.Run("adds volume and volumeMount with correct paths", func(t *testing.T) {
 		dk := getBaseDynakube()
 		enableKubeMonCapability(&dk)
+		dk.Spec.ResourceAttributes = map[string]string{"key": "value"}
 
 		mod := NewDeploymentPropertiesModifier(dk)
 		b := createBuilderForTesting()

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties_test.go
@@ -47,8 +47,8 @@ func TestDeploymentPropertiesModifierModify(t *testing.T) {
 		volumes := mod.getVolumes()
 		require.Len(t, volumes, 1)
 		assert.Equal(t, consts.DeploymentPropertiesVolumeName, volumes[0].Name)
-		assert.Equal(t, dk.ActiveGate().GetDeploymentPropertiesConfigMapName(), volumes[0].VolumeSource.ConfigMap.Name)
-		assert.Equal(t, testDynakubeName+activegate.DeploymentPropertiesConfigMapSuffix, volumes[0].VolumeSource.ConfigMap.Name)
+		assert.Equal(t, dk.ActiveGate().GetDeploymentPropertiesConfigMapName(), volumes[0].ConfigMap.Name)
+		assert.Equal(t, testDynakubeName+activegate.DeploymentPropertiesConfigMapSuffix, volumes[0].ConfigMap.Name)
 	})
 
 	t.Run("volumeMount has correct mountPath and subPath", func(t *testing.T) {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/deploymentproperties_test.go
@@ -1,0 +1,56 @@
+package modifiers
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeploymentPropertiesModifierEnabled(t *testing.T) {
+	t.Run("always enabled", func(t *testing.T) {
+		dk := getBaseDynakube()
+		mod := NewDeploymentPropertiesModifier(dk)
+		assert.True(t, mod.Enabled())
+	})
+}
+
+func TestDeploymentPropertiesModifierModify(t *testing.T) {
+	t.Run("adds volume and volumeMount with correct paths", func(t *testing.T) {
+		dk := getBaseDynakube()
+		enableKubeMonCapability(&dk)
+
+		mod := NewDeploymentPropertiesModifier(dk)
+		b := createBuilderForTesting()
+
+		sts, _ := b.AddModifier(mod).Build()
+
+		require.NotEmpty(t, sts)
+		isSubset(t, mod.getVolumes(), sts.Spec.Template.Spec.Volumes)
+		isSubset(t, mod.getVolumeMounts(), sts.Spec.Template.Spec.Containers[0].VolumeMounts)
+	})
+
+	t.Run("volume references correct configmap name", func(t *testing.T) {
+		dk := getBaseDynakube()
+		mod := NewDeploymentPropertiesModifier(dk)
+
+		volumes := mod.getVolumes()
+		require.Len(t, volumes, 1)
+		assert.Equal(t, consts.DeploymentPropertiesVolumeName, volumes[0].Name)
+		assert.Equal(t, dk.ActiveGate().GetDeploymentPropertiesConfigMapName(), volumes[0].VolumeSource.ConfigMap.Name)
+		assert.Equal(t, testDynakubeName+activegate.DeploymentPropertiesConfigMapSuffix, volumes[0].VolumeSource.ConfigMap.Name)
+	})
+
+	t.Run("volumeMount has correct mountPath and subPath", func(t *testing.T) {
+		dk := getBaseDynakube()
+		mod := NewDeploymentPropertiesModifier(dk)
+
+		mounts := mod.getVolumeMounts()
+		require.Len(t, mounts, 1)
+		assert.Equal(t, getMountPath(), mounts[0].MountPath)
+		assert.Equal(t, consts.DeploymentPropertiesFileName, mounts[0].SubPath)
+		assert.True(t, mounts[0].ReadOnly)
+	})
+}

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
@@ -104,7 +104,7 @@ func (r *Reconciler) calculateActiveGateConfigurationHash(ctx context.Context, d
 
 	resourceAttributesData := deploymentproperties.BuildContent(dk.Spec.ResourceAttributes)
 
-	if len(customPropertyData) < 1 && len(authTokenData) < 1 && len(resourceAttributesData) < 1 {
+	if len(customPropertyData) == 0 && len(authTokenData) == 0 && len(resourceAttributesData) == 0 {
 		return "", nil
 	}
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/deploymentproperties"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/authtoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
@@ -101,12 +102,14 @@ func (r *Reconciler) calculateActiveGateConfigurationHash(ctx context.Context, d
 		return "", err
 	}
 
-	if len(customPropertyData) < 1 && len(authTokenData) < 1 {
+	resourceAttributesData := deploymentproperties.BuildContent(dk.Spec.ResourceAttributes)
+
+	if len(customPropertyData) < 1 && len(authTokenData) < 1 && len(resourceAttributesData) < 1 {
 		return "", nil
 	}
 
 	hash := fnv.New32()
-	if _, err := hash.Write([]byte(customPropertyData + authTokenData)); err != nil {
+	if _, err := hash.Write([]byte(customPropertyData + authTokenData + resourceAttributesData)); err != nil {
 		return "", errors.WithStack(err)
 	}
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
@@ -104,10 +104,6 @@ func (r *Reconciler) calculateActiveGateConfigurationHash(ctx context.Context, d
 
 	resourceAttributesData := deploymentproperties.BuildContent(dk.Spec.ResourceAttributes)
 
-	if len(customPropertyData) == 0 && len(authTokenData) == 0 && len(resourceAttributesData) == 0 {
-		return "", nil
-	}
-
 	hash := fnv.New32()
 	if _, err := hash.Write([]byte(customPropertyData + authTokenData + resourceAttributesData)); err != nil {
 		return "", errors.WithStack(err)

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler_test.go
@@ -194,6 +194,56 @@ func TestReconcile_GetActiveGateAuthTokenHash(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestReconcile_GetResourceAttributesHash(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("resource attributes change the hash", func(t *testing.T) {
+		r, _, dk := createDefaultReconciler(t)
+		agCapability := capability.NewMultiCapability(dk)
+
+		hashWithout, err := r.calculateActiveGateConfigurationHash(ctx, dk, agCapability)
+		require.NoError(t, err)
+		assert.NotEmpty(t, hashWithout)
+
+		dk.Spec.ResourceAttributes = map[string]string{"key": "value"}
+		hashWith, err := r.calculateActiveGateConfigurationHash(ctx, dk, agCapability)
+		require.NoError(t, err)
+		assert.NotEmpty(t, hashWith)
+
+		assert.NotEqual(t, hashWithout, hashWith)
+	})
+
+	t.Run("different resource attributes produce different hashes", func(t *testing.T) {
+		r, _, dk := createDefaultReconciler(t)
+		agCapability := capability.NewMultiCapability(dk)
+
+		dk.Spec.ResourceAttributes = map[string]string{"key": "value1"}
+		hash1, err := r.calculateActiveGateConfigurationHash(ctx, dk, agCapability)
+		require.NoError(t, err)
+
+		dk.Spec.ResourceAttributes = map[string]string{"key": "value2"}
+		hash2, err := r.calculateActiveGateConfigurationHash(ctx, dk, agCapability)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, hash1, hash2)
+	})
+
+	t.Run("multiple resource attributes are included in hash", func(t *testing.T) {
+		r, _, dk := createDefaultReconciler(t)
+		agCapability := capability.NewMultiCapability(dk)
+
+		dk.Spec.ResourceAttributes = map[string]string{"k1": "v1"}
+		hash1, err := r.calculateActiveGateConfigurationHash(ctx, dk, agCapability)
+		require.NoError(t, err)
+
+		dk.Spec.ResourceAttributes = map[string]string{"k1": "v1", "k2": "v2"}
+		hash2, err := r.calculateActiveGateConfigurationHash(ctx, dk, agCapability)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, hash1, hash2)
+	})
+}
+
 func TestManageStatefulSet(t *testing.T) {
 	ctx := t.Context()
 

--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -8,6 +8,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	agclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/deploymentproperties"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/authtoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset"
@@ -115,6 +117,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, dtCli
 		return err
 	}
 
+	err = r.createDeploymentPropertiesConfigMap(ctx, dk)
+	if err != nil {
+		return err
+	}
+
 	versionReconciler := r.versionReconciler
 	if versionReconciler == nil {
 		versionReconciler = version.NewReconciler(r.apiReader, dtClient.Version, timeprovider.New().Freeze())
@@ -183,6 +190,29 @@ func (r *Reconciler) createActiveGateTenantConnectionInfoConfigMap(ctx context.C
 	}
 
 	return nil
+}
+
+func (r *Reconciler) createDeploymentPropertiesConfigMap(ctx context.Context, dk *dynakube.DynaKube) error {
+	if !dk.ActiveGate().IsEnabled() {
+		return nil
+	}
+
+	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.ActiveGateComponentLabel)
+
+	configMap, err := k8sconfigmap.Build(dk,
+		dk.ActiveGate().GetDeploymentPropertiesConfigMapName(),
+		map[string]string{
+			consts.DeploymentPropertiesFileName: deploymentproperties.BuildContent(dk.Spec.ResourceAttributes),
+		},
+		k8sconfigmap.SetLabels(coreLabels.BuildLabels()),
+	)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	_, err = r.configMaps.CreateOrUpdate(ctx, configMap)
+
+	return err
 }
 
 func extractPublicData(dk *dynakube.DynaKube) map[string]string {

--- a/pkg/controllers/dynakube/activegate/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	agclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/capability"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/deploymentproperties"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
@@ -692,6 +693,72 @@ func TestReconcile_ActivegateConfigMap(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, testTenantUUID, actual.Data[connectioninfo.TenantUUIDKey])
 		assert.Equal(t, testTenantEndpoints, actual.Data[connectioninfo.CommunicationEndpointsKey])
+	})
+}
+
+func TestCreateDeploymentPropertiesConfigMap(t *testing.T) {
+	t.Run("skips if ActiveGate is not enabled", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      testName,
+			},
+		}
+		fakeClient := fake.NewClient()
+		r := &Reconciler{configMaps: k8sconfigmap.Query(fakeClient, fakeClient)}
+
+		err := r.createDeploymentPropertiesConfigMap(t.Context(), dk)
+		require.NoError(t, err)
+
+		var cm corev1.ConfigMap
+		err = fakeClient.Get(t.Context(), client.ObjectKey{Name: dk.ActiveGate().GetDeploymentPropertiesConfigMapName(), Namespace: testNamespace}, &cm)
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
+
+	t.Run("creates configmap when ActiveGate is enabled", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      testName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate: activegate.Spec{Capabilities: []activegate.CapabilityDisplayName{activegate.KubeMonCapability.DisplayName}},
+			},
+		}
+		fakeClient := fake.NewClient()
+		r := &Reconciler{configMaps: k8sconfigmap.Query(fakeClient, fakeClient)}
+
+		err := r.createDeploymentPropertiesConfigMap(t.Context(), dk)
+		require.NoError(t, err)
+
+		var cm corev1.ConfigMap
+		err = fakeClient.Get(t.Context(), client.ObjectKey{Name: dk.ActiveGate().GetDeploymentPropertiesConfigMapName(), Namespace: testNamespace}, &cm)
+		require.NoError(t, err)
+		assert.Contains(t, cm.Data, consts.DeploymentPropertiesFileName)
+		assert.Equal(t, deploymentproperties.BuildContent(nil), cm.Data[consts.DeploymentPropertiesFileName])
+	})
+
+	t.Run("configmap content reflects resource attributes", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      testName,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				ActiveGate:         activegate.Spec{Capabilities: []activegate.CapabilityDisplayName{activegate.KubeMonCapability.DisplayName}},
+				ResourceAttributes: map[string]string{"key": "value"},
+			},
+		}
+		fakeClient := fake.NewClient()
+		r := &Reconciler{configMaps: k8sconfigmap.Query(fakeClient, fakeClient)}
+
+		err := r.createDeploymentPropertiesConfigMap(t.Context(), dk)
+		require.NoError(t, err)
+
+		var cm corev1.ConfigMap
+		err = fakeClient.Get(t.Context(), client.ObjectKey{Name: dk.ActiveGate().GetDeploymentPropertiesConfigMapName(), Namespace: testNamespace}, &cm)
+		require.NoError(t, err)
+		assert.Equal(t, deploymentproperties.BuildContent(dk.Spec.ResourceAttributes), cm.Data[consts.DeploymentPropertiesFileName])
 	})
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Propagates the new resource attributes from the dynakube field to the activegate.

It does this by creating a new config map and mounts it as volume to the activegate.

[ICP-3804 Propagate resource attributes to `deployment.properties` for ActiveGate - Jira](https://dt-rnd.atlassian.net/browse/ICP-3804)
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- Apply regular dk with ag: nothing new should happen.
- Apply regular dk with ag and resource attributes set:
  - `/var/lib/dynatrace/secrets/config/deployment.properties` should be mounted on the ag pod
  - `kubectl -n dynatrace logs dynakube-activegate-0 | grep deployment.prop -A 5` should indicate that the file was processed by the ag.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->