### PR TITLE
pgc fetching improvements

### DIFF
--- a/pkg/clients/dynatrace/core/client.go
+++ b/pkg/clients/dynatrace/core/client.go
@@ -51,6 +51,11 @@ type Request interface {
 	WithoutToken() Request
 	// WithHeader sets a custom header for the request, overriding any default value
 	WithHeader(key, value string) Request
+	// WithMaxBodySize sets a limit on the response body size for ExecuteWriter.
+	// If the server provides a Content-Length header exceeding size, ExecuteWriter returns a *ResponseTooLargeError
+	// before reading the body. Responses without a Content-Length header are not rejected.
+	// A size of 0 disables the check.
+	WithMaxBodySize(size int64) Request
 	// Execute executes the request and unmarshals the response into the provided model
 	// If the provided model implements the Cacheable interface, then the ClientImpl will cache the response.
 	Execute(model any) error
@@ -80,14 +85,15 @@ func NewClient(cfg Config) *ClientImpl {
 type RequestImpl struct {
 	client *ClientImpl
 
-	ctx       context.Context
-	query     url.Values
-	headers   http.Header
-	method    string
-	path      string
-	body      []byte
-	tokenType TokenType
-	err       error
+	ctx         context.Context
+	query       url.Values
+	headers     http.Header
+	method      string
+	path        string
+	body        []byte
+	tokenType   TokenType
+	err         error
+	maxBodySize int64
 }
 
 // TokenType represents the type of authentication token to use
@@ -213,6 +219,12 @@ func (r *RequestImpl) WithHeader(key, value string) Request {
 	return r
 }
 
+func (r *RequestImpl) WithMaxBodySize(size int64) Request {
+	r.maxBodySize = size
+
+	return r
+}
+
 // Execute executes the request and unmarshals the response into the provided model
 func (r *RequestImpl) Execute(model any) error {
 	cacheableModel, isCacheable := model.(Cacheable)
@@ -331,6 +343,10 @@ func (r *RequestImpl) doRequestStream(writer io.Writer) (responseHeaders http.He
 	}
 
 	log.Debug("API request", loggerArgs(resp, nil)...)
+
+	if r.maxBodySize > 0 && resp.ContentLength > r.maxBodySize {
+		return nil, &ResponseTooLargeError{ContentLength: resp.ContentLength, MaxBodySize: r.maxBodySize}
+	}
 
 	if _, err = io.Copy(writer, resp.Body); err != nil {
 		return nil, fmt.Errorf("stream response body: %w", err)

--- a/pkg/clients/dynatrace/core/client_test.go
+++ b/pkg/clients/dynatrace/core/client_test.go
@@ -247,6 +247,42 @@ func TestClient_ExecuteWriter(t *testing.T) {
 	})
 }
 
+func TestClient_WithMaxBodySize(t *testing.T) {
+	const responseBody = "hello-world" // 11 bytes; Go sets Content-Length: 11 automatically
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(responseBody))
+	}))
+	defer s.Close()
+
+	c := NewClient(Config{BaseURL: must(url.Parse(s.URL))})
+
+	t.Run("rejects response when Content-Length exceeds limit", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := c.GET(t.Context(), "/test").WithMaxBodySize(5).ExecuteWriter(&buf)
+		require.Error(t, err)
+		var tooLarge *ResponseTooLargeError
+		require.ErrorAs(t, err, &tooLarge)
+		assert.Equal(t, int64(11), tooLarge.ContentLength)
+		assert.Equal(t, int64(5), tooLarge.MaxBodySize)
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("allows response within limit", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := c.GET(t.Context(), "/test").WithMaxBodySize(100).ExecuteWriter(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, responseBody, buf.String())
+	})
+
+	t.Run("size=0 disables the check", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := c.GET(t.Context(), "/test").WithMaxBodySize(0).ExecuteWriter(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, responseBody, buf.String())
+	})
+}
+
 type brokenWriter struct{}
 
 func (brokenWriter) Write(_ []byte) (int, error) {

--- a/pkg/clients/dynatrace/core/error.go
+++ b/pkg/clients/dynatrace/core/error.go
@@ -99,6 +99,17 @@ func StatusCode(err error) int {
 	return httpErr.StatusCode
 }
 
+// ResponseTooLargeError is returned when the Content-Length of a response exceeds the configured limit,
+// before the body is read into memory.
+type ResponseTooLargeError struct {
+	ContentLength int64
+	MaxBodySize   int64
+}
+
+func (e *ResponseTooLargeError) Error() string {
+	return fmt.Sprintf("response body size %d exceeds maximum allowed size of %d", e.ContentLength, e.MaxBodySize)
+}
+
 func formatServerError(e *ServerError, statusCode int) string {
 	if len(e.Message) == 0 && e.Code == 0 {
 		return "unknown server error"

--- a/pkg/clients/dynatrace/oneagent/client.go
+++ b/pkg/clients/dynatrace/oneagent/client.go
@@ -15,7 +15,7 @@ type Client interface {
 	GetVersions(ctx context.Context, args GetParams) ([]string, error)
 
 	GetProcessModuleConfig(ctx context.Context) (*ProcessModuleConfig, error)
-	GetProcessGroupingConfig(ctx context.Context, kubernetesClusterID string, etag string) (*ProcessGroupConfig, error)
+	GetProcessGroupingConfig(ctx context.Context, kubernetesClusterID string, etag string, maxBodySize int64) (*ProcessGroupConfig, error)
 }
 
 type ClientImpl struct {

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
@@ -34,7 +34,7 @@ type ProcessGroupConfig struct {
 //   - On HTTP 304: *ProcessGroupConfig with the original ETag and nil Data, nil error.
 //   - On HTTP 404: *ProcessGroupConfig (empty), nil error. Endpoint not available.
 //   - On other errors: non-nil error.
-func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClusterID string, etag string) (*ProcessGroupConfig, error) {
+func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClusterID string, etag string, maxBodySize int64) (*ProcessGroupConfig, error) {
 	ctx, log := logd.NewFromContext(ctx, loggerName)
 
 	if kubernetesClusterID == "" {
@@ -47,7 +47,8 @@ func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClu
 
 	req := c.apiClient.GET(ctx, processGroupingConfigPath).
 		WithQueryParams(params).
-		WithHeader("Accept", "application/cbor")
+		WithHeader("Accept", "application/cbor").
+		WithMaxBodySize(maxBodySize)
 
 	if etag != "" {
 		req = req.WithHeader(requestHeaderEtag, etag)

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
@@ -57,6 +57,8 @@ func setupMockedProcessGroupingClient(
 		}).
 		Return(responseHeaders, execErr).Once()
 
+	req.EXPECT().WithMaxBodySize(mock.Anything).Return(req).Once()
+
 	coreClient := coremock.NewClient(t)
 	coreClient.EXPECT().
 		GET(anyCtx, processGroupingConfigPath).
@@ -77,7 +79,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 			nil,
 		)
 
-		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, testETag)
+		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, testETag, 0)
 		require.NoError(t, err)
 		assert.Equal(t, testCBORData, string(pgc.Data))
 		// On 200, the returned ETag comes from the response header, not the input ETag
@@ -96,7 +98,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 			nil,
 		)
 
-		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "")
+		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "", 0)
 		require.NoError(t, err)
 		assert.Equal(t, testCBORData, string(pgc.Data))
 		assert.Equal(t, testResponseETag, pgc.ETag)
@@ -113,7 +115,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 			httpErr,
 		)
 
-		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, testETag)
+		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, testETag, 0)
 		require.NoError(t, err)
 		assert.Empty(t, string(pgc.Data))
 		// On 304, the original ETag is returned for convenience
@@ -131,7 +133,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 			nil,
 		)
 
-		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "")
+		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "", 0)
 		require.NoError(t, err)
 		assert.Equal(t, testResponseETag, pgc.ETag)
 	})
@@ -141,7 +143,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		coreClient := coremock.NewClient(t)
 		client := NewClient(coreClient, "", "")
 
-		pgc, err := client.GetProcessGroupingConfig(t.Context(), "", "")
+		pgc, err := client.GetProcessGroupingConfig(t.Context(), "", "", 0)
 		require.Error(t, err)
 		assert.Nil(t, pgc)
 	})
@@ -157,7 +159,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 			serverErr,
 		)
 
-		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "")
+		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "", 0)
 		require.Error(t, err)
 		require.True(t, core.HasStatusCode(err, http.StatusInternalServerError))
 		assert.Nil(t, pgc)
@@ -175,7 +177,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 			serverErr,
 		)
 
-		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, badETag)
+		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, badETag, 0)
 		require.Error(t, err)
 		require.True(t, core.HasStatusCode(err, http.StatusBadRequest))
 		assert.Nil(t, pgc)
@@ -192,7 +194,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 			httpErr,
 		)
 
-		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "")
+		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "", 0)
 		require.NoError(t, err)
 		assert.NotNil(t, pgc)
 		assert.Empty(t, pgc.Data)

--- a/pkg/controllers/dynakube/injection/reconciler_test.go
+++ b/pkg/controllers/dynakube/injection/reconciler_test.go
@@ -130,7 +130,7 @@ func TestReconciler(t *testing.T) {
 		versionClient := versionclientmock.NewClient(t)
 		versionClient.EXPECT().GetLatestAgentVersion(anyCtx, mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("", nil)
 		oneAgentClient.EXPECT().GetProcessModuleConfig(anyCtx).Return(&oneagentclient.ProcessModuleConfig{}, nil).Once()
-		oneAgentClient.EXPECT().GetProcessGroupingConfig(anyCtx, testKubernetesMEID, "").Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
+		oneAgentClient.EXPECT().GetProcessGroupingConfig(anyCtx, testKubernetesMEID, "", mock.Anything).Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
 		settingsClient := settingsmock.NewClient(t)
 		settingsClient.EXPECT().GetRules(anyCtx, mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil, nil)
 		dtClient := &dynatrace.Client{
@@ -422,7 +422,7 @@ func TestGenerateCorrectInitSecret(t *testing.T) {
 
 		oneAgentClient := oneagentclientmock.NewClient(t)
 		oneAgentClient.EXPECT().GetProcessModuleConfig(anyCtx).Return(&oneagentclient.ProcessModuleConfig{}, nil).Once()
-		oneAgentClient.EXPECT().GetProcessGroupingConfig(anyCtx, testKubernetesMEID, "").Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
+		oneAgentClient.EXPECT().GetProcessGroupingConfig(anyCtx, testKubernetesMEID, "", mock.Anything).Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
 
 		dtClient := &dynatrace.Client{OneAgent: oneAgentClient}
 
@@ -494,7 +494,7 @@ func TestGenerateCorrectCertInitSecret(t *testing.T) {
 
 		oneAgentClient := oneagentclientmock.NewClient(t)
 		oneAgentClient.EXPECT().GetProcessModuleConfig(anyCtx).Return(&oneagentclient.ProcessModuleConfig{}, nil).Once()
-		oneAgentClient.EXPECT().GetProcessGroupingConfig(anyCtx, testKubernetesMEID, "").Return(&oneagentclient.ProcessGroupConfig{}, nil).Twice()
+		oneAgentClient.EXPECT().GetProcessGroupingConfig(anyCtx, testKubernetesMEID, "", mock.Anything).Return(&oneagentclient.ProcessGroupConfig{}, nil).Twice()
 
 		dtClient := &dynatrace.Client{OneAgent: oneAgentClient}
 

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig_test.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig_test.go
@@ -103,7 +103,7 @@ func TestGenerateForDynakube(t *testing.T) {
 
 		mockDTClient := oneagentclientmock.NewClient(t)
 		mockDTClient.EXPECT().GetProcessModuleConfig(mock.Anything).Return(&oneagentclient.ProcessModuleConfig{}, nil).Once()
-		mockDTClient.EXPECT().GetProcessGroupingConfig(mock.Anything, mock.Anything, "").Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
+		mockDTClient.EXPECT().GetProcessGroupingConfig(mock.Anything, mock.Anything, "", mock.Anything).Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
 
 		secretGenerator := NewSecretGenerator(clt, clt, mockDTClient)
 		err := secretGenerator.GenerateForDynakube(t.Context(), dk, []corev1.Namespace{*namespace})
@@ -184,7 +184,7 @@ func TestGenerateForDynakube(t *testing.T) {
 
 		mockDTClient := oneagentclientmock.NewClient(t)
 		mockDTClient.EXPECT().GetProcessModuleConfig(mock.Anything).Return(&oneagentclient.ProcessModuleConfig{}, nil).Once()
-		mockDTClient.EXPECT().GetProcessGroupingConfig(mock.Anything, mock.Anything, "").Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
+		mockDTClient.EXPECT().GetProcessGroupingConfig(mock.Anything, mock.Anything, "", mock.Anything).Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
 
 		secretGenerator := NewSecretGenerator(clt, clt, mockDTClient)
 		err := secretGenerator.GenerateForDynakube(t.Context(), dk, []corev1.Namespace{*namespace})
@@ -287,7 +287,7 @@ func TestGenerateForDynakube(t *testing.T) {
 
 		mockDTClient := oneagentclientmock.NewClient(t)
 		mockDTClient.EXPECT().GetProcessModuleConfig(mock.Anything).Return(&oneagentclient.ProcessModuleConfig{}, nil).Once()
-		mockDTClient.EXPECT().GetProcessGroupingConfig(mock.Anything, mock.Anything, "").Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
+		mockDTClient.EXPECT().GetProcessGroupingConfig(mock.Anything, mock.Anything, "", mock.Anything).Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
 
 		secretGenerator := NewSecretGenerator(clt, clt, mockDTClient)
 		err := secretGenerator.GenerateForDynakube(t.Context(), dk, []corev1.Namespace{*namespace})
@@ -420,7 +420,7 @@ func TestGenerateForDynakube(t *testing.T) {
 
 		mockDTClient := oneagentclientmock.NewClient(t)
 		mockDTClient.EXPECT().GetProcessModuleConfig(mock.Anything).Return(&oneagentclient.ProcessModuleConfig{}, nil).Once()
-		mockDTClient.EXPECT().GetProcessGroupingConfig(mock.Anything, mock.Anything, "").Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
+		mockDTClient.EXPECT().GetProcessGroupingConfig(mock.Anything, mock.Anything, "", mock.Anything).Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
 
 		secretGenerator := NewSecretGenerator(failClient, failClient, mockDTClient)
 		err := secretGenerator.GenerateForDynakube(t.Context(), dk, []corev1.Namespace{*namespace})
@@ -486,7 +486,7 @@ func TestGenerateForDynakube(t *testing.T) {
 
 		mockDTClient := oneagentclientmock.NewClient(t)
 		mockDTClient.EXPECT().GetProcessModuleConfig(mock.Anything).Return(&oneagentclient.ProcessModuleConfig{}, nil).Once()
-		mockDTClient.EXPECT().GetProcessGroupingConfig(mock.Anything, mock.Anything, "").Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
+		mockDTClient.EXPECT().GetProcessGroupingConfig(mock.Anything, mock.Anything, "", mock.Anything).Return(&oneagentclient.ProcessGroupConfig{}, nil).Once()
 
 		secretGenerator := NewSecretGenerator(failClient, failClient, mockDTClient)
 		err := secretGenerator.GenerateForDynakube(t.Context(), dk, []corev1.Namespace{*namespace})

--- a/pkg/injection/namespace/bootstrapperconfig/pgc.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pgc.go
@@ -2,9 +2,11 @@ package bootstrapperconfig
 
 import (
 	"context"
+	"errors"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
@@ -50,7 +52,15 @@ func (s *SecretGenerator) preparePGC(ctx context.Context, dk *dynakube.DynaKube)
 
 	cachedPGC := s.readCachedPGC(ctx, dk)
 
-	pgc, err := s.dtClient.GetProcessGroupingConfig(ctx, dk.Status.KubernetesClusterMEID, cachedPGC.ETag)
+	pgc, err := s.dtClient.GetProcessGroupingConfig(ctx, dk.Status.KubernetesClusterMEID, cachedPGC.ETag, declarativeMaxSizeBytes)
+
+	var tooLarge *core.ResponseTooLargeError
+	if errors.As(err, &tooLarge) {
+		log.Error(nil, "DPG API response Content-Length exceeds maximum size, skipping processgroupingconfig", "contentLength", tooLarge.ContentLength, "maxSize", tooLarge.MaxBodySize)
+
+		return &oneagent.ProcessGroupConfig{}, nil
+	}
+
 	if err != nil {
 		k8sconditions.SetDynatraceAPIError(dk.Conditions(), ConfigConditionType, err)
 

--- a/pkg/injection/namespace/bootstrapperconfig/pgc_test.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pgc_test.go
@@ -45,7 +45,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 
 		payload := bytes.Repeat([]byte("a"), 100*1024) // 100 KiB
 		mockDTClient.EXPECT().
-			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "").
+			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "", mock.Anything).
 			Return(&oneagent.ProcessGroupConfig{
 				ETag: "etag123",
 				Data: payload,
@@ -67,7 +67,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 
 		payload := bytes.Repeat([]byte("a"), 850*1024) // 850 KiB — above warn, below max
 		mockDTClient.EXPECT().
-			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "").
+			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "", mock.Anything).
 			Return(&oneagent.ProcessGroupConfig{
 				ETag: "etag123",
 				Data: payload,
@@ -88,7 +88,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 
 		payload := bytes.Repeat([]byte("a"), 920*1024) // 920 KiB — above max
 		mockDTClient.EXPECT().
-			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "").
+			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "", mock.Anything).
 			Return(&oneagent.ProcessGroupConfig{
 				ETag: "etag123",
 				Data: payload,
@@ -109,7 +109,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 
 		expectedErr := errors.New("API error")
 		mockDTClient.EXPECT().
-			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "").
+			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "", mock.Anything).
 			Return(nil, expectedErr)
 
 		sg := NewSecretGenerator(clt, clt, mockDTClient)
@@ -130,7 +130,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		mockDTClient := oneagentclientmock.NewClient(t)
 
 		mockDTClient.EXPECT().
-			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "").
+			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "", mock.Anything).
 			Return(nil, nil)
 
 		sg := NewSecretGenerator(clt, clt, mockDTClient)
@@ -163,7 +163,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		mockDTClient := oneagentclientmock.NewClient(t)
 
 		mockDTClient.EXPECT().
-			GetProcessGroupingConfig(mock.Anything, testClusterMEID, cachedETag).
+			GetProcessGroupingConfig(mock.Anything, testClusterMEID, cachedETag, mock.Anything).
 			Return(&oneagent.ProcessGroupConfig{ETag: cachedETag}, nil)
 
 		sg := NewSecretGenerator(clt, clt, mockDTClient)
@@ -199,7 +199,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		responseETag := "new-etag-xyz"
 
 		mockDTClient.EXPECT().
-			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "").
+			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "", mock.Anything).
 			Return(&oneagent.ProcessGroupConfig{
 				ETag: responseETag,
 				Data: payload,

--- a/test/mocks/pkg/clients/dynatrace/core/request.go
+++ b/test/mocks/pkg/clients/dynatrace/core/request.go
@@ -265,6 +265,59 @@ func (_c *Request_WithJSONBody_Call) RunAndReturn(run func(body any) core.Reques
 	return _c
 }
 
+// WithMaxBodySize provides a mock function for the type Request
+func (_mock *Request) WithMaxBodySize(size int64) core.Request {
+	ret := _mock.Called(size)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithMaxBodySize")
+	}
+
+	var r0 core.Request
+	if returnFunc, ok := ret.Get(0).(func(int64) core.Request); ok {
+		r0 = returnFunc(size)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(core.Request)
+		}
+	}
+	return r0
+}
+
+// Request_WithMaxBodySize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithMaxBodySize'
+type Request_WithMaxBodySize_Call struct {
+	*mock.Call
+}
+
+// WithMaxBodySize is a helper method to define mock.On call
+//   - size int64
+func (_e *Request_Expecter) WithMaxBodySize(size interface{}) *Request_WithMaxBodySize_Call {
+	return &Request_WithMaxBodySize_Call{Call: _e.mock.On("WithMaxBodySize", size)}
+}
+
+func (_c *Request_WithMaxBodySize_Call) Run(run func(size int64)) *Request_WithMaxBodySize_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int64
+		if args[0] != nil {
+			arg0 = args[0].(int64)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Request_WithMaxBodySize_Call) Return(request core.Request) *Request_WithMaxBodySize_Call {
+	_c.Call.Return(request)
+	return _c
+}
+
+func (_c *Request_WithMaxBodySize_Call) RunAndReturn(run func(size int64) core.Request) *Request_WithMaxBodySize_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // WithPaasToken provides a mock function for the type Request
 func (_mock *Request) WithPaasToken() core.Request {
 	ret := _mock.Called()

--- a/test/mocks/pkg/clients/dynatrace/oneagent/client.go
+++ b/test/mocks/pkg/clients/dynatrace/oneagent/client.go
@@ -226,8 +226,8 @@ func (_c *Client_GetLatest_Call) RunAndReturn(run func(ctx context.Context, args
 }
 
 // GetProcessGroupingConfig provides a mock function for the type Client
-func (_mock *Client) GetProcessGroupingConfig(ctx context.Context, kubernetesClusterID string, etag string) (*oneagent.ProcessGroupConfig, error) {
-	ret := _mock.Called(ctx, kubernetesClusterID, etag)
+func (_mock *Client) GetProcessGroupingConfig(ctx context.Context, kubernetesClusterID string, etag string, maxBodySize int64) (*oneagent.ProcessGroupConfig, error) {
+	ret := _mock.Called(ctx, kubernetesClusterID, etag, maxBodySize)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetProcessGroupingConfig")
@@ -235,18 +235,18 @@ func (_mock *Client) GetProcessGroupingConfig(ctx context.Context, kubernetesClu
 
 	var r0 *oneagent.ProcessGroupConfig
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*oneagent.ProcessGroupConfig, error)); ok {
-		return returnFunc(ctx, kubernetesClusterID, etag)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, int64) (*oneagent.ProcessGroupConfig, error)); ok {
+		return returnFunc(ctx, kubernetesClusterID, etag, maxBodySize)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *oneagent.ProcessGroupConfig); ok {
-		r0 = returnFunc(ctx, kubernetesClusterID, etag)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, int64) *oneagent.ProcessGroupConfig); ok {
+		r0 = returnFunc(ctx, kubernetesClusterID, etag, maxBodySize)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oneagent.ProcessGroupConfig)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = returnFunc(ctx, kubernetesClusterID, etag)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, int64) error); ok {
+		r1 = returnFunc(ctx, kubernetesClusterID, etag, maxBodySize)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -262,11 +262,12 @@ type Client_GetProcessGroupingConfig_Call struct {
 //   - ctx context.Context
 //   - kubernetesClusterID string
 //   - etag string
-func (_e *Client_Expecter) GetProcessGroupingConfig(ctx interface{}, kubernetesClusterID interface{}, etag interface{}) *Client_GetProcessGroupingConfig_Call {
-	return &Client_GetProcessGroupingConfig_Call{Call: _e.mock.On("GetProcessGroupingConfig", ctx, kubernetesClusterID, etag)}
+//   - maxBodySize int64
+func (_e *Client_Expecter) GetProcessGroupingConfig(ctx interface{}, kubernetesClusterID interface{}, etag interface{}, maxBodySize interface{}) *Client_GetProcessGroupingConfig_Call {
+	return &Client_GetProcessGroupingConfig_Call{Call: _e.mock.On("GetProcessGroupingConfig", ctx, kubernetesClusterID, etag, maxBodySize)}
 }
 
-func (_c *Client_GetProcessGroupingConfig_Call) Run(run func(ctx context.Context, kubernetesClusterID string, etag string)) *Client_GetProcessGroupingConfig_Call {
+func (_c *Client_GetProcessGroupingConfig_Call) Run(run func(ctx context.Context, kubernetesClusterID string, etag string, maxBodySize int64)) *Client_GetProcessGroupingConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -280,10 +281,15 @@ func (_c *Client_GetProcessGroupingConfig_Call) Run(run func(ctx context.Context
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 int64
+		if args[3] != nil {
+			arg3 = args[3].(int64)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -294,7 +300,7 @@ func (_c *Client_GetProcessGroupingConfig_Call) Return(processGroupConfig *oneag
 	return _c
 }
 
-func (_c *Client_GetProcessGroupingConfig_Call) RunAndReturn(run func(ctx context.Context, kubernetesClusterID string, etag string) (*oneagent.ProcessGroupConfig, error)) *Client_GetProcessGroupingConfig_Call {
+func (_c *Client_GetProcessGroupingConfig_Call) RunAndReturn(run func(ctx context.Context, kubernetesClusterID string, etag string, maxBodySize int64) (*oneagent.ProcessGroupConfig, error)) *Client_GetProcessGroupingConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

followup to: https://github.com/Dynatrace/dynatrace-operator/pull/6541

- added `WithMaxBodySize(size int64)` to  `Request` interface
- returning `ResponseTooLargeError` when `MaxBodySize` is exceeded.
- checking for `ResponseTooLargeError` in `preparePGC`.

The manual check for `size > declarativeMaxSizeBytes` is still there as a fallback when the http response is chunked (content-length is 0 in this case)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

`make go/test`
`make go/lint`

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->