### PR TITLE
increase prconcurrentlimit=20 for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,7 @@
   automergeType: "pr",
   automerge: true,
   branchNameStrict: true,
+  prconcurrentlimit: 20,
   hashedBranchLength: 27, // 63 character limit for label values with space for "dynatrace-operator.v0.0.0-snapshot-" prefix
   regexManagers: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,7 +35,7 @@
   automergeType: "pr",
   automerge: true,
   branchNameStrict: true,
-  prconcurrentlimit: 20,
+  prConcurrentLimit: 20,
   hashedBranchLength: 27, // 63 character limit for label values with space for "dynatrace-operator.v0.0.0-snapshot-" prefix
   regexManagers: [
     {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Context:

Renovate didn't upgrade go version so we do -> [https://github.com/Dynatrace/dynatrace-operator/pull/6560](https://github.com/Dynatrace/dynatrace-operator/pull/6560)

To avoid this problem we should increase renovate prconcurrentlimit = 20 **(default is 10)**

Full list of pending PRs https://developer.mend.io/github/Dynatrace/dynatrace-operator

Example that renovate will update go:

<img width="1926" height="392" alt="image" src="https://github.com/user-attachments/assets/4a323fbb-00af-41ed-8d68-72cfde8913f2" />


## How can this be tested?

n/a