### PR TITLE
Fix slack red circle for skipped jobs

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -101,7 +101,7 @@ jobs:
           PLATFORM_VERSION_CLEAN=${PLATFORM_VERSION//-/_}
 
           get_emoji() {
-            if [ "$1" = "skipped" ]; then
+            if [ "$1" = "skipped" ] || [ "$2" = "skipped" ]; then
               echo "large_yellow_circle"
             elif [ "$2" = "success" ]; then
               echo "white_check_mark"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -239,7 +239,7 @@ jobs:
           OCP_OLM_RESULT: ${{ needs.run-in-ocp-olm.result }}
         run: |
           get_emoji() {
-            if [ "$1" = "skipped" ]; then
+            if [ "$1" = "skipped" ] || [ "$2" = "skipped" ]; then
               echo "large_yellow_circle"
             elif [ "$2" = "success" ]; then
               echo "white_check_mark"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
When individual e2e test jobs are skipped, the Slack notification incorrectly shows a red circle instead of a yellow circle, which is reserved for skipped jobs. This PR fixes the bug.
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?
`N/A`

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->