### PR TITLE
Filter out invalid symlinks that attempt to escape the extraction directory

### DIFF
--- a/pkg/injection/codemodule/installer/zip/gzip.go
+++ b/pkg/injection/codemodule/installer/zip/gzip.go
@@ -55,20 +55,10 @@ func extractFilesFromGzip(ctx context.Context, targetDir string, reader *tar.Rea
 			return errors.WithStack(err)
 		}
 
-		target := filepath.Join(targetDir, header.Name)
+		target := evaluateTargetPath(targetDir, header.Name)
 
-		// Check for ZipSlip: https://snyk.io/research/zip-slip-vulnerability
-		if !strings.HasPrefix(target, targetDir) {
-			return errors.Errorf("illegal file path: %s", target)
-		}
-
-		rel, err := filepath.Rel(targetDir, target)
-		if err != nil {
+		if err := isTargetSafeToCreate(targetDir, header.Name, target); err != nil {
 			return err
-		}
-
-		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-			return errors.Errorf("%q is outside of %q", header.Name, targetDir)
 		}
 
 		err = extract(ctx, targetDir, reader, header, target)
@@ -76,6 +66,32 @@ func extractFilesFromGzip(ctx context.Context, targetDir string, reader *tar.Rea
 			return err
 		}
 	}
+}
+
+func isTargetSafeToCreate(targetDir, name, target string) error {
+	if len(name) == 0 {
+		return errors.Errorf("illegal empty file name")
+	}
+
+	// Check for ZipSlip: https://snyk.io/research/zip-slip-vulnerability
+	if !strings.HasPrefix(target, targetDir) {
+		return errors.Errorf("illegal file path: %s", target)
+	}
+
+	rel, err := filepath.Rel(targetDir, target)
+	if err != nil {
+		return err
+	}
+
+	if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return errors.Errorf("%q is outside of %q", name, targetDir)
+	}
+
+	return nil
+}
+
+func evaluateTargetPath(targetDir, name string) string {
+	return filepath.Join(targetDir, name)
 }
 
 func extract(ctx context.Context, targetDir string, reader *tar.Reader, header *tar.Header, target string) error {
@@ -108,7 +124,7 @@ func extract(ctx context.Context, targetDir string, reader *tar.Reader, header *
 func extractLink(ctx context.Context, targetDir, target string, header *tar.Header) error {
 	log := logd.FromContext(ctx)
 
-	if isSafeToLink(header.Linkname, targetDir, target) && isSafeToLink(header.Name, targetDir, target) {
+	if isHardlinkSafeToLink(header.Linkname, targetDir) {
 		if err := os.Link(filepath.Join(targetDir, header.Linkname), target); err != nil {
 			return errors.WithStack(err)
 		}
@@ -119,10 +135,26 @@ func extractLink(ctx context.Context, targetDir, target string, header *tar.Head
 	return nil
 }
 
+// isHardlinkSafeToLink checks that the provided relative hardlink is NOT pointing outside of the `targetDir`
+func isHardlinkSafeToLink(link, targetDir string) bool {
+	if filepath.IsAbs(link) {
+		return false
+	}
+
+	if len(link) == 0 {
+		return false
+	}
+
+	finalPath := filepath.Join(targetDir, link)
+	relpath, err := filepath.Rel(targetDir, finalPath)
+
+	return err == nil && !strings.HasPrefix(filepath.Clean(relpath), "..")
+}
+
 func extractSymlink(ctx context.Context, targetDir, target string, header *tar.Header) error {
 	log := logd.FromContext(ctx)
 
-	if isSafeToLink(header.Linkname, targetDir, target) && isSafeToLink(header.Name, targetDir, target) {
+	if isSymlinkSafeToLink(header.Linkname, targetDir, target) {
 		if err := os.Symlink(header.Linkname, target); err != nil {
 			return errors.WithStack(err)
 		}
@@ -133,9 +165,13 @@ func extractSymlink(ctx context.Context, targetDir, target string, header *tar.H
 	return nil
 }
 
-// isSafeToLink checks that the provided relative hard or symbolic link is NOT pointing outside of the `targetDir`
-func isSafeToLink(symlink, targetDir, target string) bool {
+// isSymlinkSafeToLink checks that the provided relative symbolic link is NOT pointing outside of the `targetDir`
+func isSymlinkSafeToLink(symlink, targetDir, target string) bool {
 	if filepath.IsAbs(symlink) {
+		return false
+	}
+
+	if len(symlink) == 0 {
 		return false
 	}
 

--- a/pkg/injection/codemodule/installer/zip/gzip.go
+++ b/pkg/injection/codemodule/installer/zip/gzip.go
@@ -139,7 +139,8 @@ func isSafeToLink(symlink, targetDir, target string) bool {
 		return false
 	}
 
-	finalPath := filepath.Join(target, symlink)
+	symlinkDir := filepath.Dir(target)
+	finalPath := filepath.Join(symlinkDir, symlink)
 	relpath, err := filepath.Rel(targetDir, finalPath)
 
 	return err == nil && !strings.HasPrefix(filepath.Clean(relpath), "..")

--- a/pkg/injection/codemodule/installer/zip/gzip_test.go
+++ b/pkg/injection/codemodule/installer/zip/gzip_test.go
@@ -239,13 +239,36 @@ func TestExtractGzip(t *testing.T) {
 		// Note: escape_parent symlink (../../outside.txt) actually resolves to a path within tmpDir
 		// so it's allowed by the security check. The function checks the final resolved path.
 		escapeParent := filepath.Join(testDir, "escape_parent")
-		info, err = os.Lstat(escapeParent)
-		require.NoError(t, err)
-		require.Equal(t, os.ModeSymlink, info.Mode()&os.ModeSymlink, "escape_parent should be a symlink")
+		_, err = os.Lstat(escapeParent)
+		require.True(t, os.IsNotExist(err), "escape_parent should not exist (should be blocked)")
+	})
 
-		// Verify that the symlink target resolves within the extraction directory
-		target, err = os.Readlink(escapeParent)
+	t.Run("extract gzip with malicious tar containing a symlink and a file of the same path and filename.", func(t *testing.T) {
+		// testRawGzipWithMaliciousSymlinkAndFile is a gzip archive containing a symlink and a file of the same path and filename that attempt to escape the extraction directory
+		// testdir/ - directory
+		// testdir/escape_parent -> ../../outside.txt - symlink (should be blocked)
+		// testdir/escape_parent - regular file
+
+		const testRawGzipWithMaliciousSymlinkAndFile = `H4sICLXb/WkAA2xheWVyLnRhcgDtk00KhDAMRnuUnqBW7c9xpGgWblTaCHP8qTqrDgwMWlHMo5Cu+iV5FCFg13uWExmxWq81ktbveymNVIzrrF19mAM6H+P3vpMOdxNw819AaN0EzeQ8DHhwxurf2j/8m0pbxishinjGGUPfgcDX0Y0tkP9T/BulfvivE/+1KiXjpyzx6f6zfCqCIAji6rwBqGlw6wAMAAA=`
+
+		tmpDir := t.TempDir()
+
+		gzipFile := SetupTestArchive(t, testRawGzipWithMaliciousSymlinkAndFile)
+
+		defer func() { _ = gzipFile.Close() }()
+
+		reader, err := gzip.NewReader(gzipFile)
 		require.NoError(t, err)
-		require.Equal(t, "../../outside.txt", target)
+
+		tarReader := tar.NewReader(reader)
+
+		err = extractFilesFromGzip(t.Context(), tmpDir, tarReader)
+		require.NoError(t, err)
+
+		// Verify safe symlink was created
+		evilFile := filepath.Join(tmpDir, "testdir/escape_parent")
+		info, err := os.Lstat(evilFile)
+		require.NoError(t, err)
+		require.True(t, info.Mode().IsRegular(), "escape_parent should be a regular file (symlink of the same name should be blocked)")
 	})
 }

--- a/pkg/injection/codemodule/installer/zip/gzip_test.go
+++ b/pkg/injection/codemodule/installer/zip/gzip_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/gzip"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -271,4 +272,281 @@ func TestExtractGzip(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, info.Mode().IsRegular(), "escape_parent should be a regular file (symlink of the same name should be blocked)")
 	})
+
+	t.Run("extract gzip with malicious tar containing a hardlink and a file of the same path and filename.", func(t *testing.T) {
+		// testRawGzipWithMaliciousSymlinkAndFile is a gzip archive containing a symlink and a file of the same path and filename that attempt to escape the extraction directory
+		// testdir/ - directory
+		// testdir/escape_parent -> ../../outside.txt - hardlink (should be blocked)
+		// testdir/escape_parent - regular file
+
+		const testRawGzipWithMaliciousSymlinkAndFile = `H4sIAAAAAAAAA+2TSwrDIBCGPYonMNr4OE6RZhbZNEEnkOPXPFYGAqUxNGQ+hHHlPzMfIkRs2sBKIhPOmLkm8rq9K2mlZtwU7WpliOhDiv/1nXy4i4CL/wriy/fw7H2ANx6cMft37gv/9mEs40qIKp1uwNg2IHA8urEJ8n+Kf6v1jv86819rJRk/ZYl391/kUxEEQRD/zgdS0LVvAAwAAA==`
+
+		tmpDir := t.TempDir()
+
+		// create a file that is dst file of the hardlink that is part ot the layer.tar
+		// to avoid "No such file" error if hardlink is created
+		err := os.WriteFile(filepath.Join(tmpDir, "outside.txt"), []byte("outside"), 0600)
+		require.NoError(t, err)
+
+		layerTmpDir := filepath.Join(tmpDir, "deeper-tmp")
+		err = os.MkdirAll(layerTmpDir, 0755)
+		require.NoError(t, err)
+
+		gzipFile := SetupTestArchive(t, testRawGzipWithMaliciousSymlinkAndFile)
+
+		defer func() { _ = gzipFile.Close() }()
+
+		reader, err := gzip.NewReader(gzipFile)
+		require.NoError(t, err)
+
+		tarReader := tar.NewReader(reader)
+
+		err = extractFilesFromGzip(t.Context(), layerTmpDir, tarReader)
+		require.NoError(t, err)
+
+		// Verify safe symlink was created
+		evilFile := filepath.Join(layerTmpDir, "testdir/escape_parent")
+		info, err := os.Lstat(evilFile)
+		require.NoError(t, err)
+		require.True(t, info.Mode().IsRegular(), "escape_parent should be a regular file (symlink of the same name should be blocked)")
+	})
+}
+
+func TestIsSymlinkSafe(t *testing.T) {
+	tests := []struct {
+		description string
+		targetDir   string
+		name        string
+		symlink     string
+		safe        bool
+	}{
+		{
+			"dir/symlink -> dir/file",
+			"/tmpDir",
+			"dir/symlink",
+			"file",
+			true,
+		},
+		{
+			"dir/symlink -> ../file",
+			"/tmpDir",
+			"dir/symlink",
+			"../file",
+			true,
+		},
+		{
+			"symlink -> ../file",
+			"/tmpDir",
+			"symlink",
+			"../file",
+			false,
+		},
+		{
+			"dir/symlink -> ../../file",
+			"/tmpDir",
+			"dir/symlink",
+			"../../file",
+			false,
+		},
+		{
+			"symlink -> /file",
+			"/tmpDir",
+			"symlink",
+			"/file",
+			false,
+		},
+		{
+			"symlink -> ..",
+			"/tmpDir",
+			"symlink",
+			"..",
+			false,
+		},
+		{
+			"dir/symlink -> ..",
+			"/tmpDir",
+			"dir/symlink",
+			"..",
+			true,
+		},
+		{
+			"dir/symlink -> .",
+			"/tmpDir",
+			"symlink",
+			".",
+			true,
+		},
+		{
+			"dir/symlink -> subdir/../../file",
+			"/tmpDir",
+			"dir/symlink",
+			"subdir/../../file",
+			true,
+		},
+		{
+			"dir/symlink -> subdir/../../../file",
+			"/tmpDir",
+			"dir/symlink",
+			"subdir/../../../file",
+			false,
+		},
+		{
+			"dir/symlink -> ''",
+			"/tmpDir",
+			"symlink",
+			"",
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			safe := isSymlinkSafeToLink(test.symlink, test.targetDir, evaluateTargetPath(test.targetDir, test.name))
+			assert.Equal(t, test.safe, safe)
+		})
+	}
+}
+
+func TestIsHardlinkSafe(t *testing.T) {
+	tests := []struct {
+		description string
+		targetDir   string
+		hardlink    string
+		safe        bool
+	}{
+		{
+			"hardlink -> file",
+			"/tmpDir",
+			"file",
+			true,
+		},
+		{
+			"hardlink -> dir/file",
+			"/tmpDir",
+			"dir/file",
+			true,
+		},
+		{
+			"hardlink -> ../file",
+			"/tmpDir",
+			"../file",
+			false,
+		},
+		{
+			"hardlink -> ../../file",
+			"/tmpDir",
+			"../../file",
+			false,
+		},
+		{
+			"hardlink -> /file",
+			"/tmpDir",
+			"/file",
+			false,
+		},
+		{
+			"hardlink -> dir/../file",
+			"/tmpDir",
+			"dir/../b",
+			true,
+		},
+		{
+			"hardlink -> dir/../../file",
+			"/tmpDir",
+			"dir/../../b",
+			false,
+		},
+		{
+			"hardlink -> dir/.././../file",
+			"/tmpDir",
+			"dir/.././../b",
+			false,
+		},
+		{
+			"hardlink -> ''",
+			"/tmpDir",
+			"",
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			safe := isHardlinkSafeToLink(test.hardlink, test.targetDir)
+			assert.Equal(t, test.safe, safe)
+		})
+	}
+}
+
+func TestIsTargetSafe(t *testing.T) {
+	tests := []struct {
+		description string
+		targetDir   string
+		name        string
+		safe        bool
+	}{
+		{
+			"file",
+			"/tmpDir",
+			"file",
+			true,
+		},
+		{
+			"/file",
+			"/tmpDir",
+			"/file",
+			true, // always relative to targetDir because target := evaluateTargetPath(targetDir, header.Name)
+		},
+		{
+			"../file",
+			"/tmpDir",
+			"../file",
+			false,
+		},
+		{
+			"/../file",
+			"/tmpDir",
+			"/../file",
+			false,
+		},
+		{
+			"../../file",
+			"/tmpDir",
+			"../../file",
+			false,
+		},
+		{
+			"./file",
+			"/tmpDir",
+			"./file",
+			true,
+		},
+		{
+			"./../file",
+			"/tmpDir",
+			"./../file",
+			false,
+		},
+		{
+			"dir/../../file",
+			"/tmpDir",
+			"dir/../../file",
+			false,
+		},
+		{
+			"empty filename",
+			"/tmpDir",
+			"",
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			err := isTargetSafeToCreate(test.targetDir, test.name, evaluateTargetPath(test.targetDir, test.name))
+			if test.safe {
+				assert.NoError(t, err, test.description)
+			} else {
+				assert.Error(t, err, test.description)
+			}
+		})
+	}
 }


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-4550)

## Description

Adds dedicated IsSafe* functions for symlink, hardlink and the target file.  

The original IsSafeToLink function concatenates _target_ (full path including filename part of the symlink) with the _link_ using Join so the result contains also filename part of the symlink in the middle increasing the depth of the path by one.

Nothing should be saved/loaded out of the _/data_ directory
```
/data/opt/symlink -> ../../outside.txt  
```
Without the fix:
```
/data/opt/symlink/../../outside.txt 
/data/opt/../outside.txt 
/data/outside.txt
```
the (correct) evaluated path returned by _EvalSymLink()_ would be
```
/outside.txt  <-- should be blocked
```

## How can this be tested?

unittests