### PR TITLE
Group golang.org updates together

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -192,6 +192,12 @@
       ],
       groupName: "istio.io",
     },
+    {
+      matchPackageNames: [
+        "golang.org/**",
+      ],
+      groupName: "golang.org",
+    },
   ],
   platformAutomerge: true,
 }


### PR DESCRIPTION
## Description

We use a few golang.org/x packages, some of which also depend on each other. Configure renovate to put all updates in a single PR.
See #6190
