### PR TITLE
e2e: fixup daily fips tests

### DIFF
--- a/.github/scripts/create-cluster.sh
+++ b/.github/scripts/create-cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+set -eu -o pipefail
 
 kubectl version
 

--- a/.github/scripts/destroy-cluster.sh
+++ b/.github/scripts/destroy-cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+set -eu -o pipefail
 
 echo "Destroying environment '$FLC_ENVIRONMENT' in namespace '$FLC_NAMESPACE'"
 

--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -31,7 +31,7 @@ if [[ $FLC_ENVIRONMENT =~ "olm" ]]; then
   make test/e2e/no-csi/publish/olm
 elif [[ $FLC_ENVIRONMENT =~ "fips" ]]; then
   echo "run fips e2e test suites"
-  make BRANCH="$TARGET_BRANCH" test/e2e-publish/fips
+  make BRANCH="$TARGET_BRANCH" FIPS=true test/e2e-publish
 elif [[ -n "${TARGET_IMAGE}" ]]; then
   make IMAGE_URI="$TARGET_IMAGE" test/e2e-publish
 else

--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -31,7 +31,7 @@ if [[ $FLC_ENVIRONMENT =~ "olm" ]]; then
   make test/e2e/no-csi/publish/olm
 elif [[ $FLC_ENVIRONMENT =~ "fips" ]]; then
   echo "run fips e2e test suites"
-  make test/e2e-publish/fips
+  make BRANCH="$TARGET_BRANCH" test/e2e-publish/fips
 elif [[ -n "${TARGET_IMAGE}" ]]; then
   make IMAGE_URI="$TARGET_IMAGE" test/e2e-publish
 else

--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -32,8 +32,6 @@ if [[ $FLC_ENVIRONMENT =~ "olm" ]]; then
 elif [[ $FLC_ENVIRONMENT =~ "fips" ]]; then
   echo "run fips e2e test suites"
   make BRANCH="$TARGET_BRANCH" FIPS=true test/e2e-publish
-elif [[ -n "${TARGET_IMAGE}" ]]; then
-  make IMAGE_URI="$TARGET_IMAGE" test/e2e-publish
 else
   echo "fall back to default branch target"
   make BRANCH="$TARGET_BRANCH" test/e2e-publish

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -16,12 +16,33 @@ on:
         options:
          - oci://ghcr.io/dynatrace/dynatrace-operator:0.0.0-nightly-chart
          - ""
+      run-e2e-in-k8s:
+        description: 'Run E2E tests in Kubernetes cluster'
+        default: true
+        required: false
+        type: boolean
+      run-e2e-in-ocp:
+        description: 'Run E2E tests in OpenShift cluster'
+        default: true
+        required: false
+        type: boolean
+      run-e2e-in-ocp-olm:
+        description: 'Run OLM E2E tests in OpenShift cluster'
+        default: true
+        required: false
+        type: boolean
+      run-e2e-in-ocp-fips:
+        description: 'Run E2E tests in using FIPS OpenShift cluster'
+        default: true
+        required: false
+        type: boolean
 
 permissions:
   checks: write
 
 jobs:
   run-in-k8s:
+    if: ${{ github.event.inputs.run-e2e-in-k8s != 'false' }}
     name: Run in Kubernetes latest (${{ github.event.inputs.target || 'main' }})
     environment: E2E
     runs-on:
@@ -63,6 +84,7 @@ jobs:
             exit 1
           fi
   run-in-ocp:
+    if: ${{ github.event.inputs.run-e2e-in-ocp != 'false' }}
     name: Run in OpenShift latest (${{ github.event.inputs.target || 'main' }})
     environment: E2E
     runs-on:
@@ -104,6 +126,7 @@ jobs:
             exit 1
           fi
   run-in-ocp-olm:
+    if: ${{ github.event.inputs.run-e2e-in-ocp-olm != 'false' }}
     name: Run OLM in OpenShift latest (${{ github.event.inputs.target || 'main' }})
     environment: E2E
     runs-on:
@@ -145,6 +168,7 @@ jobs:
             exit 1
           fi
   run-in-ocp-fips:
+    if: ${{ github.event.inputs.run-e2e-in-ocp-fips != 'false' }}
     name: Run in FIPS OpenShift (${{ github.event.inputs.target || 'main' }})
     environment: E2E
     runs-on:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -163,8 +163,7 @@ jobs:
         with:
           flc-namespace: dto
           flc-environment: dto-ocp-fips
-          helm-chart: ${{ github.event.inputs.helm-chart || 'oci://ghcr.io/dynatrace/dynatrace-operator:0.0.0-nightly-chart' }}
-          target-branch: ${{ format('{0}-fips', github.event.inputs.target || 'main') }}
+          target-branch: ${{ github.event.inputs.target }}
           tenant1-name: ${{ secrets.TENANT1_NAME }}
           tenant1-apitoken: ${{ secrets.TENANT1_APITOKEN }}
           tenant1-apitoken-nosettings: ${{ secrets.TENANT1_APITOKEN_NOSETTINGS }}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR fixes daily fips e2e tests [ICP-5366](https://dt-rnd.atlassian.net/browse/ICP-5366)

~First we need to merge this one https://github.com/Dynatrace/dynatrace-operator/pull/6759~

Bonus changes:
- Allow to run e2e tests and specify which env we want to run ( all envs by default)
- remove some noisy debug logs and align bash scripts `set -eu -o pipefail`

## How can this be tested?

- daily fips e2e tests are green

[ICP-5366]: https://dt-rnd.atlassian.net/browse/ICP-5366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ