### PR TITLE
Make deprecated metadata attributes opt-in when platform token is used

### DIFF
--- a/pkg/api/exp/enrichment.go
+++ b/pkg/api/exp/enrichment.go
@@ -5,5 +5,7 @@ const (
 )
 
 func (ff *FeatureFlags) EnableAttributesDTKubernetes() bool {
-	return ff.getBoolWithDefault(EnrichmentEnableAttributesDTKubernetes, true)
+	defaultVal := !ff.hasPlatformToken
+
+	return ff.getBoolWithDefault(EnrichmentEnableAttributesDTKubernetes, defaultVal)
 }

--- a/pkg/api/exp/enrichment_test.go
+++ b/pkg/api/exp/enrichment_test.go
@@ -8,44 +8,59 @@ import (
 
 func TestEnableAttributesDtKubernetes(t *testing.T) {
 	type testCase struct {
-		title string
-		in    string
-		out   bool
+		title            string
+		hasPlatformToken bool
+		in               string
+		out              bool
 	}
 
 	cases := []testCase{
+		// Classic token (apiToken) — opt-out: enabled by default, user must explicitly disable.
 		{
-			title: "default",
-			in:    "",
-			out:   true,
+			title:            "classic token: default (no annotation) => true",
+			hasPlatformToken: false,
+			in:               "",
+			out:              true,
 		},
 		{
-			title: "overrule to true",
-			in:    "true",
-			out:   true,
+			title:            "classic token: overrule to true",
+			hasPlatformToken: false,
+			in:               "true",
+			out:              true,
 		},
 		{
-			title: "overrule to false",
-			in:    "false",
-			out:   false,
+			title:            "classic token: overrule to false",
+			hasPlatformToken: false,
+			in:               "false",
+			out:              false,
+		},
+		// Platform token — opt-in: disabled by default, user must explicitly enable.
+		{
+			title:            "platform token: default (no annotation) => false",
+			hasPlatformToken: true,
+			in:               "",
+			out:              false,
 		},
 		{
-			title: "uppercase TRUE",
-			in:    "TRUE",
-			out:   true,
+			title:            "platform token: overrule to true",
+			hasPlatformToken: true,
+			in:               "true",
+			out:              true,
 		},
 		{
-			title: "uppercase FALSE",
-			in:    "FALSE",
-			out:   false,
+			title:            "platform token: overrule to false",
+			hasPlatformToken: true,
+			in:               "false",
+			out:              false,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			ff := FeatureFlags{annotations: map[string]string{
-				EnrichmentEnableAttributesDTKubernetes: c.in,
-			}}
+			ff := FeatureFlags{
+				annotations:      map[string]string{EnrichmentEnableAttributesDTKubernetes: c.in},
+				hasPlatformToken: c.hasPlatformToken,
+			}
 
 			out := ff.EnableAttributesDTKubernetes()
 

--- a/test/e2e/features/applicationmonitoring/metadata_enrichment.go
+++ b/test/e2e/features/applicationmonitoring/metadata_enrichment.go
@@ -42,6 +42,7 @@ func MetadataEnrichment(t *testing.T) features.Feature {
 		dynakubeComponents.WithApplicationMonitoringSpec(&oneagent.ApplicationMonitoringSpec{}),
 		dynakubeComponents.WithNameBasedMetadataEnrichmentNamespaceSelector(),
 		dynakubeComponents.WithNameBasedOneAgentNamespaceSelector(),
+		dynakubeComponents.WithAnnotations(map[string]string{exp.EnrichmentEnableAttributesDTKubernetes: "true"}),
 	)
 
 	type testCase struct {
@@ -126,7 +127,7 @@ func MetadataEnrichment(t *testing.T) features.Feature {
 		{
 			name: "metadata enrichment have deprecated attributes - pod",
 			app: sample.NewApp(t, &testDynakube,
-				sample.WithName("pod-no-dt-attributes"),
+				sample.WithName("pod-with-dt-attributes"),
 				sample.WithNamespaceLabels(injectEverythingLabels),
 			),
 			assess: assessMetadataEnrichmentHasDeprecatedAttributes,


### PR DESCRIPTION
## Description

ICP-4490

## How can this be tested?
`make test/e2e/applicationmonitoring/metadataenrichment`

> [!IMPORTANT]
>  previously the e2e test relied on default "opt-out" behavior of  operator.
> So there was no FF set and existence of deprecated attributes was asserted.
>
> In perspective of running tests with platfrom token - the test sets explicifly FF now to "true".