### PR TITLE
Add telemetry ingest status to the DK status phase computation

### DIFF
--- a/pkg/controllers/dynakube/phase.go
+++ b/pkg/controllers/dynakube/phase.go
@@ -22,6 +22,7 @@ func (controller *Controller) determineDynaKubePhase(ctx context.Context, dk *dy
 		controller.determineOneAgentPhase,
 		controller.determineLogAgentPhase,
 		controller.determineKSPMPhase,
+		controller.determineTelemetryIngestPhase,
 	}
 	for _, component := range components {
 		if phase := component(ctx, dk); phase != status.Running {
@@ -67,35 +68,50 @@ func (controller *Controller) determineExtensionsCollectorPhase(ctx context.Cont
 	return controller.determinePrometheusStatefulsetPhase(ctx, dk, dk.OtelCollectorStatefulsetName())
 }
 
+func (controller *Controller) determineTelemetryIngestPhase(ctx context.Context, dk *dynakube.DynaKube) status.DeploymentPhase {
+	if dk.TelemetryIngest().IsEnabled() {
+		return controller.determineStatefulSetPhase(ctx, dk, dk.OtelCollectorStatefulsetName())
+	}
+
+	return status.Running
+}
+
 func (controller *Controller) determinePrometheusStatefulsetPhase(ctx context.Context, dk *dynakube.DynaKube, statefulsetName string) status.DeploymentPhase {
+	if dk.Extensions().IsPrometheusEnabled() {
+		return controller.determineStatefulSetPhase(ctx, dk, statefulsetName)
+	}
+
+	return status.Running
+}
+
+func (controller *Controller) determineStatefulSetPhase(ctx context.Context, dk *dynakube.DynaKube, statefulsetName string) status.DeploymentPhase {
 	log := logd.FromContext(ctx)
 
-	if dk.Extensions().IsPrometheusEnabled() {
-		statefulSet := &appsv1.StatefulSet{}
+	statefulSet := &appsv1.StatefulSet{}
 
-		err := controller.client.Get(ctx, types.NamespacedName{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
-		if k8serrors.IsNotFound(err) {
-			log.Info("statefulset to be deployed", "dynakube", dk.Name, "statefulset", statefulsetName)
+	err := controller.client.Get(ctx, types.NamespacedName{Name: statefulsetName, Namespace: dk.Namespace}, statefulSet)
+	if k8serrors.IsNotFound(err) {
+		log.Info("statefulset to be deployed", "dynakube", dk.Name, "statefulset", statefulsetName)
 
-			return status.Deploying
-		}
+		return status.Deploying
+	}
 
-		if err != nil {
-			log.Error(err, "statefulset could not be accessed", "dynakube", dk.Name, "statefulset", statefulsetName)
+	if err != nil {
+		log.Error(err, "statefulset could not be accessed", "dynakube", dk.Name, "statefulset", statefulsetName)
 
-			return status.Error
-		}
+		return status.Error
+	}
 
-		scheduledReplicas := int32(0)
-		if statefulSet.Spec.Replicas != nil {
-			scheduledReplicas = *statefulSet.Spec.Replicas
-		}
+	scheduledReplicas := int32(0)
+	if statefulSet.Spec.Replicas != nil {
+		scheduledReplicas = *statefulSet.Spec.Replicas
+	}
 
-		if scheduledReplicas != statefulSet.Status.ReadyReplicas {
-			log.Info("statefulset is still deploying", "dynakube", dk.Name, "statefulset", statefulsetName)
+	if statefulSet.Generation != statefulSet.Status.ObservedGeneration ||
+		scheduledReplicas != statefulSet.Status.ReadyReplicas {
+		log.Info("statefulset is still deploying", "dynakube", dk.Name, "statefulset", statefulsetName)
 
-			return status.Deploying
-		}
+		return status.Deploying
 	}
 
 	return status.Running

--- a/pkg/controllers/dynakube/phase_test.go
+++ b/pkg/controllers/dynakube/phase_test.go
@@ -222,16 +222,6 @@ func TestExtensionsExecutionControllerPhaseChanges(t *testing.T) {
 		phase := controller.determineExtensionsExecutionControllerPhase(t.Context(), dk)
 		assert.Equal(t, status.Running, phase)
 	})
-	t.Run("eec pods ready but generation outdated -> deploying", func(t *testing.T) {
-		fakeClient := fake.NewClient(createOutdatedStatefulset(testNamespace, dk.Extensions().GetExecutionControllerStatefulsetName(), 1))
-
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
-		}
-		phase := controller.determineExtensionsExecutionControllerPhase(t.Context(), dk)
-		assert.Equal(t, status.Deploying, phase)
-	})
 }
 
 func TestExtensionsCollectorPhaseChanges(t *testing.T) {

--- a/pkg/controllers/dynakube/phase_test.go
+++ b/pkg/controllers/dynakube/phase_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kspm"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/telemetryingest"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
@@ -86,17 +87,26 @@ func TestActiveGatePhaseChanges(t *testing.T) {
 func createStatefulset(namespace, name string, replicas, readyReplicas int32) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:       name,
+			Namespace:  namespace,
+			Generation: 1,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,
 		},
 		Status: appsv1.StatefulSetStatus{
-			Replicas:      replicas,
-			ReadyReplicas: readyReplicas,
+			Replicas:           replicas,
+			ReadyReplicas:      readyReplicas,
+			ObservedGeneration: 1,
 		},
 	}
+}
+
+func createOutdatedStatefulset(namespace, name string, replicas int32) *appsv1.StatefulSet {
+	sts := createStatefulset(namespace, name, replicas, replicas)
+	sts.Generation = 2
+
+	return sts
 }
 
 func TestOneAgentPhaseChanges(t *testing.T) {
@@ -212,6 +222,16 @@ func TestExtensionsExecutionControllerPhaseChanges(t *testing.T) {
 		phase := controller.determineExtensionsExecutionControllerPhase(t.Context(), dk)
 		assert.Equal(t, status.Running, phase)
 	})
+	t.Run("eec pods ready but generation outdated -> deploying", func(t *testing.T) {
+		fakeClient := fake.NewClient(createOutdatedStatefulset(testNamespace, dk.Extensions().GetExecutionControllerStatefulsetName(), 1))
+
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineExtensionsExecutionControllerPhase(t.Context(), dk)
+		assert.Equal(t, status.Deploying, phase)
+	})
 }
 
 func TestExtensionsCollectorPhaseChanges(t *testing.T) {
@@ -261,6 +281,86 @@ func TestExtensionsCollectorPhaseChanges(t *testing.T) {
 			apiReader: fakeClient,
 		}
 		phase := controller.determineExtensionsCollectorPhase(t.Context(), dk)
+		assert.Equal(t, status.Running, phase)
+	})
+	t.Run("otelc pods ready but generation outdated -> deploying", func(t *testing.T) {
+		fakeClient := fake.NewClient(createOutdatedStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 2))
+
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineExtensionsCollectorPhase(t.Context(), dk)
+		assert.Equal(t, status.Deploying, phase)
+	})
+}
+
+func TestTelemetryIngestPhaseChanges(t *testing.T) {
+	dk := &dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: dynakube.DynaKubeSpec{
+			TelemetryIngest: &telemetryingest.Spec{},
+		},
+	}
+
+	t.Run("no otelc statefulset in cluster -> deploying", func(t *testing.T) {
+		fakeClient := fake.NewClient()
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineTelemetryIngestPhase(t.Context(), dk)
+		assert.Equal(t, status.Deploying, phase)
+	})
+	t.Run("error accessing k8s api -> error", func(t *testing.T) {
+		fakeClient := errorClient{}
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineTelemetryIngestPhase(t.Context(), dk)
+		assert.Equal(t, status.Error, phase)
+	})
+	t.Run("otelc pods not ready -> deploying", func(t *testing.T) {
+		fakeClient := fake.NewClient(createStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 1, 0))
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineTelemetryIngestPhase(t.Context(), dk)
+		assert.Equal(t, status.Deploying, phase)
+	})
+	t.Run("otelc deployed -> running", func(t *testing.T) {
+		fakeClient := fake.NewClient(createStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 1, 1))
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineTelemetryIngestPhase(t.Context(), dk)
+		assert.Equal(t, status.Running, phase)
+	})
+	t.Run("otelc pods ready but generation outdated -> deploying", func(t *testing.T) {
+		fakeClient := fake.NewClient(createOutdatedStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 1))
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineTelemetryIngestPhase(t.Context(), dk)
+		assert.Equal(t, status.Deploying, phase)
+	})
+	t.Run("telemetryingest not enabled -> running", func(t *testing.T) {
+		dkNoTI := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+		}
+		fakeClient := fake.NewClient()
+		controller := &Controller{
+			client:    fakeClient,
+			apiReader: fakeClient,
+		}
+		phase := controller.determineTelemetryIngestPhase(t.Context(), dkNoTI)
 		assert.Equal(t, status.Running, phase)
 	})
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
When telemetry ingest is enabled DK status computation does not include the otelc status, thus resulting in a unsynced DK phase, independent from otelc. This PR fixes the bug. 


[Jira ICP-6100](https://dt-rnd.atlassian.net/browse/ICP-6100)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Unit
`make go/test` 
E2E
`make test/e2e/telemetryingest` 

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->