### PR TITLE
Bump dynatrace-bootstrapper version to 1.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Dynatrace/dynatrace-operator
 go 1.26.0
 
 require (
-	github.com/Dynatrace/dynatrace-bootstrapper v1.4.0
+	github.com/Dynatrace/dynatrace-bootstrapper v1.4.1
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/docker/cli v29.5.2+incompatible
 	github.com/evanphx/json-patch v5.9.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Dynatrace/dynatrace-bootstrapper v1.4.0 h1:OTs49duFiaf02PF8walKmc0Ew1NWxFu7MWY7XUkzXN4=
-github.com/Dynatrace/dynatrace-bootstrapper v1.4.0/go.mod h1:omtzCB/yuM5AzD3fTuF8woye33l6mFOooqLFPypvuMI=
+github.com/Dynatrace/dynatrace-bootstrapper v1.4.1 h1:xYyjldZSJmDlx7tta0Um/5Q+qMoOrmBv9UX1NCdTdBk=
+github.com/Dynatrace/dynatrace-bootstrapper v1.4.1/go.mod h1:omtzCB/yuM5AzD3fTuF8woye33l6mFOooqLFPypvuMI=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-5530

Creating truly readonly (0444) files causes problems if the node is restarted.

- During a node restart, the contents of the emptyDirs do not get reset

- After a node restart, the init-containers runs like it was a new new, encountering the previously created (but now readonly) files → permission denied → init-container fails

Mainly an issue if our init-container’s failurePoclicy is **not** silent (by default it is silent)

## How can this be tested?

1. Inject into an app (with CSI)
2. Restart your nodes (**not** re-create)
3. Everything comes up without errors