### PR TITLE
Harden Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:best-practices",
   ],
   labels: [
     "dependencies",
@@ -26,6 +26,7 @@
     "gomod",
     "github-actions",
     "pip_requirements",
+    "npm",
   ],
   postUpdateOptions: [
     "gomodTidy",
@@ -37,6 +38,10 @@
   branchNameStrict: true,
   prConcurrentLimit: 20,
   hashedBranchLength: 27, // 63 character limit for label values with space for "dynatrace-operator.v0.0.0-snapshot-" prefix
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+  },
   regexManagers: [
     {
       fileMatch: [
@@ -61,6 +66,19 @@
     },
   ],
   packageRules: [
+    {
+      "matchDatasources": ["docker"],
+      "minimumReleaseAge": "3 days",
+    },
+    {
+      "matchManagers": ["github-actions", "pip_requirements", "npm"],
+      "minimumReleaseAge": "3 days",
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["direct"],
+      "minimumReleaseAge": "3 days",
+    },
     {
       matchBaseBranches: [
         "$default",


### PR DESCRIPTION
## Description
* Enforce best practices: https://docs.renovatebot.com/presets-config/#configbest-practices
* Check https://osv.dev for vulnerability alerts
* Set `minimumReleaseAge` to 3 days to reduce the risk of supply-chain attacks
* Enable the `npm` dependency manager
  * There are multiple node dependencies in `hack/make/prerequisites.mk`

Follow-up to [DTSEC-22604](https://dt-rnd.atlassian.net/browse/DTSEC-22604). 

[DTSEC-22604]: https://dt-rnd.atlassian.net/browse/DTSEC-22604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ