### PR TITLE
Create consts for the DTComponentsSecretsRootDir used in many components

### DIFF
--- a/pkg/consts/paths.go
+++ b/pkg/consts/paths.go
@@ -1,0 +1,3 @@
+package consts
+
+const DTComponentsSecretsRootDir = "/var/lib/dynatrace/secrets"

--- a/pkg/controllers/dynakube/activegate/consts/consts.go
+++ b/pkg/controllers/dynakube/activegate/consts/consts.go
@@ -2,7 +2,7 @@ package consts
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
-	sharedconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -23,7 +23,7 @@ const (
 
 	DeploymentPropertiesVolumeName = "deployment-properties"
 	DeploymentPropertiesFileName   = "deployment.properties"
-	DeploymentPropertiesBasePath   = sharedconsts.DTComponentsSecretsRootDir + "/config"
+	DeploymentPropertiesBasePath   = consts.DTComponentsSecretsRootDir + "/config"
 
 	EnvDTCapabilities    = "DT_CAPABILITIES"
 	EnvDTIDSeedNamespace = "DT_ID_SEED_NAMESPACE"

--- a/pkg/controllers/dynakube/activegate/consts/consts.go
+++ b/pkg/controllers/dynakube/activegate/consts/consts.go
@@ -2,6 +2,7 @@ package consts
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
+	sharedconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -22,7 +23,7 @@ const (
 
 	DeploymentPropertiesVolumeName = "deployment-properties"
 	DeploymentPropertiesFileName   = "deployment.properties"
-	DeploymentPropertiesBasePath   = "/var/lib/dynatrace/secrets/config"
+	DeploymentPropertiesBasePath   = sharedconsts.DTComponentsSecretsRootDir + "/config"
 
 	EnvDTCapabilities    = "DT_CAPABILITIES"
 	EnvDTIDSeedNamespace = "DT_ID_SEED_NAMESPACE"

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	sharedconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8scontainer"
@@ -17,8 +18,7 @@ var _ volumeMountModifier = CertificatesModifier{}
 var _ builder.Modifier = CertificatesModifier{}
 
 const (
-	jettyCerts     = "server-certs"
-	secretsRootDir = "/var/lib/dynatrace/secrets/"
+	jettyCerts = "server-certs"
 )
 
 func NewCertificatesModifier(dk dynakube.DynaKube) CertificatesModifier {
@@ -62,7 +62,7 @@ func (mod CertificatesModifier) getVolumeMounts() []corev1.VolumeMount {
 		{
 			ReadOnly:  true,
 			Name:      jettyCerts,
-			MountPath: filepath.Join(secretsRootDir, "tls"),
+			MountPath: filepath.Join(sharedconsts.DTComponentsSecretsRootDir, "/tls"),
 		},
 	}
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/certs.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	sharedconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	operatorconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8scontainer"
@@ -62,7 +62,7 @@ func (mod CertificatesModifier) getVolumeMounts() []corev1.VolumeMount {
 		{
 			ReadOnly:  true,
 			Name:      jettyCerts,
-			MountPath: filepath.Join(sharedconsts.DTComponentsSecretsRootDir, "/tls"),
+			MountPath: filepath.Join(operatorconsts.DTComponentsSecretsRootDir, "tls"),
 		},
 	}
 }

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -2,6 +2,7 @@ package modifiers
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	sharedconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	eecconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
@@ -17,7 +18,7 @@ var _ builder.Modifier = EECModifier{}
 
 const (
 	eecVolumeName = "eec-token"
-	eecMountPath  = "/var/lib/dynatrace/secrets/eec/token"
+	eecMountPath  = sharedconsts.DTComponentsSecretsRootDir + "/eec/token"
 	eecFile       = "eec.token"
 )
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/eec.go
@@ -2,7 +2,7 @@ package modifiers
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	sharedconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	operatorconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	eecconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/consts"
@@ -18,7 +18,7 @@ var _ builder.Modifier = EECModifier{}
 
 const (
 	eecVolumeName = "eec-token"
-	eecMountPath  = sharedconsts.DTComponentsSecretsRootDir + "/eec/token"
+	eecMountPath  = operatorconsts.DTComponentsSecretsRootDir + "/eec/token"
 	eecFile       = "eec.token"
 )
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kspm.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kspm.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kspm"
-	sharedconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	operatorconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8scontainer"
@@ -18,7 +18,7 @@ var _ builder.Modifier = KSPMModifier{}
 
 const (
 	kspmTokenVolumeName           = "kspm-token"
-	kspmTokenMountPath            = sharedconsts.DTComponentsSecretsRootDir + "/tokens/kspm/node-configuration-collector"
+	kspmTokenMountPath            = operatorconsts.DTComponentsSecretsRootDir + "/tokens/kspm/node-configuration-collector"
 	kspmTokenSecretHashAnnotation = api.InternalFlagPrefix + "kspm-token-secret-hash"
 )
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kspm.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kspm.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kspm"
+	sharedconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8scontainer"
@@ -17,7 +18,7 @@ var _ builder.Modifier = KSPMModifier{}
 
 const (
 	kspmTokenVolumeName           = "kspm-token"
-	kspmTokenMountPath            = "/var/lib/dynatrace/secrets/tokens/kspm/node-configuration-collector"
+	kspmTokenMountPath            = sharedconsts.DTComponentsSecretsRootDir + "/tokens/kspm/node-configuration-collector"
 	kspmTokenSecretHashAnnotation = api.InternalFlagPrefix + "kspm-token-secret-hash"
 )
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume.go
@@ -2,7 +2,7 @@ package modifiers
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	sharedconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	operatorconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8scontainer"
@@ -16,7 +16,7 @@ var _ builder.Modifier = TrustedCAsModifier{}
 
 const (
 	volumeName     = "trustedcas"
-	trustedCAsDir  = sharedconsts.DTComponentsSecretsRootDir + "/rootca"
+	trustedCAsDir  = operatorconsts.DTComponentsSecretsRootDir + "/rootca"
 	trustedCAsFile = "rootca.pem"
 )
 

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/trustedcas_volume.go
@@ -2,6 +2,7 @@ package modifiers
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	sharedconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/internal/statefulset/builder"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8scontainer"
@@ -15,7 +16,7 @@ var _ builder.Modifier = TrustedCAsModifier{}
 
 const (
 	volumeName     = "trustedcas"
-	trustedCAsDir  = "/var/lib/dynatrace/secrets/rootca"
+	trustedCAsDir  = sharedconsts.DTComponentsSecretsRootDir + "/rootca"
 	trustedCAsFile = "rootca.pem"
 )
 

--- a/pkg/controllers/dynakube/connectioninfo/common.go
+++ b/pkg/controllers/dynakube/connectioninfo/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
@@ -17,7 +18,7 @@ const (
 	TenantTokenKey            = "tenant-token"
 	CommunicationEndpointsKey = "communication-endpoints"
 
-	TokenBasePath         = "/var/lib/dynatrace/secrets/tokens"
+	TokenBasePath         = consts.DTComponentsSecretsRootDir + "/tokens"
 	TenantTokenMountPoint = TokenBasePath + "/tenant-token"
 
 	TenantSecretVolumeName = "connection-info-secret"

--- a/pkg/controllers/dynakube/kspm/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/volumes.go
@@ -7,13 +7,14 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kspm"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )
 
 const (
 	tokenVolumeName           = "kspm-token"
-	tokenMountPath            = "/var/lib/dynatrace/secrets/tokens/kspm/node-configuration-collector"
+	tokenMountPath            = consts.DTComponentsSecretsRootDir + "/tokens/kspm/node-configuration-collector"
 	tokenSecretHashAnnotation = api.InternalFlagPrefix + "kspm-token-secret-hash"
 
 	nodeRootMountPath = "/node_root"

--- a/pkg/controllers/dynakube/proxy/consts.go
+++ b/pkg/controllers/dynakube/proxy/consts.go
@@ -1,5 +1,7 @@
 package proxy
 
+import "github.com/Dynatrace/dynatrace-operator/pkg/consts"
+
 const (
 	hostField     = "host"
 	portField     = "port"
@@ -7,6 +9,6 @@ const (
 	passwordField = "password"
 	schemeField   = "scheme"
 
-	SecretMountPath  = "/var/lib/dynatrace/secrets/internal-proxy"
+	SecretMountPath  = consts.DTComponentsSecretsRootDir + "/internal-proxy"
 	SecretVolumeName = "internal-proxy-secret-volume"
 )


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Follow up PR for https://dt-rnd.atlassian.net/browse/ICP-3804. 

Moves the widely used `/var/lib/dynatrace/secrets` path into one place.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- run e2e, everything should work as before

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->