### PR TITLE
Use GH vars instead of secrets for repository names

### DIFF
--- a/.github/workflows/fips-release.yaml
+++ b/.github/workflows/fips-release.yaml
@@ -65,8 +65,8 @@ jobs:
       - name: Build ${{ matrix.platform }} image
         uses: ./.github/actions/build-push-image
         env:
-            ECR_IMAGE: public.ecr.aws/${{ secrets.ECR_REPOSITORY }}
-            DOCKER_IMAGE: docker.io/${{ secrets.DOCKERHUB_REPOSITORY }}
+            ECR_IMAGE: public.ecr.aws/${{ vars.ECR_REPOSITORY }}
+            DOCKER_IMAGE: docker.io/${{ vars.DOCKERHUB_REPOSITORY }}
         with:
           platforms: ${{ matrix.platform }}
           images: ${{ env.DOCKER_IMAGE }},${{ env.ECR_IMAGE }}
@@ -115,21 +115,21 @@ jobs:
       - name: Create image-index manifest for ${{matrix.registry}}
         id: image-index
         env:
-          IMAGE: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}-fips
+          IMAGE: ${{ matrix.url }}/${{ vars[matrix.repository] }}:${{ needs.prepare.outputs.version }}-fips
         shell: bash
         run: |
           hack/build/ci/create-image-index.sh "${IMAGE}"
       - name: Sign images for ${{matrix.registry}}
         uses: ./.github/actions/sign-image
         with:
-          image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ steps.image-index.outputs.digest }}
+          image: ${{ matrix.url }}/${{ vars[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ steps.image-index.outputs.digest }}
           signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Create sbom for ${{matrix.registry}}
         id: sbom
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ steps.image-index.outputs.digest }}
+          image-ref: ${{ matrix.url }}/${{ vars[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ steps.image-index.outputs.digest }}
           format: 'cyclonedx'
           output: 'result.json'
           skip-dirs: '/usr/share/dynatrace-operator/third_party_licenses'
@@ -137,12 +137,12 @@ jobs:
       - name: Upload sbom to ${{matrix.registry}}
         uses: ./.github/actions/upload-sbom
         with:
-          image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ steps.image-index.outputs.digest }}
+          image: ${{ matrix.url }}/${{ vars[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ steps.image-index.outputs.digest }}
           sbom: 'result.json'
           signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Add build provenance attestation for ${{ matrix.registry }}
         uses: ./.github/actions/attest-artifact
         with:
-          subject-name: ${{ matrix.url }}/${{ secrets[matrix.repository] }}
+          subject-name: ${{ matrix.url }}/${{ vars[matrix.repository] }}
           subject-digest: ${{ steps.image-index.outputs.digest }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,10 +38,10 @@ jobs:
     permissions:
       id-token: write
     env:
-      GCR_IMAGE: gcr.io/${{ secrets.GCR_REPOSITORY }}
-      ECR_IMAGE: public.ecr.aws/${{ secrets.ECR_REPOSITORY }}
-      RHCC_IMAGE: quay.io/${{ secrets.RHCC_REPOSITORY }}
-      DOCKER_IMAGE: docker.io/${{ secrets.DOCKERHUB_REPOSITORY }}
+      GCR_IMAGE: gcr.io/${{ vars.GCR_REPOSITORY }}
+      ECR_IMAGE: public.ecr.aws/${{ vars.ECR_REPOSITORY }}
+      RHCC_IMAGE: quay.io/${{ vars.RHCC_REPOSITORY }}
+      DOCKER_IMAGE: docker.io/${{ vars.DOCKERHUB_REPOSITORY }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -141,14 +141,14 @@ jobs:
       - name: Sign images for ${{matrix.registry}}
         uses: ./.github/actions/sign-image
         with:
-          image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ needs.build-push.outputs.digest }}
+          image: ${{ matrix.url }}/${{ vars[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ needs.build-push.outputs.digest }}
           signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Create sbom for ${{matrix.registry}}
         id: sbom
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ needs.build-push.outputs.digest }}
+          image-ref: ${{ matrix.url }}/${{ vars[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ needs.build-push.outputs.digest }}
           format: 'cyclonedx'
           output: 'result.json'
           skip-dirs: '/usr/share/dynatrace-operator/third_party_licenses'
@@ -156,14 +156,14 @@ jobs:
       - name: Upload sbom to ${{matrix.registry}}
         uses: ./.github/actions/upload-sbom
         with:
-          image: ${{ matrix.url }}/${{ secrets[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ needs.build-push.outputs.digest }}
+          image: ${{ matrix.url }}/${{ vars[matrix.repository] }}:${{ needs.prepare.outputs.version }}@${{ needs.build-push.outputs.digest }}
           sbom: 'result.json'
           signing-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
           signing-password: ${{ secrets.COSIGN_PASSWORD }}
       - name: Add build provenance attestation for ${{ matrix.registry }}
         uses: ./.github/actions/attest-artifact
         with:
-          subject-name: ${{ matrix.url }}/${{ secrets[matrix.repository] }}
+          subject-name: ${{ matrix.url }}/${{ vars[matrix.repository] }}
           subject-digest: ${{ needs.build-push.outputs.digest }}
 
   run-preflight-rhcc:
@@ -189,7 +189,7 @@ jobs:
         with:
           version: ${{ needs.prepare.outputs.version }}
           registry: ${{ env.SCAN_REGISTRY }}
-          repository: ${{ secrets.RHCC_REPOSITORY }}
+          repository: ${{ vars.RHCC_REPOSITORY }}
           report-name: "preflight.json"
           redhat-project-id: ${{ secrets.REDHAT_PROJECT_ID }}
           pyxis-api-token: ${{ secrets.PYXIS_API_TOKEN }}


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-3944)

## Description

`*_REPOSITORY` variables have been created.
Release and fips.Release workflows use variables instead of secrets.

## How can this be tested?
