### PR TITLE
Fix pull secret not updating on api token change

### DIFF
--- a/cmd/troubleshoot/dynakube.go
+++ b/cmd/troubleshoot/dynakube.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/dtpullsecret"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -128,7 +127,7 @@ func checkDynatraceAPITokenScopes(ctx context.Context, baseLog logd.Logger, apiR
 		return errors.Wrapf(err, "invalid '%s:%s' secret", dk.Namespace, dk.Tokens())
 	}
 
-	if dttoken.IsPlatform(tokens.APIToken().Value) {
+	if tokens.HasPlatformToken() {
 		logInfof(log, "skipping token scope lookup due to platform token")
 
 		return nil

--- a/pkg/api/latest/dynakube/dynakube_props.go
+++ b/pkg/api/latest/dynakube/dynakube_props.go
@@ -73,16 +73,13 @@ func (dk *DynaKube) TenantRegistryPullSecretName() string {
 }
 
 func (dk *DynaKube) PullSecretNames() []string {
-	customNames := dk.customPullSecretNames()
-	names := make([]string, 0, 1+len(customNames))
+	var names []string
 
 	if !ptr.Deref(dk.Status.APIToken.Platform, false) {
 		names = append(names, dk.TenantRegistryPullSecretName())
 	}
 
-	names = append(names, customNames...)
-
-	return names
+	return append(names, dk.customPullSecretNames()...)
 }
 
 func (dk *DynaKube) customPullSecretNames() []string {

--- a/pkg/api/latest/dynakube/dynakube_props.go
+++ b/pkg/api/latest/dynakube/dynakube_props.go
@@ -75,7 +75,11 @@ func (dk *DynaKube) TenantRegistryPullSecretName() string {
 func (dk *DynaKube) PullSecretNames() []string {
 	customNames := dk.customPullSecretNames()
 	names := make([]string, 0, 1+len(customNames))
-	names = append(names, dk.TenantRegistryPullSecretName())
+
+	if !ptr.Deref(dk.Status.APIToken.Platform, false) {
+		names = append(names, dk.TenantRegistryPullSecretName())
+	}
+
 	names = append(names, customNames...)
 
 	return names
@@ -117,7 +121,13 @@ func (dk *DynaKube) CustomPullSecretReferences() []corev1.LocalObjectReference {
 }
 
 func (dk *DynaKube) ImagePullSecretReferences() []corev1.LocalObjectReference {
-	return append(dk.TenantRegistryPullSecretReferences(), dk.CustomPullSecretReferences()...)
+	var refs []corev1.LocalObjectReference
+
+	if !ptr.Deref(dk.Status.APIToken.Platform, false) {
+		refs = append(refs, dk.TenantRegistryPullSecretReferences()...)
+	}
+
+	return append(refs, dk.CustomPullSecretReferences()...)
 }
 
 // Tokens returns the name of the Secret to be used for tokens.

--- a/pkg/api/latest/dynakube/dynakube_props_test.go
+++ b/pkg/api/latest/dynakube/dynakube_props_test.go
@@ -101,6 +101,26 @@ func TestImagePullSecretReferences(t *testing.T) {
 		assert.Equal(t, customPullSecret, refs[1].Name)
 		assert.Equal(t, helmPullSecret, refs[2].Name)
 	})
+	t.Run("don't return tenant pull secret if platform token", func(t *testing.T) {
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
+		dk := DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: dkName},
+			Status:     DynaKubeStatus{APIToken: APITokenStatus{Platform: new(true)}},
+		}
+		refs := dk.ImagePullSecretReferences()
+		assert.Empty(t, refs)
+	})
+	t.Run("includes DynaKube customPullSecret if platform token", func(t *testing.T) {
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
+		dk := DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: dkName},
+			Spec:       DynaKubeSpec{CustomPullSecret: customPullSecret},
+			Status:     DynaKubeStatus{APIToken: APITokenStatus{Platform: new(true)}},
+		}
+		refs := dk.ImagePullSecretReferences()
+		assert.Len(t, refs, 1)
+		assert.Equal(t, customPullSecret, refs[0].Name)
+	})
 }
 
 func TestTenantRegistryPullSecretReferences(t *testing.T) {

--- a/pkg/api/latest/dynakube/dynakube_props_test.go
+++ b/pkg/api/latest/dynakube/dynakube_props_test.go
@@ -24,6 +24,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	testDKName           = "test-dk"
+	testCustomPullSecret = "my-custom-secret"
+	testHelmPullSecret   = "helm-pull-secret"
+)
+
 func TestTokens(t *testing.T) {
 	testName := "test-name"
 	testValue := "test-value"
@@ -42,15 +48,9 @@ func TestTokens(t *testing.T) {
 }
 
 func TestImagePullSecretReferences(t *testing.T) {
-	const (
-		dkName           = "test-dk"
-		customPullSecret = "my-custom-secret"
-		helmPullSecret   = "helm-pull-secret"
-	)
-
 	t.Run("only tenant pull secret when no custom pull secret is set", func(t *testing.T) {
 		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
-		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: dkName}}
+		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testDKName}}
 		refs := dk.ImagePullSecretReferences()
 		assert.Len(t, refs, 1)
 		assert.Equal(t, dk.TenantRegistryPullSecretName(), refs[0].Name)
@@ -59,52 +59,52 @@ func TestImagePullSecretReferences(t *testing.T) {
 	t.Run("includes DynaKube customPullSecret when set", func(t *testing.T) {
 		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
 		dk := DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: dkName},
-			Spec:       DynaKubeSpec{CustomPullSecret: customPullSecret},
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Spec:       DynaKubeSpec{CustomPullSecret: testCustomPullSecret},
 		}
 		refs := dk.ImagePullSecretReferences()
 		assert.Len(t, refs, 2)
 		assert.Equal(t, dk.TenantRegistryPullSecretName(), refs[0].Name)
-		assert.Equal(t, customPullSecret, refs[1].Name)
+		assert.Equal(t, testCustomPullSecret, refs[1].Name)
 	})
 
 	t.Run("includes Helm pull secret from env var", func(t *testing.T) {
-		t.Setenv(k8senv.DTOperatorPullSecretEnvName, helmPullSecret)
-		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: dkName}}
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, testHelmPullSecret)
+		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testDKName}}
 		refs := dk.ImagePullSecretReferences()
 		assert.Len(t, refs, 2)
 		assert.Equal(t, dk.TenantRegistryPullSecretName(), refs[0].Name)
-		assert.Equal(t, helmPullSecret, refs[1].Name)
+		assert.Equal(t, testHelmPullSecret, refs[1].Name)
 	})
 
 	t.Run("does not duplicate helm pull secret when it matches DynaKube customPullSecret", func(t *testing.T) {
-		t.Setenv(k8senv.DTOperatorPullSecretEnvName, customPullSecret)
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, testCustomPullSecret)
 		dk := DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: dkName},
-			Spec:       DynaKubeSpec{CustomPullSecret: customPullSecret},
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Spec:       DynaKubeSpec{CustomPullSecret: testCustomPullSecret},
 		}
 		refs := dk.ImagePullSecretReferences()
 		assert.Len(t, refs, 2)
 		assert.Equal(t, dk.TenantRegistryPullSecretName(), refs[0].Name)
-		assert.Equal(t, customPullSecret, refs[1].Name)
+		assert.Equal(t, testCustomPullSecret, refs[1].Name)
 	})
 
 	t.Run("includes both DynaKube customPullSecret and helm pull secret", func(t *testing.T) {
-		t.Setenv(k8senv.DTOperatorPullSecretEnvName, helmPullSecret)
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, testHelmPullSecret)
 		dk := DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: dkName},
-			Spec:       DynaKubeSpec{CustomPullSecret: customPullSecret},
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Spec:       DynaKubeSpec{CustomPullSecret: testCustomPullSecret},
 		}
 		refs := dk.ImagePullSecretReferences()
 		assert.Len(t, refs, 3)
 		assert.Equal(t, dk.TenantRegistryPullSecretName(), refs[0].Name)
-		assert.Equal(t, customPullSecret, refs[1].Name)
-		assert.Equal(t, helmPullSecret, refs[2].Name)
+		assert.Equal(t, testCustomPullSecret, refs[1].Name)
+		assert.Equal(t, testHelmPullSecret, refs[2].Name)
 	})
 	t.Run("don't return tenant pull secret if platform token", func(t *testing.T) {
 		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
 		dk := DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: dkName},
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
 			Status:     DynaKubeStatus{APIToken: APITokenStatus{Platform: new(true)}},
 		}
 		refs := dk.ImagePullSecretReferences()
@@ -113,21 +113,47 @@ func TestImagePullSecretReferences(t *testing.T) {
 	t.Run("includes DynaKube customPullSecret if platform token", func(t *testing.T) {
 		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
 		dk := DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: dkName},
-			Spec:       DynaKubeSpec{CustomPullSecret: customPullSecret},
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Spec:       DynaKubeSpec{CustomPullSecret: testCustomPullSecret},
 			Status:     DynaKubeStatus{APIToken: APITokenStatus{Platform: new(true)}},
 		}
 		refs := dk.ImagePullSecretReferences()
 		assert.Len(t, refs, 1)
-		assert.Equal(t, customPullSecret, refs[0].Name)
+		assert.Equal(t, testCustomPullSecret, refs[0].Name)
+	})
+}
+
+func TestPullSecretNames(t *testing.T) {
+	t.Run("includes tenant pull secret name", func(t *testing.T) {
+		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testDKName}}
+		names := dk.PullSecretNames()
+		assert.Contains(t, names, dk.TenantRegistryPullSecretName())
+	})
+	t.Run("don't return tenant pull secret name if platform token", func(t *testing.T) {
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
+		dk := DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Status:     DynaKubeStatus{APIToken: APITokenStatus{Platform: new(true)}},
+		}
+		names := dk.PullSecretNames()
+		assert.Empty(t, names)
+	})
+	t.Run("includes DynaKube customPullSecret name if platform token", func(t *testing.T) {
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
+		dk := DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Spec:       DynaKubeSpec{CustomPullSecret: testCustomPullSecret},
+			Status:     DynaKubeStatus{APIToken: APITokenStatus{Platform: new(true)}},
+		}
+		names := dk.PullSecretNames()
+		assert.Len(t, names, 1)
+		assert.Equal(t, testCustomPullSecret, names[0])
 	})
 }
 
 func TestTenantRegistryPullSecretReferences(t *testing.T) {
-	const dkName = "test-dk"
-
 	t.Run("always returns only the tenant registry pull secret", func(t *testing.T) {
-		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: dkName}}
+		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testDKName}}
 		refs := dk.TenantRegistryPullSecretReferences()
 		assert.Len(t, refs, 1)
 		assert.Equal(t, dk.TenantRegistryPullSecretName(), refs[0].Name)
@@ -135,8 +161,8 @@ func TestTenantRegistryPullSecretReferences(t *testing.T) {
 
 	t.Run("does not include customPullSecret even when set", func(t *testing.T) {
 		dk := DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: dkName},
-			Spec:       DynaKubeSpec{CustomPullSecret: "my-custom-secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Spec:       DynaKubeSpec{CustomPullSecret: testCustomPullSecret},
 		}
 		refs := dk.TenantRegistryPullSecretReferences()
 		assert.Len(t, refs, 1)
@@ -144,8 +170,8 @@ func TestTenantRegistryPullSecretReferences(t *testing.T) {
 	})
 
 	t.Run("does not include Helm pull secret even when set", func(t *testing.T) {
-		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "helm-pull-secret")
-		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: dkName}}
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, testHelmPullSecret)
+		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testDKName}}
 		refs := dk.TenantRegistryPullSecretReferences()
 		assert.Len(t, refs, 1)
 		assert.Equal(t, dk.TenantRegistryPullSecretName(), refs[0].Name)
@@ -153,15 +179,9 @@ func TestTenantRegistryPullSecretReferences(t *testing.T) {
 }
 
 func TestCustomPullSecretReferences(t *testing.T) {
-	const (
-		dkName           = "test-dk"
-		customPullSecret = "my-custom-secret"
-		helmPullSecret   = "helm-pull-secret"
-	)
-
 	t.Run("empty when no custom or Helm pull secret is set", func(t *testing.T) {
 		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
-		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: dkName}}
+		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testDKName}}
 		refs := dk.CustomPullSecretReferences()
 		assert.Empty(t, refs)
 	})
@@ -169,50 +189,50 @@ func TestCustomPullSecretReferences(t *testing.T) {
 	t.Run("includes customPullSecret when set", func(t *testing.T) {
 		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
 		dk := DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: dkName},
-			Spec:       DynaKubeSpec{CustomPullSecret: customPullSecret},
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Spec:       DynaKubeSpec{CustomPullSecret: testCustomPullSecret},
 		}
 		refs := dk.CustomPullSecretReferences()
 		assert.Len(t, refs, 1)
-		assert.Equal(t, customPullSecret, refs[0].Name)
+		assert.Equal(t, testCustomPullSecret, refs[0].Name)
 	})
 
 	t.Run("includes Helm pull secret from env var", func(t *testing.T) {
-		t.Setenv(k8senv.DTOperatorPullSecretEnvName, helmPullSecret)
-		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: dkName}}
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, testHelmPullSecret)
+		dk := DynaKube{ObjectMeta: metav1.ObjectMeta{Name: testDKName}}
 		refs := dk.CustomPullSecretReferences()
 		assert.Len(t, refs, 1)
-		assert.Equal(t, helmPullSecret, refs[0].Name)
+		assert.Equal(t, testHelmPullSecret, refs[0].Name)
 	})
 
 	t.Run("does not duplicate when Helm pull secret matches customPullSecret", func(t *testing.T) {
-		t.Setenv(k8senv.DTOperatorPullSecretEnvName, customPullSecret)
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, testCustomPullSecret)
 		dk := DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: dkName},
-			Spec:       DynaKubeSpec{CustomPullSecret: customPullSecret},
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Spec:       DynaKubeSpec{CustomPullSecret: testCustomPullSecret},
 		}
 		refs := dk.CustomPullSecretReferences()
 		assert.Len(t, refs, 1)
-		assert.Equal(t, customPullSecret, refs[0].Name)
+		assert.Equal(t, testCustomPullSecret, refs[0].Name)
 	})
 
 	t.Run("includes both customPullSecret and Helm pull secret", func(t *testing.T) {
-		t.Setenv(k8senv.DTOperatorPullSecretEnvName, helmPullSecret)
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, testHelmPullSecret)
 		dk := DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: dkName},
-			Spec:       DynaKubeSpec{CustomPullSecret: customPullSecret},
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Spec:       DynaKubeSpec{CustomPullSecret: testCustomPullSecret},
 		}
 		refs := dk.CustomPullSecretReferences()
 		assert.Len(t, refs, 2)
-		assert.Equal(t, customPullSecret, refs[0].Name)
-		assert.Equal(t, helmPullSecret, refs[1].Name)
+		assert.Equal(t, testCustomPullSecret, refs[0].Name)
+		assert.Equal(t, testHelmPullSecret, refs[1].Name)
 	})
 
 	t.Run("never contains the operator-generated tenant registry pull secret", func(t *testing.T) {
-		t.Setenv(k8senv.DTOperatorPullSecretEnvName, helmPullSecret)
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, testHelmPullSecret)
 		dk := DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: dkName},
-			Spec:       DynaKubeSpec{CustomPullSecret: customPullSecret},
+			ObjectMeta: metav1.ObjectMeta{Name: testDKName},
+			Spec:       DynaKubeSpec{CustomPullSecret: testCustomPullSecret},
 		}
 		refs := dk.CustomPullSecretReferences()
 		assert.Len(t, refs, 2)

--- a/pkg/api/validation/dynakube/paastoken.go
+++ b/pkg/api/validation/dynakube/paastoken.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 )
 
 const (
@@ -27,7 +26,7 @@ func deprecatedPaasToken(ctx context.Context, dv *Validator, dk *dynakube.DynaKu
 	}
 
 	if tokens.PaasToken().Value != "" {
-		if dttoken.IsPlatform(tokens.APIToken().Value) {
+		if tokens.HasPlatformToken() {
 			return warningPaasTokenNotUsed
 		}
 

--- a/pkg/controllers/dynakube/controller.go
+++ b/pkg/controllers/dynakube/controller.go
@@ -29,7 +29,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/mapper"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
@@ -478,7 +477,7 @@ func (controller *Controller) warnAboutDeprecatedTokens(ctx context.Context) {
 	log := logd.FromContext(ctx)
 
 	if controller.tokens.PaasToken().Value != "" {
-		if dttoken.IsPlatform(controller.tokens.APIToken().Value) {
+		if controller.tokens.HasPlatformToken() {
 			log.Info("The '" + token.PaaSKey + "' token in the spec.tokens secret is deprecated. It will be ignored because the '" + token.APIKey + "' field in the secret contains a platform token, which will be used for authentication.")
 		} else {
 			log.Info("The '" + token.PaaSKey + "' token in the spec.tokens secret is deprecated. It will be used for authentication because the '" + token.APIKey + "' field in the secret does not contain a platform token.")
@@ -495,7 +494,7 @@ func (controller *Controller) verifyTokens(ctx context.Context, dtClient tokencl
 		return err
 	}
 
-	if dttoken.IsPlatform(controller.tokens.APIToken().Value) {
+	if controller.tokens.HasPlatformToken() {
 		dk.Status.APIToken.Platform = new(true)
 
 		logd.FromContext(ctx).Info("skipping token scope lookup due to platform token")

--- a/pkg/controllers/dynakube/dtpullsecret/generate.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/pkg/errors"
 )
 
@@ -47,7 +46,7 @@ func (r *Reconciler) generateData(dk *dynakube.DynaKube, tokens token.Tokens) (m
 	}
 
 	switch {
-	case tokens.PaasToken().Value != "" && !dttoken.IsPlatform(tokens.APIToken().Value):
+	case tokens.PaasToken().Value != "":
 		registryToken = tokens.PaasToken().Value
 	case tokens.APIToken().Value != "":
 		registryToken = tokens.APIToken().Value

--- a/pkg/controllers/dynakube/dtpullsecret/generate_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate_test.go
@@ -67,14 +67,6 @@ func TestReconciler_GenerateData(t *testing.T) {
 			},
 			testAPIToken,
 		},
-		{
-			"prefer platform token",
-			token.Tokens{
-				token.PaaSKey: &token.Token{Value: testPaasToken},
-				token.APIKey:  &token.Token{Value: testPlatformToken},
-			},
-			testPlatformToken,
-		},
 	}
 
 	for _, test := range tests {

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
@@ -34,7 +33,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, tokens token.Tokens) error {
 	ctx, log := logd.NewFromContext(ctx, "dynakube-pullsecret")
 
-	if dttoken.IsPlatform(tokens.APIToken().String()) || (!dk.OneAgent().IsDaemonsetRequired() && !dk.ActiveGate().IsEnabled()) {
+	if tokens.HasPlatformToken() || (!dk.OneAgent().IsDaemonsetRequired() && !dk.ActiveGate().IsEnabled()) {
 		if meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
@@ -33,7 +34,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, tokens token.Tokens) error {
 	ctx, log := logd.NewFromContext(ctx, "dynakube-pullsecret")
 
-	if !dk.OneAgent().IsDaemonsetRequired() && !dk.ActiveGate().IsEnabled() {
+	if dttoken.IsPlatform(tokens.APIToken().String()) || (!dk.OneAgent().IsDaemonsetRequired() && !dk.ActiveGate().IsEnabled()) {
 		if meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,14 +21,12 @@ const (
 )
 
 type Reconciler struct {
-	timeprovider *timeprovider.Provider
-	secrets      k8ssecret.QueryObject
+	secrets k8ssecret.QueryObject
 }
 
 func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 	return &Reconciler{
-		timeprovider: timeprovider.New(),
-		secrets:      k8ssecret.Query(clt, apiReader),
+		secrets: k8ssecret.Query(clt, apiReader),
 	}
 }
 
@@ -50,16 +47,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, token
 		return nil
 	}
 
-	if k8sconditions.IsOutdated(r.timeprovider, dk, PullSecretConditionType) {
-		k8sconditions.SetSecretOutdated(dk.Conditions(), PullSecretConditionType,
-			extendWithPullSecretSuffix(dk.Name)+" is not present or outdated")
+	err := r.reconcilePullSecret(ctx, dk, tokens)
+	if err != nil {
+		log.Info("could not reconcile pull secret")
 
-		err := r.reconcilePullSecret(ctx, dk, tokens)
-		if err != nil {
-			log.Info("could not reconcile pull secret")
-
-			return errors.WithStack(err)
-		}
+		return errors.WithStack(err)
 	}
 
 	return nil

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
@@ -146,78 +145,34 @@ func TestReconciler_Reconcile(t *testing.T) {
 		expectedJSON := `{"auths":{"test-api-url":{"username":"test-tenant","password":"test-value","auth":"dGVzdC10ZW5hbnQ6dGVzdC12YWx1ZQ=="}}}`
 		dk := createTestDynakube()
 		fakeClient := fake.NewClient()
-		tokens := token.Tokens{
-			token.APIKey: &token.Token{Value: testValue},
-		}
 
 		r := NewReconciler(fakeClient, fakeClient)
-		err := r.Reconcile(t.Context(), dk, tokens)
-
+		err := r.Reconcile(t.Context(), dk, token.Tokens{
+			token.APIKey: &token.Token{Value: "old-token"},
+		})
 		require.NoError(t, err)
 
 		var pullSecret corev1.Secret
 		err = fakeClient.Get(t.Context(),
 			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
 			&pullSecret)
-
 		require.NoError(t, err)
 
-		pullSecret.Data = nil
-		err = fakeClient.Update(t.Context(), &pullSecret)
+		initialDockerConfig := string(pullSecret.Data[".dockerconfigjson"])
 
-		require.NoError(t, err)
-
-		r.timeprovider.Set(r.timeprovider.Now().Add(1 * time.Hour))
-		err = r.Reconcile(t.Context(), dk, tokens)
-
+		err = r.Reconcile(t.Context(), dk, token.Tokens{
+			token.APIKey: &token.Token{Value: testValue},
+		})
 		require.NoError(t, err)
 
 		err = fakeClient.Get(t.Context(),
 			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
 			&pullSecret)
-
 		require.NoError(t, err)
-		assert.NotNil(t, pullSecret)
-		assert.NotEmpty(t, pullSecret.Data)
-		assert.Contains(t, pullSecret.Data, ".dockerconfigjson")
-		assert.NotEmpty(t, pullSecret.Data[".dockerconfigjson"])
+		require.NotEmpty(t, pullSecret.Data)
+		require.Contains(t, pullSecret.Data, ".dockerconfigjson")
 		assert.JSONEq(t, expectedJSON, string(pullSecret.Data[".dockerconfigjson"]))
-	})
-	t.Run("Reconciliation only runs every 15 min", func(t *testing.T) {
-		dk := createTestDynakube()
-		fakeClient := fake.NewClient()
-		tokens := token.Tokens{
-			token.APIKey: &token.Token{Value: testValue},
-		}
-
-		r := NewReconciler(fakeClient, fakeClient)
-		err := r.Reconcile(t.Context(), dk, tokens)
-
-		require.NoError(t, err)
-
-		var pullSecret corev1.Secret
-		err = fakeClient.Get(t.Context(),
-			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
-			&pullSecret)
-
-		require.NoError(t, err)
-
-		pullSecret.Data = nil
-		err = fakeClient.Update(t.Context(), &pullSecret)
-
-		require.NoError(t, err)
-
-		err = r.Reconcile(t.Context(), dk, tokens)
-
-		require.NoError(t, err)
-
-		err = fakeClient.Get(t.Context(),
-			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
-			&pullSecret)
-
-		require.NoError(t, err)
-		assert.NotNil(t, pullSecret)
-		assert.Empty(t, pullSecret.Data)
+		assert.NotEqual(t, initialDockerConfig, string(pullSecret.Data[".dockerconfigjson"]))
 	})
 	t.Run("Cleanup works", func(t *testing.T) {
 		dk := createTestDynakube()

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -205,6 +205,57 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.True(t, k8serrors.IsNotFound(err))
 		assert.Empty(t, meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType))
 	})
+	t.Run("Cleanup if platform token works", func(t *testing.T) {
+		dk := createTestDynakube()
+		fakeClient := fake.NewClient()
+
+		r := NewReconciler(fakeClient, fakeClient)
+		err := r.Reconcile(t.Context(), dk, token.Tokens{
+			token.APIKey: &token.Token{Value: testValue},
+		})
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType))
+
+		var pullSecret corev1.Secret
+		err = fakeClient.Get(t.Context(),
+			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
+			&pullSecret)
+
+		require.NoError(t, err)
+
+		err = r.Reconcile(t.Context(), dk, token.Tokens{
+			token.APIKey: &token.Token{Value: testPlatformToken},
+		})
+		require.NoError(t, err)
+
+		err = fakeClient.Get(t.Context(),
+			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
+			&pullSecret)
+
+		assert.True(t, k8serrors.IsNotFound(err))
+		assert.Empty(t, meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType))
+	})
+	t.Run("Don't create if platform token", func(t *testing.T) {
+		dk := createTestDynakube()
+		fakeClient := fake.NewClient()
+		tokens := token.Tokens{
+			token.APIKey: &token.Token{Value: testPlatformToken},
+		}
+
+		r := NewReconciler(fakeClient, fakeClient)
+		err := r.Reconcile(t.Context(), dk, tokens)
+		require.NoError(t, err)
+
+		assert.Empty(t, meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType))
+
+		var pullSecret corev1.Secret
+		err = fakeClient.Get(t.Context(),
+			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
+			&pullSecret)
+
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
 }
 
 func createTestDynakube() *dynakube.DynaKube {

--- a/pkg/controllers/dynakube/token/reader.go
+++ b/pkg/controllers/dynakube/token/reader.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,12 +34,7 @@ func (reader Reader) HasPlatformToken(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	token := tokens.APIToken()
-	if token != nil {
-		return dttoken.IsPlatform(token.Value), nil
-	}
-
-	return false, nil
+	return tokens.HasPlatformToken(), nil
 }
 
 func (reader Reader) ReadAndVerifyTokens(ctx context.Context) (Tokens, error) {

--- a/pkg/controllers/dynakube/token/tokens.go
+++ b/pkg/controllers/dynakube/token/tokens.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 )
 
 const (
@@ -81,6 +82,10 @@ func (tokens Tokens) VerifyValues() (err error) {
 	}
 
 	return
+}
+
+func (tokens Tokens) HasPlatformToken() bool {
+	return dttoken.IsPlatform(tokens.APIToken().String())
 }
 
 func CheckForDataIngestToken(tokens Tokens) bool {

--- a/pkg/controllers/dynakube/token/tokens_test.go
+++ b/pkg/controllers/dynakube/token/tokens_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/metadataenrichment"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/otlp"
 	tokenclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	tokenclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -498,6 +499,41 @@ func TestCheckForDataIngestToken(t *testing.T) {
 
 		assert.False(t, CheckForDataIngestToken(tokens))
 	})
+}
+
+func TestTokens_HasPlatformToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		tokens   Tokens
+		expected bool
+	}{
+		{
+			name:     "no api token",
+			tokens:   Tokens{},
+			expected: false,
+		},
+		{
+			name:     "empty api token value",
+			tokens:   Tokens{APIKey: &Token{Value: ""}},
+			expected: false,
+		},
+		{
+			name:     "regular api token",
+			tokens:   Tokens{APIKey: &Token{Value: "dt0c01.regular-token"}},
+			expected: false,
+		},
+		{
+			name:     "platform api token",
+			tokens:   Tokens{APIKey: &Token{Value: dttoken.PlatformPrefix + ".platform-token"}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.tokens.HasPlatformToken())
+		})
+	}
 }
 
 func TestGetMissingScopes(t *testing.T) {


### PR DESCRIPTION
<!--


Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
When the API token is updated (rotation, migration between token types, etc.), the pull secret is not regenerated until the 15-minute TTL expires. This happens because the pull secret reconciler is gated behind the same TTL used to rate-limit Dynatrace API calls, even though it makes no Dynatrace API calls. As a result, the pull secret holds stale credentials and images are pulled using the outdated token for up to 15 minutes.

This PR fixes the issue and adapts the tests.

> [!IMPORTANT]
Additionally after discussions it was decided to not create the secret if a platform token is used and to remove the existing secret if there is a migration to platform token. Old tests were adapted and new ones were introduced

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

[ICP-5547 Jira](https://dt-rnd.atlassian.net/browse/ICP-5547)
## How can this be tested?

`make go/test`

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->