### PR TITLE
Check PR author association before running kind e2e tests

### DIFF
--- a/.github/actions/check-comment/action.yaml
+++ b/.github/actions/check-comment/action.yaml
@@ -29,9 +29,11 @@ runs:
         fi
         echo "triggered=$triggered" >> $GITHUB_OUTPUT
         echo "detected-command=$detected_command" >> $GITHUB_OUTPUT
-    - name: Get PR details
+    - name: Get PR details (and make sure it was created by one of us)
       id: get-pr
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      env:
+        AUTHOR_AUTHORIZED: ${{ steps.check.outputs.triggered }}
       with:
         script: |
           const pr = await github.rest.pulls.get({
@@ -41,10 +43,12 @@ runs:
           });
           core.setOutput('pr_branch', pr.data.head.ref);
           core.setOutput('pr_sha', pr.data.head.sha);
+          const isLegitPr = process.env.AUTHOR_AUTHORIZED === 'true' && pr.data.author_association === 'MEMBER';
+          core.setOutput('legit-pr', isLegitPr.toString());
 outputs:
   triggered:
-    description: 'true if an allowed command was found and author is allowed'
-    value: ${{ steps.check.outputs.triggered }}
+    description: 'true if an allowed command was found, commenter is authorized, and PR author is a member'
+    value: ${{ steps.get-pr.outputs.legit-pr }}
   detected-command:
     description: 'The detected command from the comment'
     value: ${{ steps.check.outputs.detected-command }}


### PR DESCRIPTION
## Description
Inspired by https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/2130:
> [...] For additional security, we now enforce that the author of the PR must be a member of the repository.

Mitigates ICP-6219.