### PR TITLE
Set download url via arguments of the boostrapper command

### DIFF
--- a/cmd/bootstrapper/cmd.go
+++ b/cmd/bootstrapper/cmd.go
@@ -26,6 +26,7 @@ const (
 	FlavorFlag                       = "flavor"
 	MetadataEnrichmentFlag           = "metadata-enrichment"
 	EnableAttributesDTKubernetesFlag = "enable-attributes-dt-kubernetes"
+	BaseURL                          = "url"
 )
 
 var (
@@ -34,6 +35,7 @@ var (
 	areErrorsSuppressed bool
 	technologies        []string
 	flavor              string
+	url                 string
 
 	needsMetadataEnrichment      bool
 	enableAttributesDTKubernetes bool
@@ -69,6 +71,8 @@ func AddFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolVar(&enableAttributesDTKubernetes, EnableAttributesDTKubernetesFlag, true, "(Optional) Should the deprecated attributes dt.kubernetes be added to the metadata enrichment.")
 
+	cmd.PersistentFlags().StringVar(&url, BaseURL, "", "URL of the server used to download the code modules image from.")
+
 	configure.AddFlags(cmd)
 }
 
@@ -89,7 +93,7 @@ func run(cmd *cobra.Command, _ []string) error {
 			PathResolver:  metadata.PathResolver{RootDir: targetFolder},
 		}
 
-		client := download.New()
+		client := download.New(download.WithBaseURL(url))
 
 		signalHandler := ctrl.SetupSignalHandler()
 

--- a/cmd/bootstrapper/download/client.go
+++ b/cmd/bootstrapper/download/client.go
@@ -13,6 +13,7 @@ import (
 
 type Client struct {
 	newInstaller binary.NewFunc
+	baseURL      string
 }
 
 type Option func(*Client)
@@ -20,6 +21,12 @@ type Option func(*Client)
 func WithInstaller(builder binary.NewFunc) Option {
 	return func(cl *Client) {
 		cl.newInstaller = builder
+	}
+}
+
+func WithBaseURL(url string) Option {
+	return func(cl *Client) {
+		cl.baseURL = url
 	}
 }
 
@@ -70,7 +77,7 @@ func (cl *Client) createDTClientFromFs(inputDir string) (oneagent.Client, error)
 		options = append(options, dynatrace.WithCerts(certs))
 	}
 
-	options = append(options, dynatrace.WithBaseURL(config.URL))
+	options = append(options, dynatrace.WithBaseURL(cl.baseURL))
 
 	dtClient, err := dynatrace.NewClient(options...)
 	if err != nil {

--- a/cmd/bootstrapper/download/client_test.go
+++ b/cmd/bootstrapper/download/client_test.go
@@ -83,6 +83,7 @@ func TestDo(t *testing.T) {
 			WithInstaller(installerTester(t, props, func(i *installermock.Installer) {
 				i.EXPECT().InstallAgent(t.Context(), targetDir).Return(true, nil)
 			})),
+			WithBaseURL("url"),
 		}
 		client := New(opts...)
 
@@ -110,6 +111,7 @@ func TestDo(t *testing.T) {
 			WithInstaller(installerTester(t, props, func(i *installermock.Installer) {
 				i.EXPECT().InstallAgent(t.Context(), targetDir).Return(true, nil)
 			})),
+			WithBaseURL("url"),
 		}
 		client := New(opts...)
 
@@ -134,6 +136,7 @@ func TestDo(t *testing.T) {
 			WithInstaller(installerTester(t, props, func(i *installermock.Installer) {
 				i.EXPECT().InstallAgent(t.Context(), targetDir).Return(false, expectedErr)
 			})),
+			WithBaseURL("url"),
 		}
 		client := New(opts...)
 

--- a/cmd/bootstrapper/download/config.go
+++ b/cmd/bootstrapper/download/config.go
@@ -13,7 +13,6 @@ const (
 )
 
 type Config struct {
-	URL      string `json:"url"`
 	APIToken string `json:"apiToken"`
 
 	Proxy       string `json:"proxy"`

--- a/cmd/bootstrapper/download/config_test.go
+++ b/cmd/bootstrapper/download/config_test.go
@@ -108,7 +108,6 @@ func testConfig(t *testing.T) Config {
 	t.Helper()
 
 	return Config{
-		URL:           "url",
 		APIToken:      "token",
 		SkipCertCheck: true,
 		Proxy:         "proxy",

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
@@ -195,7 +195,7 @@ func (s *SecretGenerator) generateConfig(ctx context.Context, dk *dynakube.DynaK
 	data := map[string][]byte{}
 	annotations := map[string]string{}
 
-	if needsDownloadConfig(dk) {
+	if NeedsDownloadConfig(dk) {
 		downloadConfigBytes, err := s.prepareDownloadConfig(ctx, dk)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)
@@ -238,7 +238,7 @@ func (s *SecretGenerator) generateConfig(ctx context.Context, dk *dynakube.DynaK
 	return data, annotations, nil
 }
 
-func needsDownloadConfig(dk *dynakube.DynaKube) bool {
+func NeedsDownloadConfig(dk *dynakube.DynaKube) bool {
 	return dk.OneAgent().IsAppInjectionNeeded() && !dk.OneAgent().IsCSIAvailable() && dk.OneAgent().GetCodeModulesImage() == ""
 }
 
@@ -275,7 +275,6 @@ func (s *SecretGenerator) prepareDownloadConfig(ctx context.Context, dk *dynakub
 	}
 
 	downloadConfigJSON := download.Config{
-		URL:           dk.Spec.APIURL,
 		APIToken:      string(tokens.Data[token.APIKey]),
 		NoProxy:       dk.FF().GetNoProxy(),
 		NetworkZone:   dk.Spec.NetworkZone,

--- a/pkg/webhook/mutation/pod/handler/injection/init.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit/configure"
 	"github.com/Dynatrace/dynatrace-operator/cmd/bootstrapper"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/bootstrapperconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sresource"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/arg"
@@ -27,6 +28,13 @@ func (h *Handler) createInitContainerBase(pod *corev1.Pod, dk dynakube.DynaKube)
 			Name:  configure.InputFolderFlag,
 			Value: volumes.InitInputMountPath,
 		},
+	}
+
+	if bootstrapperconfig.NeedsDownloadConfig(&dk) {
+		args = append(args, arg.Arg{
+			Name:  bootstrapper.BaseURL,
+			Value: dk.Spec.APIURL,
+		})
 	}
 
 	if areErrorsSuppressed(pod, dk) {

--- a/pkg/webhook/mutation/pod/handler/injection/init_test.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8smount"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8svolume"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
@@ -190,6 +191,60 @@ func TestCreateInitContainerBase(t *testing.T) {
 		initContainer = wh.createInitContainerBase(pod, *dk)
 
 		assert.Contains(t, initContainer.Args, "--"+k8sinit.SuppressErrorsFlag)
+	})
+
+	t.Run("should set url arg in CNFS and AM modes", func(t *testing.T) {
+		installconfig.SetModulesOverride(t, installconfig.Modules{CSIDriver: false})
+
+		pod := getTestPod()
+		pod.Annotations = map[string]string{}
+
+		dk := getTestDynakube()
+		initContainer := wh.createInitContainerBase(pod, *dk)
+		assert.Contains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
+
+		dk.Spec.OneAgent = getApplicationMonitoringSpec()
+		initContainer = wh.createInitContainerBase(pod, *dk)
+		assert.Contains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
+	})
+
+	t.Run("shouldn't set url arg in CFS and HM modes", func(t *testing.T) {
+		installconfig.SetModulesOverride(t, installconfig.Modules{CSIDriver: false})
+		dk := getTestDynakube()
+
+		pod := getTestPod()
+		pod.Annotations = map[string]string{}
+
+		dk.Spec.OneAgent = getHostMonitoringSpec()
+		initContainer := wh.createInitContainerBase(pod, *dk)
+		assert.NotContains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
+
+		dk.Spec.OneAgent = getClassicFullStackSpec()
+		initContainer = wh.createInitContainerBase(pod, *dk)
+		assert.NotContains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
+	})
+
+	t.Run("shouldn't set url arg if CSI driver enabled", func(t *testing.T) {
+		installconfig.SetModulesOverride(t, installconfig.Modules{CSIDriver: true})
+		dk := getTestDynakube()
+		pod := getTestPod()
+		pod.Annotations = map[string]string{}
+
+		initContainer := wh.createInitContainerBase(pod, *dk)
+
+		assert.NotContains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
+	})
+
+	t.Run("shouldn't set url arg if codemodules image is set", func(t *testing.T) {
+		installconfig.SetModulesOverride(t, installconfig.Modules{CSIDriver: false})
+		dk := getTestDynakube()
+		dk.Status.CodeModules.ImageID = "image"
+		pod := getTestPod()
+		pod.Annotations = map[string]string{}
+
+		initContainer := wh.createInitContainerBase(pod, *dk)
+
+		assert.NotContains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
 	})
 }
 
@@ -625,6 +680,26 @@ func getCloudNativeSpec() oneagent.Spec {
 		CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{
 			AppInjectionSpec: oneagent.AppInjectionSpec{},
 		},
+	}
+}
+
+func getApplicationMonitoringSpec() oneagent.Spec {
+	return oneagent.Spec{
+		ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{
+			AppInjectionSpec: oneagent.AppInjectionSpec{},
+		},
+	}
+}
+
+func getHostMonitoringSpec() oneagent.Spec {
+	return oneagent.Spec{
+		HostMonitoring: &oneagent.HostInjectSpec{},
+	}
+}
+
+func getClassicFullStackSpec() oneagent.Spec {
+	return oneagent.Spec{
+		ClassicFullStack: &oneagent.HostInjectSpec{},
 	}
 }
 


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-5103)

## Description

Fixes the problem by moving the _url_ field in the _dtclient.config_ file to arguments of the _bootstrapper_ command.

## How can this be tested?

Install operator without CSI driver and deploy a CNFS dynakube and a sample app.
Check arguments and logs of the dynatrace-operator initContainer.

Verify if OA is injected (app shell):
```
cat /proc/1/maps
```