### PR TITLE
ICP-5114: add validation to edgeconnect apiServer

### DIFF
--- a/pkg/api/validation/edgeconnect/api_server.go
+++ b/pkg/api/validation/edgeconnect/api_server.go
@@ -36,8 +36,18 @@ var (
 )
 
 func isAllowedSuffixAPIServer(_ context.Context, _ *Validator, ec *edgeconnect.EdgeConnect) string {
+	parsed, err := url.Parse("https://" + ec.Spec.APIServer)
+	if err != nil {
+		return errorMissingAllowedSuffixAPIServer
+	}
+
+	if parsed.Host != ec.Spec.APIServer || parsed.User != nil {
+		return errorMissingAllowedSuffixAPIServer
+	}
+
+	host := parsed.Hostname()
 	for _, suffix := range allowedSuffix {
-		if strings.HasSuffix(ec.Spec.APIServer, suffix) && len(ec.Spec.APIServer) > len(suffix) {
+		if strings.HasSuffix(host, suffix) && len(host) > len(suffix) {
 			return ""
 		}
 	}

--- a/pkg/api/validation/edgeconnect/api_server_test.go
+++ b/pkg/api/validation/edgeconnect/api_server_test.go
@@ -111,4 +111,29 @@ func TestApiServer(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("invalid apiServer (path-in-host)", func(t *testing.T) {
+		for _, apiServer := range []string{
+			"someotherurl.tld/.apps.dynatrace.com",
+			"otherhost.example.org/.apps.dynatrace.com",
+			"127.0.0.1/.apps.dynatrace.com",
+			"169.254.169.254/.apps.dynatrace.com",
+			"tenantid.apps.dynatrace.com@someotherurl.tld",
+			"tenantid.apps.dynatrace.com\\.someotherurl.tld",
+			"tenantid.apps.dynatrace.com#fragment",
+			"tenantid.apps.dynatrace.com?query",
+			"//someotherurl.tld/.apps.dynatrace.com",
+		} {
+			assertDenied(t, []string{errorMissingAllowedSuffixAPIServer}, &edgeconnect.EdgeConnect{
+				Spec: edgeconnect.EdgeConnectSpec{
+					APIServer: apiServer,
+					OAuth: edgeconnect.OAuthSpec{
+						ClientSecret: "secret",
+						Endpoint:     testValidOAuthEndpoint,
+						Resource:     "resource",
+					},
+				},
+			})
+		}
+	})
 }


### PR DESCRIPTION
## Description
The EdgeConnect admission webhook validated `spec.apiServer` by doing a plain `strings.HasSuffix` on the raw value, while the controller dialed url.Parse("https://" + apiServer).Host. 
This change ensures we're only passing valid 

## How can this be tested?
Added a `invalid apiServer (path-in-host)` test case covering various invalid apiServer examples. Existing tests are unchanged. 

Also tested manually on a live cluster using a dev-image that contained my changes that resulted in a denial when applying a faulty EdgeConnect yaml: 
```
Error from server (Forbidden): error when creating "STDIN": admission webhook "v1alpha2.edgeconnect.webhook.dynatrace.com" denied the request:
3 error(s) found in the EdgeConnect
 1. The EdgeConnect's specification has an invalid apiServer value set.
        Example valid values:
        -  For prod: "<tenantID>.apps.dynatrace.com"
        -  For dev: "<tenantID>.dev.apps.dynatracelabs.com"
        -  For sprint: "<tenantID>.sprint.apps.dynatracelabs.com"
        Make sure you correctly specify the apiServer in your custom resource.

 2. The EdgeConnect's specification has an invalid oauth.endpoint value set.
        Should include 'https' protocol.
        Make sure you correctly specify the oauth.endpoint in your custom resource.

 3. The EdgeConnect's specification has an invalid oauth.endpoint value set.
        Example valid values:
        -  For prod: "sso.dynatrace.com"
        -  For dev: "sso-dev.dynatracelabs.com",
        -  For sprint: "sso.sprint.dynatracelabs.com"
        Make sure you correctly specify the endpoint in your custom resource.
```