### PR TITLE
Add validation for NetworkZone and HostGroup input strings

### DIFF
--- a/pkg/api/validation/dynakube/hostgroup.go
+++ b/pkg/api/validation/dynakube/hostgroup.go
@@ -13,22 +13,12 @@ const (
 )
 
 func invalidOneAgentHostGroup(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	hostGroup := dk.OneAgent().HostGroup
-	if hostGroup != "" {
-		sanitizedHostGroup := strings.Map(removeWhiteSpaceCharacters, hostGroup)
-
-		if len(sanitizedHostGroup) != len(hostGroup) {
-			return errorInvalidHostGroupProperty
-		}
+	if strings.ContainsFunc(dk.OneAgent().HostGroup, isWhiteSpaceCharacter) {
+		return errorInvalidHostGroupProperty
 	}
 
-	hostGroup = dk.OneAgent().GetHostGroupAsParam()
-	if hostGroup != "" {
-		sanitizedHostGroup := strings.Map(removeWhiteSpaceCharacters, hostGroup)
-
-		if len(sanitizedHostGroup) != len(hostGroup) {
-			return errorInvalidHostGroupAsParam
-		}
+	if strings.ContainsFunc(dk.OneAgent().GetHostGroupAsParam(), isWhiteSpaceCharacter) {
+		return errorInvalidHostGroupAsParam
 	}
 
 	return ""

--- a/pkg/api/validation/dynakube/hostgroup.go
+++ b/pkg/api/validation/dynakube/hostgroup.go
@@ -1,0 +1,35 @@
+package validation
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+)
+
+const (
+	errorInvalidHostGroupProperty = "The DynaKube's specification has an invalid Host Group value set using the oneAgent.hostGroup property. Make sure to remove all whitespace characters (newline, tab, carriage return, null) from the Host Group value in your custom resource."
+	errorInvalidHostGroupAsParam  = "The DynaKube's specification has an invalid Host Group value set using the --set-host-group argument. Make sure to remove all whitespace characters (newline, tab, carriage return, null) from the Host Group value in your custom resource."
+)
+
+func invalidOneAgentHostGroup(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	hostGroup := dk.OneAgent().HostGroup
+	if hostGroup != "" {
+		sanitizedHostGroup := strings.Map(removeWhiteSpaceCharacters, hostGroup)
+
+		if len(sanitizedHostGroup) != len(hostGroup) {
+			return errorInvalidHostGroupProperty
+		}
+	}
+
+	hostGroup = dk.OneAgent().GetHostGroupAsParam()
+	if hostGroup != "" {
+		sanitizedHostGroup := strings.Map(removeWhiteSpaceCharacters, hostGroup)
+
+		if len(sanitizedHostGroup) != len(hostGroup) {
+			return errorInvalidHostGroupAsParam
+		}
+	}
+
+	return ""
+}

--- a/pkg/api/validation/dynakube/hostgroup.go
+++ b/pkg/api/validation/dynakube/hostgroup.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	errorInvalidHostGroupProperty = "The DynaKube's specification has an invalid Host Group value set using the oneAgent.hostGroup property. Make sure to remove all whitespace characters (newline, tab, carriage return, null) from the Host Group value in your custom resource."
-	errorInvalidHostGroupAsParam  = "The DynaKube's specification has an invalid Host Group value set using the --set-host-group argument. Make sure to remove all whitespace characters (newline, tab, carriage return, null) from the Host Group value in your custom resource."
+	errorInvalidHostGroupProperty = "The DynaKube's specification has an invalid Host Group value set using the oneAgent.hostGroup property. Make sure to remove forbidden characters (newline, tab, carriage return, null) from the Host Group value in your custom resource."
+	errorInvalidHostGroupAsParam  = "The DynaKube's specification has an invalid Host Group value set using the --set-host-group argument. Make sure to remove forbidden characters (newline, tab, carriage return, null) from the Host Group value in your custom resource."
 )
 
 func invalidOneAgentHostGroup(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {

--- a/pkg/api/validation/dynakube/hostgroup_test.go
+++ b/pkg/api/validation/dynakube/hostgroup_test.go
@@ -1,0 +1,125 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInvalidOneAgentHostGroup(t *testing.T) {
+	t.Run("empty host group is allowed", func(t *testing.T) {
+		assertAllowed(t, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{APIURL: testAPIURL},
+		})
+	})
+
+	t.Run("valid host group property is allowed", func(t *testing.T) {
+		assertAllowed(t, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL:   testAPIURL,
+				OneAgent: oneagent.Spec{HostGroup: "host-group"},
+			},
+		})
+	})
+
+	t.Run("host group property with newline is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidHostGroupProperty}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL:   testAPIURL,
+				OneAgent: oneagent.Spec{HostGroup: "host\ngroup"},
+			},
+		})
+	})
+
+	t.Run("host group property with tab is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidHostGroupProperty}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL:   testAPIURL,
+				OneAgent: oneagent.Spec{HostGroup: "host\tgroup"},
+			},
+		})
+	})
+
+	t.Run("host group property with carriage return is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidHostGroupProperty}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL:   testAPIURL,
+				OneAgent: oneagent.Spec{HostGroup: "host\rgroup"},
+			},
+		})
+	})
+
+	t.Run("host group property with null byte is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidHostGroupProperty}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL:   testAPIURL,
+				OneAgent: oneagent.Spec{HostGroup: "host\x00group"},
+			},
+		})
+	})
+
+	t.Run("valid --set-host-group arg is allowed", func(t *testing.T) {
+		assertAllowed(t, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testAPIURL,
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{Args: []string{"--set-host-group=host-group"}},
+				},
+			},
+		})
+	})
+
+	t.Run("--set-host-group arg with newline is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidHostGroupAsParam}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testAPIURL,
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{Args: []string{"--set-host-group=host\ngroup"}},
+				},
+			},
+		})
+	})
+
+	t.Run("--set-host-group arg with tab is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidHostGroupAsParam}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testAPIURL,
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{Args: []string{"--set-host-group=host\tgroup"}},
+				},
+			},
+		})
+	})
+
+	t.Run("--set-host-group arg with carriage return is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidHostGroupAsParam}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testAPIURL,
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{Args: []string{"--set-host-group=host\rgroup"}},
+				},
+			},
+		})
+	})
+
+	t.Run("--set-host-group arg with null byte is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidHostGroupAsParam}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testAPIURL,
+				OneAgent: oneagent.Spec{
+					HostMonitoring: &oneagent.HostInjectSpec{Args: []string{"--set-host-group=host\x00group"}},
+				},
+			},
+		})
+	})
+}

--- a/pkg/api/validation/dynakube/networkzone.go
+++ b/pkg/api/validation/dynakube/networkzone.go
@@ -1,0 +1,33 @@
+package validation
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+)
+
+const (
+	errorInvalidNetworkZone = "The DynaKube's specification has an invalid Network Zone value set. Make sure to remove all whitespace characters (newline, tab, carriage return, null) from the Network Zone value in your custom resource."
+)
+
+func invalidNetworkZone(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if dk.Spec.NetworkZone != "" {
+		sanitizedNetworkZone := strings.Map(removeWhiteSpaceCharacters, dk.Spec.NetworkZone)
+
+		if len(sanitizedNetworkZone) != len(dk.Spec.NetworkZone) {
+			return errorInvalidNetworkZone
+		}
+	}
+
+	return ""
+}
+
+func removeWhiteSpaceCharacters(r rune) rune {
+	switch r {
+	case '\n', '\t', '\r', '\x00':
+		return -1 // drop the character
+	}
+
+	return r
+}

--- a/pkg/api/validation/dynakube/networkzone.go
+++ b/pkg/api/validation/dynakube/networkzone.go
@@ -12,22 +12,18 @@ const (
 )
 
 func invalidNetworkZone(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	if dk.Spec.NetworkZone != "" {
-		sanitizedNetworkZone := strings.Map(removeWhiteSpaceCharacters, dk.Spec.NetworkZone)
-
-		if len(sanitizedNetworkZone) != len(dk.Spec.NetworkZone) {
-			return errorInvalidNetworkZone
-		}
+	if strings.ContainsFunc(dk.Spec.NetworkZone, isWhiteSpaceCharacter) {
+		return errorInvalidNetworkZone
 	}
 
 	return ""
 }
 
-func removeWhiteSpaceCharacters(r rune) rune {
+func isWhiteSpaceCharacter(r rune) bool {
 	switch r {
 	case '\n', '\t', '\r', '\x00':
-		return -1 // drop the character
+		return true
 	}
 
-	return r
+	return false
 }

--- a/pkg/api/validation/dynakube/networkzone.go
+++ b/pkg/api/validation/dynakube/networkzone.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	errorInvalidNetworkZone = "The DynaKube's specification has an invalid Network Zone value set. Make sure to remove all whitespace characters (newline, tab, carriage return, null) from the Network Zone value in your custom resource."
+	errorInvalidNetworkZone = "The DynaKube's specification has an invalid Network Zone value set. Make sure to remove forbidden characters (newline, tab, carriage return, null) from the Network Zone value in your custom resource."
 )
 
 func invalidNetworkZone(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {

--- a/pkg/api/validation/dynakube/networkzone_test.go
+++ b/pkg/api/validation/dynakube/networkzone_test.go
@@ -1,0 +1,50 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInvalidNetworkZone(t *testing.T) {
+	t.Run("empty network zone is allowed", func(t *testing.T) {
+		assertAllowed(t, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{APIURL: testAPIURL},
+		})
+	})
+
+	t.Run("valid network zone is allowed", func(t *testing.T) {
+		assertAllowed(t, &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{APIURL: testAPIURL, NetworkZone: "network-zone"},
+		})
+	})
+
+	t.Run("network zone with newline is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidNetworkZone}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL, NetworkZone: "network\nzone"},
+		})
+	})
+
+	t.Run("network zone with tab is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidNetworkZone}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL, NetworkZone: "network\tzone"},
+		})
+	})
+
+	t.Run("network zone with carriage return is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidNetworkZone}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL, NetworkZone: "network\rzone"},
+		})
+	})
+
+	t.Run("network zone with null byte is denied", func(t *testing.T) {
+		assertDenied(t, []string{errorInvalidNetworkZone}, &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL, NetworkZone: "network\x00zone"},
+		})
+	})
+}

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -68,6 +68,8 @@ var (
 		invalidOneAgentResourceAttributesSanitization,
 		invalidOTLPResourceAttributesSanitization,
 		publicRegistryOverrideWithoutPublicRegistry,
+		invalidNetworkZone,
+		invalidOneAgentHostGroup,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-5479)

## Description

A dynakube CR that has an invalid NetworkZone or Host Group value is rejected by validation webhook.

## How can this be tested?

unittests

try to apply a dynakube with invalid networkZone or hostGroup value