### PR TITLE
Add digest field to helm values

### DIFF
--- a/.github/actions/update-csv-bundles/action.yml
+++ b/.github/actions/update-csv-bundles/action.yml
@@ -93,7 +93,7 @@ runs:
         VERSION: ${{ inputs.version }}
         PLATFORM: openshift
         IMAGE: registry.connect.redhat.com/dynatrace/dynatrace-operator
-        OLM_IMAGE: registry.connect.redhat.com/dynatrace/dynatrace-operator:v${{ inputs.version }}@${{ inputs.digest }}
+        TAG: v${{ inputs.version }}
       run: |
         make bundle
     - name: Generate OLM bundles (kubernetes)
@@ -103,7 +103,7 @@ runs:
         VERSION: ${{ inputs.version }}
         PLATFORM: kubernetes
         IMAGE: docker.io/dynatrace/dynatrace-operator
-        OLM_IMAGE: docker.io/dynatrace/dynatrace-operator:v${{ inputs.version }}@${{ inputs.digest }}
+        TAG: v${{ inputs.version }}
       run: |
         make bundle
     - name: Create GitHub app token

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -231,10 +231,10 @@ jobs:
         run: |
           make manifests/crd/release CHART_VERSION="${VERSION_WITHOUT_PREFIX}"
 
-          make manifests/kubernetes/olm IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}"
-          make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}"
-          make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}"
-          make manifests/openshift IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}"
+          make manifests/kubernetes/olm IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}" DIGEST="${DIGEST}"
+          make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}" DIGEST="${DIGEST}"
+          make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}" DIGEST="${DIGEST}"
+          make manifests/openshift IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}" DIGEST="${DIGEST}"
       - name: Build helm packages
         uses: ./.github/actions/build-helm
         with:

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -21,14 +21,21 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Check if default image or imageref is used
+Check if default image or imageref is used.
+When imageRef.digest is set, it wins over imageRef.tag. The rendered image
+reference uses <repository>@<digest> and the tag is omitted to avoid the
+confusing case where the tag and digest disagree.
 */}}
 {{- define "dynatrace-operator.image" -}}
 {{- if .Values.image -}}
 	{{- printf "%s" .Values.image -}}
 {{- else -}}
     {{- if (.Values.imageRef).repository -}}
-        {{- .Values.imageRef.tag | default (printf "v%s" .Chart.AppVersion) | printf "%s:%s" .Values.imageRef.repository -}}
+        {{- if .Values.imageRef.digest -}}
+            {{- printf "%s@%s" .Values.imageRef.repository .Values.imageRef.digest -}}
+        {{- else -}}
+            {{- .Values.imageRef.tag | default (printf "v%s" .Chart.AppVersion) | printf "%s:%s" .Values.imageRef.repository -}}
+        {{- end -}}
     {{- else if hasPrefix "0.0.0-nightly-" .Chart.AppVersion -}}
         {{- printf "%s:%s" "ghcr.io/dynatrace/dynatrace-operator" (.Chart.AppVersion | replace "0.0.0-" "") }}
     {{- else if eq (include "dynatrace-operator.platform" .) "openshift" -}}

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -956,3 +956,25 @@ tests:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
+
+  - it: DT_OPERATOR_IMAGE uses the digest when imageRef.digest is set
+    set:
+      platform: kubernetes
+      imageRef:
+        repository: some-repo
+        tag: tag-name
+        digest: sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "some-repo@sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DT_OPERATOR_IMAGE
+            value: "some-repo@sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
+          count: 1
+          any: true
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: 1.0.1

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -705,6 +705,29 @@ tests:
           path: spec.template.spec.containers[0].image
           value: "some-repo:v1.0.1"
 
+  - it: digest in imageref wins over tag and omits the tag
+    set:
+      platform: kubernetes
+      imageRef:
+        repository: some-repo
+        tag: tag-name
+        digest: sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "some-repo@sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
+
+  - it: digest in imageref is used when tag is omitted
+    set:
+      platform: kubernetes
+      imageRef:
+        repository: some-repo
+        digest: sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "some-repo@sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
+
   - it: debug flag disables high availability and security context
     set:
       platform: kubernetes

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -19,10 +19,11 @@ platform: ""
 # supply either image or imageref; if both supplied, imageref will be disregarded
 image: ""
 #image description using tags
-#resulting image will be named <repository>:v<tag>
+#resulting image will be named <repository>:v<tag>, or <repository>@<digest> if a digest is provided
 imageRef:
   repository: "" #path to repo
   tag: "" #defaults to chart version
+  digest: "" #optional image digest (e.g. sha256:...), when set, the tag is ignored when rendering the image reference
   pullPolicy: ""
 
 customPullSecret: ""

--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -8,7 +8,9 @@ define generate_k8s_manifest
 		--set platform="kubernetes" \
 		--set manifests=true \
 		--set olm=$(OLM) \
-		--set image=$(IMAGE_URI) > $(2)
+		--set imageRef.repository=$(IMAGE) \
+		--set imageRef.tag=$(TAG) \
+		--set imageRef.digest=$(DIGEST) > $(2)
 endef
 
 ## Generates a Kubernetes manifest including CRD and CSI driver

--- a/hack/make/manifests/openshift.mk
+++ b/hack/make/manifests/openshift.mk
@@ -8,7 +8,9 @@ define generate_openshift_manifest
 		--set platform="openshift" \
 		--set manifests=true \
 		--set olm=$(OLM) \
-		--set image=$(IMAGE_URI) > $(2)
+		--set imageRef.repository=$(IMAGE) \
+		--set imageRef.tag=$(TAG) \
+		--set imageRef.digest=$(DIGEST) > $(2)
 endef
 
 ## Generates an Openshift manifest including CRD and CSI driver


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-4258](https://dt-rnd.atlassian.net/browse/ICP-4258)

With this we add `digest` field to `values.yaml`. To deploy the operator according to Kubernetes recommendations, the images should use a digest. 

#6681 relates to this PR. There we added the digest to the `imageRef` struct.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Helm unit tests

deploy operator, set digest, check for example `DT_OPERATOR_IMAGE` env var

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[ICP-4258]: https://dt-rnd.atlassian.net/browse/ICP-4258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ