### PR TITLE
rename classicFullstack to classicFullStack in func names and strings

### DIFF
--- a/cmd/troubleshoot/image_test.go
+++ b/cmd/troubleshoot/image_test.go
@@ -105,7 +105,7 @@ func TestImagePullable(t *testing.T) {
 			proxyWarning: false,
 		},
 		{
-			name:         "Default ClassicFullstack OneAgent image",
+			name:         "Default classicFullStack OneAgent image",
 			dk:           dynakubeBuilder(dockerServer.URL).withClassicFullStack().build(),
 			component:    componentOneAgent,
 			proxyWarning: false,
@@ -125,7 +125,7 @@ func TestImagePullable(t *testing.T) {
 			proxyWarning: false,
 		},
 		{
-			name:         "Custom ClassicFullstack OneAgent image",
+			name:         "Custom classicFullStack OneAgent image",
 			dk:           dynakubeBuilder(dockerServer.URL).withClassicFullStackCustomImage(server + "/" + testCustomOneAgentImage + ":" + testVersion).build(),
 			component:    componentOneAgent,
 			proxyWarning: false,

--- a/pkg/api/latest/dynakube/oneagent/props_test.go
+++ b/pkg/api/latest/dynakube/oneagent/props_test.go
@@ -155,13 +155,13 @@ func TestCodeModulesVersion(t *testing.T) {
 }
 
 func TestGetOneAgentEnvironment(t *testing.T) {
-	t.Run("get environment from classicFullstack", func(t *testing.T) {
+	t.Run("get environment from classicFullStack", func(t *testing.T) {
 		oneAgent := OneAgent{
 			Spec: &Spec{
 				ClassicFullStack: &HostInjectSpec{
 					Env: []corev1.EnvVar{
 						{
-							Name:  "classicFullstack",
+							Name:  "classicFullStack",
 							Value: "true",
 						},
 					},
@@ -171,7 +171,7 @@ func TestGetOneAgentEnvironment(t *testing.T) {
 		env := oneAgent.GetEnvironment()
 
 		require.Len(t, env, 1)
-		assert.Equal(t, "classicFullstack", env[0].Name)
+		assert.Equal(t, "classicFullStack", env[0].Name)
 	})
 
 	t.Run("get environment from hostMonitoring", func(t *testing.T) {

--- a/pkg/api/v1beta4/dynakube/oneagent/props_test.go
+++ b/pkg/api/v1beta4/dynakube/oneagent/props_test.go
@@ -126,13 +126,13 @@ func TestCodeModulesVersion(t *testing.T) {
 }
 
 func TestGetOneAgentEnvironment(t *testing.T) {
-	t.Run("get environment from classicFullstack", func(t *testing.T) {
+	t.Run("get environment from classicFullStack", func(t *testing.T) {
 		oneAgent := OneAgent{
 			Spec: &Spec{
 				ClassicFullStack: &HostInjectSpec{
 					Env: []corev1.EnvVar{
 						{
-							Name:  "classicFullstack",
+							Name:  "classicFullStack",
 							Value: "true",
 						},
 					},
@@ -142,7 +142,7 @@ func TestGetOneAgentEnvironment(t *testing.T) {
 		env := oneAgent.GetEnvironment()
 
 		require.Len(t, env, 1)
-		assert.Equal(t, "classicFullstack", env[0].Name)
+		assert.Equal(t, "classicFullStack", env[0].Name)
 	})
 
 	t.Run("get environment from hostMonitoring", func(t *testing.T) {

--- a/pkg/api/v1beta5/dynakube/oneagent/props_test.go
+++ b/pkg/api/v1beta5/dynakube/oneagent/props_test.go
@@ -126,13 +126,13 @@ func TestCodeModulesVersion(t *testing.T) {
 }
 
 func TestGetOneAgentEnvironment(t *testing.T) {
-	t.Run("get environment from classicFullstack", func(t *testing.T) {
+	t.Run("get environment from classicFullStack", func(t *testing.T) {
 		oneAgent := OneAgent{
 			Spec: &Spec{
 				ClassicFullStack: &HostInjectSpec{
 					Env: []corev1.EnvVar{
 						{
-							Name:  "classicFullstack",
+							Name:  "classicFullStack",
 							Value: "true",
 						},
 					},
@@ -142,7 +142,7 @@ func TestGetOneAgentEnvironment(t *testing.T) {
 		env := oneAgent.GetEnvironment()
 
 		require.Len(t, env, 1)
-		assert.Equal(t, "classicFullstack", env[0].Name)
+		assert.Equal(t, "classicFullStack", env[0].Name)
 	})
 
 	t.Run("get environment from hostMonitoring", func(t *testing.T) {

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -432,7 +432,7 @@ func TestPodSpec_Arguments(t *testing.T) {
 		podSpecs := daemonset.Spec.Template.Spec
 		assert.Contains(t, podSpecs.Containers[0].Args, "--set-host-id-source=k8s-node-name")
 	})
-	t.Run("has host-group for classicFullstack", func(t *testing.T) {
+	t.Run("has host-group for classicFullStack", func(t *testing.T) {
 		classicInstance := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				OneAgent: oneagent.Spec{

--- a/pkg/controllers/dynakube/version/updater_test.go
+++ b/pkg/controllers/dynakube/version/updater_test.go
@@ -108,7 +108,7 @@ func TestRun(t *testing.T) {
 		updater.AssertNumberOfCalls(t, "UseTenantRegistry", 2)
 		assert.Equal(t, status.CustomVersionVersionSource, target.Source)
 	})
-	t.Run("classicfullstack enabled, public registry is ignored", func(t *testing.T) {
+	t.Run("classicFullStack enabled, public registry is ignored", func(t *testing.T) {
 		target := &status.VersionStatus{
 			Source: status.TenantRegistryVersionSource,
 		}
@@ -129,7 +129,7 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, status.TenantRegistryVersionSource, target.Source)
 		assert.Empty(t, target.Version)
 	})
-	t.Run("classicfullstack enabled, public registry is ignored, custom image is set", func(t *testing.T) {
+	t.Run("classicFullStack enabled, public registry is ignored, custom image is set", func(t *testing.T) {
 		target := &status.VersionStatus{
 			Source: status.TenantRegistryVersionSource,
 		}
@@ -262,7 +262,7 @@ func TestDetermineSource(t *testing.T) {
 		assert.Equal(t, status.PublicRegistryVersionSource, source)
 	})
 
-	t.Run("classicfullstack ignores public registry feature flag", func(t *testing.T) {
+	t.Run("classicFullStack ignores public registry feature flag", func(t *testing.T) {
 		updater := NewMockStatusUpdater(t)
 		updater.EXPECT().CustomImage().Return("").Once()
 		updater.EXPECT().IsPublicRegistryEnabled().Return(false).Once()
@@ -271,7 +271,7 @@ func TestDetermineSource(t *testing.T) {
 		assert.Equal(t, status.TenantRegistryVersionSource, source)
 	})
 
-	t.Run("classicfullstack ignores public registry feature flag and sets custom image if set", func(t *testing.T) {
+	t.Run("classicFullStack ignores public registry feature flag and sets custom image if set", func(t *testing.T) {
 		customVersion := "1.2.3.4-5"
 		updater := NewMockStatusUpdater(t)
 		updater.EXPECT().CustomImage().Return("").Once()

--- a/pkg/webhook/mutation/pod/volumes/volumes_test.go
+++ b/pkg/webhook/mutation/pod/volumes/volumes_test.go
@@ -218,7 +218,7 @@ func TestAddConfigVolumeMount(t *testing.T) {
 		assert.True(t, HasSplitEnrichmentMounts(container))
 	})
 
-	t.Run("should add split mounts for metadataenrichment if classicfullstack is enabled", func(t *testing.T) {
+	t.Run("should add split mounts for metadataenrichment if classicFullStack is enabled", func(t *testing.T) {
 		container := &corev1.Container{Name: "test-container"}
 		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{

--- a/test/e2e/features/classic/classic.go
+++ b/test/e2e/features/classic/classic.go
@@ -21,7 +21,7 @@ func Feature(t *testing.T) features.Feature {
 	secretConfig := tenant.GetSingleTenantSecret(t)
 	testDynakube := *dynakubeComponents.New(
 		dynakubeComponents.WithAPIURL(secretConfig.APIURL),
-		dynakubeComponents.WithClassicFullstackSpec(&oneagent.HostInjectSpec{}),
+		dynakubeComponents.WithClassicFullStackSpec(&oneagent.HostInjectSpec{}),
 	)
 
 	dynakubeComponents.Install(builder, &secretConfig, testDynakube)

--- a/test/e2e/features/classic/switchmodes/switch_modes.go
+++ b/test/e2e/features/classic/switchmodes/switch_modes.go
@@ -31,7 +31,7 @@ func Feature(t *testing.T) features.Feature {
 	}
 
 	dynakubeClassicFullStack := *dynakubeComponents.New(
-		append(commonOptions, dynakubeComponents.WithClassicFullstackSpec(&oneagent.HostInjectSpec{}))...,
+		append(commonOptions, dynakubeComponents.WithClassicFullStackSpec(&oneagent.HostInjectSpec{}))...,
 	)
 
 	sampleAppClassic := sample.NewApp(t, &dynakubeClassicFullStack,

--- a/test/e2e/features/cloudnative/switchmodes/switch_modes.go
+++ b/test/e2e/features/cloudnative/switchmodes/switch_modes.go
@@ -44,7 +44,7 @@ func Feature(t *testing.T) features.Feature {
 	cloudnative.AssessSampleInitContainers(builder, sampleAppCloudNative)
 
 	// switch to classic full stack
-	dynakubeClassicFullStack := *dynakubeComponents.New(append(commonOptions, dynakubeComponents.WithClassicFullstackSpec(&oneagent.HostInjectSpec{}))...)
+	dynakubeClassicFullStack := *dynakubeComponents.New(append(commonOptions, dynakubeComponents.WithClassicFullStackSpec(&oneagent.HostInjectSpec{}))...)
 	sampleAppClassicFullStack := sample.NewApp(t, &dynakubeClassicFullStack,
 		sample.AsDeployment(),
 		sample.WithName(sampleAppsClassicName),

--- a/test/e2e/helpers/components/dynakube/options.go
+++ b/test/e2e/helpers/components/dynakube/options.go
@@ -176,7 +176,7 @@ func WithIstioIntegration() Option {
 	}
 }
 
-func WithClassicFullstackSpec(classicFullStackSpec *oneagent.HostInjectSpec) Option {
+func WithClassicFullStackSpec(classicFullStackSpec *oneagent.HostInjectSpec) Option {
 	return func(dk *dynakube.DynaKube) {
 		dk.Spec.OneAgent.ClassicFullStack = classicFullStackSpec
 	}


### PR DESCRIPTION
## Description

there was confusion that user defined `classicFullstack` instead of `classicFullStack` in spec.
rename funcs and replace strings to avoid invalid camelCasing in codebase

## How can this be tested?
`make go/test` + e2e tests