### PR TITLE
Repeat registration procedure if the CSI driver is no longer registered

### DIFF
--- a/pkg/controllers/csi/registrar/registrar.go
+++ b/pkg/controllers/csi/registrar/registrar.go
@@ -123,6 +123,8 @@ func (s Server) NotifyRegistrationStatus(ctx context.Context, status *registerap
 
 	if !status.GetPluginRegistered() {
 		log.Error(errors.New("plugin registration failed"), "plugin registration failed", "error", status.GetError())
+
+		os.Exit(1) //nolint:revive
 	}
 
 	return &registerapi.RegistrationStatusResponse{}, nil


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-5167)

## Description

The registrar container is restarted and the procedure is repeated. 


```
"logger":"csi-registrar","msg":"starting registrar"}
"logger":"csi-registrar","msg":"CSI driver is running","driver name":"csi.oneagent.dynatrace.com"}
"logger":"csi-registrar","msg":"socket path","path":"/registration"}
"logger":"csi-registrar","msg":"starting registration server","address":"/registration/csi.oneagent.dynatrace.com-reg.sock"}
"logger":"csi-registrar","msg":"received GetInfo","request":""}
"logger":"csi-registrar","msg":"received NotifyRegistrationStatus","status":"plugin_registered:true"}
"logger":"csi-registrar","msg":"received GetInfo","request":""}
"logger":"csi-registrar","msg":"received NotifyRegistrationStatus","status":"plugin_registered:true"}
"logger":"csi-registrar","msg":"received GetInfo","request":""}
"logger":"csi-registrar","msg":"received NotifyRegistrationStatus","status":"error:\"RegisterPlugin error -- plugin registration failed with err: error updating Node object with CSI driver node ..."
```

## How can this be tested?

kubelet can be restarted via _kubectl debug pod/oneagent_ shell but  it's not enough to reproduce the error.
