### PR TITLE
Changes permissions of the appmounts directory

### DIFF
--- a/pkg/controllers/csi/config.go
+++ b/pkg/controllers/csi/config.go
@@ -40,6 +40,8 @@ const (
 	DaemonSetName = "dynatrace-oneagent-csi-driver"
 
 	UnixUmask = 0000
+
+	AppmountsDirPermissions = 0755
 )
 
 type CSIOptions struct {

--- a/pkg/controllers/csi/metadata/correctness.go
+++ b/pkg/controllers/csi/metadata/correctness.go
@@ -64,7 +64,7 @@ func (checker *CorrectnessChecker) migrateAppMounts(ctx context.Context) {
 		}
 	}
 
-	err = os.MkdirAll(checker.path.AppMountsBaseDir(), os.ModePerm)
+	err = os.MkdirAll(checker.path.AppMountsBaseDir(), 0755)
 	if err != nil {
 		log.Error(err, "failed to create app mounts base directory")
 	}

--- a/pkg/controllers/csi/metadata/correctness.go
+++ b/pkg/controllers/csi/metadata/correctness.go
@@ -64,10 +64,12 @@ func (checker *CorrectnessChecker) migrateAppMounts(ctx context.Context) {
 		}
 	}
 
-	err = os.MkdirAll(checker.path.AppMountsBaseDir(), 0755)
+	err = os.MkdirAll(checker.path.AppMountsBaseDir(), dtcsi.AppmountsDirPermissions)
 	if err != nil {
 		log.Error(err, "failed to create app mounts base directory")
 	}
+
+	_ = os.Chmod(checker.path.AppMountsBaseDir(), dtcsi.AppmountsDirPermissions)
 
 	for _, appMount := range oldAppMounts {
 		oldPath := filepath.Dir(appMount.Path)

--- a/pkg/controllers/csi/metadata/correctness.go
+++ b/pkg/controllers/csi/metadata/correctness.go
@@ -67,9 +67,12 @@ func (checker *CorrectnessChecker) migrateAppMounts(ctx context.Context) {
 	err = os.MkdirAll(checker.path.AppMountsBaseDir(), dtcsi.AppmountsDirPermissions)
 	if err != nil {
 		log.Error(err, "failed to create app mounts base directory")
+	} else {
+		err = os.Chmod(checker.path.AppMountsBaseDir(), dtcsi.AppmountsDirPermissions)
+		if err != nil {
+			log.Error(err, "failed to set permissions of the app mounts base directory")
+		}
 	}
-
-	_ = os.Chmod(checker.path.AppMountsBaseDir(), dtcsi.AppmountsDirPermissions)
 
 	for _, appMount := range oldAppMounts {
 		oldPath := filepath.Dir(appMount.Path)

--- a/pkg/controllers/csi/server/server.go
+++ b/pkg/controllers/csi/server/server.go
@@ -95,6 +95,10 @@ func (srv *Server) Start(ctx context.Context) error {
 		hostvolumes.Mode: hostvolumes.NewPublisher(srv.mounter, srv.path),
 	}
 
+	if err := os.MkdirAll(srv.path.AppMountsBaseDir(), 0755); err != nil {
+		return errors.WithMessagef(err, "failed to create '%s' directory", srv.path.AppMountsBaseDir())
+	}
+
 	log.Info("starting listener", "scheme", endpoint.Scheme, "address", addr)
 
 	listener, err := (&net.ListenConfig{}).Listen(ctx, endpoint.Scheme, addr)

--- a/pkg/controllers/csi/server/server.go
+++ b/pkg/controllers/csi/server/server.go
@@ -99,7 +99,10 @@ func (srv *Server) Start(ctx context.Context) error {
 		return errors.WithMessagef(err, "failed to create '%s' directory", srv.path.AppMountsBaseDir())
 	}
 
-	_ = os.Chmod(srv.path.AppMountsBaseDir(), dtcsi.AppmountsDirPermissions)
+	err = os.Chmod(srv.path.AppMountsBaseDir(), dtcsi.AppmountsDirPermissions)
+	if err != nil {
+		log.Error(err, "failed to set permissions of the app mounts base directory")
+	}
 
 	log.Info("starting listener", "scheme", endpoint.Scheme, "address", addr)
 

--- a/pkg/controllers/csi/server/server.go
+++ b/pkg/controllers/csi/server/server.go
@@ -95,9 +95,11 @@ func (srv *Server) Start(ctx context.Context) error {
 		hostvolumes.Mode: hostvolumes.NewPublisher(srv.mounter, srv.path),
 	}
 
-	if err := os.MkdirAll(srv.path.AppMountsBaseDir(), 0755); err != nil {
+	if err := os.MkdirAll(srv.path.AppMountsBaseDir(), dtcsi.AppmountsDirPermissions); err != nil {
 		return errors.WithMessagef(err, "failed to create '%s' directory", srv.path.AppMountsBaseDir())
 	}
+
+	_ = os.Chmod(srv.path.AppMountsBaseDir(), dtcsi.AppmountsDirPermissions)
 
 	log.Info("starting listener", "scheme", endpoint.Scheme, "address", addr)
 

--- a/pkg/controllers/csi/server/volumes/app/publisher.go
+++ b/pkg/controllers/csi/server/volumes/app/publisher.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	csivolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/server/volumes"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/symlink"
@@ -214,7 +215,7 @@ func (pub *Publisher) addPodInfoSymlink(ctx context.Context, volumeCfg *csivolum
 func (pub *Publisher) prepareUpperDir(volumeCfg *csivolumes.VolumeConfig) (string, error) {
 	upperDir := pub.path.AppMountVarDir(volumeCfg.VolumeID)
 
-	err := os.MkdirAll(upperDir, 0755)
+	err := os.MkdirAll(upperDir, dtcsi.AppmountsDirPermissions)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controllers/csi/server/volumes/app/publisher.go
+++ b/pkg/controllers/csi/server/volumes/app/publisher.go
@@ -214,7 +214,7 @@ func (pub *Publisher) addPodInfoSymlink(ctx context.Context, volumeCfg *csivolum
 func (pub *Publisher) prepareUpperDir(volumeCfg *csivolumes.VolumeConfig) (string, error) {
 	upperDir := pub.path.AppMountVarDir(volumeCfg.VolumeID)
 
-	err := os.MkdirAll(upperDir, os.ModePerm)
+	err := os.MkdirAll(upperDir, 0755)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-4570)

## Description

Changes permissions of the `appmounts` directory and `upperdir` paths  from 0777 to 0755.
Permissions of existing upperdir paths  are not changed after operator update.

## How can this be tested?
Use CSI Server shell to check permissions of `/data/*` files and directories.

1) New installation.

make cleanup/node-fs
Deploy operator from the branch
Deploy CNFS DK
Deploy sample app
Remove everything

Expected permissions:
- appmounts - 0755
- appmounts/volumeID - 0755
- appmounts/volumeID/var - 0755

2) Update

make cleanup/node-fs
Deploy operator from the `main` branch
Deploy CNFS DK
Deploy sample app
Update operator to the branch version
Install new app (or reinstall old app)

Expected permissions (old app):
- appmounts - 0775
- appmounts/volumeID - 0777
- appmounts/volumeID/var - 0777

Expected permissions (new app):
- appmounts - 0775
- appmounts/volumeID - 0755
- appmounts/volumeID/var - 0755


