### PR TITLE
Handle new settings field

### DIFF
--- a/pkg/api/latest/dynakube/metadataenrichment/spec.go
+++ b/pkg/api/latest/dynakube/metadataenrichment/spec.go
@@ -10,8 +10,8 @@ const (
 	LabelRule      RuleType = "LABEL"
 	AnnotationRule RuleType = "ANNOTATION"
 
-	K8sLabelRule      RuleType = "K8S_NAMESPACE_LABEL"
-	K8sAnnotationRule RuleType = "K8S_NAMESPACE_ANNOTATION"
+	K8sNamespaceLabelRule      RuleType = "K8S_NAMESPACE_LABEL"
+	K8sNamespaceAnnotationRule RuleType = "K8S_NAMESPACE_ANNOTATION"
 	// TODO: implement support for this type.
 	CustomRule RuleType = "CUSTOM"
 
@@ -48,8 +48,8 @@ func IsSupportedType(ruleType RuleType) bool {
 	switch ruleType {
 	case LabelRule,
 		AnnotationRule,
-		K8sLabelRule,
-		K8sAnnotationRule:
+		K8sNamespaceLabelRule,
+		K8sNamespaceAnnotationRule:
 		return true
 	}
 

--- a/pkg/api/latest/dynakube/metadataenrichment/spec.go
+++ b/pkg/api/latest/dynakube/metadataenrichment/spec.go
@@ -7,11 +7,16 @@ import (
 type RuleType string
 
 const (
-	LabelRule          RuleType = "LABEL"
-	AnnotationRule     RuleType = "ANNOTATION"
-	Annotation         string   = "metadata.dynatrace.com"
-	Prefix                      = Annotation + "/"
-	namespaceKeyPrefix string   = "k8s.namespace."
+	LabelRule      RuleType = "LABEL"
+	AnnotationRule RuleType = "ANNOTATION"
+
+	K8sLabelRule      RuleType = "K8S_NAMESPACE_LABEL"
+	K8sAnnotationRule RuleType = "K8S_NAMESPACE_ANNOTATION"
+	CustomRule        RuleType = "CUSTOM"
+
+	Annotation         = "metadata.dynatrace.com"
+	Prefix             = Annotation + "/"
+	namespaceKeyPrefix = "k8s.namespace."
 )
 
 type MetadataEnrichment struct {

--- a/pkg/api/latest/dynakube/metadataenrichment/spec.go
+++ b/pkg/api/latest/dynakube/metadataenrichment/spec.go
@@ -12,7 +12,8 @@ const (
 
 	K8sLabelRule      RuleType = "K8S_NAMESPACE_LABEL"
 	K8sAnnotationRule RuleType = "K8S_NAMESPACE_ANNOTATION"
-	CustomRule        RuleType = "CUSTOM"
+	// TODO: implement support for this type.
+	CustomRule RuleType = "CUSTOM"
 
 	Annotation         = "metadata.dynatrace.com"
 	Prefix             = Annotation + "/"
@@ -40,4 +41,17 @@ type Rule struct {
 	Type   RuleType `json:"type,omitempty"`
 	Source string   `json:"source,omitempty"`
 	Target string   `json:"target,omitempty"`
+}
+
+// IsSupportedType returns true if a rule's type should be used for further processing.
+func IsSupportedType(ruleType RuleType) bool {
+	switch ruleType {
+	case LabelRule,
+		AnnotationRule,
+		K8sLabelRule,
+		K8sAnnotationRule:
+		return true
+	}
+
+	return false
 }

--- a/pkg/api/latest/dynakube/metadataenrichment/spec.go
+++ b/pkg/api/latest/dynakube/metadataenrichment/spec.go
@@ -49,7 +49,8 @@ func IsSupportedType(ruleType RuleType) bool {
 	case LabelRule,
 		AnnotationRule,
 		K8sNamespaceLabelRule,
-		K8sNamespaceAnnotationRule:
+		K8sNamespaceAnnotationRule,
+		CustomRule:
 		return true
 	}
 

--- a/pkg/clients/dynatrace/settings/enchrichment.go
+++ b/pkg/clients/dynatrace/settings/enchrichment.go
@@ -10,15 +10,15 @@ import (
 )
 
 const (
-	metadataEnrichmentSettingsSchemaID = "builtin:kubernetes.generic.metadata.enrichment"
-	scopeQueryParam                    = "scope"
-	globalScope                        = "environment"
-	effectiveValuesPath                = "/v2/settings/effectiveValues"
+	legacyMetadataEnrichmentSchemaID = "builtin:kubernetes.generic.metadata.enrichment"
+	metadataEnrichmentSchemaID       = "builtin:ingest.enrichment.config"
+	scopeQueryParam                  = "scope"
+	globalScope                      = "environment"
+	effectiveValuesPath              = "/v2/settings/effectiveValues"
 )
 
 type getRulesResponse struct {
-	Items      []ruleItem `json:"items"`
-	TotalCount int        `json:"totalCount"`
+	Items []ruleItem `json:"items"`
 }
 
 type ruleItem struct {
@@ -27,9 +27,27 @@ type ruleItem struct {
 
 type ruleItemValue struct {
 	Rules []metadataenrichment.Rule `json:"rules"`
+
+	// If this flag is enabled, the client should retry using the new schema
+	UseIngestEnrichmentConfigSchema bool `json:"useIngestEnrichmentConfigSchema"`
+
+	// These fields are embedded into the value instead of part of a rules list, when using the builtin:ingest.enrichment.config schema.
+	// Group them in a struct for easy emptiness check.
+	ingestEnrichmentConfig
 }
 
-// GetRules returns metadata enrichment rules with the number of settings objects and their values.
+type ingestEnrichmentConfig struct {
+	Type        string `json:"type"`
+	Target      string `json:"target"`
+	ValueSource string `json:"valueSource"`
+}
+
+// Check whether necessary fields are set. For now, keep it simple and just check whether any field is set.
+func (c ingestEnrichmentConfig) isEmpty() bool {
+	return c == ingestEnrichmentConfig{}
+}
+
+// GetRules returns metadata enrichment rules.
 func (c *ClientImpl) GetRules(ctx context.Context, kubeSystemUUID, entityID string) ([]metadataenrichment.Rule, error) {
 	ctx, log := logd.NewFromContext(ctx, "dtclient-settings")
 
@@ -44,32 +62,89 @@ func (c *ClientImpl) GetRules(ctx context.Context, kubeSystemUUID, entityID stri
 		scope = globalScope
 	}
 
-	var resp getRulesResponse
+	params := map[string]string{
+		validateOnlyQueryParam: "true",
+		schemaIDsQueryParam:    legacyMetadataEnrichmentSchemaID,
+		scopeQueryParam:        scope,
+	}
 
-	err := c.apiClient.GET(ctx, effectiveValuesPath).
-		WithQueryParams(map[string]string{
-			validateOnlyQueryParam: "true",
-			schemaIDsQueryParam:    metadataEnrichmentSettingsSchemaID,
-			scopeQueryParam:        scope,
-		}).
-		Execute(&resp)
-	if err != nil {
-		if core.IsNotFound(err) {
-			log.Info("enrichment settings not available on cluster, skipping getting the enrichment rules", "schemaID", metadataEnrichmentSettingsSchemaID)
+	var (
+		resp         getRulesResponse
+		useNewSchema bool
+	)
+
+	if err := c.apiClient.GET(ctx, effectiveValuesPath).WithQueryParams(params).Execute(&resp); err != nil {
+		if !core.IsNotFound(err) {
+			return nil, err
+		}
+
+		// The schema is expected to be missing in two cases, the tenant is too new or too old.
+		log.Info("using fallback for unavailable schema", "schemaID", legacyMetadataEnrichmentSchemaID, "fallbackSchemaID", metadataEnrichmentSchemaID)
+	} else if useNewSchema = isNewSchemaRequested(resp); useNewSchema {
+		// Users can enable the use of the schema on their tenant before migrating to Latest Dynatrace environments.
+		// In this case both schemas coexist, but we should still use the new one.
+		log.Info("updating data with new schema enabled on tenant", "schemaID", metadataEnrichmentSchemaID)
+	} else {
+		// The legacy schema was found and the toggle is not enabled
+		return getRulesFromResponse(resp), nil
+	}
+
+	// Retry the request with the new schema. For managed this will always fail, but we have no practical way of knowing which environment we're running in.
+	params[schemaIDsQueryParam] = metadataEnrichmentSchemaID
+	// Clear the input so that we don't keep stale data
+	resp = getRulesResponse{}
+
+	if err := c.apiClient.GET(ctx, effectiveValuesPath).WithQueryParams(params).Execute(&resp); err != nil {
+		if !useNewSchema && core.IsNotFound(err) {
+			// Keep the established behavior of not failing when the legacy schema is not available
+			// This covers the managed use-case.
+			log.Info("enrichment settings not available on cluster, skipping getting the enrichment rules", "schemaID", legacyMetadataEnrichmentSchemaID)
 
 			return nil, nil
 		}
 
-		log.Info("failed to retrieve enrichment rules")
-
-		return nil, fmt.Errorf("get rules settings: %w", err)
+		// The error is either not 404 or the user enabled the new schema explicitly. In this case a missing schema is an error.
+		return nil, fmt.Errorf("get rules settings for schema %s: %w", metadataEnrichmentSchemaID, err)
 	}
 
-	var rules []metadataenrichment.Rule
-
-	for _, item := range resp.Items {
-		rules = append(rules, item.Value.Rules...)
+	rules := getRulesFromResponse(resp)
+	if useNewSchema && len(rules) == 0 {
+		// Rules get auto-migrated when moving to Latest Dynatrace environments, but before then it's the users responsibility to migrate them.
+		// Since the user explicitly requested the new schema, missing rules at this point are not an error.
+		log.Info("requested enrichment rules, but got empty response. manual migration of rules is required", "schemaID", metadataEnrichmentSchemaID)
 	}
 
 	return rules, nil
+}
+
+func isNewSchemaRequested(resp getRulesResponse) bool {
+	for _, item := range resp.Items {
+		if item.Value.UseIngestEnrichmentConfigSchema {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getRulesFromResponse(resp getRulesResponse) []metadataenrichment.Rule {
+	var rules []metadataenrichment.Rule
+
+	// In practice, this loop is only actually required for the new schema where each rule is a separate item.
+	// The legacy schema put all rules into a single item's value.
+	for _, item := range resp.Items {
+		if cfg := item.Value.ingestEnrichmentConfig; !cfg.isEmpty() {
+			rule := metadataenrichment.Rule{
+				Type:   metadataenrichment.RuleType(cfg.Type),
+				Target: cfg.Target,
+				Source: cfg.ValueSource,
+			}
+
+			rules = append(rules, rule)
+		} else {
+			rules = append(rules, item.Value.Rules...)
+		}
+	}
+
+	return rules
 }

--- a/pkg/clients/dynatrace/settings/enchrichment.go
+++ b/pkg/clients/dynatrace/settings/enchrichment.go
@@ -37,14 +37,9 @@ type ruleItemValue struct {
 }
 
 type ingestEnrichmentConfig struct {
-	Type        string `json:"type"`
-	Target      string `json:"target"`
-	ValueSource string `json:"valueSource"`
-}
-
-// Check whether necessary fields are set. For now, keep it simple and just check whether any field is set.
-func (c ingestEnrichmentConfig) isEmpty() bool {
-	return c == ingestEnrichmentConfig{}
+	Type        metadataenrichment.RuleType `json:"type"`
+	Target      string                      `json:"target"`
+	ValueSource string                      `json:"valueSource"`
 }
 
 // GetRules returns metadata enrichment rules.
@@ -133,17 +128,20 @@ func getRulesFromResponse(resp getRulesResponse) []metadataenrichment.Rule {
 	// In practice, this loop is only actually required for the new schema where each rule is a separate item.
 	// The legacy schema put all rules into a single item's value.
 	for _, item := range resp.Items {
-		if cfg := item.Value.ingestEnrichmentConfig; !cfg.isEmpty() {
+		if cfg := item.Value.ingestEnrichmentConfig; metadataenrichment.IsSupportedType(cfg.Type) {
 			rule := metadataenrichment.Rule{
-				Type:   metadataenrichment.RuleType(cfg.Type),
+				Type:   cfg.Type,
 				Target: cfg.Target,
 				Source: cfg.ValueSource,
 			}
 
 			rules = append(rules, rule)
-		} else {
-			rules = append(rules, item.Value.Rules...)
+
+			continue
 		}
+
+		// Old rules always have supported types
+		rules = append(rules, item.Value.Rules...)
 	}
 
 	return rules

--- a/pkg/clients/dynatrace/settings/enchrichment.go
+++ b/pkg/clients/dynatrace/settings/enchrichment.go
@@ -90,16 +90,16 @@ func (c *ClientImpl) GetRules(ctx context.Context, kubeSystemUUID, entityID stri
 	resp = getRulesResponse{}
 
 	if err := c.apiClient.GET(ctx, effectiveValuesPath).WithQueryParams(params).Execute(&resp); err != nil {
-		if !useNewSchema && core.IsNotFound(err) {
-			// Keep the established behavior of not failing when the legacy schema is not available
-			// This covers the managed use-case.
-			log.Info("enrichment settings not available on cluster, skipping getting the enrichment rules", "schemaID", legacyMetadataEnrichmentSchemaID)
-
-			return nil, nil
+		if useNewSchema || !core.IsNotFound(err) {
+			// The error is either not 404 or the user enabled the new schema explicitly. In this case a missing schema is an error.
+			return nil, fmt.Errorf("get rules settings for schema %s: %w", metadataEnrichmentSchemaID, err)
 		}
 
-		// The error is either not 404 or the user enabled the new schema explicitly. In this case a missing schema is an error.
-		return nil, fmt.Errorf("get rules settings for schema %s: %w", metadataEnrichmentSchemaID, err)
+		// Keep the established behavior of not failing when the legacy schema is not available
+		// This covers the managed use-case.
+		log.Info("enrichment settings not available on cluster, skipping getting the enrichment rules", "schemaID", legacyMetadataEnrichmentSchemaID)
+
+		return nil, nil
 	}
 
 	rules := getRulesFromResponse(resp)

--- a/pkg/clients/dynatrace/settings/enchrichment_test.go
+++ b/pkg/clients/dynatrace/settings/enchrichment_test.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/metadataenrichment"
@@ -17,9 +18,14 @@ var anyCtx = mock.MatchedBy(func(context.Context) bool { return true })
 func TestGetRulesSetting(t *testing.T) {
 	ctx := t.Context()
 
-	params := map[string]string{
+	oldParams := map[string]string{
 		"validateOnly": "true",
-		"schemaIds":    "builtin:kubernetes.generic.metadata.enrichment",
+		"schemaIds":    legacyMetadataEnrichmentSchemaID,
+		"scope":        "ENVIRONMENT_ID",
+	}
+	newParams := map[string]string{
+		"validateOnly": "true",
+		"schemaIds":    metadataEnrichmentSchemaID,
 		"scope":        "ENVIRONMENT_ID",
 	}
 
@@ -28,37 +34,47 @@ func TestGetRulesSetting(t *testing.T) {
 		{Type: "type-2", Source: "source-2", Target: "target-2"},
 	}
 
-	response := getRulesResponse{
+	oldResponse := getRulesResponse{
 		Items: []ruleItem{
 			{
 				Value: ruleItemValue{
 					Rules: []metadataenrichment.Rule{
 						{Type: "type-1", Source: "source-1", Target: "target-1"},
-					},
-				},
-			},
-			{
-				Value: ruleItemValue{
-					Rules: []metadataenrichment.Rule{
 						{Type: "type-2", Source: "source-2", Target: "target-2"},
 					},
 				},
 			},
 		},
-		TotalCount: 1,
+	}
+
+	newResponse := getRulesResponse{
+		Items: []ruleItem{
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: "type-1", ValueSource: "source-1", Target: "target-1"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: "type-2", ValueSource: "source-2", Target: "target-2"}}},
+		},
+	}
+
+	setFlag := func(resp getRulesResponse) getRulesResponse {
+		items := make([]ruleItem, len(resp.Items))
+		copy(items, resp.Items)
+
+		for i := range items {
+			items[i].Value.UseIngestEnrichmentConfigSchema = true
+		}
+
+		return getRulesResponse{Items: items}
 	}
 
 	t.Run("get rules", func(t *testing.T) {
 		apiClient := coremock.NewClient(t)
 		request := coremock.NewRequest(t)
-		request.EXPECT().WithQueryParams(params).Return(request).Once()
-		request.EXPECT().Execute(new(getRulesResponse)).Run(injectResponse(response)).Return(nil).Once()
-		apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request)
+		request.EXPECT().WithQueryParams(oldParams).Return(request).Once()
+		request.EXPECT().Execute(new(getRulesResponse)).Run(injectResponse(oldResponse)).Return(nil).Once()
+		apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once()
 
 		client := NewClient(apiClient)
 		rules, err := client.GetRules(ctx, "kube-system-uuid", "ENVIRONMENT_ID")
 		require.NoError(t, err)
-		assert.NotNil(t, rules)
 		assert.Equal(t, expectRules, rules)
 	})
 
@@ -67,6 +83,20 @@ func TestGetRulesSetting(t *testing.T) {
 		settingsClient := NewClient(apiClient)
 		rules, err := settingsClient.GetRules(ctx, "", "test-entityID")
 		require.ErrorIs(t, err, errMissingKubeSystemUUID)
+		assert.Empty(t, rules)
+	})
+
+	t.Run("non 404 error", func(t *testing.T) {
+		apiClient := coremock.NewClient(t)
+		request := coremock.NewRequest(t)
+		request.EXPECT().WithQueryParams(oldParams).Return(request).Once()
+		httpErr := &core.HTTPError{StatusCode: 503}
+		request.EXPECT().Execute(new(getRulesResponse)).Return(httpErr).Once()
+		apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once()
+
+		client := NewClient(apiClient)
+		rules, err := client.GetRules(ctx, "kube-system-uuid", "ENVIRONMENT_ID")
+		require.ErrorIs(t, err, httpErr)
 		assert.Empty(t, rules)
 	})
 
@@ -79,27 +109,163 @@ func TestGetRulesSetting(t *testing.T) {
 			"schemaIds":    "builtin:kubernetes.generic.metadata.enrichment",
 			"scope":        "environment",
 		}).Return(request).Once()
-		request.EXPECT().Execute(new(getRulesResponse)).Run(injectResponse(response)).Return(nil).Once()
+		request.EXPECT().Execute(new(getRulesResponse)).Run(injectResponse(oldResponse)).Return(nil).Once()
 		apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once()
 
 		client := NewClient(apiClient)
 		rules, err := client.GetRules(ctx, "kube-system-uuid", "")
 		require.NoError(t, err)
-		assert.NotEmpty(t, rules)
 		assert.Equal(t, expectRules, rules)
 	})
 
-	t.Run("enrichment settings schema not available", func(t *testing.T) {
+	t.Run("new schema enabled explicitly", func(t *testing.T) {
 		apiClient := coremock.NewClient(t)
 		request := coremock.NewRequest(t)
-		request.EXPECT().WithQueryParams(params).Return(request).Once()
-		httpErr := &core.HTTPError{StatusCode: 404, Body: "Schema ID not found: builtin:kubernetes.generic.metadata.enrichment"}
-		request.EXPECT().Execute(new(getRulesResponse)).Return(httpErr).Once()
-		apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once()
+
+		expectCallOrder(
+			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
+			request.EXPECT().WithQueryParams(oldParams).Return(request).Once(),
+			request.EXPECT().Execute(new(getRulesResponse)).Run(injectResponse(setFlag(oldResponse))).Return(nil).Once(),
+			// Switch to new schema
+			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
+			request.EXPECT().WithQueryParams(newParams).Return(request).Once(),
+			request.EXPECT().Execute(new(getRulesResponse)).Run(injectResponse(newResponse)).Return(nil).Once(),
+		)
+
+		client := NewClient(apiClient)
+		rules, err := client.GetRules(ctx, "kube-system-uuid", "ENVIRONMENT_ID")
+		require.NoError(t, err)
+		assert.Equal(t, expectRules, rules)
+	})
+
+	t.Run("new enrichment settings schema not available", func(t *testing.T) {
+		apiClient := coremock.NewClient(t)
+		request := coremock.NewRequest(t)
+		httpErr := &core.HTTPError{StatusCode: 404}
+
+		expectCallOrder(
+			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
+			request.EXPECT().WithQueryParams(oldParams).Return(request).Once(),
+			request.EXPECT().Execute(new(getRulesResponse)).Run(injectResponse(setFlag(oldResponse))).Return(nil).Once(),
+			// Switch to new schema
+			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
+			request.EXPECT().WithQueryParams(newParams).Return(request).Once(),
+			request.EXPECT().Execute(new(getRulesResponse)).Return(httpErr).Once(),
+		)
+
+		client := NewClient(apiClient)
+		rules, err := client.GetRules(ctx, "kube-system-uuid", "ENVIRONMENT_ID")
+		require.Error(t, err)
+		assert.Empty(t, rules)
+	})
+
+	t.Run("use enrichment settings schema fallback", func(t *testing.T) {
+		apiClient := coremock.NewClient(t)
+		request := coremock.NewRequest(t)
+		expectCallOrder(
+			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
+			request.EXPECT().WithQueryParams(oldParams).Return(request).Once(),
+			request.EXPECT().Execute(new(getRulesResponse)).Return(&core.HTTPError{StatusCode: 404}).Once(),
+			// Fallback after 404 with old schema
+			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
+			request.EXPECT().WithQueryParams(newParams).Return(request).Once(),
+			request.EXPECT().Execute(new(getRulesResponse)).Run(injectResponse(newResponse)).Return(nil).Once(),
+		)
+
+		client := NewClient(apiClient)
+		rules, err := client.GetRules(ctx, "kube-system-uuid", "ENVIRONMENT_ID")
+		require.NoError(t, err)
+		assert.Equal(t, expectRules, rules)
+	})
+
+	t.Run("neither enrichment settings schema available", func(t *testing.T) {
+		apiClient := coremock.NewClient(t)
+		request := coremock.NewRequest(t)
+		expectCallOrder(
+			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
+			request.EXPECT().WithQueryParams(oldParams).Return(request).Once(),
+			request.EXPECT().Execute(new(getRulesResponse)).Return(&core.HTTPError{StatusCode: 404}).Once(),
+			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
+			request.EXPECT().WithQueryParams(newParams).Return(request).Once(),
+			request.EXPECT().Execute(new(getRulesResponse)).Return(&core.HTTPError{StatusCode: 404}).Once(),
+		)
 
 		client := NewClient(apiClient)
 		rules, err := client.GetRules(ctx, "kube-system-uuid", "ENVIRONMENT_ID")
 		require.NoError(t, err)
 		assert.Empty(t, rules)
 	})
+}
+
+// Set up mocked calls to verify they are executed in the input order.
+func expectCallOrder(calls ...*mock.Call) {
+	if len(calls) < 2 {
+		return
+	}
+
+	prev := calls[0]
+
+	for _, call := range calls[1:] {
+		call.NotBefore(prev)
+		prev = call
+	}
+}
+
+// This is just a sanity check that the models match what's returned by the API.
+func Test_enrichmentSchemaModel(t *testing.T) {
+	const rawDataOld = `{"items":[{"origin":"environment","value":{"rules":[{"type":"LABEL","source":"test-cost","target":"dt.cost.product"},{"type":"ANNOTATION","source":"my.test.annotation/value","target":"dt.security_context"}]}}],"totalCount":1,"pageSize":100}`
+	const rawDataOldFlag = `{"items":[{"origin":"environment","value":{"rules":[{"type":"LABEL","source":"test-cost","target":"dt.cost.product"},{"type":"ANNOTATION","source":"my.test.annotation/value","target":"dt.security_context"}],"useIngestEnrichmentConfigSchema":true}}],"totalCount":1,"pageSize":100}`
+	const rawDataNew = `{"items":[{"origin":"environment","value":{"type":"K8S_NAMESPACE_LABEL","valueSource":"test-label","target":"dt.cost.product"}},{"origin":"environment","value":{"type":"K8S_NAMESPACE_ANNOTATION","valueSource":"my.test.annotation/value","target":"dt.security_context"}}],"totalCount":2,"pageSize":100}`
+
+	expectOld := getRulesResponse{
+		Items: []ruleItem{
+			{
+				Value: ruleItemValue{
+					Rules: []metadataenrichment.Rule{
+						{Type: "LABEL", Source: "test-cost", Target: "dt.cost.product"},
+						{Type: "ANNOTATION", Source: "my.test.annotation/value", Target: "dt.security_context"},
+					},
+				},
+			},
+		},
+	}
+
+	expectOldFlag := getRulesResponse{
+		Items: []ruleItem{
+			{
+				Value: ruleItemValue{
+					Rules: []metadataenrichment.Rule{
+						{Type: "LABEL", Source: "test-cost", Target: "dt.cost.product"},
+						{Type: "ANNOTATION", Source: "my.test.annotation/value", Target: "dt.security_context"},
+					},
+					UseIngestEnrichmentConfigSchema: true,
+				},
+			},
+		},
+	}
+
+	expectNew := getRulesResponse{
+		Items: []ruleItem{
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: "K8S_NAMESPACE_LABEL", ValueSource: "test-label", Target: "dt.cost.product"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: "K8S_NAMESPACE_ANNOTATION", ValueSource: "my.test.annotation/value", Target: "dt.security_context"}}},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		input  string
+		expect getRulesResponse
+	}{
+		{"old", rawDataOld, expectOld},
+		{"old with flag", rawDataOldFlag, expectOldFlag},
+		{"new", rawDataNew, expectNew},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var resp getRulesResponse
+			require.NoError(t, json.Unmarshal([]byte(test.input), &resp))
+			assert.Equal(t, test.expect, resp)
+		})
+	}
 }

--- a/pkg/clients/dynatrace/settings/enchrichment_test.go
+++ b/pkg/clients/dynatrace/settings/enchrichment_test.go
@@ -30,8 +30,8 @@ func TestGetRulesSetting(t *testing.T) {
 	}
 
 	expectRules := []metadataenrichment.Rule{
-		{Type: "type-1", Source: "source-1", Target: "target-1"},
-		{Type: "type-2", Source: "source-2", Target: "target-2"},
+		{Type: metadataenrichment.LabelRule, Source: "source-1", Target: "target-1"},
+		{Type: metadataenrichment.AnnotationRule, Source: "source-2", Target: "target-2"},
 	}
 
 	oldResponse := getRulesResponse{
@@ -39,8 +39,8 @@ func TestGetRulesSetting(t *testing.T) {
 			{
 				Value: ruleItemValue{
 					Rules: []metadataenrichment.Rule{
-						{Type: "type-1", Source: "source-1", Target: "target-1"},
-						{Type: "type-2", Source: "source-2", Target: "target-2"},
+						{Type: metadataenrichment.LabelRule, Source: "source-1", Target: "target-1"},
+						{Type: metadataenrichment.AnnotationRule, Source: "source-2", Target: "target-2"},
 					},
 				},
 			},
@@ -49,8 +49,9 @@ func TestGetRulesSetting(t *testing.T) {
 
 	newResponse := getRulesResponse{
 		Items: []ruleItem{
-			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: "type-1", ValueSource: "source-1", Target: "target-1"}}},
-			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: "type-2", ValueSource: "source-2", Target: "target-2"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sLabelRule, ValueSource: "source-1", Target: "target-1"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sAnnotationRule, ValueSource: "source-2", Target: "target-2"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.CustomRule, ValueSource: "source-3", Target: "target-3"}}},
 		},
 	}
 
@@ -121,6 +122,10 @@ func TestGetRulesSetting(t *testing.T) {
 	t.Run("new schema enabled explicitly", func(t *testing.T) {
 		apiClient := coremock.NewClient(t)
 		request := coremock.NewRequest(t)
+		expectRules := []metadataenrichment.Rule{
+			{Type: metadataenrichment.K8sLabelRule, Source: "source-1", Target: "target-1"},
+			{Type: metadataenrichment.K8sAnnotationRule, Source: "source-2", Target: "target-2"},
+		}
 
 		expectCallOrder(
 			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
@@ -162,6 +167,11 @@ func TestGetRulesSetting(t *testing.T) {
 	t.Run("use enrichment settings schema fallback", func(t *testing.T) {
 		apiClient := coremock.NewClient(t)
 		request := coremock.NewRequest(t)
+		expectRules := []metadataenrichment.Rule{
+			{Type: metadataenrichment.K8sLabelRule, Source: "source-1", Target: "target-1"},
+			{Type: metadataenrichment.K8sAnnotationRule, Source: "source-2", Target: "target-2"},
+		}
+
 		expectCallOrder(
 			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
 			request.EXPECT().WithQueryParams(oldParams).Return(request).Once(),
@@ -222,8 +232,8 @@ func Test_enrichmentSchemaModel(t *testing.T) {
 			{
 				Value: ruleItemValue{
 					Rules: []metadataenrichment.Rule{
-						{Type: "LABEL", Source: "test-cost", Target: "dt.cost.product"},
-						{Type: "ANNOTATION", Source: "my.test.annotation/value", Target: "dt.security_context"},
+						{Type: metadataenrichment.LabelRule, Source: "test-cost", Target: "dt.cost.product"},
+						{Type: metadataenrichment.AnnotationRule, Source: "my.test.annotation/value", Target: "dt.security_context"},
 					},
 				},
 			},
@@ -235,8 +245,8 @@ func Test_enrichmentSchemaModel(t *testing.T) {
 			{
 				Value: ruleItemValue{
 					Rules: []metadataenrichment.Rule{
-						{Type: "LABEL", Source: "test-cost", Target: "dt.cost.product"},
-						{Type: "ANNOTATION", Source: "my.test.annotation/value", Target: "dt.security_context"},
+						{Type: metadataenrichment.LabelRule, Source: "test-cost", Target: "dt.cost.product"},
+						{Type: metadataenrichment.AnnotationRule, Source: "my.test.annotation/value", Target: "dt.security_context"},
 					},
 					UseIngestEnrichmentConfigSchema: true,
 				},
@@ -246,8 +256,8 @@ func Test_enrichmentSchemaModel(t *testing.T) {
 
 	expectNew := getRulesResponse{
 		Items: []ruleItem{
-			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: "K8S_NAMESPACE_LABEL", ValueSource: "test-label", Target: "dt.cost.product"}}},
-			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: "K8S_NAMESPACE_ANNOTATION", ValueSource: "my.test.annotation/value", Target: "dt.security_context"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sLabelRule, ValueSource: "test-label", Target: "dt.cost.product"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sAnnotationRule, ValueSource: "my.test.annotation/value", Target: "dt.security_context"}}},
 		},
 	}
 

--- a/pkg/clients/dynatrace/settings/enchrichment_test.go
+++ b/pkg/clients/dynatrace/settings/enchrichment_test.go
@@ -49,8 +49,8 @@ func TestGetRulesSetting(t *testing.T) {
 
 	newResponse := getRulesResponse{
 		Items: []ruleItem{
-			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sLabelRule, ValueSource: "source-1", Target: "target-1"}}},
-			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sAnnotationRule, ValueSource: "source-2", Target: "target-2"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sNamespaceLabelRule, ValueSource: "source-1", Target: "target-1"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sNamespaceAnnotationRule, ValueSource: "source-2", Target: "target-2"}}},
 			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.CustomRule, ValueSource: "source-3", Target: "target-3"}}},
 		},
 	}
@@ -123,8 +123,8 @@ func TestGetRulesSetting(t *testing.T) {
 		apiClient := coremock.NewClient(t)
 		request := coremock.NewRequest(t)
 		expectRules := []metadataenrichment.Rule{
-			{Type: metadataenrichment.K8sLabelRule, Source: "source-1", Target: "target-1"},
-			{Type: metadataenrichment.K8sAnnotationRule, Source: "source-2", Target: "target-2"},
+			{Type: metadataenrichment.K8sNamespaceLabelRule, Source: "source-1", Target: "target-1"},
+			{Type: metadataenrichment.K8sNamespaceAnnotationRule, Source: "source-2", Target: "target-2"},
 		}
 
 		expectCallOrder(
@@ -168,8 +168,8 @@ func TestGetRulesSetting(t *testing.T) {
 		apiClient := coremock.NewClient(t)
 		request := coremock.NewRequest(t)
 		expectRules := []metadataenrichment.Rule{
-			{Type: metadataenrichment.K8sLabelRule, Source: "source-1", Target: "target-1"},
-			{Type: metadataenrichment.K8sAnnotationRule, Source: "source-2", Target: "target-2"},
+			{Type: metadataenrichment.K8sNamespaceLabelRule, Source: "source-1", Target: "target-1"},
+			{Type: metadataenrichment.K8sNamespaceAnnotationRule, Source: "source-2", Target: "target-2"},
 		}
 
 		expectCallOrder(
@@ -256,8 +256,8 @@ func Test_enrichmentSchemaModel(t *testing.T) {
 
 	expectNew := getRulesResponse{
 		Items: []ruleItem{
-			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sLabelRule, ValueSource: "test-label", Target: "dt.cost.product"}}},
-			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sAnnotationRule, ValueSource: "my.test.annotation/value", Target: "dt.security_context"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sNamespaceLabelRule, ValueSource: "test-label", Target: "dt.cost.product"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sNamespaceAnnotationRule, ValueSource: "my.test.annotation/value", Target: "dt.security_context"}}},
 		},
 	}
 

--- a/pkg/clients/dynatrace/settings/enchrichment_test.go
+++ b/pkg/clients/dynatrace/settings/enchrichment_test.go
@@ -51,7 +51,7 @@ func TestGetRulesSetting(t *testing.T) {
 		Items: []ruleItem{
 			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sNamespaceLabelRule, ValueSource: "source-1", Target: "target-1"}}},
 			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sNamespaceAnnotationRule, ValueSource: "source-2", Target: "target-2"}}},
-			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.CustomRule, ValueSource: "source-3", Target: "target-3"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: "FOO", ValueSource: "source-3", Target: "target-3"}}},
 		},
 	}
 

--- a/pkg/clients/dynatrace/settings/enchrichment_test.go
+++ b/pkg/clients/dynatrace/settings/enchrichment_test.go
@@ -143,6 +143,33 @@ func TestGetRulesSetting(t *testing.T) {
 		assert.Equal(t, expectRules, rules)
 	})
 
+	t.Run("use new schema with old empty rules", func(t *testing.T) {
+		apiClient := coremock.NewClient(t)
+		request := coremock.NewRequest(t)
+		expectRules := []metadataenrichment.Rule{
+			{Type: metadataenrichment.K8sNamespaceLabelRule, Source: "source-1", Target: "target-1"},
+			{Type: metadataenrichment.K8sNamespaceAnnotationRule, Source: "source-2", Target: "target-2"},
+		}
+
+		// No rules defined
+		oldResponse := getRulesResponse{Items: []ruleItem{{}}}
+
+		expectCallOrder(
+			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
+			request.EXPECT().WithQueryParams(oldParams).Return(request).Once(),
+			request.EXPECT().Execute(new(getRulesResponse)).Run(injectResponse(setFlag(oldResponse))).Return(nil).Once(),
+			// Switch to new schema
+			apiClient.EXPECT().GET(anyCtx, effectiveValuesPath).Return(request).Once(),
+			request.EXPECT().WithQueryParams(newParams).Return(request).Once(),
+			request.EXPECT().Execute(new(getRulesResponse)).Run(injectResponse(newResponse)).Return(nil).Once(),
+		)
+
+		client := NewClient(apiClient)
+		rules, err := client.GetRules(ctx, "kube-system-uuid", "ENVIRONMENT_ID")
+		require.NoError(t, err)
+		assert.Equal(t, expectRules, rules)
+	})
+
 	t.Run("new enrichment settings schema not available", func(t *testing.T) {
 		apiClient := coremock.NewClient(t)
 		request := coremock.NewRequest(t)

--- a/pkg/clients/dynatrace/settings/settings.go
+++ b/pkg/clients/dynatrace/settings/settings.go
@@ -49,7 +49,7 @@ type Client interface {
 	GetSettingsForMonitoredEntity(ctx context.Context, monitoredEntity K8sClusterME, schemaID string) (TotalCountSettingsResponse, error)
 	// GetSettingsForLogModule returns the settings response with the number of settings objects and their values.
 	GetSettingsForLogModule(ctx context.Context, monitoredEntity string) (TotalCountSettingsResponse, error)
-	// GetRules returns metadata enrichment rules with the number of settings objects.
+	// GetRules returns metadata enrichment rules.
 	GetRules(ctx context.Context, kubeSystemUUID string, entityID string) ([]metadataenrichment.Rule, error)
 	// CreateOrUpdateKubernetesSetting returns the object ID of the created k8s settings.
 	CreateOrUpdateKubernetesSetting(ctx context.Context, clusterLabel, kubeSystemUUID, scope string) (string, error)


### PR DESCRIPTION
## Description

Handle the new enrichment rule schema in the settings client. It needs to handle two different types of environment: Managed and SaaS. Managed will keep using the `builtin:kubernetes.generic.metadata.enrichment` and SaaS will eventually move towards `builtin:ingest.enrichment.config`.
We have no practical way of knowing which environment the operator runs in and what state the environment has, so we need to infer the schema according to the API responses.

There are 2 cases when the new schema should be used
* Old schema was disabled
* New schema is opted in

Add a new error case: if the new schema is opted in, but it's not present on the tenant the injection reconciliation fails and the pods are not injected. This should never happen.

This PR adds the constants for the downstream enrichment rule handling, but that will be implemented in another change.

ICP-3071
ICP-4353

## How can this be tested?

The tenant setup is a bit involved. Please refer to [this comment](https://dt-rnd.atlassian.net/browse/ICP-1164?focusedCommentId=4602926) on the epic.

To verify the API calls are simply enable metadata enrichment

```yaml
apiVersion: dynatrace.com/v1beta6
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  metadataEnrichment:
    enabled: true
    namespaceSelector:
      matchLabels:
        kubernetes.io/metadata.name: default
```

Procedure:
* Modify tenant
* Deploy DK
* Check logs for API calls
* Check status

Scenarios to test:
* No schema enabled
* Schema enabled, but flag disabled
* Schema enabled, flag enabled, no new rules
* Schema enabled, flag enabled, with rules
* Only new schema enabled