### PR TITLE
Add image digest field to imageRef spec

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1096,6 +1096,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -1405,6 +1406,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -1615,6 +1617,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -1699,6 +1702,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -3094,6 +3098,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -3403,6 +3408,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -3613,6 +3619,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -3697,6 +3704,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -6623,6 +6631,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -6932,6 +6941,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -7142,6 +7152,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -7239,6 +7250,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -7370,6 +7382,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:

--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -1095,6 +1095,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -1402,6 +1404,8 @@ spec:
                         type: array
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -1610,6 +1614,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -1692,6 +1698,8 @@ spec:
                         type: object
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -3085,6 +3093,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -3392,6 +3402,8 @@ spec:
                         type: array
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -3600,6 +3612,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -3682,6 +3696,8 @@ spec:
                         type: object
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -6606,6 +6622,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -6913,6 +6931,8 @@ spec:
                         type: array
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -7121,6 +7141,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -7216,6 +7238,8 @@ spec:
                         type: object
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -7345,6 +7369,8 @@ spec:
                     properties:
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent

--- a/config/crd/bases/dynatrace.com_edgeconnects.yaml
+++ b/config/crd/bases/dynatrace.com_edgeconnects.yaml
@@ -499,6 +499,8 @@ spec:
                 type: array
               imageRef:
                 properties:
+                  digest:
+                    type: string
                   pullPolicy:
                     enum:
                     - IfNotPresent

--- a/config/crd/bases/dynatrace.com_edgeconnects.yaml
+++ b/config/crd/bases/dynatrace.com_edgeconnects.yaml
@@ -500,6 +500,7 @@ spec:
               imageRef:
                 properties:
                   digest:
+                    pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                     type: string
                   pullPolicy:
                     enum:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -1109,6 +1109,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -1418,6 +1419,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -1628,6 +1630,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -1712,6 +1715,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -3107,6 +3111,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -3416,6 +3421,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -3626,6 +3632,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -3710,6 +3717,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -6636,6 +6644,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -6945,6 +6954,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -7155,6 +7165,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -7252,6 +7263,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -7383,6 +7395,7 @@ spec:
                       imageRef:
                         properties:
                           digest:
+                            pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                             type: string
                           pullPolicy:
                             enum:
@@ -8114,6 +8127,7 @@ spec:
               imageRef:
                 properties:
                   digest:
+                    pattern: ^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$
                     type: string
                   pullPolicy:
                     enum:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -1108,6 +1108,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -1415,6 +1417,8 @@ spec:
                         type: array
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -1623,6 +1627,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -1705,6 +1711,8 @@ spec:
                         type: object
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -3098,6 +3106,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -3405,6 +3415,8 @@ spec:
                         type: array
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -3613,6 +3625,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -3695,6 +3709,8 @@ spec:
                         type: object
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -6619,6 +6635,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -6926,6 +6944,8 @@ spec:
                         type: array
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -7134,6 +7154,8 @@ spec:
                         type: string
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -7229,6 +7251,8 @@ spec:
                         type: object
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -7358,6 +7382,8 @@ spec:
                     properties:
                       imageRef:
                         properties:
+                          digest:
+                            type: string
                           pullPolicy:
                             enum:
                             - IfNotPresent
@@ -8087,6 +8113,8 @@ spec:
                 type: array
               imageRef:
                 properties:
+                  digest:
+                    type: string
                   pullPolicy:
                     enum:
                     - IfNotPresent

--- a/doc/api/dynakube-api-ref.md
+++ b/doc/api/dynakube-api-ref.md
@@ -218,6 +218,7 @@
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
+|`digest`||-|string|
 |`pullPolicy`||-|string|
 |`repository`||-|string|
 |`tag`||-|string|
@@ -226,6 +227,7 @@
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
+|`digest`||-|string|
 |`pullPolicy`||-|string|
 |`repository`||-|string|
 |`tag`||-|string|
@@ -277,6 +279,7 @@
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
+|`digest`||-|string|
 |`pullPolicy`||-|string|
 |`repository`||-|string|
 |`tag`||-|string|
@@ -314,6 +317,7 @@
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
+|`digest`||-|string|
 |`pullPolicy`||-|string|
 |`repository`||-|string|
 |`tag`||-|string|
@@ -322,6 +326,7 @@
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
+|`digest`||-|string|
 |`pullPolicy`||-|string|
 |`repository`||-|string|
 |`tag`||-|string|

--- a/doc/api/edgeconnect-api-ref.md
+++ b/doc/api/edgeconnect-api-ref.md
@@ -42,6 +42,7 @@
 
 |Parameter|Description|Default value|Data type|
 |:-|:-|:-|:-|
+|`digest`||-|string|
 |`pullPolicy`||-|string|
 |`repository`||-|string|
 |`tag`||-|string|

--- a/pkg/api/shared/image/types.go
+++ b/pkg/api/shared/image/types.go
@@ -12,8 +12,10 @@ type Ref struct {
 	// Indicates a tag of the image to use
 	Tag string `json:"tag,omitempty"`
 
-	// Digest pins the image to a specific content-addressable hash (e.g. sha256:...).
-	// When set, the tag is ignored when rendering the image reference.
+	// Digest pins the image to a specific content-addressable hash in the OCI
+	// `<algorithm>:<hex>` form (e.g. `sha256:abc...`). When set, the tag is ignored
+	// when rendering the image reference.
+	// +kubebuilder:validation:Pattern:="^[a-z0-9]+:([a-f0-9]+|[A-F0-9]+)$"
 	Digest string `json:"digest,omitempty"`
 
 	// Image pull policy to use

--- a/pkg/api/shared/image/types.go
+++ b/pkg/api/shared/image/types.go
@@ -45,12 +45,6 @@ func (ref Ref) String() string {
 	return ref.Repository + ":" + ref.Tag
 }
 
-// IsZero returns true if the image ref is empty.
-// Prefer this name over IsEmpty for compatibility with JSON omitzero.
-func (ref *Ref) IsZero() bool {
-	return ref == nil || *ref == Ref{}
-}
-
 // HasImage returns true when the ref points to a resolvable image — i.e. a repository
 // plus at least one of a tag or a digest.
 func (ref *Ref) HasImage() bool {

--- a/pkg/api/shared/image/types.go
+++ b/pkg/api/shared/image/types.go
@@ -12,11 +12,17 @@ type Ref struct {
 	// Indicates a tag of the image to use
 	Tag string `json:"tag,omitempty"`
 
+	// Digest pins the image to a specific content-addressable hash (e.g. sha256:...).
+	// When set, the tag is ignored when rendering the image reference.
+	Digest string `json:"digest,omitempty"`
+
 	// Image pull policy to use
 	PullPolicy PullPolicy `json:"pullPolicy,omitempty"`
 }
 
 // StringWithDefaults will use the provided default values for fields that were not already set.
+// If a digest is present (either on the ref or via the default), the tag is omitted from the
+// rendered image reference.
 func (ref Ref) StringWithDefaults(repo, tag string) string {
 	if ref.Repository == "" {
 		ref.Repository = repo
@@ -29,7 +35,13 @@ func (ref Ref) StringWithDefaults(repo, tag string) string {
 	return ref.String()
 }
 
+// String renders the image reference. If a digest is set, the tag is omitted to avoid the
+// confusing case where the tag and digest disagree — the digest always wins.
 func (ref Ref) String() string {
+	if ref.Digest != "" {
+		return ref.Repository + "@" + ref.Digest
+	}
+
 	return ref.Repository + ":" + ref.Tag
 }
 
@@ -37,6 +49,16 @@ func (ref Ref) String() string {
 // Prefer this name over IsEmpty for compatibility with JSON omitzero.
 func (ref *Ref) IsZero() bool {
 	return ref == nil || *ref == Ref{}
+}
+
+// HasImage returns true when the ref points to a resolvable image — i.e. a repository
+// plus at least one of a tag or a digest.
+func (ref *Ref) HasImage() bool {
+	if ref == nil {
+		return false
+	}
+
+	return ref.Repository != "" && (ref.Tag != "" || ref.Digest != "")
 }
 
 // GetPolicy returns the image pull policy.

--- a/pkg/api/shared/image/types_test.go
+++ b/pkg/api/shared/image/types_test.go
@@ -1,0 +1,70 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRef_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		ref      Ref
+		expected string
+	}{
+		{
+			name:     "repository and tag",
+			ref:      Ref{Repository: "docker.io/dynatrace/image", Tag: "1.2.3"},
+			expected: "docker.io/dynatrace/image:1.2.3",
+		},
+		{
+			name:     "digest wins over tag",
+			ref:      Ref{Repository: "docker.io/dynatrace/image", Tag: "1.2.3", Digest: "sha256:abc"},
+			expected: "docker.io/dynatrace/image@sha256:abc",
+		},
+		{
+			name:     "digest without tag",
+			ref:      Ref{Repository: "docker.io/dynatrace/image", Digest: "sha256:abc"},
+			expected: "docker.io/dynatrace/image@sha256:abc",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.ref.String())
+		})
+	}
+}
+
+func TestRef_StringWithDefaults(t *testing.T) {
+	t.Run("falls back to default repo and tag", func(t *testing.T) {
+		ref := Ref{}
+		assert.Equal(t, "default-repo:default-tag", ref.StringWithDefaults("default-repo", "default-tag"))
+	})
+
+	t.Run("digest on ref ignores default tag", func(t *testing.T) {
+		ref := Ref{Digest: "sha256:abc"}
+		assert.Equal(t, "default-repo@sha256:abc", ref.StringWithDefaults("default-repo", "default-tag"))
+	})
+}
+
+func TestRef_HasImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		ref      Ref
+		expected bool
+	}{
+		{name: "empty", ref: Ref{}, expected: false},
+		{name: "repo only", ref: Ref{Repository: "repo"}, expected: false},
+		{name: "tag only", ref: Ref{Tag: "1.0"}, expected: false},
+		{name: "digest only", ref: Ref{Digest: "sha256:abc"}, expected: false},
+		{name: "repo + tag", ref: Ref{Repository: "repo", Tag: "1.0"}, expected: true},
+		{name: "repo + digest", ref: Ref{Repository: "repo", Digest: "sha256:abc"}, expected: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.ref.HasImage())
+		})
+	}
+}

--- a/pkg/api/v1beta4/dynakube/convert_to.go
+++ b/pkg/api/v1beta4/dynakube/convert_to.go
@@ -158,7 +158,7 @@ func toOpenTelemetryCollectorTemplate(dk *dynakubelatest.DynaKube, src OpenTelem
 	dst.Annotations = src.Annotations
 	dst.Replicas = src.Replicas
 	dst.ImageRef = src.ImageRef
-	if  dst.ImageRef.IsZero() && (dk.TelemetryIngest().IsEnabled() || dk.Extensions().IsPrometheusEnabled()) {
+	if !dst.ImageRef.HasImage() && (dk.TelemetryIngest().IsEnabled() || dk.Extensions().IsPrometheusEnabled()) {
 		dst.ImageRef.Repository = "public.ecr.aws/dynatrace/dynatrace-otel-collector"
 		dst.ImageRef.Tag = "latest"
 		dk.RemovedFields().DefaultOTELCImage.Set(ptr.To(true))

--- a/pkg/api/v1beta5/dynakube/convert_to.go
+++ b/pkg/api/v1beta5/dynakube/convert_to.go
@@ -159,7 +159,7 @@ func toOpenTelemetryCollectorTemplate(dk *dynakubelatest.DynaKube, src OpenTelem
 	dst.Annotations = src.Annotations
 	dst.Replicas = src.Replicas
 	dst.ImageRef = src.ImageRef
-	if dst.ImageRef.IsZero() && (dk.TelemetryIngest().IsEnabled() || dk.Extensions().IsPrometheusEnabled()) {
+	if !dst.ImageRef.HasImage() && (dk.TelemetryIngest().IsEnabled() || dk.Extensions().IsPrometheusEnabled()) {
 		dst.ImageRef.Repository = "public.ecr.aws/dynatrace/dynatrace-otel-collector"
 		dst.ImageRef.Tag = "latest"
 		dk.RemovedFields().DefaultOTELCImage.Set(ptr.To(true))

--- a/pkg/api/v1beta5/dynakube/convert_to_test.go
+++ b/pkg/api/v1beta5/dynakube/convert_to_test.go
@@ -203,6 +203,67 @@ func TestConvertTo(t *testing.T) {
 		compareBase(t, from, to)
 	})
 
+	t.Run("default otelc image applied when only pull policy is set", func(t *testing.T) {
+		from := getOldDynakubeBase()
+		from.Spec.Templates.OpenTelemetryCollector.ImageRef = image.Ref{PullPolicy: "Always"}
+
+		to := dynakubelatest.DynaKube{
+			Spec: dynakubelatest.DynaKubeSpec{
+				TelemetryIngest: &telemetryingestlatest.Spec{},
+			},
+		}
+
+		err := from.ConvertTo(&to)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, to.Spec.Templates.OpenTelemetryCollector.ImageRef.Repository)
+		assert.NotEmpty(t, to.Spec.Templates.OpenTelemetryCollector.ImageRef.Tag)
+		assert.Equal(t, image.PullPolicy("Always"), to.Spec.Templates.OpenTelemetryCollector.ImageRef.PullPolicy)
+		assert.Contains(t, to.Annotations, conversion.DefaultOTELCImageKey)
+
+		compareBase(t, from, to)
+	})
+
+	t.Run("default otelc image overwrites a partial repository-only ref", func(t *testing.T) {
+		from := getOldDynakubeBase()
+		from.Spec.Templates.OpenTelemetryCollector.ImageRef = image.Ref{Repository: "user-supplied-repo"}
+
+		to := dynakubelatest.DynaKube{
+			Spec: dynakubelatest.DynaKubeSpec{
+				TelemetryIngest: &telemetryingestlatest.Spec{},
+			},
+		}
+
+		err := from.ConvertTo(&to)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, "user-supplied-repo", to.Spec.Templates.OpenTelemetryCollector.ImageRef.Repository)
+		assert.NotEmpty(t, to.Spec.Templates.OpenTelemetryCollector.ImageRef.Tag)
+		assert.Contains(t, to.Annotations, conversion.DefaultOTELCImageKey)
+
+		compareBase(t, from, to)
+	})
+
+	t.Run("user-supplied complete otelc image is preserved", func(t *testing.T) {
+		from := getOldDynakubeBase()
+		from.Spec.Templates.OpenTelemetryCollector.ImageRef = image.Ref{Repository: "user-supplied-repo", Tag: "user-tag"}
+
+		to := dynakubelatest.DynaKube{
+			Spec: dynakubelatest.DynaKubeSpec{
+				TelemetryIngest: &telemetryingestlatest.Spec{},
+			},
+		}
+
+		err := from.ConvertTo(&to)
+		require.NoError(t, err)
+
+		assert.Equal(t, "user-supplied-repo", to.Spec.Templates.OpenTelemetryCollector.ImageRef.Repository)
+		assert.Equal(t, "user-tag", to.Spec.Templates.OpenTelemetryCollector.ImageRef.Tag)
+		assert.NotContains(t, to.Annotations, conversion.DefaultOTELCImageKey)
+
+		compareBase(t, from, to)
+	})
+
 	t.Run("no default otelc image when telemetry ingest is disabled", func(t *testing.T) {
 		from := getOldDynakubeBase()
 		from.Spec.TelemetryIngest = nil

--- a/pkg/api/validation/dynakube/databases.go
+++ b/pkg/api/validation/dynakube/databases.go
@@ -30,7 +30,7 @@ func missingDatabaseExecutorImage(ctx context.Context, _ *Validator, dk *dynakub
 		return ""
 	}
 
-	if dk.Spec.Templates.SQLExtensionExecutor.ImageRef.Repository == "" || dk.Spec.Templates.SQLExtensionExecutor.ImageRef.Tag == "" {
+	if !dk.Spec.Templates.SQLExtensionExecutor.ImageRef.HasImage() {
 		log.Info("requested dynakube doesn't specify the sqlExtensionExecutor image.", "name", dk.Name, "namespace", dk.Namespace)
 
 		return errorExtensionDatabaseExecutorImageNotSpecified

--- a/pkg/api/validation/dynakube/eec.go
+++ b/pkg/api/validation/dynakube/eec.go
@@ -22,7 +22,7 @@ func extensionControllerImage(ctx context.Context, _ *Validator, dk *dynakube.Dy
 		return ""
 	}
 
-	if dk.Spec.Templates.ExtensionExecutionController.ImageRef.Repository == "" || dk.Spec.Templates.ExtensionExecutionController.ImageRef.Tag == "" {
+	if !dk.Spec.Templates.ExtensionExecutionController.ImageRef.HasImage() {
 		log.Info("requested dynakube doesn't specify the ExtensionExecutionController image.", "name", dk.Name, "namespace", dk.Namespace)
 
 		return errorExtensionExecutionControllerImageNotSpecified

--- a/pkg/api/validation/dynakube/kspm.go
+++ b/pkg/api/validation/dynakube/kspm.go
@@ -39,7 +39,7 @@ func missingKSPMImage(_ context.Context, _ *Validator, dk *dynakube.DynaKube) st
 		return ""
 	}
 
-	if dk.KSPM().ImageRef.Repository == "" || dk.KSPM().ImageRef.Tag == "" {
+	if !dk.KSPM().ImageRef.HasImage() {
 		return errorKSPMMissingImage
 	}
 

--- a/pkg/api/validation/dynakube/logmonitoring.go
+++ b/pkg/api/validation/dynakube/logmonitoring.go
@@ -28,8 +28,7 @@ func missingLogMonitoringImage(_ context.Context, _ *Validator, dk *dynakube.Dyn
 		return ""
 	}
 
-	if dk.LogMonitoring().TemplateSpec == nil ||
-		dk.LogMonitoring().ImageRef.Repository == "" || dk.LogMonitoring().ImageRef.Tag == "" {
+	if dk.LogMonitoring().TemplateSpec == nil || !dk.LogMonitoring().ImageRef.HasImage() {
 		return errorLogMonitoringMissingImage
 	}
 

--- a/pkg/api/validation/dynakube/telemetryservice.go
+++ b/pkg/api/validation/dynakube/telemetryservice.go
@@ -163,7 +163,7 @@ func missingOtelCollectorImage(_ context.Context, _ *Validator, dk *dynakube.Dyn
 }
 
 func ignoredOtelCollectorTemplate(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	if !dk.TelemetryIngest().IsEnabled() && !dk.Spec.Templates.OpenTelemetryCollector.ImageRef.IsZero() {
+	if !dk.TelemetryIngest().IsEnabled() && dk.Spec.Templates.OpenTelemetryCollector.ImageRef.HasImage() {
 		return warningOtelCollectorIgnoredTemplate
 	}
 

--- a/pkg/api/validation/dynakube/telemetryservice.go
+++ b/pkg/api/validation/dynakube/telemetryservice.go
@@ -155,7 +155,7 @@ func missingOtelCollectorImage(_ context.Context, _ *Validator, dk *dynakube.Dyn
 		return ""
 	}
 
-	if dk.Spec.Templates.OpenTelemetryCollector.ImageRef.Repository == "" || dk.Spec.Templates.OpenTelemetryCollector.ImageRef.Tag == "" {
+	if !dk.Spec.Templates.OpenTelemetryCollector.ImageRef.HasImage() {
 		return errorOtelCollectorMissingImage
 	}
 

--- a/pkg/api/validation/dynakube/telemetryservice.go
+++ b/pkg/api/validation/dynakube/telemetryservice.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/telemetryingest"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	agconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
@@ -163,7 +164,7 @@ func missingOtelCollectorImage(_ context.Context, _ *Validator, dk *dynakube.Dyn
 }
 
 func ignoredOtelCollectorTemplate(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	if !dk.TelemetryIngest().IsEnabled() && dk.Spec.Templates.OpenTelemetryCollector.ImageRef.HasImage() {
+	if !dk.TelemetryIngest().IsEnabled() && dk.Spec.Templates.OpenTelemetryCollector.ImageRef != (image.Ref{}) {
 		return warningOtelCollectorIgnoredTemplate
 	}
 

--- a/pkg/api/validation/dynakube/telemetryservice_test.go
+++ b/pkg/api/validation/dynakube/telemetryservice_test.go
@@ -342,7 +342,7 @@ func TestImages(t *testing.T) {
 		assert.Contains(t, warnings, warningOtelCollectorIgnoredTemplate)
 	})
 
-	t.Run("otel collector repo and tag are empty but pull policy not, image section was ignored", func(t *testing.T) {
+	t.Run("otel collector pull policy without a usable image does not warn", func(t *testing.T) {
 		warnings, err := assertAllowed(t,
 			&dynakube.DynaKube{
 				ObjectMeta: defaultDynakubeObjectMeta,
@@ -360,7 +360,7 @@ func TestImages(t *testing.T) {
 				},
 			})
 		require.NoError(t, err)
-		assert.Contains(t, warnings, warningOtelCollectorIgnoredTemplate)
+		assert.NotContains(t, warnings, warningOtelCollectorIgnoredTemplate)
 	})
 
 	t.Run("otel collector image present", func(t *testing.T) {

--- a/pkg/api/validation/dynakube/telemetryservice_test.go
+++ b/pkg/api/validation/dynakube/telemetryservice_test.go
@@ -342,7 +342,7 @@ func TestImages(t *testing.T) {
 		assert.Contains(t, warnings, warningOtelCollectorIgnoredTemplate)
 	})
 
-	t.Run("otel collector pull policy without a usable image does not warn", func(t *testing.T) {
+	t.Run("otel collector repo and tag are empty but pull policy not, image section was ignored", func(t *testing.T) {
 		warnings, err := assertAllowed(t,
 			&dynakube.DynaKube{
 				ObjectMeta: defaultDynakubeObjectMeta,
@@ -360,7 +360,7 @@ func TestImages(t *testing.T) {
 				},
 			})
 		require.NoError(t, err)
-		assert.NotContains(t, warnings, warningOtelCollectorIgnoredTemplate)
+		assert.Contains(t, warnings, warningOtelCollectorIgnoredTemplate)
 	})
 
 	t.Run("otel collector image present", func(t *testing.T) {

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -173,7 +173,7 @@ func setImagePullSecrets(imagePullSecrets []corev1.LocalObjectReference) func(o 
 func buildContainer(dk *dynakube.DynaKube) corev1.Container {
 	return corev1.Container{
 		Name:            containerName,
-		Image:           dk.Spec.Templates.ExtensionExecutionController.ImageRef.Repository + ":" + dk.Spec.Templates.ExtensionExecutionController.ImageRef.Tag,
+		Image:           dk.Spec.Templates.ExtensionExecutionController.ImageRef.String(),
 		ImagePullPolicy: dk.Spec.Templates.ExtensionExecutionController.ImageRef.GetPullPolicy(),
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-4254](https://dt-rnd.atlassian.net/browse/ICP-4254)

With this PR `digest` field is added to the `imageRef` spec. Updated docs and added a new test file to test behavior.


<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- unit tests
- deploy operator, test out the digest field for the components.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[ICP-4254]: https://dt-rnd.atlassian.net/browse/ICP-4254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ