### PR TITLE
Add extra permissions for logmonitoring clusterrole.

### DIFF
--- a/config/helm/chart/default/templates/Common/logmonitoring/clusterrole-logmonitoring.yaml
+++ b/config/helm/chart/default/templates/Common/logmonitoring/clusterrole-logmonitoring.yaml
@@ -23,6 +23,7 @@ rules:
     - ""
   resources:
     - nodes/proxy
+    - nodes/pods
   verbs:
     - get
 {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}

--- a/config/helm/chart/default/tests/Common/logmonitoring/clusterrole-logmonitoring_test.yaml
+++ b/config/helm/chart/default/tests/Common/logmonitoring/clusterrole-logmonitoring_test.yaml
@@ -22,6 +22,7 @@ tests:
               - ""
             resources:
               - nodes/proxy
+              - nodes/pods
             verbs:
               - get
       - notContains:


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
[ICP-4010](https://dt-rnd.atlassian.net/browse/ICP-4010)
Add extra nodes/pods permission to logmonitoring clusterrole to fix issue with logmonitoring once KubeletFineGrainedAuthz is enabled in new k8s versions (already hit GKE autopilot).
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?
This can be tested by deploying the operator to a current GKE Autopilot cluster and verifying the error log line in the issue no longer occurs, and logs are seen in a tenant.
<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[ICP-4010]: https://dt-rnd.atlassian.net/browse/ICP-4010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ