### PR TITLE
Set dnsPolicy if values.webhook.hostNetwork is enabled

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -119,6 +119,7 @@ spec:
           {{- include "webhook.securityContext" . | nindent 12 }}
       serviceAccountName: dynatrace-webhook
       {{- if (.Values.webhook).hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       {{- end }}
       securityContext:

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -865,3 +865,29 @@ tests:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
+
+  - it: should set dnsPolicy if hostNetwork is enabled
+    set:
+      platform: kubernetes
+      image: image-name
+      webhook:
+        hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: should not set dnsPolicy if hostNetwork is disabled
+    set:
+      platform: kubernetes
+      image: image-name
+      webhook:
+        hostNetwork: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.hostNetwork
+      - isNull:
+          path: spec.template.spec.dnsPolicy


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-4777)

## Description
Webhook _startupProbe_ needs to resolve _kubernetes.default.svc_.

webhook.spec._dnsPolicy_ is set to `ClusterFirstWithHostNet` if webhook.spec._hostNetwork_ is enabled (via values.yaml).

## How can this be tested?

1)
```
 make test/helm
```
2)
```
make deploy
helm upgrade dynatrace-operator -n dynatrace config/helm/chart/default  --reuse-values --set webhook.hostNetwork=true
```