### PR TITLE
move getter of metadata properties file to metadataenrichment helpers

### DIFF
--- a/test/e2e/features/applicationmonitoring/metadata_enrichment.go
+++ b/test/e2e/features/applicationmonitoring/metadata_enrichment.go
@@ -182,7 +182,7 @@ func podHasOnlyMetadataEnrichmentInitContainer(samplePod *sample.App) features.F
 }
 
 func assessPodHasMetadataEnrichmentFile(ctx context.Context, t *testing.T, resource *resources.Resources, testPod corev1.Pod) {
-	enrichmentMetadata := metadataenrichment.GetMetadataFromPod(ctx, t, resource, testPod)
+	enrichmentMetadata := metadataenrichment.GetMetadataJSONFromPod(ctx, t, resource, testPod)
 
 	assert.Equal(t, "pod", enrichmentMetadata.WorkloadKind)
 	assert.Equal(t, testPod.Name, enrichmentMetadata.WorkloadName)
@@ -223,7 +223,7 @@ func podHasCompleteInitContainer(samplePod *sample.App) features.Func {
 
 func assessDeploymentHasMetadataEnrichmentFile(ctx context.Context, t *testing.T, resource *resources.Resources, deploymentName string) k8sdeployment.PodConsumer {
 	return func(pod corev1.Pod) {
-		enrichmentMetadata := metadataenrichment.GetMetadataFromPod(ctx, t, resource, pod)
+		enrichmentMetadata := metadataenrichment.GetMetadataJSONFromPod(ctx, t, resource, pod)
 
 		assert.Equal(t, "deployment", enrichmentMetadata.WorkloadKind)
 		assert.Equal(t, deploymentName, enrichmentMetadata.WorkloadName)
@@ -248,7 +248,7 @@ func assessOnlyMetadataEnrichmentIsInjected(t *testing.T) k8sdeployment.PodConsu
 func assessMetadataEnrichmentHasDeprecatedAttributes(samplePod *sample.App) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		testPod := samplePod.ListPods(ctx, t, envConfig.Client().Resources()).Items[0]
-		enrichmentMetadata := metadataenrichment.GetMetadataFromPod(ctx, t, envConfig.Client().Resources(), testPod)
+		enrichmentMetadata := metadataenrichment.GetMetadataJSONFromPod(ctx, t, envConfig.Client().Resources(), testPod)
 
 		assert.Equal(t, "pod", enrichmentMetadata.DTWorkloadKind)
 		assert.Equal(t, testPod.Name, enrichmentMetadata.DTWorkloadName)
@@ -263,7 +263,7 @@ func assessMetadataEnrichmentHasDeprecatedAttributes(samplePod *sample.App) feat
 func assessMetadataEnrichmentDoesNotHaveDeprecatedAttributes(samplePod *sample.App) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		testPod := samplePod.ListPods(ctx, t, envConfig.Client().Resources()).Items[0]
-		enrichmentMetadata := metadataenrichment.GetMetadataFromPod(ctx, t, envConfig.Client().Resources(), testPod)
+		enrichmentMetadata := metadataenrichment.GetMetadataJSONFromPod(ctx, t, envConfig.Client().Resources(), testPod)
 
 		assert.Empty(t, enrichmentMetadata.DTWorkloadKind)
 		assert.Empty(t, enrichmentMetadata.DTWorkloadName)

--- a/test/e2e/features/cloudnative/metadata_enrichment.go
+++ b/test/e2e/features/cloudnative/metadata_enrichment.go
@@ -30,7 +30,7 @@ func checkMetadataEnrichment(sampleApp *sample.App) features.Func {
 		require.NotEmpty(t, pods.Items)
 
 		for _, pod := range pods.Items {
-			enrichmentMetadata := metadataenrichment.GetMetadataFromPod(ctx, t, kubeResources, pod)
+			enrichmentMetadata := metadataenrichment.GetMetadataJSONFromPod(ctx, t, kubeResources, pod)
 			assert.Equal(t, "deployment", enrichmentMetadata.WorkloadKind)
 			assert.Equal(t, deploymentName, enrichmentMetadata.WorkloadName)
 		}

--- a/test/e2e/features/hostmonitoring/generate_metadata.go
+++ b/test/e2e/features/hostmonitoring/generate_metadata.go
@@ -4,16 +4,14 @@ package hostmonitoring
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/activegate"
 	componentDynakube "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/metadataenrichment"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sdaemonset"
-	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8spod"
-	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/shell"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,10 +20,6 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-)
-
-const (
-	generateMetadataFile = "/var/lib/dynatrace/enrichment/dt_node_metadata.properties"
 )
 
 var expectedMetadataFields = []string{
@@ -75,45 +69,11 @@ func oneAgentHaveGeneratedMetadata(dk dynakube.DynaKube) features.Func {
 
 func assertGeneratedMetadataFields(ctx context.Context, t *testing.T, resource *resources.Resources) k8sdaemonset.PodConsumer {
 	return func(pod corev1.Pod) {
-		generatedMetadata := getGeneratedMetadataFromPod(ctx, t, resource, pod)
+		generatedMetadata := metadataenrichment.GetMetadataPropertiesFromPod(ctx, t, resource, pod)
 		assert.NotEmpty(t, generatedMetadata, "generated metadata should not be empty")
 		for _, attribute := range expectedMetadataFields {
 			assert.Containsf(t, generatedMetadata, attribute, "generated metadata should contain %s attribute", attribute)
 			assert.NotEmptyf(t, generatedMetadata[attribute], "generated metadata %s attribute should not be empty", attribute)
 		}
 	}
-}
-
-func getGeneratedMetadataFromPod(ctx context.Context, t *testing.T, resource *resources.Resources, oaPod corev1.Pod) map[string]string {
-	readGeneratedMetadataCmd := shell.ReadFile(generateMetadataFile)
-	require.NotEmpty(t, oaPod.Spec.Containers, "OneAgent pod should have at least one container")
-	container := oaPod.Spec.Containers[0].Name
-	result, err := k8spod.Exec(ctx, resource, oaPod, container, readGeneratedMetadataCmd...)
-
-	require.NoError(t, err)
-
-	assert.Zero(t, result.StdErr.Len())
-	assert.NotEmpty(t, result.StdOut)
-
-	return parseGeneratedMetadata(result.StdOut.String())
-}
-
-func parseGeneratedMetadata(text string) map[string]string {
-	m := make(map[string]string)
-
-	for line := range strings.Lines(text) {
-		l := strings.TrimSpace(line)
-		if l == "" {
-			continue
-		}
-
-		key, value, found := strings.Cut(l, "=")
-		if !found {
-			continue
-		}
-
-		m[key] = value
-	}
-
-	return m
 }

--- a/test/e2e/helpers/components/metadataenrichment/assertion.go
+++ b/test/e2e/helpers/components/metadataenrichment/assertion.go
@@ -5,6 +5,7 @@ package metadataenrichment
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8spod"
@@ -16,7 +17,8 @@ import (
 )
 
 const (
-	MetadataFile = "/var/lib/dynatrace/enrichment/dt_metadata.json"
+	MetadataFile   = "/var/lib/dynatrace/enrichment/dt_metadata.json"
+	PropertiesFile = "/var/lib/dynatrace/enrichment/dt_node_metadata.properties"
 )
 
 type Metadata struct {
@@ -28,10 +30,26 @@ type Metadata struct {
 	DTWorkloadName string `json:"dt.kubernetes.workload.name,omitempty"`
 }
 
-func GetMetadataFromPod(ctx context.Context, t *testing.T, resource *resources.Resources, enrichedPod corev1.Pod) Metadata {
+func GetMetadataJSONFromPod(ctx context.Context, t *testing.T, resource *resources.Resources, enrichedPod corev1.Pod) Metadata {
+	content := readMetadataFile(ctx, t, resource, enrichedPod, MetadataFile)
+
+	var enrichmentMetadata Metadata
+	err := json.Unmarshal(content, &enrichmentMetadata)
+	require.NoError(t, err)
+
+	return enrichmentMetadata
+}
+
+func GetMetadataPropertiesFromPod(ctx context.Context, t *testing.T, resource *resources.Resources, enrichedPod corev1.Pod) map[string]string {
+	properties := readMetadataFile(ctx, t, resource, enrichedPod, PropertiesFile)
+
+	return parseProperties(string(properties))
+}
+
+func readMetadataFile(ctx context.Context, t *testing.T, resource *resources.Resources, enrichedPod corev1.Pod, path string) []byte {
 	require.NotEmpty(t, enrichedPod.Spec.Containers)
 	enrichedContainer := enrichedPod.Spec.Containers[0].Name
-	readMetadataCommand := shell.ReadFile(MetadataFile)
+	readMetadataCommand := shell.ReadFile(path)
 	result, err := k8spod.Exec(ctx, resource, enrichedPod, enrichedContainer, readMetadataCommand...)
 
 	require.NoError(t, err)
@@ -39,10 +57,25 @@ func GetMetadataFromPod(ctx context.Context, t *testing.T, resource *resources.R
 	assert.Zero(t, result.StdErr.Len())
 	assert.NotEmpty(t, result.StdOut)
 
-	var enrichmentMetadata Metadata
-	err = json.Unmarshal(result.StdOut.Bytes(), &enrichmentMetadata)
+	return result.StdOut.Bytes()
+}
 
-	require.NoError(t, err)
+func parseProperties(text string) map[string]string {
+	m := make(map[string]string)
 
-	return enrichmentMetadata
+	for line := range strings.Lines(text) {
+		l := strings.TrimSpace(line)
+		if l == "" {
+			continue
+		}
+
+		key, value, found := strings.Cut(l, "=")
+		if !found {
+			continue
+		}
+
+		m[key] = value
+	}
+
+	return m
 }


### PR DESCRIPTION
## Description

As part of ICP-2466 since i'll be reading metadata .json and .properties files a lot

## How can this be tested?
`make test/e2e/hostmonitoring/generate-metadata`