### PR TITLE
Fix reconcile loop caused by non-deterministic logmon config secret content

### DIFF
--- a/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
@@ -173,11 +174,13 @@ func (r *Reconciler) getSecretData(ctx context.Context, dk *dynakube.DynaKube) (
 		deploymentConfigContent[networkZoneKey] = dk.Spec.NetworkZone
 	}
 
+	keys := slices.Sorted(maps.Keys(deploymentConfigContent))
+
 	var content strings.Builder
-	for key, value := range deploymentConfigContent {
+	for _, key := range keys {
 		content.WriteString(key)
 		content.WriteString("=")
-		content.WriteString(value)
+		content.WriteString(deploymentConfigContent[key])
 		content.WriteString("\n")
 	}
 


### PR DESCRIPTION
## Description

The logmonitoring config secret reconciler built its secret content by iterating over a `map[string]string` with `range`. Go intentionally randomises map iteration order, so the resulting byte content changed on every reconcile even when no inputs had changed.

`isEqual` in `k8ssecret/query.go` uses `reflect.DeepEqual` on the secret data bytes, so it always detected a diff and called `CreateOrUpdate`. This caused:

1. The secret to be updated in Kubernetes on every reconcile cycle.
2. `SetSecretOutdated` → `SetSecretCreated` to be called on `LmcConditionType`, flipping the condition `True→False→True` and refreshing `LastTransitionTime` both times.
3. `hasher.IsDifferent` to detect a changed DynaKube status → `UpdateStatus` → a new reconcile event.
4. The owned Secret update to also trigger a reconcile via the `Owns(&corev1.Secret{})` watch.

The result was a tight reconcile loop running approximately every 3 seconds.

**Fix:** sort the map keys before writing, so the config file content is deterministic and `isEqual` returns `true` when nothing actually changed.

## How can this be tested?

- Deploy a DynaKube with standalone LogMonitoring enabled.
- Observe `operator.log`: before the fix every reconcile ends with `status changed, updating the DynaKube` at ~3 s intervals; after the fix reconciles should only fire on the normal `requeueAfter` interval (15 min by default) or on actual resource changes.