### PR TITLE
Adopt warning when use_public_registry FF used or (platform tokens gen 3) and version field is set

### DIFF
--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
@@ -42,6 +43,8 @@ Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 	errorSameHostTagMultipleTimes = "Providing the same tag(s) (%s) multiple times with --set-host-tag is not allowed."
 
 	warningDeprecatedVersion = `version field is deprecated. Please use "%s" field instead to set a version.`
+
+	warningDeprecatedVersionIgnored = `version field is deprecated and ignored. Please remove the version field from the DynaKube specification.`
 )
 
 func conflictingOneAgentConfiguration(ctx context.Context, _ *Validator, dk *dynakube.DynaKube) string {
@@ -278,10 +281,20 @@ func forbiddenHostIDSourceArgument(_ context.Context, _ *Validator, dk *dynakube
 	return ""
 }
 
-func deprecatedOneAgentVersionField(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+func deprecatedOneAgentVersionField(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
 	oa := dk.OneAgent()
 
 	if oa.GetCustomVersion() != "" {
+		if dk.FF().IsPublicRegistry() {
+			return warningDeprecatedVersionIgnored
+		}
+
+		// For new DynaKubes (status not yet set), check the token secret directly.
+		hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
+		if err == nil && hasPlatformToken {
+			return warningDeprecatedVersionIgnored
+		}
+
 		switch {
 		case oa.IsApplicationMonitoringMode():
 			return fmt.Sprintf(warningDeprecatedVersion, "codeModulesImage")

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -850,47 +850,6 @@ func TestDeprecatedOneAgentVersion(t *testing.T) {
 			fmt.Sprintf(warningDeprecatedVersion, "image"),
 		},
 		{
-			"classic fullstack + public registry ff",
-			dynakube.DynaKube{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "dynakube",
-					Namespace: testNamespace,
-					Annotations: map[string]string{
-						exp.UsePublicRegistryKey: "true",
-					},
-				},
-				Spec: dynakube.DynaKubeSpec{
-					APIURL: testAPIURL,
-					OneAgent: oneagent.Spec{ClassicFullStack: &oneagent.HostInjectSpec{
-						Version: "1.0.0.20240101-000000", //nolint:staticcheck
-					}},
-				},
-			},
-			apiToken,
-			fmt.Sprint(warningDeprecatedVersionIgnored),
-		},
-		{
-			"classic fullstack + public registry ff + image specified",
-			dynakube.DynaKube{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "dynakube",
-					Namespace: testNamespace,
-					Annotations: map[string]string{
-						exp.UsePublicRegistryKey: "true",
-					},
-				},
-				Spec: dynakube.DynaKubeSpec{
-					APIURL: testAPIURL,
-					OneAgent: oneagent.Spec{ClassicFullStack: &oneagent.HostInjectSpec{
-						Version: "1.0.0.20240101-000000", //nolint:staticcheck
-						Image:   "test/image/test-image:some-tag",
-					}},
-				},
-			},
-			apiToken,
-			fmt.Sprint(warningDeprecatedVersionIgnored),
-		},
-		{
 			"host monitoring",
 			dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dttoken"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -804,63 +806,294 @@ func TestDeprecatedOneAgentAutoUpdate(t *testing.T) {
 }
 
 func TestDeprecatedOneAgentVersion(t *testing.T) {
-	baseDK := &dynakube.DynaKube{
+	apiToken := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "dynakube",
 			Namespace: testNamespace,
 		},
-		Spec: dynakube.DynaKubeSpec{
-			APIURL:   testAPIURL,
-			OneAgent: oneagent.Spec{},
+		Data: map[string][]byte{
+			token.APIKey: []byte("test-platform-token"),
 		},
+		Type: corev1.SecretTypeOpaque,
 	}
-
+	platformToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dynakube",
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			token.APIKey: []byte(dttoken.PlatformPrefix + "test-platform-token"),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
 	testcases := []struct {
 		name            string
-		valid           oneagent.Spec
+		dk              dynakube.DynaKube
+		apiToken        *corev1.Secret
 		expectedWarning string
 	}{
 		{
 			"classic fullstack",
-			oneagent.Spec{ClassicFullStack: &oneagent.HostInjectSpec{
-				Version: "1.0.0.20240101-000000", //nolint:staticcheck
-			}},
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{ClassicFullStack: &oneagent.HostInjectSpec{
+						Version: "1.0.0.20240101-000000", //nolint:staticcheck
+					}},
+				},
+			},
+			apiToken,
 			fmt.Sprintf(warningDeprecatedVersion, "image"),
+		},
+		{
+			"classic fullstack + public registry ff",
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						exp.UsePublicRegistryKey: "true",
+					},
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{ClassicFullStack: &oneagent.HostInjectSpec{
+						Version: "1.0.0.20240101-000000", //nolint:staticcheck
+					}},
+				},
+			},
+			apiToken,
+			fmt.Sprint(warningDeprecatedVersionIgnored),
+		},
+		{
+			"classic fullstack + public registry ff + image specified",
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						exp.UsePublicRegistryKey: "true",
+					},
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{ClassicFullStack: &oneagent.HostInjectSpec{
+						Version: "1.0.0.20240101-000000", //nolint:staticcheck
+						Image:   "test/image/test-image:some-tag",
+					}},
+				},
+			},
+			apiToken,
+			fmt.Sprint(warningDeprecatedVersionIgnored),
 		},
 		{
 			"host monitoring",
-			oneagent.Spec{HostMonitoring: &oneagent.HostInjectSpec{
-				Version: "1.0.0.20240101-000000", //nolint:staticcheck
-			}},
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{HostMonitoring: &oneagent.HostInjectSpec{
+						Version: "1.0.0.20240101-000000", //nolint:staticcheck
+					}},
+				},
+			},
+			apiToken,
 			fmt.Sprintf(warningDeprecatedVersion, "image"),
 		},
 		{
-			"cloudnative fullstack",
-			oneagent.Spec{CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{
-				HostInjectSpec: oneagent.HostInjectSpec{
-					Version: "1.0.0.20240101-000000", //nolint:staticcheck
+			"host monitoring + public registry ff",
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						exp.UsePublicRegistryKey: "true",
+					},
 				},
-			}},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{HostMonitoring: &oneagent.HostInjectSpec{
+						Version: "1.0.0.20240101-000000", //nolint:staticcheck
+					}},
+				},
+			},
+			apiToken,
+			fmt.Sprint(warningDeprecatedVersionIgnored),
+		},
+		{
+			"host monitoring + public registry ff + image specified",
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						exp.UsePublicRegistryKey: "true",
+					},
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{HostMonitoring: &oneagent.HostInjectSpec{
+						Version: "1.0.0.20240101-000000", //nolint:staticcheck
+						Image:   "test/image/test-image:some-tag",
+					}},
+				},
+			},
+			apiToken,
+			fmt.Sprint(warningDeprecatedVersionIgnored),
+		},
+		{
+			"cloudnative fullstack",
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{
+						HostInjectSpec: oneagent.HostInjectSpec{
+							Version: "1.0.0.20240101-000000", //nolint:staticcheck
+						},
+					}},
+				},
+			},
+			apiToken,
 			fmt.Sprintf(warningDeprecatedVersion, "image and/or codeModulesImage"),
 		},
 		{
+			"cloudnative fullstack + public registry ff",
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						exp.UsePublicRegistryKey: "true",
+					},
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{
+						HostInjectSpec: oneagent.HostInjectSpec{
+							Version: "1.0.0.20240101-000000", //nolint:staticcheck
+						},
+					}},
+				},
+			},
+			apiToken,
+			fmt.Sprint(warningDeprecatedVersionIgnored),
+		},
+		{
+			"cloudnative fullstack + public registry ff + image specified",
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						exp.UsePublicRegistryKey: "true",
+					},
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{
+						HostInjectSpec: oneagent.HostInjectSpec{
+							Version: "1.0.0.20240101-000000", //nolint:staticcheck
+							Image:   "test/image/test-image:some-tag",
+						},
+					}},
+				},
+			},
+			apiToken,
+			fmt.Sprint(warningDeprecatedVersionIgnored),
+		},
+		{
 			"app monitoring",
-			oneagent.Spec{ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{
-				Version: "1.0.0.20240101-000000", //nolint:staticcheck
-			}},
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{
+						Version: "1.0.0.20240101-000000", //nolint:staticcheck
+					}},
+				},
+			},
+			apiToken,
 			fmt.Sprintf(warningDeprecatedVersion, "codeModulesImage"),
+		},
+		{
+			"app monitoring + public registry ff",
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						exp.UsePublicRegistryKey: "true",
+					},
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{
+						Version: "1.0.0.20240101-000000", //nolint:staticcheck
+					}},
+				},
+			},
+			apiToken,
+			fmt.Sprint(warningDeprecatedVersionIgnored),
+		},
+		{
+			"app monitoring + platform token",
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{
+						Version: "1.0.0.20240101-000000", //nolint:staticcheck
+					}},
+				},
+			},
+			platformToken,
+			fmt.Sprint(warningDeprecatedVersionIgnored),
+		},
+		{
+			"app monitoring + platform token + image specified",
+			dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dynakube",
+					Namespace: testNamespace,
+				},
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					OneAgent: oneagent.Spec{
+						ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{
+							Version: "1.0.0.20240101-000000", //nolint:staticcheck
+							AppInjectionSpec: oneagent.AppInjectionSpec{
+								CodeModulesImage: "test/image/test-image:some-tag",
+							},
+						},
+					},
+				},
+			},
+			platformToken,
+			fmt.Sprint(warningDeprecatedVersionIgnored),
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			validDK := baseDK.DeepCopy()
-			validDK.Spec.OneAgent = tc.valid
-
-			deprecatedDK := baseDK.DeepCopy()
-			deprecatedDK.Spec.OneAgent = tc.valid
-
-			warnings, err := assertAllowed(t, deprecatedDK)
+			deprecatedDK := &tc.dk
+			warnings, err := assertAllowed(t, deprecatedDK, tc.apiToken)
 			require.NoError(t, err, "creation")
 			require.Len(t, warnings, 1)
 			assert.Equal(t, tc.expectedWarning, warnings[0])


### PR DESCRIPTION


<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Resolves https://dt-rnd.atlassian.net/browse/ICP-5467

In gen 3 when platform token is used and where public registry is enforced and defaulted, and if user still have version field set inside dynakube spec, they should see warning about version field is ignored and deprecated. 
Also in gen2/normal token but when public registry FF is enabled we should do same.

This PRs add extra warning and action item:

```
version field is deprecated and ignored. Please remove the version field from the DynaKube specification.`
```

## How can this be tested?

unit tests

to understand better problem and solution focus on new/existing unit tests.