### PR TITLE
Add validation for public registry feature not allowed for classicFullstack

### DIFF
--- a/pkg/api/validation/dynakube/public_registry.go
+++ b/pkg/api/validation/dynakube/public_registry.go
@@ -12,6 +12,7 @@ import (
 const (
 	errorPublicRegistryOverrideWithoutPublicRegistry = `The publicRegistryOverride field is set, but the feature flag "%s" is not enabled. Either enable the feature flag or remove the publicRegistryOverride field.`
 	warningPublicRegistryFlagIgnoredForPlatformToken = `The feature flag "%s" is set, but it is ignored because a platform token is in use. The public registry endpoint is used automatically with platform tokens.`
+	errorPublicRegistryFeatureNotAllowedForClassic   = `The public-registry feature (and relatedly the use of a platform token) is not allowed when using classicFullStack. Consider upgrading to cloudnativeFullStack if you would like to use the feature.`
 )
 
 func publicRegistryOverrideWithoutPublicRegistry(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
@@ -39,4 +40,22 @@ func publicRegistryFlagIgnoredForPlatformToken(ctx context.Context, dv *Validato
 	}
 
 	return fmt.Sprintf(warningPublicRegistryFlagIgnoredForPlatformToken, exp.UsePublicRegistryKey)
+}
+
+func publicRegistryNotAllowedForClassic(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
+	if !dk.OneAgent().IsClassicFullStackMode() {
+		return ""
+	}
+
+	if dk.PublicRegistryOverride() != "" || dk.FF().IsPublicRegistry() {
+		return errorPublicRegistryFeatureNotAllowedForClassic
+	}
+
+	// For new DynaKubes (status not yet set), check the token secret directly.
+	hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
+	if err == nil && hasPlatformToken {
+		return errorPublicRegistryFeatureNotAllowedForClassic
+	}
+
+	return ""
 }

--- a/pkg/api/validation/dynakube/public_registry.go
+++ b/pkg/api/validation/dynakube/public_registry.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	errorPublicRegistryOverrideWithoutPublicRegistry = `The publicRegistryOverride field is set, but the feature flag "%s" is not enabled. Either enable the feature flag or remove the publicRegistryOverride field.`
-	warningPublicRegistryFlagIgnoredForPlatformToken = `The feature flag "%s" is set, but it is ignored because a platform token is in use. The public registry endpoint is used automatically with platform tokens.`
-	errorPublicRegistryFeatureNotAllowedForClassic   = `The public-registry feature (and relatedly the use of a platform token) is not allowed when using classicFullStack. Consider upgrading to cloudnativeFullStack if you would like to use the feature.`
+	errorPublicRegistryOverrideWithoutPublicRegistry    = `The publicRegistryOverride field is set, but the feature flag "%s" is not enabled. Either enable the feature flag or remove the publicRegistryOverride field.`
+	warningPublicRegistryFlagIgnoredForPlatformToken    = `The feature flag "%s" is set, but it is ignored because a platform token is in use. The public registry endpoint is used automatically with platform tokens.`
+	errorClassicFullStackIncompatibleWithPublicRegistry = `The DynaKube's specification uses classicFullStack, which is not compatible with the public registry feature or platform tokens. Consider upgrading to cloudNativeFullStack.`
 )
 
 func publicRegistryOverrideWithoutPublicRegistry(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
@@ -48,13 +48,13 @@ func publicRegistryNotAllowedForClassic(ctx context.Context, dv *Validator, dk *
 	}
 
 	if dk.PublicRegistryOverride() != "" || dk.FF().IsPublicRegistry() {
-		return errorPublicRegistryFeatureNotAllowedForClassic
+		return errorClassicFullStackIncompatibleWithPublicRegistry
 	}
 
 	// For new DynaKubes (status not yet set), check the token secret directly.
 	hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
 	if err == nil && hasPlatformToken {
-		return errorPublicRegistryFeatureNotAllowedForClassic
+		return errorClassicFullStackIncompatibleWithPublicRegistry
 	}
 
 	return ""

--- a/pkg/api/validation/dynakube/public_registry_test.go
+++ b/pkg/api/validation/dynakube/public_registry_test.go
@@ -98,20 +98,20 @@ func TestPublicRegistryNotAllowedForClassic(t *testing.T) {
 		dk := newClassicDynakube()
 		dk.Spec.PublicRegistryOverride = "my.custom.registry.com"
 
-		assertDenied(t, []string{errorPublicRegistryFeatureNotAllowedForClassic}, dk)
+		assertDenied(t, []string{errorClassicFullStackIncompatibleWithPublicRegistry}, dk)
 	})
 
 	t.Run("classic mode with use-public-registry FF returns error", func(t *testing.T) {
 		dk := newClassicDynakube()
 		dk.Annotations = map[string]string{exp.UsePublicRegistryKey: "true"}
 
-		assertDenied(t, []string{errorPublicRegistryFeatureNotAllowedForClassic}, dk)
+		assertDenied(t, []string{errorClassicFullStackIncompatibleWithPublicRegistry}, dk)
 	})
 
 	t.Run("classic mode with platform token returns error", func(t *testing.T) {
 		dk := newClassicDynakube()
 
-		assertDenied(t, []string{errorPublicRegistryFeatureNotAllowedForClassic}, dk, platformTokenSecret())
+		assertDenied(t, []string{errorClassicFullStackIncompatibleWithPublicRegistry}, dk, platformTokenSecret())
 	})
 
 	t.Run("classic mode with token secret read error returns no error", func(t *testing.T) {

--- a/pkg/api/validation/dynakube/public_registry_test.go
+++ b/pkg/api/validation/dynakube/public_registry_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -56,6 +57,66 @@ func TestPublicRegistryOverrideWithoutPublicRegistry(t *testing.T) {
 		dk.Spec.PublicRegistryOverride = "my.custom.registry.com"
 
 		assertAllowedWithoutWarnings(t, dk, platformTokenSecret())
+	})
+}
+
+func TestPublicRegistryNotAllowedForClassic(t *testing.T) {
+	newClassicDynakube := func() *dynakube.DynaKube {
+		return &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testAPIURL,
+				OneAgent: oneagent.Spec{
+					ClassicFullStack: &oneagent.HostInjectSpec{},
+				},
+			},
+		}
+	}
+
+	t.Run("non-classic mode returns no error", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testAPIURL,
+				OneAgent: oneagent.Spec{
+					CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{},
+				},
+			},
+		}
+		assertAllowedWithoutWarnings(t, dk)
+	})
+
+	t.Run("classic mode without public registry features returns no error", func(t *testing.T) {
+		dk := newClassicDynakube()
+		assertAllowedWithoutWarnings(t, dk, regularTokenSecret())
+	})
+
+	t.Run("classic mode with publicRegistryOverride returns error", func(t *testing.T) {
+		dk := newClassicDynakube()
+		dk.Spec.PublicRegistryOverride = "my.custom.registry.com"
+
+		assertDenied(t, []string{errorPublicRegistryFeatureNotAllowedForClassic}, dk)
+	})
+
+	t.Run("classic mode with use-public-registry FF returns error", func(t *testing.T) {
+		dk := newClassicDynakube()
+		dk.Annotations = map[string]string{exp.UsePublicRegistryKey: "true"}
+
+		assertDenied(t, []string{errorPublicRegistryFeatureNotAllowedForClassic}, dk)
+	})
+
+	t.Run("classic mode with platform token returns error", func(t *testing.T) {
+		dk := newClassicDynakube()
+
+		assertDenied(t, []string{errorPublicRegistryFeatureNotAllowedForClassic}, dk, platformTokenSecret())
+	})
+
+	t.Run("classic mode with token secret read error returns no error", func(t *testing.T) {
+		dk := newClassicDynakube()
+		assertAllowedWithoutWarnings(t, dk)
 	})
 }
 

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -70,6 +70,7 @@ var (
 		publicRegistryOverrideWithoutPublicRegistry,
 		invalidNetworkZone,
 		invalidOneAgentHostGroup,
+		publicRegistryNotAllowedForClassic,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,


### PR DESCRIPTION
…lStack

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-5676

ClassicFullStack doesn't work with public-registry images.
So we need to validate that no platform token and no public-registry FF is used with classic

## How can this be tested?

Try to deploy classic with platform token