### PR TITLE
Add liveness and readiness probes to OpenTelemetry collector deployment

### DIFF
--- a/pkg/controllers/dynakube/otelc/statefulset/container.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/container.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	"github.com/Dynatrace/dynatrace-operator/pkg/otelcgen"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -24,6 +26,34 @@ func getContainer(dk *dynakube.DynaKube, replicas int32) corev1.Container {
 		Resources:       dk.Spec.Templates.OpenTelemetryCollector.Resources,
 		Args:            buildArgs(dk),
 		VolumeMounts:    buildContainerVolumeMounts(dk),
+		LivenessProbe:   buildLivenessProbe(),
+		ReadinessProbe:  buildReadinessProbe(),
+	}
+}
+
+func buildLivenessProbe() *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/",
+				Port: intstr.FromInt32(otelcgen.ExtensionsHealthCheckPort),
+			},
+		},
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       30,
+	}
+}
+
+func buildReadinessProbe() *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/",
+				Port: intstr.FromInt32(otelcgen.ExtensionsHealthCheckPort),
+			},
+		},
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       10,
 	}
 }
 

--- a/pkg/controllers/dynakube/otelc/statefulset/container.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/container.go
@@ -41,6 +41,9 @@ func buildLivenessProbe() *corev1.Probe {
 		},
 		InitialDelaySeconds: 10,
 		PeriodSeconds:       30,
+		FailureThreshold:    3,
+		TimeoutSeconds:      2,
+		SuccessThreshold:    1,
 	}
 }
 
@@ -54,6 +57,9 @@ func buildReadinessProbe() *corev1.Probe {
 		},
 		InitialDelaySeconds: 5,
 		PeriodSeconds:       10,
+		FailureThreshold:    3,
+		TimeoutSeconds:      2,
+		SuccessThreshold:    1,
 	}
 }
 

--- a/pkg/controllers/dynakube/otelc/statefulset/container_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/container_test.go
@@ -4,8 +4,35 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/telemetryingest"
+	"github.com/Dynatrace/dynatrace-operator/pkg/otelcgen"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+func TestProbes(t *testing.T) {
+	expectedHTTPGet := &corev1.HTTPGetAction{
+		Path: "/",
+		Port: intstr.FromInt32(otelcgen.ExtensionsHealthCheckPort),
+	}
+
+	t.Run("liveness probe", func(t *testing.T) {
+		probe := buildLivenessProbe()
+		require.NotNil(t, probe)
+		assert.Equal(t, expectedHTTPGet, probe.HTTPGet)
+		assert.EqualValues(t, 10, probe.InitialDelaySeconds)
+		assert.EqualValues(t, 30, probe.PeriodSeconds)
+	})
+
+	t.Run("readiness probe", func(t *testing.T) {
+		probe := buildReadinessProbe()
+		require.NotNil(t, probe)
+		assert.Equal(t, expectedHTTPGet, probe.HTTPGet)
+		assert.EqualValues(t, 5, probe.InitialDelaySeconds)
+		assert.EqualValues(t, 10, probe.PeriodSeconds)
+	})
+}
 
 func TestContainer(t *testing.T) {
 	t.Run("only TelemetryIngest enabled", func(t *testing.T) {

--- a/pkg/controllers/dynakube/otelc/statefulset/container_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/container_test.go
@@ -23,6 +23,9 @@ func TestProbes(t *testing.T) {
 		assert.Equal(t, expectedHTTPGet, probe.HTTPGet)
 		assert.EqualValues(t, 10, probe.InitialDelaySeconds)
 		assert.EqualValues(t, 30, probe.PeriodSeconds)
+		assert.EqualValues(t, 3, probe.FailureThreshold)
+		assert.EqualValues(t, 2, probe.TimeoutSeconds)
+		assert.EqualValues(t, 1, probe.SuccessThreshold)
 	})
 
 	t.Run("readiness probe", func(t *testing.T) {
@@ -31,6 +34,9 @@ func TestProbes(t *testing.T) {
 		assert.Equal(t, expectedHTTPGet, probe.HTTPGet)
 		assert.EqualValues(t, 5, probe.InitialDelaySeconds)
 		assert.EqualValues(t, 10, probe.PeriodSeconds)
+		assert.EqualValues(t, 3, probe.FailureThreshold)
+		assert.EqualValues(t, 2, probe.TimeoutSeconds)
+		assert.EqualValues(t, 1, probe.SuccessThreshold)
 	})
 }
 


### PR DESCRIPTION
## Description

The OpenTelemetry pods up to now do not have liveness and readiness probes configured although the resp. health_check extensions is already configured and used in the collector.

Add a hardcoded default configuration for those probes.

[JIRA](https://dt-rnd.atlassian.net/browse/ICP-5165)

## How can this be tested?

1. Deploy a DynaKube with `telemetryIngest` enabled.
2. Observe the OpenTelemetry collector pod(s)
    * check their prob configs
    * produce some load on the collector
    * observe that the collector doesn't restart unexpectedly