### PR TITLE
Bump bootstrapper version to 1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Dynatrace/dynatrace-operator
 go 1.26.0
 
 require (
-	github.com/Dynatrace/dynatrace-bootstrapper v1.3.0
+	github.com/Dynatrace/dynatrace-bootstrapper v1.4.0
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/docker/cli v29.5.1+incompatible
 	github.com/evanphx/json-patch v5.9.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Dynatrace/dynatrace-bootstrapper v1.3.0 h1:456WuMVODf2bMwGRlk2puL7zLJnSvv/4USRsu1/yOQQ=
 github.com/Dynatrace/dynatrace-bootstrapper v1.3.0/go.mod h1:JOVrbT1+MTt0yZsPk9bby4Kh4eSQpjmRhvEKxC5wAOA=
+github.com/Dynatrace/dynatrace-bootstrapper v1.4.0 h1:OTs49duFiaf02PF8walKmc0Ew1NWxFu7MWY7XUkzXN4=
+github.com/Dynatrace/dynatrace-bootstrapper v1.4.0/go.mod h1:omtzCB/yuM5AzD3fTuF8woye33l6mFOooqLFPypvuMI=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Dynatrace/dynatrace-bootstrapper v1.3.0 h1:456WuMVODf2bMwGRlk2puL7zLJnSvv/4USRsu1/yOQQ=
-github.com/Dynatrace/dynatrace-bootstrapper v1.3.0/go.mod h1:JOVrbT1+MTt0yZsPk9bby4Kh4eSQpjmRhvEKxC5wAOA=
 github.com/Dynatrace/dynatrace-bootstrapper v1.4.0 h1:OTs49duFiaf02PF8walKmc0Ew1NWxFu7MWY7XUkzXN4=
 github.com/Dynatrace/dynatrace-bootstrapper v1.4.0/go.mod h1:omtzCB/yuM5AzD3fTuF8woye33l6mFOooqLFPypvuMI=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-4155

Bumps the github.com/Dynatrace/dynatrace-bootstrapper version, for the CBOR functionality.

## How can this be tested?

Check that the `var/lib/dynatrace/oneagent/agent/config/declarative.cbor` file is created for injected apps when:
- CSI volumes is used
- The url download is used (no-csi + no-codemodulesImage)

Note: Your tenant must have the related API enabled, details can be found in https://dt-rnd.atlassian.net/browse/ICP-1849