### PR TITLE
Fix tag refs for dependencies with warnings release-1.8

### DIFF
--- a/.github/workflows/fips-release.yaml
+++ b/.github/workflows/fips-release.yaml
@@ -119,7 +119,7 @@ jobs:
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Create sbom for ${{matrix.registry}}
         id: sbom
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
         with:
           image-ref: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ steps.image-index.outputs.digest }}
           format: 'cyclonedx'

--- a/.github/workflows/gcr-deployer-image.yaml
+++ b/.github/workflows/gcr-deployer-image.yaml
@@ -28,7 +28,7 @@ jobs:
       labels: ${{ steps.prep.outputs.docker_image_labels }}
       version: ${{ steps.prep.outputs.docker_image_tag }}
       version_without_prefix: ${{ steps.prep.outputs.docker_image_tag_without_prefix }}
-    
+
   build-gcr-deployer:
       if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'csv-') && startsWith(github.event.pull_request.base.ref, 'release-')
       name: Build GCR deployer image
@@ -50,9 +50,9 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # 3.11.1
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Build and push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # 6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           platforms: ${{ env.DEPLOYER_PLATFORMS }}
           provenance: false

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -85,7 +85,7 @@ jobs:
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Create SBOM
         id: sbom
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.36.0
         with:
           image-ref: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}@${{ needs.build-push.outputs.digest }}
           format: 'cyclonedx'

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -85,7 +85,7 @@ jobs:
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Create SBOM
         id: sbom
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}@${{ needs.build-push.outputs.digest }}
           format: 'cyclonedx'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,7 +138,7 @@ jobs:
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Create sbom for ${{matrix.registry}}
         id: sbom
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
         with:
           image-ref: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ needs.build-push.outputs.digest }}
           format: 'cyclonedx'


### PR DESCRIPTION

## Description
This pull request resolves the renovate warnings on the release-1.8 branch by updating the incorrect tags to their correct values.

[ICP-4899](https://dt-rnd.atlassian.net/browse/ICP-4899)

> [!WARNING]
> The trivy action tag `0.34.2` in the nightly pipeline, was deleted and the dependency is resolved by its commit hash. There is no higher patch version, so the dependency was upgraded to the latest `v0.36.0`

## How can this be tested?
Using the renovate cli + github token with repo scope, it should throw no warnings/errors
GITHUB_COM_TOKEN=ghp_*** renovate --platform=local --dry-run --repository-cache=reset 

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[ICP-4899]: https://dt-rnd.atlassian.net/browse/ICP-4899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ