### PR TITLE
Disable OTELC probes when EEC and prometheus is enabled

### DIFF
--- a/pkg/controllers/dynakube/otelc/statefulset/container.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/container.go
@@ -17,7 +17,7 @@ const (
 )
 
 func getContainer(dk *dynakube.DynaKube, replicas int32) corev1.Container {
-	return corev1.Container{
+	container := corev1.Container{
 		Name:            containerName,
 		Image:           dk.Spec.Templates.OpenTelemetryCollector.ImageRef.String(),
 		ImagePullPolicy: dk.Spec.Templates.OpenTelemetryCollector.ImageRef.GetPullPolicy(),
@@ -26,9 +26,16 @@ func getContainer(dk *dynakube.DynaKube, replicas int32) corev1.Container {
 		Resources:       dk.Spec.Templates.OpenTelemetryCollector.Resources,
 		Args:            buildArgs(dk),
 		VolumeMounts:    buildContainerVolumeMounts(dk),
-		LivenessProbe:   buildLivenessProbe(),
-		ReadinessProbe:  buildReadinessProbe(),
 	}
+
+	// It seems like EEC doesn't send the health probe config to OTELC, so disable the probes for it.
+	// The EEC + prometheus is not GA and may be removed in a future release, so it's an accepted caveat.
+	if !dk.Extensions().IsPrometheusEnabled() {
+		container.LivenessProbe = buildLivenessProbe()
+		container.ReadinessProbe = buildReadinessProbe()
+	}
+
+	return container
 }
 
 func buildLivenessProbe() *corev1.Probe {

--- a/pkg/controllers/dynakube/otelc/statefulset/container.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/container.go
@@ -28,9 +28,10 @@ func getContainer(dk *dynakube.DynaKube, replicas int32) corev1.Container {
 		VolumeMounts:    buildContainerVolumeMounts(dk),
 	}
 
-	// It seems like EEC doesn't send the health probe config to OTELC, so disable the probes for it.
-	// The EEC + prometheus is not GA and may be removed in a future release, so it's an accepted caveat.
-	if !dk.Extensions().IsPrometheusEnabled() {
+	// Only enable the probes when we control the configuration.
+	// When using Prometheus extensions, the EEC sends configuration without health checks.
+	// The feature is not GA and may be removed in a future release, so it's an accepted caveat.
+	if dk.TelemetryIngest().IsEnabled() {
 		container.LivenessProbe = buildLivenessProbe()
 		container.ReadinessProbe = buildReadinessProbe()
 	}

--- a/pkg/controllers/dynakube/otelc/statefulset/container_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/container_test.go
@@ -56,13 +56,13 @@ func TestProbes(t *testing.T) {
 		assert.Nil(t, container.ReadinessProbe)
 	})
 
-	t.Run("disable with EEC prometheus and telemetryingest", func(t *testing.T) {
+	t.Run("enabled with EEC prometheus and telemetryingest", func(t *testing.T) {
 		dk := getTestDynakubeWithExtensions()
 		dk.Spec.TelemetryIngest = &telemetryingest.Spec{}
 
 		container := getContainer(dk, 1)
-		assert.Nil(t, container.LivenessProbe)
-		assert.Nil(t, container.ReadinessProbe)
+		assert.NotNil(t, container.LivenessProbe)
+		assert.NotNil(t, container.ReadinessProbe)
 	})
 }
 

--- a/pkg/controllers/dynakube/otelc/statefulset/container_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/container_test.go
@@ -38,6 +38,32 @@ func TestProbes(t *testing.T) {
 		assert.EqualValues(t, 2, probe.TimeoutSeconds)
 		assert.EqualValues(t, 1, probe.SuccessThreshold)
 	})
+
+	t.Run("enable with telemetryIngest", func(t *testing.T) {
+		dk := getTestDynakube()
+		dk.Spec.TelemetryIngest = &telemetryingest.Spec{}
+
+		container := getContainer(dk, 1)
+		assert.NotNil(t, container.LivenessProbe)
+		assert.NotNil(t, container.ReadinessProbe)
+	})
+
+	t.Run("disable with EEC prometheus", func(t *testing.T) {
+		dk := getTestDynakubeWithExtensions()
+
+		container := getContainer(dk, 1)
+		assert.Nil(t, container.LivenessProbe)
+		assert.Nil(t, container.ReadinessProbe)
+	})
+
+	t.Run("disable with EEC prometheus and telemetryingest", func(t *testing.T) {
+		dk := getTestDynakubeWithExtensions()
+		dk.Spec.TelemetryIngest = &telemetryingest.Spec{}
+
+		container := getContainer(dk, 1)
+		assert.Nil(t, container.LivenessProbe)
+		assert.Nil(t, container.ReadinessProbe)
+	})
 }
 
 func TestContainer(t *testing.T) {


### PR DESCRIPTION
## Description

When deploying the OTEL statefulset with the Prometheus extension the configuration is missing the health check port which causes the probes to fail.
The probes work when we deploy it using telemetryIngest.

Fixes test failures introduced in #6787

ICP-6010

## How can this be tested?

* Deploy prometheus extension and check that probes are not present
* Deploy telemetryIngest and check the pod comes up
