### PR TITLE
Automatically enable public registry and warn if FF is set

### DIFF
--- a/pkg/api/exp/flag.go
+++ b/pkg/api/exp/flag.go
@@ -22,11 +22,7 @@ type FeatureFlags struct {
 	hasPlatformToken bool
 }
 
-func NewFlags(annotations map[string]string) *FeatureFlags {
-	return &FeatureFlags{annotations: annotations}
-}
-
-func NewFlagsWithPlatformToken(annotations map[string]string, hasPlatformToken bool) *FeatureFlags {
+func NewFlags(annotations map[string]string, hasPlatformToken bool) *FeatureFlags {
 	return &FeatureFlags{annotations: annotations, hasPlatformToken: hasPlatformToken}
 }
 

--- a/pkg/api/exp/flag.go
+++ b/pkg/api/exp/flag.go
@@ -18,11 +18,16 @@ const (
 )
 
 type FeatureFlags struct {
-	annotations map[string]string
+	annotations      map[string]string
+	hasPlatformToken bool
 }
 
 func NewFlags(annotations map[string]string) *FeatureFlags {
 	return &FeatureFlags{annotations: annotations}
+}
+
+func NewFlagsWithPlatformToken(annotations map[string]string, hasPlatformToken bool) *FeatureFlags {
+	return &FeatureFlags{annotations: annotations, hasPlatformToken: hasPlatformToken}
 }
 
 // IsSet checks if the annotation(feature-flag) is present, does not check the value in any way.
@@ -42,8 +47,7 @@ func (ff *FeatureFlags) UseEECLegacyMounts() bool {
 }
 
 func (ff *FeatureFlags) IsPublicRegistry() bool {
-	// TODO: ICP-3643 - Implement public registry selection based on gen3 platformToken; if user defines FF use-public-registry, ignore it and display warning when platformToken is used.
-	return ff.getBoolWithDefault(UsePublicRegistryKey, false)
+	return ff.hasPlatformToken || ff.getBoolWithDefault(UsePublicRegistryKey, false)
 }
 
 // Deprecated: Do not use "disable" feature flags.

--- a/pkg/api/exp/flag_test.go
+++ b/pkg/api/exp/flag_test.go
@@ -6,6 +6,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsPublicRegistry(t *testing.T) {
+	t.Run("no FF, no platform token => false", func(t *testing.T) {
+		ff := NewFlags(nil)
+		assert.False(t, ff.IsPublicRegistry())
+	})
+
+	t.Run("FF=true, no platform token => true", func(t *testing.T) {
+		ff := NewFlags(map[string]string{UsePublicRegistryKey: "true"})
+		assert.True(t, ff.IsPublicRegistry())
+	})
+
+	t.Run("no FF, platform token => true", func(t *testing.T) {
+		ff := NewFlagsWithPlatformToken(nil, true)
+		assert.True(t, ff.IsPublicRegistry())
+	})
+
+	t.Run("FF=false, platform token => true (FF ignored)", func(t *testing.T) {
+		ff := NewFlagsWithPlatformToken(map[string]string{UsePublicRegistryKey: "false"}, true)
+		assert.True(t, ff.IsPublicRegistry())
+	})
+}
+
 func TestGetNoProxy(t *testing.T) {
 	type testCase struct {
 		title string

--- a/pkg/api/exp/flag_test.go
+++ b/pkg/api/exp/flag_test.go
@@ -8,22 +8,22 @@ import (
 
 func TestIsPublicRegistry(t *testing.T) {
 	t.Run("no FF, no platform token => false", func(t *testing.T) {
-		ff := NewFlags(nil)
+		ff := NewFlags(nil, false)
 		assert.False(t, ff.IsPublicRegistry())
 	})
 
 	t.Run("FF=true, no platform token => true", func(t *testing.T) {
-		ff := NewFlags(map[string]string{UsePublicRegistryKey: "true"})
+		ff := NewFlags(map[string]string{UsePublicRegistryKey: "true"}, false)
 		assert.True(t, ff.IsPublicRegistry())
 	})
 
 	t.Run("no FF, platform token => true", func(t *testing.T) {
-		ff := NewFlagsWithPlatformToken(nil, true)
+		ff := NewFlags(nil, true)
 		assert.True(t, ff.IsPublicRegistry())
 	})
 
 	t.Run("FF=false, platform token => true (FF ignored)", func(t *testing.T) {
-		ff := NewFlagsWithPlatformToken(map[string]string{UsePublicRegistryKey: "false"}, true)
+		ff := NewFlags(map[string]string{UsePublicRegistryKey: "false"}, true)
 		assert.True(t, ff.IsPublicRegistry())
 	})
 }

--- a/pkg/api/latest/dynakube/dynakube_props.go
+++ b/pkg/api/latest/dynakube/dynakube_props.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 )
 
 func (dk *DynaKube) FF() *exp.FeatureFlags {
-	return exp.NewFlags(dk.Annotations)
+	return exp.NewFlagsWithPlatformToken(dk.Annotations, ptr.Deref(dk.Status.APIToken.Platform, false))
 }
 
 func (dk *DynaKube) RemovedFields() *conversion.RemovedFields {

--- a/pkg/api/latest/dynakube/dynakube_props.go
+++ b/pkg/api/latest/dynakube/dynakube_props.go
@@ -27,7 +27,7 @@ const (
 )
 
 func (dk *DynaKube) FF() *exp.FeatureFlags {
-	return exp.NewFlagsWithPlatformToken(dk.Annotations, ptr.Deref(dk.Status.APIToken.Platform, false))
+	return exp.NewFlags(dk.Annotations, ptr.Deref(dk.Status.APIToken.Platform, false))
 }
 
 func (dk *DynaKube) RemovedFields() *conversion.RemovedFields {

--- a/pkg/api/v1beta4/dynakube/dynakube_props.go
+++ b/pkg/api/v1beta4/dynakube/dynakube_props.go
@@ -20,9 +20,8 @@ const (
 	DefaultMinRequestThresholdMinutes = 15
 )
 
-
 func (dk *DynaKube) FF() *exp.FeatureFlags {
-	return exp.NewFlags(dk.Annotations)
+	return exp.NewFlags(dk.Annotations, false)
 }
 
 // APIURL is a getter for dk.Spec.APIURL.

--- a/pkg/api/v1beta5/dynakube/dynakube_props.go
+++ b/pkg/api/v1beta5/dynakube/dynakube_props.go
@@ -20,9 +20,8 @@ const (
 	DefaultMinRequestThresholdMinutes = 15
 )
 
-
 func (dk *DynaKube) FF() *exp.FeatureFlags {
-	return exp.NewFlags(dk.Annotations)
+	return exp.NewFlags(dk.Annotations, false)
 }
 
 // APIURL is a getter for dk.Spec.APIURL.

--- a/pkg/api/validation/dynakube/public_registry.go
+++ b/pkg/api/validation/dynakube/public_registry.go
@@ -6,20 +6,37 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 )
 
 const (
 	errorPublicRegistryOverrideWithoutPublicRegistry = `The publicRegistryOverride field is set, but the feature flag "%s" is not enabled. Either enable the feature flag or remove the publicRegistryOverride field.`
+	warningPublicRegistryFlagIgnoredForPlatformToken = `The feature flag "%s" is set, but it is ignored because a platform token is in use. The public registry endpoint is used automatically with platform tokens.`
 )
 
-func publicRegistryOverrideWithoutPublicRegistry(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	// TODO: ICP-3643 - Implement public registry selection based on gen3 platformToken:
-	// - If user sets publicRegistryOverride without use-public-registry FF and without platformToken, show error (current behavior)
-	// - If user sets use-public-registry FF, ignore it and display warning when platformToken is used
-	// - Add logic to allow publicRegistryOverride when platformToken is set, even without use-public-registry FF
-	if dk.PublicRegistryOverride() != "" && !dk.FF().IsPublicRegistry() {
-		return fmt.Sprintf(errorPublicRegistryOverrideWithoutPublicRegistry, exp.UsePublicRegistryKey)
+func publicRegistryOverrideWithoutPublicRegistry(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	if dk.PublicRegistryOverride() == "" || dk.FF().IsPublicRegistry() {
+		return ""
 	}
 
-	return ""
+	// For new DynaKubes (status not yet set), check the token secret directly.
+	hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
+	if err == nil && hasPlatformToken {
+		return ""
+	}
+
+	return fmt.Sprintf(errorPublicRegistryOverrideWithoutPublicRegistry, exp.UsePublicRegistryKey)
+}
+
+func publicRegistryFlagIgnoredForPlatformToken(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	if _, hasAnnotation := dk.Annotations[exp.UsePublicRegistryKey]; !hasAnnotation {
+		return ""
+	}
+
+	hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
+	if err != nil || !hasPlatformToken {
+		return ""
+	}
+
+	return fmt.Sprintf(warningPublicRegistryFlagIgnoredForPlatformToken, exp.UsePublicRegistryKey)
 }

--- a/pkg/api/validation/dynakube/public_registry_test.go
+++ b/pkg/api/validation/dynakube/public_registry_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -46,5 +47,47 @@ func TestPublicRegistryOverrideWithoutPublicRegistry(t *testing.T) {
 	t.Run("publicRegistryOverride not set returns no error", func(t *testing.T) {
 		dk := newDynakube()
 		assertAllowed(t, dk)
+	})
+
+	t.Run("publicRegistryOverride set with platform token and no FF returns no error", func(t *testing.T) {
+		dk := newDynakube()
+		dk.Name = testName
+		dk.Namespace = testNamespace
+		dk.Spec.PublicRegistryOverride = "my.custom.registry.com"
+
+		assertAllowedWithoutWarnings(t, dk, platformTokenSecret())
+	})
+}
+
+func TestPublicRegistryFlagIgnoredForPlatformToken(t *testing.T) {
+	newDynakube := func(annotations map[string]string) *dynakube.DynaKube {
+		return &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        testName,
+				Namespace:   testNamespace,
+				Annotations: annotations,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testAPIURL,
+			},
+		}
+	}
+
+	t.Run("FF set with platform token returns warning", func(t *testing.T) {
+		dk := newDynakube(map[string]string{exp.UsePublicRegistryKey: "true"})
+		warnings, _ := assertAllowed(t, dk, platformTokenSecret())
+		assert.Contains(t, warnings, fmt.Sprintf(warningPublicRegistryFlagIgnoredForPlatformToken, exp.UsePublicRegistryKey))
+	})
+
+	t.Run("FF set with regular token returns no warning", func(t *testing.T) {
+		dk := newDynakube(map[string]string{exp.UsePublicRegistryKey: "true"})
+		warnings, _ := assertAllowed(t, dk, regularTokenSecret())
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("FF not set with platform token returns no warning", func(t *testing.T) {
+		dk := newDynakube(nil)
+		warnings, _ := assertAllowed(t, dk, platformTokenSecret())
+		assert.Empty(t, warnings)
 	})
 }

--- a/pkg/api/validation/dynakube/public_registry_test.go
+++ b/pkg/api/validation/dynakube/public_registry_test.go
@@ -81,13 +81,11 @@ func TestPublicRegistryFlagIgnoredForPlatformToken(t *testing.T) {
 
 	t.Run("FF set with regular token returns no warning", func(t *testing.T) {
 		dk := newDynakube(map[string]string{exp.UsePublicRegistryKey: "true"})
-		warnings, _ := assertAllowed(t, dk, regularTokenSecret())
-		assert.Empty(t, warnings)
+		assertAllowedWithoutWarnings(t, dk, regularTokenSecret())
 	})
 
 	t.Run("FF not set with platform token returns no warning", func(t *testing.T) {
 		dk := newDynakube(nil)
-		warnings, _ := assertAllowed(t, dk, platformTokenSecret())
-		assert.Empty(t, warnings)
+		assertAllowedWithoutWarnings(t, dk, platformTokenSecret())
 	})
 }

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -87,6 +87,7 @@ var (
 		oneAgentResourceAttributesExceedsLimit,
 		otlpResourceAttributesExceedsLimit,
 		deprecatedPaasToken,
+		publicRegistryFlagIgnoredForPlatformToken,
 		isNodeImagePullWithoutCSI,
 	}
 	updateValidatorErrorFuncs = []updateValidatorFunc{

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -79,7 +79,7 @@ const (
 )
 
 func useLegacyMounts(dk *dynakube.DynaKube) bool {
-	return exp.NewFlags(dk.Annotations).UseEECLegacyMounts()
+	return exp.NewFlags(dk.Annotations, false).UseEECLegacyMounts()
 }
 
 func (r *reconciler) createOrUpdateStatefulset(ctx context.Context) error {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR automatically enables the public registry feature as soon as a platform token is used. 
In addition, if the FF + platform token is used, a warning will be displayed.

[ICP-3643 Use new endpoint to update OA/CM/AG and ignore FF with warning when gen3 (platformToken) detected - Jira](https://dt-rnd.atlassian.net/browse/ICP-3643)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Ensure you have a gen 3 tenant.

- Create platform token
- deploy operator without CSI
- deploy cloudnativefs
- check oneagent/ag images
- create application and check init container/code module


<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->