### PR TITLE
Validate env refs in resource attributes

### DIFF
--- a/pkg/webhook/mutation/pod/attributes/keys.go
+++ b/pkg/webhook/mutation/pod/attributes/keys.go
@@ -18,3 +18,9 @@ const (
 	K8sWorkloadKindAttr = "k8s.workload.kind"
 	K8sWorkloadNameAttr = "k8s.workload.name"
 )
+
+var SafeEnvRefs = []string{
+	K8sPodNameEnv,
+	K8sPodUIDEnv,
+	K8sNodeNameEnv,
+}

--- a/pkg/webhook/mutation/pod/attributes/keys.go
+++ b/pkg/webhook/mutation/pod/attributes/keys.go
@@ -1,5 +1,7 @@
 package attributes
 
+import "github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
+
 const (
 	K8sContainerNameAttr = "k8s.container.name"
 	K8sNodeNameEnv       = "K8S_NODE_NAME"
@@ -20,7 +22,7 @@ const (
 )
 
 var SafeEnvRefs = []string{
-	K8sPodNameEnv,
-	K8sPodUIDEnv,
-	K8sNodeNameEnv,
+	k8senv.NewRef(K8sPodNameEnv),
+	k8senv.NewRef(K8sPodUIDEnv),
+	k8senv.NewRef(K8sNodeNameEnv),
 }

--- a/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/attributes.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/attributes.go
@@ -40,9 +40,10 @@ func isSafeEnvRef(value string) bool {
 	return found && slices.Contains(attributes.SafeEnvRefs, before)
 }
 
+// sanitizeValue percent-encodes value for use in OTEL_RESOURCE_ATTRIBUTES, except for the
+// small set of operator-injected env refs that the kubelet must expand at pod startup.
+// See https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable
 func sanitizeValue(value string) string {
-	// apply percent encoding to prevent errors when passing attribute values with special characters to the OTEL SDKs
-	// see https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable
 	if isSafeEnvRef(value) {
 		return value
 	}

--- a/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/attributes.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/attributes.go
@@ -29,22 +29,11 @@ func NewAttributesFromEnv(envs []corev1.EnvVar, name string) (map[string]string,
 	return res, found
 }
 
-func isSafeEnvRef(value string) bool {
-	after, found := strings.CutPrefix(value, "$(")
-	if !found {
-		return false
-	}
-
-	before, found := strings.CutSuffix(after, ")")
-
-	return found && slices.Contains(attributes.SafeEnvRefs, before)
-}
-
 // sanitizeValue percent-encodes value for use in OTEL_RESOURCE_ATTRIBUTES, except for the
 // small set of operator-injected env refs that the kubelet must expand at pod startup.
 // See https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable
 func sanitizeValue(value string) string {
-	if isSafeEnvRef(value) {
+	if slices.Contains(attributes.SafeEnvRefs, value) {
 		return value
 	}
 

--- a/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/attributes.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/attributes.go
@@ -2,9 +2,11 @@ package resourceattributes
 
 import (
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
+	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/attributes"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -27,10 +29,21 @@ func NewAttributesFromEnv(envs []corev1.EnvVar, name string) (map[string]string,
 	return res, found
 }
 
+func isSafeEnvRef(value string) bool {
+	after, found := strings.CutPrefix(value, "$(")
+	if !found {
+		return false
+	}
+
+	before, found := strings.CutSuffix(after, ")")
+
+	return found && slices.Contains(attributes.SafeEnvRefs, before)
+}
+
 func sanitizeValue(value string) string {
 	// apply percent encoding to prevent errors when passing attribute values with special characters to the OTEL SDKs
 	// see https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable
-	if strings.HasPrefix(value, "$(") && strings.HasSuffix(value, ")") {
+	if isSafeEnvRef(value) {
 		return value
 	}
 

--- a/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/attributes_test.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/attributes_test.go
@@ -17,9 +17,28 @@ func TestSanitizeValue(t *testing.T) {
 		assert.Equal(t, "hello", sanitizeValue("hello"))
 	})
 
-	t.Run("env var reference is passed through unchanged", func(t *testing.T) {
-		assert.Equal(t, "$(K8S_POD_NAME)", sanitizeValue("$(K8S_POD_NAME)"))
-	})
+	envRefCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"K8S_PODNAME (allowlisted) => no changes", "$(K8S_PODNAME)", "$(K8S_PODNAME)"},
+		{"K8S_PODUID (allowlisted) => no changes", "$(K8S_PODUID)", "$(K8S_PODUID)"},
+		{"K8S_NODE_NAME (allowlisted) => no changes", "$(K8S_NODE_NAME)", "$(K8S_NODE_NAME)"},
+		{"DT_API_TOKEN (not allowlisted) => encoded", "$(DT_API_TOKEN)", "%24%28DT_API_TOKEN%29"},
+		{"lowercase name (case-sensitive) => encoded", "$(k8s_podname)", "%24%28k8s_podname%29"},
+		{"whitespace inside parens => encoded", "$( K8S_PODNAME )", "%24%28+K8S_PODNAME+%29"},
+		{"chars before $(...) (not anchored) => encoded", "helloo$(K8S_PODNAME)", "helloo%24%28K8S_PODNAME%29"},
+		{"chars after $(...) (not anchored) => encoded", "$(K8S_PODNAME)byeee", "%24%28K8S_PODNAME%29byeee"},
+		{"nested reference => encoded", "$($(K8S_PODNAME))", "%24%28%24%28K8S_PODNAME%29%29"},
+		{"missing ')' at the end => encoded", "$(K8S_PODNAME", "%24%28K8S_PODNAME"},
+		{"unknown name => encoded", "$(UNKNOWN_VAR)", "%24%28UNKNOWN_VAR%29"},
+	}
+	for _, tc := range envRefCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, sanitizeValue(tc.input))
+		})
+	}
 
 	t.Run("spaces are encoded as +", func(t *testing.T) {
 		assert.Equal(t, "hello+world", sanitizeValue("hello world"))

--- a/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/mutator_test.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/mutator_test.go
@@ -377,40 +377,51 @@ func runMutatorTests(t *testing.T, dk latestdynakube.DynaKube, tests []mutatorTe
 	}
 }
 
-func Test_Mutator_EncodesClusterNameWithSpecialChars(t *testing.T) {
+func Test_Mutator_EncodesAttributeValues(t *testing.T) {
 	_ = appsv1.AddToScheme(scheme.Scheme)
 	_ = corev1.AddToScheme(scheme.Scheme)
 
-	baseDK := latestdynakube.DynaKube{}
-	baseDK.Status.KubeSystemUUID = "cluster-uid"
-	baseDK.Status.KubernetesClusterName = "bh-eks-test1 with space=equals,comma"
-	baseDK.Status.KubernetesClusterMEID = "cluster-meid"
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
-		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c1"}}},
+	tests := []struct {
+		name        string
+		clusterName string
+		annotations map[string]string
+		expected    string
+	}{
+		{
+			name:        "cluster name with special chars",
+			clusterName: "bh-eks-test1 with space=equals,comma",
+			expected:    "k8s.cluster.name=" + url.QueryEscape("bh-eks-test1 with space=equals,comma"),
+		},
+		{
+			name:        "env ref in pod annotation value",
+			clusterName: "cluster-name",
+			annotations: map[string]string{"metadata.dynatrace.com/booom": "$(DT_API_TOKEN)"},
+			expected:    "booom=" + url.QueryEscape("$(DT_API_TOKEN)"),
+		},
 	}
 
-	namespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseDK := latestdynakube.DynaKube{}
+			baseDK.Status.KubeSystemUUID = "cluster-uid"
+			baseDK.Status.KubernetesClusterName = tt.clusterName
+			baseDK.Status.KubernetesClusterMEID = "cluster-meid"
 
-	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
-	mut := New(client)
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Annotations: tt.annotations},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c1"}}},
+			}
+			namespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
 
-	req := dtwebhook.NewMutationRequest(
-		t.Context(),
-		namespace,
-		nil,
-		pod,
-		baseDK,
-	)
-	err := mut.Mutate(req)
-	require.NoError(t, err)
+			client := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+			req := dtwebhook.NewMutationRequest(t.Context(), namespace, nil, pod, baseDK)
+			require.NoError(t, New(client).Mutate(req))
 
-	resourceAttributes := k8senv.Find(pod.Spec.Containers[0].Env, "OTEL_RESOURCE_ATTRIBUTES").Value
-	require.NotEmpty(t, resourceAttributes, "OTEL_RESOURCE_ATTRIBUTES must be set")
-
-	expected := "k8s.cluster.name=" + url.QueryEscape("bh-eks-test1 with space=equals,comma")
-	assert.Contains(t, resourceAttributes, expected)
+			resourceAttributes := k8senv.Find(pod.Spec.Containers[0].Env, "OTEL_RESOURCE_ATTRIBUTES").Value
+			require.NotEmpty(t, resourceAttributes, "OTEL_RESOURCE_ATTRIBUTES must be set")
+			assert.Contains(t, resourceAttributes, tt.expected)
+		})
+	}
 }
 
 // Abort mutation if owner reference cannot be resolved, be consistent with metadata mutator


### PR DESCRIPTION
## Description
Our pod mutating webhook builds `OTEL_RESOURCE_ATTRIBUTES` from values that include namespace annotations. In `sanitizeValue`, env refs like `$(SOME_VAR)` are passed through unencoded (and expanded by the kubelet), as long as they start with `$(` and end with `)`.
Sadly, this also includes refs like `$(DT_API_TOKEN)`. Improve the validation by introducing an allowlist for legit ref names.

Addresses [DTSEC-25207](https://dt-rnd.atlassian.net/browse/DTSEC-25207).

## How can this be tested?
1. Set `TENANT` in the script.
2. Run the script before and after applying the change.
3. Compare the before/after values of `OTEL_RESOURCE_ATTRIBUTES`.
<details>
<summary>Repro script</summary>

```sh
#!/usr/bin/env bash

set -euo pipefail

NAMESPACE=env-ref-repro
TENANT=<some-tenant>

kubectl apply -f - <<EOF
apiVersion: dynatrace.com/v1beta6
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
spec:
  apiUrl: https://${TENANT}.dev.dynatracelabs.com/api
  otlpExporterConfiguration:
    signals:
      traces: {}
      metrics: {}
      logs: {}
  metadataEnrichment:
    enabled: true
EOF

echo "Waiting for dynakube-otlp-exporter-config secret..."
for _ in {1..60}; do
  kubectl get secret dynakube-otlp-exporter-config -n dynatrace >/dev/null 2>&1 && break
  sleep 2
done
kubectl get secret dynakube-otlp-exporter-config -n dynatrace >/dev/null

kubectl create namespace "$NAMESPACE"
kubectl label namespace "$NAMESPACE" dynakube.internal.dynatrace.com/instance=dynakube
kubectl annotate namespace "$NAMESPACE" 'metadata.dynatrace.com/exfil=$(DT_API_TOKEN)'

kubectl apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: sample-app
  namespace: $NAMESPACE
spec:
  restartPolicy: Never
  containers:
  - name: app
    image: busybox:1.36
    command: ["sleep", "3600"]
EOF

kubectl wait --for=condition=Ready pod/sample-app -n "$NAMESPACE" --timeout=60s
kubectl exec sample-app -n "$NAMESPACE" -- env | grep 'OTEL_RESOURCE'
```
</details>

[DTSEC-25207]: https://dt-rnd.atlassian.net/browse/DTSEC-25207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ