### PR TITLE
fixup: skipping helm_chart env var if branch env var is not set

### DIFF
--- a/test/e2e/helpers/components/operator/installation.go
+++ b/test/e2e/helpers/components/operator/installation.go
@@ -217,7 +217,7 @@ func getHelmOptions(releaseTag, platform string, withCSI bool) ([]helm.Option, e
 
 	// if target branch is set and not main, it means that we are running tests on a feature branch, so we want to
 	// install the operator using local helm chart and target branch
-	if targetBranch := os.Getenv("TARGET_BRANCH"); targetBranch != "main" {
+	if targetBranch, ok := os.LookupEnv("TARGET_BRANCH"); ok && targetBranch != "main" {
 		return append(opts,
 			helm.WithArgs("--set", "image="+strings.TrimSpace(imageRef)),
 			helm.WithArgs("--set", "imageRef.pullPolicy=Always"),


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR prevents skipping helm_chart, when branch env var is not specified.

follow up for https://dt-rnd.atlassian.net/browse/ICP-4839

> [!WARNING]
> This problem exists only locally, on CI since `branch` env var is always set (we are good). 

## How can this be tested?

Locally run:

```
make HELM_CHART=oci://ghcr.io/dynatrace/dynatrace-operator:0.0.0-nightly-chart test/e2e/edgeconnect/normal
```

make sure operator had been deployed from nightly-helm chart.

```
go test -v -count 1 -tags e2e -timeout 20m ./test/e2e/scenarios/nocsi -run "TestNoCSI_edgeconnect_install"
I0527 17:31:55.466444   62965 helm.go:253] "Determining if helm binary is available or not" executable="helm"
I0527 17:31:55.466727   62965 helm.go:262] "Running Helm Operation" command="helm upgrade dynatrace-operator --namespace dynatrace --create-nam
espace --install --set platform=kubernetes --set installCRD=true --set csidriver.enabled=false --set manifests=true --set debugLogs=true oci://
ghcr.io/dynatrace/dynatrace-operator:0.0.0-nightly-chart --kubeconfig ''"
I0527 17:32:18.683977   62965 helm.go:269] Helm Command output
Release "dynatrace-operator" does not exist. Installing it now.
NAME: dynatrace-operator
LAST DEPLOYED: Wed May 27 17:31:59 2026
NAMESPACE: dynatrace
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None
NOTES:
Thank you for installing dynatrace-operator.

Your release is named dynatrace-operator.

To find more information about the Dynatrace Operator, try:
https://github.com/Dynatrace/dynatrace-operator

To verify the current state of the deployments, try:
  $ kubectl get pods -n dynatrace
  $ kubectl logs -f deployment/dynatrace-operator -n dynatrace
Metadata for all containers for dynatrace-operator
        container name: operator
        image: ghcr.io/dynatrace/dynatrace-operator:nightly-2026-05-27
        imageID: ghcr.io/dynatrace/dynatrace-operator@sha256:ee21787c97fb91abceba759d666e9abd9be691cb4640dca1bf2c13c5085c29bd
=== RUN   TestNoCSI_edgeconnect_install
```