### PR TITLE
Add configurable cache cleanup period (via helm+env)

### DIFF
--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -123,6 +123,10 @@ spec:
             - name: DT_CLIENT_LOG_LEVEL
               value: {{ . }}
             {{- end }}
+            {{- if .Values.operator.clientCacheCleanupInterval }}
+            - name: DT_CLIENT_CACHE_CLEAN_INTERVAL
+              value: "{{ .Values.operator.clientCacheCleanupInterval }}"
+            {{- end }}
             {{- if .Values.enableInsecurePprofEndpoint }}
             - name: PPROF_BIND_ADDRESS
               value: ":6060"

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -647,6 +647,29 @@ tests:
           count: 1
           any: true
 
+  - it: should have DT_CLIENT_CACHE_CLEAN_INTERVAL if operator.clientCacheCleanupInterval is set
+    set:
+      platform: kubernetes
+      operator.clientCacheCleanupInterval: "30m"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DT_CLIENT_CACHE_CLEAN_INTERVAL
+            value: "30m"
+          count: 1
+          any: true
+
+  - it: should not have DT_CLIENT_CACHE_CLEAN_INTERVAL if operator.clientCacheCleanupInterval is not set
+    set:
+      platform: kubernetes
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DT_CLIENT_CACHE_CLEAN_INTERVAL
+          any: true
+
   - it: should have PPROF_BIND_ADDRESS if enableInsecurePprofEndpoint is set
     set:
       enableInsecurePprofEndpoint: true

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -64,6 +64,7 @@ operator:
     cpu: 100m
     memory: 128Mi
   startupProbe: {} # configurable: periodSeconds, timeoutSeconds, failureThreshold
+  clientCacheCleanupInterval: "" # defined in the Golang time.Duration format, like "30m" == 30 minutes. Defaults to 1h
 
 webhook:
   hostNetwork: false


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-4105](https://dt-rnd.atlassian.net/browse/ICP-4105)

With this the earlier introduced env var: `DT_CLIENT_CACHE_CLEAN_INTERVAL` is being made configurable via helm `values.yaml` and env vars. This is basically a follow up of https://dt-rnd.atlassian.net/browse/ICP-1115

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Deploy the operator with `operator.clientCacheCleanupInterval` set to a short value (for example "5m") and verify:

- The env var `DT_CLIENT_CACHE_CLEAN_INTERVAL=5m` is present in the operator pod
- The operator logs show the cleanup goroutine running at the configured interval (look for "periodic cache cleanup")

Deploy without the value set and verify the env var is absent from the Pod spec and the goroutine defaults to 1h.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[ICP-4105]: https://dt-rnd.atlassian.net/browse/ICP-4105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ