### PR TITLE
ICP-5582: Deprecate k8s-app-enabled feature flag

### DIFF
--- a/pkg/api/exp/activegate.go
+++ b/pkg/api/exp/activegate.go
@@ -12,8 +12,8 @@ const (
 	AGAutomaticK8sAPIMonitoringKey            = FFPrefix + "automatic-kubernetes-api-monitoring"
 	AGAutomaticK8sAPIMonitoringClusterNameKey = FFPrefix + "automatic-kubernetes-api-monitoring-cluster-name"
 	// Deprecated: The builtin:app-transition.kubernetes schema is no longer available on phase 3 tenants.
-	AGK8sAppEnabledKey = FFPrefix + "k8s-app-enabled"
-	AGAutomaticTLSCertificateKey              = FFPrefix + "automatic-tls-certificate"
+	AGK8sAppEnabledKey           = FFPrefix + "k8s-app-enabled"
+	AGAutomaticTLSCertificateKey = FFPrefix + "automatic-tls-certificate"
 )
 
 // IsActiveGateUpdatesDisabled is a feature flag to disable ActiveGate updates.

--- a/pkg/api/exp/activegate.go
+++ b/pkg/api/exp/activegate.go
@@ -11,7 +11,8 @@ const (
 	AGAppArmorKey                             = FFPrefix + "activegate-apparmor"
 	AGAutomaticK8sAPIMonitoringKey            = FFPrefix + "automatic-kubernetes-api-monitoring"
 	AGAutomaticK8sAPIMonitoringClusterNameKey = FFPrefix + "automatic-kubernetes-api-monitoring-cluster-name"
-	AGK8sAppEnabledKey                        = FFPrefix + "k8s-app-enabled"
+	// Deprecated: The builtin:app-transition.kubernetes schema is no longer available on phase 3 tenants.
+	AGK8sAppEnabledKey = FFPrefix + "k8s-app-enabled"
 	AGAutomaticTLSCertificateKey              = FFPrefix + "automatic-tls-certificate"
 )
 
@@ -36,9 +37,10 @@ func (ff *FeatureFlags) GetAutomaticK8sAPIMonitoringClusterName() string {
 	return ff.getRaw(AGAutomaticK8sAPIMonitoringClusterNameKey)
 }
 
+// Deprecated: The builtin:app-transition.kubernetes schema is no longer available on phase 3 tenants.
 // IsK8sAppEnabled is a feature flag to enable automatically enable current Kubernetes cluster for the Kubernetes app.
 func (ff *FeatureFlags) IsK8sAppEnabled() bool {
-	return ff.getBoolWithDefault(AGK8sAppEnabledKey, false)
+	return ff.getBoolWithDefault(AGK8sAppEnabledKey, false) //nolint:staticcheck
 }
 
 // IsActiveGateAppArmor is a feature flag to enable AppArmor in ActiveGate container.

--- a/pkg/api/exp/activegate.go
+++ b/pkg/api/exp/activegate.go
@@ -11,7 +11,7 @@ const (
 	AGAppArmorKey                             = FFPrefix + "activegate-apparmor"
 	AGAutomaticK8sAPIMonitoringKey            = FFPrefix + "automatic-kubernetes-api-monitoring"
 	AGAutomaticK8sAPIMonitoringClusterNameKey = FFPrefix + "automatic-kubernetes-api-monitoring-cluster-name"
-	// Deprecated: The builtin:app-transition.kubernetes schema is no longer available on phase 3 tenants.
+	// Deprecated: The builtin:app-transition.kubernetes schema is no longer available on the "Latest Dynatrace" environments. Remove this annotation if you are on a "Latest Dynatrace" environment.
 	AGK8sAppEnabledKey           = FFPrefix + "k8s-app-enabled"
 	AGAutomaticTLSCertificateKey = FFPrefix + "automatic-tls-certificate"
 )
@@ -37,7 +37,7 @@ func (ff *FeatureFlags) GetAutomaticK8sAPIMonitoringClusterName() string {
 	return ff.getRaw(AGAutomaticK8sAPIMonitoringClusterNameKey)
 }
 
-// Deprecated: The builtin:app-transition.kubernetes schema is no longer available on phase 3 tenants.
+// Deprecated: The builtin:app-transition.kubernetes schema is no longer available on the "Latest Dynatrace" environments. Remove this annotation if you are on a "Latest Dynatrace" environment.
 // IsK8sAppEnabled is a feature flag to enable automatically enable current Kubernetes cluster for the Kubernetes app.
 func (ff *FeatureFlags) IsK8sAppEnabled() bool {
 	return ff.getBoolWithDefault(AGK8sAppEnabledKey, false) //nolint:staticcheck

--- a/pkg/api/exp/activegate_test.go
+++ b/pkg/api/exp/activegate_test.go
@@ -177,10 +177,10 @@ func TestIsK8sAppEnabled(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
 			ff := FeatureFlags{annotations: map[string]string{
-				AGK8sAppEnabledKey: c.in,
+				AGK8sAppEnabledKey: c.in, //nolint:staticcheck
 			}}
 
-			out := ff.IsK8sAppEnabled()
+			out := ff.IsK8sAppEnabled() //nolint:staticcheck
 
 			assert.Equal(t, c.out, out)
 		})

--- a/pkg/api/validation/dynakube/featureflag.go
+++ b/pkg/api/validation/dynakube/featureflag.go
@@ -21,6 +21,7 @@ var deprecatedFeatureFlags = []string{
 	exp.AGUpdatesKey,        //nolint:staticcheck
 	exp.AGDisableUpdatesKey, //nolint:staticcheck
 	exp.OAMaxUnavailableKey, //nolint:staticcheck
+	exp.AGK8sAppEnabledKey,  //nolint:staticcheck
 }
 
 var knownFeatureFlags = []string{
@@ -35,7 +36,7 @@ var knownFeatureFlags = []string{
 	exp.AGAppArmorKey,
 	exp.AGAutomaticK8sAPIMonitoringKey,
 	exp.AGAutomaticK8sAPIMonitoringClusterNameKey,
-	exp.AGK8sAppEnabledKey,
+	exp.AGK8sAppEnabledKey, //nolint:staticcheck
 	exp.AGAutomaticTLSCertificateKey,
 	// csi.go
 	exp.CSIMaxFailedMountAttemptsKey,

--- a/pkg/controllers/dynakube/k8sentity/reconciler.go
+++ b/pkg/controllers/dynakube/k8sentity/reconciler.go
@@ -189,7 +189,7 @@ func (r *Reconciler) createK8sAppSettingIfAbsent(ctx context.Context, dtClient s
 	log := logd.FromContext(ctx)
 
 	k8sEntity := settings.K8sClusterME{ID: dk.Status.KubernetesClusterMEID, Name: dk.Status.KubernetesClusterName}
-	if dk.FF().IsK8sAppEnabled() {
+	if dk.FF().IsK8sAppEnabled() { //nolint:staticcheck
 		appSettings, err := dtClient.GetSettingsForMonitoredEntity(ctx, k8sEntity, settings.AppTransitionSchemaID)
 		if err != nil {
 			if !core.IsNotFound(err) {

--- a/pkg/controllers/dynakube/k8sentity/reconciler_test.go
+++ b/pkg/controllers/dynakube/k8sentity/reconciler_test.go
@@ -54,7 +54,7 @@ func setClusterNameFF(dk *dynakube.DynaKube, name string) {
 }
 
 func enableAppFF(dk *dynakube.DynaKube) {
-	dk.Annotations[exp.AGK8sAppEnabledKey] = "true"
+	dk.Annotations[exp.AGK8sAppEnabledKey] = "true" //nolint:staticcheck
 }
 
 func setMEInfo(dk *dynakube.DynaKube, me settings.K8sClusterME) {


### PR DESCRIPTION
## Description

Deprecates the `k8s-app-enabled` feature flag. The `builtin:app-transition.kubernetes` schema is no longer available on phase 3 tenants, so the flag has run its course. Users who still have it set will receive a validation warning on apply; the underlying behavior is unchanged.

[ICP-5582](https://dt-rnd.atlassian.net/browse/ICP-5582)

## How can this be tested?

1. Deploy a DynaKube with the annotation set:
   ```yaml
   metadata:
     annotations:
       feature.dynatrace.com/k8s-app-enabled: "true"
   ```
2. Apply it and observe the deprecation warning in `kubectl apply` output:
   ```
   Warning: Using deprecated feature flags: feature.dynatrace.com/k8s-app-enabled
   ```
3. Verify the DynaKube reaches `Running` state.
4. Remove the annotation and re-apply — no warning should appear and the DynaKube should remain `Running`.

[ICP-5582]: https://dt-rnd.atlassian.net/browse/ICP-5582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ