### PR TITLE
Tighten (additional)resourceAttributes validation

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -5838,6 +5838,7 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
+                        maxProperties: 10
                         type: object
                       codeModulesImage:
                         type: string
@@ -5915,6 +5916,7 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
+                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6103,6 +6105,7 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
+                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6360,6 +6363,7 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
+                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6548,6 +6552,7 @@ spec:
                   additionalResourceAttributes:
                     additionalProperties:
                       type: string
+                    maxProperties: 10
                     type: object
                   namespaceSelector:
                     properties:
@@ -6601,6 +6606,7 @@ spec:
               resourceAttributes:
                 additionalProperties:
                   type: string
+                maxProperties: 10
                 type: object
               skipCertCheck:
                 type: boolean

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -5851,6 +5851,7 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
+                        maxProperties: 10
                         type: object
                       codeModulesImage:
                         type: string
@@ -5928,6 +5929,7 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
+                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6116,6 +6118,7 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
+                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6373,6 +6376,7 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
+                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6561,6 +6565,7 @@ spec:
                   additionalResourceAttributes:
                     additionalProperties:
                       type: string
+                    maxProperties: 10
                     type: object
                   namespaceSelector:
                     properties:
@@ -6614,6 +6619,7 @@ spec:
               resourceAttributes:
                 additionalProperties:
                   type: string
+                maxProperties: 10
                 type: object
               skipCertCheck:
                 type: boolean

--- a/pkg/api/latest/dynakube/dynakube_types.go
+++ b/pkg/api/latest/dynakube/dynakube_types.go
@@ -104,6 +104,7 @@ type DynaKubeSpec struct { //nolint:revive
 	// Global default resource attributes applied to every component that supports resource attributes.
 	// Per-component additionalResourceAttributes take precedence over these values when the same key is present in both.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxProperties=10
 	ResourceAttributes map[string]string `json:"resourceAttributes,omitempty"`
 
 	// Configuration for OTLP Exporter Configuration

--- a/pkg/api/latest/dynakube/oneagent/spec.go
+++ b/pkg/api/latest/dynakube/oneagent/spec.go
@@ -145,6 +145,7 @@ type HostInjectSpec struct {
 	// Additional resource attributes that are merged on top of the global spec.resourceAttributes.
 	// If the same key exists in both, the value from additionalResourceAttributes takes precedence.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxProperties=10
 	AdditionalResourceAttributes map[string]string `json:"additionalResourceAttributes,omitempty"`
 }
 
@@ -162,6 +163,7 @@ type ApplicationMonitoringSpec struct {
 	// Additional resource attributes that are merged on top of the global spec.resourceAttributes.
 	// If the same key exists in both, the value from additionalResourceAttributes takes precedence.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxProperties=10
 	AdditionalResourceAttributes map[string]string `json:"additionalResourceAttributes,omitempty"`
 }
 

--- a/pkg/api/latest/dynakube/otlp/spec.go
+++ b/pkg/api/latest/dynakube/otlp/spec.go
@@ -42,6 +42,7 @@ type ExporterConfigurationSpec struct {
 	// Additional resource attributes that are merged on top of the global spec.resourceAttributes.
 	// If the same key exists in both, the value from additionalResourceAttributes takes precedence.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxProperties=10
 	AdditionalResourceAttributes map[string]string `json:"additionalResourceAttributes,omitempty"`
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Tighten validation for limit of items in (additional)resourceAttributes by adding `kubebuilder` `MaxProperties` to the field.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Test `DynaKubes` that violate this validation.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->