### PR TITLE
Remove deprecated gomodguard linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,6 @@ linters:
     - godot
     - goheader
     - gomoddirectives
-    - gomodguard
     - goprintffuncname
     - gosec
     - gosmopolitan


### PR DESCRIPTION
## Description

The linter was deprecated in golangci-lint 2.12.0. The replacement is gomodguard_v2, but we actually don't use this linter at all since it requires some configuration to work.
See: https://github.com/ryancurrah/gomodguard

Add it back if we have a use-case for it.
