### PR TITLE
Remove platform token requirement for 3rd gen URL

### DIFF
--- a/pkg/api/validation/dynakube/api_url.go
+++ b/pkg/api/validation/dynakube/api_url.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 )
 
@@ -19,11 +18,6 @@ const (
 	errorInvalidAPIURL = `The DynaKube's specification has an invalid API URL value set.
 	Make sure you correctly specify the URL in your custom resource (including the /api postfix).
 	`
-
-	errorThirdGenAPIURL = `The DynaKube's specification has an 3rd gen API URL and the apiToken provided is not a platform token. Make sure to remove the 'apps' part
-	out of it. Example: ` + ExampleAPIURL
-
-	errorCheckingSecret = `Failed to check the DynaKube's secret to check for 3rd gen API URL. Make sure the secret exists and is accessible by the operator.`
 
 	errorMutatedAPIURL = `The DynaKube's specification mutated the tenant in the API URL although it is immutable. Please delete the CR and then apply a new one`
 )
@@ -85,26 +79,6 @@ func isInvalidAPIURL(ctx context.Context, _ *Validator, dk *dynakube.DynaKube) s
 
 func isThirdGenHost(hostname string) bool {
 	return strings.Contains(hostname, ".apps.")
-}
-
-func isThirdGenAPIURL(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
-	parsed, err := url.Parse(dk.APIURL())
-	if err != nil || !isThirdGenHost(parsed.Hostname()) {
-		return ""
-	}
-
-	tokenReader := token.NewReader(dv.apiReader, dk)
-
-	hasPlatformToken, err := tokenReader.HasPlatformToken(ctx)
-	if err != nil {
-		return errorCheckingSecret
-	}
-
-	if !hasPlatformToken {
-		return errorThirdGenAPIURL
-	}
-
-	return ""
 }
 
 func tenantUUIDFromAPIURL(apiURL string) string {

--- a/pkg/api/validation/dynakube/api_url_test.go
+++ b/pkg/api/validation/dynakube/api_url_test.go
@@ -72,8 +72,8 @@ func TestHasApiUrl(t *testing.T) {
 			},
 		})
 	})
-	t.Run("third gen API URL with regular token is rejected", func(t *testing.T) {
-		assertDenied(t, []string{errorThirdGenAPIURL}, &dynakube.DynaKube{
+	t.Run("third gen API URL with regular token is allowed", func(t *testing.T) {
+		assertAllowed(t, &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: "https://tenantid.doma.apps.in/api",

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -33,7 +33,6 @@ var (
 		forbiddenHostIDSourceArgument,
 		NoAPIURL,
 		isInvalidAPIURL,
-		isThirdGenAPIURL,
 		invalidActiveGateCapabilities,
 		mutuallyExclusiveActiveGatePVsettings,
 		invalidActiveGateProxyURL,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-5483

3rd gen URLs support non-platform tokens, as it is handled in the client.
Therefore this validation is an artificial limitation, that becomes problematic if the user changes their URL / token without thinking about this. (we validate the DK -> can deny it, we do NOT validate the token secret -> user is free to "break it")

## How can this be tested?

Use your non-platform token
Add use the 3rd gen URL of your tenant
All should work