### PR TITLE
fix: stop hard links escaping the codemodule extraction dir

### DIFF
--- a/pkg/injection/codemodule/installer/zip/gzip.go
+++ b/pkg/injection/codemodule/installer/zip/gzip.go
@@ -108,7 +108,7 @@ func extract(ctx context.Context, targetDir string, reader *tar.Reader, header *
 func extractLink(ctx context.Context, targetDir, target string, header *tar.Header) error {
 	log := logd.FromContext(ctx)
 
-	if isSafeToLink(header.Linkname, targetDir, target) && isSafeToLink(header.Name, targetDir, target) {
+	if isSafeToLink(header.Linkname, targetDir, targetDir) && isSafeToLink(header.Name, targetDir, target) {
 		if err := os.Link(filepath.Join(targetDir, header.Linkname), target); err != nil {
 			return errors.WithStack(err)
 		}

--- a/pkg/injection/codemodule/installer/zip/gzip_test.go
+++ b/pkg/injection/codemodule/installer/zip/gzip_test.go
@@ -2,6 +2,7 @@ package zip
 
 import (
 	"archive/tar"
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -247,5 +248,59 @@ func TestExtractGzip(t *testing.T) {
 		target, err = os.Readlink(escapeParent)
 		require.NoError(t, err)
 		require.Equal(t, "../../outside.txt", target)
+	})
+
+	t.Run("extract gzip with malicious hard link blocks escaping link", func(t *testing.T) {
+		base := t.TempDir()
+		root := filepath.Join(base, "extract")
+		require.NoError(t, os.MkdirAll(root, 0o755))
+
+		secret := filepath.Join(base, "secret.txt")
+		require.NoError(t, os.WriteFile(secret, []byte("secret"), 0o600))
+
+		var buf bytes.Buffer
+		writer := tar.NewWriter(&buf)
+		require.NoError(t, writer.WriteHeader(&tar.Header{
+			Name:     "payload",
+			Linkname: "../secret.txt",
+			Typeflag: tar.TypeLink,
+			Mode:     0o644,
+		}))
+		require.NoError(t, writer.Close())
+
+		err := extractFilesFromGzip(t.Context(), root, tar.NewReader(&buf))
+		require.NoError(t, err)
+
+		_, err = os.Lstat(filepath.Join(root, "payload"))
+		require.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("extract gzip with hard link inside target dir", func(t *testing.T) {
+		root := t.TempDir()
+
+		var buf bytes.Buffer
+		writer := tar.NewWriter(&buf)
+		require.NoError(t, writer.WriteHeader(&tar.Header{
+			Name:     "original.txt",
+			Typeflag: tar.TypeReg,
+			Mode:     0o644,
+			Size:     int64(len("payload")),
+		}))
+		_, err := writer.Write([]byte("payload"))
+		require.NoError(t, err)
+		require.NoError(t, writer.WriteHeader(&tar.Header{
+			Name:     "hardlink.txt",
+			Linkname: "original.txt",
+			Typeflag: tar.TypeLink,
+			Mode:     0o644,
+		}))
+		require.NoError(t, writer.Close())
+
+		err = extractFilesFromGzip(t.Context(), root, tar.NewReader(&buf))
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(filepath.Join(root, "hardlink.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "payload", string(content))
 	})
 }


### PR DESCRIPTION
## problem

hard link extraction in the codemodule gzip unpacker checks the wrong base path

`extractLink` validates with `isSafeToLink(header.Linkname, targetDir, target)` but `os.Link` resolves the source as `filepath.Join(targetDir, header.Linkname)`
the check uses `target` (the deep `targetDir/header.Name`) while os.Link uses `targetDir`
tar hard link linknames are relative to the archive root so os.Link is right and the check is wrong - the extra depth in `target` eats leading `../`
so a layer entry with a deep name and a matching `../` linkname passes the check but links outside the extraction dir

## impact

extraction runs in the privileged csi provisioner and the unpacked dir is renamed into the codemodule dir mounted into pods
a malicious or compromised codemodule image can hard link to a file outside the extraction root on the same csi volume - cross pod disclosure
bounded by exdev so not arbitrary host files
the symlink branch is fine - only the hard link base was wrong

## fix

validate the linkname against `targetDir` - the same base os.Link uses

## test

`extract gzip with malicious hard link blocks escaping link` fails on main and passes here
plus a positive case so legit in archive hard links still work
