### PR TITLE
Add data ingest token hash to OTelC manifest to trigger restarts on data ingest token rotation

### DIFF
--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -31,6 +31,7 @@ const (
 	serviceAccountName                                  = "dynatrace" + consts.OTELCollectorNameSuffix
 	annotationTelemetryIngestSecretHash                 = api.InternalFlagPrefix + "telemetry-ingest-secret-hash"
 	annotationTelemetryIngestConfigurationConfigMapHash = api.InternalFlagPrefix + "telemetry-ingest-config-hash"
+	annotationDataIngestTokenSecretHash                 = api.InternalFlagPrefix + "data-ingest-token-hash"
 
 	runAs int64 = 10001
 )
@@ -170,6 +171,13 @@ func (r *Reconciler) buildTemplateAnnotations(ctx context.Context, dk *dynakube.
 		}
 
 		templateAnnotations[annotationTelemetryIngestConfigurationConfigMapHash] = configConfigMapHash
+
+		dataIngestTokenHash, err := r.calculateDataIngestTokenHash(ctx, dk)
+		if err != nil {
+			return nil, err
+		}
+
+		templateAnnotations[annotationDataIngestTokenSecretHash] = dataIngestTokenHash
 	}
 
 	return templateAnnotations, nil
@@ -211,6 +219,17 @@ func (r *Reconciler) calculateConfigMapHash(ctx context.Context, configMapName s
 	}
 
 	return configConfigMaptHash, nil
+}
+
+func (r *Reconciler) calculateDataIngestTokenHash(ctx context.Context, dk *dynakube.DynaKube) (string, error) {
+	tokenReader := token.NewReader(r.apiReader, dk)
+
+	tokens, err := tokenReader.ReadTokens(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return hasher.GenerateHash(tokens.DataIngestToken().Value)
 }
 
 func (r *Reconciler) checkDataIngestTokenExists(ctx context.Context, dk *dynakube.DynaKube) bool {

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -229,7 +229,7 @@ func (r *Reconciler) calculateDataIngestTokenHash(ctx context.Context, dk *dynak
 		return "", err
 	}
 
-	return hasher.GenerateHash(tokens.DataIngestToken().Value)
+	return hasher.GenerateSecureHash(tokens.DataIngestToken().Value)
 }
 
 func (r *Reconciler) checkDataIngestTokenExists(ctx context.Context, dk *dynakube.DynaKube) bool {

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
@@ -151,6 +151,59 @@ func TestSecretHashAnnotation(t *testing.T) {
 	})
 }
 
+func TestDataIngestTokenHashAnnotation(t *testing.T) {
+	t.Run("annotation is set when TelemetryIngest is enabled", func(t *testing.T) {
+		t.Cleanup(version.DisableCacheForTest(123))
+
+		dk := getTestDynakubeWithTelemetryIngest()
+		clt := fake.NewClient(dk)
+
+		tokenSecret := getTokens(dk.Tokens(), dk.Namespace)
+		require.NoError(t, clt.Create(t.Context(), &tokenSecret))
+
+		configMap := getConfigConfigMap(dk.Name, dk.Namespace)
+		require.NoError(t, clt.Create(t.Context(), &configMap))
+
+		require.NoError(t, NewReconciler(clt, clt).Reconcile(t.Context(), dk))
+
+		sts := &appsv1.StatefulSet{}
+		require.NoError(t, clt.Get(t.Context(), client.ObjectKey{Name: dk.OtelCollectorStatefulsetName(), Namespace: dk.Namespace}, sts))
+
+		assert.NotEmpty(t, sts.Spec.Template.Annotations[annotationDataIngestTokenSecretHash])
+	})
+
+	t.Run("annotation changes when data ingest token is rotated", func(t *testing.T) {
+		t.Cleanup(version.DisableCacheForTest(123))
+
+		dk := getTestDynakubeWithTelemetryIngest()
+		clt := fake.NewClient(dk)
+
+		tokenSecret := getTokens(dk.Tokens(), dk.Namespace)
+		require.NoError(t, clt.Create(t.Context(), &tokenSecret))
+
+		configMap := getConfigConfigMap(dk.Name, dk.Namespace)
+		require.NoError(t, clt.Create(t.Context(), &configMap))
+
+		reconciler := NewReconciler(clt, clt)
+		require.NoError(t, reconciler.Reconcile(t.Context(), dk))
+
+		sts := &appsv1.StatefulSet{}
+		require.NoError(t, clt.Get(t.Context(), client.ObjectKey{Name: dk.OtelCollectorStatefulsetName(), Namespace: dk.Namespace}, sts))
+		originalHash := sts.Spec.Template.Annotations[annotationDataIngestTokenSecretHash]
+		require.NotEmpty(t, originalHash)
+
+		tokenSecret.Data[token.DataIngestKey] = []byte("rotated-token-value")
+		require.NoError(t, clt.Update(t.Context(), &tokenSecret))
+
+		require.NoError(t, reconciler.Reconcile(t.Context(), dk))
+
+		sts = &appsv1.StatefulSet{}
+		require.NoError(t, clt.Get(t.Context(), client.ObjectKey{Name: dk.OtelCollectorStatefulsetName(), Namespace: dk.Namespace}, sts))
+
+		assert.NotEqual(t, originalHash, sts.Spec.Template.Annotations[annotationDataIngestTokenSecretHash])
+	})
+}
+
 func TestStatefulsetBase(t *testing.T) {
 	t.Run("replicas", func(t *testing.T) {
 		statefulSet := getStatefulset(t, getTestDynakubeWithExtensions())


### PR DESCRIPTION
## Description

OTelC pod needs to be restarted, if data ingest token is rotated.

[JIRA](https://dt-rnd.atlassian.net/browse/ICP-4734)


## How can this be tested?

* deploy DK with telemetry ingest
* change data ingest token
* wait for next recon loop
* check that OTelC pod restarts and token hash has been updated