### PR TITLE
Add full service FQDN to webhook cert SANs

### DIFF
--- a/pkg/controllers/certificates/certificate_secret.go
+++ b/pkg/controllers/certificates/certificate_secret.go
@@ -69,7 +69,7 @@ func (certSecret *certificateSecret) isRecent() bool {
 
 func (certSecret *certificateSecret) validateCertificates(ctx context.Context, namespace string) error {
 	certs := Certs{
-		Domain:  getDomain(namespace),
+		Domain:  webhook.DeploymentName + "." + namespace,
 		SrcData: certSecret.secret.Data,
 		Now:     time.Now(),
 	}
@@ -86,8 +86,12 @@ func buildSecretName() string {
 	return fmt.Sprintf("%s%s", webhook.DeploymentName, secretPostfix)
 }
 
-func getDomain(namespace string) string {
-	return fmt.Sprintf("%s.%s.svc", webhook.DeploymentName, namespace)
+func buildSANs(domain string) []string {
+	return []string{
+		domain,
+		domain + ".svc",
+		domain + ".svc.cluster.local",
+	}
 }
 
 func (certSecret *certificateSecret) areWebhookConfigsValid(configs []*admissionregistrationv1.WebhookClientConfig) bool {

--- a/pkg/controllers/certificates/certs.go
+++ b/pkg/controllers/certificates/certs.go
@@ -155,6 +155,8 @@ func (cs *Certs) generateRootCerts(ctx context.Context, domain string, now time.
 		},
 		IsCA: true,
 
+		DNSNames: buildSANs(domain),
+
 		NotBefore: now,
 		NotAfter:  now.Add(365 * 24 * time.Hour),
 
@@ -209,7 +211,7 @@ func (cs *Certs) generateServerCerts(ctx context.Context, domain string, now tim
 			CommonName:         domain,
 		},
 
-		DNSNames: []string{domain},
+		DNSNames: buildSANs(domain),
 
 		NotBefore: now,
 		NotAfter:  now.Add(7 * 24 * time.Hour),

--- a/pkg/controllers/certificates/webhook_cert_controller_test.go
+++ b/pkg/controllers/certificates/webhook_cert_controller_test.go
@@ -288,7 +288,7 @@ func prepareController(clt client.Client) (*WebhookCertificateController, reconc
 func verifyCertificates(t *testing.T, secret *corev1.Secret, clt client.Client, isUpdate bool) {
 	t.Helper()
 	cert := Certs{
-		Domain:  getDomain(testNamespace),
+		Domain:  webhook.DeploymentName + "." + testNamespace,
 		Data:    secret.Data,
 		SrcData: secret.Data,
 		Now:     time.Now(),


### PR DESCRIPTION
## Description

The all service DNS variants to the webhook certificates.
The operator will update the certs on the next cycle.

ICP-5252
ICP-5362

## How can this be tested?

* Deploy a previous build/release
* Check the caBundle cert: `kubectl get validatingwebhookconfigurations dynatrace-webhook -o json | jq -r '.webhooks[0].clientConfig.caBundle' | base64 -d | openssl x509 -text -noout`
* Deploy this branch
* Invalidate the certs, e.g. by deleting the `ca.crt` key
* Trigger a secret reconcile: `kubectl -n dynatrace annotate deployment dynatrace-webhook test=test`
* Check the caBundle cert
* Check that the webhook works, e.g. create a v1beta5 DynaKube and test validation
