### PR TITLE
Fix otelc template annotation propagation

### DIFF
--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -90,6 +90,7 @@ func (r *Reconciler) createOrUpdateStatefulset(ctx context.Context, dk *dynakube
 	}
 
 	appLabels := buildAppLabels(dk.Name)
+
 	templateAnnotations, err := r.buildTemplateAnnotations(ctx, dk)
 	if err != nil {
 		return err

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -90,7 +90,6 @@ func (r *Reconciler) createOrUpdateStatefulset(ctx context.Context, dk *dynakube
 	}
 
 	appLabels := buildAppLabels(dk.Name)
-
 	templateAnnotations, err := r.buildTemplateAnnotations(ctx, dk)
 	if err != nil {
 		return err
@@ -142,11 +141,11 @@ func (r *Reconciler) createOrUpdateStatefulset(ctx context.Context, dk *dynakube
 func (r *Reconciler) buildTemplateAnnotations(ctx context.Context, dk *dynakube.DynaKube) (map[string]string, error) {
 	templateAnnotations := map[string]string{}
 
-	if dk.Extensions().IsPrometheusEnabled() {
-		if dk.Spec.Templates.OpenTelemetryCollector.Annotations != nil {
-			templateAnnotations = k8ssecuritycontext.RemoveAppArmorAnnotation(dk.Spec.Templates.OpenTelemetryCollector.Annotations, containerName)
-		}
+	if dk.Spec.Templates.OpenTelemetryCollector.Annotations != nil {
+		templateAnnotations = k8ssecuritycontext.RemoveAppArmorAnnotation(dk.Spec.Templates.OpenTelemetryCollector.Annotations, containerName)
+	}
 
+	if dk.Extensions().IsPrometheusEnabled() {
 		tlsSecretHash, err := r.calculateSecretHash(ctx, dk.Extensions().GetTLSSecretName(), dk.Namespace)
 		if err != nil {
 			return nil, err

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler_test.go
@@ -479,7 +479,7 @@ func TestReconcileReplicas(t *testing.T) {
 func TestAppArmorAnnotationHandling(t *testing.T) {
 	const appArmorAnnotationKey = corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + containerName
 
-	getStatefulSet := func(t *testing.T) *appsv1.StatefulSet {
+	getStatefulSetWithExtensions := func(t *testing.T) *appsv1.StatefulSet {
 		t.Helper()
 
 		dk := getTestDynakubeWithExtensions()
@@ -496,24 +496,68 @@ func TestAppArmorAnnotationHandling(t *testing.T) {
 		return sts
 	}
 
-	t.Run("apparmor annotation present in 1.30", func(t *testing.T) {
-		t.Cleanup(version.DisableCacheForTest(30))
+	getStatefulSetWithTelemetryIngest := func(t *testing.T) *appsv1.StatefulSet {
+		t.Helper()
 
-		sts := getStatefulSet(t)
-		require.Len(t, sts.Spec.Template.Spec.Containers, 1)
-		require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
-		assert.Nil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile)
-		assert.Contains(t, sts.Spec.Template.Annotations, appArmorAnnotationKey)
+		dk := getTestDynakubeWithTelemetryIngest()
+		dk.Spec.Templates.OpenTelemetryCollector.Annotations = map[string]string{appArmorAnnotationKey: corev1.DeprecatedAppArmorBetaProfileRuntimeDefault}
+		clt := fake.NewClient(dk)
+
+		tokenSecret := getTokens(dk.Tokens(), dk.Namespace)
+		require.NoError(t, clt.Create(t.Context(), &tokenSecret))
+
+		configMap := getConfigConfigMap(dk.Name, dk.Namespace)
+		require.NoError(t, clt.Create(t.Context(), &configMap))
+
+		require.NoError(t, NewReconciler(clt, clt).Reconcile(t.Context(), dk))
+		sts := &appsv1.StatefulSet{}
+		require.NoError(t, clt.Get(t.Context(), client.ObjectKey{Name: dk.OtelCollectorStatefulsetName(), Namespace: dk.Namespace}, sts))
+
+		return sts
+	}
+
+	t.Run("with extensions", func(t *testing.T) {
+		t.Run("apparmor annotation present in 1.30", func(t *testing.T) {
+			t.Cleanup(version.DisableCacheForTest(30))
+
+			sts := getStatefulSetWithExtensions(t)
+			require.Len(t, sts.Spec.Template.Spec.Containers, 1)
+			require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
+			assert.Nil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile)
+			assert.Contains(t, sts.Spec.Template.Annotations, appArmorAnnotationKey)
+		})
+
+		t.Run("apparmor annotation absent in 1.31", func(t *testing.T) {
+			t.Cleanup(version.DisableCacheForTest(31))
+
+			sts := getStatefulSetWithExtensions(t)
+			require.Len(t, sts.Spec.Template.Spec.Containers, 1)
+			require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
+			assert.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile)
+			assert.NotContains(t, sts.Spec.Template.Annotations, appArmorAnnotationKey)
+		})
 	})
 
-	t.Run("apparmor annotation absent in 1.31", func(t *testing.T) {
-		t.Cleanup(version.DisableCacheForTest(31))
+	t.Run("with telemetry ingest only", func(t *testing.T) {
+		t.Run("apparmor annotation present in 1.30", func(t *testing.T) {
+			t.Cleanup(version.DisableCacheForTest(30))
 
-		sts := getStatefulSet(t)
-		require.Len(t, sts.Spec.Template.Spec.Containers, 1)
-		require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
-		assert.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile)
-		assert.NotContains(t, sts.Spec.Template.Annotations, appArmorAnnotationKey)
+			sts := getStatefulSetWithTelemetryIngest(t)
+			require.Len(t, sts.Spec.Template.Spec.Containers, 1)
+			require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
+			assert.Nil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile)
+			assert.Contains(t, sts.Spec.Template.Annotations, appArmorAnnotationKey)
+		})
+
+		t.Run("apparmor annotation absent in 1.31", func(t *testing.T) {
+			t.Cleanup(version.DisableCacheForTest(31))
+
+			sts := getStatefulSetWithTelemetryIngest(t)
+			require.Len(t, sts.Spec.Template.Spec.Containers, 1)
+			require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
+			assert.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile)
+			assert.NotContains(t, sts.Spec.Template.Annotations, appArmorAnnotationKey)
+		})
 	})
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-5016

The `templates.otelCollector.annotations` were only used if extensions were used.

## How can this be tested?

unit tests + just use `templates.otelCollector.annotations` with telemetry ingest alone