### PR TITLE
bump controller-gen.kubebuilder.io/version to v0.21.0 in crd template - make doc

### DIFF
--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     {{- include "dynatrace-operator.commonLabels" . | nindent 4 }}
   name: dynakubes.dynatrace.com
@@ -7617,7 +7617,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     {{- include "dynatrace-operator.commonLabels" . | nindent 4 }}
   name: edgeconnects.dynatrace.com


### PR DESCRIPTION
## Description
after merge of #6604 the `make doc` target was failing on CI

## How can this be tested?
`make doc`
